### PR TITLE
fix(nextjs): Remove `webpack://` prefix more broadly from source map `sources` field

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -764,7 +764,7 @@ export function getWebpackPluginOptions(
     project: process.env.SENTRY_PROJECT,
     authToken: process.env.SENTRY_AUTH_TOKEN,
     configFile: hasSentryProperties ? 'sentry.properties' : undefined,
-    stripPrefix: ['webpack://_N_E/'],
+    stripPrefix: ['webpack://_N_E/', 'webpack://'],
     urlPrefix,
     entries: [], // The webpack plugin's release injection breaks the `app` directory - we inject the release manually with the value injection loader instead.
     release: getSentryRelease(buildId),

--- a/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
+++ b/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
@@ -35,7 +35,7 @@ describe('Sentry webpack plugin config', () => {
         org: 'squirrelChasers', // from user webpack plugin config
         project: 'simulator', // from user webpack plugin config
         authToken: 'dogsarebadatkeepingsecrets', // picked up from env
-        stripPrefix: ['webpack://_N_E/'], // default
+        stripPrefix: ['webpack://_N_E/', 'webpack://'], // default
         urlPrefix: '~/_next', // default
         entries: [],
         release: 'doGsaREgReaT', // picked up from env


### PR DESCRIPTION
This is a forward-port of https://github.com/getsentry/sentry-javascript/pull/10641