### PR TITLE
feat(core): Lookup client on current scope, not hub

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -349,8 +349,7 @@ export async function close(timeout?: number): Promise<boolean> {
  * Get the currently active client.
  */
 export function getClient<C extends Client>(): C | undefined {
-  // eslint-disable-next-line deprecation/deprecation
-  return getCurrentHub().getClient<C>();
+  return getCurrentScope().getClient<C>();
 }
 
 /**

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -163,8 +163,8 @@ export class Scope implements ScopeInterface {
    *
    * It is generally recommended to use the global function `Sentry.getClient()` instead, unless you know what you are doing.
    */
-  public getClient(): Client | undefined {
-    return this._client;
+  public getClient<C extends Client>(): C | undefined {
+    return this._client as C | undefined;
   }
 
   /**

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -9,7 +9,6 @@ import {
   spanToJSON,
   withScope,
 } from '../../../src';
-import { Scope } from '../../../src/scope';
 import {
   Span,
   continueTrace,
@@ -304,7 +303,7 @@ describe('startSpan', () => {
   it('allows to pass a scope', () => {
     const initialScope = getCurrentScope();
 
-    const manualScope = new Scope();
+    const manualScope = initialScope.clone();
     const parentSpan = new Span({ spanId: 'parent-span-id' });
     // eslint-disable-next-line deprecation/deprecation
     manualScope.setSpan(parentSpan);
@@ -463,7 +462,7 @@ describe('startSpanManual', () => {
   it('allows to pass a scope', () => {
     const initialScope = getCurrentScope();
 
-    const manualScope = new Scope();
+    const manualScope = initialScope.clone();
     const parentSpan = new Span({ spanId: 'parent-span-id' });
     // eslint-disable-next-line deprecation/deprecation
     manualScope.setSpan(parentSpan);
@@ -568,7 +567,9 @@ describe('startInactiveSpan', () => {
   });
 
   it('allows to pass a scope', () => {
-    const manualScope = new Scope();
+    const initialScope = getCurrentScope();
+
+    const manualScope = initialScope.clone();
     const parentSpan = new Span({ spanId: 'parent-span-id' });
     // eslint-disable-next-line deprecation/deprecation
     manualScope.setSpan(parentSpan);


### PR DESCRIPTION
One more step to avoid the hub...

Note: This showed a potential footgun (?), where if you pass a client-less scope to `startSpan()`, no span will be created (because no client = no tracing, and the given scope will be made the current scope in the callback). this is correct behavior here, but _could_ be a bit unexpected ("why is no span being created here??"). We could think about warning if a client-less scope is passed in there, but not sure if that's worth it...
