### PR TITLE
ref(core): Skip hub in top level `captureXXX` methods

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -41,8 +41,7 @@ export function captureException(
   exception: any,
   hint?: ExclusiveEventHintOrCaptureContext,
 ): string {
-  // eslint-disable-next-line deprecation/deprecation
-  return getCurrentHub().captureException(exception, parseEventHintOrCaptureContext(hint));
+  return getCurrentScope().captureException(exception, parseEventHintOrCaptureContext(hint));
 }
 
 /**
@@ -57,8 +56,7 @@ export function captureMessage(message: string, captureContext?: CaptureContext 
   // arity of the `captureMessage(message, level)` method.
   const level = typeof captureContext === 'string' ? captureContext : undefined;
   const context = typeof captureContext !== 'string' ? { captureContext } : undefined;
-  // eslint-disable-next-line deprecation/deprecation
-  return getCurrentHub().captureMessage(message, level, context);
+  return getCurrentScope().captureMessage(message, level, context);
 }
 
 /**
@@ -69,8 +67,7 @@ export function captureMessage(message: string, captureContext?: CaptureContext 
  * @returns the id of the captured event.
  */
 export function captureEvent(event: Event, hint?: EventHint): string {
-  // eslint-disable-next-line deprecation/deprecation
-  return getCurrentHub().captureEvent(event, hint);
+  return getCurrentScope().captureEvent(event, hint);
 }
 
 /**


### PR DESCRIPTION
Directly call these on `getCurrentScope()` instead.
