### PR TITLE
fx(node): Fix anr worker check

### DIFF
--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -173,7 +173,7 @@ if (options.captureStackTrace) {
         {
           // Grab the trace context from the current scope
           expression:
-            'const ctx = __SENTRY__.hub.getScope().getPropagationContext(); ctx.traceId + "-" + ctx.spanId + "-" + ctx.parentSpanId',
+            'const ctx = __SENTRY__.acs?.getCurrentScope().getPropagationContext() || {}; ctx.traceId + "-" + ctx.spanId + "-" + ctx.parentSpanId',
           // Don't re-trigger the debugger if this causes an error
           silent: true,
         },


### PR DESCRIPTION
I've removed the `hub` global on the carrier in a recent PR, and noticed this leftover. Guess this is not used/covered by tests...? It should work with using `acs` as that should now always be set too (also for the default case), unless sentry is not initialized. But for type safety, the acs _may_ be undefined.