### PR TITLE
fix(sveltekit): Ensure navigations and redirects always create a new transaction

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
@@ -6,6 +6,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
+    "proxy": "ts-node-script start-event-proxy.ts",
     "clean": "npx rimraf node_modules,pnpm-lock.yaml",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/+layout.svelte
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/+layout.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
-import { onMount } from "svelte";
+  import { onMount } from "svelte";
 
-onMount(() => {
-  // Indicate that the SvelteKit app was hydrated
-  document.body.classList.add("hydrated");
-});
+  import { navigating } from "$app/stores";
+
+  onMount(() => {
+    // Indicate that the SvelteKit app was hydrated
+    document.body.classList.add("hydrated");
+  });
+
+  navigating.subscribe((navigation) => {
+    console.log("XXX navigating", navigation);
+  });
+
 </script>
 
 <h1>Sveltekit E2E Test app</h1>

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/+layout.svelte
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/+layout.svelte
@@ -8,9 +8,6 @@
     document.body.classList.add("hydrated");
   });
 
-  navigating.subscribe((navigation) => {
-    console.log("XXX navigating", navigation);
-  });
 
 </script>
 

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/+page.svelte
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/+page.svelte
@@ -15,12 +15,15 @@
     <a href="/server-route-error">Server Route error</a>
   </li>
   <li>
-    <a href="/users/123abc">Route with Params</a>
+    <a id="routeWithParamsLink" href="/users/123abc">Route with Params</a>
   </li>
   <li>
     <a href="/users">Route with Server Load</a>
   </li>
   <li>
     <a href="/universal-load-fetch">Route with fetch in universal load</a>
+  </li>
+  <li>
+    <a id="redirectLink" href="/redirect1">Redirect</a>
   </li>
 </ul>

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/redirect1/+page.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/redirect1/+page.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export const load = async () => {
+  redirect(301, '/redirect2');
+};

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/redirect2/+page.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/redirect2/+page.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export const load = async () => {
+  redirect(301, '/users/789');
+};

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/test/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/test/performance.test.ts
@@ -185,7 +185,7 @@ test.describe('performance events', () => {
     });
   });
 
-  test.only('captures a navigation transaction directly after pageload', async ({ page }) => {
+  test('captures a navigation transaction directly after pageload', async ({ page }) => {
     await page.goto('/');
 
     const clientPageloadTxnPromise = waitForTransaction('sveltekit-2', txnEvent => {
@@ -226,6 +226,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
+          data: {
+            'sentry.sveltekit.navigation.from': '/',
+            'sentry.sveltekit.navigation.to': '/users/[id]',
+            'sentry.sveltekit.navigation.type': 'link',
+          },
         },
       },
     });
@@ -240,43 +245,126 @@ test.describe('performance events', () => {
       data: {
         'sentry.op': 'ui.sveltekit.routing',
         'sentry.origin': 'auto.ui.sveltekit',
+        'sentry.sveltekit.navigation.from': '/',
+        'sentry.sveltekit.navigation.to': '/users/[id]',
+        'sentry.sveltekit.navigation.type': 'link',
       },
     });
   });
 
