### PR TITLE
fix(replay): Add `errorHandler` for replayCanvas integration

### DIFF
--- a/packages/replay-canvas/src/canvas.ts
+++ b/packages/replay-canvas/src/canvas.ts
@@ -79,7 +79,7 @@ export const _replayCanvasIntegration = ((options: Partial<ReplayCanvasOptions> 
             errorHandler: (err: unknown) => {
               try {
                 if (typeof err === 'object') {
-                  (err as Error & {__rrweb__?: boolean}).__rrweb__ = true;
+                  (err as Error & { __rrweb__?: boolean }).__rrweb__ = true;
                 }
               } catch (error) {
                 // ignore errors here

--- a/packages/replay-canvas/src/canvas.ts
+++ b/packages/replay-canvas/src/canvas.ts
@@ -76,9 +76,11 @@ export const _replayCanvasIntegration = ((options: Partial<ReplayCanvasOptions> 
           const manager = new CanvasManager({
             ...options,
             enableManualSnapshot,
-            errorHandler: (err: Error & { __rrweb__?: boolean }) => {
+            errorHandler: (err: unknown) => {
               try {
-                err.__rrweb__ = true;
+                if (typeof err === 'object') {
+                  (err as Error & {__rrweb__?: boolean}).__rrweb__ = true;
+                }
               } catch (error) {
                 // ignore errors here
                 // this can happen if the error is frozen or does not allow mutation for other reasons

--- a/packages/replay-canvas/src/canvas.ts
+++ b/packages/replay-canvas/src/canvas.ts
@@ -73,7 +73,18 @@ export const _replayCanvasIntegration = ((options: Partial<ReplayCanvasOptions> 
         enableManualSnapshot,
         recordCanvas: true,
         getCanvasManager: (options: CanvasManagerOptions) => {
-          const manager = new CanvasManager({ ...options, enableManualSnapshot });
+          const manager = new CanvasManager({
+            ...options,
+            enableManualSnapshot,
+            errorHandler: (err: Error & { __rrweb__?: boolean }) => {
+              try {
+                err.__rrweb__ = true;
+              } catch (error) {
+                // ignore errors here
+                // this can happen if the error is frozen or does not allow mutation for other reasons
+              }
+            },
+          });
           canvasManagerResolve(manager);
           return manager;
         },


### PR DESCRIPTION
`errorHandler` for `CanvasManager` was added in the latest rrweb, but was not configured in our integration.