### PR TITLE
chore(ci): Always run Node unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -516,7 +516,6 @@ jobs:
 
   job_node_unit_tests:
     name: Node (${{ matrix.node }}) Unit Tests
-    if: needs.job_get_metadata.outputs.changed_node == 'true' || github.event_name != 'pull_request'
     needs: [job_get_metadata, job_build]
     timeout-minutes: 10
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Always run Node unit tests because unlike the name suggests, they not only execute @sentry/node specific unit tests but all server-side package unit tests, including packages like Astro, NextJS or Serverless.  