### PR TITLE
test(astro): Remove old `BrowserTracing` test

### DIFF
--- a/packages/astro/src/client/sdk.ts
+++ b/packages/astro/src/client/sdk.ts
@@ -8,7 +8,7 @@ import {
 import { applySdkMetadata, hasTracingEnabled } from '@sentry/core';
 import type { Integration } from '@sentry/types';
 
-// Treeshakable guard to remove all code related to tracing
+// Tree-shakable guard to remove all code related to tracing
 declare const __SENTRY_TRACING__: boolean;
 
 /**

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -102,27 +102,6 @@ describe('Sentry client SDK', () => {
         delete globalThis.__SENTRY_TRACING__;
       });
 
-      it('Overrides the automatically default BrowserTracing instance with a a user-provided BrowserTracing instance', () => {
-        init({
-          dsn: 'https://public@dsn.ingest.sentry.io/1337',
-          // eslint-disable-next-line deprecation/deprecation
-          integrations: [new BrowserTracing({ finalTimeout: 10, startTransactionOnLocationChange: false })],
-          enableTracing: true,
-        });
-
-        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
-
-        // eslint-disable-next-line deprecation/deprecation
-        const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing') as BrowserTracing;
-        const options = browserTracing.options;
-
-        expect(integrationsToInit).toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
-        expect(browserTracing).toBeDefined();
-
-        // This shows that the user-configured options are still here
-        expect(options.finalTimeout).toEqual(10);
-      });
-
       it('Overrides the automatically default BrowserTracing instance with a a user-provided browserTracingIntegration instance', () => {
         init({
           dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -2,7 +2,7 @@ import type { BrowserClient } from '@sentry/browser';
 import { getActiveSpan } from '@sentry/browser';
 import { browserTracingIntegration } from '@sentry/browser';
 import * as SentryBrowser from '@sentry/browser';
-import { BrowserTracing, SDK_VERSION, WINDOW, getClient } from '@sentry/browser';
+import { SDK_VERSION, WINDOW, getClient } from '@sentry/browser';
 import { vi } from 'vitest';
 
 import { getIsolationScope } from '@sentry/core';


### PR DESCRIPTION
Spotted one more deprecation ignore in Astro (after #10611) where I initially thought there's more logic to consider but turns out it's just the test that's no longer necessary in a v8 world.