### PR TITLE
feat(core): Remove health check transaction filters

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,11 @@
 # Upgrading from 7.x to 8.x
 
+## Removal of Client-Side health check transaction filters
+
+The SDK no longer filters out health check transactions by default. Instead, they are sent to Sentry but still dropped
+by the Sentry backend by default. You can disable dropping them in your Sentry project settings. If you still want to
+drop specific transactions within the SDK you can either use the `ignoreTransactions` SDK option.
+
 ## Removal of the `MetricsAggregator` integration class and `metricsAggregatorIntegration`
 
 The SDKs now support metrics features without any additional configuration.

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -8,16 +8,6 @@ import { convertIntegrationFnToClass, defineIntegration } from '../integration';
 // this is the result of a script being pulled in from an external domain and CORS.
 const DEFAULT_IGNORE_ERRORS = [/^Script error\.?$/, /^Javascript error: Script error\.? on line 0$/];
 
-const DEFAULT_IGNORE_TRANSACTIONS = [
-  /^.*\/healthcheck$/,
-  /^.*\/healthy$/,
-  /^.*\/live$/,
-  /^.*\/ready$/,
-  /^.*\/heartbeat$/,
-  /^.*\/health$/,
-  /^.*\/healthz$/,
-];
-
 /** Options for the InboundFilters integration */
 export interface InboundFiltersOptions {
   allowUrls: Array<string | RegExp>;
@@ -26,7 +16,6 @@ export interface InboundFiltersOptions {
   ignoreTransactions: Array<string | RegExp>;
   ignoreInternal: boolean;
   disableErrorDefaults: boolean;
-  disableTransactionDefaults: boolean;
 }
 
 const INTEGRATION_NAME = 'InboundFilters';
@@ -77,11 +66,7 @@ function _mergeOptions(
       ...(clientOptions.ignoreErrors || []),
       ...(internalOptions.disableErrorDefaults ? [] : DEFAULT_IGNORE_ERRORS),
     ],
-    ignoreTransactions: [
-      ...(internalOptions.ignoreTransactions || []),
-      ...(clientOptions.ignoreTransactions || []),
-      ...(internalOptions.disableTransactionDefaults ? [] : DEFAULT_IGNORE_TRANSACTIONS),
-    ],
+    ignoreTransactions: [...(internalOptions.ignoreTransactions || []), ...(clientOptions.ignoreTransactions || [])],
     ignoreInternal: internalOptions.ignoreInternal !== undefined ? internalOptions.ignoreInternal : true,
   };
 }

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -216,21 +216,6 @@ const TRANSACTION_EVENT_3: Event = {
   type: 'transaction',
 };
 
-const TRANSACTION_EVENT_HEALTH: Event = {
-  transaction: 'GET /health',
-  type: 'transaction',
-};
-
-const TRANSACTION_EVENT_HEALTH_2: Event = {
-  transaction: 'GET /healthy',
-  type: 'transaction',
-};
-
-const TRANSACTION_EVENT_HEALTH_3: Event = {
-  transaction: 'GET /live',
-  type: 'transaction',
-};
-
 describe('InboundFilters', () => {
   describe('_isSentryError', () => {
     it('should work as expected', () => {
@@ -408,39 +393,12 @@ describe('InboundFilters', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(null);
       expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(TRANSACTION_EVENT);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH, {})).toBe(null);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH_2, {})).toBe(null);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH_3, {})).toBe(null);
     });
 
     it('disable default error filters', () => {
       const eventProcessor = createInboundFiltersEventProcessor({ disableErrorDefaults: true });
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(SCRIPT_ERROR_EVENT);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH, {})).toBe(null);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH_2, {})).toBe(null);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH_3, {})).toBe(null);
     });
-
-    it('disable default transaction filters', () => {
-      const eventProcessor = createInboundFiltersEventProcessor({ disableTransactionDefaults: true });
-      expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(null);
-      expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(TRANSACTION_EVENT);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH, {})).toBe(TRANSACTION_EVENT_HEALTH);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH_2, {})).toBe(TRANSACTION_EVENT_HEALTH_2);
-      expect(eventProcessor(TRANSACTION_EVENT_HEALTH_3, {})).toBe(TRANSACTION_EVENT_HEALTH_3);
-    });
-
-    it.each(['/delivery', '/already', '/healthysnacks'])(
-      "doesn't filter out transactions that have similar names to health check ones (%s)",
-      transaction => {
-        const eventProcessor = createInboundFiltersEventProcessor();
-        const evt: Event = {
-          transaction,
-          type: 'transaction',
-        };
-        expect(eventProcessor(evt, {})).toBe(evt);
-      },
-    );
   });
 
   describe('denyUrls/allowUrls', () => {


### PR DESCRIPTION
This PR removes the `ignoreTransactions` default values which were all patterns trying to identify health check transactions.

We remove these because:
- We now have server-side inbound filters that are configurable in the Sentry UI
- Having two filters (SDK and Sentry backend) is more than unintuitive for users
- The patterns between the SDK and the Sentry backend filters were slightly different
- There's no other SDK that has client-side health check transaction filtering
- There simply is no safe way to filter such transactions without dropping false positives. This ofc also applies to the server-side filter but it's better to have this questionable heuristic only in one place than two.

Implementation note: Decided to remove the entire defaults array b/c there's no point in keeping around an empty array. Therefore, I also removed the `ignoreTransactionDefaults` option. We can re-add all of this if we ever want to filter out something by default again but for now, I'd argue the bundle size reduction is worth removing this code.
