### PR TITLE
ref: Remove usage of `makeMain` in tests

### DIFF
--- a/packages/bun/test/integrations/bunserver.test.ts
+++ b/packages/bun/test/integrations/bunserver.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
-import { Hub, getDynamicSamplingContextFromSpan, makeMain, spanIsSampled, spanToJSON } from '@sentry/core';
+import { getDynamicSamplingContextFromSpan, setCurrentClient, spanIsSampled, spanToJSON } from '@sentry/core';
 
 import { BunClient } from '../../src/client';
 import { instrumentBunServe } from '../../src/integrations/bunserver';
@@ -9,7 +9,6 @@ import { getDefaultBunClientOptions } from '../helpers';
 const DEFAULT_PORT = 22114;
 
 describe('Bun Serve Integration', () => {
-  let hub: Hub;
   let client: BunClient;
 
   beforeAll(() => {
@@ -19,10 +18,8 @@ describe('Bun Serve Integration', () => {
   beforeEach(() => {
     const options = getDefaultBunClientOptions({ tracesSampleRate: 1, debug: true });
     client = new BunClient(options);
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
   });
 
   test('generates a transaction around a request', async () => {

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -1,7 +1,7 @@
 import type { Integration, Options } from '@sentry/types';
 import { logger } from '@sentry/utils';
+import { getCurrentScope } from '../../src/currentScopes';
 
-import { Hub, makeMain } from '../../src/hub';
 import {
   addIntegration,
   convertIntegrationFnToClass,
@@ -9,6 +9,7 @@ import {
   installedIntegrations,
   setupIntegration,
 } from '../../src/integration';
+import { setCurrentClient } from '../../src/sdk';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
 function getTestClient(): TestClient {
@@ -617,10 +618,7 @@ describe('addIntegration', () => {
     }
 
     const client = getTestClient();
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
 
     const integration = new CustomIntegration();
     addIntegration(integration);
@@ -636,10 +634,7 @@ describe('addIntegration', () => {
       setupOnce = jest.fn();
     }
 
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = new Hub();
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    getCurrentScope().setClient(undefined);
 
     const integration = new CustomIntegration();
     addIntegration(integration);
@@ -662,10 +657,8 @@ describe('addIntegration', () => {
     }
 
     const client = getTestClient();
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
 
     const integration = new CustomIntegration();
     addIntegration(integration);
@@ -686,10 +679,8 @@ describe('addIntegration', () => {
     }
 
     const client = getTestClient();
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
 
     const integration1 = new CustomIntegration();
     const integration2 = new CustomIntegration();

--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -1,13 +1,12 @@
 import type { Attachment, Breadcrumb, Client, Event } from '@sentry/types';
 import {
-  Hub,
   addTracingExtensions,
   applyScopeDataToEvent,
   getActiveSpan,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  makeMain,
+  setCurrentClient,
   setGlobalScope,
   spanToJSON,
   startInactiveSpan,
@@ -555,10 +554,8 @@ describe('withActiveSpan()', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ enableTracing: true });
     const client = new TestClient(options);
-    const scope = new Scope();
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = new Hub(client, scope);
-    makeMain(hub); // eslint-disable-line deprecation/deprecation
+    setCurrentClient(client);
+    client.init();
   });
 
   it('should set the active span within the callback', () => {

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -1,4 +1,4 @@
-import { Hub, captureCheckIn, makeMain, setCurrentClient } from '@sentry/core';
+import { captureCheckIn, getCurrentScope, setCurrentClient } from '@sentry/core';
 import type { Client, Integration, IntegrationFnResult } from '@sentry/types';
 
 import { installedIntegrations } from '../../src/integration';
@@ -86,13 +86,6 @@ describe('SDK', () => {
 });
 
 describe('captureCheckIn', () => {
-  afterEach(function () {
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = new Hub();
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
-  });
-
   it('returns an id when client is defined', () => {
     const client = {
       captureCheckIn: () => 'some-id-wasd-1234',
@@ -103,6 +96,7 @@ describe('captureCheckIn', () => {
   });
 
   it('returns an id when client is undefined', () => {
+    getCurrentScope().setClient(undefined);
     expect(captureCheckIn({ monitorSlug: 'gogogo', status: 'in_progress' })).toStrictEqual(expect.any(String));
   });
 });

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -1,18 +1,19 @@
 import type { TransactionSource } from '@sentry/types';
-import { Hub, SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, makeMain } from '../../../src';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  setCurrentClient,
+} from '../../../src';
 import { Transaction, getDynamicSamplingContextFromSpan, startInactiveSpan } from '../../../src/tracing';
 import { addTracingExtensions } from '../../../src/tracing';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 describe('getDynamicSamplingContextFromSpan', () => {
-  let hub: Hub;
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 1.0, release: '1.0.1' });
     const client = new TestClient(options);
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
     addTracingExtensions();
   });
 

--- a/packages/core/test/lib/tracing/errors.test.ts
+++ b/packages/core/test/lib/tracing/errors.test.ts
@@ -1,5 +1,5 @@
 import { BrowserClient } from '@sentry/browser';
-import { Hub, addTracingExtensions, makeMain, spanToJSON, startInactiveSpan, startSpan } from '@sentry/core';
+import { addTracingExtensions, setCurrentClient, spanToJSON, startInactiveSpan, startSpan } from '@sentry/core';
 import type { HandlerDataError, HandlerDataUnhandledRejection } from '@sentry/types';
 
 import { getDefaultBrowserClientOptions } from '../../../../tracing/test/testutils';
@@ -34,10 +34,9 @@ describe('registerErrorHandlers()', () => {
     mockAddGlobalErrorInstrumentationHandler.mockClear();
     mockAddGlobalUnhandledRejectionInstrumentationHandler.mockClear();
     const options = getDefaultBrowserClientOptions({ enableTracing: true });
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = new Hub(new BrowserClient(options));
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    const client = new BrowserClient(options);
+    setCurrentClient(client);
+    client.init();
   });
 
   it('registers error instrumentation', () => {

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1,10 +1,11 @@
 import type { Span as SpanType } from '@sentry/types';
 import {
-  Hub,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   addTracingExtensions,
+  getCurrentHub,
   getCurrentScope,
-  makeMain,
+  getGlobalScope,
+  getIsolationScope,
   setCurrentClient,
   spanToJSON,
   withScope,
@@ -28,17 +29,24 @@ const enum Type {
   Async = 'async',
 }
 
-let hub: Hub;
 let client: TestClient;
 
 describe('startSpan', () => {
   beforeEach(() => {
+    addTracingExtensions();
+
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
     const options = getDefaultTestClientOptions({ tracesSampleRate: 0.0 });
     client = new TestClient(options);
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe.each([
@@ -70,7 +78,9 @@ describe('startSpan', () => {
       // @ts-expect-error we are force overriding the transaction return to be undefined
       // The `startTransaction` types are actually wrong - it can return undefined
       // if tracingExtensions are not enabled
-      jest.spyOn(hub, 'startTransaction').mockReturnValue(undefined);
+      // eslint-disable-next-line deprecation/deprecation
+      jest.spyOn(getCurrentHub(), 'startTransaction').mockImplementationOnce(() => undefined);
+
       try {
         const result = await startSpan({ name: 'GET users/[id]' }, () => {
           return callback();
@@ -280,7 +290,7 @@ describe('startSpan', () => {
     expect(spanToJSON(_span!).timestamp).toBeDefined();
   });
 
-  it('allows to pass a `startTime`', () => {
+  it('allows to pass a `startTime` yyy', () => {
     const start = startSpan({ name: 'outer', startTime: [1234, 0] }, span => {
       return spanToJSON(span!).start_timestamp;
     });
@@ -368,6 +378,7 @@ describe('startSpan', () => {
     const options = getDefaultTestClientOptions({ tracesSampler });
     client = new TestClient(options);
     setCurrentClient(client);
+    client.init();
 
     startSpan(
       { name: 'outer', attributes: { test1: 'aa', test2: 'aa' }, data: { test1: 'bb', test3: 'bb' } },
@@ -390,20 +401,17 @@ describe('startSpan', () => {
   });
 
   it('includes the scope at the time the span was started when finished', async () => {
-    const transactionEventPromise = new Promise(resolve => {
-      setCurrentClient(
-        new TestClient(
-          getDefaultTestClientOptions({
-            dsn: 'https://username@domain/123',
-            tracesSampleRate: 1,
-            beforeSendTransaction(event) {
-              resolve(event);
-              return event;
-            },
-          }),
-        ),
-      );
-    });
+    const beforeSendTransaction = jest.fn(event => event);
+
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://username@domain/123',
+        tracesSampleRate: 1,
+        beforeSendTransaction,
+      }),
+    );
+    setCurrentClient(client);
+    client.init();
 
     withScope(scope1 => {
       scope1.setTag('scope', 1);
@@ -415,11 +423,17 @@ describe('startSpan', () => {
       });
     });
 
-    expect(await transactionEventPromise).toMatchObject({
-      tags: {
-        scope: 1,
-      },
-    });
+    await client.flush();
+
+    expect(beforeSendTransaction).toHaveBeenCalledTimes(1);
+    expect(beforeSendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          scope: 1,
+        }),
+      }),
+      expect.anything(),
+    );
   });
 });
 
@@ -427,10 +441,8 @@ describe('startSpanManual', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 1 });
     client = new TestClient(options);
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
   });
 
   it('creates & finishes span', async () => {
@@ -538,10 +550,8 @@ describe('startInactiveSpan', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 1 });
     client = new TestClient(options);
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
   });
 
   it('creates & finishes span', async () => {
@@ -627,20 +637,17 @@ describe('startInactiveSpan', () => {
   });
 
   it('includes the scope at the time the span was started when finished', async () => {
-    const transactionEventPromise = new Promise(resolve => {
-      setCurrentClient(
-        new TestClient(
-          getDefaultTestClientOptions({
-            dsn: 'https://username@domain/123',
-            tracesSampleRate: 1,
-            beforeSendTransaction(event) {
-              resolve(event);
-              return event;
-            },
-          }),
-        ),
-      );
-    });
+    const beforeSendTransaction = jest.fn(event => event);
+
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://username@domain/123',
+        tracesSampleRate: 1,
+        beforeSendTransaction,
+      }),
+    );
+    setCurrentClient(client);
+    client.init();
 
     let span: SpanType | undefined;
 
@@ -654,11 +661,17 @@ describe('startInactiveSpan', () => {
       span?.end();
     });
 
-    expect(await transactionEventPromise).toMatchObject({
-      tags: {
-        scope: 1,
-      },
-    });
+    await client.flush();
+
+    expect(beforeSendTransaction).toHaveBeenCalledTimes(1);
+    expect(beforeSendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          scope: 1,
+        }),
+      }),
+      expect.anything(),
+    );
   });
 });
 
@@ -666,10 +679,8 @@ describe('continueTrace', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 0.0 });
     client = new TestClient(options);
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
   });
 
   it('works without trace & baggage data', () => {

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -7,8 +7,8 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { Hub, Transaction, addTracingExtensions, makeMain } from '@sentry/core';
-import type { TransactionContext } from '@sentry/types';
+import { Transaction, addTracingExtensions, getCurrentHub, setCurrentClient } from '@sentry/core';
+import type { Client, TransactionContext } from '@sentry/types';
 
 import {
   SENTRY_BAGGAGE_HEADER,
@@ -46,12 +46,9 @@ describe('SentryPropagator', () => {
           publicKey: 'abc',
         }),
         emit: () => {},
-      };
-      // @ts-expect-error Use mock client for unit tests
-      // eslint-disable-next-line deprecation/deprecation
-      const hub = new Hub(client);
-      // eslint-disable-next-line deprecation/deprecation
-      makeMain(hub);
+      } as unknown as Client;
+
+      setCurrentClient(client);
 
       afterEach(() => {
         SPAN_MAP.clear();
@@ -64,7 +61,7 @@ describe('SentryPropagator', () => {
 
       function createTransactionAndMaybeSpan(type: PerfType, transactionContext: TransactionContext) {
         // eslint-disable-next-line deprecation/deprecation
-        const transaction = new Transaction(transactionContext, hub);
+        const transaction = new Transaction(transactionContext, getCurrentHub());
         setSentrySpan(transaction.spanContext().spanId, transaction);
         if (type === PerfType.Span) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -5,15 +5,8 @@ import type { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SemanticAttributes, SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import type { SpanStatusType } from '@sentry/core';
-import {
-  Hub,
-  Span as SentrySpan,
-  Transaction,
-  addTracingExtensions,
-  createTransport,
-  makeMain,
-  spanToJSON,
-} from '@sentry/core';
+import { captureException, getCurrentScope, setCurrentClient } from '@sentry/core';
+import { Span as SentrySpan, Transaction, addTracingExtensions, createTransport, spanToJSON } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
 import { resolvedSyncPromise } from '@sentry/utils';
 
@@ -36,7 +29,6 @@ beforeAll(() => {
 });
 
 describe('SentrySpanProcessor', () => {
-  let hub: Hub;
   let client: NodeClient;
   let provider: NodeTracerProvider;
   let spanProcessor: SentrySpanProcessor;
@@ -46,10 +38,8 @@ describe('SentrySpanProcessor', () => {
     SPAN_MAP.clear();
 
     client = new NodeClient(DEFAULT_NODE_CLIENT_OPTIONS);
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
 
     spanProcessor = new SentrySpanProcessor();
     provider = new NodeTracerProvider({
@@ -130,7 +120,7 @@ describe('SentrySpanProcessor', () => {
         expect(sentrySpan?.parentSpanId).toEqual(sentrySpanTransaction?.spanContext().spanId);
 
         // eslint-disable-next-line deprecation/deprecation
-        expect(hub.getScope().getSpan()).toBeUndefined();
+        expect(getCurrentScope().getSpan()).toBeUndefined();
 
         child.end(endTime);
 
@@ -174,7 +164,7 @@ describe('SentrySpanProcessor', () => {
         expect(sentrySpan?.parentSpanId).toEqual(parentOtelSpan.spanContext().spanId);
 
         // eslint-disable-next-line deprecation/deprecation
-        expect(hub.getScope().getSpan()).toBeUndefined();
+        expect(getCurrentScope().getSpan()).toBeUndefined();
 
         child.end(endTime);
 
@@ -965,10 +955,8 @@ describe('SentrySpanProcessor', () => {
         return null;
       },
     });
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
+    client.init();
 
     // Need to register the spanprocessor again
     spanProcessor = new SentrySpanProcessor();
@@ -984,8 +972,7 @@ describe('SentrySpanProcessor', () => {
 
     tracer.startActiveSpan('GET /users', parentOtelSpan => {
       tracer.startActiveSpan('SELECT * FROM users;', child => {
-        // eslint-disable-next-line deprecation/deprecation
-        hub.captureException(new Error('oh nooooo!'));
+        captureException(new Error('oh nooooo!'));
         otelSpan = child as OtelSpan;
         child.end();
       });
@@ -1013,11 +1000,8 @@ describe('SentrySpanProcessor', () => {
         return null;
       },
     });
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
-
+    setCurrentClient(client);
+    client.init();
     const tracer = provider.getTracer('default');
 
     tracer.startActiveSpan('GET /users', parentOtelSpan => {
@@ -1042,48 +1026,6 @@ describe('SentrySpanProcessor', () => {
       span_id: otelSpan.spanContext().spanId,
       trace_id: otelSpan.spanContext().traceId,
     });
-  });
-
-  // Regression test for https://github.com/getsentry/sentry-javascript/issues/7538
-  // Since otel context does not map to when Sentry hubs are cloned
-  // we can't rely on the original hub at transaction creation to contain all
-  // the scope information we want. Let's test to make sure that the information is
-  // grabbed from the new hub.
-  it('handles when a different hub creates the transaction', () => {
-    let sentryTransaction: any;
-
-    client = new NodeClient({
-      ...DEFAULT_NODE_CLIENT_OPTIONS,
-      tracesSampleRate: 1.0,
-    });
-
-    client.on('finishTransaction', transaction => {
-      sentryTransaction = transaction;
-    });
-
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
-
-    // eslint-disable-next-line deprecation/deprecation
-    const newHub = new Hub(client, hub.getScope().clone());
-    // eslint-disable-next-line deprecation/deprecation
-    newHub.getScope().setTag('foo', 'bar');
-
-    const tracer = provider.getTracer('default');
-
-    tracer.startActiveSpan('GET /users', parentOtelSpan => {
-      tracer.startActiveSpan('SELECT * FROM users;', child => {
-        // eslint-disable-next-line deprecation/deprecation
-        makeMain(newHub);
-        child.end();
-      });
-
-      parentOtelSpan.end();
-    });
-
-    expect(sentryTransaction._hub.getScope()._tags.foo).toEqual('bar');
   });
 });
 

--- a/packages/opentelemetry/test/propagator.test.ts
+++ b/packages/opentelemetry/test/propagator.test.ts
@@ -7,8 +7,8 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { Hub, addTracingExtensions, makeMain } from '@sentry/core';
-import type { PropagationContext } from '@sentry/types';
+import { addTracingExtensions, setCurrentClient } from '@sentry/core';
+import type { Client, PropagationContext } from '@sentry/types';
 
 import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER } from '../src/constants';
 import { SentryPropagator } from '../src/propagator';
@@ -40,13 +40,9 @@ describe('SentryPropagator', () => {
         publicKey: 'abc',
       }),
       emit: () => {},
-    };
+    } as unknown as Client;
 
-    // @ts-expect-error Use mock client for unit tests
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = new Hub(client);
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    setCurrentClient(client);
 
     describe('with active span', () => {
       it.each([

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -1,5 +1,5 @@
-import { Hub, addTracingExtensions, makeMain } from '@sentry/core';
-import { NodeClient } from '@sentry/node';
+import { addTracingExtensions } from '@sentry/core';
+import { NodeClient, setCurrentClient } from '@sentry/node';
 import * as SentryNode from '@sentry/node';
 import type { Transaction } from '@sentry/types';
 import type { Handle } from '@sveltejs/kit';
@@ -81,7 +81,6 @@ function resolve(
   };
 }
 
-let hub: Hub;
 let client: NodeClient;
 
 beforeAll(() => {
@@ -91,10 +90,8 @@ beforeAll(() => {
 beforeEach(() => {
   const options = getDefaultNodeClientOptions({ tracesSampleRate: 1.0 });
   client = new NodeClient(options);
-  // eslint-disable-next-line deprecation/deprecation
-  hub = new Hub(client);
-  // eslint-disable-next-line deprecation/deprecation
-  makeMain(hub);
+  setCurrentClient(client);
+  client.init();
 
   mockCaptureException.mockClear();
 });

--- a/packages/tracing-internal/test/browser/backgroundtab.test.ts
+++ b/packages/tracing-internal/test/browser/backgroundtab.test.ts
@@ -1,4 +1,5 @@
-import { Hub, makeMain, spanToJSON, startSpan } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
+import { setCurrentClient, spanToJSON, startSpan } from '@sentry/core';
 import { JSDOM } from 'jsdom';
 
 import { addExtensionMethods } from '../../../tracing/src';
@@ -8,17 +9,15 @@ import { TestClient } from '../utils/TestClient';
 
 describe('registerBackgroundTabDetection', () => {
   let events: Record<string, any> = {};
-  let hub: Hub;
   beforeEach(() => {
     const dom = new JSDOM();
     // @ts-expect-error need to override global document
     global.document = dom.window.document;
 
     const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
-    // eslint-disable-next-line deprecation/deprecation
-    hub = new Hub(new TestClient(options));
-    // eslint-disable-next-line deprecation/deprecation
-    makeMain(hub);
+    const client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
 
     // If we do not add extension methods, invoking hub.startTransaction returns undefined
     // eslint-disable-next-line deprecation/deprecation
@@ -32,8 +31,7 @@ describe('registerBackgroundTabDetection', () => {
 
   afterEach(() => {
     events = {};
-    // eslint-disable-next-line deprecation/deprecation
-    hub.getScope().setSpan(undefined);
+    getCurrentScope().clear();
   });
 
   it('does not create an event listener if global document is undefined', () => {

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -3,23 +3,35 @@ import { BrowserClient } from '@sentry/browser';
 import {
   TRACING_DEFAULTS,
   Transaction,
+  getCurrentHub,
   getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  setCurrentClient,
   spanToJSON,
   startInactiveSpan,
   startSpan,
   startSpanManual,
 } from '@sentry/core';
 
-import { Hub, IdleTransaction, Span, getClient, makeMain } from '../../core/src';
+import { IdleTransaction, Span, getClient } from '../../core/src';
 import { IdleTransactionSpanRecorder } from '../../core/src/tracing/idletransaction';
 import { getDefaultBrowserClientOptions } from './testutils';
 
 const dsn = 'https://123@sentry.io/42';
-let hub: Hub;
 beforeEach(() => {
+  getCurrentScope().clear();
+  getIsolationScope().clear();
+  getGlobalScope().clear();
+
   const options = getDefaultBrowserClientOptions({ dsn, tracesSampleRate: 1 });
-  hub = new Hub(new BrowserClient(options));
-  makeMain(hub);
+  const client = new BrowserClient(options);
+  setCurrentClient(client);
+  client.init();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
 });
 
 describe('IdleTransaction', () => {
@@ -27,7 +39,7 @@ describe('IdleTransaction', () => {
     it('sets the transaction on the scope on creation if onScope is true', () => {
       const transaction = new IdleTransaction(
         { name: 'foo' },
-        hub,
+        getCurrentHub(),
         TRACING_DEFAULTS.idleTimeout,
         TRACING_DEFAULTS.finalTimeout,
         TRACING_DEFAULTS.heartbeatInterval,
@@ -41,7 +53,7 @@ describe('IdleTransaction', () => {
     });
 
     it('does not set the transaction on the scope on creation if onScope is falsey', () => {
-      const transaction = new IdleTransaction({ name: 'foo' }, hub);
+      const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub());
       transaction.initSpanRecorder(10);
 
       const scope = getCurrentScope();
@@ -52,7 +64,7 @@ describe('IdleTransaction', () => {
     it('removes sampled transaction from scope on finish if onScope is true', () => {
       const transaction = new IdleTransaction(
         { name: 'foo' },
-        hub,
+        getCurrentHub(),
         TRACING_DEFAULTS.idleTimeout,
         TRACING_DEFAULTS.finalTimeout,
         TRACING_DEFAULTS.heartbeatInterval,
@@ -71,7 +83,7 @@ describe('IdleTransaction', () => {
     it('removes unsampled transaction from scope on finish if onScope is true', () => {
       const transaction = new IdleTransaction(
         { name: 'foo', sampled: false },
-        hub,
+        getCurrentHub(),
         TRACING_DEFAULTS.idleTimeout,
         TRACING_DEFAULTS.finalTimeout,
         TRACING_DEFAULTS.heartbeatInterval,
@@ -89,7 +101,7 @@ describe('IdleTransaction', () => {
     it('does not remove transaction from scope on finish if another transaction was set there', () => {
       const transaction = new IdleTransaction(
         { name: 'foo' },
-        hub,
+        getCurrentHub(),
         TRACING_DEFAULTS.idleTimeout,
         TRACING_DEFAULTS.finalTimeout,
         TRACING_DEFAULTS.heartbeatInterval,
@@ -97,7 +109,7 @@ describe('IdleTransaction', () => {
       );
       transaction.initSpanRecorder(10);
 
-      const otherTransaction = new Transaction({ name: 'bar' }, hub);
+      const otherTransaction = new Transaction({ name: 'bar' }, getCurrentHub());
       // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(otherTransaction);
 
@@ -115,7 +127,7 @@ describe('IdleTransaction', () => {
   });
 
   it('push and pops activities', () => {
-    const transaction = new IdleTransaction({ name: 'foo' }, hub);
+    const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub());
     const mockFinish = jest.spyOn(transaction, 'end');
     transaction.initSpanRecorder(10);
     expect(transaction.activities).toMatchObject({});
@@ -135,7 +147,7 @@ describe('IdleTransaction', () => {
   });
 
   it('does not push activities if a span already has an end timestamp', () => {
-    const transaction = new IdleTransaction({ name: 'foo' }, hub);
+    const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub());
     transaction.initSpanRecorder(10);
     expect(transaction.activities).toMatchObject({});
     // eslint-disable-next-line deprecation/deprecation
@@ -146,7 +158,7 @@ describe('IdleTransaction', () => {
   });
 
   it('does not finish if there are still active activities', () => {
-    const transaction = new IdleTransaction({ name: 'foo' }, hub);
+    const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub());
     const mockFinish = jest.spyOn(transaction, 'end');
     transaction.initSpanRecorder(10);
     expect(transaction.activities).toMatchObject({});
@@ -170,7 +182,7 @@ describe('IdleTransaction', () => {
   it('calls beforeFinish callback before finishing', () => {
     const mockCallback1 = jest.fn();
     const mockCallback2 = jest.fn();
-    const transaction = new IdleTransaction({ name: 'foo' }, hub);
+    const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub());
     transaction.initSpanRecorder(10);
     transaction.registerBeforeFinishCallback(mockCallback1);
     transaction.registerBeforeFinishCallback(mockCallback2);
@@ -190,7 +202,7 @@ describe('IdleTransaction', () => {
   });
 
   it('filters spans on finish', () => {
-    const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub);
+    const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub());
     transaction.initSpanRecorder(10);
     // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
@@ -231,7 +243,7 @@ describe('IdleTransaction', () => {
   });
 
   it('filters out spans that exceed final timeout', () => {
-    const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, 1000, 3000);
+    const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub(), 1000, 3000);
     transaction.initSpanRecorder(10);
     // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
@@ -246,7 +258,11 @@ describe('IdleTransaction', () => {
   });
 
   it('should record dropped transactions', async () => {
-    const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234, sampled: false }, hub, 1000);
+    const transaction = new IdleTransaction(
+      { name: 'foo', startTimestamp: 1234, sampled: false },
+      getCurrentHub(),
+      1000,
+    );
 
     const client = getClient()!;
 
@@ -260,7 +276,7 @@ describe('IdleTransaction', () => {
 
   describe('_idleTimeout', () => {
     it('finishes if no activities are added to the transaction', () => {
-      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub);
+      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub());
       transaction.initSpanRecorder(10);
 
       jest.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
@@ -268,7 +284,7 @@ describe('IdleTransaction', () => {
     });
 
     it('does not finish if a activity is started', () => {
-      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub);
+      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub());
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
@@ -281,7 +297,7 @@ describe('IdleTransaction', () => {
 
     it('does not finish when idleTimeout is not exceed after last activity finished', () => {
       const idleTimeout = 10;
-      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
+      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub(), idleTimeout);
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
@@ -299,7 +315,7 @@ describe('IdleTransaction', () => {
 
     it('finish when idleTimeout is exceeded after last activity finished', () => {
       const idleTimeout = 10;
-      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
+      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub(), idleTimeout);
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
@@ -319,7 +335,7 @@ describe('IdleTransaction', () => {
   describe('cancelIdleTimeout', () => {
     it('permanent idle timeout cancel is not restarted by child span start', () => {
       const idleTimeout = 10;
-      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
+      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub(), idleTimeout);
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
@@ -335,7 +351,7 @@ describe('IdleTransaction', () => {
 
     it('permanent idle timeout cancel finished the transaction with the last child', () => {
       const idleTimeout = 10;
-      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
+      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub(), idleTimeout);
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
@@ -357,7 +373,7 @@ describe('IdleTransaction', () => {
 
     it('permanent idle timeout cancel finishes transaction if there are no activities', () => {
       const idleTimeout = 10;
-      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
+      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub(), idleTimeout);
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
@@ -373,7 +389,7 @@ describe('IdleTransaction', () => {
 
     it('default idle cancel timeout is restarted by child span change', () => {
       const idleTimeout = 10;
-      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
+      const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, getCurrentHub(), idleTimeout);
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
@@ -397,7 +413,7 @@ describe('IdleTransaction', () => {
   describe('heartbeat', () => {
     it('does not mark transaction as `DeadlineExceeded` if idle timeout has not been reached', () => {
       // 20s to exceed 3 heartbeats
-      const transaction = new IdleTransaction({ name: 'foo' }, hub, 20000);
+      const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub(), 20000);
       const mockFinish = jest.spyOn(transaction, 'end');
 
       expect(transaction.status).not.toEqual('deadline_exceeded');
@@ -420,7 +436,7 @@ describe('IdleTransaction', () => {
     });
 
     it('finishes a transaction after 3 beats', () => {
-      const transaction = new IdleTransaction({ name: 'foo' }, hub, TRACING_DEFAULTS.idleTimeout);
+      const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub(), TRACING_DEFAULTS.idleTimeout);
       const mockFinish = jest.spyOn(transaction, 'end');
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
@@ -443,7 +459,7 @@ describe('IdleTransaction', () => {
     });
 
     it('resets after new activities are added', () => {
-      const transaction = new IdleTransaction({ name: 'foo' }, hub, TRACING_DEFAULTS.idleTimeout, 50000);
+      const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub(), TRACING_DEFAULTS.idleTimeout, 50000);
       const mockFinish = jest.spyOn(transaction, 'end');
       transaction.initSpanRecorder(10);
       // eslint-disable-next-line deprecation/deprecation
@@ -537,7 +553,7 @@ describe('IdleTransactionSpanRecorder', () => {
     const mockPushActivity = jest.fn();
     const mockPopActivity = jest.fn();
 
-    const transaction = new IdleTransaction({ name: 'foo' }, hub);
+    const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub());
     const spanRecorder = new IdleTransactionSpanRecorder(
       mockPushActivity,
       mockPopActivity,


### PR DESCRIPTION
This removes most (but not all) usage of `makeMain` in our own tests.
Some node tests remain for now, most of these will eventually be removed, so I figured no need to change them right now.