### PR TITLE
feat(opentelemetry): Align span options with core span options

### DIFF
--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -291,7 +291,7 @@ describe('startSpan', () => {
     expect(spanToJSON(_span!).timestamp).toBeDefined();
   });
 
-  it('allows to pass a `startTime` yyy', () => {
+  it('allows to pass a `startTime`', () => {
     const start = startSpan({ name: 'outer', startTime: [1234, 0] }, span => {
       return spanToJSON(span!).start_timestamp;
     });

--- a/packages/opentelemetry/src/contextManager.ts
+++ b/packages/opentelemetry/src/contextManager.ts
@@ -8,7 +8,7 @@ import {
   SENTRY_FORK_SET_SCOPE_CONTEXT_KEY,
 } from './constants';
 import { getCurrentHub } from './custom/getCurrentHub';
-import { getScopesFromContext, setHubOnContext, setScopesOnContext } from './utils/contextData';
+import { getScopesFromContext, setContextOnScope, setHubOnContext, setScopesOnContext } from './utils/contextData';
 
 /**
  * Wrap an OpenTelemetry ContextManager in a way that ensures the context is kept in sync with the Sentry Hub.
@@ -69,6 +69,8 @@ export function wrapContextManagerClass<ContextManagerInstance extends ContextMa
         .deleteValue(SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY)
         .deleteValue(SENTRY_FORK_SET_SCOPE_CONTEXT_KEY)
         .deleteValue(SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY);
+
+      setContextOnScope(newCurrentScope, ctx3);
 
       return super.with(ctx3, fn, thisArg, ...args);
     }

--- a/packages/opentelemetry/src/types.ts
+++ b/packages/opentelemetry/src/types.ts
@@ -1,25 +1,15 @@
-import type { Attributes, Span as WriteableSpan, SpanKind, TimeInput, Tracer } from '@opentelemetry/api';
+import type { Span as WriteableSpan, SpanKind, Tracer } from '@opentelemetry/api';
 import type { BasicTracerProvider, ReadableSpan, Span } from '@opentelemetry/sdk-trace-base';
-import type { Scope, SpanOrigin, TransactionMetadata, TransactionSource } from '@sentry/types';
+import type { Scope, StartSpanOptions } from '@sentry/types';
 
 export interface OpenTelemetryClient {
   tracer: Tracer;
   traceProvider: BasicTracerProvider | undefined;
 }
 
-export interface OpenTelemetrySpanContext {
-  name: string;
-  op?: string;
-  metadata?: Partial<TransactionMetadata>;
-  origin?: SpanOrigin;
-  source?: TransactionSource;
-  scope?: Scope;
-  onlyIfParent?: boolean;
-
-  // Base SpanOptions we support
-  attributes?: Attributes;
+export interface OpenTelemetrySpanContext extends StartSpanOptions {
+  // Additional otel-only option, for now...?
   kind?: SpanKind;
-  startTime?: TimeInput;
 }
 
 /**

--- a/packages/opentelemetry/src/utils/contextData.ts
+++ b/packages/opentelemetry/src/utils/contextData.ts
@@ -55,10 +55,15 @@ export function getScopesFromContext(context: Context): CurrentScopes | undefine
  * This will return a forked context with the Propagation Context set.
  */
 export function setScopesOnContext(context: Context, scopes: CurrentScopes): Context {
-  // So we can look up the context from the scope later
-  SCOPE_CONTEXT_MAP.set(scopes.scope, context);
-
   return context.setValue(SENTRY_SCOPES_CONTEXT_KEY, scopes);
+}
+
+/**
+ * Set the context on the scope so we can later look it up.
+ * We need this to get the context from the scope in the `trace` functions.
+ */
+export function setContextOnScope(scope: Scope, context: Context): void {
+  SCOPE_CONTEXT_MAP.set(scope, context);
 }
 
 /**


### PR DESCRIPTION
This aligns the options for `startSpan` in otel with the core ones. Only the `kind` is there in addition for now (we may want to remove this, let's see).

Especially, this also adds the ability to pass a `scope` there and pick up the correct context & span to continue, as well as adding tests for the options.