### PR TITLE
test: Add SLA label to canary test failure issues

### DIFF
--- a/.github/CANARY_FAILURE_TEMPLATE.md
+++ b/.github/CANARY_FAILURE_TEMPLATE.md
@@ -1,5 +1,5 @@
 ---
 title: '{{ env.TITLE }}'
-labels: 'Type: Tests'
+labels: 'Type: Tests, Waiting for: Product Owner'
 ---
 Canary tests failed: {{ env.RUN_LINK }}


### PR DESCRIPTION
We don't wanna miss those.