### PR TITLE
ref: Remove `reuseExisting` option for ACS

### DIFF
--- a/packages/core/src/asyncContext.ts
+++ b/packages/core/src/asyncContext.ts
@@ -1,11 +1,6 @@
 import type { Hub, Integration } from '@sentry/types';
 import { GLOBAL_OBJ } from '@sentry/utils';
 
-export interface RunWithAsyncContextOptions {
-  /** Whether to reuse an existing async context if one exists. Defaults to false. */
-  reuseExisting?: boolean;
-}
-
 /**
  * @private Private API with no semver guarantees!
  *
@@ -20,7 +15,7 @@ export interface AsyncContextStrategy {
   /**
    * Runs the supplied callback in its own async context.
    */
-  runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions): T;
+  runWithAsyncContext<T>(callback: () => T): T;
 }
 
 /**

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -22,7 +22,7 @@ import type {
 } from '@sentry/types';
 import { GLOBAL_OBJ, consoleSandbox, dateTimestampInSeconds, isThenable, logger, uuid4 } from '@sentry/utils';
 
-import type { AsyncContextStrategy, Carrier, RunWithAsyncContextOptions } from './asyncContext';
+import type { AsyncContextStrategy, Carrier } from './asyncContext';
 import { getMainCarrier, getSentryCarrier } from './asyncContext';
 import { DEFAULT_ENVIRONMENT } from './constants';
 import { DEBUG_BUILD } from './debug-build';
@@ -661,12 +661,12 @@ export function getCurrentHub(): HubInterface {
  * @param options Options to pass to the async context strategy
  * @returns The result of the callback
  */
