### PR TITLE
feat(v8/astro): Remove deprecated exports from Astro SDK

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -8,8 +8,6 @@ import { handleRequest } from './server/middleware';
 
 // Hence, we export everything from the Node SDK explicitly:
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  addGlobalEventProcessor,
   addEventProcessor,
   addBreadcrumb,
   captureException,
@@ -18,10 +16,6 @@ export {
   captureCheckIn,
   withMonitor,
   createTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
-  // eslint-disable-next-line deprecation/deprecation
-  getActiveTransaction,
   getHubFromCarrier,
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
@@ -31,12 +25,8 @@ export {
   getGlobalScope,
   getIsolationScope,
   Hub,
-  // eslint-disable-next-line deprecation/deprecation
-  makeMain,
   setCurrentClient,
   Scope,
-  // eslint-disable-next-line deprecation/deprecation
-  startTransaction,
   SDK_VERSION,
   setContext,
   setExtra,
@@ -46,14 +36,10 @@ export {
   setUser,
   getSpanStatusFromHttpCode,
   setHttpStatus,
-  // eslint-disable-next-line deprecation/deprecation
-  trace,
   withScope,
   withIsolationScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,
   makeNodeTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
   flush,
@@ -78,8 +64,6 @@ export {
   setMeasurement,
   getActiveSpan,
   startSpan,
-  // eslint-disable-next-line deprecation/deprecation
-  startActiveSpan,
   startInactiveSpan,
   startSpanManual,
   continueTrace,

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -1,5 +1,5 @@
 // We export everything from both the client part of the SDK and from the server part.
-// Some of the exports collide, which is not allowed, unless we redifine the colliding
+// Some of the exports collide, which is not allowed, unless we redefine the colliding
 // exports in this file - which we do below.
 export * from './index.client';
 export * from './index.server';
@@ -13,9 +13,9 @@ import sentryAstro from './index.server';
 /** Initializes Sentry Astro SDK */
 export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): void;
 
-// We export a merged Integrations object so that users can (at least typing-wise) use all integrations everywhere.
-// eslint-disable-next-line deprecation/deprecation
-export declare const Integrations: typeof clientSdk.Integrations & typeof serverSdk.Integrations;
+// We only export server Integrations for now, until the exports are removed from Svelte and Node SDKs.
+// Necessary to avoid type collision.
+export declare const Integrations: typeof serverSdk.Integrations;
 
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 


### PR DESCRIPTION
This PR removes all deprecations except for `getCurrentHub` which (unless I missed something last week) stays deprecated for now.