### PR TITLE
test: Improve node integration test running

### DIFF
--- a/dev-packages/node-integration-tests/jest.config.js
+++ b/dev-packages/node-integration-tests/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   ...baseConfig,
   testMatch: ['**/test.ts'],
   setupFilesAfterEnv: ['./jest.setup.js'],
+  coverageReporters: ['json', 'lcov', 'clover'],
 };

--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -10,7 +10,6 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  debug: true,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 

--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -10,13 +10,13 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  debug: true,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 
 function longWork() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
-    // eslint-disable-next-line no-unused-vars
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);
   }

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -10,7 +10,6 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  debug: true,
   autoSessionTracking: false,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -10,6 +10,7 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  debug: true,
   autoSessionTracking: false,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
@@ -17,7 +18,6 @@ Sentry.init({
 function longWork() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
-    // eslint-disable-next-line no-unused-vars
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);
   }

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -10,7 +10,6 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  debug: true,
   autoSessionTracking: false,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -10,6 +10,7 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  debug: true,
   autoSessionTracking: false,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
@@ -17,7 +18,6 @@ Sentry.init({
 function longWork() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
-    // eslint-disable-next-line no-unused-vars
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);
   }

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -10,7 +10,6 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  debug: true,
   autoSessionTracking: false,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
@@ -18,7 +17,6 @@ Sentry.init({
 function longWork() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
-    // eslint-disable-next-line no-unused-vars
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);
   }

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -11,6 +11,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   autoSessionTracking: false,
+  debug: true,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 

--- a/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
@@ -5,6 +5,7 @@ function configureSentry() {
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     autoSessionTracking: false,
+    debug: true,
     integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
   });
 }

--- a/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
@@ -4,7 +4,6 @@ function configureSentry() {
   Sentry.init({
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
-    debug: true,
     autoSessionTracking: false,
     integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
   });

--- a/dev-packages/node-integration-tests/suites/anr/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit.js
@@ -5,6 +5,7 @@ function configureSentry() {
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     autoSessionTracking: false,
+    debug: true,
     integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
   });
 }

--- a/dev-packages/node-integration-tests/suites/anr/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit.js
@@ -4,7 +4,6 @@ function configureSentry() {
   Sentry.init({
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
-    debug: true,
     autoSessionTracking: false,
     integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
   });

--- a/dev-packages/node-integration-tests/suites/proxy/basic.js
+++ b/dev-packages/node-integration-tests/suites/proxy/basic.js
@@ -8,7 +8,6 @@ proxy.listen(0, () => {
 
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    debug: true,
     transportOptions: {
       proxy: `http://localhost:${proxyPort}`,
     },

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/scenario.js
@@ -4,7 +4,6 @@ const Sentry = require('@sentry/node-experimental');
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  debug: true,
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/mongoose/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/mongoose/scenario.js
@@ -4,7 +4,6 @@ const Sentry = require('@sentry/node-experimental');
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  debug: true,
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing-new/httpIntegration/spans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/httpIntegration/spans/scenario.ts
@@ -8,7 +8,6 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   integrations: [Sentry.httpIntegration({})],
-  debug: true,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
This improves the output and formatting of the node integration tests, making it a bit easier to work with them:

1. Removed the coverage output, making the general output much clearer
2. Ensure we have color in the jest output, making it easier to scan it
3. Remove logging around started tests & workers, streamlining the output and aligning it more with the usual jest output.
4. Move skipped output to the end of the test, clearing up the output for actually run tests
5. Update summary at the bottom to show success/failed/skipped test numbers
6. Add color to summary output (error/success/skipped) to make it clearer.
7. Show relative path names instead of full path names

Skipped tests:
<img width="528" alt="Screenshot 2024-02-15 at 12 04 29" src="https://github.com/getsentry/sentry-javascript/assets/2411343/02d849c8-b8f4-4775-bd5c-ce4e8e18cfc2">

Failed test:
<img width="1138" alt="Screenshot 2024-02-15 at 11 46 42" src="https://github.com/getsentry/sentry-javascript/assets/2411343/72ee1d31-6c49-4108-b891-ed5492d183ac">

Successful test:

<img width="1002" alt="Screenshot 2024-02-15 at 11 48 28" src="https://github.com/getsentry/sentry-javascript/assets/2411343/1ee3b2a2-ecd0-4eaf-b68b-2d534f1c4622">

Failed test summary:
<img width="491" alt="Screenshot 2024-02-15 at 11 52 19" src="https://github.com/getsentry/sentry-javascript/assets/2411343/b19d051d-189b-4459-8a28-9b9c6dcc2bb5">

Successful test summary:
<img width="296" alt="Screenshot 2024-02-15 at 11 55 28" src="https://github.com/getsentry/sentry-javascript/assets/2411343/bc369482-08ab-4b50-8cf8-3c7c2e9cf51c">

