### PR TITLE
feat(core): Update `Sentry.addBreadcrumb` to skip hub

### DIFF
--- a/packages/core/src/breadcrumbs.ts
+++ b/packages/core/src/breadcrumbs.ts
@@ -1,0 +1,41 @@
+import type { Breadcrumb, BreadcrumbHint } from '@sentry/types';
+import { consoleSandbox, dateTimestampInSeconds } from '@sentry/utils';
+import { getClient } from './exports';
+import { getIsolationScope } from './hub';
+
+/**
+ * Default maximum number of breadcrumbs added to an event. Can be overwritten
+ * with {@link Options.maxBreadcrumbs}.
+ */
+const DEFAULT_BREADCRUMBS = 100;
+
+/**
+ * Records a new breadcrumb which will be attached to future events.
+ *
+ * Breadcrumbs will be added to subsequent events to provide more context on
+ * user's actions prior to an error or crash.
+ */
+export function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void {
+  const client = getClient();
+  const isolationScope = getIsolationScope();
+
+  if (!client) return;
+
+  const { beforeBreadcrumb = null, maxBreadcrumbs = DEFAULT_BREADCRUMBS } = client.getOptions();
+
+  if (maxBreadcrumbs <= 0) return;
+
+  const timestamp = dateTimestampInSeconds();
+  const mergedBreadcrumb = { timestamp, ...breadcrumb };
+  const finalBreadcrumb = beforeBreadcrumb
+    ? (consoleSandbox(() => beforeBreadcrumb(mergedBreadcrumb, hint)) as Breadcrumb | null)
+    : mergedBreadcrumb;
+
+  if (finalBreadcrumb === null) return;
+
+  if (client.emit) {
+    client.emit('beforeAddBreadcrumb', finalBreadcrumb, hint);
+  }
+
+  isolationScope.addBreadcrumb(finalBreadcrumb, maxBreadcrumbs);
+}

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -1,6 +1,4 @@
 import type {
-  Breadcrumb,
-  BreadcrumbHint,
   CaptureContext,
   CheckIn,
   Client,
@@ -74,19 +72,6 @@ export function captureMessage(message: string, captureContext?: CaptureContext 
 export function captureEvent(event: Event, hint?: EventHint): string {
   // eslint-disable-next-line deprecation/deprecation
   return getCurrentHub().captureEvent(event, hint);
-}
-
-/**
- * Records a new breadcrumb which will be attached to future events.
- *
- * Breadcrumbs will be added to subsequent events to provide more context on
- * user's actions prior to an error or crash.
- *
- * @param breadcrumb The breadcrumb to record.
- */
-export function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): ReturnType<Hub['addBreadcrumb']> {
-  // eslint-disable-next-line deprecation/deprecation
-  getCurrentHub().addBreadcrumb(breadcrumb, hint);
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,6 @@ export * from './tracing';
 export * from './semanticAttributes';
 export { createEventEnvelope, createSessionEnvelope } from './envelope';
 export {
-  addBreadcrumb,
   captureCheckIn,
   withMonitor,
   captureException,
@@ -94,6 +93,7 @@ export { RequestData } from './integrations/requestdata';
 export { InboundFilters } from './integrations/inboundfilters';
 export { FunctionToString } from './integrations/functiontostring';
 export { LinkedErrors } from './integrations/linkederrors';
+export { addBreadcrumb } from './breadcrumbs';
 /* eslint-enable deprecation/deprecation */
 import * as INTEGRATIONS from './integrations';
 export { functionToStringIntegration } from './integrations/functiontostring';

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -30,7 +30,6 @@ export { startSpan, startSpanManual, startInactiveSpan, getActiveSpan } from '@s
 export {
   getClient,
   isInitialized,
-  addBreadcrumb,
   captureException,
   captureEvent,
   captureMessage,
@@ -55,6 +54,7 @@ export { getCurrentHub, makeMain } from './sdk/hub';
 export { Scope } from './sdk/scope';
 
 export {
+  addBreadcrumb,
   makeNodeTransport,
   defaultStackParser,
   getSentryRelease,

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -3,8 +3,6 @@
 import type { Span } from '@opentelemetry/api';
 import { context, trace } from '@opentelemetry/api';
 import type {
-  Breadcrumb,
-  BreadcrumbHint,
   CaptureContext,
   Event,
   EventHint,
@@ -15,7 +13,6 @@ import type {
   SeverityLevel,
   User,
 } from '@sentry/types';
-import { consoleSandbox, dateTimestampInSeconds } from '@sentry/utils';
 import { getContextFromScope, getScopesFromContext, setScopesOnContext } from '../utils/contextData';
 
 import type { ExclusiveEventHintOrCaptureContext } from '../utils/prepareEvent';
@@ -114,29 +111,6 @@ export function captureMessage(message: string, captureContext?: CaptureContext 
 /** Capture a generic event and send it to Sentry. */
 export function captureEvent(event: Event, hint?: EventHint): string {
   return getCurrentScope().captureEvent(event, hint);
-}
-
-/**
- * Add a breadcrumb to the current isolation scope.
- */
-export function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void {
-  const client = getClient();
-
-  const { beforeBreadcrumb, maxBreadcrumbs } = client.getOptions();
-
-  if (maxBreadcrumbs && maxBreadcrumbs <= 0) return;
-
-  const timestamp = dateTimestampInSeconds();
-  const mergedBreadcrumb = { timestamp, ...breadcrumb };
-  const finalBreadcrumb = beforeBreadcrumb
-    ? (consoleSandbox(() => beforeBreadcrumb(mergedBreadcrumb, hint)) as Breadcrumb | null)
-    : mergedBreadcrumb;
-
-  if (finalBreadcrumb === null) return;
-
-  client.emit('beforeAddBreadcrumb', finalBreadcrumb, hint);
-
-  getIsolationScope().addBreadcrumb(finalBreadcrumb, maxBreadcrumbs);
 }
 
 /**

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -9,9 +9,8 @@ import type {
   TransactionContext,
 } from '@sentry/types';
 
-import { endSession, startSession } from '@sentry/core';
+import { addBreadcrumb, endSession, startSession } from '@sentry/core';
 import {
-  addBreadcrumb,
   captureEvent,
   getClient,
   getCurrentScope,

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -1,6 +1,6 @@
 import { getGlobalScope as _getGlobalScope, setGlobalScope } from '@sentry/core';
 import { OpenTelemetryScope } from '@sentry/opentelemetry';
-import type { Breadcrumb, Client, Event, EventHint, SeverityLevel } from '@sentry/types';
+import type { Client, Event, EventHint, SeverityLevel } from '@sentry/types';
 import { uuid4 } from '@sentry/utils';
 
 import { getGlobalCarrier } from './globals';
@@ -159,13 +159,6 @@ export class Scope extends OpenTelemetryScope implements ScopeInterface {
     getClient().captureEvent(event, { ...hint, event_id: eventId }, this);
 
     return eventId;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
-    return this._addBreadcrumb(breadcrumb, maxBreadcrumbs);
   }
 
   /** Get scope data for this scope only. */

--- a/packages/node-experimental/test/integration/breadcrumbs.test.ts
+++ b/packages/node-experimental/test/integration/breadcrumbs.test.ts
@@ -1,6 +1,6 @@
-import { captureException, withScope } from '@sentry/core';
+import { addBreadcrumb, captureException, withScope } from '@sentry/core';
 import { startSpan } from '@sentry/opentelemetry';
-import { addBreadcrumb, getClient, withIsolationScope } from '../../src/sdk/api';
+import { getClient, withIsolationScope } from '../../src/sdk/api';
 
 import type { NodeExperimentalClient } from '../../src/types';
 import { cleanupOtel, mockSdkInit } from '../helpers/mockSdkInit';

--- a/packages/node-experimental/test/integration/scope.test.ts
+++ b/packages/node-experimental/test/integration/scope.test.ts
@@ -41,11 +41,7 @@ describe('Integration | Scope', () => {
           scope2.setTag('tag3', 'val3');
 
           Sentry.startSpan({ name: 'outer' }, span => {
-            // TODO: This is "incorrect" until we stop cloning the current scope for setSpanScopes
-            // Once we change this, the scopes _should_ be the same again
-            if (enableTracing) {
-              expect(getSpanScopes(span)?.scope).not.toBe(scope2);
-            }
+            expect(getSpanScopes(span)?.scope).toBe(enableTracing ? scope2 : undefined);
 
             spanId = span.spanContext().spanId;
             traceId = span.spanContext().traceId;

--- a/packages/opentelemetry/src/custom/scope.ts
+++ b/packages/opentelemetry/src/custom/scope.ts
@@ -2,23 +2,17 @@ import type { Span } from '@opentelemetry/api';
 import type { TimedEvent } from '@opentelemetry/sdk-trace-base';
 import { Scope } from '@sentry/core';
 import type { Breadcrumb, ScopeData, SeverityLevel, Span as SentrySpan } from '@sentry/types';
-import { dateTimestampInSeconds, dropUndefinedKeys, logger, normalize } from '@sentry/utils';
+import { dropUndefinedKeys, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 import { InternalSentrySemanticAttributes } from '../semanticAttributes';
 import { convertOtelTimeToSeconds } from '../utils/convertOtelTimeToSeconds';
-import { getActiveSpan, getRootSpan } from '../utils/getActiveSpan';
+import { getActiveSpan } from '../utils/getActiveSpan';
 import { getSpanParent } from '../utils/spanData';
 import { spanHasEvents } from '../utils/spanTypes';
 
 /** A fork of the classic scope with some otel specific stuff. */
 export class OpenTelemetryScope extends Scope {
-  /**
-   * This can be set to ensure the scope uses _this_ span as the active one,
-   * instead of using getActiveSpan().
-   */
-  public activeSpan: Span | undefined;
-
   /**
    * @inheritDoc
    */
@@ -71,26 +65,6 @@ export class OpenTelemetryScope extends Scope {
     return this;
   }
 
-  /**
-   * @inheritDoc
-   */
-  public addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
-    const activeSpan = this.activeSpan || getActiveSpan();
-    const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
-
-    if (rootSpan) {
-      const mergedBreadcrumb = {
-        timestamp: dateTimestampInSeconds(),
-        ...breadcrumb,
-      };
-
-      rootSpan.addEvent(...breadcrumbToOtelEvent(mergedBreadcrumb));
-      return this;
-    }
-
-    return this._addBreadcrumb(breadcrumb, maxBreadcrumbs);
-  }
-
   /** @inheritDoc */
   public getScopeData(): ScopeData {
     const data = super.getScopeData();
@@ -100,17 +74,11 @@ export class OpenTelemetryScope extends Scope {
     return data;
   }
 
-  /** Add a breadcrumb to this scope. */
-  protected _addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
-    return super.addBreadcrumb(breadcrumb, maxBreadcrumbs);
-  }
-
   /**
    * @inheritDoc
    */
   protected _getBreadcrumbs(): Breadcrumb[] {
-    const span = this.activeSpan || getActiveSpan();
-
+    const span = getActiveSpan();
     const spanBreadcrumbs = span ? getBreadcrumbsForSpan(span) : [];
 
     return spanBreadcrumbs.length > 0 ? this._breadcrumbs.concat(spanBreadcrumbs) : this._breadcrumbs;
@@ -124,39 +92,6 @@ function getBreadcrumbsForSpan(span: Span): Breadcrumb[] {
   const events = span ? getOtelEvents(span) : [];
 
   return events.map(otelEventToBreadcrumb);
-}
-
-function breadcrumbToOtelEvent(breadcrumb: Breadcrumb): Parameters<Span['addEvent']> {
-  const name = breadcrumb.message || '<no message>';
-
-  const dataAttrs = serializeBreadcrumbData(breadcrumb.data);
-
-  return [
-    name,
-    dropUndefinedKeys({
-      [InternalSentrySemanticAttributes.BREADCRUMB_TYPE]: breadcrumb.type,
-      [InternalSentrySemanticAttributes.BREADCRUMB_LEVEL]: breadcrumb.level,
-      [InternalSentrySemanticAttributes.BREADCRUMB_EVENT_ID]: breadcrumb.event_id,
-      [InternalSentrySemanticAttributes.BREADCRUMB_CATEGORY]: breadcrumb.category,
-      ...dataAttrs,
-    }),
-    breadcrumb.timestamp ? new Date(breadcrumb.timestamp * 1000) : undefined,
-  ];
-}
-
-function serializeBreadcrumbData(data: Breadcrumb['data']): undefined | Record<string, unknown> {
-  if (!data || Object.keys(data).length === 0) {
-    return undefined;
-  }
-
-  try {
-    const normalizedData = normalize(data);
-    return {
-      [InternalSentrySemanticAttributes.BREADCRUMB_DATA]: JSON.stringify(normalizedData),
-    };
-  } catch (e) {
-    return undefined;
-  }
 }
 
 function otelEventToBreadcrumb(event: TimedEvent): Breadcrumb {

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -37,15 +37,7 @@ function onSpanStart(span: Span, parentContext: Context, _ScopeClass: typeof Ope
     // eslint-disable-next-line deprecation/deprecation
     const isolationScope = actualHub.getIsolationScope();
     setSpanHub(span, actualHub);
-
-    // Use this scope for finishing the span
-    // TODO: For now we need to clone this, as we need to store the `activeSpan` on it
-    // Once we can get rid of this (when we move breadcrumbs to the isolation scope),
-    // we can stop cloning this here
-    const finishScope = (scope as OpenTelemetryScope).clone();
-    // this is needed for breadcrumbs, for now, as they are stored on the span currently
-    finishScope.activeSpan = span;
-    setSpanScopes(span, { scope: finishScope, isolationScope });
+    setSpanScopes(span, { scope, isolationScope });
   }
 }
 

--- a/packages/opentelemetry/test/custom/scope.test.ts
+++ b/packages/opentelemetry/test/custom/scope.test.ts
@@ -94,182 +94,8 @@ describe('NodeExperimentalScope', () => {
     expect(scope['_span']).toBeUndefined();
   });
 
-  describe('addBreadcrumb', () => {
-    it('adds to scope if no root span is found', () => {
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(undefined);
-
-      const scope = new OpenTelemetryScope();
-      const breadcrumb: Breadcrumb = { message: 'test' };
-
-      const now = Date.now();
-      jest.useFakeTimers();
-      jest.setSystemTime(now);
-
-      scope.addBreadcrumb(breadcrumb);
-
-      expect(scope['_breadcrumbs']).toEqual([{ message: 'test', timestamp: now / 1000 }]);
-    });
-
-    it('adds to scope if no root span is found & uses given timestamp', () => {
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(undefined);
-
-      const scope = new OpenTelemetryScope();
-      const breadcrumb: Breadcrumb = { message: 'test', timestamp: 1234 };
-
-      scope.addBreadcrumb(breadcrumb);
-
-      expect(scope['_breadcrumbs']).toEqual([breadcrumb]);
-    });
-
-    it('adds to root span if found', () => {
-      const span = createSpan();
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(span);
-
-      const scope = new OpenTelemetryScope();
-      const breadcrumb: Breadcrumb = { message: 'test' };
-
-      const now = Date.now();
-      jest.useFakeTimers();
-      jest.setSystemTime(now);
-
-      scope.addBreadcrumb(breadcrumb);
-
-      expect(scope['_breadcrumbs']).toEqual([]);
-      expect(span.events).toEqual([
-        expect.objectContaining({
-          name: 'test',
-          time: [Math.floor(now / 1000), (now % 1000) * 1_000_000],
-          attributes: {},
-        }),
-      ]);
-    });
-
-    it('adds to root span if found & uses given timestamp', () => {
-      const span = createSpan();
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(span);
-
-      const scope = new OpenTelemetryScope();
-      const breadcrumb: Breadcrumb = { timestamp: 12345, message: 'test' };
-
-      scope.addBreadcrumb(breadcrumb);
-
-      expect(scope['_breadcrumbs']).toEqual([]);
-      expect(span.events).toEqual([
-        expect.objectContaining({
-          name: 'test',
-          time: [12345, 0],
-          attributes: {},
-        }),
-      ]);
-    });
-
-    it('adds many breadcrumbs to root span if found', () => {
-      const span = createSpan();
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(span);
-
-      const scope = new OpenTelemetryScope();
-      const breadcrumb1: Breadcrumb = { timestamp: 12345, message: 'test1' };
-      const breadcrumb2: Breadcrumb = { timestamp: 5678, message: 'test2' };
-      const breadcrumb3: Breadcrumb = { timestamp: 9101112, message: 'test3' };
-
-      scope.addBreadcrumb(breadcrumb1);
-      scope.addBreadcrumb(breadcrumb2);
-      scope.addBreadcrumb(breadcrumb3);
-
-      expect(scope['_breadcrumbs']).toEqual([]);
-      expect(span.events).toEqual([
-        expect.objectContaining({
-          name: 'test1',
-          time: [12345, 0],
-          attributes: {},
-        }),
-        expect.objectContaining({
-          name: 'test2',
-          time: [5678, 0],
-          attributes: {},
-        }),
-        expect.objectContaining({
-          name: 'test3',
-          time: [9101112, 0],
-          attributes: {},
-        }),
-      ]);
-    });
-
-    it('adds to root span if found & no message is given', () => {
-      const span = createSpan();
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(span);
-
-      const scope = new OpenTelemetryScope();
-      const breadcrumb: Breadcrumb = { timestamp: 12345 };
-
-      scope.addBreadcrumb(breadcrumb);
-
-      expect(scope['_breadcrumbs']).toEqual([]);
-      expect(span.events).toEqual([
-        expect.objectContaining({
-          name: '<no message>',
-          time: [12345, 0],
-          attributes: {},
-        }),
-      ]);
-    });
-
-    it('adds to root span with full attributes', () => {
-      const span = createSpan();
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(span);
-
-      const scope = new OpenTelemetryScope();
-      const breadcrumb: Breadcrumb = {
-        timestamp: 12345,
-        message: 'test',
-        data: { nested: { indeed: true } },
-        level: 'info',
-        category: 'test-category',
-        type: 'test-type',
-        event_id: 'test-event-id',
-      };
-
-      scope.addBreadcrumb(breadcrumb);
-
-      expect(scope['_breadcrumbs']).toEqual([]);
-      expect(span.events).toEqual([
-        expect.objectContaining({
-          name: 'test',
-          time: [12345, 0],
-          attributes: {
-            [InternalSentrySemanticAttributes.BREADCRUMB_DATA]: JSON.stringify({ nested: { indeed: true } }),
-            [InternalSentrySemanticAttributes.BREADCRUMB_TYPE]: 'test-type',
-            [InternalSentrySemanticAttributes.BREADCRUMB_LEVEL]: 'info',
-            [InternalSentrySemanticAttributes.BREADCRUMB_EVENT_ID]: 'test-event-id',
-            [InternalSentrySemanticAttributes.BREADCRUMB_CATEGORY]: 'test-category',
-          },
-        }),
-      ]);
-    });
-
-    it('adds to root span with empty data', () => {
-      const span = createSpan();
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(span);
-
-      const scope = new OpenTelemetryScope();
-      const breadcrumb: Breadcrumb = { timestamp: 12345, message: 'test', data: {} };
-
-      scope.addBreadcrumb(breadcrumb);
-
-      expect(scope['_breadcrumbs']).toEqual([]);
-      expect(span.events).toEqual([
-        expect.objectContaining({
-          name: 'test',
-          time: [12345, 0],
-          attributes: {},
-        }),
-      ]);
-    });
-  });
-
   describe('_getBreadcrumbs', () => {
-    it('gets from scope if no root span is found', () => {
+    it('gets from scope if no span is found', () => {
       jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(undefined);
 
       const scope = new OpenTelemetryScope();
@@ -283,7 +109,7 @@ describe('NodeExperimentalScope', () => {
       expect(scope['_getBreadcrumbs']()).toEqual(breadcrumbs);
     });
 
-    it('gets from root span if found', () => {
+    it('gets events from active span if found', () => {
       const span = createSpan();
       jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(span);
 
@@ -328,7 +154,7 @@ describe('NodeExperimentalScope', () => {
       ]);
     });
 
-    it('gets from spans up the parent chain if found', () => {
+    it('gets events from spans up the parent chain if found', () => {
       const span = createSpan();
       const parentSpan = createSpan();
       const rootSpan = createSpan();
@@ -390,46 +216,6 @@ describe('NodeExperimentalScope', () => {
         { message: 'test3', timestamp: 12346 },
         { message: 'basic event', timestamp: now / 1000 },
         { message: 'breadcrumb event', timestamp: now / 1000 + 1 },
-      ]);
-    });
-
-    it('gets from activeSpan if defined', () => {
-      const span = createSpan();
-      jest.spyOn(GetActiveSpan, 'getActiveSpan').mockReturnValue(span);
-
-      const scope = new OpenTelemetryScope();
-
-      const now = Date.now();
-
-      span.addEvent('basic event', now);
-      span.addEvent('breadcrumb event', {}, now + 1000);
-      span.addEvent(
-        'breadcrumb event 2',
-        {
-          [InternalSentrySemanticAttributes.BREADCRUMB_DATA]: JSON.stringify({ nested: { indeed: true } }),
-          [InternalSentrySemanticAttributes.BREADCRUMB_TYPE]: 'test-type',
-          [InternalSentrySemanticAttributes.BREADCRUMB_LEVEL]: 'info',
-          [InternalSentrySemanticAttributes.BREADCRUMB_EVENT_ID]: 'test-event-id',
-          [InternalSentrySemanticAttributes.BREADCRUMB_CATEGORY]: 'test-category',
-        },
-        now + 3000,
-      );
-      span.addEvent(
-        'breadcrumb event invalid JSON data',
-        {
-          [InternalSentrySemanticAttributes.BREADCRUMB_DATA]: 'this is not JSON...',
-        },
-        now + 2000,
-      );
-
-      const activeSpan = createSpan();
-      activeSpan.addEvent('event 1', now);
-      activeSpan.addEvent('event 2', {}, now + 1000);
-      scope.activeSpan = activeSpan;
-
-      expect(scope['_getBreadcrumbs']()).toEqual([
-        { message: 'event 1', timestamp: now / 1000 },
-        { message: 'event 2', timestamp: now / 1000 + 1 },
       ]);
     });
   });

--- a/packages/opentelemetry/test/integration/scope.test.ts
+++ b/packages/opentelemetry/test/integration/scope.test.ts
@@ -57,11 +57,7 @@ describe('Integration | Scope', () => {
           scope2.setTag('tag3', 'val3');
 
           startSpan({ name: 'outer' }, span => {
-            // TODO: This is "incorrect" until we stop cloning the current scope for setSpanScopes
-            // Once we change this, the scopes _should_ be the same again
-            if (enableTracing) {
-              expect(getSpanScopes(span)?.scope).not.toBe(scope2);
-            }
+            expect(getSpanScopes(span)?.scope).toBe(enableTracing ? scope2 : undefined);
 
             spanId = span.spanContext().spanId;
             traceId = span.spanContext().traceId;


### PR DESCRIPTION
Build on top of https://github.com/getsentry/sentry-javascript/pull/10600, as that relies on this to ensure replay still works.

This basically goes a step further than https://github.com/getsentry/sentry-javascript/pull/10586/files to actually change the implementation to skip the hub completely.