### PR TITLE
fix(node): Record local variables with falsy values, `null` and `undefined`

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
@@ -20,6 +20,9 @@ function one(name) {
     name,
     num: 5,
   };
+  const bool = false;
+  const num = 0;
+  const str = '';
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
@@ -23,6 +23,8 @@ function one(name) {
   const bool = false;
   const num = 0;
   const str = '';
+  const something = undefined;
+  const somethingElse = null;
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
@@ -22,6 +22,9 @@ function one(name) {
     functionsShouldNotBeIncluded: () => {},
     functionsShouldNotBeIncluded2() {},
   };
+  const bool = false;
+  const num = 0;
+  const str = '';
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
@@ -25,6 +25,8 @@ function one(name) {
   const bool = false;
   const num = 0;
   const str = '';
+  const something = undefined;
+  const somethingElse = null;
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-memory-test.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-memory-test.js
@@ -22,6 +22,9 @@ function one(name) {
     name,
     num: 5,
   };
+  const bool = false;
+  const num = 0;
+  const str = '';
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-memory-test.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-memory-test.js
@@ -25,6 +25,8 @@ function one(name) {
   const bool = false;
   const num = 0;
   const str = '';
+  const something = undefined;
+  const somethingElse = null;
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables.js
@@ -27,6 +27,8 @@ function one(name) {
   const bool = false;
   const num = 0;
   const str = '';
+  const something = undefined;
+  const somethingElse = null;
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables.js
@@ -24,6 +24,9 @@ function one(name) {
     name,
     num: 5,
   };
+  const bool = false;
+  const num = 0;
+  const str = '';
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/no-local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/no-local-variables.js
@@ -26,6 +26,8 @@ function one(name) {
   const bool = false;
   const num = 0;
   const str = '';
+  const something = undefined;
+  const somethingElse = null;
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/no-local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/no-local-variables.js
@@ -23,6 +23,9 @@ function one(name) {
     name,
     num: 5,
   };
+  const bool = false;
+  const num = 0;
+  const str = '';
 
   const ty = new Some();
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -19,6 +19,8 @@ const EXPECTED_LOCAL_VARIABLES_EVENT = {
                 bool: false,
                 num: 0,
                 str: '',
+                something: '<undefined>',
+                somethingElse: '<null>',
               },
             }),
             expect.objectContaining({

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -16,6 +16,9 @@ const EXPECTED_LOCAL_VARIABLES_EVENT = {
                 arr: [1, '2', null],
                 obj: { name: 'some name', num: 5 },
                 ty: '<Some>',
+                bool: false,
+                num: 0,
+                str: '',
               },
             }),
             expect.objectContaining({

--- a/packages/node-experimental/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-async.ts
@@ -52,8 +52,10 @@ function unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables): void {
     } else {
       vars[prop.name] = prop.value.value;
     }
-  } else if (prop.value.description && prop.value.type !== 'function') {
+  } else if ('description' in prop.value && prop.value.type !== 'function') {
     vars[prop.name] = `<${prop.value.description}>`;
+  } else if (prop.value.type === 'undefined') {
+    vars[prop.name] = '<undefined>';
   }
 }
 

--- a/packages/node-experimental/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-async.ts
@@ -42,9 +42,9 @@ async function unrollObject(session: Session, objectId: string, name: string, va
 }
 
 function unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables): void {
-  if (prop?.value?.value) {
+  if (prop?.value?.value != null) {
     vars[prop.name] = prop.value.value;
-  } else if (prop?.value?.description && prop?.value?.type !== 'function') {
+  } else if (prop?.value?.description != null && prop?.value?.type !== 'function') {
     vars[prop.name] = `<${prop.value.description}>`;
   }
 }
@@ -63,7 +63,7 @@ async function getLocalVariables(session: Session, objectId: string): Promise<Va
     } else if (prop?.value?.objectId && prop?.value?.className === 'Object') {
       const id = prop.value.objectId;
       await unrollObject(session, id, prop.name, variables);
-    } else if (prop?.value?.value || prop?.value?.description) {
+    } else if (prop?.value?.value != null || prop?.value?.description != null) {
       unrollOther(prop, variables);
     }
   }

