### PR TITLE
feat(browser): Export `getIsolationScope` and `getGlobalScope`

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -37,6 +37,8 @@ export {
   getClient,
   isInitialized,
   getCurrentScope,
+  getIsolationScope,
+  getGlobalScope,
   Hub,
   // eslint-disable-next-line deprecation/deprecation
   // eslint-disable-next-line deprecation/deprecation


### PR DESCRIPTION
We forgot to re-export these, apparently.