### PR TITLE
ref(sveltekit): Update trace propagation & span options

### DIFF
--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -1,5 +1,5 @@
 import { flush } from '@sentry/node-experimental';
-import { logger, tracingContextFromHeaders } from '@sentry/utils';
+import { logger } from '@sentry/utils';
 import type { RequestEvent } from '@sveltejs/kit';
 
 import { DEBUG_BUILD } from '../common/debug-build';
@@ -10,12 +10,11 @@ import { DEBUG_BUILD } from '../common/debug-build';
  *
  * Sets propagation context as a side effect.
  */
-// eslint-disable-next-line deprecation/deprecation
-export function getTracePropagationData(event: RequestEvent): ReturnType<typeof tracingContextFromHeaders> {
-  const sentryTraceHeader = event.request.headers.get('sentry-trace') || '';
-  const baggageHeader = event.request.headers.get('baggage');
-  // eslint-disable-next-line deprecation/deprecation
-  return tracingContextFromHeaders(sentryTraceHeader, baggageHeader);
+export function getTracePropagationData(event: RequestEvent): { sentryTrace: string; baggage: string | null } {
+  const sentryTrace = event.request.headers.get('sentry-trace') || '';
+  const baggage = event.request.headers.get('baggage');
+
+  return { sentryTrace, baggage };
 }
 
 /** Flush the event queue to ensure that events get sent to Sentry before the response is finished and the lambda ends */

--- a/packages/sveltekit/test/server/utils.test.ts
+++ b/packages/sveltekit/test/server/utils.test.ts
@@ -23,32 +23,27 @@ const MOCK_REQUEST_EVENT: any = {
 };
 
 describe('getTracePropagationData', () => {
-  it('returns traceParentData and DSC if both are available', () => {
+  it('returns sentryTrace & baggage strings if both are available', () => {
     const event: any = MOCK_REQUEST_EVENT;
 
-    const { traceparentData, dynamicSamplingContext } = getTracePropagationData(event);
+    const { sentryTrace, baggage } = getTracePropagationData(event);
 
-    expect(traceparentData).toEqual({
-      parentSampled: true,
-      parentSpanId: '1234567890abcdef',
-      traceId: '1234567890abcdef1234567890abcdef',
-    });
-
-    expect(dynamicSamplingContext).toEqual({
-      environment: 'production',
-      public_key: 'dogsarebadatkeepingsecrets',
-      release: '1.0.0',
-      sample_rate: '1',
-      trace_id: '1234567890abcdef1234567890abcdef',
-      transaction: 'dogpark',
-    });
+    expect(sentryTrace).toEqual('1234567890abcdef1234567890abcdef-1234567890abcdef-1');
+    expect(baggage?.split(',').sort()).toEqual([
+      'sentry-environment=production',
+      'sentry-public_key=dogsarebadatkeepingsecrets',
+      'sentry-release=1.0.0',
+      'sentry-sample_rate=1',
+      'sentry-trace_id=1234567890abcdef1234567890abcdef',
+      'sentry-transaction=dogpark',
+    ]);
   });
 
-  it('returns undefined if the necessary header is not avaolable', () => {
+  it('returns empty if the necessary header is not available', () => {
     const event: any = { request: { headers: { get: () => undefined } } };
-    const { traceparentData, dynamicSamplingContext } = getTracePropagationData(event);
+    const { sentryTrace, baggage } = getTracePropagationData(event);
 
-    expect(traceparentData).toBeUndefined();
-    expect(dynamicSamplingContext).toBeUndefined();
+    expect(sentryTrace).toBe('');
+    expect(baggage).toBeUndefined();
   });
 });


### PR DESCRIPTION
This WIP updates sveltekit to avoid deprecated options to `startSpan`, which also includes changing how we propagate traces to use `continueTrace`.

I fixed the tests to ensure this still works, but would appreciate a review from @Lms24 if that all seems correct 😅 