### PR TITLE
ref(eslint): Remove unused eslint-disable directives

### DIFF
--- a/dev-packages/e2e-tests/prepare.ts
+++ b/dev-packages/e2e-tests/prepare.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 /* eslint-disable no-console */
 import * as dotenv from 'dotenv';
 

--- a/dev-packages/e2e-tests/publish-packages.ts
+++ b/dev-packages/e2e-tests/publish-packages.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as childProcess from 'child_process';
 import * as path from 'path';
 import * as glob from 'glob';

--- a/dev-packages/e2e-tests/run.ts
+++ b/dev-packages/e2e-tests/run.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 /* eslint-disable no-console */
 import { spawn } from 'child_process';
 import { resolve } from 'path';

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -91,7 +91,6 @@ describe('SentryBrowser', () => {
         getCurrentScope().setUser(EX_USER);
         setCurrentClient(client);
 
-        // eslint-disable-next-line deprecation/deprecation
         showReportDialog({ eventId: 'foobar' });
 
         expect(getReportDialogEndpoint).toHaveBeenCalledTimes(1);
@@ -106,7 +105,6 @@ describe('SentryBrowser', () => {
         setCurrentClient(client);
 
         const DIALOG_OPTION_USER = { email: 'option@example.com' };
-        // eslint-disable-next-line deprecation/deprecation
         showReportDialog({ eventId: 'foobar', user: DIALOG_OPTION_USER });
 
         expect(getReportDialogEndpoint).toHaveBeenCalledTimes(1);
@@ -140,7 +138,7 @@ describe('SentryBrowser', () => {
 
       it('should call `onClose` when receiving `__sentry_reportdialog_closed__` MessageEvent', async () => {
         const onClose = jest.fn();
-        // eslint-disable-next-line deprecation/deprecation
+
         showReportDialog({ eventId: 'foobar', onClose });
 
         await waitForPostMessage('__sentry_reportdialog_closed__');
@@ -155,7 +153,7 @@ describe('SentryBrowser', () => {
         const onClose = jest.fn(() => {
           throw new Error();
         });
-        // eslint-disable-next-line deprecation/deprecation
+
         showReportDialog({ eventId: 'foobar', onClose });
 
         await waitForPostMessage('__sentry_reportdialog_closed__');
@@ -168,7 +166,7 @@ describe('SentryBrowser', () => {
 
       it('should not call `onClose` for other MessageEvents', async () => {
         const onClose = jest.fn();
-        // eslint-disable-next-line deprecation/deprecation
+
         showReportDialog({ eventId: 'foobar', onClose });
 
         await waitForPostMessage('some_message');

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -123,7 +123,6 @@ export { bunServerIntegration } from './integrations/bunserver';
 const INTEGRATIONS = {
   // eslint-disable-next-line deprecation/deprecation
   ...CoreIntegrations,
-  // eslint-disable-next-line deprecation/deprecation
   ...NodeIntegrations,
   BunServer,
 };

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -150,7 +150,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   /**
    * @inheritDoc
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public captureException(exception: any, hint?: EventHint, scope?: Scope): string | undefined {
     // ensure we haven't captured this very object before
     if (checkOrSetAlreadyCaught(exception)) {
@@ -857,7 +857,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   /**
    * @inheritDoc
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public abstract eventFromException(_exception: any, _hint?: EventHint): PromiseLike<Event>;
 
   /**

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -173,7 +173,6 @@ function _getPossibleEventMessages(event: Event): string[] {
   let lastException;
   try {
     // @ts-expect-error Try catching to save bundle size
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     lastException = event.exception.values[event.exception.values.length - 1];
   } catch (e) {
     // try catching to save bundle size checking existence of variables
@@ -198,7 +197,6 @@ function _getPossibleEventMessages(event: Event): string[] {
 function _isSentryError(event: Event): boolean {
   try {
     // @ts-expect-error can't be a sentry error if undefined
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return event.exception.values[0].type === 'SentryError';
   } catch (e) {
     // ignore

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -57,7 +57,6 @@ function _startTransaction(
 The transaction will not be sampled. Please use the ${configInstrumenter} instrumentation to start transactions.`,
       );
 
-    // eslint-disable-next-line deprecation/deprecation
     transactionContext.sampled = false;
   }
 

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import type { Hub, SpanTimeInput, TransactionContext } from '@sentry/types';
 import { logger, timestampInSeconds } from '@sentry/utils';
 

--- a/packages/core/src/tracing/sampling.ts
+++ b/packages/core/src/tracing/sampling.ts
@@ -107,7 +107,6 @@ export function sampleTransaction<T extends Transaction>(
  */
 function isValidSampleRate(rate: unknown): boolean {
   // we need to check NaN explicitly because it's of type 'number' and therefore wouldn't get caught by this typecheck
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (isNaN(rate) || !(typeof rate === 'number' || typeof rate === 'boolean')) {
     DEBUG_BUILD &&
       logger.warn(

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -89,7 +89,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
   }
 
   // This sadly conflicts with the getter/setter ordering :(
-  /* eslint-disable @typescript-eslint/member-ordering */
 
   /**
    * Get the metadata for this transaction.

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable deprecation/deprecation */
 import type { ClientOptions, DsnComponents } from '@sentry/types';
 import { makeDsn } from '@sentry/utils';
 

--- a/packages/core/test/lib/session.test.ts
+++ b/packages/core/test/lib/session.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable deprecation/deprecation */
-
 import type { SessionContext } from '@sentry/types';
 import { timestampInSeconds } from '@sentry/utils';
 

--- a/packages/core/test/lib/sessionflusher.test.ts
+++ b/packages/core/test/lib/sessionflusher.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable deprecation/deprecation */
-
 import type { Client } from '@sentry/types';
 
 import { SessionFlusher } from '../../src/sessionflusher';

--- a/packages/core/test/lib/tracing/span.test.ts
+++ b/packages/core/test/lib/tracing/span.test.ts
@@ -4,7 +4,6 @@ import { TRACE_FLAG_NONE, TRACE_FLAG_SAMPLED, spanToJSON } from '../../../src/ut
 
 describe('span', () => {
   describe('name', () => {
-    /* eslint-disable deprecation/deprecation */
     it('works with name', () => {
       const span = new SentrySpan({ name: 'span name' });
       expect(spanToJSON(span).description).toEqual('span name');

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -49,13 +49,11 @@ export class TestClient extends BaseClient<TestClientOptions> {
     TestClient.instance = this;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public eventFromException(exception: any): PromiseLike<Event> {
     const event: Event = {
       exception: {
         values: [
           {
-            /* eslint-disable @typescript-eslint/no-unsafe-member-access */
             type: exception.name,
             value: exception.message,
             /* eslint-enable @typescript-eslint/no-unsafe-member-access */
@@ -86,7 +84,6 @@ export class TestClient extends BaseClient<TestClientOptions> {
       super.sendEvent(event, hint);
       return;
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     TestClient.sendEventCalled && TestClient.sendEventCalled(event);
   }
 

--- a/packages/feedback/test/utils/TestClient.ts
+++ b/packages/feedback/test/utils/TestClient.ts
@@ -14,7 +14,6 @@ export class TestClient extends BaseClient<TestClientOptions> {
       exception: {
         values: [
           {
-            /* eslint-disable @typescript-eslint/no-unsafe-member-access */
             type: exception.name,
             value: exception.message,
             /* eslint-enable @typescript-eslint/no-unsafe-member-access */

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -314,7 +314,6 @@ function _createWrappedRequestMethodFactory(
     return function wrappedMethod(this: unknown, ...args: RequestMethodArgs): http.ClientRequest {
       const requestArgs = normalizeRequestArgs(httpModule, args);
       const requestOptions = requestArgs[0];
-      // eslint-disable-next-line deprecation/deprecation
       const rawRequestUrl = extractRawUrl(requestOptions);
       const requestUrl = extractUrl(requestOptions);
       const client = getClient();

--- a/packages/profiling-node/src/cpu_profiler.ts
+++ b/packages/profiling-node/src/cpu_profiler.ts
@@ -34,7 +34,6 @@ export function importCppBindingsModule(): PrivateV8CpuProfilerBindings {
     return require(`${binaryPath}.node`);
   }
 
-  /* eslint-disable no-fallthrough */
   // We need the fallthrough so that in the end, we can fallback to the require dynamice require.
   // This is for cases where precompiled binaries were not provided, but may have been compiled from source.
   if (platform === 'darwin') {

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -140,7 +140,6 @@ export class ProfilingIntegration implements Integration {
 
           // Remove the profile from the transaction context before sending, relay will take care of the rest.
           if (profileContext) {
-            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
             delete profiledTransaction.contexts?.['profile'];
           }
 

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -26,7 +26,6 @@ import type { DebugImage } from './types';
 
 // We require the file because if we import it, it will be included in the bundle.
 // I guess tsc does not check file contents when it's imported.
-// eslint-disable-next-line
 const THREAD_ID_STRING = String(threadId);
 const THREAD_NAME = isMainThread ? 'main' : 'worker';
 const FORMAT_VERSION = '1';

--- a/packages/replay/src/util/getReplay.ts
+++ b/packages/replay/src/util/getReplay.ts
@@ -4,7 +4,6 @@ import type { replayIntegration } from '../integration';
 /**
  * This is a small utility to get a type-safe instance of the Replay integration.
  */
-// eslint-disable-next-line deprecation/deprecation
 export function getReplay(): ReturnType<typeof replayIntegration> | undefined {
   const client = getClient();
   return client && client.getIntegrationByName<ReturnType<typeof replayIntegration>>('Replay');

--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 import type { IdleTransaction } from '@sentry/core';
 import { getActiveSpan } from '@sentry/core';
 import { getCurrentHub } from '@sentry/core';

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -340,7 +340,6 @@ export class BrowserTracing implements Integration {
       this._latestRouteSource = finalContext.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
     }
 
-    // eslint-disable-next-line deprecation/deprecation
     if (finalContext.sampled === false) {
       DEBUG_BUILD && logger.log(`[Tracing] Will not send ${finalContext.op} transaction because of beforeNavigate.`);
     }

--- a/packages/tracing-internal/src/node/integrations/mongo.ts
+++ b/packages/tracing-internal/src/node/integrations/mongo.ts
@@ -174,7 +174,6 @@ export class Mongo implements LazyLoadedIntegration<MongoModule> {
     fill(collection.prototype, operation, function (orig: () => void | Promise<unknown>) {
       return function (this: unknown, ...args: unknown[]) {
         const lastArg = args[args.length - 1];
-        // eslint-disable-next-line deprecation/deprecation
         const hub = getCurrentHub();
         // eslint-disable-next-line deprecation/deprecation
         const scope = hub.getScope();

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -159,7 +159,6 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   init(): void;
 
   /** Creates an {@link Event} from all inputs to `captureException` and non-primitive inputs to `captureMessage`. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   eventFromException(exception: any, hint?: EventHint): PromiseLike<Event>;
 
   /** Creates an {@link Event} from primitive inputs to `captureMessage`. */

--- a/packages/types/src/startSpanOptions.ts
+++ b/packages/types/src/startSpanOptions.ts
@@ -85,7 +85,6 @@ export interface StartSpanOptions extends TransactionContext {
   /**
    * @deprecated Use attributes instead.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: { [key: string]: any };
 
   /**

--- a/packages/utils/src/browser.ts
+++ b/packages/utils/src/browser.ts
@@ -111,7 +111,6 @@ function _htmlElementAsString(el: unknown, keyAttrs?: string[]): string {
       out.push(`#${elem.id}`);
     }
 
-    // eslint-disable-next-line prefer-const
     className = elem.className;
     if (className && isString(className)) {
       classes = className.split(/\s+/);

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/ban-types */
 import type { HandlerDataFetch } from '@sentry/types';
 
 import { fill } from '../object';

--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 import type { ParameterizedString, PolymorphicEvent, Primitive } from '@sentry/types';
 

--- a/packages/utils/src/node-stack-trace.ts
+++ b/packages/utils/src/node-stack-trace.ts
@@ -50,7 +50,6 @@ export function filenameIsInApp(filename: string, isNative: boolean = false): bo
 }
 
 /** Node Stack line parser */
-// eslint-disable-next-line complexity
 export function node(getModule?: GetModuleFn): StackLineParserFn {
   const FILENAME_MATCH = /^\s*[-]{4,}$/;
   const FULL_MATCH = /at (?:async )?(?:(.+?)\s+\()?(?:(.+):(\d+):(\d+)?|([^)]+))\)?/;

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -24,7 +24,7 @@ export function isNodeEnv(): boolean {
  *
  * @param request The module path to resolve
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function dynamicRequire(mod: any, request: string): any {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   return mod.require(request);

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { WrappedFunction } from '@sentry/types';
 

--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-/* eslint-disable @typescript-eslint/typedef */
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { isThenable } from './is';
 
@@ -182,7 +180,6 @@ class SyncPromise<T> implements PromiseLike<T> {
       }
 
       if (this._state === States.RESOLVED) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         handler[1](this._value as unknown as any);
       }
 

--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -190,7 +190,6 @@ describe('normalize()', () => {
     });
 
     test('circular arrays', () => {
-      // eslint-disable-next-line @typescript-eslint/ban-types
       const obj: object[] = [];
       obj.push(obj);
       obj.push(obj);
@@ -198,7 +197,6 @@ describe('normalize()', () => {
     });
 
     test('circular arrays with intermediaries', () => {
-      // eslint-disable-next-line @typescript-eslint/ban-types
       const obj: object[] = [];
       obj.push({ name: 'Alice', self: obj });
       obj.push({ name: 'Bob', self: obj });

--- a/packages/utils/test/syncpromise.test.ts
+++ b/packages/utils/test/syncpromise.test.ts
@@ -138,7 +138,6 @@ describe('SyncPromise', () => {
 
     let foo: number = 1;
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     new SyncPromise<number>(_ => {
       foo = 2;
     });


### PR DESCRIPTION
Remove some unused directives to for less eslint warnings. Related to https://github.com/getsentry/sentry-javascript/pull/10610
