### PR TITLE
feat(v8): Remove span.origin

### DIFF
--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -315,24 +315,6 @@ export class SentrySpan implements SpanInterface {
     this.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, op);
   }
 
-  /**
-   * The origin of the span, giving context about what created the span.
-   *
-   * @deprecated Use `spanToJSON().origin` to read the origin instead.
-   */
-  public get origin(): SpanOrigin | undefined {
-    return this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined;
-  }
-
-  /**
-   * The origin of the span, giving context about what created the span.
-   *
-   * @deprecated Use `startSpan()` functions to set the origin instead.
-   */
-  public set origin(origin: SpanOrigin | undefined) {
-    this.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
-  }
-
   /* eslint-enable @typescript-eslint/member-ordering */
 
   /** @inheritdoc */

--- a/packages/opentelemetry-node/src/utils/spanData.ts
+++ b/packages/opentelemetry-node/src/utils/spanData.ts
@@ -1,5 +1,5 @@
 /* eslint-disable deprecation/deprecation */
-import { Transaction } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, Transaction } from '@sentry/core';
 import type { Context, SpanOrigin } from '@sentry/types';
 
 import { getSentrySpan } from './spanMap';
@@ -46,7 +46,7 @@ export function addOtelSpanData(
   }
 
   if (origin) {
-    sentrySpan.origin = origin;
+    sentrySpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
   }
 
   if (sentrySpan instanceof Transaction) {

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -261,13 +261,6 @@ export interface Span extends Omit<SpanContext, 'name' | 'op' | 'status' | 'orig
   status?: string | undefined;
 
   /**
-   * The origin of the span, giving context about what created the span.
-   *
-   * @deprecated Use `startSpan` function to set and `spanToJSON(span).origin` to read the origin instead.
-   */
-  origin?: SpanOrigin | undefined;
-
-  /**
    * Get context data for this span.
    * This includes the spanId & the traceId.
    */


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10677

Removes `span.origin` as a getter.