### PR TITLE
ref(core): Always use a (default) ACS

### DIFF
--- a/packages/core/src/asyncContext.ts
+++ b/packages/core/src/asyncContext.ts
@@ -70,25 +70,6 @@ export function setAsyncContextStrategy(strategy: AsyncContextStrategy | undefin
   sentry.acs = strategy;
 }
 
-/**
- * Runs the supplied callback in its own async context. Async Context strategies are defined per SDK.
- *
- * @param callback The callback to run in its own async context
- * @param options Options to pass to the async context strategy
- * @returns The result of the callback
- */
-export function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions = {}): T {
-  const registry = getMainCarrier();
-  const sentry = getSentryCarrier(registry);
-
-  if (sentry.acs) {
-    return sentry.acs.runWithAsyncContext(callback, options);
-  }
-
-  // if there was no strategy, fallback to just calling the callback
-  return callback();
-}
-
 /** Will either get the existing sentry carrier, or create a new one. */
 export function getSentryCarrier(carrier: Carrier): SentryCarrier {
   if (!carrier.__SENTRY__) {

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -20,13 +20,12 @@ import type {
   User,
 } from '@sentry/types';
 import { GLOBAL_OBJ, isThenable, logger, timestampInSeconds, uuid4 } from '@sentry/utils';
-import { runWithAsyncContext } from './asyncContext';
 
 import { DEFAULT_ENVIRONMENT } from './constants';
 import { getCurrentScope, getIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { Hub } from './hub';
-import { getCurrentHub } from './hub';
+import { getCurrentHub, runWithAsyncContext } from './hub';
 import type { Scope } from './scope';
 import { closeSession, makeSession, updateSession } from './session';
 import type { ExclusiveEventHintOrCaptureContext } from './utils/prepareEvent';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
   makeMain,
   setHubOnCarrier,
   ensureHubOnCarrier,
+  runWithAsyncContext,
 } from './hub';
 export {
   getCurrentScope,
@@ -53,7 +54,6 @@ export {
 } from './currentScopes';
 export {
   getMainCarrier,
-  runWithAsyncContext,
   setAsyncContextStrategy,
 } from './asyncContext';
 export { makeSession, closeSession, updateSession } from './session';

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -1,12 +1,11 @@
 import type { Hub, Scope, Span, SpanTimeInput, StartSpanOptions, TransactionContext } from '@sentry/types';
 
 import { addNonEnumerableProperty, dropUndefinedKeys, logger, tracingContextFromHeaders } from '@sentry/utils';
-import { runWithAsyncContext } from '../asyncContext';
 import { getCurrentScope, getIsolationScope } from '../currentScopes';
 
 import { DEBUG_BUILD } from '../debug-build';
 import { withScope } from '../exports';
-import { getCurrentHub } from '../hub';
+import { getCurrentHub, runWithAsyncContext } from '../hub';
 import { handleCallbackErrors } from '../utils/handleCallbackErrors';
 import { hasTracingEnabled } from '../utils/hasTracingEnabled';
 import { spanTimeInputToSeconds, spanToJSON } from '../utils/spanUtils';


### PR DESCRIPTION
Small refactor to ensure we _always_ use a default async context strategy, making the default behavior more explicit.

This will (hopefully) make it easier to encapsulate this going forward.