### PR TITLE
feat(core): Allow to pass `forceTransaction` to `startSpan()` APIs

### DIFF
--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -301,7 +301,9 @@ export class Transaction extends SentrySpan implements TransactionInterface {
         ...metadata,
         capturedSpanScope,
         capturedSpanIsolationScope,
-        dynamicSamplingContext: getDynamicSamplingContextFromSpan(this),
+        ...dropUndefinedKeys({
+          dynamicSamplingContext: getDynamicSamplingContextFromSpan(this),
+        }),
       },
       _metrics_summary: getMetricSummaryJsonForSpan(this),
       ...(source && {

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -154,7 +154,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
     });
   });
 
-  it('creates a span for invalid looking urls xxx', async () => {
+  it('creates a span for invalid looking urls', async () => {
     await startSpan({ name: 'outer-span' }, async outerSpan => {
       try {
         // Intentionally add // to the url

--- a/packages/types/src/startSpanOptions.ts
+++ b/packages/types/src/startSpanOptions.ts
@@ -20,6 +20,13 @@ export interface StartSpanOptions extends TransactionContext {
   op?: string;
 
   /**
+   * If set to true, this span will be forced to be treated as a transaction in the Sentry UI, if possible and applicable.
+   * Note that it is up to the SDK to decide how exactly the span will be sent, which may change in future SDK versions.
+   * It is not guaranteed that a span started with this flag set to `true` will be sent as a transaction.
+   */
+  forceTransaction?: boolean;
+
+  /**
    * The origin of the span - if it comes from auto instrumentation or manual instrumentation.
    *
    * @deprecated Set `attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]` instead.


### PR DESCRIPTION
This will ensure a span is sent as a transaction to Sentry.

This only implements this option for the core implementation, not yet for OTEL - that is a follow up here: https://github.com/getsentry/sentry-javascript/pull/10807