### PR TITLE
feat: Remove tags from spans & transactions

### DIFF
--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -1,5 +1,4 @@
 import type {
-  Primitive,
   Span,
   SpanAttributeValue,
   SpanAttributes,
@@ -66,12 +65,6 @@ export class SpanRecorder {
  */
 export class SentrySpan implements Span {
   /**
-   * Tags for the span.
-   * @deprecated Use `spanToJSON(span).atttributes` instead.
-   */
-  public tags: { [key: string]: Primitive };
-
-  /**
    * Data for the span.
    * @deprecated Use `spanToJSON(span).atttributes` instead.
    */
@@ -116,8 +109,6 @@ export class SentrySpan implements Span {
     this._traceId = spanContext.traceId || uuid4();
     this._spanId = spanContext.spanId || uuid4().substring(16);
     this._startTime = spanContext.startTimestamp || timestampInSeconds();
-    // eslint-disable-next-line deprecation/deprecation
-    this.tags = spanContext.tags ? { ...spanContext.tags } : {};
     // eslint-disable-next-line deprecation/deprecation
     this.data = spanContext.data ? { ...spanContext.data } : {};
 
@@ -329,21 +320,6 @@ export class SentrySpan implements Span {
   }
 
   /**
-   * Sets the tag attribute on the current span.
-   *
-   * Can also be used to unset a tag, by passing `undefined`.
-   *
-   * @param key Tag key
-   * @param value Tag value
-   * @deprecated Use `setAttribute()` instead.
-   */
-  public setTag(key: string, value: Primitive): this {
-    // eslint-disable-next-line deprecation/deprecation
-    this.tags = { ...this.tags, [key]: value };
-    return this;
-  }
-
-  /**
    * Sets the data attribute on the current span
    * @param key Data key
    * @param value Data value
@@ -439,8 +415,6 @@ export class SentrySpan implements Span {
       spanId: this._spanId,
       startTimestamp: this._startTime,
       status: this._status,
-      // eslint-disable-next-line deprecation/deprecation
-      tags: this.tags,
       traceId: this._traceId,
     });
   }
@@ -471,8 +445,6 @@ export class SentrySpan implements Span {
       span_id: this._spanId,
       start_timestamp: this._startTime,
       status: getStatusMessage(this._status),
-      // eslint-disable-next-line deprecation/deprecation
-      tags: Object.keys(this.tags).length > 0 ? this.tags : undefined,
       timestamp: this._endTime,
       trace_id: this._traceId,
       origin: this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined,

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -286,8 +286,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
       },
       spans,
       start_timestamp: this._startTime,
-      // eslint-disable-next-line deprecation/deprecation
-      tags: this.tags,
       timestamp: this._endTime,
       transaction: this._name,
       type: 'transaction',

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -22,7 +22,7 @@ export const TRACE_FLAG_SAMPLED = 0x1;
  */
 export function spanToTraceContext(span: Span): TraceContext {
   const { spanId: span_id, traceId: trace_id } = span.spanContext();
-  const { data, op, parent_span_id, status, tags, origin } = spanToJSON(span);
+  const { data, op, parent_span_id, status, origin } = spanToJSON(span);
 
   return dropUndefinedKeys({
     data,
@@ -30,7 +30,6 @@ export function spanToTraceContext(span: Span): TraceContext {
     parent_span_id,
     span_id,
     status,
-    tags,
     trace_id,
     origin,
   });

--- a/packages/profiling-node/test/hubextensions.test.ts
+++ b/packages/profiling-node/test/hubextensions.test.ts
@@ -15,7 +15,6 @@ import { __PRIVATE__wrapStartTransactionWithProfiling } from '../src/hubextensio
 function makeTransactionMock(options = {}): Transaction {
   return {
     metadata: {},
-    tags: {},
     sampled: true,
     contexts: {},
     startChild: () => ({ end: () => void 0 }),
@@ -28,10 +27,6 @@ function makeTransactionMock(options = {}): Transaction {
     setContext(this: Transaction, key: string, context: Context) {
       // @ts-expect-error - contexts is private
       this.contexts[key] = context;
-    },
-    setTag(this: Transaction, key: string, value: any) {
-      // eslint-disable-next-line deprecation/deprecation
-      this.tags[key] = value;
     },
     setMetadata(this: Transaction, metadata: Partial<TransactionMetadata>) {
       // eslint-disable-next-line deprecation/deprecation

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -50,7 +50,6 @@ export interface SpanJSON {
   span_id: string;
   start_timestamp: number;
   status?: string;
-  tags?: { [key: string]: Primitive };
   timestamp?: number;
   trace_id: string;
   origin?: SpanOrigin;
@@ -131,12 +130,6 @@ export interface SpanContext {
    * Trace ID
    */
   traceId?: string | undefined;
-
-  /**
-   * Tags of the Span.
-   * @deprecated Pass `attributes` instead.
-   */
-  tags?: { [key: string]: Primitive };
 
   /**
    * Data of the Span.

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,7 +1,7 @@
 import type { Context } from './context';
 import type { DynamicSamplingContext } from './envelope';
 import type { MeasurementUnit } from './measurement';
-import type { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
+import type { ExtractedNodeRequestData, WorkerLocation } from './misc';
 import type { PolymorphicRequest } from './polymorphics';
 import type { Span, SpanAttributes, SpanContext } from './span';
 
@@ -80,12 +80,6 @@ export interface Transaction extends Omit<TransactionContext, 'name' | 'op'>, Sp
    * @inheritDoc
    */
   startTimestamp: number;
-
-  /**
-   * Tags for the transaction.
-   * @deprecated Use `getSpanAttributes(transaction)` instead.
-   */
-  tags: { [key: string]: Primitive };
 
   /**
    * Data for the transaction.


### PR DESCRIPTION
We've refactored all usage away, now we can actually get rid of the tags on the span themselves.