### PR TITLE
fix(browser): Wait for document 'complete' state before terminating pageload transaction

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,13 @@
 # Upgrading from 7.x to 8.x
 
+## Updated Logic for Browser Pageload Transactions
+
+The v8 release includes a behavioural change for pageload transactions. Transactions that track browser pageloads will
+now at least wait for the
+[`complete` document ready state](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) before being
+finished. Note that this change may affect span duration in Sentry - keep this in mind if you have alerts set up for
+this metric.
+
 ## Updated behaviour of `tracePropagationTargets` in the browser (HTTP tracing headers & CORS)
 
 We updated the behaviour of the SDKs when no `tracePropagationTargets` option was defined. As a reminder, you can

--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -268,12 +268,12 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
 
     if (isPageloadTransaction && WINDOW.document) {
       WINDOW.document.addEventListener('readystatechange', () => {
-        if (['interactive', 'complete'].includes(WINDOW.document.readyState)) {
+        if (WINDOW.document.readyState === 'complete') {
           idleTransaction.sendAutoFinishSignal();
         }
       });
 
-      if (['interactive', 'complete'].includes(WINDOW.document.readyState)) {
+      if (WINDOW.document.readyState === 'complete') {
         idleTransaction.sendAutoFinishSignal();
       }
     }

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -363,12 +363,12 @@ export class BrowserTracing implements Integration {
 
     if (isPageloadTransaction) {
       WINDOW.document.addEventListener('readystatechange', () => {
-        if (['interactive', 'complete'].includes(WINDOW.document.readyState)) {
+        if (WINDOW.document.readyState === 'complete') {
           idleTransaction.sendAutoFinishSignal();
         }
       });
 
-      if (['interactive', 'complete'].includes(WINDOW.document.readyState)) {
+      if (WINDOW.document.readyState === 'complete') {
         idleTransaction.sendAutoFinishSignal();
       }
     }


### PR DESCRIPTION
We have the theory that we are missing out on web vitals because we are still ending transactions too early.

This PR builds on https://github.com/getsentry/sentry-javascript/pull/10215 where we started to delay the txn auto-finishing until the document is interactive. With the change in this PR we delay it even further until al dom resources have loaded.

We make the assumption that this is what users actually want.