### PR TITLE
ref(core): Rename `Span` class to `SentrySpan`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -55,6 +55,11 @@ The following previously deprecated API has been removed from the `@sentry/nextj
 - `IS_BUILD`
 - `isBuild`
 
+## Removal of `Span` class export from SDK packages
+
+In v8, we are no longer exporting the `Span` class from SDK packages (e.g. `@sentry/browser` or `@sentry/node`).
+Internally, this class is now called `SentrySpan`, and it is no longer meant to be used by users directly.
+
 ## Removal of Severity Enum
 
 In v7 we deprecated the `Severity` enum in favor of using the `SeverityLevel` type. In v8 we removed the `Severity`

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -1,5 +1,5 @@
 import { Feedback, feedbackIntegration } from '@sentry-internal/feedback';
-import { BrowserTracing, Span, addExtensionMethods } from '@sentry-internal/tracing';
+import { BrowserTracing, addExtensionMethods } from '@sentry-internal/tracing';
 import { Replay, replayIntegration } from '@sentry/replay';
 import { bundleBrowserTracingIntegration as browserTracingIntegration } from './helpers';
 
@@ -27,7 +27,6 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
-  Span,
   addExtensionMethods,
 };
 export * from './index.bundle.base';

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -1,5 +1,5 @@
 import { Feedback, feedbackIntegration } from '@sentry-internal/integration-shims';
-import { BrowserTracing, Span, addExtensionMethods } from '@sentry-internal/tracing';
+import { BrowserTracing, addExtensionMethods } from '@sentry-internal/tracing';
 import { Replay, replayIntegration } from '@sentry/replay';
 import { bundleBrowserTracingIntegration as browserTracingIntegration } from './helpers';
 
@@ -27,7 +27,6 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
-  Span,
   addExtensionMethods,
 };
 export * from './index.bundle.base';

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -1,6 +1,6 @@
 // This is exported so the loader does not fail when switching off Replay
 import { Feedback, Replay, feedbackIntegration, replayIntegration } from '@sentry-internal/integration-shims';
-import { BrowserTracing, Span, addExtensionMethods } from '@sentry-internal/tracing';
+import { BrowserTracing, addExtensionMethods } from '@sentry-internal/tracing';
 import { bundleBrowserTracingIntegration as browserTracingIntegration } from './helpers';
 
 import * as Sentry from './index.bundle.base';
@@ -27,7 +27,6 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
-  Span,
   addExtensionMethods,
 };
 export * from './index.bundle.base';

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -4,8 +4,8 @@ import { logger, timestampInSeconds } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 import { spanTimeInputToSeconds, spanToJSON } from '../utils/spanUtils';
-import type { Span } from './span';
-import { SpanRecorder } from './span';
+import type { SentrySpan } from './sentrySpan';
+import { SpanRecorder } from './sentrySpan';
 import { Transaction } from './transaction';
 
 export const TRACING_DEFAULTS = {
@@ -41,7 +41,7 @@ export class IdleTransactionSpanRecorder extends SpanRecorder {
   /**
    * @inheritDoc
    */
-  public add(span: Span): void {
+  public add(span: SentrySpan): void {
     // We should make sure we do not push and pop activities for
     // the transaction that this span recorder belongs to.
     if (span.spanContext().spanId !== this.transactionSpanId) {
@@ -178,7 +178,7 @@ export class IdleTransaction extends Transaction {
       }
 
       // eslint-disable-next-line deprecation/deprecation
-      this.spanRecorder.spans = this.spanRecorder.spans.filter((span: Span) => {
+      this.spanRecorder.spans = this.spanRecorder.spans.filter((span: SentrySpan) => {
         // If we are dealing with the transaction itself, we just return it
         if (span.spanContext().spanId === this.spanContext().spanId) {
           return true;

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -1,7 +1,7 @@
 export { startIdleTransaction, addTracingExtensions } from './hubextensions';
 export { IdleTransaction, TRACING_DEFAULTS } from './idletransaction';
 export type { BeforeFinishCallback } from './idletransaction';
-export { Span } from './span';
+export { SentrySpan } from './sentrySpan';
 export { Transaction } from './transaction';
 // eslint-disable-next-line deprecation/deprecation
 export { getActiveTransaction } from './utils';

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -37,7 +37,7 @@ import { setHttpStatus } from './spanstatus';
  * @hidden
  */
 export class SpanRecorder {
-  public spans: Span[];
+  public spans: SentrySpan[];
 
   private readonly _maxlen: number;
 
@@ -52,7 +52,7 @@ export class SpanRecorder {
    * trace tree (i.e.the first n spans with the smallest
    * start_timestamp).
    */
-  public add(span: Span): void {
+  public add(span: SentrySpan): void {
     if (this.spans.length > this._maxlen) {
       // eslint-disable-next-line deprecation/deprecation
       span.spanRecorder = undefined;
@@ -65,7 +65,7 @@ export class SpanRecorder {
 /**
  * Span contains all data about a span
  */
-export class Span implements SpanInterface {
+export class SentrySpan implements SpanInterface {
   /**
    * Tags for the span.
    * @deprecated Use `spanToJSON(span).atttributes` instead.
@@ -386,7 +386,7 @@ export class Span implements SpanInterface {
   public startChild(
     spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'sampled' | 'traceId' | 'parentSpanId'>>,
   ): SpanInterface {
-    const childSpan = new Span({
+    const childSpan = new SentrySpan({
       ...spanContext,
       parentSpanId: this._spanId,
       sampled: this._sampled,

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -19,11 +19,11 @@ import { getMetricSummaryJsonForSpan } from '../metrics/metric-summary';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../semanticAttributes';
 import { spanTimeInputToSeconds, spanToJSON, spanToTraceContext } from '../utils/spanUtils';
 import { getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
-import { Span as SpanClass, SpanRecorder } from './span';
+import { SentrySpan, SpanRecorder } from './sentrySpan';
 import { getCapturedScopesOnSpan } from './trace';
 
 /** JSDoc */
-export class Transaction extends SpanClass implements TransactionInterface {
+export class Transaction extends SentrySpan implements TransactionInterface {
   /**
    * The reference to the current hub.
    */

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -1,6 +1,6 @@
 import type { Span, SpanJSON, SpanTimeInput, TraceContext } from '@sentry/types';
 import { dropUndefinedKeys, generateSentryTraceHeader, timestampInSeconds } from '@sentry/utils';
-import type { Span as SpanClass } from '../tracing/span';
+import type { SentrySpan } from '../tracing/sentrySpan';
 
 // These are aligned with OpenTelemetry trace flags
 export const TRACE_FLAG_NONE = 0x0;
@@ -72,7 +72,7 @@ function ensureTimestampInSeconds(timestamp: number): number {
  * TODO v8: When we remove the deprecated stuff from `span.ts`, we can remove the circular dependency again.
  */
 export function spanToJSON(span: Span): Partial<SpanJSON> {
-  if (spanIsSpanClass(span)) {
+  if (spanIsSentrySpan(span)) {
     return span.getSpanJSON();
   }
 
@@ -90,8 +90,8 @@ export function spanToJSON(span: Span): Partial<SpanJSON> {
  * Sadly, due to circular dependency checks we cannot actually import the Span class here and check for instanceof.
  * :( So instead we approximate this by checking if it has the `getSpanJSON` method.
  */
-function spanIsSpanClass(span: Span): span is SpanClass {
-  return typeof (span as SpanClass).getSpanJSON === 'function';
+function spanIsSentrySpan(span: Span): span is SentrySpan {
+  return typeof (span as SentrySpan).getSpanJSON === 'function';
 }
 
 /**

--- a/packages/core/test/lib/tracing/span.test.ts
+++ b/packages/core/test/lib/tracing/span.test.ts
@@ -1,30 +1,30 @@
 import { timestampInSeconds } from '@sentry/utils';
-import { Span } from '../../../src';
+import { SentrySpan } from '../../../src';
 import { TRACE_FLAG_NONE, TRACE_FLAG_SAMPLED, spanToJSON } from '../../../src/utils/spanUtils';
 
 describe('span', () => {
   describe('name', () => {
     /* eslint-disable deprecation/deprecation */
     it('works with name', () => {
-      const span = new Span({ name: 'span name' });
+      const span = new SentrySpan({ name: 'span name' });
       expect(span.name).toEqual('span name');
       expect(span.description).toEqual('span name');
     });
 
     it('works with description', () => {
-      const span = new Span({ description: 'span name' });
+      const span = new SentrySpan({ description: 'span name' });
       expect(span.name).toEqual('span name');
       expect(span.description).toEqual('span name');
     });
 
     it('works without name', () => {
-      const span = new Span({});
+      const span = new SentrySpan({});
       expect(span.name).toEqual('');
       expect(span.description).toEqual(undefined);
     });
 
     it('allows to update the name via setter', () => {
-      const span = new Span({ name: 'span name' });
+      const span = new SentrySpan({ name: 'span name' });
       expect(span.name).toEqual('span name');
       expect(span.description).toEqual('span name');
 
@@ -35,7 +35,7 @@ describe('span', () => {
     });
 
     it('allows to update the name via setName', () => {
-      const span = new Span({ name: 'span name' });
+      const span = new SentrySpan({ name: 'span name' });
       expect(span.name).toEqual('span name');
       expect(span.description).toEqual('span name');
 
@@ -47,7 +47,7 @@ describe('span', () => {
     });
 
     it('allows to update the name via updateName', () => {
-      const span = new Span({ name: 'span name' });
+      const span = new SentrySpan({ name: 'span name' });
       expect(span.name).toEqual('span name');
       expect(span.description).toEqual('span name');
 
@@ -61,7 +61,7 @@ describe('span', () => {
 
   describe('setAttribute', () => {
     it('allows to set attributes', () => {
-      const span = new Span();
+      const span = new SentrySpan();
 
       span.setAttribute('str', 'bar');
       span.setAttribute('num', 1);
@@ -84,13 +84,13 @@ describe('span', () => {
         strArray: ['aa', 'bb'],
         boolArray: [true, false],
         arrayWithUndefined: [1, undefined, 2],
-        // origin is set by default to 'manual' in the Span constructor
+        // origin is set by default to 'manual' in the SentrySpan constructor
         'sentry.origin': 'manual',
       });
     });
 
     it('deletes attributes when setting to `undefined`', () => {
-      const span = new Span();
+      const span = new SentrySpan();
 
       span.setAttribute('str', 'bar');
 
@@ -103,7 +103,7 @@ describe('span', () => {
     });
 
     it('disallows invalid attribute types', () => {
-      const span = new Span();
+      const span = new SentrySpan();
 
       /** @ts-expect-error this is invalid */
       span.setAttribute('str', {});
@@ -118,12 +118,12 @@ describe('span', () => {
 
   describe('setAttributes', () => {
     it('allows to set attributes', () => {
-      const span = new Span();
+      const span = new SentrySpan();
 
       const initialAttributes = span['_attributes'];
 
       expect(initialAttributes).toEqual({
-        // origin is set by default to 'manual' in the Span constructor
+        // origin is set by default to 'manual' in the SentrySpan constructor
         'sentry.origin': 'manual',
       });
 
@@ -176,7 +176,7 @@ describe('span', () => {
     });
 
     it('deletes attributes when setting to `undefined`', () => {
-      const span = new Span();
+      const span = new SentrySpan();
 
       span.setAttribute('str', 'bar');
 
@@ -191,7 +191,7 @@ describe('span', () => {
 
   describe('end', () => {
     it('works without endTimestamp', () => {
-      const span = new Span();
+      const span = new SentrySpan();
       const now = timestampInSeconds();
       span.end();
 
@@ -199,7 +199,7 @@ describe('span', () => {
     });
 
     it('works with endTimestamp in seconds', () => {
-      const span = new Span();
+      const span = new SentrySpan();
       const timestamp = timestampInSeconds() - 1;
       span.end(timestamp);
 
@@ -207,7 +207,7 @@ describe('span', () => {
     });
 
     it('works with endTimestamp in milliseconds', () => {
-      const span = new Span();
+      const span = new SentrySpan();
       const timestamp = Date.now() - 1000;
       span.end(timestamp);
 
@@ -215,7 +215,7 @@ describe('span', () => {
     });
 
     it('works with endTimestamp in array form', () => {
-      const span = new Span();
+      const span = new SentrySpan();
       const seconds = Math.floor(timestampInSeconds() - 1);
       span.end([seconds, 0]);
 
@@ -225,7 +225,7 @@ describe('span', () => {
     it('skips if span is already ended', () => {
       const startTimestamp = timestampInSeconds() - 5;
       const endTimestamp = timestampInSeconds() - 1;
-      const span = new Span({ startTimestamp, endTimestamp });
+      const span = new SentrySpan({ startTimestamp, endTimestamp });
 
       span.end();
 
@@ -235,24 +235,24 @@ describe('span', () => {
 
   describe('isRecording', () => {
     it('returns true for sampled span', () => {
-      const span = new Span({ sampled: true });
+      const span = new SentrySpan({ sampled: true });
       expect(span.isRecording()).toEqual(true);
     });
 
     it('returns false for sampled, finished span', () => {
-      const span = new Span({ sampled: true, endTimestamp: Date.now() });
+      const span = new SentrySpan({ sampled: true, endTimestamp: Date.now() });
       expect(span.isRecording()).toEqual(false);
     });
 
     it('returns false for unsampled span', () => {
-      const span = new Span({ sampled: false });
+      const span = new SentrySpan({ sampled: false });
       expect(span.isRecording()).toEqual(false);
     });
   });
 
   describe('spanContext', () => {
     it('works with default span', () => {
-      const span = new Span();
+      const span = new SentrySpan();
       expect(span.spanContext()).toEqual({
         spanId: span['_spanId'],
         traceId: span['_traceId'],
@@ -261,7 +261,7 @@ describe('span', () => {
     });
 
     it('works sampled span', () => {
-      const span = new Span({ sampled: true });
+      const span = new SentrySpan({ sampled: true });
       expect(span.spanContext()).toEqual({
         spanId: span['_spanId'],
         traceId: span['_traceId'],
@@ -270,7 +270,7 @@ describe('span', () => {
     });
 
     it('works unsampled span', () => {
-      const span = new Span({ sampled: false });
+      const span = new SentrySpan({ sampled: false });
       expect(span.spanContext()).toEqual({
         spanId: span['_spanId'],
         traceId: span['_traceId'],
@@ -282,22 +282,22 @@ describe('span', () => {
   // Ensure that attributes & data are merged together
   describe('_getData', () => {
     it('works without data & attributes', () => {
-      const span = new Span();
+      const span = new SentrySpan();
 
       expect(span['_getData']()).toEqual({
-        // origin is set by default to 'manual' in the Span constructor
+        // origin is set by default to 'manual' in the SentrySpan constructor
         'sentry.origin': 'manual',
       });
     });
 
     it('works with data only', () => {
-      const span = new Span();
+      const span = new SentrySpan();
       // eslint-disable-next-line deprecation/deprecation
       span.setData('foo', 'bar');
 
       expect(span['_getData']()).toEqual({
         foo: 'bar',
-        // origin is set by default to 'manual' in the Span constructor
+        // origin is set by default to 'manual' in the SentrySpan constructor
         'sentry.origin': 'manual',
       });
       expect(span['_getData']()).toStrictEqual({
@@ -308,12 +308,12 @@ describe('span', () => {
     });
 
     it('works with attributes only', () => {
-      const span = new Span();
+      const span = new SentrySpan();
       span.setAttribute('foo', 'bar');
 
       expect(span['_getData']()).toEqual({
         foo: 'bar',
-        // origin is set by default to 'manual' in the Span constructor
+        // origin is set by default to 'manual' in the SentrySpan constructor
         'sentry.origin': 'manual',
       });
       // eslint-disable-next-line deprecation/deprecation
@@ -321,7 +321,7 @@ describe('span', () => {
     });
 
     it('merges data & attributes', () => {
-      const span = new Span();
+      const span = new SentrySpan();
       span.setAttribute('foo', 'foo');
       span.setAttribute('bar', 'bar');
       // eslint-disable-next-line deprecation/deprecation
@@ -333,7 +333,7 @@ describe('span', () => {
         foo: 'foo',
         bar: 'bar',
         baz: 'baz',
-        // origin is set by default to 'manual' in the Span constructor
+        // origin is set by default to 'manual' in the SentrySpan constructor
         'sentry.origin': 'manual',
       });
       // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/test/lib/tracing/spanstatus.test.ts
+++ b/packages/core/test/lib/tracing/spanstatus.test.ts
@@ -1,4 +1,4 @@
-import { Span, setHttpStatus, spanToJSON } from '../../../src/index';
+import { SentrySpan, setHttpStatus, spanToJSON } from '../../../src/index';
 
 describe('setHttpStatus', () => {
   it.each([
@@ -16,7 +16,7 @@ describe('setHttpStatus', () => {
     [504, 'deadline_exceeded'],
     [520, 'internal_error'],
   ])('applies the correct span status and http status code to the span (%s - $%s)', (code, status) => {
-    const span = new Span({ name: 'test' });
+    const span = new SentrySpan({ name: 'test' });
 
     setHttpStatus(span!, code);
 
@@ -28,7 +28,7 @@ describe('setHttpStatus', () => {
   });
 
   it("doesn't set the status for an unknown http status code", () => {
-    const span = new Span({ name: 'test' });
+    const span = new SentrySpan({ name: 'test' });
 
     setHttpStatus(span!, 600);
 

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -11,7 +11,7 @@ import {
   withScope,
 } from '../../../src';
 import {
-  Span,
+  SentrySpan,
   continueTrace,
   getActiveSpan,
   startInactiveSpan,
@@ -279,11 +279,11 @@ describe('startSpan', () => {
   });
 
   it('creates & finishes span', async () => {
-    let _span: Span | undefined;
+    let _span: SentrySpan | undefined;
     startSpan({ name: 'GET users/[id]' }, span => {
       expect(span).toBeDefined();
       expect(spanToJSON(span!).timestamp).toBeUndefined();
-      _span = span as Span;
+      _span = span as SentrySpan;
     });
 
     expect(_span).toBeDefined();
@@ -314,7 +314,7 @@ describe('startSpan', () => {
     const initialScope = getCurrentScope();
 
     const manualScope = initialScope.clone();
-    const parentSpan = new Span({ spanId: 'parent-span-id' });
+    const parentSpan = new SentrySpan({ spanId: 'parent-span-id' });
     // eslint-disable-next-line deprecation/deprecation
     manualScope.setSpan(parentSpan);
 
@@ -475,7 +475,7 @@ describe('startSpanManual', () => {
     const initialScope = getCurrentScope();
 
     const manualScope = initialScope.clone();
-    const parentSpan = new Span({ spanId: 'parent-span-id' });
+    const parentSpan = new SentrySpan({ spanId: 'parent-span-id' });
     // eslint-disable-next-line deprecation/deprecation
     manualScope.setSpan(parentSpan);
 
@@ -580,7 +580,7 @@ describe('startInactiveSpan', () => {
     const initialScope = getCurrentScope();
 
     const manualScope = initialScope.clone();
-    const parentSpan = new Span({ spanId: 'parent-span-id' });
+    const parentSpan = new SentrySpan({ spanId: 'parent-span-id' });
     // eslint-disable-next-line deprecation/deprecation
     manualScope.setSpan(parentSpan);
 

--- a/packages/core/test/lib/utils/getRootSpan.ts
+++ b/packages/core/test/lib/utils/getRootSpan.ts
@@ -1,8 +1,8 @@
-import { Span, Transaction, getRootSpan } from '../../../src';
+import { SentrySpan, Transaction, getRootSpan } from '../../../src';
 
 describe('getRootSpan', () => {
-  it('returns the root span of a span (Span)', () => {
-    const root = new Span({ name: 'test' });
+  it('returns the root span of a span (SentrySpan)', () => {
+    const root = new SentrySpan({ name: 'test' });
     // @ts-expect-error this is highly illegal and shouldn't happen IRL
     // eslint-disable-next-line deprecation/deprecation
     root.transaction = root;
@@ -29,7 +29,7 @@ describe('getRootSpan', () => {
   });
 
   it('returns undefined if span has no root span', () => {
-    const span = new Span({ name: 'test' });
+    const span = new SentrySpan({ name: 'test' });
 
     expect(getRootSpan(span)).toBe(undefined);
   });

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -1,14 +1,14 @@
 import { TRACEPARENT_REGEXP, timestampInSeconds } from '@sentry/utils';
-import { Span, spanToTraceHeader } from '../../../src';
+import { SentrySpan, spanToTraceHeader } from '../../../src';
 import { spanIsSampled, spanTimeInputToSeconds, spanToJSON } from '../../../src/utils/spanUtils';
 
 describe('spanToTraceHeader', () => {
   test('simple', () => {
-    const span = new Span();
+    const span = new SentrySpan();
     expect(spanToTraceHeader(span)).toMatch(TRACEPARENT_REGEXP);
   });
   test('with sample', () => {
-    const span = new Span({ sampled: true });
+    const span = new SentrySpan({ sampled: true });
     expect(spanToTraceHeader(span)).toMatch(TRACEPARENT_REGEXP);
   });
 });
@@ -49,7 +49,7 @@ describe('spanTimeInputToSeconds', () => {
 
 describe('spanToJSON', () => {
   it('works with a simple span', () => {
-    const span = new Span();
+    const span = new SentrySpan();
     expect(spanToJSON(span)).toEqual({
       span_id: span.spanContext().spanId,
       trace_id: span.spanContext().traceId,
@@ -62,7 +62,7 @@ describe('spanToJSON', () => {
   });
 
   it('works with a full span', () => {
-    const span = new Span({
+    const span = new SentrySpan({
       name: 'test name',
       op: 'test op',
       parentSpanId: '1234',
@@ -107,7 +107,7 @@ describe('spanToJSON', () => {
           start_timestamp: 123,
         };
       },
-    } as unknown as Span;
+    } as unknown as SentrySpan;
 
     expect(spanToJSON(span)).toEqual({
       span_id: 'span_id',
@@ -119,20 +119,20 @@ describe('spanToJSON', () => {
 
   it('returns empty object if span does not have getter methods', () => {
     // eslint-disable-next-line
-    const span = new Span().toJSON();
+    const span = new SentrySpan().toJSON();
 
-    expect(spanToJSON(span as unknown as Span)).toEqual({});
+    expect(spanToJSON(span as unknown as SentrySpan)).toEqual({});
   });
 });
 
 describe('spanIsSampled', () => {
   test('sampled', () => {
-    const span = new Span({ sampled: true });
+    const span = new SentrySpan({ sampled: true });
     expect(spanIsSampled(span)).toBe(true);
   });
 
   test('not sampled', () => {
-    const span = new Span({ sampled: false });
+    const span = new SentrySpan({ sampled: false });
     expect(spanIsSampled(span)).toBe(false);
   });
 });

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -48,7 +48,7 @@ export function withSentryConfig<T>(exportedUserNextConfig: T): T {
 }
 
 export * from '@sentry/vercel-edge';
-export { Span, Transaction } from '@sentry/core';
+export { Transaction } from '@sentry/core';
 
 export * from '../common';
 

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -33,7 +33,6 @@ export declare const ErrorBoundary: typeof clientSdk.ErrorBoundary;
 export declare const showReportDialog: typeof clientSdk.showReportDialog;
 export declare const withErrorBoundary: typeof clientSdk.withErrorBoundary;
 
-export declare const Span: typeof edgeSdk.Span;
 export declare const Transaction: typeof edgeSdk.Transaction;
 
 export { withSentryConfig } from './config';

--- a/packages/node-experimental/test/helpers/createSpan.ts
+++ b/packages/node-experimental/test/helpers/createSpan.ts
@@ -1,13 +1,13 @@
 import type { Context, SpanContext } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import type { Tracer } from '@opentelemetry/sdk-trace-base';
-import { Span } from '@opentelemetry/sdk-trace-base';
+import { SentrySpan } from '@opentelemetry/sdk-trace-base';
 import { uuid4 } from '@sentry/utils';
 
 export function createSpan(
   name?: string,
   { spanId, parentSpanId }: { spanId?: string; parentSpanId?: string } = {},
-): Span {
+): SentrySpan {
   const spanProcessor = {
     onStart: () => {},
     onEnd: () => {},
@@ -26,5 +26,5 @@ export function createSpan(
   };
 
   // eslint-disable-next-line deprecation/deprecation
-  return new Span(tracer, {} as Context, name || 'test', spanContext, SpanKind.INTERNAL, parentSpanId);
+  return new SentrySpan(tracer, {} as Context, name || 'test', spanContext, SpanKind.INTERNAL, parentSpanId);
 }

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
-import type { Span } from '@sentry/core';
+import type { SentrySpan } from '@sentry/core';
 import { Transaction } from '@sentry/core';
 import { getCurrentScope, makeMain, setUser, spanToJSON, startInactiveSpan } from '@sentry/core';
 import { Hub, addTracingExtensions } from '@sentry/core';
@@ -79,7 +79,7 @@ describe('tracing', () => {
 
     const transaction = createTransactionOnScope();
     // eslint-disable-next-line deprecation/deprecation
-    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+    const spans = (transaction as unknown as SentrySpan).spanRecorder?.spans as SentrySpan[];
 
     http.get('http://dogs.are.great/');
 
@@ -97,7 +97,7 @@ describe('tracing', () => {
 
     const transaction = createTransactionOnScope();
     // eslint-disable-next-line deprecation/deprecation
-    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+    const spans = (transaction as unknown as SentrySpan).spanRecorder?.spans as SentrySpan[];
 
     http.get('http://squirrelchasers.ingest.sentry.io/api/12312012/store/');
 
@@ -288,7 +288,7 @@ describe('tracing', () => {
 
     const transaction = createTransactionOnScope();
     // eslint-disable-next-line deprecation/deprecation
-    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+    const spans = (transaction as unknown as SentrySpan).spanRecorder?.spans as SentrySpan[];
 
     http.get('http://dogs.are.great/spaniel?tail=wag&cute=true#learn-more');
 
@@ -313,7 +313,7 @@ describe('tracing', () => {
 
     const transaction = createTransactionOnScope();
     // eslint-disable-next-line deprecation/deprecation
-    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+    const spans = (transaction as unknown as SentrySpan).spanRecorder?.spans as SentrySpan[];
 
     http.request({ method: 'GET', host: 'dogs.are.great', path: '/spaniel?tail=wag&cute=true#learn-more' });
 
@@ -343,7 +343,7 @@ describe('tracing', () => {
 
     const transaction = createTransactionOnScope();
     // eslint-disable-next-line deprecation/deprecation
-    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+    const spans = (transaction as unknown as SentrySpan).spanRecorder?.spans as SentrySpan[];
 
     http.get(`http://${auth}@dogs.are.great/`);
 
