### PR TITLE
fix: Export session API

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -67,6 +67,9 @@ export {
   functionToStringIntegration,
   inboundFiltersIntegration,
   parameterize,
+  startSession,
+  captureSession,
+  endSession,
 } from '@sentry/core';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -77,6 +77,9 @@ export {
   linkedErrorsIntegration,
   requestDataIntegration,
   parameterize,
+  startSession,
+  captureSession,
+  endSession,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 export {

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -78,6 +78,9 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  startSession,
+  captureSession,
+  endSession,
 } from '@sentry/core';
 
 export type { SpanStatusType } from '@sentry/core';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -76,6 +76,9 @@ export {
   linkedErrorsIntegration,
   requestDataIntegration,
   metricsDefault as metrics,
+  startSession,
+  captureSession,
+  endSession,
 } from '@sentry/core';
 
 export {

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -100,4 +100,7 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  startSession,
+  captureSession,
+  endSession,
 } from '@sentry/node';


### PR DESCRIPTION
We missed exporting the top-level session APIs.