### PR TITLE
ref(astro): Put request as SDK processing metadata instead of span data

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,22 @@
 # Upgrading from 7.x to 8.x
 
+## Removal of `trackHeaders` option for Astro middleware
+
+Instead of opting-in via the middleware config, you can configure if headers should be captured via
+`requestDataIntegration` options, which defaults to `true` but can be disabled like this:
+
+```
+Sentry.init({
+  integrations: [
+    Sentry.requestDataIntegration({
+      include: {
+        headers: false
+      },
+    }),
+  ],
+});
+```
+
 ## Removal of Client-Side health check transaction filters
 
 The SDK no longer filters out health check transactions by default. Instead, they are sent to Sentry but still dropped


### PR DESCRIPTION
This removes usage of deprecated options to `startSpan`, and removes the `trackHeaders` option to the astro middleware in favor of using the general request data integration that should pick this up if put on the scope as SDK processing metadata.