### PR TITLE
ref: Remove deprecated `showReportDialog` APIs

### DIFF
--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -2,6 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import type { ErrorHandler as AngularErrorHandler } from '@angular/core';
 import { Inject, Injectable } from '@angular/core';
 import * as Sentry from '@sentry/browser';
+import type { ReportDialogOptions } from '@sentry/browser';
 import type { Event } from '@sentry/types';
 import { isString } from '@sentry/utils';
 
@@ -13,8 +14,7 @@ import { runOutsideAngular } from './zone';
 export interface ErrorHandlerOptions {
   logErrors?: boolean;
   showDialog?: boolean;
-  // eslint-disable-next-line deprecation/deprecation
-  dialogOptions?: Omit<Sentry.ReportDialogOptions, 'eventId'>;
+  dialogOptions?: Omit<ReportDialogOptions, 'eventId'>;
   /**
    * Custom implementation of error extraction from the raw value captured by the Angular.
    * @param error Value captured by Angular's ErrorHandler provider
@@ -120,8 +120,7 @@ class SentryErrorHandler implements AngularErrorHandler {
 
       if (client && !this._registeredAfterSendEventHandler) {
         client.on('afterSendEvent', (event: Event) => {
-          if (!event.type) {
-            // eslint-disable-next-line deprecation/deprecation
+          if (!event.type && event.event_id) {
             Sentry.showReportDialog({ ...this._options.dialogOptions, eventId: event.event_id });
           }
         });

--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -514,7 +514,7 @@ describe('SentryErrorHandler', () => {
         expect(client.on).toHaveBeenCalledWith('afterSendEvent', expect.any(Function));
 
         // this simulates the afterSend hook being called
-        client.cb({});
+        client.cb({ event_id: 'foobar' });
 
         expect(showReportDialogSpy).toBeCalledTimes(1);
       });

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -17,8 +17,7 @@ export type {
 
 export type { BrowserOptions } from './client';
 
-// eslint-disable-next-line deprecation/deprecation
-export type { ReportDialogOptions } from './helpers';
+export type { ReportDialogOptions } from './sdk';
 
 export {
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -1,7 +1,7 @@
 import type { browserTracingIntegration } from '@sentry-internal/tracing';
 import { BrowserTracing } from '@sentry-internal/tracing';
 import { captureException, withScope } from '@sentry/core';
-import type { DsnLike, Integration, Mechanism, WrappedFunction } from '@sentry/types';
+import type { Integration, Mechanism, WrappedFunction } from '@sentry/types';
 import {
   GLOBAL_OBJ,
   addExceptionMechanism,
@@ -154,38 +154,6 @@ export function wrap(
   } catch (_oO) {}
 
   return sentryWrapped;
-}
-
-/**
- * All properties the report dialog supports
- *
- * @deprecated This type will be removed in the next major version of the Sentry SDK. `showReportDialog` will still be around, however the `eventId` option will now be required.
- */
-export interface ReportDialogOptions {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-  eventId?: string;
-  dsn?: DsnLike;
-  user?: {
-    email?: string;
-    name?: string;
-  };
-  lang?: string;
-  title?: string;
-  subtitle?: string;
-  subtitle2?: string;
-  labelName?: string;
-  labelEmail?: string;
-  labelComments?: string;
-  labelClose?: string;
-  labelSubmit?: string;
-  errorGeneric?: string;
-  errorFormEntry?: string;
-  successMessage?: string;
-  /** Callback after reportDialog showed up */
-  onLoad?(this: void): void;
-  /** Callback after reportDialog closed */
-  onClose?(this: void): void;
 }
 
 /**

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -88,7 +88,7 @@ describe('SentryBrowser', () => {
         setCurrentClient(client);
 
         // eslint-disable-next-line deprecation/deprecation
-        showReportDialog();
+        showReportDialog({ eventId: 'foobar' });
 
         expect(getReportDialogEndpoint).toHaveBeenCalledTimes(1);
         expect(getReportDialogEndpoint).toHaveBeenCalledWith(
@@ -103,7 +103,7 @@ describe('SentryBrowser', () => {
 
         const DIALOG_OPTION_USER = { email: 'option@example.com' };
         // eslint-disable-next-line deprecation/deprecation
-        showReportDialog({ user: DIALOG_OPTION_USER });
+        showReportDialog({ eventId: 'foobar', user: DIALOG_OPTION_USER });
 
         expect(getReportDialogEndpoint).toHaveBeenCalledTimes(1);
         expect(getReportDialogEndpoint).toHaveBeenCalledWith(
@@ -137,7 +137,7 @@ describe('SentryBrowser', () => {
       it('should call `onClose` when receiving `__sentry_reportdialog_closed__` MessageEvent', async () => {
         const onClose = jest.fn();
         // eslint-disable-next-line deprecation/deprecation
-        showReportDialog({ onClose });
+        showReportDialog({ eventId: 'foobar', onClose });
 
         await waitForPostMessage('__sentry_reportdialog_closed__');
         expect(onClose).toHaveBeenCalledTimes(1);
@@ -152,7 +152,7 @@ describe('SentryBrowser', () => {
           throw new Error();
         });
         // eslint-disable-next-line deprecation/deprecation
-        showReportDialog({ onClose });
+        showReportDialog({ eventId: 'foobar', onClose });
 
         await waitForPostMessage('__sentry_reportdialog_closed__');
         expect(onClose).toHaveBeenCalledTimes(1);
@@ -165,7 +165,7 @@ describe('SentryBrowser', () => {
       it('should not call `onClose` for other MessageEvents', async () => {
         const onClose = jest.fn();
         // eslint-disable-next-line deprecation/deprecation
-        showReportDialog({ onClose });
+        showReportDialog({ eventId: 'foobar', onClose });
 
         await waitForPostMessage('some_message');
         expect(onClose).not.toHaveBeenCalled();

--- a/packages/nextjs/test/integration/pages/reportDialog.tsx
+++ b/packages/nextjs/test/integration/pages/reportDialog.tsx
@@ -1,9 +1,10 @@
-import { showReportDialog } from '@sentry/nextjs';
+import { captureException, showReportDialog } from '@sentry/nextjs';
 
 const ReportDialogPage = (): JSX.Element => (
   <button
     onClick={() => {
-      showReportDialog();
+      const eventId = captureException(new Error('show-report-dialog-error'));
+      showReportDialog({ eventId });
     }}
   >
     Open Report Dialog

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -28,7 +28,6 @@ export type ErrorBoundaryProps = {
    * Options to be passed into the Sentry report dialog.
    * No-op if {@link showDialog} is false.
    */
-  // eslint-disable-next-line deprecation/deprecation
   dialogOptions?: Omit<ReportDialogOptions, 'eventId'> | undefined;
   /**
    * A fallback component that gets rendered when the error boundary encounters an error.


### PR DESCRIPTION
Removes all deprecated showReportDialog APIs. I noticed we had one deprecation too many in there on the exported options type. I will silently remove this deprecation.