### PR TITLE
feat(core): Allow to pass `forceTransaction` to `startSpan()` APIs (backport)

### DIFF
--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -330,7 +330,9 @@ export class Transaction extends SpanClass implements TransactionInterface {
         ...metadata,
         capturedSpanScope,
         capturedSpanIsolationScope,
-        dynamicSamplingContext: getDynamicSamplingContextFromSpan(this),
+        ...dropUndefinedKeys({
+          dynamicSamplingContext: getDynamicSamplingContextFromSpan(this),
+        }),
       },
       _metrics_summary: getMetricSummaryJsonForSpan(this),
       ...(source && {

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1,4 +1,4 @@
-import type { Span as SpanType } from '@sentry/types';
+import type { Event, Span as SpanType } from '@sentry/types';
 import {
   Hub,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -323,6 +323,110 @@ describe('startSpan', () => {
     expect(getActiveSpan()).toBe(undefined);
   });
 
+  it('allows to force a transaction with forceTransaction=true', async () => {
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 1.0 });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    const transactionEvents: Event[] = [];
+
+    client.addEventProcessor(event => {
+      if (event.type === 'transaction') {
+        transactionEvents.push(event);
+      }
+      return event;
+    });
+
+    startSpan({ name: 'outer transaction' }, () => {
+      startSpan({ name: 'inner span' }, () => {
+        startSpan({ name: 'inner transaction', forceTransaction: true }, () => {
+          startSpan({ name: 'inner span 2' }, () => {
+            // all good
+          });
+        });
+      });
+    });
+
+    await client.flush();
+
+    const normalizedTransactionEvents = transactionEvents.map(event => {
+      return {
+        ...event,
+        spans: event.spans?.map(span => ({ name: spanToJSON(span).description, id: span.spanContext().spanId })),
+        sdkProcessingMetadata: {
+          dynamicSamplingContext: event.sdkProcessingMetadata?.dynamicSamplingContext,
+        },
+      };
+    });
+
+    expect(normalizedTransactionEvents).toHaveLength(2);
+
+    const outerTransaction = normalizedTransactionEvents.find(event => event.transaction === 'outer transaction');
+    const innerTransaction = normalizedTransactionEvents.find(event => event.transaction === 'inner transaction');
+
+    const outerTraceId = outerTransaction?.contexts?.trace?.trace_id;
+    // The inner transaction should be a child of the last span of the outer transaction
+    const innerParentSpanId = outerTransaction?.spans?.[0].id;
+    const innerSpanId = innerTransaction?.contexts?.trace?.span_id;
+
+    expect(outerTraceId).toBeDefined();
+    expect(innerParentSpanId).toBeDefined();
+    expect(innerSpanId).toBeDefined();
+    // inner span ID should _not_ be the parent span ID, but the id of the new span
+    expect(innerSpanId).not.toEqual(innerParentSpanId);
+
+    expect(outerTransaction?.contexts).toEqual({
+      trace: {
+        data: {
+          'sentry.sample_rate': 1,
+          'sentry.origin': 'manual',
+        },
+        span_id: expect.any(String),
+        trace_id: expect.any(String),
+        origin: 'manual',
+      },
+    });
+    expect(outerTransaction?.spans).toEqual([{ name: 'inner span', id: expect.any(String) }]);
+    expect(outerTransaction?.tags).toEqual({
+      transaction: 'outer transaction',
+    });
+    expect(outerTransaction?.sdkProcessingMetadata).toEqual({
+      dynamicSamplingContext: {
+        environment: 'production',
+        trace_id: outerTraceId,
+        sample_rate: '1',
+        transaction: 'outer transaction',
+        sampled: 'true',
+      },
+    });
+
+    expect(innerTransaction?.contexts).toEqual({
+      trace: {
+        data: {
+          'sentry.origin': 'manual',
+        },
+        parent_span_id: innerParentSpanId,
+        span_id: expect.any(String),
+        trace_id: outerTraceId,
+        origin: 'manual',
+      },
+    });
+    expect(innerTransaction?.spans).toEqual([{ name: 'inner span 2', id: expect.any(String) }]);
+    expect(innerTransaction?.tags).toEqual({
+      transaction: 'inner transaction',
+    });
+    expect(innerTransaction?.sdkProcessingMetadata).toEqual({
+      dynamicSamplingContext: {
+        environment: 'production',
+        trace_id: outerTraceId,
+        sample_rate: '1',
+        transaction: 'outer transaction',
+        sampled: 'true',
+      },
+    });
+  });
+
   it("picks up the trace id off the parent scope's propagation context", () => {
     expect.assertions(1);
     withScope(scope => {
@@ -486,6 +590,114 @@ describe('startSpanManual', () => {
     expect(getActiveSpan()).toBe(undefined);
   });
 
+  it('allows to force a transaction with forceTransaction=true', async () => {
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 1.0 });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    const transactionEvents: Event[] = [];
+
+    client.addEventProcessor(event => {
+      if (event.type === 'transaction') {
+        transactionEvents.push(event);
+      }
+      return event;
+    });
+
+    startSpanManual({ name: 'outer transaction' }, span => {
+      startSpanManual({ name: 'inner span' }, span => {
+        startSpanManual({ name: 'inner transaction', forceTransaction: true }, span => {
+          startSpanManual({ name: 'inner span 2' }, span => {
+            // all good
+            span?.end();
+          });
+          span?.end();
+        });
+        span?.end();
+      });
+      span?.end();
+    });
+
+    await client.flush();
+
+    const normalizedTransactionEvents = transactionEvents.map(event => {
+      return {
+        ...event,
+        spans: event.spans?.map(span => ({ name: spanToJSON(span).description, id: span.spanContext().spanId })),
+        sdkProcessingMetadata: {
+          dynamicSamplingContext: event.sdkProcessingMetadata?.dynamicSamplingContext,
+        },
+      };
+    });
+
+    expect(normalizedTransactionEvents).toHaveLength(2);
+
+    const outerTransaction = normalizedTransactionEvents.find(event => event.transaction === 'outer transaction');
+    const innerTransaction = normalizedTransactionEvents.find(event => event.transaction === 'inner transaction');
+
+    const outerTraceId = outerTransaction?.contexts?.trace?.trace_id;
+    // The inner transaction should be a child of the last span of the outer transaction
+    const innerParentSpanId = outerTransaction?.spans?.[0].id;
+    const innerSpanId = innerTransaction?.contexts?.trace?.span_id;
+
+    expect(outerTraceId).toBeDefined();
+    expect(innerParentSpanId).toBeDefined();
+    expect(innerSpanId).toBeDefined();
+    // inner span ID should _not_ be the parent span ID, but the id of the new span
+    expect(innerSpanId).not.toEqual(innerParentSpanId);
+
+    expect(outerTransaction?.contexts).toEqual({
+      trace: {
+        data: {
+          'sentry.sample_rate': 1,
+          'sentry.origin': 'manual',
+        },
+        span_id: expect.any(String),
+        trace_id: expect.any(String),
+        origin: 'manual',
+      },
+    });
+    expect(outerTransaction?.spans).toEqual([{ name: 'inner span', id: expect.any(String) }]);
+    expect(outerTransaction?.tags).toEqual({
+      transaction: 'outer transaction',
+    });
+    expect(outerTransaction?.sdkProcessingMetadata).toEqual({
+      dynamicSamplingContext: {
+        environment: 'production',
+        trace_id: outerTraceId,
+        sample_rate: '1',
+        transaction: 'outer transaction',
+        sampled: 'true',
+      },
+    });
+
+    expect(innerTransaction?.contexts).toEqual({
+      trace: {
+        data: {
+          'sentry.origin': 'manual',
+        },
+        parent_span_id: innerParentSpanId,
+        span_id: expect.any(String),
+        trace_id: outerTraceId,
+        origin: 'manual',
+      },
+    });
+    expect(innerTransaction?.spans).toEqual([{ name: 'inner span 2', id: expect.any(String) }]);
+    expect(innerTransaction?.tags).toEqual({
+      transaction: 'inner transaction',
+    });
+    expect(innerTransaction?.sdkProcessingMetadata).toEqual({
+      dynamicSamplingContext: {
+        environment: 'production',
+        trace_id: outerTraceId,
+        sample_rate: '1',
+        transaction: 'outer transaction',
+        sampled: 'true',
+      },
+    });
+  });
+
   it('allows to pass a `startTime`', () => {
     const start = startSpanManual({ name: 'outer', startTime: [1234, 0] }, span => {
       span?.end();
@@ -584,6 +796,107 @@ describe('startInactiveSpan', () => {
     span?.end();
 
     expect(getActiveSpan()).toBeUndefined();
+  });
+
+  it('allows to force a transaction with forceTransaction=true', async () => {
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 1.0 });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    const transactionEvents: Event[] = [];
+
+    client.addEventProcessor(event => {
+      if (event.type === 'transaction') {
+        transactionEvents.push(event);
+      }
+      return event;
+    });
+
+    startSpan({ name: 'outer transaction' }, () => {
+      startSpan({ name: 'inner span' }, () => {
+        const innerTransaction = startInactiveSpan({ name: 'inner transaction', forceTransaction: true });
+        innerTransaction?.end();
+      });
+    });
+
+    await client.flush();
+
+    const normalizedTransactionEvents = transactionEvents.map(event => {
+      return {
+        ...event,
+        spans: event.spans?.map(span => ({ name: spanToJSON(span).description, id: span.spanContext().spanId })),
+        sdkProcessingMetadata: {
+          dynamicSamplingContext: event.sdkProcessingMetadata?.dynamicSamplingContext,
+        },
+      };
+    });
+
+    expect(normalizedTransactionEvents).toHaveLength(2);
+
+    const outerTransaction = normalizedTransactionEvents.find(event => event.transaction === 'outer transaction');
+    const innerTransaction = normalizedTransactionEvents.find(event => event.transaction === 'inner transaction');
+
+    const outerTraceId = outerTransaction?.contexts?.trace?.trace_id;
+    // The inner transaction should be a child of the last span of the outer transaction
+    const innerParentSpanId = outerTransaction?.spans?.[0].id;
+    const innerSpanId = innerTransaction?.contexts?.trace?.span_id;
+
+    expect(outerTraceId).toBeDefined();
+    expect(innerParentSpanId).toBeDefined();
+    expect(innerSpanId).toBeDefined();
+    // inner span ID should _not_ be the parent span ID, but the id of the new span
+    expect(innerSpanId).not.toEqual(innerParentSpanId);
+
+    expect(outerTransaction?.contexts).toEqual({
+      trace: {
+        data: {
+          'sentry.sample_rate': 1,
+          'sentry.origin': 'manual',
+        },
+        span_id: expect.any(String),
+        trace_id: expect.any(String),
+        origin: 'manual',
+      },
+    });
+    expect(outerTransaction?.spans).toEqual([{ name: 'inner span', id: expect.any(String) }]);
+    expect(outerTransaction?.tags).toEqual({
+      transaction: 'outer transaction',
+    });
+    expect(outerTransaction?.sdkProcessingMetadata).toEqual({
+      dynamicSamplingContext: {
+        environment: 'production',
+        trace_id: outerTraceId,
+        sample_rate: '1',
+        transaction: 'outer transaction',
+        sampled: 'true',
+      },
+    });
+
+    expect(innerTransaction?.contexts).toEqual({
+      trace: {
+        data: {
+          'sentry.origin': 'manual',
+        },
+        parent_span_id: innerParentSpanId,
+        span_id: expect.any(String),
+        trace_id: outerTraceId,
+        origin: 'manual',
+      },
+    });
+    expect(innerTransaction?.spans).toEqual([]);
+    expect(innerTransaction?.tags).toEqual({
+      transaction: 'inner transaction',
+    });
+    expect(innerTransaction?.sdkProcessingMetadata).toEqual({
+      dynamicSamplingContext: {
+        environment: 'production',
+        trace_id: outerTraceId,
+        sample_rate: '1',
+        transaction: 'outer transaction',
+        sampled: 'true',
+      },
+    });
   });
 
   it('allows to pass a `startTime`', () => {

--- a/packages/types/src/startSpanOptions.ts
+++ b/packages/types/src/startSpanOptions.ts
@@ -21,6 +21,13 @@ export interface StartSpanOptions extends TransactionContext {
   op?: string;
 
   /**
+   * If set to true, this span will be forced to be treated as a transaction in the Sentry UI, if possible and applicable.
+   * Note that it is up to the SDK to decide how exactly the span will be sent, which may change in future SDK versions.
+   * It is not guaranteed that a span started with this flag set to `true` will be sent as a transaction.
+   */
+  forceTransaction?: boolean;
+
+  /**
    * The origin of the span - if it comes from auto instrumentation or manual instrumentation.
    *
    * @deprecated Set `attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]` instead.


### PR DESCRIPTION
This will ensure a span is sent as a transaction to Sentry.

This only implements this option for the core implementation, not yet for OTEL - that is a follow up here:
https://github.com/getsentry/sentry-javascript/pull/10807

This is a backport to v7 of https://github.com/getsentry/sentry-javascript/pull/10749