### PR TITLE
feat: Allow passing `null` to `withActiveSpan`

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -127,16 +127,18 @@ export function setUser(user: User | null): ReturnType<Hub['setUser']> {
 }
 
 /**
- * Forks the current scope and sets the provided span as active span in the context of the provided callback.
+ * Forks the current scope and sets the provided span as active span in the context of the provided callback. Can be
+ * passed `null` to start an entirely new span tree.
  *
- * @param span Spans started in the context of the provided callback will be children of this span.
+ * @param span Spans started in the context of the provided callback will be children of this span. If `null` is passed,
+ * spans started within the callback will not be attached to a parent span.
  * @param callback Execution context in which the provided span will be active. Is passed the newly forked scope.
  * @returns the value returned from the provided callback function.
  */
-export function withActiveSpan<T>(span: Span, callback: (scope: ScopeInterface) => T): T {
+export function withActiveSpan<T>(span: Span | null, callback: (scope: ScopeInterface) => T): T {
   return withScope(scope => {
     // eslint-disable-next-line deprecation/deprecation
-    scope.setSpan(span);
+    scope.setSpan(span || undefined);
     return callback(scope);
   });
 }

--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -582,4 +582,13 @@ describe('withActiveSpan()', () => {
       });
     });
   });
+
+  it('when `null` is passed, no span should be active within the callback', () => {
+    expect.assertions(1);
+    startSpan({ name: 'parent-span' }, () => {
+      withActiveSpan(null, () => {
+        expect(getActiveSpan()).toBeUndefined();
+      });
+    });
+  });
 });

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -102,14 +102,16 @@ export function startInactiveSpan(spanContext: OpenTelemetrySpanContext): Span {
 }
 
 /**
- * Forks the current scope and sets the provided span as active span in the context of the provided callback.
+ * Forks the current scope and sets the provided span as active span in the context of the provided callback. Can be
+ * passed `null` to start an entirely new span tree.
  *
- * @param span Spans started in the context of the provided callback will be children of this span.
+ * @param span Spans started in the context of the provided callback will be children of this span. If `null` is passed,
+ * spans started within the callback will not be attached to a parent span.
  * @param callback Execution context in which the provided span will be active. Is passed the newly forked scope.
  * @returns the value returned from the provided callback function.
  */
-export function withActiveSpan<T>(span: Span, callback: (scope: Scope) => T): T {
-  const newContextWithActiveSpan = trace.setSpan(context.active(), span);
+export function withActiveSpan<T>(span: Span | null, callback: (scope: Scope) => T): T {
+  const newContextWithActiveSpan = span ? trace.setSpan(context.active(), span) : trace.deleteSpan(context.active());
   return context.with(newContextWithActiveSpan, () => callback(getCurrentScope()));
 }
 


### PR DESCRIPTION
Passing null to withActiveSpan will allow people to start isolated spans without attaching them to any existing ones that may float around in the scope.

This is a sort of replacement to `startTransaction` where it was desired to start a new transaction even though one is already active on the scope.