### PR TITLE
feat: Export semantic attribute keys from SDK packages

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -69,6 +69,10 @@ export {
   continueTrace,
   cron,
   parameterize,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -69,6 +69,13 @@ export {
   parameterize,
 } from '@sentry/core';
 
+export {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+} from '@sentry/core';
+
 export { WINDOW } from './helpers';
 export { BrowserClient } from './client';
 export { makeFetchTransport, makeXHRTransport } from './transports';

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -101,6 +101,10 @@ export {
   onUncaughtExceptionIntegration,
   onUnhandledRejectionIntegration,
   spotlightIntegration,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
 } from '@sentry/node';
 
 export { BunClient } from './client';

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -73,7 +73,12 @@ export {
   linkedErrorsIntegration,
   functionToStringIntegration,
   requestDataIntegration,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
 } from '@sentry/core';
+
 export type { SpanStatusType } from '@sentry/core';
 
 export { DenoClient } from './client';

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -84,6 +84,10 @@ export {
   functionToStringIntegration,
   inboundFiltersIntegration,
   linkedErrorsIntegration,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
 } from '@sentry/node';
 
 export type {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -76,7 +76,16 @@ export {
   linkedErrorsIntegration,
   requestDataIntegration,
 } from '@sentry/core';
+
+export {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+} from '@sentry/core';
+
 export type { SpanStatusType } from '@sentry/core';
+
 export { autoDiscoverNodePerformanceMonitoringIntegrations } from './tracing';
 
 export { NodeClient } from './client';

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -90,6 +90,10 @@ export {
   createGetModuleFromFilename,
   hapiErrorPlugin,
   runWithAsyncContext,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
 } from '@sentry/node';
 
 // Keeping the `*` exports for backwards compatibility and types

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -95,4 +95,8 @@ export {
   httpIntegration,
   nativeNodeFetchintegration,
   spotlightIntegration,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
 } from '@sentry/node';

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -83,6 +83,10 @@ export {
   hapiErrorPlugin,
   metrics,
   runWithAsyncContext,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -74,6 +74,10 @@ export {
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 


### PR DESCRIPTION
Given users should make use of attributes when performing custom instrumentation, this PR adds exports for our semantic attributes keys from the SDK packages so that users don't have to install `@sentry/core` explicitly. 