--- a/packages/node-experimental/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-async.ts
@@ -42,9 +42,17 @@ async function unrollObject(session: Session, objectId: string, name: string, va
 }
 
 function unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables): void {
-  if (prop?.value?.value != null) {
-    vars[prop.name] = prop.value.value;
-  } else if (prop?.value?.description != null && prop?.value?.type !== 'function') {
+  if (!prop.value) {
+    return;
+  }
+
+  if ('value' in prop.value) {
+    if (prop.value.value === undefined || prop.value.value === null) {
+      vars[prop.name] = `<${prop.value.value}>`;
+    } else {
+      vars[prop.name] = prop.value.value;
+    }
+  } else if (prop.value.description && prop.value.type !== 'function') {
     vars[prop.name] = `<${prop.value.description}>`;
   }
 }
@@ -63,7 +71,7 @@ async function getLocalVariables(session: Session, objectId: string): Promise<Va
     } else if (prop?.value?.objectId && prop?.value?.className === 'Object') {
       const id = prop.value.objectId;
       await unrollObject(session, id, prop.name, variables);
-    } else if (prop?.value?.value != null || prop?.value?.description != null) {
+    } else if (prop?.value) {
       unrollOther(prop, variables);
     }
   }

--- a/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
@@ -276,12 +276,11 @@ const _localVariablesSyncIntegration = ((
         });
       } else {
         const id = localScope.object.objectId;
-        add(
-          frames =>
-            session?.getLocalVariables(id, vars => {
-              frames[i] = { function: fn, vars };
-              next(frames);
-            }),
+        add(frames =>
+          session?.getLocalVariables(id, vars => {
+            frames[i] = { function: fn, vars };
+            next(frames);
+          }),
         );
       }
     }

--- a/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
@@ -268,12 +268,11 @@ const _localVariablesSyncIntegration = ((
         });
       } else {
         const id = localScope.object.objectId;
-        add(
-          frames =>
-            session?.getLocalVariables(id, vars => {
-              frames[i] = { function: fn, vars };
-              next(frames);
-            }),
+        add(frames =>
+          session?.getLocalVariables(id, vars => {
+            frames[i] = { function: fn, vars };
+            next(frames);
+          }),
         );
       }
     }

--- a/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
@@ -198,8 +198,10 @@ class AsyncSession implements DebugSession {
         } else {
           vars[prop.name] = prop.value.value;
         }
-      } else if (prop.value.description && prop.value.type !== 'function') {
+      } else if ('description' in prop.value && prop.value.type !== 'function') {
         vars[prop.name] = `<${prop.value.description}>`;
+      } else if (prop.value.type === 'undefined') {
+        vars[prop.name] = '<undefined>';
       }
     }
 
@@ -274,11 +276,12 @@ const _localVariablesSyncIntegration = ((
         });
       } else {
         const id = localScope.object.objectId;
-        add(frames =>
-          session?.getLocalVariables(id, vars => {
-            frames[i] = { function: fn, vars };
-            next(frames);
-          }),
+        add(
+          frames =>
+            session?.getLocalVariables(id, vars => {
+              frames[i] = { function: fn, vars };
+              next(frames);
+            }),
         );
       }
     }

--- a/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
@@ -128,7 +128,7 @@ class AsyncSession implements DebugSession {
         } else if (prop?.value?.objectId && prop?.value?.className === 'Object') {
           const id = prop.value.objectId;
           add(vars => this._unrollObject(id, prop.name, vars, next));
-        } else if (prop?.value?.value || prop?.value?.description) {
+        } else if (prop?.value?.value != null || prop?.value?.description != null) {
           add(vars => this._unrollOther(prop, vars, next));
         }
       }
@@ -191,9 +191,9 @@ class AsyncSession implements DebugSession {
    * Unrolls other properties
    */
   private _unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables, next: (vars: Variables) => void): void {
-    if (prop?.value?.value) {
+    if (prop?.value?.value != null) {
       vars[prop.name] = prop.value.value;
-    } else if (prop?.value?.description && prop?.value?.type !== 'function') {
+    } else if (prop?.value?.description != null && prop?.value?.type !== 'function') {
       vars[prop.name] = `<${prop.value.description}>`;
     }
 
@@ -268,11 +268,12 @@ const _localVariablesSyncIntegration = ((
         });
       } else {
         const id = localScope.object.objectId;
-        add(frames =>
-          session?.getLocalVariables(id, vars => {
-            frames[i] = { function: fn, vars };
-            next(frames);
-          }),
+        add(
+          frames =>
+            session?.getLocalVariables(id, vars => {
+              frames[i] = { function: fn, vars };
+              next(frames);
+            }),
         );
       }
     }

--- a/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
@@ -128,7 +128,7 @@ class AsyncSession implements DebugSession {
         } else if (prop?.value?.objectId && prop?.value?.className === 'Object') {
           const id = prop.value.objectId;
           add(vars => this._unrollObject(id, prop.name, vars, next));
-        } else if (prop?.value?.value != null || prop?.value?.description != null) {
+        } else if (prop?.value) {
           add(vars => this._unrollOther(prop, vars, next));
         }
       }
