### PR TITLE
ref: Refactor some deprecated `startSpan` options

### DIFF
--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -11,7 +11,7 @@ import {
   startSpan,
   withIsolationScope,
 } from '@sentry/core';
-import type { IntegrationFn } from '@sentry/types';
+import type { IntegrationFn, SpanAttributes } from '@sentry/types';
 import { getSanitizedUrlString, parseUrl } from '@sentry/utils';
 
 const INTEGRATION_NAME = 'BunServer';
@@ -53,7 +53,7 @@ export function instrumentBunServe(): void {
 function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]): void {
   serveOptions.fetch = new Proxy(serveOptions.fetch, {
     apply(fetchTarget, fetchThisArg, fetchArgs: Parameters<typeof serveOptions.fetch>) {
-      return withIsolationScope(() => {
+      return withIsolationScope(isolationScope => {
         const request = fetchArgs[0];
         const upperCaseMethod = request.method.toUpperCase();
         if (upperCaseMethod === 'OPTIONS' || upperCaseMethod === 'HEAD') {
@@ -61,37 +61,34 @@ function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]
         }
 
         const parsedUrl = parseUrl(request.url);
-        const data: Record<string, unknown> = {
+        const attributes: SpanAttributes = {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.bun.serve',
           'http.request.method': request.method || 'GET',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
         };
         if (parsedUrl.search) {
-          data['http.query'] = parsedUrl.search;
+          attributes['http.query'] = parsedUrl.search;
         }
 
         const url = getSanitizedUrlString(parsedUrl);
+
+        isolationScope.setSDKProcessingMetadata({
+          request: {
+            url,
+            method: request.method,
+            headers: request.headers.toJSON(),
+          },
+        });
 
         return continueTrace(
           { sentryTrace: request.headers.get('sentry-trace') || '', baggage: request.headers.get('baggage') },
           ctx => {
             return startSpan(
               {
-                attributes: {
-                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.bun.serve',
-                },
+                attributes,
                 op: 'http.server',
                 name: `${request.method} ${parsedUrl.path || '/'}`,
                 ...ctx,
-                data,
-                metadata: {
-                  // eslint-disable-next-line deprecation/deprecation
-                  ...ctx.metadata,
-                  request: {
-                    url,
-                    method: request.method,
-                    headers: request.headers.toJSON(),
-                  },
-                },
               },
               async span => {
                 try {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,5 +1,5 @@
 import { startInactiveSpan } from '@sentry/browser';
-import { spanToJSON, withActiveSpan } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON, withActiveSpan } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { timestampInSeconds } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
@@ -59,8 +59,10 @@ class Profiler extends React.Component<ProfilerProps> {
       name: `<${name}>`,
       onlyIfParent: true,
       op: REACT_MOUNT_OP,
-      origin: 'auto.ui.react.profiler',
-      attributes: { 'ui.component_name': name },
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
+        'ui.component_name': name,
+      },
     });
   }
 
@@ -86,9 +88,9 @@ class Profiler extends React.Component<ProfilerProps> {
             name: `<${this.props.name}>`,
             onlyIfParent: true,
             op: REACT_UPDATE_OP,
-            origin: 'auto.ui.react.profiler',
-            startTimestamp: now,
+            startTime: now,
             attributes: {
+              [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
               'ui.component_name': this.props.name,
               'ui.react.changed_props': changedProps,
             },
@@ -114,15 +116,17 @@ class Profiler extends React.Component<ProfilerProps> {
     const { name, includeRender = true } = this.props;
 
     if (this._mountSpan && includeRender) {
-      const startTimestamp = spanToJSON(this._mountSpan).timestamp;
+      const startTime = spanToJSON(this._mountSpan).timestamp;
       withActiveSpan(this._mountSpan, () => {
         const renderSpan = startInactiveSpan({
           onlyIfParent: true,
           name: `<${name}>`,
           op: REACT_RENDER_OP,
-          origin: 'auto.ui.react.profiler',
-          startTimestamp,
-          attributes: { 'ui.component_name': name },
+          startTime,
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
+            'ui.component_name': name,
+          },
         });
         if (renderSpan) {
           // Have to cast to Span because the type of _mountSpan is Span | undefined
@@ -192,8 +196,10 @@ function useProfiler(
       name: `<${name}>`,
       onlyIfParent: true,
       op: REACT_MOUNT_OP,
-      origin: 'auto.ui.react.profiler',
-      attributes: { 'ui.component_name': name },
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
+        'ui.component_name': name,
+      },
     });
   });
 
@@ -204,16 +210,18 @@ function useProfiler(
 
     return (): void => {
       if (mountSpan && options.hasRenderSpan) {
-        const startTimestamp = spanToJSON(mountSpan).timestamp;
+        const startTime = spanToJSON(mountSpan).timestamp;
         const endTimestamp = timestampInSeconds();
 
         const renderSpan = startInactiveSpan({
           name: `<${name}>`,
           onlyIfParent: true,
           op: REACT_RENDER_OP,
-          origin: 'auto.ui.react.profiler',
-          startTimestamp,
-          attributes: { 'ui.component_name': name },
+          startTime,
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
+            'ui.component_name': name,
+          },
         });
         if (renderSpan) {
           // Have to cast to Span because the type of _mountSpan is Span | undefined

--- a/packages/react/test/profiler.test.tsx
+++ b/packages/react/test/profiler.test.tsx
@@ -74,8 +74,10 @@ describe('withProfiler', () => {
         name: `<${UNKNOWN_COMPONENT}>`,
         onlyIfParent: true,
         op: REACT_MOUNT_OP,
-        origin: 'auto.ui.react.profiler',
-        attributes: { 'ui.component_name': 'unknown' },
+        attributes: {
+          'sentry.origin': 'auto.ui.react.profiler',
+          'ui.component_name': 'unknown',
+        },
       });
     });
   });
@@ -93,9 +95,11 @@ describe('withProfiler', () => {
         name: `<${UNKNOWN_COMPONENT}>`,
         onlyIfParent: true,
         op: REACT_RENDER_OP,
-        origin: 'auto.ui.react.profiler',
-        startTimestamp: undefined,
-        attributes: { 'ui.component_name': 'unknown' },
+        startTime: undefined,
+        attributes: {
+          'sentry.origin': 'auto.ui.react.profiler',
+          'ui.component_name': 'unknown',
+        },
       });
       expect(mockFinish).toHaveBeenCalledTimes(2);
     });
@@ -123,24 +127,30 @@ describe('withProfiler', () => {
       rerender(<ProfiledComponent num={1} />);
       expect(mockStartInactiveSpan).toHaveBeenCalledTimes(2);
       expect(mockStartInactiveSpan).toHaveBeenLastCalledWith({
-        attributes: { 'ui.react.changed_props': ['num'], 'ui.component_name': 'unknown' },
+        attributes: {
+          'sentry.origin': 'auto.ui.react.profiler',
+          'ui.react.changed_props': ['num'],
+          'ui.component_name': 'unknown',
+        },
         name: `<${UNKNOWN_COMPONENT}>`,
         onlyIfParent: true,
         op: REACT_UPDATE_OP,
-        origin: 'auto.ui.react.profiler',
-        startTimestamp: expect.any(Number),
+        startTime: expect.any(Number),
       });
       expect(mockFinish).toHaveBeenCalledTimes(2);
       // New props yet again
       rerender(<ProfiledComponent num={2} />);
       expect(mockStartInactiveSpan).toHaveBeenCalledTimes(3);
       expect(mockStartInactiveSpan).toHaveBeenLastCalledWith({
-        attributes: { 'ui.react.changed_props': ['num'], 'ui.component_name': 'unknown' },
+        attributes: {
+          'sentry.origin': 'auto.ui.react.profiler',
+          'ui.react.changed_props': ['num'],
+          'ui.component_name': 'unknown',
+        },
         name: `<${UNKNOWN_COMPONENT}>`,
         onlyIfParent: true,
         op: REACT_UPDATE_OP,
-        origin: 'auto.ui.react.profiler',
-        startTimestamp: expect.any(Number),
+        startTime: expect.any(Number),
       });
       expect(mockFinish).toHaveBeenCalledTimes(3);
 
@@ -179,8 +189,10 @@ describe('useProfiler()', () => {
         name: '<Example>',
         onlyIfParent: true,
         op: REACT_MOUNT_OP,
-        origin: 'auto.ui.react.profiler',
-        attributes: { 'ui.component_name': 'Example' },
+        attributes: {
+          'ui.component_name': 'Example',
+          'sentry.origin': 'auto.ui.react.profiler',
+        },
       });
     });
   });
@@ -204,8 +216,10 @@ describe('useProfiler()', () => {
           name: '<Example>',
           onlyIfParent: true,
           op: REACT_RENDER_OP,
-          origin: 'auto.ui.react.profiler',
-          attributes: { 'ui.component_name': 'Example' },
+          attributes: {
+            'sentry.origin': 'auto.ui.react.profiler',
+            'ui.component_name': 'Example',
+          },
         }),
       );
     });

--- a/packages/remix/src/client/performance.tsx
+++ b/packages/remix/src/client/performance.tsx
@@ -1,4 +1,9 @@
-import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, getActiveSpan, getRootSpan } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  getActiveSpan,
+  getRootSpan,
+} from '@sentry/core';
 import type { browserTracingIntegration as originalBrowserTracingIntegration } from '@sentry/react';
 import type { BrowserClient, ErrorBoundaryProps } from '@sentry/react';
 import {
@@ -72,8 +77,8 @@ export function startPageloadSpan(): void {
   const spanContext: StartSpanOptions = {
     name: initPathName,
     op: 'pageload',
-    origin: 'auto.pageload.remix',
     attributes: {
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.remix',
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
     },
   };
@@ -96,8 +101,8 @@ function startNavigationSpan(matches: RouteMatch<string>[]): void {
   const spanContext: StartSpanOptions = {
     name: matches[matches.length - 1].id,
     op: 'navigation',
-    origin: 'auto.navigation.remix',
     attributes: {
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.remix',
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
     },
   };

--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -1,4 +1,5 @@
 import type { IdleTransaction } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { getActiveSpan } from '@sentry/core';
 import { getCurrentHub } from '@sentry/core';
 import {
@@ -232,7 +233,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
       };
     }
 
-    const finalContext = beforeStartSpan ? beforeStartSpan(expandedContext) : expandedContext;
+    const finalContext: TransactionContext = beforeStartSpan ? beforeStartSpan(expandedContext) : expandedContext;
 
     // If `beforeStartSpan` set a custom name, record that fact
     finalContext.attributes =
@@ -323,10 +324,10 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         const context: StartSpanOptions = {
           name: WINDOW.location.pathname,
           // pageload should always start at timeOrigin (and needs to be in s, not ms)
-          startTimestamp: browserPerformanceTimeOrigin ? browserPerformanceTimeOrigin / 1000 : undefined,
-          origin: 'auto.pageload.browser',
+          startTime: browserPerformanceTimeOrigin ? browserPerformanceTimeOrigin / 1000 : undefined,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
           },
         };
         startBrowserTracingPageLoadSpan(client, context);
@@ -352,9 +353,9 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
             startingUrl = undefined;
             const context: StartSpanOptions = {
               name: WINDOW.location.pathname,
-              origin: 'auto.navigation.browser',
               attributes: {
                 [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+                [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
               },
             };
 

--- a/packages/tracing-internal/src/node/integrations/prisma.ts
+++ b/packages/tracing-internal/src/node/integrations/prisma.ts
@@ -101,8 +101,9 @@ export class Prisma implements Integration {
             op: 'db.prisma',
             attributes: {
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.prisma',
+              ...clientData,
+              'db.operation': action,
             },
-            data: { ...clientData, 'db.operation': action },
           },
           () => next(params),
         );

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -1,4 +1,4 @@
-import { getActiveSpan, startInactiveSpan } from '@sentry/browser';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, getActiveSpan, startInactiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/types';
 import { logger, timestampInSeconds } from '@sentry/utils';
 
@@ -75,7 +75,9 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
               startInactiveSpan({
                 name: 'Application Render',
                 op: `${VUE_OP}.render`,
-                origin: 'auto.ui.vue',
+                attributes: {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.vue',
+                },
               });
           }
         }
@@ -109,7 +111,9 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
             this.$_sentrySpans[operation] = startInactiveSpan({
               name: `Vue <${name}>`,
               op: `${VUE_OP}.${operation}`,
-              origin: 'auto.ui.vue',
+              attributes: {
+                [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.vue',
+              },
             });
           }
         } else {


### PR DESCRIPTION
Mostly, changes `origin` to be set as an attribute, plus some further small adjustments.

In one case, we replaced `headers` data with a flattened `headers.xxx` object (astro).

In the case of bun, I also changed it to keep the request on the isolation scope (vs. the span).