### PR TITLE
ref(node-integration-tests): Migrate to new Http integration

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/server.ts
@@ -7,8 +7,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Sentry.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import express from 'express';
 
 const app = express();
@@ -8,8 +7,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
@@ -1,7 +1,6 @@
 import http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -14,8 +13,7 @@ Sentry.init({
   release: '1.0',
   environment: 'prod',
   tracePropagationTargets: [/^(?!.*express).*$/],
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
@@ -1,7 +1,6 @@
 import * as http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -15,8 +14,7 @@ Sentry.init({
   environment: 'prod',
   // disable requests to /express
   tracePropagationTargets: [/^(?!.*express).*$/],
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
@@ -1,7 +1,6 @@
 import http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -15,8 +14,7 @@ Sentry.init({
   environment: 'prod',
   // disable requests to /express
   tracePropagationTargets: [/^(?!.*express).*$/],
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
@@ -2,7 +2,6 @@ import http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -16,8 +15,7 @@ Sentry.init({
   environment: 'prod',
   // disable requests to /express
   tracePropagationTargets: [/^(?!.*express).*$/],
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   // TODO: We're rethinking the mechanism for including Pii data in DSC, hence commenting out sendDefaultPii for now
   // sendDefaultPii: true,

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/server.ts
@@ -1,7 +1,6 @@
 import http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -14,8 +13,7 @@ Sentry.init({
   release: '1.0',
   environment: 'prod',
   tracePropagationTargets: [/^(?!.*express).*$/],
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/tracing/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/server.ts
@@ -10,7 +10,7 @@ Sentry.init({
   release: '1.0',
   // disable attaching headers to /test/* endpoints
   tracePropagationTargets: [/^(?!.*test).*$/],
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Sentry.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing-new/tracePropagationTargets/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/tracePropagationTargets/scenario.ts
@@ -6,7 +6,7 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   tracePropagationTargets: [/\/v0/, 'v1'],
-  integrations: [new Sentry.Integrations.Http({ tracing: true })],
+  integrations: [Sentry.httpIntegration({ tracing: true })],
 });
 
 Sentry.startSpan({ name: 'test_span' }, () => {

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario.ts
@@ -1,13 +1,11 @@
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import { ApolloServer, gql } from 'apollo-server';
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Tracing.Integrations.GraphQL(), new Tracing.Integrations.Apollo()],
+  integrations: [new Sentry.Integrations.GraphQL(), new Sentry.Integrations.Apollo()],
 });
 
 const typeDefs = gql`

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/scenario.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { PrismaClient } from '@prisma/client';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 
 const client = new PrismaClient();
 
@@ -9,8 +8,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Tracing.Integrations.Prisma({ client })],
+  integrations: [new Sentry.Integrations.Prisma({ client })],
 });
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
@@ -6,7 +6,7 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   tracePropagationTargets: [/\/v0/, 'v1'],
-  integrations: [new Sentry.Integrations.Http({ tracing: true })],
+  integrations: [Sentry.httpIntegration({ tracing: true })],
 });
 
 Sentry.startSpan({ name: 'test_span' }, () => {


### PR DESCRIPTION
This PR migrates the Http integration in node-integration-tests (`new Sentry.Integrations.Http` gets `Sentry.httpIntegration`). I also exchanged `Tracing` to `Sentry`.