@@ -191,10 +191,16 @@ class AsyncSession implements DebugSession {
    * Unrolls other properties
    */
   private _unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables, next: (vars: Variables) => void): void {
-    if (prop?.value?.value != null) {
-      vars[prop.name] = prop.value.value;
-    } else if (prop?.value?.description != null && prop?.value?.type !== 'function') {
-      vars[prop.name] = `<${prop.value.description}>`;
+    if (prop.value) {
+      if ('value' in prop.value) {
+        if (prop.value.value === undefined || prop.value.value === null) {
+          vars[prop.name] = `<${prop.value.value}>`;
+        } else {
+          vars[prop.name] = prop.value.value;
+        }
+      } else if (prop.value.description && prop.value.type !== 'function') {
+        vars[prop.name] = `<${prop.value.description}>`;
+      }
     }
 
     next(vars);

--- a/packages/node/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-async.ts
@@ -52,8 +52,10 @@ function unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables): void {
     } else {
       vars[prop.name] = prop.value.value;
     }
-  } else if (prop.value.description && prop.value.type !== 'function') {
+  } else if ('description' in prop.value && prop.value.type !== 'function') {
     vars[prop.name] = `<${prop.value.description}>`;
+  } else if (prop.value.type === 'undefined') {
+    vars[prop.name] = '<undefined>';
   }
 }
 

--- a/packages/node/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-async.ts
@@ -42,9 +42,9 @@ async function unrollObject(session: Session, objectId: string, name: string, va
 }
 
 function unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables): void {
-  if (prop?.value?.value) {
+  if (prop?.value?.value != null) {
     vars[prop.name] = prop.value.value;
-  } else if (prop?.value?.description && prop?.value?.type !== 'function') {
+  } else if (prop?.value?.description != null && prop?.value?.type !== 'function') {
     vars[prop.name] = `<${prop.value.description}>`;
   }
 }
@@ -63,7 +63,7 @@ async function getLocalVariables(session: Session, objectId: string): Promise<Va
     } else if (prop?.value?.objectId && prop?.value?.className === 'Object') {
       const id = prop.value.objectId;
       await unrollObject(session, id, prop.name, variables);
-    } else if (prop?.value?.value || prop?.value?.description) {
+    } else if (prop?.value?.value != null || prop?.value?.description != null) {
       unrollOther(prop, variables);
     }
   }

--- a/packages/node/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-async.ts
@@ -42,9 +42,17 @@ async function unrollObject(session: Session, objectId: string, name: string, va
 }
 
 function unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables): void {
-  if (prop?.value?.value != null) {
-    vars[prop.name] = prop.value.value;
-  } else if (prop?.value?.description != null && prop?.value?.type !== 'function') {
+  if (!prop.value) {
+    return;
+  }
+
+  if ('value' in prop.value) {
+    if (prop.value.value === undefined || prop.value.value === null) {
+      vars[prop.name] = `<${prop.value.value}>`;
+    } else {
+      vars[prop.name] = prop.value.value;
+    }
+  } else if (prop.value.description && prop.value.type !== 'function') {
     vars[prop.name] = `<${prop.value.description}>`;
   }
 }
@@ -63,7 +71,7 @@ async function getLocalVariables(session: Session, objectId: string): Promise<Va
     } else if (prop?.value?.objectId && prop?.value?.className === 'Object') {
       const id = prop.value.objectId;
       await unrollObject(session, id, prop.name, variables);
-    } else if (prop?.value?.value != null || prop?.value?.description != null) {
+    } else if (prop?.value) {
       unrollOther(prop, variables);
     }
   }

--- a/packages/node/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-sync.ts
@@ -129,7 +129,7 @@ class AsyncSession implements DebugSession {
         } else if (prop?.value?.objectId && prop?.value?.className === 'Object') {
           const id = prop.value.objectId;
           add(vars => this._unrollObject(id, prop.name, vars, next));
-        } else if (prop?.value?.value || prop?.value?.description) {
+        } else if (prop?.value?.value != null || prop?.value?.description != null) {
           add(vars => this._unrollOther(prop, vars, next));
         }
       }
