### PR TITLE
feat(core): Decouple metrics aggregation from client

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/metric-summaries/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing/metric-summaries/scenario.js
@@ -6,9 +6,6 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  _experiments: {
-    metricsAggregator: true,
-  },
 });
 
 // Stop the process from exiting before the transaction is sent

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -26,6 +26,8 @@ export declare const defaultStackParser: StackParser;
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 
+export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;
+
 /**
  * @deprecated This function will be removed in the next major version of the Sentry SDK.
  */

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -68,12 +68,12 @@ export {
   FunctionToString,
   // eslint-disable-next-line deprecation/deprecation
   InboundFilters,
-  metrics,
   functionToStringIntegration,
   inboundFiltersIntegration,
   parameterize,
 } from '@sentry/core';
 
+export * from './metrics';
 export { WINDOW } from './helpers';
 export { BrowserClient } from './client';
 export { makeFetchTransport, makeXHRTransport } from './transports';

--- a/packages/browser/src/metrics.ts
+++ b/packages/browser/src/metrics.ts
@@ -1,0 +1,51 @@
+import type { MetricData } from '@sentry/core';
+import { BrowserMetricsAggregator, metrics as metricsCore } from '@sentry/core';
+
+/**
+ * Adds a value to a counter metric
+ *
+ * @experimental This API is experimental and might have breaking changes in the future.
+ */
+function increment(name: string, value: number = 1, data?: MetricData): void {
+  metricsCore.increment(BrowserMetricsAggregator, name, value, data);
+}
+
+/**
+ * Adds a value to a distribution metric
+ *
+ * @experimental This API is experimental and might have breaking changes in the future.
+ */
+function distribution(name: string, value: number, data?: MetricData): void {
+  metricsCore.distribution(BrowserMetricsAggregator, name, value, data);
+}
+
+/**
+ * Adds a value to a set metric. Value must be a string or integer.
+ *
+ * @experimental This API is experimental and might have breaking changes in the future.
+ */
+function set(name: string, value: number | string, data?: MetricData): void {
+  metricsCore.set(BrowserMetricsAggregator, name, value, data);
+}
+
+/**
+ * Adds a value to a gauge metric
+ *
+ * @experimental This API is experimental and might have breaking changes in the future.
+ */
+function gauge(name: string, value: number, data?: MetricData): void {
+  metricsCore.gauge(BrowserMetricsAggregator, name, value, data);
+}
+
+export const metrics = {
+  increment,
+  distribution,
+  set,
+  gauge,
+  /** @deprecated An integration is no longer required to use the metrics feature */
+  // eslint-disable-next-line deprecation/deprecation
+  MetricsAggregator: metricsCore.MetricsAggregator,
+  /** @deprecated An integration is no longer required to use the metrics feature */
+  // eslint-disable-next-line deprecation/deprecation
+  metricsAggregatorIntegration: metricsCore.metricsAggregatorIntegration,
+};

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -78,7 +78,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   continueTrace,
-  metrics,
+  metricsNode as metrics,
   functionToStringIntegration,
   inboundFiltersIntegration,
   linkedErrorsIntegration,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,9 @@ export { linkedErrorsIntegration } from './integrations/linkederrors';
 export { moduleMetadataIntegration } from './integrations/metadata';
 export { requestDataIntegration } from './integrations/requestdata';
 export { metrics } from './metrics/exports';
+export type { MetricData } from './metrics/exports';
+export { metricsNode } from './metrics/exports-node';
+export { BrowserMetricsAggregator } from './metrics/browser-aggregator';
 
 /** @deprecated Import the integration function directly, e.g. `inboundFiltersIntegration()` instead of `new Integrations.InboundFilter(). */
 const Integrations = INTEGRATIONS;

--- a/packages/core/src/metrics/exports-node.ts
+++ b/packages/core/src/metrics/exports-node.ts
@@ -1,0 +1,52 @@
+import { MetricsAggregator } from './aggregator';
+import type { MetricData } from './exports';
+import { metrics as metricsCore } from './exports';
+
+/**
+ * Adds a value to a counter metric
+ *
+ * @experimental This API is experimental and might have breaking changes in the future.
+ */
+function increment(name: string, value: number = 1, data?: MetricData): void {
+  metricsCore.increment(MetricsAggregator, name, value, data);
+}
+
+/**
+ * Adds a value to a distribution metric
+ *
+ * @experimental This API is experimental and might have breaking changes in the future.
+ */
+function distribution(name: string, value: number, data?: MetricData): void {
+  metricsCore.distribution(MetricsAggregator, name, value, data);
+}
+
+/**
+ * Adds a value to a set metric. Value must be a string or integer.
+ *
+ * @experimental This API is experimental and might have breaking changes in the future.
+ */
+function set(name: string, value: number | string, data?: MetricData): void {
+  metricsCore.set(MetricsAggregator, name, value, data);
+}
+
+/**
+ * Adds a value to a gauge metric
+ *
+ * @experimental This API is experimental and might have breaking changes in the future.
+ */
+function gauge(name: string, value: number, data?: MetricData): void {
+  metricsCore.gauge(MetricsAggregator, name, value, data);
+}
+
+export const metricsNode = {
+  increment,
+  distribution,
+  set,
+  gauge,
+  /** @deprecated An integration is no longer required to use the metrics feature */
+  // eslint-disable-next-line deprecation/deprecation
+  MetricsAggregator: metricsCore.MetricsAggregator,
+  /** @deprecated An integration is no longer required to use the metrics feature */
+  // eslint-disable-next-line deprecation/deprecation
+  metricsAggregatorIntegration: metricsCore.metricsAggregatorIntegration,
+};

