### PR TITLE
ref(node-experimental): Remove custom `isInitialized`

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -357,8 +357,7 @@ export function getClient<C extends Client>(): C | undefined {
  * Returns true if Sentry has been properly initialized.
  */
 export function isInitialized(): boolean {
-  const client = getClient();
-  return !!client && !!client.getDsn();
+  return !!getClient();
 }
 
 /**

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -357,7 +357,8 @@ export function getClient<C extends Client>(): C | undefined {
  * Returns true if Sentry has been properly initialized.
  */
 export function isInitialized(): boolean {
-  return !!getClient();
+  const client = getClient();
+  return !!client && !!client.getDsn();
 }
 
 /**

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -29,7 +29,6 @@ export type { Span } from './types';
 export { startSpan, startSpanManual, startInactiveSpan, getActiveSpan } from '@sentry/opentelemetry';
 export {
   getClient,
-  isInitialized,
   captureException,
   captureEvent,
   captureMessage,
@@ -52,6 +51,7 @@ export { getCurrentHub, makeMain } from './sdk/hub';
 
 export {
   addBreadcrumb,
+  isInitialized,
   makeNodeTransport,
   defaultStackParser,
   getSentryRelease,

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -18,9 +18,9 @@ import { getContextFromScope, getScopesFromContext, setScopesOnContext } from '.
 
 import type { ExclusiveEventHintOrCaptureContext } from '../utils/prepareEvent';
 import { parseEventHintOrCaptureContext } from '../utils/prepareEvent';
-import { getClient, getCurrentScope, getIsolationScope, isInitialized } from './scope';
+import { getClient, getCurrentScope, getIsolationScope } from './scope';
 
-export { getCurrentScope, getIsolationScope, getClient, isInitialized };
+export { getCurrentScope, getIsolationScope, getClient };
 export { setCurrentScope, setIsolationScope } from './scope';
 
 /**

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -46,11 +46,6 @@ export function getClient<C extends Client>(): C {
   return {} as C;
 }
 
-/** If the SDK was initialized. */
-export function isInitialized(): boolean {
-  return !!getClient().getDsn();
-}
-
 function getScopes(): CurrentScopes {
   const carrier = getGlobalCarrier();
 


### PR DESCRIPTION
We have this in core now, and align the implementation there to work consistently (and also in a future where a client may not be undefined).