-  test.only('captures a navigation transaction directly after pageload', async ({ page }) => {
+  test('captures one navigation transaction per redirect', async ({ page }) => {
     await page.goto('/');
 
-    const clientPageloadTxnPromise = waitForTransaction('sveltekit-2', txnEvent => {
-      return txnEvent?.contexts?.trace?.op === 'pageload' && txnEvent?.tags?.runtime === 'browser';
+    const clientNavigationRedirect1TxnPromise = waitForTransaction('sveltekit-2', txnEvent => {
+      return (
+        txnEvent?.contexts?.trace?.op === 'navigation' &&
+        txnEvent?.tags?.runtime === 'browser' &&
+        txnEvent?.transaction === '/redirect1'
+      );
     });
 
-    const clientNavigationTxnPromise = waitForTransaction('sveltekit-2', txnEvent => {
-      return txnEvent?.contexts?.trace?.op === 'navigation' && txnEvent?.tags?.runtime === 'browser';
+    const clientNavigationRedirect2TxnPromise = waitForTransaction('sveltekit-2', txnEvent => {
+      return (
+        txnEvent?.contexts?.trace?.op === 'navigation' &&
+        txnEvent?.tags?.runtime === 'browser' &&
+        txnEvent?.transaction === '/redirect2'
+      );
     });
 
-    const navigationClickPromise = page.locator('#routeWithParamsLink').click();
+    const clientNavigationRedirect3TxnPromise = waitForTransaction('sveltekit-2', txnEvent => {
+      return (
+        txnEvent?.contexts?.trace?.op === 'navigation' &&
+        txnEvent?.tags?.runtime === 'browser' &&
+        txnEvent?.transaction === '/users/[id]'
+      );
+    });
 
-    const [pageloadTxnEvent, navigationTxnEvent, _] = await Promise.all([
-      clientPageloadTxnPromise,
-      clientNavigationTxnPromise,
+    const navigationClickPromise = page.locator('#redirectLink').click();
+
+    const [redirect1TxnEvent, redirect2TxnEvent, redirect3TxnEvent, _] = await Promise.all([
+      clientNavigationRedirect1TxnPromise,
+      clientNavigationRedirect2TxnPromise,
+      clientNavigationRedirect3TxnPromise,
       navigationClickPromise,
     ]);
 
-    expect(pageloadTxnEvent).toMatchObject({
-      transaction: '/',
+    expect(redirect1TxnEvent).toMatchObject({
+      transaction: '/redirect1',
       tags: { runtime: 'browser' },
       transaction_info: { source: 'route' },
       type: 'transaction',
       contexts: {
         trace: {
-          op: 'pageload',
-          origin: 'auto.pageload.sveltekit',
+          op: 'navigation',
+          origin: 'auto.navigation.sveltekit',
+          data: {
+            'sentry.origin': 'auto.navigation.sveltekit',
+            'sentry.op': 'navigation',
+            'sentry.source': 'route',
+            'sentry.sveltekit.navigation.type': 'link',
+            'sentry.sveltekit.navigation.from': '/',
+            'sentry.sveltekit.navigation.to': '/redirect1',
+            'sentry.sample_rate': 1,
+          },
         },
       },
     });
 
-    expect(navigationTxnEvent).toMatchObject({
+    const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    expect(redirect1Spans).toHaveLength(1);
+
+    const redirect1Span = redirect1Spans && redirect1Spans[0];
+    expect(redirect1Span).toMatchObject({
+      op: 'ui.sveltekit.routing',
+      description: 'SvelteKit Route Change',
+      data: {
+        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.origin': 'auto.ui.sveltekit',
+        'sentry.sveltekit.navigation.from': '/',
+        'sentry.sveltekit.navigation.to': '/redirect1',
+        'sentry.sveltekit.navigation.type': 'link',
+      },
+    });
+
+    expect(redirect2TxnEvent).toMatchObject({
+      transaction: '/redirect2',
+      tags: { runtime: 'browser' },
+      transaction_info: { source: 'route' },
+      type: 'transaction',
+      contexts: {
+        trace: {
+          op: 'navigation',
+          origin: 'auto.navigation.sveltekit',
+          data: {
+            'sentry.origin': 'auto.navigation.sveltekit',
+            'sentry.op': 'navigation',
+            'sentry.source': 'route',
+            'sentry.sveltekit.navigation.type': 'goto',
+            'sentry.sveltekit.navigation.from': '/',
+            'sentry.sveltekit.navigation.to': '/redirect2',
+            'sentry.sample_rate': 1,
+          },
+        },
+      },
+    });
+
+    const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    expect(redirect2Spans).toHaveLength(1);
+
+    const redirect2Span = redirect2Spans && redirect2Spans[0];
+    expect(redirect2Span).toMatchObject({
+      op: 'ui.sveltekit.routing',
+      description: 'SvelteKit Route Change',
+      data: {
+        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.origin': 'auto.ui.sveltekit',
+        'sentry.sveltekit.navigation.from': '/',
+        'sentry.sveltekit.navigation.to': '/redirect2',
+        'sentry.sveltekit.navigation.type': 'goto',
+      },
+    });
+
+    expect(redirect3TxnEvent).toMatchObject({
       transaction: '/users/[id]',
       tags: { runtime: 'browser' },
       transaction_info: { source: 'route' },
@@ -285,20 +373,32 @@ test.describe('performance events', () => {
         trace: {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
+          data: {
+            'sentry.origin': 'auto.navigation.sveltekit',
+            'sentry.op': 'navigation',
+            'sentry.source': 'route',
+            'sentry.sveltekit.navigation.type': 'goto',
+            'sentry.sveltekit.navigation.from': '/',
+            'sentry.sveltekit.navigation.to': '/users/[id]',
+            'sentry.sample_rate': 1,
+          },
         },
       },
     });
 
-    const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
-    expect(routingSpans).toHaveLength(1);
+    const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    expect(redirect3Spans).toHaveLength(1);
 
-    const routingSpan = routingSpans && routingSpans[0];
-    expect(routingSpan).toMatchObject({
+    const redirect3Span = redirect3Spans && redirect3Spans[0];
+    expect(redirect3Span).toMatchObject({
       op: 'ui.sveltekit.routing',
       description: 'SvelteKit Route Change',
       data: {
         'sentry.op': 'ui.sveltekit.routing',
         'sentry.origin': 'auto.ui.sveltekit',
+        'sentry.sveltekit.navigation.from': '/',
+        'sentry.sveltekit.navigation.to': '/users/[id]',
+        'sentry.sveltekit.navigation.type': 'goto',
       },
     });
   });

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -10,6 +10,7 @@ import {
   startInactiveSpan,
 } from '@sentry/svelte';
 import type { Client, Integration, Span } from '@sentry/types';
+import { dropUndefinedKeys } from '@sentry/utils';
 import { svelteKitRoutingInstrumentation } from './router';
 
 /**
@@ -137,7 +138,7 @@ function _instrumentNavigations(client: Client): void {
       routingSpan.end();
     }
 
-    const navigationInfo = {
+    const navigationInfo = dropUndefinedKeys({
       //  `navigation.type` denotes the origin of the navigation. e.g.:
       //   - link (clicking on a link)
       //   - goto (programmatic via goto() or redirect())
@@ -145,7 +146,7 @@ function _instrumentNavigations(client: Client): void {
       'sentry.sveltekit.navigation.type': navigation.type,
       'sentry.sveltekit.navigation.from': parameterizedRouteOrigin || undefined,
       'sentry.sveltekit.navigation.to': parameterizedRouteDestination || undefined,
-    };
+    });
 
     startBrowserTracingNavigationSpan(client, {
       name: parameterizedRouteDestination || rawRouteDestination || 'unknown',

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -4,7 +4,6 @@ import {
   BrowserTracing as OriginalBrowserTracing,
   WINDOW,
   browserTracingIntegration as originalBrowserTracingIntegration,
-  getActiveSpan,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
   startInactiveSpan,

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -137,20 +137,23 @@ function _instrumentNavigations(client: Client): void {
       routingSpan.end();
     }
 
+    const navigationInfo = {
+      //  `navigation.type` denotes the origin of the navigation. e.g.:
+      //   - link (clicking on a link)
+      //   - goto (programmatic via goto() or redirect())
+      //   - popstate (back/forward navigation)
+      'sentry.sveltekit.navigation.type': navigation.type,
+      'sentry.sveltekit.navigation.from': parameterizedRouteOrigin || undefined,
+      'sentry.sveltekit.navigation.to': parameterizedRouteDestination || undefined,
+    };
+
     startBrowserTracingNavigationSpan(client, {
       name: parameterizedRouteDestination || rawRouteDestination || 'unknown',
       op: 'navigation',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: parameterizedRouteDestination ? 'route' : 'url',
-        'sentry.sveltekit.navigation.from': parameterizedRouteOrigin || undefined,
-        'sentry.sveltekit.navigation.to': parameterizedRouteDestination || undefined,
-
-        //  `navigation.type` denotes the origin of the navigation. e.g.:
-        //   - link (clicking on a link)
-        //   - goto (programmatic via goto() or redirect())
-        //   - popstate (back/forward navigation)
-        'sentry.sveltekit.navigation.type': navigation.type,
+        ...navigationInfo,
       },
     });
 
@@ -159,6 +162,7 @@ function _instrumentNavigations(client: Client): void {
       name: 'SvelteKit Route Change',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
+        ...navigationInfo,
       },
       onlyIfParent: true,
     });

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -45,6 +45,7 @@ describe('browserTracingIntegration', () => {
         }),
         setTag: vi.fn(),
       };
+      return createdRootSpan;
     });
 
   const startBrowserTracingNavigationSpanSpy = vi
@@ -56,6 +57,7 @@ describe('browserTracingIntegration', () => {
         setAttribute: vi.fn(),
         setTag: vi.fn(),
       };
+      return createdRootSpan;
     });
 
   const fakeClient = { getOptions: () => ({}), on: () => {} };
@@ -173,6 +175,7 @@ describe('browserTracingIntegration', () => {
     navigating.set({
       from: { route: { id: '/users' }, url: { pathname: '/users' } },
       to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
+      type: 'link',
     });
 
     // This should update the transaction name with the parameterized route:
@@ -183,9 +186,9 @@ describe('browserTracingIntegration', () => {
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
-      },
-      tags: {
-        'routing.instrumentation': '@sentry/sveltekit',
+        'sentry.sveltekit.navigation.from': '/users',
+        'sentry.sveltekit.navigation.to': '/users/[id]',
+        'sentry.sveltekit.navigation.type': 'link',
       },
     });
 
@@ -195,11 +198,12 @@ describe('browserTracingIntegration', () => {
       name: 'SvelteKit Route Change',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
+        'sentry.sveltekit.navigation.from': '/users',
+        'sentry.sveltekit.navigation.to': '/users/[id]',
+        'sentry.sveltekit.navigation.type': 'link',
       },
+      onlyIfParent: true,
     });
-
-    // eslint-disable-next-line deprecation/deprecation
-    expect(createdRootSpan?.setAttribute).toHaveBeenCalledWith('sentry.sveltekit.navigation.from', '/users');
 
     // We emit `null` here to simulate the end of the navigation lifecycle
     // @ts-expect-error - page is a writable but the types say it's just readable
@@ -246,9 +250,8 @@ describe('browserTracingIntegration', () => {
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
-        },
-        tags: {
-          'routing.instrumentation': '@sentry/sveltekit',
+          'sentry.sveltekit.navigation.from': '/users/[id]',
+          'sentry.sveltekit.navigation.to': '/users/[id]',
         },
       });
 
@@ -258,11 +261,11 @@ describe('browserTracingIntegration', () => {
         name: 'SvelteKit Route Change',
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
+          'sentry.sveltekit.navigation.from': '/users/[id]',
+          'sentry.sveltekit.navigation.to': '/users/[id]',
         },
+        onlyIfParent: true,
       });
-
-      // eslint-disable-next-line deprecation/deprecation
-      expect(createdRootSpan?.setAttribute).toHaveBeenCalledWith('sentry.sveltekit.navigation.from', '/users/[id]');
     });
 
     it('falls back to `window.location.pathname` to determine the raw origin', () => {


### PR DESCRIPTION
Similarly to #10646, this PR adjusts the root span/transaction creation behaviour of the SvelteKit router instrumentation:

- We no longer check for an active span to create a new navigation span
  - This is possible without any `pageloadOngoing` flag because, luckily, pageload and navigation instrumentation is completely decoupled
- Consequently, navigations happening directly after the first pageload will now create their own transaction instead of being attached to the pageload transaction
- Consequently, redirects within a (user perceived) navigation are now treated as separate transactions, where the "current" navigation finishes the transaction of the previous redirect.

Additional changes:
* Removed tag for routing instrumentation (we now have `sentry.origin` for this anyway)
* Added more navigation info to the spans:
  * `sentry.sveltekit.navigation.type`: indicates the source of the navigation (link click, back/forward button press, goto/redirect call, etc)
  * `sentry.sveltekit.navigation.from`: parameterized navigation start
  * `sentry.sveltekit.navigation.to`: parameterized navigation end
  
Added e2e tests to cover new scenarios and additional data.   

closes #10634 