--- a/packages/core/src/metrics/integration.ts
+++ b/packages/core/src/metrics/integration.ts
@@ -1,7 +1,8 @@
 import type { Client, ClientOptions, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
 import type { BaseClient } from '../baseclient';
 import { convertIntegrationFnToClass, defineIntegration } from '../integration';
-import { BrowserMetricsAggregator } from './browser-aggregator';
+
+// TODO (v8): Remove this entire file
 
 const INTEGRATION_NAME = 'MetricsAggregator';
 
@@ -10,22 +11,26 @@ const _metricsAggregatorIntegration = (() => {
     name: INTEGRATION_NAME,
     // TODO v8: Remove this
     setupOnce() {}, // eslint-disable-line @typescript-eslint/no-empty-function
-    setup(client: BaseClient<ClientOptions>) {
-      client.metricsAggregator = new BrowserMetricsAggregator(client);
+    setup(_client: BaseClient<ClientOptions>) {
+      //
     },
   };
 }) satisfies IntegrationFn;
 
+/**
+ * @deprecated An integration is no longer required to use the metrics feature
+ */
 export const metricsAggregatorIntegration = defineIntegration(_metricsAggregatorIntegration);
 
 /**
  * Enables Sentry metrics monitoring.
  *
  * @experimental This API is experimental and might having breaking changes in the future.
- * @deprecated Use `metricsAggegratorIntegration()` instead.
+ * @deprecated An integration is no longer required to use the metrics feature
  */
 // eslint-disable-next-line deprecation/deprecation
 export const MetricsAggregator = convertIntegrationFnToClass(
   INTEGRATION_NAME,
+  // eslint-disable-next-line deprecation/deprecation
   metricsAggregatorIntegration,
 ) as IntegrationClass<Integration & { setup: (client: Client) => void }>;

--- a/packages/core/src/metrics/metric-summary.ts
+++ b/packages/core/src/metrics/metric-summary.ts
@@ -32,7 +32,7 @@ export function getMetricSummaryJsonForSpan(span: Span): Record<string, Array<Me
     if (!output[exportKey]) {
       output[exportKey] = [];
     }
-    
+
     output[exportKey].push(dropUndefinedKeys(summary));
   }
 

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -17,7 +17,6 @@ import { BaseClient } from './baseclient';
 import { createCheckInEnvelope } from './checkin';
 import { DEBUG_BUILD } from './debug-build';
 import { getClient } from './exports';
-import { MetricsAggregator } from './metrics/aggregator';
 import type { Scope } from './scope';
 import { SessionFlusher } from './sessionflusher';
 import {
@@ -51,10 +50,6 @@ export class ServerRuntimeClient<
     addTracingExtensions();
 
     super(options);
-
-    if (options._experiments && options._experiments['metricsAggregator']) {
-      this.metricsAggregator = new MetricsAggregator(this);
-    }
   }
 
   /**

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -76,7 +76,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
-  metrics,
+  metricsNode as metrics,
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   functionToStringIntegration,

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -44,6 +44,8 @@ export declare const withErrorBoundary: typeof clientSdk.withErrorBoundary;
 export declare const Span: typeof edgeSdk.Span;
 export declare const Transaction: typeof edgeSdk.Transaction;
 
+export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;
+
 export { withSentryConfig } from './config';
 
 /**

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -80,11 +80,11 @@ export {
   startSpanManual,
   continueTrace,
   parameterize,
-  metrics,
   functionToStringIntegration,
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,
+  metricsNode as metrics,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 export { autoDiscoverNodePerformanceMonitoringIntegrations } from './tracing';

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -30,6 +30,8 @@ declare const runtime: 'client' | 'server';
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
 export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;
 
+export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;
+
 /**
  * @deprecated This function will be removed in the next major version of the Sentry SDK.
  */

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -49,6 +49,8 @@ export declare const defaultStackParser: StackParser;
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 
+export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;
+
 /**
  * @deprecated This function will be removed in the next major version of the Sentry SDK.
  */

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -273,6 +273,16 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   on?(hook: 'startNavigationSpan', callback: (options: StartSpanOptions) => void): void;
 
   /**
+   * A hook that is called when the client is flushing
+   */
+  on?(hook: 'flush', callback: () => void): void;
+
+  /**
+   * A hook that is called when the client is closing
+   */
+  on?(hook: 'close', callback: () => void): void;
+
+  /**
    * Fire a hook event for transaction start.
    * Expects to be given a transaction as the second argument.
    */
@@ -342,6 +352,16 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * Emit a hook event for BrowserTracing to trigger a span for a navigation.
    */
   emit?(hook: 'startNavigationSpan', options: StartSpanOptions): void;
+
+  /**
+   * Emit a hook event for client flush
+   */
+  emit?(hook: 'flush'): void;
+
+  /**
+   * Emit a hook event for client close
+   */
+  emit?(hook: 'close'): void;
 
   /* eslint-enable @typescript-eslint/unified-signatures */
 }


### PR DESCRIPTION
Part of the work for #10595

This PR decouples metrics aggregation from the client and stores the aggregator globally the first time it is required.

This PR does not remove `captureAggregateMetrics` from the `BaseClient` or make `sendEnvelope` public as this can occur in a later PR. This will remove the remaining metrics code from the most basic tree-shaken Sentry configuration. 

The Node metrics implementation remains in `@sentry/core` because it's required for Deno and Vercel-Edge which don't ref. `@sentry/node`.

There's a load of extra deletions and cleanup that can occur for v8 when the integration is deleted. For example `BrowserMetricsAggregator` can probably move to `@sentry/browser`.