### PR TITLE
fix(angular): Ensure navigations always create a transaction

### DIFF
--- a/dev-packages/e2e-tests/test-applications/angular-17/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-17/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "ng": "ng",
     "dev": "ng serve",
-    "preview": "http-server dist/angular-17/browser",
+    "proxy": "ts-node-script start-event-proxy.ts",
+    "preview": "http-server dist/angular-17/browser --port 8080",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "playwright test",
@@ -22,6 +23,7 @@
     "@angular/platform-browser": "^17.1.0",
     "@angular/platform-browser-dynamic": "^17.1.0",
     "@angular/router": "^17.1.0",
+    "@sentry/angular-ivy": "* || latest",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"
@@ -31,7 +33,6 @@
     "@angular/cli": "^17.1.1",
     "@angular/compiler-cli": "^17.1.0",
     "@playwright/test": "^1.41.1",
-    "@sentry/angular-ivy": "latest || *",
     "@types/jasmine": "~5.1.0",
     "http-server": "^14.1.1",
     "jasmine-core": "~5.1.0",
@@ -40,11 +41,18 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.3.2",
     "ts-node": "10.9.1",
+    "typescript": "~5.3.2",
     "wait-port": "1.0.4"
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "@sentry/browser": "latest || *",
+      "@sentry/core": "latest || *",
+      "@sentry/utils": "latest || *"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/angular-17/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/playwright.config.ts
@@ -29,8 +29,8 @@ const config: PlaywrightTestConfig = {
      */
     timeout: 10000,
   },
-  /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
+  workers: 1,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* `next dev` is incredibly buggy with the app dir */

--- a/dev-packages/e2e-tests/test-applications/angular-17/src/app/app.routes.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/src/app/app.routes.ts
@@ -12,6 +12,18 @@ export const routes: Routes = [
     component: HomeComponent,
   },
   {
+    path: 'redirect1',
+    redirectTo: '/redirect2',
+  },
+  {
+    path: 'redirect2',
+    redirectTo: '/redirect3',
+  },
+  {
+    path: 'redirect3',
+    redirectTo: '/users/456',
+  },
+  {
     path: '**',
     redirectTo: 'home',
   },

--- a/dev-packages/e2e-tests/test-applications/angular-17/src/app/home/home.component.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/src/app/home/home.component.ts
@@ -10,6 +10,7 @@ import { RouterLink } from '@angular/router';
     <h1>Welcome to Sentry's Angular 17 E2E test app</h1>
     <ul>
       <li> <a id="navLink" [routerLink]="['/users', '123']">Visit User 123</a> </li>
+      <li> <a id="redirectLink" [routerLink]="['/redirect1']">Redirect</a> </li>
     </ul>
     <button id="errorBtn" (click)="throwError()">Throw error</button>
   </main>

--- a/dev-packages/e2e-tests/test-applications/angular-17/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/tests/performance.test.ts
@@ -52,3 +52,77 @@ test('sends a navigation transaction with a parameterized URL', async ({ page })
     },
   });
 });
+
+test('sends a navigation transaction even if the pageload span is still active', async ({ page }) => {
+  const pageloadTxnPromise = waitForTransaction('angular-17', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  });
+
+  const navigationTxnPromise = waitForTransaction('angular-17', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'navigation';
+  });
+
+  await page.goto(`/`);
+
+  // immediately navigate to a different route
+  const [_, pageloadTxn, navigationTxn] = await Promise.all([
+    page.locator('#navLink').click(),
+    pageloadTxnPromise,
+    navigationTxnPromise,
+  ]);
+
+  expect(pageloadTxn).toMatchObject({
+    contexts: {
+      trace: {
+        op: 'pageload',
+        origin: 'auto.pageload.angular',
+      },
+    },
+    transaction: '/home/',
+    transaction_info: {
+      source: 'route',
+    },
+  });
+
+  expect(navigationTxn).toMatchObject({
+    contexts: {
+      trace: {
+        op: 'navigation',
+        origin: 'auto.navigation.angular',
+      },
+    },
+    transaction: '/users/:id/',
+    transaction_info: {
+      source: 'route',
+    },
+  });
+});
+
+test('groups redirects within one navigation root span', async ({ page }) => {
+  const navigationTxnPromise = waitForTransaction('angular-17', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'navigation';
+  });
+
+  await page.goto(`/`);
+
+  // immediately navigate to a different route
+  const [_, navigationTxn] = await Promise.all([page.locator('#redirectLink').click(), navigationTxnPromise]);
+
+  expect(navigationTxn).toMatchObject({
+    contexts: {
+      trace: {
+        op: 'navigation',
+        origin: 'auto.navigation.angular',
+      },
+    },
+    transaction: '/users/:id/',
+    transaction_info: {
+      source: 'route',
+    },
+  });
+
+  const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+
+  expect(routingSpan).toBeDefined();
+  expect(routingSpan?.description).toBe('/redirect1');
+});


### PR DESCRIPTION
This PR addresses the problematic check of `getActiveSpan()` in  our Angular SDK's `TraceService` raised in #10634.

In certain situations (e.g. very quick navigations after the initial pageload) the check of `getActiveSpan()` could lead to navigations not getting their own transaction, as the pageload transaction was still active at that time.

I also checked the behaviour of multiple subsequent redirects and here, we only create one navigation transaction for all redirects. The reason for this is that the Angular router doesn't fire individual events for the redirects but only one for the final redirect. IMHO this is fine and should be expected behaviour. 

ref #10634 