### PR TITLE
test(nextjs): Fix failing unit tests on `v7`

### DIFF
--- a/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
+++ b/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
@@ -35,7 +35,7 @@ describe('Sentry webpack plugin config', () => {
         org: 'squirrelChasers', // from user webpack plugin config
         project: 'simulator', // from user webpack plugin config
         authToken: 'dogsarebadatkeepingsecrets', // picked up from env
-        stripPrefix: ['webpack://_N_E/'], // default
+        stripPrefix: ['webpack://_N_E/', 'webpack://'], // default
         urlPrefix: '~/_next', // default
         entries: [],
         release: 'doGsaREgReaT', // picked up from env


### PR DESCRIPTION
Looks like we forgot to adjust a test in https://github.com/getsentry/sentry-javascript/pull/10641 and for some reason CI gave green light (caching issue?). This PR fixes the test so that we can hopefully release 7.101.1 afterwards.