### PR TITLE
feat(v8/browser): Rename TryCatch integration to `browserApiErrorsIntegration`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/debug/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/debug/test.ts
@@ -25,7 +25,7 @@ sentryTest('logs debug messages correctly', async ({ getLocalTestUrl, page }) =>
       ? [
           'Sentry Logger [log]: Integration installed: InboundFilters',
           'Sentry Logger [log]: Integration installed: FunctionToString',
-          'Sentry Logger [log]: Integration installed: TryCatch',
+          'Sentry Logger [log]: Integration installed: BrowserApiErrors',
           'Sentry Logger [log]: Integration installed: Breadcrumbs',
           'Sentry Logger [log]: Global Handler attached: onerror',
           'Sentry Logger [log]: Global Handler attached: onunhandledrejection',

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -45,7 +45,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       integrations: [
         'InboundFilters',
         'FunctionToString',
-        'TryCatch',
+        'BrowserApiErrors',
         'Breadcrumbs',
         'GlobalHandlers',
         'LinkedErrors',
@@ -82,7 +82,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       integrations: [
         'InboundFilters',
         'FunctionToString',
-        'TryCatch',
+        'BrowserApiErrors',
         'Breadcrumbs',
         'GlobalHandlers',
         'LinkedErrors',

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -45,7 +45,7 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
       integrations: [
         'InboundFilters',
         'FunctionToString',
-        'TryCatch',
+        'BrowserApiErrors',
         'Breadcrumbs',
         'GlobalHandlers',
         'LinkedErrors',
@@ -82,7 +82,7 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
       integrations: [
         'InboundFilters',
         'FunctionToString',
-        'TryCatch',
+        'BrowserApiErrors',
         'Breadcrumbs',
         'GlobalHandlers',
         'LinkedErrors',

--- a/dev-packages/browser-integration-tests/utils/replayEventTemplates.ts
+++ b/dev-packages/browser-integration-tests/utils/replayEventTemplates.ts
@@ -19,7 +19,7 @@ const DEFAULT_REPLAY_EVENT = {
     integrations: [
       'InboundFilters',
       'FunctionToString',
-      'TryCatch',
+      'BrowserApiErrors',
       'Breadcrumbs',
       'GlobalHandlers',
       'LinkedErrors',

--- a/packages/angular-ivy/src/sdk.ts
+++ b/packages/angular-ivy/src/sdk.ts
@@ -11,14 +11,14 @@ import { IS_DEBUG_BUILD } from './flags';
  */
 export function init(options: BrowserOptions): void {
   const opts = {
-    // Filter out TryCatch integration as it interferes with our Angular `ErrorHandler`:
-    // TryCatch would catch certain errors before they reach the `ErrorHandler` and thus provide a
+    // Filter out BrowserApiErrors integration as it interferes with our Angular `ErrorHandler`:
+    // BrowserApiErrors would catch certain errors before they reach the `ErrorHandler` and thus provide a
     // lower fidelity error than what `SentryErrorHandler` (see errorhandler.ts) would provide.
     // see:
     //  - https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097
     //  - https://github.com/getsentry/sentry-javascript/issues/2744
     defaultIntegrations: getDefaultIntegrations(options).filter(integration => {
-      return integration.name !== 'TryCatch';
+      return integration.name !== 'BrowserApiErrors';
     }),
     ...options,
   };

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -11,14 +11,14 @@ import { IS_DEBUG_BUILD } from './flags';
  */
 export function init(options: BrowserOptions): void {
   const opts = {
-    // Filter out TryCatch integration as it interferes with our Angular `ErrorHandler`:
-    // TryCatch would catch certain errors before they reach the `ErrorHandler` and thus provide a
+    // Filter out BrowserApiErrors integration as it interferes with our Angular `ErrorHandler`:
+    // BrowserApiErrors would catch certain errors before they reach the `ErrorHandler` and thus provide a
     // lower fidelity error than what `SentryErrorHandler` (see errorhandler.ts) would provide.
     // see:
     //  - https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097
     //  - https://github.com/getsentry/sentry-javascript/issues/2744
     defaultIntegrations: getDefaultIntegrations(options).filter(integration => {
-      return integration.name !== 'TryCatch';
+      return integration.name !== 'BrowserApiErrors';
     }),
     ...options,
   };

--- a/packages/angular/test/sdk.test.ts
+++ b/packages/angular/test/sdk.test.ts
@@ -14,7 +14,7 @@ describe('init', () => {
     expect(setContextSpy).toHaveBeenCalledWith('angular', { version: 10 });
   });
 
-  describe('filtering out the `TryCatch` integration', () => {
+  describe('filtering out the `BrowserApiErrors` integration', () => {
     const browserInitSpy = jest.spyOn(SentryBrowser, 'init');
 
     beforeEach(() => {
@@ -27,7 +27,7 @@ describe('init', () => {
       expect(browserInitSpy).toHaveBeenCalledTimes(1);
 
       const options = browserInitSpy.mock.calls[0][0] || {};
-      expect(options.defaultIntegrations).not.toContainEqual(expect.objectContaining({ name: 'TryCatch' }));
+      expect(options.defaultIntegrations).not.toContainEqual(expect.objectContaining({ name: 'BrowserApiErrors' }));
     });
 
     it("doesn't filter if `defaultIntegrations` is set to `false`", () => {

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -110,7 +110,7 @@ export { dedupeIntegration } from './integrations/dedupe';
 export { globalHandlersIntegration } from './integrations/globalhandlers';
 export { httpContextIntegration } from './integrations/httpcontext';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
-export { browserApiErrorsIntegration } from './integrations/trycatch';
+export { browserApiErrorsIntegration } from './integrations/browserapierrors';
 
 // eslint-disable-next-line deprecation/deprecation
-export { TryCatch, Breadcrumbs, LinkedErrors, HttpContext, Dedupe } from './integrations';
+export { Breadcrumbs, LinkedErrors, HttpContext, Dedupe } from './integrations';

--- a/packages/browser/src/integrations/browserapierrors.ts
+++ b/packages/browser/src/integrations/browserapierrors.ts
@@ -1,5 +1,5 @@
-import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
-import type { Integration, IntegrationClass, IntegrationFn, WrappedFunction } from '@sentry/types';
+import { defineIntegration } from '@sentry/core';
+import type { IntegrationFn, WrappedFunction } from '@sentry/types';
 import { fill, getFunctionName, getOriginalFunction } from '@sentry/utils';
 
 import { WINDOW, wrap } from '../helpers';
@@ -38,11 +38,11 @@ const DEFAULT_EVENT_TARGET = [
   'XMLHttpRequestUpload',
 ];
 
-const INTEGRATION_NAME = 'TryCatch';
+const INTEGRATION_NAME = 'BrowserApiErrors';
 
 type XMLHttpRequestProp = 'onload' | 'onerror' | 'onprogress' | 'onreadystatechange';
 
-interface TryCatchOptions {
+interface BrowserApiErrorsOptions {
   setTimeout: boolean;
   setInterval: boolean;
   requestAnimationFrame: boolean;
@@ -50,7 +50,7 @@ interface TryCatchOptions {
   eventTarget: boolean | string[];
 }
 
-const _browserApiErrorsIntegration = ((options: Partial<TryCatchOptions> = {}) => {
+const _browserApiErrorsIntegration = ((options: Partial<BrowserApiErrorsOptions> = {}) => {
   const _options = {
     XMLHttpRequest: true,
     eventTarget: true,
@@ -90,25 +90,10 @@ const _browserApiErrorsIntegration = ((options: Partial<TryCatchOptions> = {}) =
   };
 }) satisfies IntegrationFn;
 
-export const browserApiErrorsIntegration = defineIntegration(_browserApiErrorsIntegration);
-
 /**
  * Wrap timer functions and event targets to catch errors and provide better meta data.
- * @deprecated Use `browserApiErrorsIntegration()` instead.
  */
-// eslint-disable-next-line deprecation/deprecation
-export const TryCatch = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  browserApiErrorsIntegration,
-) as IntegrationClass<Integration> & {
-  new (options?: {
-    setTimeout: boolean;
-    setInterval: boolean;
-    requestAnimationFrame: boolean;
-    XMLHttpRequest: boolean;
-    eventTarget: boolean | string[];
-  }): Integration;
-};
+export const browserApiErrorsIntegration = defineIntegration(_browserApiErrorsIntegration);
 
 function _wrapTimeFunction(original: () => void): () => number {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -167,7 +152,7 @@ function _wrapXHR(originalSend: () => void): () => void {
             },
           };
 
-          // If Instrument integration has been called before TryCatch, get the name of original function
+          // If Instrument integration has been called before BrowserApiErrors, get the name of original function
           const originalFunction = getOriginalFunction(original);
           if (originalFunction) {
             wrapOptions.mechanism.data.handler = getFunctionName(originalFunction);

--- a/packages/browser/src/integrations/index.ts
+++ b/packages/browser/src/integrations/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable deprecation/deprecation */
-export { TryCatch } from './trycatch';
 export { Breadcrumbs } from './breadcrumbs';
 export { LinkedErrors } from './linkederrors';
 export { HttpContext } from './httpcontext';

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -25,7 +25,7 @@ import { dedupeIntegration } from './integrations/dedupe';
 import { globalHandlersIntegration } from './integrations/globalhandlers';
 import { httpContextIntegration } from './integrations/httpcontext';
 import { linkedErrorsIntegration } from './integrations/linkederrors';
-import { browserApiErrorsIntegration } from './integrations/trycatch';
+import { browserApiErrorsIntegration } from './integrations/browserapierrors';
 import { defaultStackParser } from './stack-parsers';
 import { makeFetchTransport } from './transports/fetch';
 

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -21,11 +21,11 @@ import { BrowserClient } from './client';
 import { DEBUG_BUILD } from './debug-build';
 import { WINDOW, wrap as internalWrap } from './helpers';
 import { breadcrumbsIntegration } from './integrations/breadcrumbs';
+import { browserApiErrorsIntegration } from './integrations/browserapierrors';
 import { dedupeIntegration } from './integrations/dedupe';
 import { globalHandlersIntegration } from './integrations/globalhandlers';
 import { httpContextIntegration } from './integrations/httpcontext';
 import { linkedErrorsIntegration } from './integrations/linkederrors';
-import { browserApiErrorsIntegration } from './integrations/browserapierrors';
 import { defaultStackParser } from './stack-parsers';
 import { makeFetchTransport } from './transports/fetch';
 

--- a/packages/replay/test/fixtures/error.ts
+++ b/packages/replay/test/fixtures/error.ts
@@ -41,7 +41,7 @@ export function Error(obj?: Event): any {
       integrations: [
         'InboundFilters',
         'FunctionToString',
-        'TryCatch',
+        'BrowserApiErrors',
         'Breadcrumbs',
         'GlobalHandlers',
         'LinkedErrors',

--- a/packages/replay/test/fixtures/transaction.ts
+++ b/packages/replay/test/fixtures/transaction.ts
@@ -249,7 +249,7 @@ export function Transaction(traceId?: string, obj?: Partial<Event>): any {
       integrations: [
         'InboundFilters',
         'FunctionToString',
-        'TryCatch',
+        'BrowserApiErrors',
         'Breadcrumbs',
         'GlobalHandlers',
         'LinkedErrors',


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/8838

- Removes `TryCatch` integration class export
- Updates angular to refer to browserApiErrorsIntegration by name instead of using `TryCatch`