### PR TITLE
docs: Fix deprecation message for span data/attributes

### DIFF
--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -67,13 +67,13 @@ export class SpanRecorder {
 export class Span implements SpanInterface {
   /**
    * Tags for the span.
-   * @deprecated Use `getSpanAttributes(span)` instead.
+   * @deprecated Use `spanToJSON(span).atttributes` instead.
    */
   public tags: { [key: string]: Primitive };
 
   /**
    * Data for the span.
-   * @deprecated Use `getSpanAttributes(span)` instead.
+   * @deprecated Use `spanToJSON(span).atttributes` instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public data: { [key: string]: any };
@@ -263,7 +263,7 @@ export class Span implements SpanInterface {
 
   /**
    * Attributes for the span.
-   * @deprecated Use `getSpanAttributes(span)` instead.
+   * @deprecated Use `spanToJSON(span).atttributes` instead.
    */
   public get attributes(): SpanAttributes {
     return this._attributes;

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -226,19 +226,19 @@ export interface Span extends Omit<SpanContext, 'op' | 'status' | 'origin'> {
 
   /**
    * Tags for the span.
-   * @deprecated Use `getSpanAttributes(span)` instead.
+   * @deprecated Use `spanToJSON(span).atttributes` instead.
    */
   tags: { [key: string]: Primitive };
 
   /**
    * Data for the span.
-   * @deprecated Use `getSpanAttributes(span)` instead.
+   * @deprecated Use `spanToJSON(span).atttributes` instead.
    */
   data: { [key: string]: any };
 
   /**
    * Attributes for the span.
-   * @deprecated Use `getSpanAttributes(span)` instead.
+   * @deprecated Use `spanToJSON(span).atttributes` instead.
    */
   attributes: SpanAttributes;
 


### PR DESCRIPTION
This was apparently left over from some in-between state, users should actually use `spanToJSON(span)` there to get attributes.