### PR TITLE
Backport SvelteKit and Angular fixes to v7

### DIFF
--- a/packages/angular-ivy/scripts/prepack.ts
+++ b/packages/angular-ivy/scripts/prepack.ts
@@ -6,6 +6,7 @@ type PackageJson = {
   type?: string;
   nx?: string;
   volta?: any;
+  exports?: Record<string, string | Record<string, string>>;
 };
 
 const buildDir = path.join(process.cwd(), 'build');
@@ -17,6 +18,18 @@ const pkgJson: PackageJson = JSON.parse(fs.readFileSync(pkjJsonPath).toString())
 // use the fesm2015 bundle instead of the UMD bundle.
 delete pkgJson.main;
 pkgJson.type = 'module';
+
+pkgJson.exports = {
+  '.': {
+    es2015: './fesm2015/sentry-angular-ivy.js',
+    esm2015: './esm2015/sentry-angular-ivy.js',
+    fesm2015: './fesm2015/sentry-angular-ivy.js',
+    import: './fesm2015/sentry-angular-ivy.js',
+    require: './bundles/sentry-angular-ivy.umd.js',
+    types: './sentry-angular-ivy.d.ts',
+  },
+  './*': './*',
+};
 
 // no need to keep around other properties that are only relevant for our reop:
 delete pkgJson.nx;

--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -4,7 +4,7 @@ import { addNonEnumerableProperty, objectify } from '@sentry/utils';
 import type { LoadEvent } from '@sveltejs/kit';
 
 import type { SentryWrappedFlag } from '../common/utils';
-import { isRedirect } from '../common/utils';
+import { isHttpError, isRedirect } from '../common/utils';
 
 type PatchedLoadEvent = LoadEvent & Partial<SentryWrappedFlag>;
 
@@ -14,7 +14,11 @@ function sendErrorToSentry(e: unknown): unknown {
   const objectifiedErr = objectify(e);
 
   // We don't want to capture thrown `Redirect`s as these are not errors but expected behaviour
-  if (isRedirect(objectifiedErr)) {
+  // Neither 4xx errors, given that they are not valuable.
+  if (
+    isRedirect(objectifiedErr) ||
+    (isHttpError(objectifiedErr) && objectifiedErr.status < 500 && objectifiedErr.status >= 400)
+  ) {
     return objectifiedErr;
   }
 

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -166,7 +166,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
       // eslint-disable-next-line no-console
       debug && console.log('[Source Maps Plugin] Flattening source maps');
 
-      jsFiles.forEach(async file => {
+      for (const file of jsFiles) {
         try {
           await (sorcery as Sorcery).load(file).then(async chain => {
             if (!chain) {
@@ -202,7 +202,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
           );
           await fs.promises.writeFile(mapFile, cleanedMapContent);
         }
-      });
+      }
 
       try {
         // @ts-expect-error - this hook exists on the plugin!


### PR DESCRIPTION
Backports the following fixes to the v7 branch:

- fix(sveltekit): Properly await sourcemaps flattening (#10602)
- fix(sveltekit): Avoid capturing Http 4xx errors on the client (#10571)
- fix(angular-ivy): Add `exports` field to `package.json` (#10569)
