### PR TITLE
fix(tracing): Guard against missing `window.location`

### DIFF
--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -266,7 +266,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
       isPageloadTransaction, // should wait for finish signal if it's a pageload transaction
     );
 
-    if (isPageloadTransaction) {
+    if (isPageloadTransaction && WINDOW.document) {
       WINDOW.document.addEventListener('readystatechange', () => {
         if (['interactive', 'complete'].includes(WINDOW.document.readyState)) {
           idleTransaction.sendAutoFinishSignal();
@@ -295,7 +295,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         options;
 
       let activeSpan: Span | undefined;
-      let startingUrl: string | undefined = WINDOW.location.href;
+      let startingUrl: string | undefined = WINDOW.location && WINDOW.location.href;
 
       client.on('startNavigationSpan', (context: StartSpanOptions) => {
         if (activeSpan) {
@@ -321,7 +321,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         });
       });
 
-      if (options.instrumentPageLoad) {
+      if (options.instrumentPageLoad && WINDOW.location) {
         const context: StartSpanOptions = {
           name: WINDOW.location.pathname,
           // pageload should always start at timeOrigin (and needs to be in s, not ms)
@@ -334,7 +334,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         startBrowserTracingPageLoadSpan(client, context);
       }
 
-      if (options.instrumentNavigation) {
+      if (options.instrumentNavigation && WINDOW.location) {
         addHistoryInstrumentationHandler(({ to, from }) => {
           /**
            * This early return is there to account for some cases where a navigation transaction starts right after


### PR DESCRIPTION
We should also backport this to v7, probably.

Closes https://github.com/getsentry/sentry-javascript/issues/10578