### PR TITLE
feat(v8): Remove deprecated `span.isSuccess` method

### DIFF
--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -500,15 +500,6 @@ export class SentrySpan implements SpanInterface {
   /**
    * @inheritDoc
    *
-   * @deprecated Use `spanToJSON(span).status === 'ok'` instead.
-   */
-  public isSuccess(): boolean {
-    return this._status === 'ok';
-  }
-
-  /**
-   * @inheritDoc
-   *
    * @deprecated Use `.end()` instead.
    */
   public finish(endTimestamp?: number): void {

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -123,31 +123,6 @@ describe('SentrySpan', () => {
       expect(span.tags['http.status_code']).toBe('404');
       expect(span.data['http.response.status_code']).toBe(404);
     });
-
-    // TODO (v8): Remove
-    test('isSuccess', () => {
-      const span = new SentrySpan({});
-      expect(span.isSuccess()).toBe(false);
-      expect(spanToJSON(span).status).not.toBe('ok');
-      span.setHttpStatus(200);
-      expect(span.isSuccess()).toBe(true);
-      expect(spanToJSON(span).status).toBe('ok');
-      span.setStatus('permission_denied');
-      expect(span.isSuccess()).toBe(false);
-      expect(spanToJSON(span).status).not.toBe('ok');
-      span.setHttpStatus(0);
-      expect(span.isSuccess()).toBe(false);
-      expect(spanToJSON(span).status).not.toBe('ok');
-      span.setHttpStatus(-1);
-      expect(span.isSuccess()).toBe(false);
-      expect(spanToJSON(span).status).not.toBe('ok');
-      span.setHttpStatus(99);
-      expect(span.isSuccess()).toBe(false);
-      expect(spanToJSON(span).status).not.toBe('ok');
-      span.setHttpStatus(100);
-      expect(span.isSuccess()).toBe(true);
-      expect(spanToJSON(span).status).toBe('ok');
-    });
   });
 
   describe('toTraceparent', () => {

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -366,13 +366,6 @@ export interface Span extends Omit<SpanContext, 'op' | 'status' | 'origin'> {
   startChild(spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'sampled' | 'traceId' | 'parentSpanId'>>): Span;
 
   /**
-   * Determines whether span was successful (HTTP200)
-   *
-   * @deprecated Use `spanToJSON(span).status === 'ok'` instead.
-   */
-  isSuccess(): boolean;
-
-  /**
    * Return a traceparent compatible header string.
    * @deprecated Use `spanToTraceHeader()` instead.
    */


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10677

deprecation PR: #10213