### PR TITLE
test: Adjust Next.js dev error symbolication tests to new behaviour

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/devErrorSymbolification.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/devErrorSymbolification.test.ts
@@ -24,7 +24,7 @@ test.describe('dev mode error symbolification', () => {
         function: 'onClick',
         filename: 'components/client-error-debug-tools.tsx',
         lineno: 54,
-        colno: 16,
+        colno: expect.any(Number),
         in_app: true,
         pre_context: ['       <button', '         onClick={() => {'],
         context_line: "           throw new Error('Click Error');",


### PR DESCRIPTION
Apparently the colno shifted by one https://github.com/getsentry/sentry-javascript/actions/runs/7894509917/job/21545636786

We cannot also just shift it by one because that would then fail the tests on non-canary.

Fixes https://github.com/getsentry/sentry-javascript/issues/10544