### PR TITLE
ref: Store runtime on isolation scope

### DIFF
--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -40,15 +40,11 @@ describe('Sentry client SDK', () => {
     });
 
     it('sets the runtime tag on the isolation scope', () => {
-      const isolationScope = getIsolationScope();
-
-      // @ts-expect-error need access to protected _tags attribute
-      expect(isolationScope._tags).toEqual({});
+      expect(getIsolationScope().getScopeData().tags).toEqual({});
 
       init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-      // @ts-expect-error need access to protected _tags attribute
-      expect(isolationScope._tags).toEqual({ runtime: 'browser' });
+      expect(getIsolationScope().getScopeData().tags).toEqual({ runtime: 'browser' });
     });
 
     describe('automatically adds integrations', () => {

--- a/packages/astro/test/server/sdk.test.ts
+++ b/packages/astro/test/server/sdk.test.ts
@@ -1,6 +1,5 @@
 import * as SentryNode from '@sentry/node';
 import { SDK_VERSION } from '@sentry/node';
-import { GLOBAL_OBJ } from '@sentry/utils';
 import { vi } from 'vitest';
 
 import { init } from '../../src/server/sdk';
@@ -11,7 +10,10 @@ describe('Sentry server SDK', () => {
   describe('init', () => {
     afterEach(() => {
       vi.clearAllMocks();
-      GLOBAL_OBJ.__SENTRY__.hub = undefined;
+
+      SentryNode.getGlobalScope().clear();
+      SentryNode.getIsolationScope().clear();
+      SentryNode.getCurrentScope().clear();
     });
 
     it('adds Astro metadata to the SDK options', () => {
@@ -37,15 +39,11 @@ describe('Sentry server SDK', () => {
     });
 
     it('sets the runtime tag on the isolation scope', () => {
-      const isolationScope = SentryNode.getIsolationScope();
-
-      // @ts-expect-error need access to protected _tags attribute
-      expect(isolationScope._tags).toEqual({});
+      expect(SentryNode.getIsolationScope().getScopeData().tags).toEqual({});
 
       init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-      // @ts-expect-error need access to protected _tags attribute
-      expect(isolationScope._tags).toEqual({ runtime: 'node' });
+      expect(SentryNode.getIsolationScope().getScopeData().tags).toEqual({ runtime: 'node' });
     });
   });
 });

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -1,8 +1,7 @@
-import { applySdkMetadata, hasTracingEnabled } from '@sentry/core';
+import { addEventProcessor, applySdkMetadata, hasTracingEnabled, setTag } from '@sentry/core';
 import type { BrowserOptions } from '@sentry/react';
 import {
   DEFAULT_TRACE_PROPAGATION_TARGETS,
-  getCurrentScope,
   getDefaultIntegrations as getReactDefaultIntegrations,
   init as reactInit,
 } from '@sentry/react';
@@ -49,15 +48,14 @@ export function init(options: BrowserOptions): void {
 
   reactInit(opts);
 
-  const scope = getCurrentScope();
-  scope.setTag('runtime', 'browser');
+  setTag('runtime', 'browser');
   const filterTransactions: EventProcessor = event =>
     event.type === 'transaction' && event.transaction === '/404' ? null : event;
   filterTransactions.id = 'NextClient404Filter';
-  scope.addEventProcessor(filterTransactions);
+  addEventProcessor(filterTransactions);
 
   if (process.env.NODE_ENV === 'development') {
-    scope.addEventProcessor(devErrorSymbolicationEventProcessor);
+    addEventProcessor(devErrorSymbolicationEventProcessor);
   }
 }
 

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -1,11 +1,6 @@
-import { addTracingExtensions, applySdkMetadata, getClient } from '@sentry/core';
+import { addEventProcessor, addTracingExtensions, applySdkMetadata, getClient, setTag } from '@sentry/core';
 import type { NodeOptions } from '@sentry/node';
-import {
-  Integrations as OriginalIntegrations,
-  getCurrentScope,
-  getDefaultIntegrations,
-  init as nodeInit,
-} from '@sentry/node';
+import { Integrations as OriginalIntegrations, getDefaultIntegrations, init as nodeInit } from '@sentry/node';
 import type { EventProcessor } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -120,16 +115,15 @@ export function init(options: NodeOptions): void {
 
   filterTransactions.id = 'NextServer404TransactionFilter';
 
-  const scope = getCurrentScope();
-  scope.setTag('runtime', 'node');
+  setTag('runtime', 'node');
   if (IS_VERCEL) {
-    scope.setTag('vercel', true);
+    setTag('vercel', true);
   }
 
-  scope.addEventProcessor(filterTransactions);
+  addEventProcessor(filterTransactions);
 
   if (process.env.NODE_ENV === 'development') {
-    scope.addEventProcessor(devErrorSymbolicationEventProcessor);
+    addEventProcessor(devErrorSymbolicationEventProcessor);
   }
 
   DEBUG_BUILD && logger.log('SDK successfully initialized');

--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -1,4 +1,4 @@
-import { BaseClient } from '@sentry/core';
+import { BaseClient, getGlobalScope, getIsolationScope } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import type { BrowserClient } from '@sentry/react';
 import { WINDOW, getClient, getCurrentScope } from '@sentry/react';
@@ -36,7 +36,10 @@ const TEST_DSN = 'https://public@dsn.ingest.sentry.io/1337';
 describe('Client init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    WINDOW.__SENTRY__.hub = undefined;
+
+    getGlobalScope().clear();
+    getIsolationScope().clear();
+    getCurrentScope().clear();
   });
 
   it('inits the React SDK', () => {
@@ -72,15 +75,11 @@ describe('Client init()', () => {
   });
 
   it('sets runtime on scope', () => {
-    const currentScope = getCurrentScope();
+    expect(SentryReact.getIsolationScope().getScopeData().tags).toEqual({});
 
-    // @ts-expect-error need access to protected _tags attribute
-    expect(currentScope._tags).toEqual({});
+    init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-    init({});
-
-    // @ts-expect-error need access to protected _tags attribute
-    expect(currentScope._tags).toEqual({ runtime: 'browser' });
+    expect(SentryReact.getIsolationScope().getScopeData().tags).toEqual({ runtime: 'browser' });
   });
 
   it('adds 404 transaction filter', () => {

--- a/packages/nextjs/test/serverSdk.test.ts
+++ b/packages/nextjs/test/serverSdk.test.ts
@@ -18,8 +18,12 @@ function findIntegrationByName(integrations: Integration[] = [], name: string): 
 describe('Server init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    // @ts-expect-error for testing
-    delete GLOBAL_OBJ.__SENTRY__;
+
+    SentryNode.getGlobalScope().clear();
+    SentryNode.getIsolationScope().clear();
+    SentryNode.getCurrentScope().clear();
+
+    GLOBAL_OBJ.__SENTRY__.hub = undefined;
     delete process.env.VERCEL;
   });
 
@@ -68,15 +72,11 @@ describe('Server init()', () => {
   });
 
   it('sets runtime on scope', () => {
-    const currentScope = getCurrentScope();
+    expect(SentryNode.getIsolationScope().getScopeData().tags).toEqual({});
 
-    // @ts-expect-error need access to protected _tags attribute
-    expect(currentScope._tags).toEqual({});
+    init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-    init({});
-
-    // @ts-expect-error need access to protected _tags attribute
-    expect(currentScope._tags).toEqual({ runtime: 'node' });
+    expect(SentryNode.getIsolationScope().getScopeData().tags).toEqual({ runtime: 'node' });
   });
 
   // TODO: test `vercel` tag when running on Vercel

--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -1,5 +1,5 @@
-import { applySdkMetadata } from '@sentry/core';
-import { getCurrentScope, init as reactInit } from '@sentry/react';
+import { applySdkMetadata, setTag } from '@sentry/core';
+import { init as reactInit } from '@sentry/react';
 import type { RemixOptions } from './utils/remixOptions';
 export { captureRemixErrorBoundaryError } from './client/errors';
 export {
@@ -22,5 +22,5 @@ export function init(options: RemixOptions): void {
 
   reactInit(opts);
 
-  getCurrentScope().setTag('runtime', 'browser');
+  setTag('runtime', 'browser');
 }

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -1,7 +1,6 @@
 import { applySdkMetadata } from '@sentry/core';
 import type { NodeOptions } from '@sentry/node';
-import { getClient } from '@sentry/node';
-import { getCurrentScope, init as nodeInit } from '@sentry/node';
+import { getClient, init as nodeInit, setTag } from '@sentry/node';
 import { logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './utils/debug-build';
@@ -127,5 +126,5 @@ export function init(options: RemixOptions): void {
 
   nodeInit(options as NodeOptions);
 
-  getCurrentScope().setTag('runtime', 'node');
+  setTag('runtime', 'node');
 }

--- a/packages/remix/test/index.client.test.ts
+++ b/packages/remix/test/index.client.test.ts
@@ -1,6 +1,4 @@
-import { getCurrentScope } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
-import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { init } from '../src/index.client';
 
@@ -9,7 +7,10 @@ const reactInit = jest.spyOn(SentryReact, 'init');
 describe('Client init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    GLOBAL_OBJ.__SENTRY__.hub = undefined;
+
+    SentryReact.getGlobalScope().clear();
+    SentryReact.getIsolationScope().clear();
+    SentryReact.getCurrentScope().clear();
   });
 
   it('inits the React SDK', () => {
@@ -39,14 +40,10 @@ describe('Client init()', () => {
   });
 
   it('sets runtime on scope', () => {
-    const currentScope = getCurrentScope();
+    expect(SentryReact.getIsolationScope().getScopeData().tags).toEqual({});
 
-    // @ts-expect-error need access to protected _tags attribute
-    expect(currentScope._tags).toEqual({});
+    init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-    init({});
-
-    // @ts-expect-error need access to protected _tags attribute
-    expect(currentScope._tags).toEqual({ runtime: 'browser' });
+    expect(SentryReact.getIsolationScope().getScopeData().tags).toEqual({ runtime: 'browser' });
   });
 });

--- a/packages/remix/test/index.server.test.ts
+++ b/packages/remix/test/index.server.test.ts
@@ -8,6 +8,11 @@ const nodeInit = jest.spyOn(SentryNode, 'init');
 describe('Server init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
+
+    SentryNode.getGlobalScope().clear();
+    SentryNode.getIsolationScope().clear();
+    SentryNode.getCurrentScope().clear();
+
     GLOBAL_OBJ.__SENTRY__.hub = undefined;
   });
 
@@ -46,15 +51,11 @@ describe('Server init()', () => {
   });
 
   it('sets runtime on scope', () => {
-    const currentScope = SentryNode.getCurrentScope();
+    expect(SentryNode.getIsolationScope().getScopeData().tags).toEqual({});
 
-    // @ts-expect-error need access to protected _tags attribute
-    expect(currentScope._tags).toEqual({});
+    init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-    init({});
-
-    // @ts-expect-error need access to protected _tags attribute
-    expect(currentScope._tags).toEqual({ runtime: 'node' });
+    expect(SentryNode.getIsolationScope().getScopeData().tags).toEqual({ runtime: 'node' });
   });
 
   it('has both node and tracing integrations', () => {

--- a/packages/sveltekit/test/client/sdk.test.ts
+++ b/packages/sveltekit/test/client/sdk.test.ts
@@ -1,7 +1,13 @@
-import { getClient, getIsolationScope } from '@sentry/core';
 import type { BrowserClient } from '@sentry/svelte';
 import * as SentrySvelte from '@sentry/svelte';
-import { SDK_VERSION, WINDOW, browserTracingIntegration } from '@sentry/svelte';
+import {
+  SDK_VERSION,
+  browserTracingIntegration,
+  getClient,
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+} from '@sentry/svelte';
 import { vi } from 'vitest';
 
 import { BrowserTracing, init } from '../../src/client';
@@ -13,7 +19,10 @@ describe('Sentry client SDK', () => {
   describe('init', () => {
     afterEach(() => {
       vi.clearAllMocks();
-      WINDOW.__SENTRY__.hub = undefined;
+
+      getGlobalScope().clear();
+      getIsolationScope().clear();
+      getCurrentScope().clear();
     });
 
     it('adds SvelteKit metadata to the SDK options', () => {
@@ -39,15 +48,11 @@ describe('Sentry client SDK', () => {
     });
 
     it('sets the runtime tag on the isolation scope', () => {
-      const isolationScope = getIsolationScope();
-
-      // @ts-expect-error need access to protected _tags attribute
-      expect(isolationScope._tags).toEqual({});
+      expect(getIsolationScope().getScopeData().tags).toEqual({});
 
       init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-      // @ts-expect-error need access to protected _tags attribute
-      expect(isolationScope._tags).toEqual({ runtime: 'browser' });
+      expect(getIsolationScope().getScopeData().tags).toEqual({ runtime: 'browser' });
     });
 
     describe('automatically added integrations', () => {

--- a/packages/sveltekit/test/server/sdk.test.ts
+++ b/packages/sveltekit/test/server/sdk.test.ts
@@ -1,7 +1,6 @@
 import * as SentryNode from '@sentry/node';
 import type { NodeClient } from '@sentry/node';
 import { SDK_VERSION, getClient } from '@sentry/node';
-import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { init } from '../../src/server/sdk';
 
@@ -11,7 +10,10 @@ describe('Sentry server SDK', () => {
   describe('init', () => {
     afterEach(() => {
       vi.clearAllMocks();
-      GLOBAL_OBJ.__SENTRY__.hub = undefined;
+
+      SentryNode.getGlobalScope().clear();
+      SentryNode.getIsolationScope().clear();
+      SentryNode.getCurrentScope().clear();
     });
 
     it('adds SvelteKit metadata to the SDK options', () => {
@@ -37,15 +39,11 @@ describe('Sentry server SDK', () => {
     });
 
     it('sets the runtime tag on the isolation scope', () => {
-      const isolationScope = SentryNode.getIsolationScope();
-
-      // @ts-expect-error need access to protected _tags attribute
-      expect(isolationScope._tags).toEqual({});
+      expect(SentryNode.getIsolationScope().getScopeData().tags).toEqual({});
 
       init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-      // @ts-expect-error need access to protected _tags attribute
-      expect(isolationScope._tags).toEqual({ runtime: 'node' });
+      expect(SentryNode.getIsolationScope().getScopeData().tags).toEqual({ runtime: 'node' });
     });
 
     it('adds rewriteFramesIntegration by default', () => {


### PR DESCRIPTION
This was a bit inconsistent now, we sometimes stored it on the current and sometimes on the isolation scope. Fixing this to always be on the isolation scope, for consistency.