### PR TITLE
feat(v8): Remove deprecated Replay, Feedback, ReplayCanvas exports

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -154,7 +154,7 @@ module.exports = [
   {
     name: '@sentry/nextjs Client (incl. Tracing, Replay) - Webpack (gzipped)',
     path: 'packages/nextjs/build/esm/client/index.js',
-    import: '{ init, browserTracingIntegration, Replay }',
+    import: '{ init, browserTracingIntegration, replayIntegration }',
     gzip: true,
     limit: '110 KB',
   },

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -3,28 +3,28 @@ module.exports = [
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
-    import: '{ init, Replay, browserTracingIntegration, Feedback }',
+    import: '{ init, replayIntegration, browserTracingIntegration, Feedback }',
     gzip: true,
     limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
-    import: '{ init, Replay, browserTracingIntegration }',
+    import: '{ init, replayIntegration, browserTracingIntegration }',
     gzip: true,
     limit: '75 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay with Canvas) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
-    import: '{ init, Replay, browserTracingIntegration, ReplayCanvas }',
+    import: '{ init, replayIntegration, browserTracingIntegration, replayCanvasIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - Webpack with treeshaking flags (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
-    import: '{ init, Replay, browserTracingIntegration }',
+    import: '{ init, replayIntegration, browserTracingIntegration }',
     gzip: true,
     limit: '75 KB',
     modifyWebpackConfig: function (config) {

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -57,7 +57,7 @@ module.exports = [
   {
     name: '@sentry/browser (incl. Feedback) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
-    import: '{ init, Feedback }',
+    import: '{ init, feedbackIntegration }',
     gzip: true,
     limit: '50 KB',
   },
@@ -168,7 +168,7 @@ module.exports = [
   {
     name: '@sentry-internal/feedback - Webpack (gzipped)',
     path: 'packages/feedback/build/npm/esm/index.js',
-    import: '{ Feedback }',
+    import: '{ feedbackIntegration }',
     gzip: true,
     limit: '25 KB',
   },

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -3,7 +3,7 @@ module.exports = [
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
-    import: '{ init, replayIntegration, browserTracingIntegration, Feedback }',
+    import: '{ init, replayIntegration, browserTracingIntegration, feedbackIntegration }',
     gzip: true,
     limit: '90 KB',
   },
@@ -138,7 +138,7 @@ module.exports = [
   {
     name: '@sentry/react (incl. Tracing, Replay) - Webpack (gzipped)',
     path: 'packages/react/build/esm/index.js',
-    import: '{ init, browserTracingIntegration, Replay }',
+    import: '{ init, browserTracingIntegration, replayIntegration }',
     gzip: true,
     limit: '75 KB',
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -531,7 +531,7 @@ import * as Sentry from '@sentry/browser';
 Sentry.init({
   integrations: [
     // Instead of
-    Sentry.replayIntegration(),
+    new Sentry.Replay(),
     new Sentry.Feedback(),
     // Use the functional replacement:
     Sentry.replayIntegration(),
@@ -601,7 +601,7 @@ Just add it _in addition_ to the regular replay integration:
 
 ```js
 Sentry.init({
-  integrations: [Sentry.replayIntegration(), new Sentry.ReplayCanvas()],
+  integrations: [new Sentry.Replay(), new Sentry.ReplayCanvas()],
 });
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -531,7 +531,7 @@ import * as Sentry from '@sentry/browser';
 Sentry.init({
   integrations: [
     // Instead of
-    new Sentry.Replay(),
+    Sentry.replayIntegration(),
     new Sentry.Feedback(),
     // Use the functional replacement:
     Sentry.replayIntegration(),
@@ -601,7 +601,7 @@ Just add it _in addition_ to the regular replay integration:
 
 ```js
 Sentry.init({
-  integrations: [new Sentry.Replay(), new Sentry.ReplayCanvas()],
+  integrations: [Sentry.replayIntegration(), new Sentry.ReplayCanvas()],
 });
 ```
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/init.js
@@ -2,7 +2,7 @@ Sentry.onLoad(function () {
   Sentry.init({
     integrations: [
       // Without this syntax, this will be re-written by the test framework
-      new window['Sentry'].Replay({
+      new window['Sentry'].replayIntegration({
         useCompression: false,
       }),
     ],

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/init.js
@@ -2,7 +2,7 @@ Sentry.onLoad(function () {
   Sentry.init({
     integrations: [
       // Without this syntax, this will be re-written by the test framework
-      new window['Sentry'].replayIntegration({
+      window['Sentry'].replayIntegration({
         useCompression: false,
       }),
     ],

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/init.js
@@ -4,5 +4,5 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [Sentry.feedbackIntegration],
+  integrations: [Sentry.feedbackIntegration()],
 });

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/init.js
@@ -1,9 +1,8 @@
-import { Feedback } from '@sentry-internal/feedback';
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [new Feedback()],
+  integrations: [Sentry.feedbackIntegration],
 });

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackAndReplay/hasSampling/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackAndReplay/hasSampling/init.js
@@ -1,4 +1,3 @@
-import { Feedback } from '@sentry-internal/feedback';
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
@@ -8,11 +7,11 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
   replaysSessionSampleRate: 0,
   integrations: [
-    new Sentry.Replay({
+    Sentry.replayIntegration({
       flushMinDelay: 200,
       flushMaxDelay: 200,
       minReplayDuration: 0,
     }),
-    new Feedback(),
+    Sentry.feedbackIntegration(),
   ],
 });

--- a/dev-packages/browser-integration-tests/suites/replay/bufferMode/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferMode/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/bufferMode/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferMode/test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import type { Replay } from '@sentry/replay';
+import type { replayIntegration as actualReplayIntegration } from '@sentry/replay';
 import type { ReplayContainer } from '@sentry/replay/build/npm/types/types';
 
 import { sentryTest } from '../../../utils/fixtures';
@@ -58,8 +58,9 @@ sentryTest(
 
     expect(
       await page.evaluate(() => {
-        const replayIntegration = (window as unknown as Window & { Replay: { _replay: ReplayContainer } }).Replay;
-        const replay = replayIntegration._replay;
+        const replayIntegration = (window as unknown as Window & { Replay: ReturnType<typeof actualReplayIntegration> })
+          .Replay;
+        const replay = replayIntegration['_replay'];
         return replay.isEnabled();
       }),
     ).toBe(false);
@@ -67,10 +68,9 @@ sentryTest(
     // Start buffering and assert that it is enabled
     expect(
       await page.evaluate(() => {
-        // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof Replay> }).Replay;
-        // @ts-expect-error private
-        const replay = replayIntegration._replay;
+        const replayIntegration = (window as unknown as Window & { Replay: ReturnType<typeof actualReplayIntegration> })
+          .Replay;
+        const replay = replayIntegration['_replay'];
         replayIntegration.startBuffering();
         return replay.isEnabled();
       }),
@@ -88,8 +88,8 @@ sentryTest(
     const [req0] = await Promise.all([
       reqPromise0,
       page.evaluate(async () => {
-        // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
+        const replayIntegration = (window as unknown as Window & { Replay: ReturnType<typeof actualReplayIntegration> })
+          .Replay;
         await replayIntegration.flush();
       }),
     ]);
@@ -212,10 +212,9 @@ sentryTest(
     // Start buffering and assert that it is enabled
     expect(
       await page.evaluate(() => {
-        // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof Replay> }).Replay;
-        // @ts-expect-error private
-        const replay = replayIntegration._replay;
+        const replayIntegration = (window as unknown as Window & { Replay: ReturnType<typeof actualReplayIntegration> })
+          .Replay;
+        const replay = replayIntegration['_replay'];
         replayIntegration.startBuffering();
         return replay.isEnabled();
       }),
@@ -233,8 +232,8 @@ sentryTest(
     const [req0] = await Promise.all([
       reqPromise0,
       page.evaluate(async () => {
-        // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
+        const replayIntegration = (window as unknown as Window & { Replay: ReturnType<typeof actualReplayIntegration> })
+          .Replay;
         await replayIntegration.flush({ continueRecording: false });
       }),
     ]);
@@ -328,8 +327,8 @@ sentryTest(
     // Start buffering and assert that it is enabled
     expect(
       await page.evaluate(() => {
-        // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof Replay> }).Replay;
+        const replayIntegration = (window as unknown as Window & { Replay: ReturnType<typeof actualReplayIntegration> })
+          .Replay;
         const replay = replayIntegration['_replay'];
         replayIntegration.startBuffering();
         return replay.isEnabled();
@@ -347,8 +346,8 @@ sentryTest(
     expect(errorEvent0.tags?.replayId).toBeUndefined();
 
     await page.evaluate(async () => {
-      // eslint-disable-next-line deprecation/deprecation
-      const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
+      const replayIntegration = (window as unknown as Window & { Replay: ReturnType<typeof actualReplayIntegration> })
+        .Replay;
       replayIntegration['_replay'].getOptions().errorSampleRate = 1.0;
     });
 

--- a/dev-packages/browser-integration-tests/suites/replay/bufferModeReload/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferModeReload/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/manualSnapshot/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/manualSnapshot/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 50,
   flushMaxDelay: 50,
   minReplayDuration: 0,
@@ -14,5 +14,5 @@ Sentry.init({
   replaysOnErrorSampleRate: 0.0,
   debug: true,
 
-  integrations: [window.Replay, new Sentry.ReplayCanvas({ enableManualSnapshot: true })],
+  integrations: [window.Replay, Sentry.replayCanvasIntegration({ enableManualSnapshot: true })],
 });

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/records/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/records/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 50,
   flushMaxDelay: 50,
   minReplayDuration: 0,
@@ -14,5 +14,5 @@ Sentry.init({
   replaysOnErrorSampleRate: 0.0,
   debug: true,
 
-  integrations: [window.Replay, new Sentry.ReplayCanvas()],
+  integrations: [window.Replay, Sentry.replayCanvasIntegration()],
 });

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,
@@ -14,5 +14,5 @@ Sentry.init({
   replaysOnErrorSampleRate: 0.0,
   debug: true,
 
-  integrations: [new Sentry.ReplayCanvas(), window.Replay],
+  integrations: [Sentry.replayCanvasIntegration(), window.Replay],
 });

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,
@@ -14,5 +14,5 @@ Sentry.init({
   replaysOnErrorSampleRate: 0.0,
   debug: true,
 
-  integrations: [window.Replay, new Sentry.ReplayCanvas()],
+  integrations: [window.Replay, Sentry.replayCanvasIntegration()],
 });

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/captureComponentName/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/captureComponentName/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/init.js
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/browser';
-import { Replay } from '@sentry/replay';
+import { replayIntegration } from '@sentry/replay';
 
 window.Sentry = Sentry;
-window.Replay = new Replay({
+window.Replay = replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/compressionDisabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionDisabled/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/compressionEnabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionEnabled/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/compressionWorkerUrl/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionWorkerUrl/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/customEvents/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/customEvents/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/dsc/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/dsc/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -8,8 +8,7 @@ import { getReplaySnapshot, shouldSkipReplayTest, waitForReplayRunning } from '.
 
 type TestWindow = Window & {
   Sentry: typeof Sentry;
-  // eslint-disable-next-line deprecation/deprecation
-  Replay: Sentry.Replay;
+  Replay: ReturnType<typeof Sentry.replayIntegration>;
 };
 
 sentryTest(

--- a/dev-packages/browser-integration-tests/suites/replay/errors/beforeErrorSampling/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/beforeErrorSampling/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/droppedError/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/droppedError/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorModeCustomTransport/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorModeCustomTransport/init.js
@@ -5,16 +5,19 @@ window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,
-  useCompression: false,
-  blockAllMedia: false,
-  block: ['link[rel="icon"]', 'video', '.nested-hide'],
 });
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  sampleRate: 0,
-  replaysSessionSampleRate: 1.0,
-  replaysOnErrorSampleRate: 0.0,
-
+  sampleRate: 1,
+  replaysSessionSampleRate: 0.0,
+  replaysOnErrorSampleRate: 1.0,
   integrations: [window.Replay],
+  transport: options => {
+    const transport = new Sentry.makeFetchTransport(options);
+
+    delete transport.send.__sentry__baseTransport__;
+
+    return transport;
+  },
 });

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorNotSent/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorNotSent/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
@@ -38,12 +38,10 @@ sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     fetch('http://localhost:7654/foo').then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -114,12 +112,10 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     fetch('http://localhost:7654/foo').then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -196,12 +192,10 @@ sentryTest('does not capture response headers if URL does not match', async ({ g
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     fetch('http://localhost:7654/bar').then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/fileInput/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/fileInput/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/flushing/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/flushing/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/keyboardEvents/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/keyboardEvents/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/maxReplayDuration/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/maxReplayDuration/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/minReplayDuration/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/minReplayDuration/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 2000,

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/privacyDefault/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyDefault/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/privacyInput/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyInput/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/privacyInputMaskAll/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyInputMaskAll/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/replayIntegrationShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/replayIntegrationShim/test.ts
@@ -30,6 +30,8 @@ sentryTest(
     await forceFlushReplay();
 
     expect(requestCount).toBe(0);
-    expect(consoleMessages).toEqual(['You are using new Replay() even though this bundle does not include replay.']);
+    expect(consoleMessages).toEqual([
+      'You are using replayIntegration() even though this bundle does not include replay.',
+    ]);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/replay/replayShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/replayShim/init.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 // Replay should not actually work, but still not error out
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/replayShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/replayShim/test.ts
@@ -30,6 +30,8 @@ sentryTest(
     await forceFlushReplay();
 
     expect(requestCount).toBe(0);
-    expect(consoleMessages).toEqual(['You are using new Replay() even though this bundle does not include replay.']);
+    expect(consoleMessages).toEqual([
+      'You are using replayIntegration() even though this bundle does not include replay.',
+    ]);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/replay/requests/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/requests/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/sampling/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/sampling/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/sessionExpiry/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionExpiry/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/sessionInactive/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionInactive/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/disable/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/disable/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/error/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/error/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/throttleBreadcrumbs/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/throttleBreadcrumbs/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 5000,
   flushMaxDelay: 5000,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/unicode/compressed/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/unicode/compressed/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/browser-integration-tests/suites/replay/unicode/uncompressed/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/unicode/uncompressed/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/app/entry.client.tsx
@@ -12,7 +12,7 @@ Sentry.init({
       useLocation,
       useMatches,
     }),
-    new Sentry.Replay(),
+    Sentry.replayIntegration(),
   ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
@@ -18,7 +18,7 @@ Sentry.init({
       useLocation,
       useMatches,
     }),
-    new Sentry.Replay(),
+    Sentry.replayIntegration(),
   ],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
@@ -12,7 +12,7 @@ import { hydrateRoot } from 'react-dom/client';
 Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
-  integrations: [Sentry.browserTracingIntegration({ useEffect, useMatches, useLocation }), new Sentry.Replay()],
+  integrations: [Sentry.browserTracingIntegration({ useEffect, useMatches, useLocation }), Sentry.replayIntegration()],
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   // Session Replay

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
@@ -12,7 +12,7 @@ import {
 import Index from './pages/Index';
 import User from './pages/User';
 
-const replay = new Sentry.Replay();
+const replay = Sentry.replayIntegration();
 
 Sentry.init({
   // environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
@@ -12,7 +12,7 @@ import {
 import Index from './pages/Index';
 import User from './pages/User';
 
-const replay = new Sentry.Replay();
+const replay = Sentry.replayIntegration();
 
 Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/src/index.tsx
@@ -13,7 +13,7 @@ import {
 import Index from './pages/Index';
 import User from './pages/User';
 
-const replay = new Sentry.Replay();
+const replay = Sentry.replayIntegration();
 
 Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/overhead-metrics/test-apps/booking-app/with-replay.html
+++ b/dev-packages/overhead-metrics/test-apps/booking-app/with-replay.html
@@ -224,7 +224,7 @@
         enableTracing: true,
         integrations: [
           Sentry.browserTracingIntegration(),
-          new Sentry.Integrations.Replay({
+          Sentry.replayIntegration({
             useCompression: true,
             flushMinDelay: 2000,
             flushMaxDelay: 2000,

--- a/dev-packages/overhead-metrics/test-apps/jank/with-replay.html
+++ b/dev-packages/overhead-metrics/test-apps/jank/with-replay.html
@@ -31,7 +31,7 @@
         dsn: 'https://d16ae2d36f9249849c7964e9a3a8a608@o447951.ingest.sentry.io/5429213',
         replaysSessionSampleRate: 1.0,
         replaysOnErrorSampleRate: 1.0,
-        integrations: [new Sentry.Integrations.Replay({})],
+        integrations: [Sentry.replayIntegration({})],
       });
     </script>
   </head>

--- a/packages/browser/src/index.bundle.feedback.ts
+++ b/packages/browser/src/index.bundle.feedback.ts
@@ -1,27 +1,16 @@
 // This is exported so the loader does not fail when switching off Replay/Tracing
-import { Feedback, feedbackIntegration } from '@sentry-internal/feedback';
+import { feedbackIntegration } from '@sentry-internal/feedback';
 import {
-  ReplayShim,
   addTracingExtensionsShim,
   browserTracingIntegrationShim,
   replayIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
-import * as Sentry from './index.bundle.base';
-
-// TODO (v8): Remove this as it was only needed for backwards compatibility
-// eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = ReplayShim;
-
 export * from './index.bundle.base';
 export {
   browserTracingIntegrationShim as browserTracingIntegration,
   addTracingExtensionsShim as addTracingExtensions,
-  // eslint-disable-next-line deprecation/deprecation
-  ReplayShim as Replay,
   replayIntegrationShim as replayIntegration,
-  // eslint-disable-next-line deprecation/deprecation
-  Feedback,
   feedbackIntegration,
 };
 // Note: We do not export a shim for `Span` here, as that is quite complex and would blow up the bundle

--- a/packages/browser/src/index.bundle.replay.ts
+++ b/packages/browser/src/index.bundle.replay.ts
@@ -1,27 +1,16 @@
 // This is exported so the loader does not fail when switching off Replay/Tracing
 import {
-  FeedbackShim,
   addTracingExtensionsShim,
   browserTracingIntegrationShim,
   feedbackIntegrationShim,
 } from '@sentry-internal/integration-shims';
-import { Replay, replayIntegration } from '@sentry/replay';
-
-import * as Sentry from './index.bundle.base';
-
-// TODO (v8): Remove this as it was only needed for backwards compatibility
-// eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = Replay;
+import { replayIntegration } from '@sentry/replay';
 
 export * from './index.bundle.base';
 export {
   browserTracingIntegrationShim as browserTracingIntegration,
   addTracingExtensionsShim as addTracingExtensions,
-  // eslint-disable-next-line deprecation/deprecation
-  Replay,
   replayIntegration,
-  // eslint-disable-next-line deprecation/deprecation
-  FeedbackShim as Feedback,
   feedbackIntegrationShim as feedbackIntegration,
 };
 // Note: We do not export a shim for `Span` here, as that is quite complex and would blow up the bundle

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -1,15 +1,7 @@
-import { Feedback, feedbackIntegration } from '@sentry-internal/feedback';
+import { feedbackIntegration } from '@sentry-internal/feedback';
 import { browserTracingIntegration } from '@sentry-internal/tracing';
 import { addTracingExtensions } from '@sentry/core';
-import { Replay, replayIntegration } from '@sentry/replay';
-
-import * as Sentry from './index.bundle.base';
-
-// TODO (v8): Remove this as it was only needed for backwards compatibility
-// We want replay to be available under Sentry.Replay, to be consistent
-// with the NPM package version.
-// eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = Replay;
+import { replayIntegration } from '@sentry/replay';
 
 // We are patching the global object with our hub extension methods
 addTracingExtensions();
@@ -22,14 +14,6 @@ export {
   withActiveSpan,
 } from '@sentry/core';
 
-export {
-  // eslint-disable-next-line deprecation/deprecation
-  Feedback,
-  // eslint-disable-next-line deprecation/deprecation
-  Replay,
-  feedbackIntegration,
-  replayIntegration,
-  browserTracingIntegration,
-  addTracingExtensions,
-};
+export { feedbackIntegration, replayIntegration, browserTracingIntegration, addTracingExtensions };
+
 export * from './index.bundle.base';

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -1,15 +1,7 @@
-import { FeedbackShim, feedbackIntegrationShim } from '@sentry-internal/integration-shims';
+import { feedbackIntegrationShim } from '@sentry-internal/integration-shims';
 import { browserTracingIntegration } from '@sentry-internal/tracing';
 import { addTracingExtensions } from '@sentry/core';
-import { Replay, replayIntegration } from '@sentry/replay';
-
-import * as Sentry from './index.bundle.base';
-
-// TODO (v8): Remove this as it was only needed for backwards compatibility
-// We want replay to be available under Sentry.Replay, to be consistent
-// with the NPM package version.
-// eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = Replay;
+import { replayIntegration } from '@sentry/replay';
 
 // We are patching the global object with our hub extension methods
 addTracingExtensions();
@@ -23,13 +15,10 @@ export {
 } from '@sentry/core';
 
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  FeedbackShim as Feedback,
-  // eslint-disable-next-line deprecation/deprecation
-  Replay,
   replayIntegration,
   feedbackIntegrationShim as feedbackIntegration,
   browserTracingIntegration,
   addTracingExtensions,
 };
+
 export * from './index.bundle.base';

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -1,20 +1,7 @@
 // This is exported so the loader does not fail when switching off Replay
-import {
-  FeedbackShim,
-  ReplayShim,
-  feedbackIntegrationShim,
-  replayIntegrationShim,
-} from '@sentry-internal/integration-shims';
+import { feedbackIntegrationShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
 import { browserTracingIntegration } from '@sentry-internal/tracing';
 import { addTracingExtensions } from '@sentry/core';
-
-import * as Sentry from './index.bundle.base';
-
-// TODO(v8): Remove this as it was only needed for backwards compatibility
-// We want replay to be available under Sentry.Replay, to be consistent
-// with the NPM package version.
-// eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = ReplayShim;
 
 // We are patching the global object with our hub extension methods
 addTracingExtensions();
@@ -28,13 +15,10 @@ export {
 } from '@sentry/core';
 
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  FeedbackShim as Feedback,
-  // eslint-disable-next-line deprecation/deprecation
-  ReplayShim as Replay,
   feedbackIntegrationShim as feedbackIntegration,
   replayIntegrationShim as replayIntegration,
   browserTracingIntegration,
   addTracingExtensions,
 };
+
 export * from './index.bundle.base';

--- a/packages/browser/src/index.bundle.ts
+++ b/packages/browser/src/index.bundle.ts
@@ -1,26 +1,14 @@
 // This is exported so the loader does not fail when switching off Replay/Tracing
 import {
-  FeedbackShim,
-  ReplayShim,
   addTracingExtensionsShim,
   browserTracingIntegrationShim,
   feedbackIntegrationShim,
   replayIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
-import * as Sentry from './index.bundle.base';
-
-// TODO (v8): Remove this as it was only needed for backwards compatibility
-// eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = ReplayShim;
-
 export * from './index.bundle.base';
 export {
   addTracingExtensionsShim as addTracingExtensions,
-  // eslint-disable-next-line deprecation/deprecation
-  ReplayShim as Replay,
-  // eslint-disable-next-line deprecation/deprecation
-  FeedbackShim as Feedback,
   browserTracingIntegrationShim as browserTracingIntegration,
   feedbackIntegrationShim as feedbackIntegration,
   replayIntegrationShim as replayIntegration,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -30,8 +30,6 @@ export {
 } from '@sentry/core';
 
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  Replay,
   replayIntegration,
   getReplay,
 } from '@sentry/replay';
@@ -47,15 +45,9 @@ export type {
   ReplaySpanFrameEvent,
 } from '@sentry/replay';
 
-export {
-  // eslint-disable-next-line deprecation/deprecation
-  ReplayCanvas,
-  replayCanvasIntegration,
-} from '@sentry-internal/replay-canvas';
+export { replayCanvasIntegration } from '@sentry-internal/replay-canvas';
 
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  Feedback,
   feedbackIntegration,
   sendFeedback,
 } from '@sentry-internal/feedback';

--- a/packages/browser/test/unit/index.bundle.feedback.test.ts
+++ b/packages/browser/test/unit/index.bundle.feedback.test.ts
@@ -1,6 +1,5 @@
-/* eslint-disable deprecation/deprecation */
-import { ReplayShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
-import { Feedback, feedbackIntegration } from '@sentry/browser';
+import { replayIntegrationShim } from '@sentry-internal/integration-shims';
+import { feedbackIntegration } from '@sentry/browser';
 
 import * as TracingReplayBundle from '../../src/index.bundle.feedback';
 
@@ -10,11 +9,7 @@ describe('index.bundle.feedback', () => {
       expect((TracingReplayBundle.Integrations[key] as any).id).toStrictEqual(expect.any(String));
     });
 
-    expect(TracingReplayBundle.Integrations.Replay).toBe(ReplayShim);
-    expect(TracingReplayBundle.Replay).toBe(ReplayShim);
     expect(TracingReplayBundle.replayIntegration).toBe(replayIntegrationShim);
-
-    expect(TracingReplayBundle.Feedback).toBe(Feedback);
     expect(TracingReplayBundle.feedbackIntegration).toBe(feedbackIntegration);
   });
 });

--- a/packages/browser/test/unit/index.bundle.replay.test.ts
+++ b/packages/browser/test/unit/index.bundle.replay.test.ts
@@ -1,6 +1,5 @@
-/* eslint-disable deprecation/deprecation */
-import { FeedbackShim, feedbackIntegrationShim } from '@sentry-internal/integration-shims';
-import { Replay, replayIntegration } from '@sentry/browser';
+import { feedbackIntegrationShim } from '@sentry-internal/integration-shims';
+import { replayIntegration } from '@sentry/browser';
 
 import * as TracingReplayBundle from '../../src/index.bundle.replay';
 
@@ -10,11 +9,7 @@ describe('index.bundle.replay', () => {
       expect((TracingReplayBundle.Integrations[key] as any).id).toStrictEqual(expect.any(String));
     });
 
-    expect(TracingReplayBundle.Integrations.Replay).toBe(Replay);
-    expect(TracingReplayBundle.Replay).toBe(Replay);
     expect(TracingReplayBundle.replayIntegration).toBe(replayIntegration);
-
-    expect(TracingReplayBundle.Feedback).toBe(FeedbackShim);
     expect(TracingReplayBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
   });
 });

--- a/packages/browser/test/unit/index.bundle.test.ts
+++ b/packages/browser/test/unit/index.bundle.test.ts
@@ -1,10 +1,4 @@
-/* eslint-disable deprecation/deprecation */
-import {
-  FeedbackShim,
-  ReplayShim,
-  feedbackIntegrationShim,
-  replayIntegrationShim,
-} from '@sentry-internal/integration-shims';
+import { feedbackIntegrationShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
 
 import * as TracingBundle from '../../src/index.bundle';
 
@@ -14,11 +8,7 @@ describe('index.bundle', () => {
       expect((TracingBundle.Integrations[key] as any).name).toStrictEqual(expect.any(String));
     });
 
-    expect(TracingBundle.Integrations.Replay).toBe(ReplayShim);
-    expect(TracingBundle.Replay).toBe(ReplayShim);
     expect(TracingBundle.replayIntegration).toBe(replayIntegrationShim);
-
-    expect(TracingBundle.Feedback).toBe(FeedbackShim);
     expect(TracingBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
   });
 });

--- a/packages/browser/test/unit/index.bundle.tracing.replay.feedback.test.ts
+++ b/packages/browser/test/unit/index.bundle.tracing.replay.feedback.test.ts
@@ -1,6 +1,5 @@
-/* eslint-disable deprecation/deprecation */
 import { browserTracingIntegration } from '@sentry-internal/tracing';
-import { Feedback, Replay, feedbackIntegration, replayIntegration } from '@sentry/browser';
+import { feedbackIntegration, replayIntegration } from '@sentry/browser';
 
 import * as TracingReplayFeedbackBundle from '../../src/index.bundle.tracing.replay.feedback';
 
@@ -10,13 +9,8 @@ describe('index.bundle.tracing.replay.feedback', () => {
       expect((TracingReplayFeedbackBundle.Integrations[key] as any).id).toStrictEqual(expect.any(String));
     });
 
-    expect(TracingReplayFeedbackBundle.Integrations.Replay).toBe(Replay);
-    expect(TracingReplayFeedbackBundle.Replay).toBe(Replay);
     expect(TracingReplayFeedbackBundle.replayIntegration).toBe(replayIntegration);
-
     expect(TracingReplayFeedbackBundle.browserTracingIntegration).toBe(browserTracingIntegration);
-
-    expect(TracingReplayFeedbackBundle.Feedback).toBe(Feedback);
     expect(TracingReplayFeedbackBundle.feedbackIntegration).toBe(feedbackIntegration);
   });
 });

--- a/packages/browser/test/unit/index.bundle.tracing.replay.test.ts
+++ b/packages/browser/test/unit/index.bundle.tracing.replay.test.ts
@@ -1,7 +1,6 @@
-/* eslint-disable deprecation/deprecation */
-import { FeedbackShim, feedbackIntegrationShim } from '@sentry-internal/integration-shims';
+import { feedbackIntegrationShim } from '@sentry-internal/integration-shims';
 import { browserTracingIntegration } from '@sentry-internal/tracing';
-import { Replay, replayIntegration } from '@sentry/browser';
+import { replayIntegration } from '@sentry/browser';
 
 import * as TracingReplayBundle from '../../src/index.bundle.tracing.replay';
 
@@ -11,13 +10,10 @@ describe('index.bundle.tracing.replay', () => {
       expect((TracingReplayBundle.Integrations[key] as any).id).toStrictEqual(expect.any(String));
     });
 
-    expect(TracingReplayBundle.Integrations.Replay).toBe(Replay);
-    expect(TracingReplayBundle.Replay).toBe(Replay);
     expect(TracingReplayBundle.replayIntegration).toBe(replayIntegration);
 
     expect(TracingReplayBundle.browserTracingIntegration).toBe(browserTracingIntegration);
 
-    expect(TracingReplayBundle.Feedback).toBe(FeedbackShim);
     expect(TracingReplayBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
   });
 });

--- a/packages/browser/test/unit/index.bundle.tracing.test.ts
+++ b/packages/browser/test/unit/index.bundle.tracing.test.ts
@@ -1,10 +1,4 @@
-/* eslint-disable deprecation/deprecation */
-import {
-  FeedbackShim,
-  ReplayShim,
-  feedbackIntegrationShim,
-  replayIntegrationShim,
-} from '@sentry-internal/integration-shims';
+import { feedbackIntegrationShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
 import { browserTracingIntegration } from '@sentry-internal/tracing';
 
 import * as TracingBundle from '../../src/index.bundle.tracing';
@@ -15,13 +9,8 @@ describe('index.bundle.tracing', () => {
       expect((TracingBundle.Integrations[key] as any).id).toStrictEqual(expect.any(String));
     });
 
-    expect(TracingBundle.Integrations.Replay).toBe(ReplayShim);
-    expect(TracingBundle.Replay).toBe(ReplayShim);
     expect(TracingBundle.replayIntegration).toBe(replayIntegrationShim);
-
     expect(TracingBundle.browserTracingIntegration).toBe(browserTracingIntegration);
-
-    expect(TracingBundle.Feedback).toBe(FeedbackShim);
     expect(TracingBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
   });
 });

--- a/packages/feedback/src/index.ts
+++ b/packages/feedback/src/index.ts
@@ -1,6 +1,2 @@
 export { sendFeedback } from './sendFeedback';
-export {
-  // eslint-disable-next-line deprecation/deprecation
-  Feedback,
-  feedbackIntegration,
-} from './integration';
+export { feedbackIntegration } from './integration';

--- a/packages/feedback/src/integration.ts
+++ b/packages/feedback/src/integration.ts
@@ -25,19 +25,17 @@ import { createWidget } from './widget/createWidget';
 
 const doc = WINDOW.document;
 
-export const feedbackIntegration = ((options?: OptionalFeedbackConfiguration) => {
-  // eslint-disable-next-line deprecation/deprecation
-  return new Feedback(options);
-}) satisfies IntegrationFn;
-
 /**
  * Feedback integration. When added as an integration to the SDK, it will
  * inject a button in the bottom-right corner of the window that opens a
  * feedback modal when clicked.
- *
- * @deprecated Use `feedbackIntegration()` instead.
  */
-export class Feedback implements Integration {
+export const feedbackIntegration = ((options?: OptionalFeedbackConfiguration) => {
+  return new Feedback(options);
+}) satisfies IntegrationFn;
+
+// TODO: Rewrite this to be functional integration
+class Feedback implements Integration {
   /**
    * @inheritDoc
    */
@@ -112,7 +110,6 @@ export class Feedback implements Integration {
     onSubmitError,
     onSubmitSuccess,
   }: OptionalFeedbackConfiguration = {}) {
-    // eslint-disable-next-line deprecation/deprecation
     this.name = Feedback.id;
 
     // tsc fails if these are not initialized explicitly constructor, e.g. can't call `_initialize()`

--- a/packages/integration-shims/src/Feedback.ts
+++ b/packages/integration-shims/src/Feedback.ts
@@ -1,81 +1,37 @@
 import type { Integration } from '@sentry/types';
 import { consoleSandbox } from '@sentry/utils';
+import { FAKE_FUNCTION } from './common';
 
-/**
- * This is a shim for the Feedback integration.
- * It is needed in order for the CDN bundles to continue working when users add/remove feedback
- * from it, without changing their config. This is necessary for the loader mechanism.
- *
- * @deprecated Use `feedbackIntegration()` instead.
- */
-export class FeedbackShim implements Integration {
-  /**
-   * @inheritDoc
-   */
-  public static id: string = 'Feedback';
+const FEEDBACK_INTEGRATION_METHODS = [
+  'openDialog',
+  'closeDialog',
+  'attachTo',
+  'createWidget',
+  'removeWidget',
+  'getWidget',
+  'remove',
+] as const;
 
-  /**
-   * @inheritDoc
-   */
-  public name: string;
+type FeedbackSpecificMethods = Record<(typeof FEEDBACK_INTEGRATION_METHODS)[number], () => void>;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public constructor(_options: any) {
-    // eslint-disable-next-line deprecation/deprecation
-    this.name = FeedbackShim.id;
-
-    consoleSandbox(() => {
-      // eslint-disable-next-line no-console
-      console.warn('You are using new Feedback() even though this bundle does not include Feedback.');
-    });
-  }
-
-  /** jsdoc */
-  public setupOnce(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public openDialog(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public closeDialog(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public attachTo(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public createWidget(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public removeWidget(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public getWidget(): void {
-    // noop
-  }
-  /** jsdoc */
-  public remove(): void {
-    // noop
-  }
-}
+interface FeedbackIntegration extends Integration, FeedbackSpecificMethods {}
 
 /**
  * This is a shim for the Feedback integration.
  * It is needed in order for the CDN bundles to continue working when users add/remove feedback
  * from it, without changing their config. This is necessary for the loader mechanism.
  */
-export function feedbackIntegrationShim(_options: unknown): Integration {
-  // eslint-disable-next-line deprecation/deprecation
-  return new FeedbackShim({});
+export function feedbackIntegrationShim(_options: unknown): FeedbackIntegration {
+  consoleSandbox(() => {
+    // eslint-disable-next-line no-console
+    console.warn('You are using feedbackIntegration() even though this bundle does not include feedback.');
+  });
+
+  return {
+    name: 'Feedback',
+    ...(FEEDBACK_INTEGRATION_METHODS.reduce((acc, method) => {
+      acc[method] = FAKE_FUNCTION;
+      return acc;
+    }, {} as FeedbackSpecificMethods) as FeedbackSpecificMethods),
+  };
 }

--- a/packages/integration-shims/src/Replay.ts
+++ b/packages/integration-shims/src/Replay.ts
@@ -1,62 +1,29 @@
 import type { Integration } from '@sentry/types';
 import { consoleSandbox } from '@sentry/utils';
+import { FAKE_FUNCTION } from './common';
 
-/**
- * This is a shim for the Replay integration.
- * It is needed in order for the CDN bundles to continue working when users add/remove replay
- * from it, without changing their config. This is necessary for the loader mechanism.
- *
- * @deprecated Use `replayIntegration()` instead.
- */
-export class ReplayShim implements Integration {
-  /**
-   * @inheritDoc
-   */
-  public static id: string = 'Replay';
+const REPLAY_INTEGRATION_METHODS = ['start', 'stop', 'flush'] as const;
 
-  /**
-   * @inheritDoc
-   */
-  public name: string;
+type ReplaySpecificMethods = Record<(typeof REPLAY_INTEGRATION_METHODS)[number], () => void>;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public constructor(_options: any) {
-    // eslint-disable-next-line deprecation/deprecation
-    this.name = ReplayShim.id;
-
-    consoleSandbox(() => {
-      // eslint-disable-next-line no-console
-      console.warn('You are using new Replay() even though this bundle does not include replay.');
-    });
-  }
-
-  /** jsdoc */
-  public setupOnce(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public start(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public stop(): void {
-    // noop
-  }
-
-  /** jsdoc */
-  public flush(): void {
-    // noop
-  }
-}
+interface ReplayIntegration extends Integration, ReplaySpecificMethods {}
 
 /**
  * This is a shim for the Replay integration.
  * It is needed in order for the CDN bundles to continue working when users add/remove replay
  * from it, without changing their config. This is necessary for the loader mechanism.
  */
-export function replayIntegrationShim(_options: unknown): Integration {
-  // eslint-disable-next-line deprecation/deprecation
-  return new ReplayShim({});
+export function replayIntegrationShim(_options: unknown): ReplayIntegration {
+  consoleSandbox(() => {
+    // eslint-disable-next-line no-console
+    console.warn('You are using replayIntegration() even though this bundle does not include replay.');
+  });
+
+  return {
+    name: 'Replay',
+    ...(REPLAY_INTEGRATION_METHODS.reduce((acc, method) => {
+      acc[method] = FAKE_FUNCTION;
+      return acc;
+    }, {} as ReplaySpecificMethods) as ReplaySpecificMethods),
+  };
 }

--- a/packages/integration-shims/src/common.ts
+++ b/packages/integration-shims/src/common.ts
@@ -1,0 +1,1 @@
+export const FAKE_FUNCTION = (): undefined => undefined;

--- a/packages/integration-shims/src/index.ts
+++ b/packages/integration-shims/src/index.ts
@@ -1,6 +1,6 @@
-export { feedbackIntegrationShim } from './feedback';
-export { replayIntegrationShim } from './replay';
+export { feedbackIntegrationShim } from './Feedback';
+export { replayIntegrationShim } from './Replay';
 export {
   browserTracingIntegrationShim,
   addTracingExtensionsShim,
-} from './browsertracing';
+} from './BrowserTracing';

--- a/packages/integration-shims/src/index.ts
+++ b/packages/integration-shims/src/index.ts
@@ -1,16 +1,6 @@
-export {
-  // eslint-disable-next-line deprecation/deprecation
-  FeedbackShim,
-  feedbackIntegrationShim,
-} from './Feedback';
-
-export {
-  // eslint-disable-next-line deprecation/deprecation
-  ReplayShim,
-  replayIntegrationShim,
-} from './Replay';
-
+export { feedbackIntegrationShim } from './feedback';
+export { replayIntegrationShim } from './replay';
 export {
   browserTracingIntegrationShim,
   addTracingExtensionsShim,
-} from './BrowserTracing';
+} from './browsertracing';

--- a/packages/replay-canvas/README.md
+++ b/packages/replay-canvas/README.md
@@ -22,7 +22,7 @@ For details on using Replay when using Sentry via the CDN bundles, see [CDN bund
 To set up the canvas integration, add the following to your Sentry integrations:
 
 ```javascript
-new Sentry.ReplayCanvas(),
+Sentry.replayCanvasIntegration(),
 ```
 
 ### Full Example
@@ -43,8 +43,8 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
 
   integrations: [
-    new Sentry.Replay(),
-    new Sentry.ReplayCanvas(),
+    Sentry.replayIntegration(),
+    Sentry.replayCanvasIntegration(),
   ],
   // ...
 });

--- a/packages/replay-canvas/src/canvas.ts
+++ b/packages/replay-canvas/src/canvas.ts
@@ -1,7 +1,7 @@
 import { CanvasManager } from '@sentry-internal/rrweb';
-import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
+import { defineIntegration } from '@sentry/core';
 import type { CanvasManagerInterface, CanvasManagerOptions } from '@sentry/replay';
-import type { Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
+import type { IntegrationFn } from '@sentry/types';
 
 interface ReplayCanvasOptions {
   enableManualSnapshot?: boolean;
@@ -104,13 +104,3 @@ export const _replayCanvasIntegration = ((options: Partial<ReplayCanvasOptions> 
  * Add this in addition to `replayIntegration()` to enable canvas recording.
  */
 export const replayCanvasIntegration = defineIntegration(_replayCanvasIntegration);
-
-/**
- * @deprecated Use `replayCanvasIntegration()` instead
- */
-// eslint-disable-next-line deprecation/deprecation
-export const ReplayCanvas = convertIntegrationFnToClass(INTEGRATION_NAME, replayCanvasIntegration) as IntegrationClass<
-  Integration & {
-    getOptions: () => ReplayCanvasIntegrationOptions;
-  }
->;

--- a/packages/replay-canvas/src/index.ts
+++ b/packages/replay-canvas/src/index.ts
@@ -1,6 +1,2 @@
-export {
-  // eslint-disable-next-line deprecation/deprecation
-  ReplayCanvas,
-  replayCanvasIntegration,
-} from './canvas';
+export { replayCanvasIntegration } from './canvas';
 export type { ReplayCanvasIntegrationOptions } from './canvas';

--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -42,7 +42,7 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
 
   integrations: [
-    new Sentry.Replay({
+    Sentry.replayIntegration({
       // Additional SDK configuration goes in here, for example:
       maskAllText: true,
       blockAllMedia: true
@@ -73,7 +73,7 @@ const { Replay } = await import('@sentry/browser');
 const client = Sentry.getCurrentHub().getClient<BrowserClient>();
 
 // Client can be undefined
-client?.addIntegration(new Replay());
+client?.addIntegration(Sentry.replayIntegration());
 ```
 
 ### Identifying Users
@@ -94,7 +94,7 @@ Replay recording only starts when it is included in the `integrations` array whe
 import * as Sentry from "@sentry/react";
 import { BrowserClient } from "@sentry/browser";
 
-const replay = new Replay();
+const replay = Sentry.replayIntegration();
 
 Sentry.init({
   integrations: [replay]
@@ -184,7 +184,7 @@ The following options can be configured on the root level of your browser-based 
 
 ### General Integration Configuration
 
-The following options can be configured as options to the integration, in `new Replay({})`:
+The following options can be configured as options to the integration, in `Sentry.replayIntegration({})`:
 
 | key                 | type    | default | description                                                                                                                                                                                                                     |
 | ------------------- | ------- | ------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------   |
@@ -193,7 +193,7 @@ The following options can be configured as options to the integration, in `new R
 
 ### Privacy Configuration
 
-The following options can be configured as options to the integration, in `new Replay({})`:
+The following options can be configured as options to the integration, in `Sentry.replayIntegration({})`:
 
 | key              | type                     | default                                 | description                                                                                                                                  |
 | ---------------- | ------------------------ | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,8 +1,4 @@
-export {
-  // eslint-disable-next-line deprecation/deprecation
-  Replay,
-  replayIntegration,
-} from './integration';
+export { replayIntegration } from './integration';
 
 export type {
   ReplayConfiguration,

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -30,16 +30,26 @@ let _initialized = false;
 type InitialReplayPluginOptions = Omit<ReplayPluginOptions, 'sessionSampleRate' | 'errorSampleRate'> &
   Partial<Pick<ReplayPluginOptions, 'sessionSampleRate' | 'errorSampleRate'>>;
 
+/**
+ * Sentry integration for [Session Replay](https://sentry.io/for/session-replay/).
+ *
+ * See the [Replay documentation](https://docs.sentry.io/platforms/javascript/guides/session-replay/) for more information.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.init({
+ *   dsn: '__DSN__',
+ *   integrations: [Sentry.replayIntegration()],
+ * });
+ * ```
+ */
 export const replayIntegration = ((options?: ReplayConfiguration) => {
-  // eslint-disable-next-line deprecation/deprecation
   return new Replay(options);
 }) satisfies IntegrationFn;
 
-/**
- * The main replay integration class, to be passed to `init({  integrations: [] })`.
- * @deprecated Use `replayIntegration()` instead.
- */
-export class Replay implements Integration {
+// TODO: Rewrite this to be functional integration
+class Replay implements Integration {
   /**
    * @inheritDoc
    */

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -48,8 +48,13 @@ export const replayIntegration = ((options?: ReplayConfiguration) => {
   return new Replay(options);
 }) satisfies IntegrationFn;
 
-// TODO: Rewrite this to be functional integration
-class Replay implements Integration {
+/**
+ * Replay integration
+ *
+ * TODO: Rewrite this to be functional integration
+ * Exported for tests.
+ */
+export class Replay implements Integration {
   /**
    * @inheritDoc
    */
@@ -127,7 +132,6 @@ class Replay implements Integration {
     // eslint-disable-next-line deprecation/deprecation
     ignoreClass,
   }: ReplayConfiguration = {}) {
-    // eslint-disable-next-line deprecation/deprecation
     this.name = Replay.id;
 
     const privacyOptions = getPrivacyOptions({

--- a/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
+++ b/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
@@ -2,7 +2,7 @@ import * as SentryCore from '@sentry/core';
 import type { Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
 
-import type { Replay } from '../../src';
+import type { Replay } from '../../src/integration';
 import type { ReplayContainer } from '../../src/replay';
 import { clearSession } from '../../src/session/clearSession';
 import { createPerformanceEntries } from '../../src/util/createPerformanceEntries';
@@ -23,7 +23,6 @@ type MockTransportSend = jest.MockedFunction<Transport['send']>;
 
 describe('Integration | beforeAddRecordingEvent', () => {
   let replay: ReplayContainer;
-  // eslint-disable-next-line deprecation/deprecation
   let integration: Replay;
   let mockTransportSend: MockTransportSend;
   let mockSendReplayRequest: jest.SpyInstance<any>;

--- a/packages/replay/test/integration/stop.test.ts
+++ b/packages/replay/test/integration/stop.test.ts
@@ -1,7 +1,7 @@
 import * as SentryUtils from '@sentry/utils';
 
-import type { Replay } from '../../src';
 import { WINDOW } from '../../src/constants';
+import type { Replay } from '../../src/integration';
 import type { ReplayContainer } from '../../src/replay';
 import { clearSession } from '../../src/session/clearSession';
 import { addEvent } from '../../src/util/addEvent';
@@ -17,7 +17,6 @@ type MockRunFlush = jest.MockedFunction<ReplayContainer['_runFlush']>;
 
 describe('Integration | stop', () => {
   let replay: ReplayContainer;
-  // eslint-disable-next-line deprecation/deprecation
   let integration: Replay;
   const prevLocation = WINDOW.location;
 

--- a/packages/replay/test/mocks/mockSdk.ts
+++ b/packages/replay/test/mocks/mockSdk.ts
@@ -1,6 +1,6 @@
 import type { Envelope, Transport, TransportMakeRequestResponse } from '@sentry/types';
 
-import type { Replay as ReplayIntegration } from '../../src';
+import type { Replay as ReplayIntegration } from '../../src/integration';
 import type { ReplayContainer } from '../../src/replay';
 import type { ReplayConfiguration } from '../../src/types';
 import type { TestClientOptions } from '../utils/TestClient';
@@ -46,11 +46,9 @@ class MockTransport implements Transport {
 
 export async function mockSdk({ replayOptions, sentryOptions, autoStart = true }: MockSdkParams = {}): Promise<{
   replay: ReplayContainer;
-  // eslint-disable-next-line deprecation/deprecation
   integration: ReplayIntegration;
 }> {
-  // eslint-disable-next-line deprecation/deprecation
-  const { Replay } = await import('../../src');
+  const { Replay } = await import('../../src/integration');
 
   // Scope this to the test, instead of the module
   let _initialized = false;

--- a/packages/replay/test/mocks/resetSdkMock.ts
+++ b/packages/replay/test/mocks/resetSdkMock.ts
@@ -1,7 +1,7 @@
 import type { EventProcessor } from '@sentry/types';
 import { getGlobalSingleton, resetInstrumentationHandlers } from '@sentry/utils';
 
-import type { Replay as ReplayIntegration } from '../../src';
+import type { Replay as ReplayIntegration } from '../../src/integration';
 import type { ReplayContainer } from '../../src/replay';
 import type { RecordMock } from './../index';
 import { BASE_TIMESTAMP } from './../index';
@@ -13,7 +13,6 @@ export async function resetSdkMock({ replayOptions, sentryOptions, autoStart }: 
   domHandler: DomHandler;
   mockRecord: RecordMock;
   replay: ReplayContainer;
-  // eslint-disable-next-line deprecation/deprecation
   integration: ReplayIntegration;
 }> {
   let domHandler: DomHandler;

--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -77,7 +77,7 @@ The Sentry SvelteKit SDK mostly relies on [SvelteKit Hooks](https://kit.svelte.d
       // For instance, initialize Session Replay:
       replaysSessionSampleRate: 0.1,
       replaysOnErrorSampleRate: 1.0,
-      integrations: [new Sentry.Replay()],
+      integrations: [Sentry.replayIntegration()],
     });
    ```
 


### PR DESCRIPTION
On the road to deleting `Sentry.Integrations` exports - we remove all exports for `Sentry.Replay`, `Sentry.Feedback`, and `Sentry.ReplayCanvas`.

ref https://github.com/getsentry/sentry-javascript/issues/8844