### PR TITLE
fix(sveltekit): Properly await sourcemaps flattening

### DIFF
--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -166,7 +166,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
       // eslint-disable-next-line no-console
       debug && console.log('[Source Maps Plugin] Flattening source maps');
 
-      jsFiles.forEach(async file => {
+      for (const file of jsFiles) {
         try {
           await (sorcery as Sorcery).load(file).then(async chain => {
             if (!chain) {
@@ -202,7 +202,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
           );
           await fs.promises.writeFile(mapFile, cleanedMapContent);
         }
-      });
+      }
 
       try {
         // @ts-expect-error - this hook exists on the plugin!


### PR DESCRIPTION
As pointed out in https://github.com/getsentry/sentry-javascript/issues/10589, we didn't properly await sourcemaps flattening via sorcery before proceeding to upload them. The reason is that the async callbacks in `forEach` weren't awaited. A `for` loop is the better approach here. Wondering if we should lint against async `forEach` callbacks.
This behaviour could have caused various inconsistencies. My suspicion is that the timing worked _well enough_ in most cases but we definitely want to properly await this step.

Thanks to @MSDev201 for bringing this up!

Unfortunately this likely won't fix #10589 as a whole :(