### PR TITLE
feat(core): Remove deprecated `scope.applyToEvent()` method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ env:
     ${{ github.workspace }}/packages/utils/cjs
     ${{ github.workspace }}/packages/utils/esm
 
-  BUILD_CACHE_KEY: ${{ github.event.inputs.commit || github.sha }}
+  BUILD_CACHE_KEY: build-cache-${{ github.event.inputs.commit || github.sha }}
   BUILD_PROFILING_NODE_CACHE_TARBALL_KEY: profiling-node-tarball-${{ github.event.inputs.commit || github.sha }}
 
   # GH will use the first restore-key it finds that matches

--- a/nx.json
+++ b/nx.json
@@ -32,7 +32,7 @@
     "build:types": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:types"],
-      "outputs": ["{projectRoot}/build/**/*.d.ts", "{projectRoot}/build/**/*.d.ts.map"]
+      "outputs": ["{projectRoot}/build/{types,types-ts3.8}", "{projectRoot}/build/npm/{types,types-ts3.8}"]
     },
     "lint": {
       "inputs": ["default"],

--- a/packages/core/src/metrics/metric-summary.ts
+++ b/packages/core/src/metrics/metric-summary.ts
@@ -2,7 +2,7 @@ import type { MeasurementUnit, Span } from '@sentry/types';
 import type { MetricSummary } from '@sentry/types';
 import type { Primitive } from '@sentry/types';
 import { dropUndefinedKeys } from '@sentry/utils';
-import { getActiveSpan } from '../tracing';
+import { getActiveSpan } from '../tracing/utils';
 import type { MetricType } from './types';
 
 /**

--- a/packages/core/src/tracing/getActiveSpan.ts
+++ b/packages/core/src/tracing/getActiveSpan.ts
@@ -1,0 +1,2 @@
+import type { Span } from '@sentry/types';
+import { getCurrentScope } from '../currentScopes';

--- a/packages/core/src/tracing/getActiveSpan.ts
+++ b/packages/core/src/tracing/getActiveSpan.ts
@@ -1,2 +1,0 @@
-import type { Span } from '@sentry/types';
-import { getCurrentScope } from '../currentScopes';

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -4,7 +4,7 @@ export type { BeforeFinishCallback } from './idletransaction';
 export { SentrySpan } from './sentrySpan';
 export { Transaction } from './transaction';
 // eslint-disable-next-line deprecation/deprecation
-export { getActiveTransaction } from './utils';
+export { getActiveTransaction, getActiveSpan } from './utils';
 // eslint-disable-next-line deprecation/deprecation
 export { SpanStatus } from './spanstatus';
 export {
@@ -13,7 +13,6 @@ export {
 } from './spanstatus';
 export type { SpanStatusType } from './spanstatus';
 export {
-  getActiveSpan,
   startSpan,
   startInactiveSpan,
   startSpanManual,

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -25,7 +25,7 @@ import {
   spanToTraceContext,
 } from '../utils/spanUtils';
 import type { SpanStatusType } from './spanstatus';
-import { addChildSpanToSpan } from './trace';
+import { addChildSpanToSpan } from './utils';
 
 /**
  * Keeps track of finished spans for a given transaction

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -21,7 +21,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE
 import { spanTimeInputToSeconds, spanToJSON, spanToTraceContext } from '../utils/spanUtils';
 import { getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { SentrySpan, SpanRecorder } from './sentrySpan';
-import { getCapturedScopesOnSpan, getSpanTree } from './trace';
+import { getCapturedScopesOnSpan, getSpanTree } from './utils';
 
 /** JSDoc */
 export class Transaction extends SentrySpan implements TransactionInterface {

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,4 +1,7 @@
-import type { Transaction } from '@sentry/types';
+import type { Span, Transaction } from '@sentry/types';
+import { Scope } from '@sentry/types';
+import { addNonEnumerableProperty } from '@sentry/utils';
+import { getCurrentScope } from '../currentScopes';
 
 import type { Hub } from '../hub';
 import { getCurrentHub } from '../hub';
@@ -19,3 +22,78 @@ export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T |
 
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';
+
+/**
+ * Returns the currently active span.
+ */
+export function getActiveSpan(): Span | undefined {
+  // eslint-disable-next-line deprecation/deprecation
+  return getCurrentScope().getSpan();
+}
+
+const CHILD_SPANS_FIELD = '_sentryChildSpans';
+
+type SpanWithPotentialChildren = Span & {
+  [CHILD_SPANS_FIELD]?: Set<Span>;
+};
+
+/**
+ * Adds an opaque child span reference to a span.
+ */
+export function addChildSpanToSpan(span: SpanWithPotentialChildren, childSpan: Span): void {
+  if (span[CHILD_SPANS_FIELD] && span[CHILD_SPANS_FIELD].size < 1000) {
+    span[CHILD_SPANS_FIELD].add(childSpan);
+  } else {
+    span[CHILD_SPANS_FIELD] = new Set([childSpan]);
+  }
+}
+
+/**
+ * Obtains the entire span tree, meaning a span + all of its descendants for a particular span.
+ */
+export function getSpanTree(span: SpanWithPotentialChildren): Span[] {
+  const resultSet = new Set<Span>();
+
+  function addSpanChildren(span: SpanWithPotentialChildren): void {
+    // This exit condition is required to not infinitely loop in case of a circular dependency.
+    if (resultSet.has(span)) {
+      return;
+    } else {
+      resultSet.add(span);
+      const childSpans = span[CHILD_SPANS_FIELD] ? Array.from(span[CHILD_SPANS_FIELD]) : [];
+      for (const childSpan of childSpans) {
+        addSpanChildren(childSpan);
+      }
+    }
+  }
+
+  addSpanChildren(span);
+
+  return Array.from(resultSet);
+}
+
+const SCOPE_ON_START_SPAN_FIELD = '_sentryScope';
+const ISOLATION_SCOPE_ON_START_SPAN_FIELD = '_sentryIsolationScope';
+
+type SpanWithScopes = Span & {
+  [SCOPE_ON_START_SPAN_FIELD]?: Scope;
+  [ISOLATION_SCOPE_ON_START_SPAN_FIELD]?: Scope;
+};
+
+/** Store the scope & isolation scope for a span, which can the be used when it is finished. */
+export function setCapturedScopesOnSpan(span: Span | undefined, scope: Scope, isolationScope: Scope): void {
+  if (span) {
+    addNonEnumerableProperty(span, ISOLATION_SCOPE_ON_START_SPAN_FIELD, isolationScope);
+    addNonEnumerableProperty(span, SCOPE_ON_START_SPAN_FIELD, scope);
+  }
+}
+
+/**
+ * Grabs the scope and isolation scope off a span that were active when the span was started.
+ */
+export function getCapturedScopesOnSpan(span: Span): { scope?: Scope; isolationScope?: Scope } {
+  return {
+    scope: (span as SpanWithScopes)[SCOPE_ON_START_SPAN_FIELD],
+    isolationScope: (span as SpanWithScopes)[ISOLATION_SCOPE_ON_START_SPAN_FIELD],
+  };
+}

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,5 +1,5 @@
 import type { Span, Transaction } from '@sentry/types';
-import { Scope } from '@sentry/types';
+import type { Scope } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
 import { getCurrentScope } from '../currentScopes';
 

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -46,7 +46,7 @@ export interface ScopeData {
 }
 
 /**
- * Holds additional event information. {@link Scope.applyToEvent} will be called by the client before an event is sent.
+ * Holds additional event information.
  */
 export interface Scope {
   /**
@@ -61,7 +61,7 @@ export interface Scope {
    */
   getClient<C extends Client>(): C | undefined;
 
-  /** Add new event processor that will be called after {@link applyToEvent}. */
+  /** Add new event processor that will be called during event processing. */
   addEventProcessor(callback: EventProcessor): this;
 
   /** Get the data of this scope, which is applied to an event during processing. */


### PR DESCRIPTION
This also resolves the circular dependencies we have in core right now by moving utils around a bit.