### PR TITLE
fix(nextjs): Remove `webpack://` prefix more broadly from source map `sources` field

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -764,7 +764,7 @@ export function getWebpackPluginOptions(
     project: process.env.SENTRY_PROJECT,
     authToken: process.env.SENTRY_AUTH_TOKEN,
     configFile: hasSentryProperties ? 'sentry.properties' : undefined,
-    stripPrefix: ['webpack://_N_E/'],
+    stripPrefix: ['webpack://_N_E/', 'webpack://'],
     urlPrefix,
     entries: [], // The webpack plugin's release injection breaks the `app` directory - we inject the release manually with the value injection loader instead.
     release: getSentryRelease(buildId),


### PR DESCRIPTION
It seems like newer versions of Next.js do not use the `_N_E` namespace anymore but leave it up to the user. We need to adjust our config for that.

We should in the near future add E2E tests that check for source mapping in Next.js.