### PR TITLE
feat(webvitals): Adds INP instrumentation to browserTracingIntegration

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,7 @@ export {
 export { applyScopeDataToEvent, mergeScopeData } from './utils/applyScopeDataToEvent';
 export { prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';
+export { createSpanEnvelope } from './span';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';
 export { isSentryRequestUrl } from './utils/isSentryRequestUrl';
 export { handleCallbackErrors } from './utils/handleCallbackErrors';

--- a/packages/core/src/span.ts
+++ b/packages/core/src/span.ts
@@ -1,0 +1,22 @@
+import type { SpanEnvelope, SpanItem } from '@sentry/types';
+import type { Span } from '@sentry/types/build/types/span';
+import { createEnvelope } from '@sentry/utils';
+
+/**
+ * Create envelope from Span item.
+ */
+export function createSpanEnvelope(span: Span): SpanEnvelope {
+  const headers: SpanEnvelope[0] = {
+    sent_at: new Date().toISOString(),
+  };
+
+  const item = createSpanItem(span);
+  return createEnvelope<SpanEnvelope>(headers, [item]);
+}
+
+function createSpanItem(span: Span): SpanItem {
+  const spanHeaders: SpanItem[0] = {
+    type: 'span',
+  };
+  return [spanHeaders, span];
+}

--- a/packages/tracing-internal/src/browser/instrument.ts
+++ b/packages/tracing-internal/src/browser/instrument.ts
@@ -3,12 +3,13 @@ import { getFunctionName, logger } from '@sentry/utils';
 import { DEBUG_BUILD } from '../common/debug-build';
 import { onCLS } from './web-vitals/getCLS';
 import { onFID } from './web-vitals/getFID';
+import { onINP } from './web-vitals/getINP';
 import { onLCP } from './web-vitals/getLCP';
 import { observe } from './web-vitals/lib/observe';
 
 type InstrumentHandlerTypePerformanceObserver = 'longtask' | 'event' | 'navigation' | 'paint' | 'resource';
 
-type InstrumentHandlerTypeMetric = 'cls' | 'lcp' | 'fid';
+type InstrumentHandlerTypeMetric = 'cls' | 'lcp' | 'fid' | 'inp';
 
 // We provide this here manually instead of relying on a global, as this is not available in non-browser environements
 // And we do not want to expose such types
@@ -86,6 +87,7 @@ const instrumented: { [key in InstrumentHandlerType]?: boolean } = {};
 let _previousCls: Metric | undefined;
 let _previousFid: Metric | undefined;
 let _previousLcp: Metric | undefined;
+let _previousInp: Metric | undefined;
 
 /**
  * Add a callback that will be triggered when a CLS metric is available.
@@ -123,9 +125,19 @@ export function addFidInstrumentationHandler(callback: (data: { metric: Metric }
   return addMetricObserver('fid', callback, instrumentFid, _previousFid);
 }
 
+/**
+ * Add a callback that will be triggered when a INP metric is available.
+ * Returns a cleanup callback which can be called to remove the instrumentation handler.
+ */
+export function addInpInstrumentationHandler(
+  callback: (data: { metric: Omit<Metric, 'entries'> & { entries: PerformanceEventTiming[] } }) => void,
+): CleanupHandlerCallback {
+  return addMetricObserver('inp', callback, instrumentInp, _previousInp);
+}
+
 export function addPerformanceInstrumentationHandler(
   type: 'event',
-  callback: (data: { entries: (PerformanceEntry & { target?: unknown | null })[] }) => void,
+  callback: (data: { entries: ((PerformanceEntry & { target?: unknown | null }) | PerformanceEventTiming)[] }) => void,
 ): CleanupHandlerCallback;
 export function addPerformanceInstrumentationHandler(
   type: InstrumentHandlerTypePerformanceObserver,
@@ -196,6 +208,15 @@ function instrumentLcp(): StopListening {
       metric,
     });
     _previousLcp = metric;
+  });
+}
+
+function instrumentInp(): void {
+  return onINP(metric => {
+    triggerHandlers('inp', {
+      metric,
+    });
+    _previousInp = metric;
   });
 }
 

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import type { IdleTransaction, Transaction } from '@sentry/core';
-import { getActiveTransaction, setMeasurement } from '@sentry/core';
+import { Span, getActiveTransaction, getClient, setMeasurement } from '@sentry/core';
 import type { Measurements, SpanContext } from '@sentry/types';
 import { browserPerformanceTimeOrigin, getComponentName, htmlTreeAsString, logger, parseUrl } from '@sentry/utils';
 
@@ -9,13 +9,20 @@ import { DEBUG_BUILD } from '../../common/debug-build';
 import {
   addClsInstrumentationHandler,
   addFidInstrumentationHandler,
+  addInpInstrumentationHandler,
   addLcpInstrumentationHandler,
   addPerformanceInstrumentationHandler,
 } from '../instrument';
 import { WINDOW } from '../types';
 import { getVisibilityWatcher } from '../web-vitals/lib/getVisibilityWatcher';
