### PR TITLE
feat(v8): Remove defaultIntegrations deprecated export

### DIFF
--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -19,7 +19,6 @@ export declare const Integrations: typeof serverSdk.Integrations;
 
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 
-export declare const defaultIntegrations: Integration[];
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -92,8 +92,6 @@ export {
 export { eventFromException, eventFromMessage, exceptionFromError } from './eventbuilder';
 export { createUserFeedbackEnvelope } from './userfeedback';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   forceLoad,
   init,

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -29,24 +29,17 @@ import { browserApiErrorsIntegration } from './integrations/trycatch';
 import { defaultStackParser } from './stack-parsers';
 import { makeFetchTransport, makeXHRTransport } from './transports';
 
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations = [
-  inboundFiltersIntegration(),
-  functionToStringIntegration(),
-  browserApiErrorsIntegration(),
-  breadcrumbsIntegration(),
-  globalHandlersIntegration(),
-  linkedErrorsIntegration(),
-  dedupeIntegration(),
-  httpContextIntegration(),
-];
-
 /** Get the default integrations for the browser SDK. */
 export function getDefaultIntegrations(_options: Options): Integration[] {
-  // We return a copy of the defaultIntegrations here to avoid mutating this
   return [
-    // eslint-disable-next-line deprecation/deprecation
-    ...defaultIntegrations,
+    inboundFiltersIntegration(),
+    functionToStringIntegration(),
+    browserApiErrorsIntegration(),
+    breadcrumbsIntegration(),
+    globalHandlersIntegration(),
+    linkedErrorsIntegration(),
+    dedupeIntegration(),
+    httpContextIntegration(),
   ];
 }
 

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -110,8 +110,6 @@ export {
 
 export { BunClient } from './client';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   init,
 } from './sdk';

--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -21,34 +21,28 @@ import { bunServerIntegration } from './integrations/bunserver';
 import { makeFetchTransport } from './transports';
 import type { BunOptions } from './types';
 
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations = [
-  // Common
-  inboundFiltersIntegration(),
-  functionToStringIntegration(),
-  linkedErrorsIntegration(),
-  requestDataIntegration(),
-  // Native Wrappers
-  consoleIntegration(),
-  httpIntegration(),
-  nativeNodeFetchintegration(),
-  // Global Handlers # TODO (waiting for https://github.com/oven-sh/bun/issues/5091)
-  // new NodeIntegrations.OnUncaughtException(),
-  // new NodeIntegrations.OnUnhandledRejection(),
-  // Event Info
-  contextLinesIntegration(),
-  nodeContextIntegration(),
-  modulesIntegration(),
-  // Bun Specific
-  bunServerIntegration(),
-];
-
 /** Get the default integrations for the Bun SDK. */
 export function getDefaultIntegrations(_options: Options): Integration[] {
   // We return a copy of the defaultIntegrations here to avoid mutating this
   return [
-    // eslint-disable-next-line deprecation/deprecation
-    ...defaultIntegrations,
+    // Common
+    inboundFiltersIntegration(),
+    functionToStringIntegration(),
+    linkedErrorsIntegration(),
+    requestDataIntegration(),
+    // Native Wrappers
+    consoleIntegration(),
+    httpIntegration(),
+    nativeNodeFetchintegration(),
+    // Global Handlers # TODO (waiting for https://github.com/oven-sh/bun/issues/5091)
+    // new NodeIntegrations.OnUncaughtException(),
+    // new NodeIntegrations.OnUnhandledRejection(),
+    // Event Info
+    contextLinesIntegration(),
+    nodeContextIntegration(),
+    modulesIntegration(),
+    // Bun Specific
+    bunServerIntegration(),
   ];
 }
 

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -85,8 +85,6 @@ export type { SpanStatusType } from '@sentry/core';
 export { DenoClient } from './client';
 
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   init,
 } from './sdk';