-export function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions = {}): T {
+export function runWithAsyncContext<T>(callback: () => T): T {
   // Get main carrier (global for every environment)
   const carrier = getMainCarrier();
 
   const acs = getAsyncContextStrategy(carrier);
-  return acs.runWithAsyncContext(callback, options);
+  return acs.runWithAsyncContext(callback);
 }
 
 function getGlobalHub(): HubInterface {
@@ -752,7 +752,7 @@ export function getAsyncContextStrategy(carrier: Carrier): AsyncContextStrategy 
 function getHubStackAsyncContextStrategy(): AsyncContextStrategy {
   return {
     getCurrentHub: getGlobalHub,
-    runWithAsyncContext: <T>(callback: () => T, _options: RunWithAsyncContextOptions = {}): T => {
+    runWithAsyncContext: <T>(callback: () => T): T => {
       return callback();
     },
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export type { ClientClass } from './sdk';
 export type { Layer } from './hub';
-export type { AsyncContextStrategy, Carrier, RunWithAsyncContextOptions } from './asyncContext';
+export type { AsyncContextStrategy, Carrier } from './asyncContext';
 export type { OfflineStore, OfflineTransportOptions } from './transports/offline';
 export type { ServerRuntimeClientOptions } from './server-runtime-client';
 export type { RequestDataIntegrationOptions } from './integrations/requestdata';

--- a/packages/node/src/async/domain.ts
+++ b/packages/node/src/async/domain.ts
@@ -1,5 +1,5 @@
 import * as domain from 'domain';
-import type { Carrier, RunWithAsyncContextOptions } from '@sentry/core';
+import type { Carrier } from '@sentry/core';
 import { ensureHubOnCarrier, getHubFromCarrier, setAsyncContextStrategy, setHubOnCarrier } from '@sentry/core';
 import type { Hub } from '@sentry/types';
 
@@ -27,13 +27,8 @@ function createNewHub(parent: Hub | undefined): Hub {
   return getHubFromCarrier(carrier);
 }
 
-function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions): T {
+function runWithAsyncContext<T>(callback: () => T): T {
   const activeDomain = getActiveDomain<domain.Domain & Carrier>();
-
-  if (activeDomain && options?.reuseExisting) {
-    // We're already in a domain, so we don't need to create a new one, just call the callback with the current hub
-    return callback();
-  }
 
   const local = domain.create() as domain.Domain & Carrier;
 

--- a/packages/node/src/async/hooks.ts
+++ b/packages/node/src/async/hooks.ts
@@ -1,4 +1,4 @@
-import type { Carrier, RunWithAsyncContextOptions } from '@sentry/core';
+import type { Carrier } from '@sentry/core';
 import { ensureHubOnCarrier, getHubFromCarrier, setAsyncContextStrategy } from '@sentry/core';
 import type { Hub } from '@sentry/types';
 import * as async_hooks from 'async_hooks';
@@ -33,14 +33,8 @@ export function setHooksAsyncContextStrategy(): void {
     return getHubFromCarrier(carrier);
   }
 
-  function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions): T {
+  function runWithAsyncContext<T>(callback: () => T): T {
     const existingHub = getCurrentHub();
-
-    if (existingHub && options?.reuseExisting) {
-      // We're already in an async context, so we don't need to create a new one
-      // just call the callback with the current hub
-      return callback();
-    }
 
     const newHub = createNewHub(existingHub);
 

--- a/packages/node/test/async/domain.test.ts
+++ b/packages/node/test/async/domain.test.ts
@@ -160,21 +160,6 @@ describe('setDomainAsyncContextStrategy()', () => {
       });
     });
 
-    test('within a domain reused when requested', () => {
-      setDomainAsyncContextStrategy();
-
-      runWithAsyncContext(() => {
-        const hub1 = getCurrentHub();
-        runWithAsyncContext(
-          () => {
-            const hub2 = getCurrentHub();
-            expect(hub1).toBe(hub2);
-          },
-          { reuseExisting: true },
-        );
-      });
-    });
-
     test('concurrent hub contexts', done => {
       setDomainAsyncContextStrategy();
 

--- a/packages/node/test/async/hooks.test.ts
+++ b/packages/node/test/async/hooks.test.ts
@@ -166,21 +166,6 @@ describe('setHooksAsyncContextStrategy()', () => {
       });
     });
 
-    test('context within a context reused when requested', () => {
-      setHooksAsyncContextStrategy();
-
-      runWithAsyncContext(() => {
-        const hub1 = getCurrentHub();
-        runWithAsyncContext(
-          () => {
-            const hub2 = getCurrentHub();
-            expect(hub1).toBe(hub2);
-          },
-          { reuseExisting: true },
-        );
-      });
-    });
-
     test('concurrent hub contexts', done => {
       setHooksAsyncContextStrategy();
 

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,5 +1,5 @@
 import * as api from '@opentelemetry/api';
-import type { Hub, RunWithAsyncContextOptions } from '@sentry/core';
+import type { Hub } from '@sentry/core';
 import { setAsyncContextStrategy } from '@sentry/core';
 import { SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY } from './constants';
 
@@ -19,15 +19,7 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
   }
 
   /* This is more or less a NOOP - we rely on the OTEL context manager for this */
-  function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions): T {
-    const existingHub = getCurrentHub();
-
-    if (existingHub && options?.reuseExisting) {
-      // We're already in an async context, so we don't need to create a new one
-      // just call the callback with the current hub
-      return callback();
-    }
-
+  function runWithAsyncContext<T>(callback: () => T): T {
     const ctx = api.context.active();
 
     // We depend on the otelContextManager to handle the context/hub

--- a/packages/opentelemetry/test/asyncContextStrategy.test.ts
+++ b/packages/opentelemetry/test/asyncContextStrategy.test.ts
@@ -111,21 +111,6 @@ describe('asyncContextStrategy', () => {
     });
   });
 
-  test('context within a context reused when requested', () => {
-    runWithAsyncContext(() => {
-      // eslint-disable-next-line deprecation/deprecation
-      const hub1 = getCurrentHub();
-      runWithAsyncContext(
-        () => {
-          // eslint-disable-next-line deprecation/deprecation
-          const hub2 = getCurrentHub();
-          expect(hub1).toBe(hub2);
-        },
-        { reuseExisting: true },
-      );
-    });
-  });
-
   test('concurrent hub contexts', done => {
     let d1done = false;
     let d2done = false;

--- a/packages/serverless/src/utils.ts
+++ b/packages/serverless/src/utils.ts
@@ -7,7 +7,7 @@ import { addExceptionMechanism } from '@sentry/utils';
  * @returns function which runs in the newly created domain or in the existing one
  */
 export function domainify<A extends unknown[], R>(fn: (...args: A) => R): (...args: A) => R | void {
-  return (...args) => runWithAsyncContext(() => fn(...args), { reuseExisting: true });
+  return (...args) => runWithAsyncContext(() => fn(...args));
 }
 
 /**

--- a/packages/vercel-edge/src/async.ts
+++ b/packages/vercel-edge/src/async.ts
@@ -1,4 +1,4 @@
-import type { Carrier, RunWithAsyncContextOptions } from '@sentry/core';
+import type { Carrier } from '@sentry/core';
 import { ensureHubOnCarrier, getHubFromCarrier, setAsyncContextStrategy } from '@sentry/core';
 import type { Hub } from '@sentry/types';
 import { GLOBAL_OBJ, logger } from '@sentry/utils';
@@ -42,14 +42,8 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     return getHubFromCarrier(carrier);
   }
 
-  function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions): T {
+  function runWithAsyncContext<T>(callback: () => T): T {
     const existingHub = getCurrentHub();
-
-    if (existingHub && options?.reuseExisting) {
-      // We're already in an async context, so we don't need to create a new one
-      // just call the callback with the current hub
-      return callback();
-    }
 
     const newHub = createNewHub(existingHub);
 


### PR DESCRIPTION
We don't have this anymore in the new model.