### PR TITLE
ref(core): Make remaining client methods required

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -466,7 +466,7 @@ function _sendSessionUpdate(): void {
   // TODO (v8): Remove currentScope and only use the isolation scope(?).
   // For v7 though, we can't "soft-break" people using getCurrentHub().getScope().setSession()
   const session = currentScope.getSession() || isolationScope.getSession();
-  if (session && client && client.captureSession) {
+  if (session && client) {
     client.captureSession(session);
   }
 }

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -145,7 +145,7 @@ export function setupIntegration(client: Client, integration: Integration, integ
     client.on('preprocessEvent', (event, hint) => callback(event, hint, client));
   }
 
-  if (client.addEventProcessor && typeof integration.processEvent === 'function') {
+  if (typeof integration.processEvent === 'function') {
     const callback = integration.processEvent.bind(integration) as typeof integration.processEvent;
 
     const processor = Object.assign((event: Event, hint: EventHint) => callback(event, hint, client), {
@@ -162,7 +162,7 @@ export function setupIntegration(client: Client, integration: Integration, integ
 export function addIntegration(integration: Integration): void {
   const client = getClient();
 
-  if (!client || !client.addIntegration) {
+  if (!client) {
     DEBUG_BUILD && logger.warn(`Cannot add integration "${integration.name}" because no SDK Client is available.`);
     return;
   }

--- a/packages/core/src/metrics/aggregator.ts
+++ b/packages/core/src/metrics/aggregator.ts
@@ -153,7 +153,7 @@ export class MetricsAggregator implements MetricsAggregatorBase {
    * @param flushedBuckets
    */
   private _captureMetrics(flushedBuckets: MetricBucket): void {
-    if (flushedBuckets.size > 0 && this._client.captureAggregateMetrics) {
+    if (flushedBuckets.size > 0) {
       // TODO(@anonrig): Optimization opportunity.
       // This copy operation can be avoided if we store the key in the bucketItem.
       const buckets = Array.from(flushedBuckets).map(([, bucketItem]) => bucketItem);

--- a/packages/core/src/metrics/browser-aggregator.ts
+++ b/packages/core/src/metrics/browser-aggregator.ts
@@ -74,11 +74,11 @@ export class BrowserMetricsAggregator implements MetricsAggregator {
     if (this._buckets.size === 0) {
       return;
     }
-    if (this._client.captureAggregateMetrics) {
-      // TODO(@anonrig): Use Object.values() when we support ES6+
-      const metricBuckets = Array.from(this._buckets).map(([, bucketItem]) => bucketItem);
-      this._client.captureAggregateMetrics(metricBuckets);
-    }
+
+    // TODO(@anonrig): Use Object.values() when we support ES6+
+    const metricBuckets = Array.from(this._buckets).map(([, bucketItem]) => bucketItem);
+    this._client.captureAggregateMetrics(metricBuckets);
+
     this._buckets.clear();
   }
 

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -35,7 +35,7 @@ export function initAndBind<F extends Client, O extends ClientOptions>(
 
   const client = new clientClass(options);
   setCurrentClient(client);
-  initializeClient(client);
+  client.init();
 }
 
 /**
@@ -48,19 +48,4 @@ export function setCurrentClient(client: Client): void {
   const top = hub.getStackTop();
   top.client = client;
   top.scope.setClient(client);
-}
-
-/**
- * Initialize the client for the current scope.
- * Make sure to call this after `setCurrentClient()`.
- */
-function initializeClient(client: Client): void {
-  if (client.init) {
-    client.init();
-    // TODO v8: Remove this fallback
-    // eslint-disable-next-line deprecation/deprecation
-  } else if (client.setupIntegrations) {
-    // eslint-disable-next-line deprecation/deprecation
-    client.setupIntegrations();
-  }
 }

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -75,7 +75,7 @@ export function prepareEvent(
     addExceptionMechanism(prepared, hint.mechanism);
   }
 
-  const clientEventProcessors = client && client.getEventProcessors ? client.getEventProcessors() : [];
+  const clientEventProcessors = client ? client.getEventProcessors() : [];
 
   // This should be the last thing called, since we want that
   // {@link Hub.addEventProcessor} gets the finished prepared event.

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -145,7 +145,7 @@ function _sendSessionUpdate(): void {
   const client = getClient();
 
   const session = scope.getSession();
-  if (session && client.captureSession) {
+  if (session) {
     client.captureSession(session);
   }
 }

--- a/packages/node-experimental/src/sdk/init.ts
+++ b/packages/node-experimental/src/sdk/init.ts
@@ -86,19 +86,18 @@ export function init(options: NodeExperimentalOptions | undefined = {}): void {
 
   if (options.spotlight) {
     const client = getClient();
-    if (client.addIntegration) {
-      // force integrations to be setup even if no DSN was set
-      // If they have already been added before, they will be ignored anyhow
-      const integrations = client.getOptions().integrations;
-      for (const integration of integrations) {
-        client.addIntegration(integration);
-      }
-      client.addIntegration(
-        spotlightIntegration({
-          sidecarUrl: typeof options.spotlight === 'string' ? options.spotlight : undefined,
-        }),
-      );
+
+    // force integrations to be setup even if no DSN was set
+    // If they have already been added before, they will be ignored anyhow
+    const integrations = client.getOptions().integrations;
+    for (const integration of integrations) {
+      client.addIntegration(integration);
     }
+    client.addIntegration(
+      spotlightIntegration({
+        sidecarUrl: typeof options.spotlight === 'string' ? options.spotlight : undefined,
+      }),
+    );
   }
 
   // Always init Otel, even if tracing is disabled, because we need it for trace propagation & the HTTP integration

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -176,7 +176,7 @@ export function init(options: NodeOptions = {}): void {
 
   if (options.spotlight) {
     const client = getClient();
-    if (client && client.addIntegration) {
+    if (client) {
       // force integrations to be setup even if no DSN was set
       // If they have already been added before, they will be ignored anyhow
       const integrations = client.getOptions().integrations;

--- a/packages/opentelemetry/src/setupEventContextTrace.ts
+++ b/packages/opentelemetry/src/setupEventContextTrace.ts
@@ -5,10 +5,6 @@ import { spanHasParentId } from './utils/spanTypes';
 
 /** Ensure the `trace` context is set on all events. */
 export function setupEventContextTrace(client: Client): void {
-  if (!client.addEventProcessor) {
-    return;
-  }
-
   client.addEventProcessor(event => {
     const span = getActiveSpan();
     if (!span) {

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -367,7 +367,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
     try {
       const client = getClient()!;
-      const canvasIntegration = client.getIntegrationByName!('ReplayCanvas') as Integration & {
+      const canvasIntegration = client.getIntegrationByName('ReplayCanvas') as Integration & {
         getOptions(): ReplayCanvasIntegrationOptions;
       };
       if (!canvasIntegration) {

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -25,7 +25,7 @@ export function addGlobalListeners(replay: ReplayContainer): void {
 
   // Tag all (non replay) events that get sent to Sentry with the current
   // replay ID so that we can reference them later in the UI
-  const eventProcessor = handleGlobalEventListener(replay, !hasHooks(client));
+  const eventProcessor = handleGlobalEventListener(replay);
   addEventProcessor(eventProcessor);
 
   // If a custom client has no hooks yet, we continue to use the "old" implementation

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -25,12 +25,8 @@ export function addGlobalListeners(replay: ReplayContainer): void {
 
   // Tag all (non replay) events that get sent to Sentry with the current
   // replay ID so that we can reference them later in the UI
-  const eventProcessor = handleGlobalEventListener(replay);
-  if (client && client.addEventProcessor) {
-    client.addEventProcessor(eventProcessor);
-  } else {
-    addEventProcessor(eventProcessor);
-  }
+  const eventProcessor = handleGlobalEventListener(replay, !hasHooks(client));
+  addEventProcessor(eventProcessor);
 
   // If a custom client has no hooks yet, we continue to use the "old" implementation
   if (client) {

--- a/packages/replay/src/util/getReplay.ts
+++ b/packages/replay/src/util/getReplay.ts
@@ -7,7 +7,5 @@ import type { replayIntegration } from '../integration';
 // eslint-disable-next-line deprecation/deprecation
 export function getReplay(): ReturnType<typeof replayIntegration> | undefined {
   const client = getClient();
-  return (
-    client && client.getIntegrationByName && client.getIntegrationByName<ReturnType<typeof replayIntegration>>('Replay')
-  );
+  return client && client.getIntegrationByName<ReturnType<typeof replayIntegration>>('Replay');
 }

--- a/packages/replay/src/util/prepareReplayEvent.ts
+++ b/packages/replay/src/util/prepareReplayEvent.ts
@@ -46,7 +46,7 @@ export async function prepareReplayEvent({
   preparedEvent.platform = preparedEvent.platform || 'javascript';
 
   // extract the SDK name because `client._prepareEvent` doesn't add it to the event
-  const metadata = client.getSdkMetadata && client.getSdkMetadata();
+  const metadata = client.getSdkMetadata();
   const { name, version } = (metadata && metadata.sdk) || {};
 
   preparedEvent.sdk = {

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -65,7 +65,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    *
    * @param session Session to be delivered
    */
-  captureSession?(session: Session): void;
+  captureSession(session: Session): void;
 
   /**
    * Create a cron monitor check in and send it to Sentry. This method is not available on all clients.
@@ -89,7 +89,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    *
    * TODO (v8): Make this a required method.
    */
-  getSdkMetadata?(): SdkMetadata | undefined;
+  getSdkMetadata(): SdkMetadata | undefined;
 
   /**
    * Returns the transport that is used by the client.
@@ -121,17 +121,13 @@ export interface Client<O extends ClientOptions = ClientOptions> {
 
   /**
    * Adds an event processor that applies to any event processed by this client.
-   *
-   * TODO (v8): Make this a required method.
    */
-  addEventProcessor?(eventProcessor: EventProcessor): void;
+  addEventProcessor(eventProcessor: EventProcessor): void;
 
   /**
    * Get all added event processors for this client.
-   *
-   * TODO (v8): Make this a required method.
    */
-  getEventProcessors?(): EventProcessor[];
+  getEventProcessors(): EventProcessor[];
 
   /**
    * Returns the client's instance of the given integration class, it any.
@@ -140,7 +136,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;
 
   /** Get the instance of the integration with the given name on the client, if it was added. */
-  getIntegrationByName?<T extends Integration = Integration>(name: string): T | undefined;
+  getIntegrationByName<T extends Integration = Integration>(name: string): T | undefined;
 
   /**
    * Add an integration to the client.
@@ -150,7 +146,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    *
    * TODO (v8): Make this a required method.
    * */
-  addIntegration?(integration: Integration): void;
+  addIntegration(integration: Integration): void;
 
   /**
    * This is an internal function to setup all integrations that should run on the client.
@@ -162,7 +158,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * Initialize this client.
    * Call this after the client was set on a scope.
    */
-  init?(): void;
+  init(): void;
 
   /** Creates an {@link Event} from all inputs to `captureException` and non-primitive inputs to `captureMessage`. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -191,7 +187,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    *
    * @experimental This API is experimental and might experience breaking changes
    */
-  captureAggregateMetrics?(metricBucketItems: Array<MetricBucketItem>): void;
+  captureAggregateMetrics(metricBucketItems: Array<MetricBucketItem>): void;
 
   // HOOKS
   // TODO(v8): Make the hooks non-optional.

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -87,7 +87,6 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   /**
    * @inheritdoc
    *
-   * TODO (v8): Make this a required method.
    */
   getSdkMetadata(): SdkMetadata | undefined;
 
@@ -144,7 +143,6 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * In most cases, this should not be necessary, and you're better off just passing the integrations via `integrations: []` at initialization time.
    * However, if you find the need to conditionally load & add an integration, you can use `addIntegration` to do so.
    *
-   * TODO (v8): Make this a required method.
    * */
   addIntegration(integration: Integration): void;
 


### PR DESCRIPTION
This makes the following required on the client:

* `captureSession`
* `getSdkMetadata`
* `addEventProcessor`
* `getEventProcessor`
* `getIntegrationByName`
* `addIntegration`
* `init`
* `captureAggregrateMetrics`