-import type { NavigatorDeviceMemory, NavigatorNetworkInformation } from '../web-vitals/types';
+import type {
+  InteractionRouteNameMapping,
+  NavigatorDeviceMemory,
+  NavigatorNetworkInformation,
+} from '../web-vitals/types';
 import { _startChild, isMeasurementValue } from './utils';
+
+import { createSpanEnvelope } from '@sentry/core';
 
 const MAX_INT_AS_BYTES = 2147483647;
 
@@ -127,6 +134,22 @@ export function startTrackingInteractions(): void {
   });
 }
 
+/**
+ * Start tracking INP webvital events.
+ */
+export function startTrackingINP(interactionIdtoRouteNameMapping: InteractionRouteNameMapping): () => void {
+  const performance = getBrowserPerformanceAPI();
+  if (performance && browserPerformanceTimeOrigin) {
+    const inpCallback = _trackINP(interactionIdtoRouteNameMapping);
+
+    return (): void => {
+      inpCallback();
+    };
+  }
+
+  return () => undefined;
+}
+
 /** Starts tracking the Cumulative Layout Shift on the current page. */
 function _trackCLS(): () => void {
   return addClsInstrumentationHandler(({ metric }) => {
@@ -168,6 +191,43 @@ function _trackFID(): () => void {
     DEBUG_BUILD && logger.log('[Measurements] Adding FID');
     _measurements['fid'] = { value: metric.value, unit: 'millisecond' };
     _measurements['mark.fid'] = { value: timeOrigin + startTime, unit: 'second' };
+  });
+}
+
+/** Starts tracking the Interaction to Next Paint on the current page. */
+function _trackINP(interactionIdtoRouteNameMapping: InteractionRouteNameMapping): () => void {
+  return addInpInstrumentationHandler(({ metric }) => {
+    const entry = metric.entries.find(e => e.name === 'click');
+    const client = getClient();
+    if (!entry || !client) {
+      return;
+    }
+    const { release, environment } = client.getOptions();
+    /** Build the INP span, create an envelope from the span, and then send the envelope */
+    const startTime = msToSec((browserPerformanceTimeOrigin as number) + entry.startTime);
+    const duration = msToSec(metric.value);
+    const routeName =
+      entry.interactionId !== undefined ? interactionIdtoRouteNameMapping[entry.interactionId].routeName : undefined;
+    const span = new Span({
+      startTimestamp: startTime,
+      endTimestamp: startTime + duration,
+      op: 'ui.interaction.click',
+      name: routeName,
+      attributes: {
+        measurements: {
+          inp: { value: metric.value, unit: 'millisecond' },
+        },
+        release,
+        environment,
+      },
+    });
+    const envelope = span ? createSpanEnvelope(span) : undefined;
+    const transport = client && client.getTransport();
+    if (transport && envelope) {
+      transport.send(envelope).then(null, reason => {
+        DEBUG_BUILD && logger.error('Error while sending interaction:', reason);
+      });
+    }
   });
 }
 

--- a/packages/tracing-internal/src/browser/web-vitals/types.ts
+++ b/packages/tracing-internal/src/browser/web-vitals/types.ts
@@ -162,3 +162,5 @@ declare global {
     element?: Element;
   }
 }
+
+export type InteractionRouteNameMapping = { [key: string]: { routeName: string; duration: number } };

--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -27,4 +27,6 @@ export type DataCategory =
   // Feedback type event (v2)
   | 'feedback'
   // Unknown data category
-  | 'unknown';
+  | 'unknown'
+  // Span
+  | 'span';

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -7,6 +7,7 @@ import type { Profile } from './profiling';
 import type { ReplayEvent, ReplayRecordingData } from './replay';
 import type { SdkInfo } from './sdkinfo';
 import type { SerializedSession, Session, SessionAggregates } from './session';
+import type { Span } from './span';
 import type { Transaction } from './transaction';
 import type { UserFeedback } from './user';
 
@@ -41,7 +42,8 @@ export type EnvelopeItemType =
   | 'replay_event'
   | 'replay_recording'
   | 'check_in'
