### PR TITLE
build: Fix nx cache outputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -27,12 +27,12 @@
     "build:transpile": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:transpile"],
-      "outputs": ["{projectRoot}/build"]
+      "outputs": ["{projectRoot}/build/{esm,cjs}", "{projectRoot}/build/npm/{esm,cjs}"]
     },
     "build:types": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:types"],
-      "outputs": ["{projectRoot}/build/**/*.d.ts"]
+      "outputs": ["{projectRoot}/build/**/*.d.ts", "{projectRoot}/build/**/*.d.ts.map"]
     },
     "lint": {
       "inputs": ["default"],

--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -65,6 +65,12 @@
         "dependsOn": [
           "^build:transpile",
           "^build:types"
+        ],
+        "outputs": [
+          "{projectRoot}/build/esm2015",
+          "{projectRoot}/build/fesm2015",
+          "{projectRoot}/build/*.{md,json}",
+          "{projectRoot}/build/LICENCE"
         ]
       }
     }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -66,9 +66,12 @@
   "nx": {
     "targets": {
       "build:transpile": {
-        "dependsOn": [
-          "^build:transpile",
-          "^build:types"
+        "dependsOn": ["^build:transpile", "^build:types"],
+        "outputs": [
+          "{projectRoot}/build/esm2015",
+          "{projectRoot}/build/fesm2015",
+          "{projectRoot}/build/*.{md,json}",
+          "{projectRoot}/build/LICENCE"
         ]
       }
     }

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -11,11 +11,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "index.mjs",
-    "index.mjs.map",
-    "index.d.ts"
-  ],
+  "files": ["index.mjs", "index.mjs.map", "index.d.ts"],
   "dependencies": {
     "@sentry/browser": "7.100.0",
     "@sentry/core": "7.100.0",
@@ -59,6 +55,16 @@
     "detectiveOptions": {
       "ts": {
         "skipTypeImports": true
+      }
+    }
+  },
+  "nx": {
+    "targets": {
+      "build:transpile": {
+        "outputs": ["{projectRoot}/build"]
+      },
+      "build:types": {
+        "outputs": ["{projectRoot}/build-types"]
       }
     }
   }


### PR DESCRIPTION
After this annoying me for quite some time, I finally figured out what the problem with our build was - we had our nx cache outputs wrong. This lead to conflicts when caches were restored etc.

Now, this should be more narrow & correct in what it caches per step, leading to caching actually working (hopefully..)