### PR TITLE
feat(core): Update `addEventProcessor` to add to isolation scope

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -49,7 +49,6 @@ import {
 import { getEnvelopeEndpointWithUrlEncodedAuth } from './api';
 import { DEBUG_BUILD } from './debug-build';
 import { createEventEnvelope, createSessionEnvelope } from './envelope';
-import { getClient } from './exports';
 import { getIsolationScope } from './hub';
 import type { IntegrationIndex } from './integration';
 import { afterSetupIntegrations } from './integration';
@@ -932,18 +931,4 @@ function isErrorEvent(event: Event): event is ErrorEvent {
 
 function isTransactionEvent(event: Event): event is TransactionEvent {
   return event.type === 'transaction';
-}
-
-/**
- * Add an event processor to the current client.
- * This event processor will run for all events processed by this client.
- */
-export function addEventProcessor(callback: EventProcessor): void {
-  const client = getClient();
-
-  if (!client || !client.addEventProcessor) {
-    return;
-  }
-
-  client.addEventProcessor(callback);
 }

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -7,6 +7,7 @@ import type {
   CustomSamplingContext,
   Event,
   EventHint,
+  EventProcessor,
   Extra,
   Extras,
   FinishedCheckIn,
@@ -380,6 +381,15 @@ export function isInitialized(): boolean {
 export function getCurrentScope(): Scope {
   // eslint-disable-next-line deprecation/deprecation
   return getCurrentHub().getScope();
+}
+
+/**
+ * Add an event processor.
+ * This will be added to the current isolation scope, ensuring any event that is processed in the current execution
+ * context will have the processor applied.
+ */
+export function addEventProcessor(callback: EventProcessor): void {
+  getIsolationScope().addEventProcessor(callback);
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export {
   endSession,
   captureSession,
   withActiveSpan,
+  addEventProcessor,
 } from './exports';
 export {
   // eslint-disable-next-line deprecation/deprecation
@@ -58,7 +59,7 @@ export {
   addGlobalEventProcessor,
 } from './eventProcessors';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
-export { BaseClient, addEventProcessor } from './baseclient';
+export { BaseClient } from './baseclient';
 export { ServerRuntimeClient } from './server-runtime-client';
 export { initAndBind, setCurrentClient } from './sdk';
 export { createTransport } from './transports/base';


### PR DESCRIPTION
Instead of to the client.
This was done to ensure this would be "global" without using the fully global event processors (which need to be removed in a separate step). But in the new model, it makes more sense to add them to the isolation scope.