### PR TITLE
feat(node-experimental): Move `defaultStackParser` & `getSentryRelease`

### DIFF
--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -17,7 +17,8 @@ export * as Handlers from './sdk/handlers';
 export type { Span } from './types';
 
 export { startSpan, startSpanManual, startInactiveSpan, getActiveSpan, withActiveSpan } from '@sentry/opentelemetry';
-export { getClient } from './sdk/api';
+export { getClient, getSentryRelease, defaultStackParser } from './sdk/api';
+export { createGetModuleFromFilename } from './utils/module';
 // eslint-disable-next-line deprecation/deprecation
 export { getCurrentHub } from './sdk/hub';
 
@@ -25,15 +26,12 @@ export {
   addBreadcrumb,
   isInitialized,
   makeNodeTransport,
-  defaultStackParser,
-  getSentryRelease,
   getGlobalScope,
   addRequestDataToEvent,
   DEFAULT_USER_INCLUDES,
   extractRequestData,
   // eslint-disable-next-line deprecation/deprecation
   getModuleFromFilename,
-  createGetModuleFromFilename,
   close,
   createTransport,
   flush,

--- a/packages/node-experimental/src/sdk/init.ts
+++ b/packages/node-experimental/src/sdk/init.ts
@@ -6,12 +6,7 @@ import {
   hasTracingEnabled,
   startSession,
 } from '@sentry/core';
-import {
-  defaultStackParser,
-  getDefaultIntegrations as getDefaultNodeIntegrations,
-  getSentryRelease,
-  spotlightIntegration,
-} from '@sentry/node';
+import { getDefaultIntegrations as getDefaultNodeIntegrations, spotlightIntegration } from '@sentry/node';
 import { setOpenTelemetryContextAsyncContextStrategy } from '@sentry/opentelemetry';
 import type { Client, Integration, Options } from '@sentry/types';
 import {
@@ -28,6 +23,7 @@ import { httpIntegration } from '../integrations/http';
 import { nativeNodeFetchIntegration } from '../integrations/node-fetch';
 import { makeNodeTransport } from '../transports';
 import type { NodeClientOptions, NodeOptions } from '../types';
+import { defaultStackParser, getSentryRelease } from './api';
 import { NodeClient } from './client';
 import { initOtel } from './initOtel';
 

--- a/packages/node-experimental/src/utils/module.ts
+++ b/packages/node-experimental/src/utils/module.ts
@@ -1,0 +1,57 @@
+import { posix, sep } from 'path';
+import { dirname } from '@sentry/utils';
+
+/** normalizes Windows paths */
+function normalizeWindowsPath(path: string): string {
+  return path
+    .replace(/^[A-Z]:/, '') // remove Windows-style prefix
+    .replace(/\\/g, '/'); // replace all `\` instances with `/`
+}
+
+/** Creates a function that gets the module name from a filename */
+export function createGetModuleFromFilename(
+  basePath: string = process.argv[1] ? dirname(process.argv[1]) : process.cwd(),
+  isWindows: boolean = sep === '\\',
+): (filename: string | undefined) => string | undefined {
+  const normalizedBase = isWindows ? normalizeWindowsPath(basePath) : basePath;
+
+  return (filename: string | undefined) => {
+    if (!filename) {
+      return;
+    }
+
+    const normalizedFilename = isWindows ? normalizeWindowsPath(filename) : filename;
+
+    // eslint-disable-next-line prefer-const
+    let { dir, base: file, ext } = posix.parse(normalizedFilename);
+
+    if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
+      file = file.slice(0, ext.length * -1);
+    }
+
+    if (!dir) {
+      // No dirname whatsoever
+      dir = '.';
+    }
+
+    const n = dir.lastIndexOf('/node_modules');
+    if (n > -1) {
+      return `${dir.slice(n + 14).replace(/\//g, '.')}:${file}`;
+    }
+
+    // Let's see if it's a part of the main module
+    // To be a part of main module, it has to share the same base
+    if (dir.startsWith(normalizedBase)) {
+      let moduleName = dir.slice(normalizedBase.length + 1).replace(/\//g, '.');
+
+      if (moduleName) {
+        moduleName += ':';
+      }
+      moduleName += file;
+
+      return moduleName;
+    }
+
+    return file;
+  };
+}


### PR DESCRIPTION
These were imported from `@sentry/node` before.
Also moves the `createGetModuleFromFilename` utility over, which is needed for `defaultStackParser`.