### PR TITLE
chore(publish): [v8] Use craft config from merge target branch for release preparation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,3 +36,4 @@ jobs:
           version: ${{ steps.version.outputs.group1 }}
           force: false
           merge_target: master
+          craft_config_from_merge_target: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,5 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
+          craft_config_from_merge_target: true
+


### PR DESCRIPTION
Same principle as in #10763 but with config from v8 and releasing from `master`. 

This isn't strictly necessary but I'd say, we also change this to take the config from `master` because technically, our default branch is `develop` and the config _could_ diverge. Unlikely but still something I'd say we should do now that we can.

ref https://github.com/getsentry/publish/issues/3441
