### PR TITLE
chore(ci): Ensure "Build & Test" workflow runs on `v7`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - v7
       - master
       - release/**
   pull_request:
@@ -168,7 +169,7 @@ jobs:
       changed_browser_integration: ${{ steps.changed.outputs.browser_integration }}
       changed_any_code: ${{ steps.changed.outputs.any_code }}
       # Note: These next three have to be checked as strings ('true'/'false')!
-      is_develop: ${{ github.ref == 'refs/heads/develop' }}
+      is_develop: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/v7' }}
       is_release: ${{ startsWith(github.ref, 'refs/heads/release/') }}
       # When merging into master, or from master
       is_gitflow_sync: ${{ github.head_ref == 'master' || github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,6 +169,7 @@ jobs:
       changed_browser_integration: ${{ steps.changed.outputs.browser_integration }}
       changed_any_code: ${{ steps.changed.outputs.any_code }}
       # Note: These next three have to be checked as strings ('true'/'false')!
+      # is_develop for v7 now also means we're on the `v7` branch.
       is_develop: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/v7' }}
       is_release: ${{ startsWith(github.ref, 'refs/heads/release/') }}
       # When merging into master, or from master
@@ -314,7 +315,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           skip_step: build
-          main_branch: develop
+          main_branch: v7
           # When on release branch, we want to always run
           # Else, we fall back to the default handling of the action
           run_for_branch: ${{ (needs.job_get_metadata.outputs.is_release == 'true' && 'true') || '' }}


### PR DESCRIPTION
Noticed our "Build & Test" workflow doesn't run on v7 which caused failing tests on the v7 branch, [blocking](https://github.com/getsentry/publish/issues/3412) a release. This PR adds `v7` to one of the branches where the workflow is running. 

Furthermore:
- adjusted the `is_develop` variable to also be `true` for `v7`
- size check to compare against `v7`

I think these additional changes make sense but happy to revert if reviewers have concerns