@@ -192,9 +192,9 @@ class AsyncSession implements DebugSession {
    * Unrolls other properties
    */
   private _unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables, next: (vars: Variables) => void): void {
-    if (prop?.value?.value) {
+    if (prop?.value?.value != null) {
       vars[prop.name] = prop.value.value;
-    } else if (prop?.value?.description && prop?.value?.type !== 'function') {
+    } else if (prop?.value?.description != null && prop?.value?.type !== 'function') {
       vars[prop.name] = `<${prop.value.description}>`;
     }
 
@@ -269,11 +269,12 @@ const _localVariablesSyncIntegration = ((
         });
       } else {
         const id = localScope.object.objectId;
-        add(frames =>
-          session?.getLocalVariables(id, vars => {
-            frames[i] = { function: fn, vars };
-            next(frames);
-          }),
+        add(
+          frames =>
+            session?.getLocalVariables(id, vars => {
+              frames[i] = { function: fn, vars };
+              next(frames);
+            }),
         );
       }
     }

--- a/packages/node/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-sync.ts
@@ -129,7 +129,7 @@ class AsyncSession implements DebugSession {
         } else if (prop?.value?.objectId && prop?.value?.className === 'Object') {
           const id = prop.value.objectId;
           add(vars => this._unrollObject(id, prop.name, vars, next));
-        } else if (prop?.value?.value != null || prop?.value?.description != null) {
+        } else if (prop?.value) {
           add(vars => this._unrollOther(prop, vars, next));
         }
       }
@@ -192,10 +192,16 @@ class AsyncSession implements DebugSession {
    * Unrolls other properties
    */
   private _unrollOther(prop: Runtime.PropertyDescriptor, vars: Variables, next: (vars: Variables) => void): void {
-    if (prop?.value?.value != null) {
-      vars[prop.name] = prop.value.value;
-    } else if (prop?.value?.description != null && prop?.value?.type !== 'function') {
-      vars[prop.name] = `<${prop.value.description}>`;
+    if (prop.value) {
+      if ('value' in prop.value) {
+        if (prop.value.value === undefined || prop.value.value === null) {
+          vars[prop.name] = `<${prop.value.value}>`;
+        } else {
+          vars[prop.name] = prop.value.value;
+        }
+      } else if (prop.value.description && prop.value.type !== 'function') {
+        vars[prop.name] = `<${prop.value.description}>`;
+      }
     }
 
     next(vars);

--- a/packages/node/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-sync.ts
@@ -269,12 +269,11 @@ const _localVariablesSyncIntegration = ((
         });
       } else {
         const id = localScope.object.objectId;
-        add(
-          frames =>
-            session?.getLocalVariables(id, vars => {
-              frames[i] = { function: fn, vars };
-              next(frames);
-            }),
+        add(frames =>
+          session?.getLocalVariables(id, vars => {
+            frames[i] = { function: fn, vars };
+            next(frames);
+          }),
         );
       }
     }

--- a/packages/node/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-sync.ts
@@ -199,8 +199,10 @@ class AsyncSession implements DebugSession {
         } else {
           vars[prop.name] = prop.value.value;
         }
-      } else if (prop.value.description && prop.value.type !== 'function') {
+      } else if ('description' in prop.value && prop.value.type !== 'function') {
         vars[prop.name] = `<${prop.value.description}>`;
+      } else if (prop.value.type === 'undefined') {
+        vars[prop.name] = '<undefined>';
       }
     }
 
@@ -275,11 +277,12 @@ const _localVariablesSyncIntegration = ((
         });
       } else {
         const id = localScope.object.objectId;
-        add(frames =>
-          session?.getLocalVariables(id, vars => {
-            frames[i] = { function: fn, vars };
-            next(frames);
-          }),
+        add(
+          frames =>
+            session?.getLocalVariables(id, vars => {
+              frames[i] = { function: fn, vars };
+              next(frames);
+            }),
         );
       }
     }

--- a/packages/node/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-sync.ts
@@ -277,12 +277,11 @@ const _localVariablesSyncIntegration = ((
         });
       } else {
         const id = localScope.object.objectId;
-        add(
-          frames =>
-            session?.getLocalVariables(id, vars => {
-              frames[i] = { function: fn, vars };
-              next(frames);
-            }),
+        add(frames =>
+          session?.getLocalVariables(id, vars => {
+            frames[i] = { function: fn, vars };
+            next(frames);
+          }),
         );
       }
     }


### PR DESCRIPTION
We previously didn't record local local variables with falsy values because we checked for truthiness instead of definedness when unrolling and serializing the variable values. This PR changes how we check for and extract variable properties to record

- falsy values (`0`, `''`, `false`)
- `null`
- `undefined`

Fixes implementations in `node` and `node-experimental`

fixes https://github.com/getsentry/sentry-javascript/issues/10815