@@ -405,7 +405,7 @@ describe('tracing', () => {
 
         const transaction = createTransactionAndPutOnScope();
         // eslint-disable-next-line deprecation/deprecation
-        const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+        const spans = (transaction as unknown as SentrySpan).spanRecorder?.spans as SentrySpan[];
 
         const request = http.get(url);
 
@@ -515,7 +515,7 @@ describe('tracing', () => {
 
         const transaction = createTransactionAndPutOnScope();
         // eslint-disable-next-line deprecation/deprecation
-        const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+        const spans = (transaction as unknown as SentrySpan).spanRecorder?.spans as SentrySpan[];
 
         const request = http.get(url);
 

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -6,7 +6,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SemanticAttributes, SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import type { SpanStatusType } from '@sentry/core';
 import { captureException, getCurrentScope, setCurrentClient } from '@sentry/core';
-import { Span as SentrySpan, Transaction, addTracingExtensions, createTransport, spanToJSON } from '@sentry/core';
+import { SentrySpan, Transaction, addTracingExtensions, createTransport, spanToJSON } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
 import { resolvedSyncPromise } from '@sentry/utils';
 

--- a/packages/tracing-internal/src/exports/index.ts
+++ b/packages/tracing-internal/src/exports/index.ts
@@ -3,7 +3,6 @@ export {
   getActiveTransaction,
   hasTracingEnabled,
   IdleTransaction,
-  Span,
   // eslint-disable-next-line deprecation/deprecation
   SpanStatus,
   startIdleTransaction,

--- a/packages/tracing-internal/test/browser/metrics/utils.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/utils.test.ts
@@ -1,5 +1,4 @@
-import { spanToJSON } from '@sentry/core';
-import { Span, Transaction } from '../../../src';
+import { SentrySpan, Transaction, spanToJSON } from '@sentry/core';
 import { _startChild } from '../../../src/browser/metrics/utils';
 
 describe('_startChild()', () => {
@@ -11,7 +10,7 @@ describe('_startChild()', () => {
       op: 'script',
     });
 
-    expect(span).toBeInstanceOf(Span);
+    expect(span).toBeInstanceOf(SentrySpan);
     expect(spanToJSON(span).description).toBe('evaluation');
     // eslint-disable-next-line deprecation/deprecation
     expect(span.op).toBe('script');

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -13,7 +13,6 @@ import {
   Mysql,
   Postgres,
   Prisma,
-  Span as SpanT,
   SpanStatus as SpanStatusT,
   TRACEPARENT_REGEXP as TRACEPARENT_REGEXP_T,
   Transaction as TransactionT,
@@ -85,20 +84,6 @@ export const Transaction = TransactionT;
  * `Transaction` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
  */
 export type Transaction = TransactionT;
-
-/**
- * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.
- *
- * `Span` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
- */
-export const Span = SpanT;
-
-/**
- * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.
- *
- * `Span` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
- */
-export type Span = SpanT;
 
 /**
  * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -14,7 +14,7 @@ import {
   startSpanManual,
 } from '@sentry/core';
 
-import { IdleTransaction, Span, getClient } from '../../core/src';
+import { IdleTransaction, SentrySpan, getClient } from '../../core/src';
 import { IdleTransactionSpanRecorder } from '../../core/src/tracing/idletransaction';
 import { getDefaultBrowserClientOptions } from './testutils';
 
@@ -231,11 +231,11 @@ describe('IdleTransaction', () => {
       expect(spans).toHaveLength(3);
       expect(spans[0].spanContext().spanId).toBe(transaction.spanContext().spanId);
 
-      // Regular Span - should not modified
+      // Regular SentrySpan - should not modified
       expect(spans[1].spanContext().spanId).toBe(regularSpan.spanContext().spanId);
       expect(spans[1]['_endTime']).not.toBe(spanToJSON(transaction).timestamp);
 
-      // Cancelled Span - has endtimestamp of transaction
+      // Cancelled SentrySpan - has endtimestamp of transaction
       expect(spans[2].spanContext().spanId).toBe(cancelledSpan.spanContext().spanId);
       expect(spans[2].status).toBe('cancelled');
       expect(spans[2]['_endTime']).toBe(spanToJSON(transaction).timestamp);
@@ -522,7 +522,7 @@ describe('IdleTransactionSpanRecorder', () => {
     expect(mockPushActivity).toHaveBeenCalledTimes(0);
     expect(mockPopActivity).toHaveBeenCalledTimes(0);
 
-    const span = new Span({ sampled: true });
+    const span = new SentrySpan({ sampled: true });
 
     expect(spanRecorder.spans).toHaveLength(0);
     spanRecorder.add(span);
@@ -543,7 +543,7 @@ describe('IdleTransactionSpanRecorder', () => {
     const mockPopActivity = jest.fn();
     const spanRecorder = new IdleTransactionSpanRecorder(mockPushActivity, mockPopActivity, '', 10);
 
-    const span = new Span({ sampled: true, startTimestamp: 765, endTimestamp: 345 });
+    const span = new SentrySpan({ sampled: true, startTimestamp: 765, endTimestamp: 345 });
     spanRecorder.add(span);
 
     expect(mockPushActivity).toHaveBeenCalledTimes(0);

--- a/packages/tracing/test/integrations/apollo-nestjs.test.ts
+++ b/packages/tracing/test/integrations/apollo-nestjs.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Hub, Scope, Span as SpanClass } from '@sentry/core';
+import { Hub, Scope, SentrySpan } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -80,7 +80,7 @@ describe('setupOnce', () => {
 
   beforeEach(() => {
     scope = new Scope();
-    parentSpan = new SpanClass();
+    parentSpan = new SentrySpan();
     childSpan = parentSpan.startChild();
     jest.spyOn(scope, 'getSpan').mockReturnValueOnce(parentSpan);
     jest.spyOn(scope, 'setSpan');

--- a/packages/tracing/test/integrations/apollo.test.ts
+++ b/packages/tracing/test/integrations/apollo.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Hub, Scope, Span as SpanClass } from '@sentry/core';
+import { Hub, Scope, SentrySpan } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -80,7 +80,7 @@ describe('setupOnce', () => {
 
   beforeEach(() => {
     scope = new Scope();
-    parentSpan = new SpanClass();
+    parentSpan = new SentrySpan();
     childSpan = parentSpan.startChild();
     jest.spyOn(scope, 'getSpan').mockReturnValueOnce(parentSpan);
     jest.spyOn(scope, 'setSpan');

--- a/packages/tracing/test/integrations/graphql.test.ts
+++ b/packages/tracing/test/integrations/graphql.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Hub, Scope, Span as SpanClass } from '@sentry/core';
+import { Hub, Scope, SentrySpan } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -42,7 +42,7 @@ describe('setupOnce', () => {
 
   beforeEach(() => {
     scope = new Scope();
-    parentSpan = new SpanClass();
+    parentSpan = new SentrySpan();
     childSpan = parentSpan.startChild();
     jest.spyOn(scope, 'getSpan').mockReturnValueOnce(parentSpan);
     jest.spyOn(scope, 'setSpan');

--- a/packages/tracing/test/integrations/node/mongo.test.ts
+++ b/packages/tracing/test/integrations/node/mongo.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Hub, Scope, Span as SpanClass } from '@sentry/core';
+import { Hub, Scope, SentrySpan } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -64,7 +64,7 @@ describe('patchOperation()', () => {
 
   beforeEach(() => {
     scope = new Scope();
-    parentSpan = new SpanClass();
+    parentSpan = new SentrySpan();
     childSpan = parentSpan.startChild();
     testClient = getTestClient({});
     jest.spyOn(scope, 'getSpan').mockReturnValueOnce(parentSpan);

--- a/packages/tracing/test/integrations/node/postgres.test.ts
+++ b/packages/tracing/test/integrations/node/postgres.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Hub, Scope, Span as SpanClass } from '@sentry/core';
+import { Hub, Scope, SentrySpan } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { loadModule, logger } from '@sentry/utils';
 import pg from 'pg';
@@ -64,7 +64,7 @@ describe('setupOnce', () => {
 
     beforeEach(() => {
       scope = new Scope();
-      parentSpan = new SpanClass();
+      parentSpan = new SentrySpan();
       childSpan = parentSpan.startChild();
       jest.spyOn(scope, 'getSpan').mockReturnValueOnce(parentSpan);
       jest.spyOn(parentSpan, 'startChild').mockReturnValueOnce(childSpan);
@@ -135,7 +135,7 @@ describe('setupOnce', () => {
 
   it('does not attempt resolution when module is passed directly', async () => {
     const scope = new Scope();
-    jest.spyOn(scope, 'getSpan').mockReturnValueOnce(new SpanClass());
+    jest.spyOn(scope, 'getSpan').mockReturnValueOnce(new SentrySpan());
 
     new Integrations.Postgres({ module: mockModule }).setupOnce(
       () => undefined,


### PR DESCRIPTION
And stop exporting it from packages other than core.