### PR TITLE
ref(node): Align semantic attribute handling

### DIFF
--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -70,6 +70,9 @@ describe('Integration | Transactions', () => {
           otel: {
             attributes: {
               'test.outer': 'test value',
+              'sentry.op': 'test op',
+              'sentry.origin': 'auto.test',
+              'sentry.source': 'task',
             },
             resource: {
               'service.name': 'node-experimental',
@@ -241,6 +244,9 @@ describe('Integration | Transactions', () => {
           otel: expect.objectContaining({
             attributes: {
               'test.outer': 'test value',
+              'sentry.op': 'test op',
+              'sentry.origin': 'auto.test',
+              'sentry.source': 'task',
             },
           }),
           trace: {
@@ -283,6 +289,7 @@ describe('Integration | Transactions', () => {
           otel: expect.objectContaining({
             attributes: {
               'test.outer': 'test value b',
+              'sentry.op': 'test op b',
             },
           }),
           trace: {
@@ -513,7 +520,11 @@ describe('Integration | Transactions', () => {
       expect.objectContaining({
         contexts: expect.objectContaining({
           otel: expect.objectContaining({
-            attributes: {},
+            attributes: {
+              'sentry.op': 'test op',
+              'sentry.origin': 'auto.test',
+              'sentry.source': 'task',
+            },
           }),
           trace: {
             data: {

--- a/packages/opentelemetry/src/semanticAttributes.ts
+++ b/packages/opentelemetry/src/semanticAttributes.ts
@@ -3,13 +3,5 @@
  * No guarantees apply to these attributes, and the may change/disappear at any time.
  */
 export const InternalSentrySemanticAttributes = {
-  ORIGIN: 'sentry.origin',
-  OP: 'sentry.op',
-  SOURCE: 'sentry.source',
   PARENT_SAMPLED: 'sentry.parentSampled',
-  BREADCRUMB_TYPE: 'sentry.breadcrumb.type',
-  BREADCRUMB_LEVEL: 'sentry.breadcrumb.level',
-  BREADCRUMB_EVENT_ID: 'sentry.breadcrumb.event_id',
-  BREADCRUMB_CATEGORY: 'sentry.breadcrumb.category',
-  BREADCRUMB_DATA: 'sentry.breadcrumb.data',
 } as const;

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -3,12 +3,19 @@ import { TraceFlags } from '@opentelemetry/api';
 import { context } from '@opentelemetry/api';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { TraceState, suppressTracing } from '@opentelemetry/core';
-import { SDK_VERSION, getClient, getCurrentScope, handleCallbackErrors } from '@sentry/core';
+import {
+  SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  getClient,
+  getCurrentScope,
+  handleCallbackErrors,
+} from '@sentry/core';
 import type { Client, Scope } from '@sentry/types';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import { SENTRY_TRACE_STATE_DSC } from './constants';
 
-import { InternalSentrySemanticAttributes } from './semanticAttributes';
 import type { OpenTelemetryClient, OpenTelemetrySpanContext } from './types';
 import { getContextFromScope } from './utils/contextData';
 import { getDynamicSamplingContextFromSpan } from './utils/dynamicSamplingContext';
@@ -137,15 +144,15 @@ function _applySentryAttributesToSpan(span: Span, options: OpenTelemetrySpanCont
   const { origin, op, source, metadata } = options;
 
   if (origin) {
-    span.setAttribute(InternalSentrySemanticAttributes.ORIGIN, origin);
+    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
   }
 
   if (op) {
-    span.setAttribute(InternalSentrySemanticAttributes.OP, op);
+    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, op);
   }
 
   if (source) {
-    span.setAttribute(InternalSentrySemanticAttributes.SOURCE, source);
+    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
   }
 
   if (metadata) {

--- a/packages/opentelemetry/src/utils/addOriginToSpan.ts
+++ b/packages/opentelemetry/src/utils/addOriginToSpan.ts
@@ -1,9 +1,8 @@
 import type { Span } from '@opentelemetry/api';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import type { SpanOrigin } from '@sentry/types';
-
-import { InternalSentrySemanticAttributes } from '../semanticAttributes';
 
 /** Adds an origin to an OTEL Span. */
 export function addOriginToSpan(span: Span, origin: SpanOrigin): void {
-  span.setAttribute(InternalSentrySemanticAttributes.ORIGIN, origin);
+  span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
 }

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -77,6 +77,9 @@ describe('Integration | Transactions', () => {
           otel: {
             attributes: {
               'test.outer': 'test value',
+              'sentry.op': 'test op',
+              'sentry.origin': 'auto.test',
+              'sentry.source': 'task',
             },
             resource: {
               'service.name': 'opentelemetry-test',
@@ -245,6 +248,9 @@ describe('Integration | Transactions', () => {
           otel: expect.objectContaining({
             attributes: {
               'test.outer': 'test value',
+              'sentry.op': 'test op',
+              'sentry.origin': 'auto.test',
+              'sentry.source': 'task',
             },
           }),
           trace: {
@@ -287,6 +293,7 @@ describe('Integration | Transactions', () => {
           otel: expect.objectContaining({
             attributes: {
               'test.outer': 'test value b',
+              'sentry.op': 'test op b',
             },
           }),
           trace: {
@@ -364,7 +371,11 @@ describe('Integration | Transactions', () => {
       expect.objectContaining({
         contexts: expect.objectContaining({
           otel: expect.objectContaining({
-            attributes: {},
+            attributes: {
+              'sentry.op': 'test op',
+              'sentry.origin': 'auto.test',
+              'sentry.source': 'task',
+            },
           }),
           trace: {
             data: {

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -3,10 +3,16 @@ import { SpanKind } from '@opentelemetry/api';
 import { TraceFlags, context, trace } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { Span as SpanClass } from '@opentelemetry/sdk-trace-base';
-import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, getClient, getCurrentScope, spanToJSON } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  getClient,
+  getCurrentScope,
+} from '@sentry/core';
 import type { Event, PropagationContext, Scope } from '@sentry/types';
 
-import { InternalSentrySemanticAttributes } from '../src/semanticAttributes';
 import { startInactiveSpan, startSpan, startSpanManual } from '../src/trace';
 import type { AbstractSpan } from '../src/types';
 import { setPropagationContextOnContext } from '../src/utils/contextData';
@@ -220,15 +226,15 @@ describe('trace', () => {
           origin: 'auto.test.origin',
           metadata: { requestPath: 'test-path' },
           attributes: {
-            [InternalSentrySemanticAttributes.SOURCE]: 'task',
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
           },
         },
         span => {
           expect(span).toBeDefined();
           expect(getSpanAttributes(span)).toEqual({
-            [InternalSentrySemanticAttributes.SOURCE]: 'task',
-            [InternalSentrySemanticAttributes.ORIGIN]: 'auto.test.origin',
-            [InternalSentrySemanticAttributes.OP]: 'my-op',
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test.origin',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'my-op',
             [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           });
 
@@ -481,7 +487,7 @@ describe('trace', () => {
         op: 'my-op',
         origin: 'auto.test.origin',
         attributes: {
-          [InternalSentrySemanticAttributes.SOURCE]: 'task',
+          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
         },
         metadata: { requestPath: 'test-path' },
       });
@@ -489,9 +495,9 @@ describe('trace', () => {
       expect(span2).toBeDefined();
       expect(getSpanAttributes(span2)).toEqual({
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
-        [InternalSentrySemanticAttributes.SOURCE]: 'task',
-        [InternalSentrySemanticAttributes.ORIGIN]: 'auto.test.origin',
-        [InternalSentrySemanticAttributes.OP]: 'my-op',
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test.origin',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'my-op',
       });
 
       expect(getSpanMetadata(span2)).toEqual({ requestPath: 'test-path' });

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -10,6 +10,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   getClient,
   getCurrentScope,
+  spanToJSON,
 } from '@sentry/core';
 import type { Event, PropagationContext, Scope } from '@sentry/types';
 


### PR DESCRIPTION
Also stop clearing out sentry attributes, we don't actually want that (except for the parent sampled stuff for now).