--- a/packages/deno/src/sdk.ts
+++ b/packages/deno/src/sdk.ts
@@ -13,32 +13,26 @@ import { normalizePathsIntegration } from './integrations/normalizepaths';
 import { makeFetchTransport } from './transports';
 import type { DenoOptions } from './types';
 
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations = [
-  // Common
-  inboundFiltersIntegration(),
-  functionToStringIntegration(),
-  linkedErrorsIntegration(),
-  // From Browser
-  dedupeIntegration(),
-  breadcrumbsIntegration({
-    dom: false,
-    history: false,
-    xhr: false,
-  }),
-  // Deno Specific
-  denoContextIntegration(),
-  contextLinesIntegration(),
-  normalizePathsIntegration(),
-  globalHandlersIntegration(),
-];
-
 /** Get the default integrations for the Deno SDK. */
 export function getDefaultIntegrations(_options: Options): Integration[] {
   // We return a copy of the defaultIntegrations here to avoid mutating this
   return [
-    // eslint-disable-next-line deprecation/deprecation
-    ...defaultIntegrations,
+    // Common
+    inboundFiltersIntegration(),
+    functionToStringIntegration(),
+    linkedErrorsIntegration(),
+    // From Browser
+    dedupeIntegration(),
+    breadcrumbsIntegration({
+      dom: false,
+      history: false,
+      xhr: false,
+    }),
+    // Deno Specific
+    denoContextIntegration(),
+    contextLinesIntegration(),
+    normalizePathsIntegration(),
+    globalHandlersIntegration(),
   ];
 }
 

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -23,7 +23,6 @@ export declare const Integrations: undefined; // TODO(v8): Remove this line. Can
 
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 
-export declare const defaultIntegrations: Integration[];
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -92,8 +92,6 @@ export { autoDiscoverNodePerformanceMonitoringIntegrations } from './tracing';
 export { NodeClient } from './client';
 export { makeNodeTransport } from './transports';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   init,
   defaultStackParser,

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -37,27 +37,6 @@ import { createGetModuleFromFilename } from './module';
 import { makeNodeTransport } from './transports';
 import type { NodeClientOptions, NodeOptions } from './types';
 
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations = [
-  // Common
-  inboundFiltersIntegration(),
-  functionToStringIntegration(),
-  linkedErrorsIntegration(),
-  requestDataIntegration(),
-  // Native Wrappers
-  consoleIntegration(),
-  httpIntegration(),
-  nativeNodeFetchintegration(),
-  // Global Handlers
-  onUncaughtExceptionIntegration(),
-  onUnhandledRejectionIntegration(),
-  // Event Info
-  contextLinesIntegration(),
-  localVariablesIntegration(),
-  nodeContextIntegration(),
-  modulesIntegration(),
-];
-
 /** Get the default integrations for the Node SDK. */
 export function getDefaultIntegrations(_options: Options): Integration[] {
   const carrier = getMainCarrier();
@@ -65,8 +44,23 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   const autoloadedIntegrations = carrier.__SENTRY__?.integrations || [];
 
   return [
-    // eslint-disable-next-line deprecation/deprecation
-    ...defaultIntegrations,
+    // Common
+    inboundFiltersIntegration(),
+    functionToStringIntegration(),
+    linkedErrorsIntegration(),
+    requestDataIntegration(),
+    // Native Wrappers
+    consoleIntegration(),
+    httpIntegration(),
+    nativeNodeFetchintegration(),
+    // Global Handlers
+    onUncaughtExceptionIntegration(),
+    onUnhandledRejectionIntegration(),
+    // Event Info
+    contextLinesIntegration(),
+    localVariablesIntegration(),
+    nodeContextIntegration(),
+    modulesIntegration(),
     ...autoloadedIntegrations,
   ];
 }

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -51,8 +51,6 @@ export {
   withIsolationScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,
   makeNodeTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
   flush,

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -18,7 +18,6 @@ export declare const Integrations: typeof clientSdk.Integrations & typeof server
 
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 
-export declare const defaultIntegrations: Integration[];
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -8,7 +8,6 @@ import {
   captureException,
   captureMessage,
   continueTrace,
-  defaultIntegrations as nodeDefaultIntegrations,
   flush,
   getCurrentScope,
   getDefaultIntegrations as getNodeDefaultIntegrations,
@@ -65,13 +64,6 @@ export interface WrapperOptions {
    */
   startTrace: boolean;
 }
-
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations: Integration[] = [
-  // eslint-disable-next-line deprecation/deprecation
-  ...nodeDefaultIntegrations,
-  awsServicesIntegration({ optional: true }),
-];
 
 /** Get the default integrations for the AWSLambda SDK. */
 export function getDefaultIntegrations(options: Options): Integration[] {

--- a/packages/serverless/src/gcpfunction/index.ts
+++ b/packages/serverless/src/gcpfunction/index.ts
@@ -1,10 +1,5 @@
 import type { NodeOptions } from '@sentry/node';
-import {
-  SDK_VERSION,
-  defaultIntegrations as defaultNodeIntegrations,
-  getDefaultIntegrations as getDefaultNodeIntegrations,
-  init as initNode,
-} from '@sentry/node';
+import { SDK_VERSION, getDefaultIntegrations as getDefaultNodeIntegrations, init as initNode } from '@sentry/node';
 import type { Integration, Options, SdkMetadata } from '@sentry/types';
 
 import { googleCloudGrpcIntegration } from '../google-cloud-grpc';
@@ -13,14 +8,6 @@ import { googleCloudHttpIntegration } from '../google-cloud-http';
 export * from './http';
 export * from './events';
 export * from './cloud_events';
-
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations: Integration[] = [
-  // eslint-disable-next-line deprecation/deprecation
-  ...defaultNodeIntegrations,
-  googleCloudHttpIntegration({ optional: true }), // We mark this integration optional since '@google-cloud/common' module could be missing.
-  googleCloudGrpcIntegration({ optional: true }), // We mark this integration optional since 'google-gax' module could be missing.
-];
 
 /** Get the default integrations for the GCP SDK. */
 export function getDefaultIntegrations(options: Options): Integration[] {

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -54,8 +54,6 @@ export {
   NodeClient,
   makeNodeTransport,
   close,
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
   flush,

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -42,7 +42,6 @@ export declare const Integrations: typeof clientSdk.Integrations & typeof server
 
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 
-export declare const defaultIntegrations: Integration[];
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -46,8 +46,6 @@ export {
   withIsolationScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,
   makeNodeTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
   flush,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -84,8 +84,6 @@ export type { SpanStatusType } from '@sentry/core';
 
 export { VercelEdgeClient } from './client';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   init,
 } from './sdk';

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -22,19 +22,13 @@ declare const process: {
 
 const nodeStackParser = createStackParser(nodeStackLineParser());
 
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations = [
-  inboundFiltersIntegration(),
-  functionToStringIntegration(),
-  linkedErrorsIntegration(),
-  winterCGFetchIntegration(),
-];
-
 /** Get the default integrations for the browser SDK. */
 export function getDefaultIntegrations(options: Options): Integration[] {
   return [
-    // eslint-disable-next-line deprecation/deprecation
-    ...defaultIntegrations,
+    inboundFiltersIntegration(),
+    functionToStringIntegration(),
+    linkedErrorsIntegration(),
+    winterCGFetchIntegration(),
     ...(options.sendDefaultPii ? [requestDataIntegration()] : []),
   ];
 }


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10100

Removes deprecated `defaultIntegrations` export everywhere.