-  | 'statsd';
+  | 'statsd'
+  | 'span';
 
 export type BaseEnvelopeHeaders = {
   [key: string]: unknown;
@@ -82,6 +84,7 @@ type ReplayRecordingItemHeaders = { type: 'replay_recording'; length: number };
 type CheckInItemHeaders = { type: 'check_in' };
 type StatsdItemHeaders = { type: 'statsd'; length: number };
 type ProfileItemHeaders = { type: 'profile' };
+type SpanItemHeaders = { type: 'span' };
 
 // TODO (v8): Replace `Event` with `SerializedEvent`
 export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event>;
@@ -98,6 +101,7 @@ type ReplayRecordingItem = BaseEnvelopeItem<ReplayRecordingItemHeaders, ReplayRe
 export type StatsdItem = BaseEnvelopeItem<StatsdItemHeaders, string>;
 export type FeedbackItem = BaseEnvelopeItem<FeedbackItemHeaders, FeedbackEvent>;
 export type ProfileItem = BaseEnvelopeItem<ProfileItemHeaders, Profile>;
+export type SpanItem = BaseEnvelopeItem<SpanItemHeaders, Span>;
 
 export type EventEnvelopeHeaders = { event_id: string; sent_at: string; trace?: DynamicSamplingContext };
 type SessionEnvelopeHeaders = { sent_at: string };
@@ -105,6 +109,7 @@ type CheckInEnvelopeHeaders = { trace?: DynamicSamplingContext };
 type ClientReportEnvelopeHeaders = BaseEnvelopeHeaders;
 type ReplayEnvelopeHeaders = BaseEnvelopeHeaders;
 type StatsdEnvelopeHeaders = BaseEnvelopeHeaders;
+type SpanEnvelopeHeaders = BaseEnvelopeHeaders;
 
 export type EventEnvelope = BaseEnvelope<
   EventEnvelopeHeaders,
@@ -115,6 +120,7 @@ export type ClientReportEnvelope = BaseEnvelope<ClientReportEnvelopeHeaders, Cli
 export type ReplayEnvelope = [ReplayEnvelopeHeaders, [ReplayEventItem, ReplayRecordingItem]];
 export type CheckInEnvelope = BaseEnvelope<CheckInEnvelopeHeaders, CheckInItem>;
 export type StatsdEnvelope = BaseEnvelope<StatsdEnvelopeHeaders, StatsdItem>;
+export type SpanEnvelope = BaseEnvelope<SpanEnvelopeHeaders, SpanItem>;
 
 export type Envelope =
   | EventEnvelope
@@ -122,5 +128,6 @@ export type Envelope =
   | ClientReportEnvelope
   | ReplayEnvelope
   | CheckInEnvelope
-  | StatsdEnvelope;
+  | StatsdEnvelope
+  | SpanEnvelope;
 export type EnvelopeItem = Envelope[1][number];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -45,6 +45,8 @@ export type {
   StatsdItem,
   StatsdEnvelope,
   ProfileItem,
+  SpanEnvelope,
+  SpanItem,
 } from './envelope';
 export type { ExtendedError } from './error';
 export type { Event, EventHint, EventType, ErrorEvent, TransactionEvent, SerializedEvent } from './event';

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -1,5 +1,6 @@
 import type { TraceContext } from './context';
 import type { Instrumenter } from './instrumenter';
+import type { Measurements } from './measurement';
 import type { Primitive } from './misc';
 import type { HrTime } from './opentelemetry';
 import type { Transaction } from './transaction';
@@ -21,7 +22,8 @@ export type SpanAttributeValue =
   | boolean
   | Array<null | undefined | string>
   | Array<null | undefined | number>
-  | Array<null | undefined | boolean>;
+  | Array<null | undefined | boolean>
+  | Measurements;
 
 export type SpanAttributes = Partial<{
   'sentry.origin': string;

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -209,6 +209,7 @@ const ITEM_TYPE_TO_DATA_CATEGORY_MAP: Record<EnvelopeItemType, DataCategory> = {
   replay_recording: 'replay',
   check_in: 'monitor',
   feedback: 'feedback',
+  span: 'span',
   // TODO: This is a temporary workaround until we have a proper data category for metrics
   statsd: 'unknown',
 };


### PR DESCRIPTION
Adds an experimental `enableInp` flag to v8 browserTracingIntegration, which picks up INP webvital entries from the browser and sends a span envelope containing INP data.

Some notes and changes involve:
- Adds generic span envelope types, helpers, categories, etc
- Adds `registerInpInteractionListener`, which tracks a mapping of interaction ids to the origin route names. This is used to get the route name when constructing the interaction span payload. The length of the mapping is capped at 10 (therefore no creeping memory issues), similar to how `getINP.ts` tracks candidate interactions.
- INP is placed in the span `attributes`, nested inside an `measurements` object. This is because the `Span` class doesn't have a `measurements` field. Not sure if this is the ideal approach, feedback appreciated here.
- Span and envelope creation + sending happens in `_trackINP`
- Should have added this to v7 (I forgot I needed this in v7), so we'll need to back port these changes.
- Looked into added an e2e playwright test, but I ended up running into v7 vs v8 issues. I think the playwright tests are currently on v7. Plan to add these tests later.

Some TODOS for future prs:
- Backport to v7
- e2e tests
- Start recording additional spans for INP once idle spans are available
- Figure out how to extend or start profiles to capture INP events