### PR TITLE
chore(publish): [v7] Use craft config from merge target branch for release preparation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,3 +36,4 @@ jobs:
           version: ${{ steps.version.outputs.group1 }}
           force: false
           merge_target: master
+          craft_config_from_merge_target: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,5 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
+          craft_config_from_merge_target: true
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
       merge_target:
         description: Target branch to merge into. Uses the default branch as a fallback (optional)
         required: false
-        default: master
+        default: v7
 jobs:
   release:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR updates our prepare release workflows on the `v7` branch to use the craft config from the merge target branch (which for v7 releases should always be `v7`) instead of the config from the default branch (`develop` in our case). 

Once this PR and https://github.com/getsentry/publish/pull/3467 are merged, we can start customizing the craft config on both, `develop` and `v7` to our convenience.

ref https://github.com/getsentry/publish/issues/3441