### PR TITLE
fix: Make breadcrumbs option optional in WinterCGFetch integration

### DIFF
--- a/packages/vercel-edge/src/integrations/wintercg-fetch.ts
+++ b/packages/vercel-edge/src/integrations/wintercg-fetch.ts
@@ -129,10 +129,7 @@ export const WinterCGFetch = convertIntegrationFnToClass(
   INTEGRATION_NAME,
   winterCGFetchIntegration,
 ) as IntegrationClass<Integration & { setupOnce: () => void }> & {
-  new (options?: {
-    breadcrumbs: boolean;
-    shouldCreateSpanForRequest?: (url: string) => boolean;
-  }): Integration;
+  new (options?: Partial<Options>): Integration;
 };
 
 // eslint-disable-next-line deprecation/deprecation


### PR DESCRIPTION
Right now it's not possible to use it as:

```js
new Sentry.Integrations.WinterCGFetch({
  shouldCreateSpanForRequest: (url) => {
    return !url.startsWith(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest`);
  }
})
```

due to `breadcrubs` not being marked as optional. Instead of changing it to such, reuse already existing `Options` interface to keep it in sync with the integration itself.