### PR TITLE
fix(publish): Ensure `@sentry/hub` is published in v7

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -133,6 +133,9 @@ targets:
 
   ## 8. Deprecated packages we still release (but no packages depend on them anymore)
   - name: npm
+    id: '@sentry/hub'
+    includeNames: /^sentry-hub-\d.*\.tgz$/
+  - name: npm
     id: '@sentry/tracing'
     includeNames: /^sentry-tracing-\d.*\.tgz$/
 

--- a/dev-packages/e2e-tests/verdaccio-config/config.yaml
+++ b/dev-packages/e2e-tests/verdaccio-config/config.yaml
@@ -200,6 +200,12 @@ packages:
     unpublish: $all
     # proxy: npmjs # Don't proxy for E2E tests!
 
+  '@sentry/hub':
+    access: $all
+    publish: $all
+    unpublish: $all
+    # proxy: npmjs # Don't proxy for E2E tests!
+
   '@sentry-internal/*':
     access: $all
     publish: $all

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "packages/eslint-plugin-sdk",
     "packages/feedback",
     "packages/gatsby",
+    "packages/hub",
     "packages/integrations",
     "packages/integration-shims",
     "packages/nextjs",

--- a/packages/hub/LICENSE
+++ b/packages/hub/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2019 Sentry (https://sentry.io) and individual contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -1,0 +1,21 @@
+<p align="center">
+  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+  </a>
+</p>
+
+# Sentry JavaScript SDK Hub
+
+[![npm version](https://img.shields.io/npm/v/@sentry/hub.svg)](https://www.npmjs.com/package/@sentry/hub)
+[![npm dm](https://img.shields.io/npm/dm/@sentry/hub.svg)](https://www.npmjs.com/package/@sentry/hub)
+[![npm dt](https://img.shields.io/npm/dt/@sentry/hub.svg)](https://www.npmjs.com/package/@sentry/hub)
+
+## Links
+
+- [Official SDK Docs](https://docs.sentry.io/quickstart/)
+- [TypeDoc](http://getsentry.github.io/sentry-javascript/)
+
+## General
+
+This package only exists anymore to enable a seamless publishing process between v7 and v8 of the JS SDK packages. It
+will be removed in a future version.

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -15,7 +15,7 @@
 - [Official SDK Docs](https://docs.sentry.io/quickstart/)
 - [TypeDoc](http://getsentry.github.io/sentry-javascript/)
 
-## General
+## IMPORTANT
 
 This package only exists anymore to enable a seamless publishing process between v7 and v8 of the JS SDK packages. It
 will be removed in a future version.

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -14,7 +14,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "mkdir -p build",
+    "build": "mkdir -p build && touch build/dummy.js",
     "build:tarball": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "clean": "rimraf build coverage sentry-hub-*.tgz"
   },

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@sentry/hub",
+  "version": "7.100.0",
+  "description": "Placeholder package for the former @sentry/hub package for publishing",
+  "repository": "git://github.com/getsentry/sentry-javascript.git",
+  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/hub",
+  "author": "Sentry",
+  "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
+  "files": [],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "mkdir -p build",
+    "build:tarball": "ts-node ../../scripts/prepack.ts && npm pack ./build",
+    "clean": "rimraf build coverage sentry-hub-*.tgz"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "sideEffects": false
+}

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "mkdir -p build && touch build/dummy.js",
+    "build:transpile": "yarn build",
     "build:tarball": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "clean": "rimraf build coverage sentry-hub-*.tgz"
   },


### PR DESCRIPTION
Since we deleted `@sentry/hub` in #10530, we also removed the craft NPM target for the hub package. Given that the craft config is always taken from `develop` (generally, the default branch of the repository), Craft no longer published `@sentry/hub` when we cut a release from our `v7` branch.

Unfortunately, the NPM target does not support an optional `onlyIfPresent` configuration, meaning for now, we have to continue publishing a `@sentry/hub` placeholder package when we cut a release from `develop` (i.e. our v8 branch at the moment).

I'll spend some time trying to adjust our publishing/craft process to finally unblock us here. We shouldn't have to continue publishing a placeholder just to ensure we can publish v7 correctly.