### PR TITLE
feat(v8): Remove usage of span.description and span.name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1056,7 +1056,8 @@ jobs:
             'sveltekit-2',
             'generic-ts3.8',
             'node-experimental-fastify-app',
-            'node-hapi-app',
+            # TODO(v8): Re-enable hapi tests
+            # 'node-hapi-app',
             'node-exports-test-app',
             'vue-3'
           ]

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/test.ts
@@ -23,23 +23,23 @@ sentryTest('should finish a custom transaction when the page goes background', a
   const transactionHandle = await page.evaluateHandle('window.transaction');
 
   const id_before = await getPropertyValue(transactionHandle, 'span_id');
-  const name_before = await getPropertyValue(transactionHandle, 'name');
+  const nameBefore = JSON.parse(await transactionHandle.evaluate((t: any) => JSON.stringify(t))).description;
   const status_before = await getPropertyValue(transactionHandle, 'status');
   const tags_before = await getPropertyValue(transactionHandle, 'tags');
 
-  expect(name_before).toBe('test-transaction');
+  expect(nameBefore).toBe('test-transaction');
   expect(status_before).toBeUndefined();
   expect(tags_before).toStrictEqual({});
 
   await page.locator('#go-background').click();
 
   const id_after = await getPropertyValue(transactionHandle, 'span_id');
-  const name_after = await getPropertyValue(transactionHandle, 'name');
+  const nameAfter = JSON.parse(await transactionHandle.evaluate((t: any) => JSON.stringify(t))).description;
   const status_after = await getPropertyValue(transactionHandle, 'status');
   const tags_after = await getPropertyValue(transactionHandle, 'tags');
 
   expect(id_before).toBe(id_after);
-  expect(name_after).toBe(name_before);
+  expect(nameAfter).toBe('test-transaction');
   expect(status_after).toBe('cancelled');
   expect(tags_after).toStrictEqual({ visibilitychange: 'document.hidden' });
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithHeartbeatTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithHeartbeatTimeout/test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { spanToJSON } from '@sentry/core';
 import type { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
@@ -20,8 +21,10 @@ sentryTest(
 
     expect(eventData.contexts?.trace?.op).toBe('pageload');
     expect(
-      // eslint-disable-next-line deprecation/deprecation
-      eventData.spans?.find(span => span.description === 'pageload-child-span' && span.status === 'cancelled'),
+      eventData.spans?.find(
+        // eslint-disable-next-line deprecation/deprecation
+        span => spanToJSON(span).description === 'pageload-child-span' && span.status === 'cancelled',
+      ),
     ).toBeDefined();
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithHeartbeatTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithHeartbeatTimeout/test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { spanToJSON } from '@sentry/core';
-import type { Event } from '@sentry/types';
+import type { SerializedEvent } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
@@ -17,14 +16,11 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+    const eventData = await getFirstSentryEnvelopeRequest<SerializedEvent>(page, url);
 
     expect(eventData.contexts?.trace?.op).toBe('pageload');
     expect(
-      eventData.spans?.find(
-        // eslint-disable-next-line deprecation/deprecation
-        span => spanToJSON(span).description === 'pageload-child-span' && span.status === 'cancelled',
-      ),
+      eventData.spans?.find(span => span.description === 'pageload-child-span' && span.status === 'cancelled'),
     ).toBeDefined();
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/browsertracing/backgroundtab-custom/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browsertracing/backgroundtab-custom/test.ts
@@ -23,23 +23,23 @@ sentryTest('should finish a custom transaction when the page goes background', a
   const transactionHandle = await page.evaluateHandle('window.transaction');
 
   const id_before = await getPropertyValue(transactionHandle, 'span_id');
-  const name_before = await getPropertyValue(transactionHandle, 'name');
+  const nameBefore = JSON.parse(await transactionHandle.evaluate((t: any) => JSON.stringify(t))).description;
   const status_before = await getPropertyValue(transactionHandle, 'status');
   const tags_before = await getPropertyValue(transactionHandle, 'tags');
 
-  expect(name_before).toBe('test-transaction');
+  expect(nameBefore).toBe('test-transaction');
   expect(status_before).toBeUndefined();
   expect(tags_before).toStrictEqual({});
 
   await page.locator('#go-background').click();
 
   const id_after = await getPropertyValue(transactionHandle, 'span_id');
-  const name_after = await getPropertyValue(transactionHandle, 'name');
+  const nameAfter = JSON.parse(await transactionHandle.evaluate((t: any) => JSON.stringify(t))).description;
   const status_after = await getPropertyValue(transactionHandle, 'status');
   const tags_after = await getPropertyValue(transactionHandle, 'tags');
 
   expect(id_before).toBe(id_after);
-  expect(name_after).toBe(name_before);
+  expect(nameAfter).toBe('test-transaction');
   expect(status_after).toBe('cancelled');
   expect(tags_after).toStrictEqual({ visibilitychange: 'document.hidden' });
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browsertracing/pageloadWithHeartbeatTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browsertracing/pageloadWithHeartbeatTimeout/test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { spanToJSON } from '@sentry/core';
 import type { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
@@ -20,8 +21,10 @@ sentryTest(
 
     expect(eventData.contexts?.trace?.op).toBe('pageload');
     expect(
-      // eslint-disable-next-line deprecation/deprecation
-      eventData.spans?.find(span => span.description === 'pageload-child-span' && span.status === 'cancelled'),
+      eventData.spans?.find(
+        // eslint-disable-next-line deprecation/deprecation
+        span => spanToJSON(span).description === 'pageload-child-span' && span.status === 'cancelled',
+      ),
     ).toBeDefined();
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/browsertracing/pageloadWithHeartbeatTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browsertracing/pageloadWithHeartbeatTimeout/test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { spanToJSON } from '@sentry/core';
-import type { Event } from '@sentry/types';
+import type { SerializedEvent } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
@@ -17,14 +16,11 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+    const eventData = await getFirstSentryEnvelopeRequest<SerializedEvent>(page, url);
 
     expect(eventData.contexts?.trace?.op).toBe('pageload');
     expect(
-      eventData.spans?.find(
-        // eslint-disable-next-line deprecation/deprecation
-        span => spanToJSON(span).description === 'pageload-child-span' && span.status === 'cancelled',
-      ),
+      eventData.spans?.find(span => span.description === 'pageload-child-span' && span.status === 'cancelled'),
     ).toBeDefined();
   },
 );

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -173,7 +173,7 @@ export class TraceService implements OnDestroy {
       if (activeTransaction) {
         // eslint-disable-next-line deprecation/deprecation
         this._routingSpan = activeTransaction.startChild({
-          description: `${navigationEvent.url}`,
+          name: `${navigationEvent.url}`,
           op: ANGULAR_ROUTING_OP,
           origin: 'auto.ui.angular',
           tags: {
@@ -327,7 +327,7 @@ export class TraceDirective implements OnInit, AfterViewInit {
     if (activeTransaction) {
       // eslint-disable-next-line deprecation/deprecation
       this._tracingSpan = activeTransaction.startChild({
-        description: `<${this.componentName}>`,
+        name: `<${this.componentName}>`,
         op: ANGULAR_INIT_OP,
         origin: 'auto.ui.angular.trace_directive',
       });
@@ -371,7 +371,7 @@ export function TraceClassDecorator(): ClassDecorator {
       if (activeTransaction) {
         // eslint-disable-next-line deprecation/deprecation
         tracingSpan = activeTransaction.startChild({
-          description: `<${target.name}>`,
+          name: `<${target.name}>`,
           op: ANGULAR_INIT_OP,
           origin: 'auto.ui.angular.trace_class_decorator',
         });
@@ -410,7 +410,7 @@ export function TraceMethodDecorator(): MethodDecorator {
       if (activeTransaction) {
         // eslint-disable-next-line deprecation/deprecation
         activeTransaction.startChild({
-          description: `<${target.constructor.name}>`,
+          name: `<${target.constructor.name}>`,
           endTimestamp: now,
           op: `${ANGULAR_OP}.${String(propertyKey)}`,
           origin: 'auto.ui.angular.trace_method_decorator',

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -113,7 +113,7 @@ describe('Angular Tracing', () => {
   });
 
   describe('TraceService', () => {
-    it('does not change the transaction name if the source is something other than `url`', async () => {
+    it.only('does not change the transaction name if the source is something other than `url`', async () => {
       const customStartTransaction = jest.fn((ctx: any) => {
         transaction = {
           ...ctx,
@@ -153,7 +153,7 @@ describe('Angular Tracing', () => {
       });
 
       expect(transaction.updateName).toHaveBeenCalledTimes(0);
-      expect(spanToJSON(transaction).description).toEqual(url);
+      expect(transaction.name).toEqual(url);
       expect(transaction.toJSON().data).toEqual({ [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom' });
 
       env.destroy();

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -373,13 +373,13 @@ describe('Angular Tracing', () => {
       expect(transaction.startChild).toHaveBeenCalledWith({
         op: 'ui.angular.init',
         origin: 'auto.ui.angular.trace_directive',
-        description: '<unknown>',
+        name: '<unknown>',
       });
 
       env.destroy();
     });
 
-    it('should use component name as span description', async () => {
+    it('should use component name as span name', async () => {
       const directive = new TraceDirective();
       const finishMock = jest.fn();
       const customStartTransaction = jest.fn(defaultStartTransaction);
@@ -400,7 +400,7 @@ describe('Angular Tracing', () => {
       expect(transaction.startChild).toHaveBeenCalledWith({
         op: 'ui.angular.init',
         origin: 'auto.ui.angular.trace_directive',
-        description: '<test-component>',
+        name: '<test-component>',
       });
 
       env.destroy();
@@ -472,7 +472,7 @@ describe('Angular Tracing', () => {
       });
 
       expect(transaction.startChild).toHaveBeenCalledWith({
-        description: '<DecoratedComponent>',
+        name: '<DecoratedComponent>',
         op: 'ui.angular.init',
         origin: 'auto.ui.angular.trace_class_decorator',
       });
@@ -526,7 +526,7 @@ describe('Angular Tracing', () => {
 
       expect(transaction.startChild).toHaveBeenCalledTimes(2);
       expect(transaction.startChild.mock.calls[0][0]).toEqual({
-        description: '<DecoratedComponent>',
+        name: '<DecoratedComponent>',
         op: 'ui.angular.ngOnInit',
         origin: 'auto.ui.angular.trace_method_decorator',
         startTimestamp: expect.any(Number),
@@ -534,7 +534,7 @@ describe('Angular Tracing', () => {
       });
 
       expect(transaction.startChild.mock.calls[1][0]).toEqual({
-        description: '<DecoratedComponent>',
+        name: '<DecoratedComponent>',
         op: 'ui.angular.ngAfterViewInit',
         origin: 'auto.ui.angular.trace_method_decorator',
         startTimestamp: expect.any(Number),

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import type { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
-import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
 
 import { TraceClassDecorator, TraceDirective, TraceMethodDecorator, instrumentAngularRouting } from '../src';
 import { getParameterizedRouteFromSnapshot } from '../src/tracing';
@@ -153,7 +153,7 @@ describe('Angular Tracing', () => {
       });
 
       expect(transaction.updateName).toHaveBeenCalledTimes(0);
-      expect(transaction.name).toEqual(url);
+      expect(spanToJSON(transaction).description).toEqual(url);
       expect(transaction.toJSON().data).toEqual({ [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom' });
 
       env.destroy();

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import type { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
-import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 
 import { TraceClassDecorator, TraceDirective, TraceMethodDecorator, instrumentAngularRouting } from '../src';
 import { getParameterizedRouteFromSnapshot } from '../src/tracing';
@@ -113,7 +113,7 @@ describe('Angular Tracing', () => {
   });
 
   describe('TraceService', () => {
-    it.only('does not change the transaction name if the source is something other than `url`', async () => {
+    it('does not change the transaction name if the source is something other than `url`', async () => {
       const customStartTransaction = jest.fn((ctx: any) => {
         transaction = {
           ...ctx,

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -165,22 +165,6 @@ export class SentrySpan implements SpanInterface {
   /* eslint-disable @typescript-eslint/member-ordering */
 
   /**
-   * An alias for `description` of the Span.
-   * @deprecated Use `spanToJSON(span).description` instead.
-   */
-  public get name(): string {
-    return this._name || '';
-  }
-
-  /**
-   * Update the name of the span.
-   * @deprecated Use `spanToJSON(span).description` instead.
-   */
-  public set name(name: string) {
-    this.updateName(name);
-  }
-
-  /**
    * The ID of the trace.
    * @deprecated Use `spanContext().traceId` instead.
    */
@@ -467,15 +451,6 @@ export class SentrySpan implements SpanInterface {
   public setHttpStatus(httpStatus: number): this {
     setHttpStatus(this, httpStatus);
     return this;
-  }
-
-  /**
-   * @inheritdoc
-   *
-   * @deprecated Use `.updateName()` instead.
-   */
-  public setName(name: string): void {
-    this.updateName(name);
   }
 
   /**

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -509,7 +509,7 @@ export class SentrySpan implements SpanInterface {
   public toContext(): SpanContext {
     return dropUndefinedKeys({
       data: this._getData(),
-      description: this._name,
+      name: this._name,
       endTimestamp: this._endTime,
       // eslint-disable-next-line deprecation/deprecation
       op: this.op,

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -144,8 +144,7 @@ export class SentrySpan implements SpanInterface {
       ...spanContext.attributes,
     });
 
-    // eslint-disable-next-line deprecation/deprecation
-    this._name = spanContext.name || spanContext.description;
+    this._name = spanContext.name;
 
     if (spanContext.parentSpanId) {
       this._parentSpanId = spanContext.parentSpanId;
@@ -179,22 +178,6 @@ export class SentrySpan implements SpanInterface {
    */
   public set name(name: string) {
     this.updateName(name);
-  }
-
-  /**
-   * Get the description of the Span.
-   * @deprecated Use `spanToJSON(span).description` instead.
-   */
-  public get description(): string | undefined {
-    return this._name;
-  }
-
-  /**
-   * Get the description of the Span.
-   * @deprecated Use `spanToJSON(span).description` instead.
-   */
-  public set description(description: string | undefined) {
-    this._name = description;
   }
 
   /**
@@ -574,8 +557,7 @@ export class SentrySpan implements SpanInterface {
   public updateWithContext(spanContext: SpanContext): this {
     // eslint-disable-next-line deprecation/deprecation
     this.data = spanContext.data || {};
-    // eslint-disable-next-line deprecation/deprecation
-    this._name = spanContext.name || spanContext.description;
+    this._name = spanContext.name;
     this._endTime = spanContext.endTimestamp;
     // eslint-disable-next-line deprecation/deprecation
     this.op = spanContext.op;

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -124,6 +124,7 @@ export class Transaction extends SentrySpan implements TransactionInterface {
   /** @inheritdoc */
   public updateName(name: string): this {
     this._name = name;
+    this.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'custom');
     return this;
   }
 

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -92,23 +92,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
   /* eslint-disable @typescript-eslint/member-ordering */
 
   /**
-   * Getter for `name` property.
-   * @deprecated Use `spanToJSON(span).description` instead.
-   */
-  public get name(): string {
-    return this._name;
-  }
-
-  /**
-   * Setter for `name` property, which also sets `source` as custom.
-   * @deprecated Use `updateName()` and `setMetadata()` instead.
-   */
-  public set name(newName: string) {
-    // eslint-disable-next-line deprecation/deprecation
-    this.setName(newName);
-  }
-
-  /**
    * Get the metadata for this transaction.
    * @deprecated Use `spanGetMetadata(transaction)` instead.
    */
@@ -137,16 +120,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
   }
 
   /* eslint-enable @typescript-eslint/member-ordering */
-
-  /**
-   * Setter for `name` property, which also sets `source` on the metadata.
-   *
-   * @deprecated Use `.updateName()` and `.setAttribute()` instead.
-   */
-  public setName(name: string, source: TransactionSource = 'custom'): void {
-    this._name = name;
-    this.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
-  }
 
   /** @inheritdoc */
   public updateName(name: string): this {

--- a/packages/core/test/lib/tracing/span.test.ts
+++ b/packages/core/test/lib/tracing/span.test.ts
@@ -8,53 +8,34 @@ describe('span', () => {
     it('works with name', () => {
       const span = new SentrySpan({ name: 'span name' });
       expect(span.name).toEqual('span name');
-      expect(span.description).toEqual('span name');
-    });
-
-    it('works with description', () => {
-      const span = new SentrySpan({ description: 'span name' });
-      expect(span.name).toEqual('span name');
-      expect(span.description).toEqual('span name');
-    });
-
-    it('works without name', () => {
-      const span = new SentrySpan({});
-      expect(span.name).toEqual('');
-      expect(span.description).toEqual(undefined);
     });
 
     it('allows to update the name via setter', () => {
       const span = new SentrySpan({ name: 'span name' });
       expect(span.name).toEqual('span name');
-      expect(span.description).toEqual('span name');
 
       span.name = 'new name';
 
       expect(span.name).toEqual('new name');
-      expect(span.description).toEqual('new name');
     });
 
     it('allows to update the name via setName', () => {
       const span = new SentrySpan({ name: 'span name' });
       expect(span.name).toEqual('span name');
-      expect(span.description).toEqual('span name');
 
       // eslint-disable-next-line deprecation/deprecation
       span.setName('new name');
 
       expect(span.name).toEqual('new name');
-      expect(span.description).toEqual('new name');
     });
 
     it('allows to update the name via updateName', () => {
       const span = new SentrySpan({ name: 'span name' });
       expect(span.name).toEqual('span name');
-      expect(span.description).toEqual('span name');
 
       span.updateName('new name');
 
       expect(span.name).toEqual('new name');
-      expect(span.description).toEqual('new name');
     });
   });
   /* eslint-enable deprecation/deprecation */

--- a/packages/core/test/lib/tracing/span.test.ts
+++ b/packages/core/test/lib/tracing/span.test.ts
@@ -7,35 +7,16 @@ describe('span', () => {
     /* eslint-disable deprecation/deprecation */
     it('works with name', () => {
       const span = new SentrySpan({ name: 'span name' });
-      expect(span.name).toEqual('span name');
-    });
-
-    it('allows to update the name via setter', () => {
-      const span = new SentrySpan({ name: 'span name' });
-      expect(span.name).toEqual('span name');
-
-      span.name = 'new name';
-
-      expect(span.name).toEqual('new name');
-    });
-
-    it('allows to update the name via setName', () => {
-      const span = new SentrySpan({ name: 'span name' });
-      expect(span.name).toEqual('span name');
-
-      // eslint-disable-next-line deprecation/deprecation
-      span.setName('new name');
-
-      expect(span.name).toEqual('new name');
+      expect(spanToJSON(span).description).toEqual('span name');
     });
 
     it('allows to update the name via updateName', () => {
       const span = new SentrySpan({ name: 'span name' });
-      expect(span.name).toEqual('span name');
+      expect(spanToJSON(span).description).toEqual('span name');
 
       span.updateName('new name');
 
-      expect(span.name).toEqual('new name');
+      expect(spanToJSON(span).description).toEqual('new name');
     });
   });
   /* eslint-enable deprecation/deprecation */

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -105,7 +105,7 @@ describe('startSpan', () => {
       }
       expect(ref).toBeDefined();
 
-      expect(ref.name).toEqual('GET users/[id]');
+      expect(spanToJSON(ref).description).toEqual('GET users/[id]');
       expect(ref.status).toEqual(isError ? 'internal_error' : undefined);
     });
 
@@ -192,7 +192,7 @@ describe('startSpan', () => {
       }
 
       expect(ref.spanRecorder.spans).toHaveLength(2);
-      expect(ref.spanRecorder.spans[1].description).toEqual('SELECT * from users');
+      expect(spanToJSON(ref.spanRecorder.spans[1]).description).toEqual('SELECT * from users');
       expect(ref.spanRecorder.spans[1].parentSpanId).toEqual(ref.spanId);
       expect(ref.spanRecorder.spans[1].status).toEqual(isError ? 'internal_error' : undefined);
     });

--- a/packages/core/test/lib/tracing/transaction.test.ts
+++ b/packages/core/test/lib/tracing/transaction.test.ts
@@ -18,11 +18,12 @@ describe('transaction', () => {
       const transaction = new Transaction({ name: 'span name' });
       transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
       expect(spanToJSON(transaction).description).toEqual('span name');
+      expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
 
       transaction.updateName('new name');
 
       expect(spanToJSON(transaction).description).toEqual('new name');
-      expect(transaction.metadata.source).toEqual('route');
+      expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
     });
     /* eslint-enable deprecation/deprecation */
   });

--- a/packages/core/test/lib/tracing/transaction.test.ts
+++ b/packages/core/test/lib/tracing/transaction.test.ts
@@ -3,6 +3,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   Transaction,
+  spanToJSON,
 } from '../../../src';
 
 describe('transaction', () => {
@@ -10,40 +11,18 @@ describe('transaction', () => {
     /* eslint-disable deprecation/deprecation */
     it('works with name', () => {
       const transaction = new Transaction({ name: 'span name' });
-      expect(transaction.name).toEqual('span name');
-    });
-
-    it('allows to update the name via setter', () => {
-      const transaction = new Transaction({ name: 'span name' });
-      transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
-      expect(transaction.name).toEqual('span name');
-
-      transaction.name = 'new name';
-
-      expect(transaction.name).toEqual('new name');
-      expect(transaction.attributes['sentry.source']).toEqual('custom');
-    });
-
-    it('allows to update the name via setName', () => {
-      const transaction = new Transaction({ name: 'span name' });
-      transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
-      expect(transaction.name).toEqual('span name');
-
-      transaction.updateName('new name');
-
-      expect(transaction.name).toEqual('new name');
-      expect(transaction.attributes['sentry.source']).toEqual('custom');
+      expect(spanToJSON(transaction).description).toEqual('span name');
     });
 
     it('allows to update the name via updateName', () => {
       const transaction = new Transaction({ name: 'span name' });
       transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
-      expect(transaction.name).toEqual('span name');
+      expect(spanToJSON(transaction).description).toEqual('span name');
 
       transaction.updateName('new name');
 
-      expect(transaction.name).toEqual('new name');
-      expect(transaction.attributes['sentry.source']).toEqual('route');
+      expect(spanToJSON(transaction).description).toEqual('new name');
+      expect(transaction.metadata.source).toEqual('route');
     });
     /* eslint-enable deprecation/deprecation */
   });

--- a/packages/core/test/lib/tracing/transaction.test.ts
+++ b/packages/core/test/lib/tracing/transaction.test.ts
@@ -29,7 +29,7 @@ describe('transaction', () => {
       transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
       expect(transaction.name).toEqual('span name');
 
-      transaction.setName('new name');
+      transaction.updateName('new name');
 
       expect(transaction.name).toEqual('new name');
       expect(transaction.attributes['sentry.source']).toEqual('custom');

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -66,7 +66,7 @@ export const instrumentRoutePerformance = <T extends RouteConstructor>(BaseRoute
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const instrumentFunction = async <X extends (...args: unknown[]) => any>(
     op: string,
-    description: string,
+    name: string,
     fn: X,
     args: Parameters<X>,
     source: TransactionSource,
@@ -77,7 +77,7 @@ export const instrumentRoutePerformance = <T extends RouteConstructor>(BaseRoute
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
         },
         op,
-        name: description,
+        name,
       },
       () => {
         return fn(...args);

--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -115,14 +115,7 @@ describe('Integration | Transactions', () => {
         server_name: expect.any(String),
         // spans are circular (they have a reference to the transaction), which leads to jest choking on this
         // instead we compare them in detail below
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         tags: {
           'outer.tag': 'test value',
@@ -270,14 +263,7 @@ describe('Integration | Transactions', () => {
             origin: 'auto.test',
           },
         }),
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         tags: { 'test.tag': 'test value' },
         timestamp: expect.any(Number),
@@ -317,14 +303,7 @@ describe('Integration | Transactions', () => {
             origin: 'manual',
           },
         }),
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1b',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2b',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         tags: { 'test.tag': 'test value b' },
         timestamp: expect.any(Number),
@@ -429,14 +408,7 @@ describe('Integration | Transactions', () => {
             origin: 'manual',
           },
         }),
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         tags: { 'test.tag': 'test value' },
         timestamp: expect.any(Number),
@@ -473,14 +445,7 @@ describe('Integration | Transactions', () => {
             origin: 'manual',
           },
         }),
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1b',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2b',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         tags: { 'test.tag': 'test value b' },
         timestamp: expect.any(Number),
@@ -565,14 +530,7 @@ describe('Integration | Transactions', () => {
         }),
         // spans are circular (they have a reference to the transaction), which leads to jest choking on this
         // instead we compare them in detail below
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
         transaction: 'test name',

--- a/packages/node-experimental/test/sdk/api.test.ts
+++ b/packages/node-experimental/test/sdk/api.test.ts
@@ -40,7 +40,7 @@ describe('withActiveSpan()', () => {
     expect(beforeSendTransaction).toHaveBeenCalledWith(
       expect.objectContaining({
         transaction: 'inactive-span',
-        spans: expect.arrayContaining([expect.objectContaining({ description: 'child-span' })]),
+        spans: expect.arrayContaining([expect.any(Object)]),
       }),
       expect.anything(),
     );

--- a/packages/node/src/integrations/hapi/index.ts
+++ b/packages/node/src/integrations/hapi/index.ts
@@ -83,8 +83,7 @@ export const hapiTracingPlugin = {
           return startTransaction({
             ...transactionContext,
             op: 'hapi.request',
-            name: request.route.path,
-            description: `${request.route.method} ${request.path}`,
+            name: `${request.route.method} ${request.path}`,
           });
         },
       );

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -40,7 +40,7 @@ import { DEBUG_BUILD } from '../debug-build';
 import { NODE_VERSION } from '../nodeVersion';
 import type { NodeClientOptions } from '../types';
 import type { RequestMethod, RequestMethodArgs, RequestOptions } from './utils/http';
-import { cleanSpanDescription, extractRawUrl, extractUrl, normalizeRequestArgs } from './utils/http';
+import { cleanSpanName, extractRawUrl, extractUrl, normalizeRequestArgs } from './utils/http';
 
 interface TracingOptions {
   /**
@@ -335,7 +335,7 @@ function _createWrappedRequestMethodFactory(
           parentSpan?.startChild({
             op: 'http.client',
             origin: 'auto.http.node.http',
-            description: `${data['http.method']} ${data.url}`,
+            name: `${data['http.method']} ${data.url}`,
             data,
           })
         : undefined;
@@ -378,9 +378,7 @@ function _createWrappedRequestMethodFactory(
             if (res.statusCode) {
               setHttpStatus(requestSpan, res.statusCode);
             }
-            requestSpan.updateName(
-              cleanSpanDescription(spanToJSON(requestSpan).description || '', requestOptions, req) || '',
-            );
+            requestSpan.updateName(cleanSpanName(spanToJSON(requestSpan).description || '', requestOptions, req) || '');
             requestSpan.end();
           }
         })
@@ -393,9 +391,7 @@ function _createWrappedRequestMethodFactory(
           }
           if (requestSpan) {
             setHttpStatus(requestSpan, 500);
-            requestSpan.updateName(
-              cleanSpanDescription(spanToJSON(requestSpan).description || '', requestOptions, req) || '',
-            );
+            requestSpan.updateName(cleanSpanName(spanToJSON(requestSpan).description || '', requestOptions, req) || '');
             requestSpan.end();
           }
         });

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -340,7 +340,7 @@ function createRequestSpan(
   return activeSpan?.startChild({
     op: 'http.client',
     origin: 'auto.http.node.undici',
-    description: `${method} ${getSanitizedUrlString(url)}`,
+    name: `${method} ${getSanitizedUrlString(url)}`,
     data,
   });
 }

--- a/packages/node/src/integrations/utils/http.ts
+++ b/packages/node/src/integrations/utils/http.ts
@@ -42,26 +42,26 @@ function redactAuthority(auth: string): string {
 }
 
 /**
- * Handle various edge cases in the span description (for spans representing http(s) requests).
+ * Handle various edge cases in the span name (for spans representing http(s) requests).
  *
- * @param description current `description` property of the span representing the request
+ * @param description current `name` property of the span representing the request
  * @param requestOptions Configuration data for the request
  * @param Request Request object
  *
- * @returns The cleaned description
+ * @returns The cleaned name
  */
-export function cleanSpanDescription(
-  description: string | undefined,
+export function cleanSpanName(
+  name: string | undefined,
   requestOptions: RequestOptions,
   request: http.ClientRequest,
 ): string | undefined {
   // nothing to clean
-  if (!description) {
-    return description;
+  if (!name) {
+    return name;
   }
 
   // eslint-disable-next-line prefer-const
-  let [method, requestUrl] = description.split(' ');
+  let [method, requestUrl] = name.split(' ');
 
   // superagent sticks the protocol in a weird place (we check for host because if both host *and* protocol are missing,
   // we're likely dealing with an internal route and this doesn't apply)

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -466,7 +466,7 @@ describe('tracingHandler', () => {
     transaction.initSpanRecorder();
     // eslint-disable-next-line deprecation/deprecation
     const span = transaction.startChild({
-      description: 'reallyCoolHandler',
+      name: 'reallyCoolHandler',
       op: 'middleware',
     });
     jest.spyOn(sentryCore, 'startTransaction').mockReturnValue(transaction as Transaction);

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -2,6 +2,7 @@ import * as http from 'http';
 import * as sentryCore from '@sentry/core';
 import {
   Hub,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   Transaction,
   getClient,
   getCurrentScope,
@@ -377,9 +378,9 @@ describe('tracingHandler', () => {
     const transaction = getCurrentScope().getTransaction();
 
     expect(transaction).toBeDefined();
-    expect(transaction).toEqual(
-      expect.objectContaining({ name: `${method.toUpperCase()} ${path}`, op: 'http.server' }),
-    );
+    const transactionJson = spanToJSON(transaction as Transaction);
+    expect(transactionJson.description).toEqual(`${method.toUpperCase()} ${path}`);
+    expect(transactionJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual('http.server');
   });
 
   it('puts its transaction on the response object', () => {
@@ -388,9 +389,10 @@ describe('tracingHandler', () => {
     const transaction = (res as any).__sentry_transaction;
 
     expect(transaction).toBeDefined();
-    expect(transaction).toEqual(
-      expect.objectContaining({ name: `${method.toUpperCase()} ${path}`, op: 'http.server' }),
-    );
+
+    const transactionJson = spanToJSON(transaction);
+    expect(transactionJson.description).toEqual(`${method.toUpperCase()} ${path}`);
+    expect(transactionJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual('http.server');
   });
 
   it('pulls status code from the response', done => {
@@ -422,7 +424,7 @@ describe('tracingHandler', () => {
 
     const transaction = (res as any).__sentry_transaction;
 
-    expect(transaction?.name).toBe(`${method.toUpperCase()} ${path}`);
+    expect(spanToJSON(transaction).description).toBe(`${method.toUpperCase()} ${path}`);
   });
 
   it('strips fragment from request path', () => {
@@ -432,7 +434,7 @@ describe('tracingHandler', () => {
 
     const transaction = (res as any).__sentry_transaction;
 
-    expect(transaction?.name).toBe(`${method.toUpperCase()} ${path}`);
+    expect(spanToJSON(transaction).description).toBe(`${method.toUpperCase()} ${path}`);
   });
 
   it('strips query string and fragment from request path', () => {
@@ -442,7 +444,7 @@ describe('tracingHandler', () => {
 
     const transaction = (res as any).__sentry_transaction;
 
-    expect(transaction?.name).toBe(`${method.toUpperCase()} ${path}`);
+    expect(spanToJSON(transaction).description).toBe(`${method.toUpperCase()} ${path}`);
   });
 
   it('closes the transaction when request processing is done', done => {

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -7,6 +7,7 @@ import {
   getIsolationScope,
   getMainCarrier,
   setCurrentClient,
+  spanToJSON,
   startSpan,
   withIsolationScope,
 } from '@sentry/core';
@@ -69,7 +70,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100',
       undefined,
       {
-        name: 'GET http://localhost:18100/',
+        description: 'GET http://localhost:18100/',
         op: 'http.client',
         data: expect.objectContaining({
           'http.method': 'GET',
@@ -81,7 +82,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100?foo=bar',
       undefined,
       {
-        name: 'GET http://localhost:18100/',
+        description: 'GET http://localhost:18100/',
         op: 'http.client',
         data: expect.objectContaining({
           'http.method': 'GET',
@@ -94,7 +95,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100',
       { method: 'POST' },
       {
-        name: 'POST http://localhost:18100/',
+        description: 'POST http://localhost:18100/',
         data: expect.objectContaining({
           'http.method': 'POST',
         }),
@@ -105,7 +106,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100',
       { method: 'POST' },
       {
-        name: 'POST http://localhost:18100/',
+        description: 'POST http://localhost:18100/',
         data: expect.objectContaining({
           'http.method': 'POST',
         }),
@@ -116,7 +117,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100',
       { method: undefined },
       {
-        name: 'GET http://localhost:18100/',
+        description: 'GET http://localhost:18100/',
       },
     ],
   ])('creates a span with a %s', async (_: string, request, requestInit, expected) => {
@@ -129,7 +130,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
 
       expect(spans.length).toBe(2);
 
-      const span = spans[1];
+      const span = spanToJSON(spans[1]);
       expect(span).toEqual(expect.objectContaining(expected));
     });
   });
@@ -169,9 +170,9 @@ conditionalTest({ min: 16 })('Undici integration', () => {
 
       expect(spans.length).toBe(2);
 
-      const span = spans[1];
-      expect(span).toEqual(expect.objectContaining({ name: 'GET http://a-url-that-no-exists.com//' }));
-      expect(span).toEqual(expect.objectContaining({ status: 'internal_error' }));
+      const spanJson = spanToJSON(spans[1]);
+      expect(spanJson.description).toEqual('GET http://a-url-that-no-exists.com//');
+      expect(spanJson.status).toEqual('internal_error');
     });
   });
 

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -69,7 +69,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100',
       undefined,
       {
-        description: 'GET http://localhost:18100/',
+        name: 'GET http://localhost:18100/',
         op: 'http.client',
         data: expect.objectContaining({
           'http.method': 'GET',
@@ -81,7 +81,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100?foo=bar',
       undefined,
       {
-        description: 'GET http://localhost:18100/',
+        name: 'GET http://localhost:18100/',
         op: 'http.client',
         data: expect.objectContaining({
           'http.method': 'GET',
@@ -94,7 +94,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100',
       { method: 'POST' },
       {
-        description: 'POST http://localhost:18100/',
+        name: 'POST http://localhost:18100/',
         data: expect.objectContaining({
           'http.method': 'POST',
         }),
@@ -105,7 +105,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100',
       { method: 'POST' },
       {
-        description: 'POST http://localhost:18100/',
+        name: 'POST http://localhost:18100/',
         data: expect.objectContaining({
           'http.method': 'POST',
         }),
@@ -116,7 +116,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       'http://localhost:18100',
       { method: undefined },
       {
-        description: 'GET http://localhost:18100/',
+        name: 'GET http://localhost:18100/',
       },
     ],
   ])('creates a span with a %s', async (_: string, request, requestInit, expected) => {
@@ -170,7 +170,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       expect(spans.length).toBe(2);
 
       const span = spans[1];
-      expect(span).toEqual(expect.objectContaining({ description: 'GET http://a-url-that-no-exists.com//' }));
+      expect(span).toEqual(expect.objectContaining({ name: 'GET http://a-url-that-no-exists.com//' }));
       expect(span).toEqual(expect.objectContaining({ status: 'internal_error' }));
     });
   });

--- a/packages/node/test/performance.test.ts
+++ b/packages/node/test/performance.test.ts
@@ -1,6 +1,7 @@
 import {
   setAsyncContextStrategy,
   setCurrentClient,
+  spanToJSON,
   startInactiveSpan,
   startSpan,
   startSpanManual,
@@ -81,7 +82,7 @@ describe('startSpan()', () => {
 
     const transactionEvent = await transactionEventPromise;
 
-    expect(transactionEvent.spans).toContainEqual(expect.objectContaining({ description: 'second' }));
+    expect(spanToJSON(transactionEvent.spans?.[0] as any).description).toBe('second');
   });
 });
 
@@ -153,7 +154,7 @@ describe('startSpanManual()', () => {
 
     const transactionEvent = await transactionEventPromise;
 
-    expect(transactionEvent.spans).toContainEqual(expect.objectContaining({ description: 'second' }));
+    expect(spanToJSON(transactionEvent.spans?.[0] as any).description).toBe('second');
   });
 
   it('should use the scopes at time of creation instead of the scopes at time of termination', async () => {

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -66,7 +66,7 @@ export class SentrySpanProcessor implements OtelSpanProcessor {
     if (sentryParentSpan) {
       // eslint-disable-next-line deprecation/deprecation
       const sentryChildSpan = sentryParentSpan.startChild({
-        description: otelSpan.name,
+        name: otelSpan.name,
         instrumenter: 'otel',
         startTimestamp: convertOtelTimeToSeconds(otelSpan.startTime),
         spanId: otelSpanId,

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -209,7 +209,7 @@ function createAndFinishSpanForOtelSpan(node: SpanNode, sentryParentSpan: Sentry
 
   // eslint-disable-next-line deprecation/deprecation
   const sentrySpan = sentryParentSpan.startChild({
-    description,
+    name: description,
     op,
     data: allData,
     status: mapStatus(span),

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -114,14 +114,7 @@ describe('Integration | Transactions', () => {
         }),
         // spans are circular (they have a reference to the transaction), which leads to jest choking on this
         // instead we compare them in detail below
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         tags: {
           'outer.tag': 'test value',
@@ -261,14 +254,7 @@ describe('Integration | Transactions', () => {
             origin: 'auto.test',
           },
         }),
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         tags: { 'test.tag': 'test value' },
         timestamp: expect.any(Number),
@@ -308,14 +294,7 @@ describe('Integration | Transactions', () => {
             origin: 'manual',
           },
         }),
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1b',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2b',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         tags: { 'test.tag': 'test value b' },
         timestamp: expect.any(Number),
@@ -393,14 +372,7 @@ describe('Integration | Transactions', () => {
         }),
         // spans are circular (they have a reference to the transaction), which leads to jest choking on this
         // instead we compare them in detail below
-        spans: [
-          expect.objectContaining({
-            description: 'inner span 1',
-          }),
-          expect.objectContaining({
-            description: 'inner span 2',
-          }),
-        ],
+        spans: [expect.any(Object), expect.any(Object)],
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
         transaction: 'test name',

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -196,7 +196,7 @@ function makeWrappedDocumentRequestFunction(remixVersion?: number) {
         const span = activeTransaction?.startChild({
           op: 'function.remix.document_request',
           origin: 'auto.function.remix',
-          description: spanToJSON(activeTransaction).description,
+          name: spanToJSON(activeTransaction).description,
           tags: {
             method: request.method,
             url: request.url,
@@ -253,7 +253,7 @@ function makeWrappedDataFunction(
       const span = activeTransaction?.startChild({
         op: `function.remix.${name}`,
         origin: 'auto.ui.remix',
-        description: id,
+        name: id,
         tags: {
           name,
         },

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -51,7 +51,7 @@ function recordInitSpan(transaction: Transaction, componentName: string): Span {
   // eslint-disable-next-line deprecation/deprecation
   const initSpan = transaction.startChild({
     op: UI_SVELTE_INIT,
-    description: componentName,
+    name: componentName,
     origin: 'auto.ui.svelte',
   });
 
@@ -80,7 +80,7 @@ function recordUpdateSpans(componentName: string, initSpan?: Span): void {
     // eslint-disable-next-line deprecation/deprecation
     updateSpan = parentSpan.startChild({
       op: UI_SVELTE_UPDATE,
-      description: componentName,
+      name: componentName,
       origin: 'auto.ui.svelte',
     });
   });

--- a/packages/svelte/test/performance.test.ts
+++ b/packages/svelte/test/performance.test.ts
@@ -59,13 +59,13 @@ describe('Sentry.trackComponent()', () => {
     render(DummyComponent, { props: { options: {} } });
 
     expect(testTransaction.startChild).toHaveBeenCalledWith({
-      description: '<Dummy$>',
+      name: '<Dummy$>',
       op: 'ui.svelte.init',
       origin: 'auto.ui.svelte',
     });
 
     expect(testInitSpan.startChild).toHaveBeenCalledWith({
-      description: '<Dummy$>',
+      name: '<Dummy$>',
       op: 'ui.svelte.update',
       origin: 'auto.ui.svelte',
     });
@@ -92,7 +92,7 @@ describe('Sentry.trackComponent()', () => {
     // once for init (unimportant here), once for starting the update span
     expect(testTransaction.startChild).toHaveBeenCalledTimes(2);
     expect(testTransaction.startChild).toHaveBeenLastCalledWith({
-      description: '<Dummy$>',
+      name: '<Dummy$>',
       op: 'ui.svelte.update',
       origin: 'auto.ui.svelte',
     });
@@ -103,7 +103,7 @@ describe('Sentry.trackComponent()', () => {
     render(DummyComponent, { props: { options: { trackUpdates: false } } });
 
     expect(testTransaction.startChild).toHaveBeenCalledWith({
-      description: '<Dummy$>',
+      name: '<Dummy$>',
       op: 'ui.svelte.init',
       origin: 'auto.ui.svelte',
     });
@@ -118,7 +118,7 @@ describe('Sentry.trackComponent()', () => {
     render(DummyComponent, { props: { options: { trackInit: false } } });
 
     expect(testTransaction.startChild).toHaveBeenCalledWith({
-      description: '<Dummy$>',
+      name: '<Dummy$>',
       op: 'ui.svelte.update',
       origin: 'auto.ui.svelte',
     });
@@ -137,19 +137,19 @@ describe('Sentry.trackComponent()', () => {
     expect(testTransaction.spans.length).toEqual(0);
   });
 
-  it('sets a custom component name as a span description if `componentName` is provided', async () => {
+  it('sets a custom component name as a span name if `componentName` is provided', async () => {
     render(DummyComponent, {
       props: { options: { componentName: 'CustomComponentName' } },
     });
 
     expect(testTransaction.startChild).toHaveBeenCalledWith({
-      description: '<CustomComponentName>',
+      name: '<CustomComponentName>',
       op: 'ui.svelte.init',
       origin: 'auto.ui.svelte',
     });
 
     expect(testInitSpan.startChild).toHaveBeenCalledWith({
-      description: '<CustomComponentName>',
+      name: '<CustomComponentName>',
       op: 'ui.svelte.update',
       origin: 'auto.ui.svelte',
     });
@@ -188,7 +188,7 @@ describe('Sentry.trackComponent()', () => {
     // but not the second update
     expect(testTransaction.startChild).toHaveBeenCalledTimes(1);
     expect(testTransaction.startChild).toHaveBeenLastCalledWith({
-      description: '<Dummy$>',
+      name: '<Dummy$>',
       op: 'ui.svelte.init',
       origin: 'auto.ui.svelte',
     });

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -67,7 +67,6 @@ function _instrumentPageload(client: Client): void {
   const pageloadSpan = startBrowserTracingPageLoadSpan(client, {
     name: initialPath,
     op: 'pageload',
-    description: initialPath,
     tags: {
       'routing.instrumentation': '@sentry/sveltekit',
     },

--- a/packages/sveltekit/src/client/router.ts
+++ b/packages/sveltekit/src/client/router.ts
@@ -42,7 +42,6 @@ function instrumentPageload(startTransactionFn: (context: TransactionContext) =>
     name: initialPath,
     op: 'pageload',
     origin: 'auto.pageload.sveltekit',
-    description: initialPath,
     tags: {
       ...DEFAULT_TAGS,
     },
@@ -124,7 +123,7 @@ function instrumentNavigations(startTransactionFn: (context: TransactionContext)
       // eslint-disable-next-line deprecation/deprecation
       routingSpan = activeTransaction.startChild({
         op: 'ui.sveltekit.routing',
-        description: 'SvelteKit Route Change',
+        name: 'SvelteKit Route Change',
         origin: 'auto.ui.sveltekit',
       });
       // eslint-disable-next-line deprecation/deprecation

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -115,7 +115,6 @@ describe('browserTracingIntegration', () => {
     expect(startBrowserTracingPageLoadSpanSpy).toHaveBeenCalledWith(fakeClient, {
       name: '/',
       op: 'pageload',
-      description: '/',
       tags: {
         'routing.instrumentation': '@sentry/sveltekit',
       },

--- a/packages/sveltekit/test/client/router.test.ts
+++ b/packages/sveltekit/test/client/router.test.ts
@@ -57,7 +57,6 @@ describe('sveltekitRoutingInstrumentation', () => {
       name: '/',
       op: 'pageload',
       origin: 'auto.pageload.sveltekit',
-      description: '/',
       tags: {
         'routing.instrumentation': '@sentry/sveltekit',
       },
@@ -121,7 +120,7 @@ describe('sveltekitRoutingInstrumentation', () => {
     expect(returnedTransaction?.startChild).toHaveBeenCalledWith({
       op: 'ui.sveltekit.routing',
       origin: 'auto.ui.sveltekit',
-      description: 'SvelteKit Route Change',
+      name: 'SvelteKit Route Change',
     });
 
     // eslint-disable-next-line deprecation/deprecation
@@ -171,7 +170,7 @@ describe('sveltekitRoutingInstrumentation', () => {
       expect(returnedTransaction?.startChild).toHaveBeenCalledWith({
         op: 'ui.sveltekit.routing',
         origin: 'auto.ui.sveltekit',
-        description: 'SvelteKit Route Change',
+        name: 'SvelteKit Route Change',
       });
 
       // eslint-disable-next-line deprecation/deprecation

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -1,4 +1,4 @@
-import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, addTracingExtensions } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, addTracingExtensions, spanToJSON } from '@sentry/core';
 import { NodeClient, setCurrentClient } from '@sentry/node';
 import * as SentryNode from '@sentry/node';
 import type { Transaction } from '@sentry/types';
@@ -130,8 +130,8 @@ describe('handleSentry', () => {
 
       expect(ref).toBeDefined();
 
-      expect(ref.name).toEqual('GET /users/[id]');
-      expect(ref.op).toEqual('http.server');
+      expect(spanToJSON(ref).description).toEqual('GET /users/[id]');
+      expect(spanToJSON(ref).op).toEqual('http.server');
       expect(ref.status).toEqual(isError ? 'internal_error' : 'ok');
       expect(ref.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
 
@@ -166,17 +166,18 @@ describe('handleSentry', () => {
       expect(txnCount).toEqual(1);
       expect(ref).toBeDefined();
 
-      expect(ref.name).toEqual('GET /users/[id]');
-      expect(ref.op).toEqual('http.server');
+      expect(spanToJSON(ref).description).toEqual('GET /users/[id]');
+      expect(spanToJSON(ref).op).toEqual('http.server');
       expect(ref.status).toEqual(isError ? 'internal_error' : 'ok');
       expect(ref.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
 
       expect(ref.endTimestamp).toBeDefined();
 
       expect(ref.spanRecorder.spans).toHaveLength(2);
-      expect(ref.spanRecorder.spans).toEqual(
+      const spans = ref.spanRecorder.spans.map(spanToJSON);
+      expect(spans).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ op: 'http.server', name: 'GET /users/[id]' }),
+          expect.objectContaining({ op: 'http.server', description: 'GET /users/[id]' }),
           expect.objectContaining({ op: 'http.server', description: 'GET api/users/details/[id]' }),
         ]),
       );

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -81,7 +81,7 @@ export function startTrackingLongTasks(): void {
 
       // eslint-disable-next-line deprecation/deprecation
       transaction.startChild({
-        description: 'Main UI thread blocked',
+        name: 'Main UI thread blocked',
         op: 'ui.long-task',
         origin: 'auto.ui.browser.metrics',
         startTimestamp: startTime,
@@ -108,7 +108,7 @@ export function startTrackingInteractions(): void {
         const duration = msToSec(entry.duration);
 
         const span: SpanContext = {
-          description: htmlTreeAsString(entry.target),
+          name: htmlTreeAsString(entry.target),
           op: `ui.interaction.${entry.name}`,
           origin: 'auto.ui.browser.metrics',
           startTimestamp: startTime,
@@ -265,7 +265,7 @@ export function addPerformanceEntries(transaction: Transaction): void {
     if (fidMark && _measurements['fid']) {
       // create span for FID
       _startChild(transaction, {
-        description: 'first input delay',
+        name: 'first input delay',
         endTimestamp: fidMark.value + msToSec(_measurements['fid'].value),
         op: 'ui.action',
         origin: 'auto.ui.browser.metrics',
@@ -307,7 +307,7 @@ export function _addMeasureSpans(
   const measureEndTimestamp = measureStartTimestamp + duration;
 
   _startChild(transaction, {
-    description: entry.name as string,
+    name: entry.name as string,
     endTimestamp: measureEndTimestamp,
     op: entry.entryType as string,
     origin: 'auto.resource.browser.metrics',
@@ -336,7 +336,7 @@ function _addPerformanceNavigationTiming(
   entry: Record<string, any>,
   event: string,
   timeOrigin: number,
-  description?: string,
+  name?: string,
   eventEnd?: string,
 ): void {
   const end = eventEnd ? (entry[eventEnd] as number | undefined) : (entry[`${event}End`] as number | undefined);
@@ -347,7 +347,7 @@ function _addPerformanceNavigationTiming(
   _startChild(transaction, {
     op: 'browser',
     origin: 'auto.browser.browser.metrics',
-    description: description || event,
+    name: name || event,
     startTimestamp: timeOrigin + msToSec(start),
     endTimestamp: timeOrigin + msToSec(end),
   });
@@ -364,7 +364,7 @@ function _addRequest(transaction: Transaction, entry: Record<string, any>, timeO
     _startChild(transaction, {
       op: 'browser',
       origin: 'auto.browser.browser.metrics',
-      description: 'request',
+      name: 'request',
       startTimestamp: timeOrigin + msToSec(entry.requestStart as number),
       endTimestamp: timeOrigin + msToSec(entry.responseEnd as number),
     });
@@ -372,7 +372,7 @@ function _addRequest(transaction: Transaction, entry: Record<string, any>, timeO
     _startChild(transaction, {
       op: 'browser',
       origin: 'auto.browser.browser.metrics',
-      description: 'response',
+      name: 'response',
       startTimestamp: timeOrigin + msToSec(entry.responseStart as number),
       endTimestamp: timeOrigin + msToSec(entry.responseEnd as number),
     });
@@ -427,7 +427,7 @@ export function _addResourceSpans(
   const endTimestamp = startTimestamp + duration;
 
   _startChild(transaction, {
-    description: resourceUrl.replace(WINDOW.location.origin, ''),
+    name: resourceUrl.replace(WINDOW.location.origin, ''),
     endTimestamp,
     op: entry.initiatorType ? `resource.${entry.initiatorType}` : 'resource.other',
     origin: 'auto.resource.browser.metrics',

--- a/packages/tracing-internal/src/node/integrations/apollo.ts
+++ b/packages/tracing-internal/src/node/integrations/apollo.ts
@@ -194,7 +194,7 @@ function wrapResolver(
       const parentSpan = scope.getSpan();
       // eslint-disable-next-line deprecation/deprecation
       const span = parentSpan?.startChild({
-        description: `${resolverGroupName}.${resolverName}`,
+        name: `${resolverGroupName}.${resolverName}`,
         op: 'graphql.resolve',
         origin: 'auto.graphql.apollo',
       });

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -160,7 +160,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         if (transaction) {
           // eslint-disable-next-line deprecation/deprecation
           const span = transaction.startChild({
-            description: fn.name,
+            name: fn.name,
             op: `middleware.express.${method}`,
             origin: 'auto.middleware.express',
           });
@@ -181,7 +181,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         const transaction = res.__sentry_transaction;
         // eslint-disable-next-line deprecation/deprecation
         const span = transaction?.startChild({
-          description: fn.name,
+          name: fn.name,
           op: `middleware.express.${method}`,
           origin: 'auto.middleware.express',
         });
@@ -202,7 +202,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         const transaction = res.__sentry_transaction;
         // eslint-disable-next-line deprecation/deprecation
         const span = transaction?.startChild({
-          description: fn.name,
+          name: fn.name,
           op: `middleware.express.${method}`,
           origin: 'auto.middleware.express',
         });

--- a/packages/tracing-internal/src/node/integrations/graphql.ts
+++ b/packages/tracing-internal/src/node/integrations/graphql.ts
@@ -58,7 +58,7 @@ export class GraphQL implements LazyLoadedIntegration<GraphQLModule> {
 
         // eslint-disable-next-line deprecation/deprecation
         const span = parentSpan?.startChild({
-          description: 'execute',
+          name: 'execute',
           op: 'graphql.execute',
           origin: 'auto.graphql.graphql',
         });

--- a/packages/tracing-internal/src/node/integrations/mongo.ts
+++ b/packages/tracing-internal/src/node/integrations/mongo.ts
@@ -250,7 +250,7 @@ export class Mongo implements LazyLoadedIntegration<MongoModule> {
       op: 'db',
       // TODO v8: Use `${collection.collectionName}.${operation}`
       origin: 'auto.db.mongo',
-      description: operation,
+      name: operation,
       data,
     };
 

--- a/packages/tracing-internal/src/node/integrations/mysql.ts
+++ b/packages/tracing-internal/src/node/integrations/mysql.ts
@@ -110,7 +110,7 @@ export class Mysql implements LazyLoadedIntegration<MysqlConnection> {
 
         // eslint-disable-next-line deprecation/deprecation
         const span = parentSpan?.startChild({
-          description: typeof options === 'string' ? options : (options as { sql: string }).sql,
+          name: typeof options === 'string' ? options : (options as { sql: string }).sql,
           op: 'db',
           origin: 'auto.db.mysql',
           data: {

--- a/packages/tracing-internal/src/node/integrations/postgres.ts
+++ b/packages/tracing-internal/src/node/integrations/postgres.ts
@@ -132,7 +132,7 @@ export class Postgres implements LazyLoadedIntegration<PGModule> {
 
         // eslint-disable-next-line deprecation/deprecation
         const span = parentSpan?.startChild({
-          description: typeof config === 'string' ? config : (config as { text: string }).text,
+          name: typeof config === 'string' ? config : (config as { text: string }).text,
           op: 'db',
           origin: 'auto.db.postgres',
           data,

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -247,7 +247,7 @@ describe('BrowserTracing', () => {
         const transaction = getActiveTransaction() as IdleTransaction;
         expect(transaction).toBeDefined();
         expect(spanToJSON(transaction).description).toBe('newName');
-        expect(transaction.metadata.source).toBe('custom');
+        expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
 
         expect(mockBeforeNavigation).toHaveBeenCalledTimes(1);
       });
@@ -269,7 +269,7 @@ describe('BrowserTracing', () => {
         const transaction = getActiveTransaction() as IdleTransaction;
         expect(transaction).toBeDefined();
         expect(spanToJSON(transaction).description).toBe('a/path');
-        expect(transaction.metadata.source).toBe('url');
+        expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('url');
 
         expect(mockBeforeNavigation).toHaveBeenCalledTimes(1);
       });

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -175,7 +175,7 @@ describe('BrowserTracing', () => {
 
       const transaction = getActiveTransaction() as IdleTransaction;
       expect(transaction).toBeDefined();
-      expect(transaction.name).toBe('a/path');
+      expect(spanToJSON(transaction).description).toBe('a/path');
       expect(transaction.op).toBe('pageload');
     });
 
@@ -246,8 +246,8 @@ describe('BrowserTracing', () => {
         });
         const transaction = getActiveTransaction() as IdleTransaction;
         expect(transaction).toBeDefined();
-        expect(transaction.name).toBe('newName');
-        expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+        expect(spanToJSON(transaction).description).toBe('newName');
+        expect(transaction.metadata.source).toBe('custom');
 
         expect(mockBeforeNavigation).toHaveBeenCalledTimes(1);
       });
@@ -268,8 +268,8 @@ describe('BrowserTracing', () => {
         });
         const transaction = getActiveTransaction() as IdleTransaction;
         expect(transaction).toBeDefined();
-        expect(transaction.name).toBe('a/path');
-        expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('url');
+        expect(spanToJSON(transaction).description).toBe('a/path');
+        expect(transaction.metadata.source).toBe('url');
 
         expect(mockBeforeNavigation).toHaveBeenCalledTimes(1);
       });

--- a/packages/tracing-internal/test/browser/metrics/index.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/index.test.ts
@@ -50,7 +50,7 @@ describe('_addMeasureSpans', () => {
     expect(transaction.startChild).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenLastCalledWith({
-      description: 'measure-1',
+      name: 'measure-1',
       startTimestamp: timeOrigin + startTime,
       endTimestamp: timeOrigin + startTime + duration,
       op: 'measure',
@@ -133,7 +133,7 @@ describe('_addResourceSpans', () => {
         ['server.address']: 'example.com',
         ['url.same_origin']: true,
       },
-      description: '/assets/to/css',
+      name: '/assets/to/css',
       endTimestamp: timeOrigin + startTime + duration,
       op: 'resource.css',
       origin: 'auto.resource.browser.metrics',
@@ -225,7 +225,7 @@ describe('_addResourceSpans', () => {
     expect(transaction.startChild).toHaveBeenLastCalledWith(
       expect.objectContaining({
         data: { 'server.address': 'example.com', 'url.same_origin': true, 'url.scheme': 'https' },
-        description: '/assets/to/css',
+        name: '/assets/to/css',
         endTimestamp: 468,
         op: 'resource.css',
         origin: 'auto.resource.browser.metrics',
@@ -252,7 +252,7 @@ describe('_addResourceSpans', () => {
     expect(transaction.startChild).toHaveBeenLastCalledWith(
       expect.objectContaining({
         data: { 'server.address': 'example.com', 'url.same_origin': true, 'url.scheme': 'https' },
-        description: '/assets/to/css',
+        name: '/assets/to/css',
         endTimestamp: 468,
         op: 'resource.css',
         origin: 'auto.resource.browser.metrics',

--- a/packages/tracing-internal/test/browser/metrics/utils.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/utils.test.ts
@@ -6,7 +6,7 @@ describe('_startChild()', () => {
     // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'test' });
     const span = _startChild(transaction, {
-      description: 'evaluation',
+      name: 'evaluation',
       op: 'script',
     });
 
@@ -21,7 +21,7 @@ describe('_startChild()', () => {
     // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'test', startTimestamp: 123 });
     const span = _startChild(transaction, {
-      description: 'script.js',
+      name: 'script.js',
       op: 'resource',
       startTimestamp: 100,
     });
@@ -34,7 +34,7 @@ describe('_startChild()', () => {
     // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'test', startTimestamp: 123 });
     const span = _startChild(transaction, {
-      description: 'script.js',
+      name: 'script.js',
       op: 'resource',
       startTimestamp: 150,
     });

--- a/packages/tracing/test/integrations/apollo-nestjs.test.ts
+++ b/packages/tracing/test/integrations/apollo-nestjs.test.ts
@@ -92,7 +92,7 @@ describe('setupOnce', () => {
     GraphQLFactoryInstance._resolvers[0]?.['Query']?.['res_1']?.();
     expect(scope.getSpan).toBeCalled();
     expect(parentSpan.startChild).toBeCalledWith({
-      description: 'Query.res_1',
+      name: 'Query.res_1',
       op: 'graphql.resolve',
       origin: 'auto.graphql.apollo',
     });
@@ -103,7 +103,7 @@ describe('setupOnce', () => {
     GraphQLFactoryInstance._resolvers[0]?.['Mutation']?.['res_2']?.();
     expect(scope.getSpan).toBeCalled();
     expect(parentSpan.startChild).toBeCalledWith({
-      description: 'Mutation.res_2',
+      name: 'Mutation.res_2',
       op: 'graphql.resolve',
       origin: 'auto.graphql.apollo',
     });

--- a/packages/tracing/test/integrations/apollo.test.ts
+++ b/packages/tracing/test/integrations/apollo.test.ts
@@ -92,7 +92,7 @@ describe('setupOnce', () => {
     ApolloServer.config.resolvers[0]?.['Query']?.['res_1']?.();
     expect(scope.getSpan).toBeCalled();
     expect(parentSpan.startChild).toBeCalledWith({
-      description: 'Query.res_1',
+      name: 'Query.res_1',
       op: 'graphql.resolve',
       origin: 'auto.graphql.apollo',
     });
@@ -103,7 +103,7 @@ describe('setupOnce', () => {
     ApolloServer.config.resolvers[0]?.['Mutation']?.['res_2']?.();
     expect(scope.getSpan).toBeCalled();
     expect(parentSpan.startChild).toBeCalledWith({
-      description: 'Mutation.res_2',
+      name: 'Mutation.res_2',
       op: 'graphql.resolve',
       origin: 'auto.graphql.apollo',
     });

--- a/packages/tracing/test/integrations/graphql.test.ts
+++ b/packages/tracing/test/integrations/graphql.test.ts
@@ -54,7 +54,7 @@ describe('setupOnce', () => {
     await GQLExecute.execute();
     expect(scope.getSpan).toBeCalled();
     expect(parentSpan.startChild).toBeCalledWith({
-      description: 'execute',
+      name: 'execute',
       op: 'graphql.execute',
       origin: 'auto.graphql.graphql',
     });

--- a/packages/tracing/test/integrations/node/mongo.test.ts
+++ b/packages/tracing/test/integrations/node/mongo.test.ts
@@ -84,7 +84,7 @@ describe('patchOperation()', () => {
         },
         op: 'db',
         origin: 'auto.db.mongo',
-        description: 'insertOne',
+        name: 'insertOne',
       });
       expect(childSpan.end).toBeCalled();
       done();
@@ -103,7 +103,7 @@ describe('patchOperation()', () => {
       },
       op: 'db',
       origin: 'auto.db.mongo',
-      description: 'insertOne',
+      name: 'insertOne',
     });
     expect(childSpan.end).toBeCalled();
   });
@@ -122,7 +122,7 @@ describe('patchOperation()', () => {
       },
       op: 'db',
       origin: 'auto.db.mongo',
-      description: 'insertOne',
+      name: 'insertOne',
     });
     expect(childSpan.end).toBeCalled();
   });
@@ -139,7 +139,7 @@ describe('patchOperation()', () => {
       },
       op: 'db',
       origin: 'auto.db.mongo',
-      description: 'initializeOrderedBulkOp',
+      name: 'initializeOrderedBulkOp',
     });
     expect(childSpan.end).toBeCalled();
   });

--- a/packages/tracing/test/integrations/node/postgres.test.ts
+++ b/packages/tracing/test/integrations/node/postgres.test.ts
@@ -75,7 +75,7 @@ describe('setupOnce', () => {
       Client.query('SELECT NOW()', {}, function () {
         expect(scope.getSpan).toBeCalled();
         expect(parentSpan.startChild).toBeCalledWith({
-          description: 'SELECT NOW()',
+          name: 'SELECT NOW()',
           op: 'db',
           origin: 'auto.db.postgres',
           data: {
@@ -91,7 +91,7 @@ describe('setupOnce', () => {
       Client.query('SELECT NOW()', function () {
         expect(scope.getSpan).toBeCalled();
         expect(parentSpan.startChild).toBeCalledWith({
-          description: 'SELECT NOW()',
+          name: 'SELECT NOW()',
           op: 'db',
           origin: 'auto.db.postgres',
           data: {
@@ -107,7 +107,7 @@ describe('setupOnce', () => {
       await Client.query('SELECT NOW()', null);
       expect(scope.getSpan).toBeCalled();
       expect(parentSpan.startChild).toBeCalledWith({
-        description: 'SELECT NOW()',
+        name: 'SELECT NOW()',
         op: 'db',
         origin: 'auto.db.postgres',
         data: {

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -102,9 +102,9 @@ describe('SentrySpan', () => {
 
     test('setName', () => {
       const span = new SentrySpan({});
-      expect(span.name).toBeUndefined();
+      expect(spanToJSON(span).description).toBeUndefined();
       span.updateName('foo');
-      expect(span.name).toBe('foo');
+      expect(spanToJSON(span).description).toBe('foo');
     });
   });
 
@@ -506,7 +506,7 @@ describe('SentrySpan', () => {
       expect(span.spanContext().traceId).toBe('c');
       expect(span.spanContext().spanId).toBe('d');
       expect(span.sampled).toBe(true);
-      expect(span.name).toBe(undefined);
+      expect(spanToJSON(span).description).toBe(undefined);
       expect(span.op).toBe(undefined);
       expect(span.tags).toStrictEqual({});
     });
@@ -543,7 +543,7 @@ describe('SentrySpan', () => {
 
       expect(span.spanContext().traceId).toBe('a');
       expect(span.spanContext().spanId).toBe('b');
-      expect(span.name).toBe('new');
+      expect(spanToJSON(span).description).toBe('new');
       expect(spanToJSON(span).timestamp).toBe(1);
       expect(span.op).toBe('new-op');
       expect(span.sampled).toBe(true);

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -102,9 +102,9 @@ describe('SentrySpan', () => {
 
     test('setName', () => {
       const span = new SentrySpan({});
-      expect(span.description).toBeUndefined();
+      expect(span.name).toBeUndefined();
       span.updateName('foo');
-      expect(span.description).toBe('foo');
+      expect(span.name).toBe('foo');
     });
   });
 
@@ -464,7 +464,7 @@ describe('SentrySpan', () => {
         traceId: 'a',
         spanId: 'b',
         sampled: false,
-        description: 'test',
+        name: 'test',
         op: 'op',
       };
       const span = new SentrySpan(originalContext);
@@ -489,7 +489,7 @@ describe('SentrySpan', () => {
         traceId: 'a',
         spanId: 'b',
         sampled: false,
-        description: 'test',
+        name: 'test',
         op: 'op',
         tags: {
           tag0: 'hello',
@@ -506,7 +506,7 @@ describe('SentrySpan', () => {
       expect(span.spanContext().traceId).toBe('c');
       expect(span.spanContext().spanId).toBe('d');
       expect(span.sampled).toBe(true);
-      expect(span.description).toBe(undefined);
+      expect(span.name).toBe(undefined);
       expect(span.op).toBe(undefined);
       expect(span.tags).toStrictEqual({});
     });
@@ -516,7 +516,7 @@ describe('SentrySpan', () => {
         traceId: 'a',
         spanId: 'b',
         sampled: false,
-        description: 'test',
+        name: 'test',
         op: 'op',
         tags: { tag0: 'hello' },
         data: { data0: 'foo' },
@@ -525,7 +525,7 @@ describe('SentrySpan', () => {
 
       const newContext = {
         ...span.toContext(),
-        description: 'new',
+        name: 'new',
         endTimestamp: 1,
         op: 'new-op',
         sampled: true,
@@ -543,7 +543,7 @@ describe('SentrySpan', () => {
 
       expect(span.spanContext().traceId).toBe('a');
       expect(span.spanContext().spanId).toBe('b');
-      expect(span.description).toBe('new');
+      expect(span.name).toBe('new');
       expect(spanToJSON(span).timestamp).toBe(1);
       expect(span.op).toBe('new-op');
       expect(span.sampled).toBe(true);

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -23,14 +23,14 @@ describe('`Transaction` class', () => {
       });
 
       expect(spanToJSON(transaction).description).toEqual('dogpark');
-      expect(transaction.metadata.source).toEqual('route');
+      expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
     });
 
     it("sets source to be `'custom'` in constructor if not provided", () => {
       const transaction = new Transaction({ name: 'dogpark' });
 
       expect(spanToJSON(transaction).description).toEqual('dogpark');
-      expect(transaction.metadata.source).toBe('custom');
+      expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
     });
 
     it("sets source to `'custom'` when assigning to `name` property", () => {
@@ -38,7 +38,7 @@ describe('`Transaction` class', () => {
       transaction.updateName('ballpit');
 
       expect(spanToJSON(transaction).description).toEqual('ballpit');
-      expect(transaction.metadata.source).toEqual('custom');
+      expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
     });
 
     it('sets instrumenter to be `sentry` in constructor if not provided', () => {
@@ -59,7 +59,7 @@ describe('`Transaction` class', () => {
         transaction.updateName('ballpit');
 
         expect(spanToJSON(transaction).description).toEqual('ballpit');
-        expect(transaction.metadata.source).toEqual('custom');
+        expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
       });
 
       it('uses given `source` value', () => {
@@ -68,7 +68,7 @@ describe('`Transaction` class', () => {
         transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
 
         expect(spanToJSON(transaction).description).toEqual('ballpit');
-        expect(transaction.metadata.source).toEqual('route');
+        expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
       });
     });
   });

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -55,7 +55,7 @@ describe('`Transaction` class', () => {
     describe('`setName` method', () => {
       it("sets source to `'custom'` if no source provided", () => {
         const transaction = new Transaction({ name: 'dogpark' });
-        transaction.setName('ballpit');
+        transaction.updateName('ballpit');
 
         expect(transaction.name).toEqual('ballpit');
         expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
@@ -63,7 +63,7 @@ describe('`Transaction` class', () => {
 
       it('uses given `source` value', () => {
         const transaction = new Transaction({ name: 'dogpark' });
-        transaction.setName('ballpit', 'route');
+        transaction.updateName('ballpit', 'route');
 
         expect(transaction.name).toEqual('ballpit');
         expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -4,6 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  spanToJSON,
 } from '@sentry/core';
 
 import { Transaction, addExtensionMethods } from '../src';
@@ -21,23 +22,23 @@ describe('`Transaction` class', () => {
         attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route' },
       });
 
-      expect(transaction.name).toEqual('dogpark');
-      expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
+      expect(spanToJSON(transaction).description).toEqual('dogpark');
+      expect(transaction.metadata.source).toEqual('route');
     });
 
     it("sets source to be `'custom'` in constructor if not provided", () => {
       const transaction = new Transaction({ name: 'dogpark' });
 
-      expect(transaction.name).toEqual('dogpark');
-      expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+      expect(spanToJSON(transaction).description).toEqual('dogpark');
+      expect(transaction.metadata.source).toBe('custom');
     });
 
     it("sets source to `'custom'` when assigning to `name` property", () => {
       const transaction = new Transaction({ name: 'dogpark' });
-      transaction.name = 'ballpit';
+      transaction.updateName('ballpit');
 
-      expect(transaction.name).toEqual('ballpit');
-      expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
+      expect(spanToJSON(transaction).description).toEqual('ballpit');
+      expect(transaction.metadata.source).toEqual('custom');
     });
 
     it('sets instrumenter to be `sentry` in constructor if not provided', () => {
@@ -52,32 +53,22 @@ describe('`Transaction` class', () => {
       expect(transaction.instrumenter).toEqual('otel');
     });
 
-    describe('`setName` method', () => {
+    describe('`updateName` method', () => {
       it("sets source to `'custom'` if no source provided", () => {
         const transaction = new Transaction({ name: 'dogpark' });
         transaction.updateName('ballpit');
 
-        expect(transaction.name).toEqual('ballpit');
-        expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
+        expect(spanToJSON(transaction).description).toEqual('ballpit');
+        expect(transaction.metadata.source).toEqual('custom');
       });
 
       it('uses given `source` value', () => {
         const transaction = new Transaction({ name: 'dogpark' });
-        transaction.updateName('ballpit', 'route');
-
-        expect(transaction.name).toEqual('ballpit');
-        expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
-      });
-    });
-
-    describe('`updateName` method', () => {
-      it('does not change the source', () => {
-        const transaction = new Transaction({ name: 'dogpark' });
-        transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
         transaction.updateName('ballpit');
+        transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
 
-        expect(transaction.name).toEqual('ballpit');
-        expect(transaction.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
+        expect(spanToJSON(transaction).description).toEqual('ballpit');
+        expect(transaction.metadata.source).toEqual('route');
       });
     });
   });

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -176,12 +176,6 @@ export interface SpanContext {
 /** Span holding trace_id, span_id */
 export interface Span extends Omit<SpanContext, 'op' | 'status' | 'origin'> {
   /**
-   * Human-readable identifier for the span. Identical to span.description.
-   * @deprecated Use `spanToJSON(span).description` instead.
-   */
-  name: string;
-
-  /**
    * Operation of the Span.
    *
    * @deprecated Use `startSpan()` functions to set, `span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'op')
@@ -337,13 +331,6 @@ export interface Span extends Omit<SpanContext, 'op' | 'status' | 'origin'> {
    * @deprecated Use top-level `setHttpStatus()` instead.
    */
   setHttpStatus(httpStatus: number): this;
-
-  /**
-   * Set the name of the span.
-   *
-   * @deprecated Use `updateName()` instead.
-   */
-  setName(name: string): void;
 
   /**
    * Update the name of the span.

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -100,13 +100,6 @@ export interface SpanContextData {
 /** Interface holding all properties that can be set on a Span on creation. */
 export interface SpanContext {
   /**
-   * Description of the Span.
-   *
-   * @deprecated Use `name` instead.
-   */
-  description?: string | undefined;
-
-  /**
    * Human-readable identifier for the span. Alias for span.description.
    */
   name?: string | undefined;

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -100,7 +100,7 @@ export interface SpanContextData {
 /** Interface holding all properties that can be set on a Span on creation. */
 export interface SpanContext {
   /**
-   * Human-readable identifier for the span. Alias for span.description.
+   * Human-readable identifier for the span.
    */
   name?: string | undefined;
 
@@ -174,7 +174,7 @@ export interface SpanContext {
 }
 
 /** Span holding trace_id, span_id */
-export interface Span extends Omit<SpanContext, 'op' | 'status' | 'origin'> {
+export interface Span extends Omit<SpanContext, 'name' | 'op' | 'status' | 'origin'> {
   /**
    * Operation of the Span.
    *

--- a/packages/types/src/startSpanOptions.ts
+++ b/packages/types/src/startSpanOptions.ts
@@ -48,12 +48,6 @@ export interface StartSpanOptions extends TransactionContext {
   metadata?: Partial<TransactionMetadata>;
 
   /**
-   * The name thingy.
-   * @deprecated Use `name` instead.
-   */
-  description?: string;
-
-  /**
    * @deprecated Use `span.setStatus()` instead.
    */
   status?: string;

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -105,13 +105,6 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
   instrumenter: Instrumenter;
 
   /**
-   * Set the name of the transaction
-   *
-   * @deprecated Use `.updateName()` and `.setAttribute()` instead.
-   */
-  setName(name: string, source?: TransactionSource): void;
-
-  /**
    * Set the context of a transaction event.
    * @deprecated Use either `.setAttribute()`, or set the context on the scope before creating the transaction.
    */

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -43,13 +43,7 @@ export type TraceparentData = Pick<TransactionContext, 'traceId' | 'parentSpanId
 /**
  * Transaction "Class", inherits Span only has `setName`
  */
-export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 'name'> {
-  /**
-   * Human-readable identifier for the transaction.
-   * @deprecated Use `spanToJSON(span).description` instead.
-   */
-  name: string;
-
+export interface Transaction extends Omit<TransactionContext, 'name'>, Span {
   /**
    * The ID of the transaction.
    * @deprecated Use `spanContext().spanId` instead.

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -58,7 +58,7 @@ export function getNumberOfUrlSegments(url: string): number {
 }
 
 /**
- * Takes a URL object and returns a sanitized string which is safe to use as span description
+ * Takes a URL object and returns a sanitized string which is safe to use as span name
  * see: https://develop.sentry.dev/sdk/data-handling/#structuring-data
  */
 export function getSanitizedUrlString(url: PartialURL): string {


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10677

Removes all usage of setting/getting `span.description` and `span.name`, and removes the `span.setName` method.