### PR TITLE
feat(browser): Prevent initialization in browser extensions

### DIFF
--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/init.js
@@ -1,6 +1,8 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
+
+// We mock this here to simulate a Firefox/Safari browser extension
 window.browser = { runtime: { id: 'mock-extension-id' } };
 
 Sentry.init({

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/init.js
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.browser = { runtime: { id: 'mock-extension-id' } };
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
@@ -1,31 +1,34 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 
-sentryTest('should not initialize when inside a Chrome browser extension', async ({ getLocalTestUrl, page }) => {
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
+sentryTest(
+  'should not initialize when inside a Firefox/Safari browser extension',
+  async ({ getLocalTestUrl, page }) => {
+    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'test-id' }),
+      });
     });
-  });
 
-  const errorLogs: string[] = [];
+    const errorLogs: string[] = [];
 
-  page.on('console', message => {
-    if (message.type() === 'error') errorLogs.push(message.text());
-  });
+    page.on('console', message => {
+      if (message.type() === 'error') errorLogs.push(message.text());
+    });
 
-  const url = await getLocalTestUrl({ testDir: __dirname });
-  await page.goto(url);
+    const url = await getLocalTestUrl({ testDir: __dirname });
+    await page.goto(url);
 
-  const isInitialized = await page.evaluate(() => {
-    return !!(window as any).Sentry.isInitialized();
-  });
+    const isInitialized = await page.evaluate(() => {
+      return !!(window as any).Sentry.isInitialized();
+    });
 
-  expect(isInitialized).toEqual(false);
-  expect(errorLogs.length).toEqual(1);
-  expect(errorLogs[0]).toEqual(
-    '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
-  );
-});
+    expect(isInitialized).toEqual(false);
+    expect(errorLogs.length).toEqual(1);
+    expect(errorLogs[0]).toEqual(
+      '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+    );
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../utils/fixtures';
+
+sentryTest('should not initialize when inside a Chrome browser extension', async ({ getLocalTestUrl, page }) => {
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const errorLogs: string[] = [];
+
+  page.on('console', message => {
+    if (message.type() === 'error') errorLogs.push(message.text());
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  const isInitialized = await page.evaluate(() => {
+    return !!(window as any).Sentry.isInitialized();
+  });
+
+  expect(isInitialized).toEqual(false);
+  expect(errorLogs.length).toEqual(1);
+  expect(errorLogs[0]).toEqual(
+    '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+  );
+});

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/init.js
@@ -1,6 +1,8 @@
 import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
+
+// We mock this here to simulate a Chrome browser extension
 window.chrome = { runtime: { id: 'mock-extension-id' } };
 
 Sentry.init({

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/init.js
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.chrome = { runtime: { id: 'mock-extension-id' } };
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
@@ -26,6 +26,6 @@ sentryTest('should not initialize when inside a Chrome browser extension', async
   expect(isInitialized).toEqual(false);
   expect(errorLogs.length).toEqual(1);
   expect(errorLogs[0]).toEqual(
-    '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+    '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
   );
 });

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../utils/fixtures';
+
+sentryTest('should not initialize when inside a Chrome browser extension', async ({ getLocalTestUrl, page }) => {
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const errorLogs: string[] = [];
+
+  page.on('console', message => {
+    if (message.type() === 'error') errorLogs.push(message.text());
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  const isInitialized = await page.evaluate(() => {
+    return !!(window as any).Sentry.isInitialized();
+  });
+
+  expect(isInitialized).toEqual(false);
+  expect(errorLogs.length).toEqual(1);
+  expect(errorLogs[0]).toEqual(
+    '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+  );
+});

--- a/packages/astro/src/client/sdk.ts
+++ b/packages/astro/src/client/sdk.ts
@@ -30,15 +30,13 @@ export function init(options: BrowserOptions): void {
 }
 
 function getDefaultIntegrations(options: BrowserOptions): Integration[] | undefined {
-  const defaultIntegrations = [...getBrowserDefaultIntegrations(options)];
-
   // This evaluates to true unless __SENTRY_TRACING__ is text-replaced with "false",
   // in which case everything inside will get treeshaken away
   if (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) {
     if (hasTracingEnabled(options)) {
-      return [...defaultIntegrations, browserTracingIntegration()];
+      return [...getBrowserDefaultIntegrations(options), browserTracingIntegration()];
     }
   }
 
-  return defaultIntegrations;
+  return undefined;
 }

--- a/packages/astro/src/client/sdk.ts
+++ b/packages/astro/src/client/sdk.ts
@@ -30,13 +30,15 @@ export function init(options: BrowserOptions): void {
 }
 
 function getDefaultIntegrations(options: BrowserOptions): Integration[] | undefined {
+  const defaultIntegrations = [...getBrowserDefaultIntegrations(options)];
+
   // This evaluates to true unless __SENTRY_TRACING__ is text-replaced with "false",
   // in which case everything inside will get treeshaken away
   if (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) {
     if (hasTracingEnabled(options)) {
-      return [...getBrowserDefaultIntegrations(options), browserTracingIntegration()];
+      return [...defaultIntegrations, browserTracingIntegration()];
     }
   }
 
-  return undefined;
+  return defaultIntegrations;
 }

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -78,7 +78,7 @@ describe('Sentry client SDK', () => {
           ...tracingOptions,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
+        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations || [];
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
@@ -93,7 +93,7 @@ describe('Sentry client SDK', () => {
           enableTracing: true,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
+        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations || [];
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -44,6 +44,40 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   ];
 }
 
+function applyDefaultOptions(options: BrowserOptions = {}): BrowserOptions {
+  const defaultOptions: BrowserOptions = {
+    defaultIntegrations: getDefaultIntegrations(options),
+    release:
+      typeof __SENTRY_RELEASE__ === 'string' // This allows build tooling to find-and-replace __SENTRY_RELEASE__ to inject a release value
+        ? __SENTRY_RELEASE__
+        : WINDOW.SENTRY_RELEASE && WINDOW.SENTRY_RELEASE.id // This supports the variable that sentry-webpack-plugin injects
+          ? WINDOW.SENTRY_RELEASE.id
+          : undefined,
+    autoSessionTracking: true,
+    sendClientReports: true,
+  };
+
+  return { ...defaultOptions, ...options };
+}
+
+function shouldShowBrowserExtensionError(): boolean {
+  const windowWithMaybeChrome = WINDOW as typeof WINDOW & { chrome?: { runtime?: { id?: string } } };
+  const isInsideChromeExtension =
+    windowWithMaybeChrome &&
+    windowWithMaybeChrome.chrome &&
+    windowWithMaybeChrome.chrome.runtime &&
+    windowWithMaybeChrome.chrome.runtime.id;
+
+  const windowWithMaybeBrowser = WINDOW as typeof WINDOW & { browser?: { runtime?: { id?: string } } };
+  const isInsideBrowserExtension =
+    windowWithMaybeBrowser &&
+    windowWithMaybeBrowser.browser &&
+    windowWithMaybeBrowser.browser.runtime &&
+    windowWithMaybeBrowser.browser.runtime.id;
+
+  return !!isInsideBrowserExtension || !!isInsideChromeExtension;
+}
+
 /**
  * A magic string that build tooling can leverage in order to inject a release value into the SDK.
  */
@@ -95,48 +129,14 @@ declare const __SENTRY_RELEASE__: string | undefined;
  *
  * @see {@link BrowserOptions} for documentation on configuration options.
  */
-export function init(options: BrowserOptions = {}): void {
-  if (options.defaultIntegrations === undefined) {
-    options.defaultIntegrations = getDefaultIntegrations(options);
-  }
-  if (options.release === undefined) {
-    // This allows build tooling to find-and-replace __SENTRY_RELEASE__ to inject a release value
-    if (typeof __SENTRY_RELEASE__ === 'string') {
-      options.release = __SENTRY_RELEASE__;
-    }
+export function init(browserOptions: BrowserOptions = {}): void {
+  const options = applyDefaultOptions(browserOptions);
 
-    // This supports the variable that sentry-webpack-plugin injects
-    if (WINDOW.SENTRY_RELEASE && WINDOW.SENTRY_RELEASE.id) {
-      options.release = WINDOW.SENTRY_RELEASE.id;
-    }
-  }
-  if (options.autoSessionTracking === undefined) {
-    options.autoSessionTracking = true;
-  }
-  if (options.sendClientReports === undefined) {
-    options.sendClientReports = true;
-  }
-
-  // inside Chrome extension (chrome.* API)
-  const windowWithMaybeChrome = WINDOW as typeof WINDOW & { chrome?: { runtime?: { id?: string } } };
-
-  // inside Firefox/Safari extension (browser.* API)
-  const windowWithMaybeBrowser = WINDOW as typeof WINDOW & { browser?: { runtime?: { id?: string } } };
-
-  if (
-    (windowWithMaybeBrowser &&
-      windowWithMaybeBrowser.browser &&
-      windowWithMaybeBrowser.browser.runtime &&
-      windowWithMaybeBrowser.browser.runtime.id) ||
-    (windowWithMaybeChrome &&
-      windowWithMaybeChrome.chrome &&
-      windowWithMaybeChrome.chrome.runtime &&
-      windowWithMaybeChrome.chrome.runtime.id)
-  ) {
+  if (shouldShowBrowserExtensionError()) {
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
       console.error(
-        '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+        '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
       );
     });
     return;

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -44,9 +44,9 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   ];
 }
 
-function applyDefaultOptions(options: BrowserOptions = {}): BrowserOptions {
+function applyDefaultOptions(optionsArg: BrowserOptions = {}): BrowserOptions {
   const defaultOptions: BrowserOptions = {
-    defaultIntegrations: getDefaultIntegrations(options),
+    defaultIntegrations: getDefaultIntegrations(optionsArg),
     release:
       typeof __SENTRY_RELEASE__ === 'string' // This allows build tooling to find-and-replace __SENTRY_RELEASE__ to inject a release value
         ? __SENTRY_RELEASE__
@@ -57,7 +57,7 @@ function applyDefaultOptions(options: BrowserOptions = {}): BrowserOptions {
     sendClientReports: true,
   };
 
-  return { ...defaultOptions, ...options };
+  return { ...defaultOptions, ...optionsArg };
 }
 
 function shouldShowBrowserExtensionError(): boolean {

--- a/packages/browser/test/unit/sdk.test.ts
+++ b/packages/browser/test/unit/sdk.test.ts
@@ -4,6 +4,7 @@ import type { Client, Integration } from '@sentry/types';
 import { resolvedSyncPromise } from '@sentry/utils';
 
 import type { BrowserOptions } from '../../src';
+import { WINDOW } from '../../src';
 import { init } from '../../src/sdk';
 
 const PUBLIC_DSN = 'https://username@domain/123';
@@ -126,5 +127,64 @@ describe('init', () => {
     expect(DEFAULT_INTEGRATIONS[0].setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
     expect(newIntegration.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
     expect(DEFAULT_INTEGRATIONS[1].setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
+  });
+
+  describe('initialization error in browser extension', () => {
+    const DEFAULT_INTEGRATIONS: Integration[] = [
+      new MockIntegration('MockIntegration 0.1'),
+      new MockIntegration('MockIntegration 0.2'),
+    ];
+
+    const options = getDefaultBrowserOptions({ dsn: PUBLIC_DSN, defaultIntegrations: DEFAULT_INTEGRATIONS });
+
+    it('should not log a browser extension error if executed inside regular browser environment', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      init(options);
+
+      expect(consoleErrorSpy).toBeCalledTimes(0);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should log a browser extension error if executed inside a Chrome extension', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      Object.defineProperty(WINDOW, 'chrome', {
+        value: { runtime: { id: 'mock-extension-id' } },
+        writable: true,
+      });
+
+      init(options);
+
+      expect(consoleErrorSpy).toBeCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+      );
+
+      consoleErrorSpy.mockRestore();
+
+      Object.defineProperty(WINDOW, 'chrome', {
+        value: null,
+        writable: true,
+      });
+    });
+
+    it('should log a browser extension error if executed inside a Firefox/Safari extension', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      Object.defineProperty(WINDOW, 'browser', { value: { runtime: { id: 'mock-extension-id' } }, writable: true });
+
+      init(options);
+
+      expect(consoleErrorSpy).toBeCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+      );
+
+      consoleErrorSpy.mockRestore();
+
+      Object.defineProperty(WINDOW, 'browser', { value: null, writable: true });
+    });
   });
 });

--- a/packages/browser/test/unit/sdk.test.ts
+++ b/packages/browser/test/unit/sdk.test.ts
@@ -137,14 +137,9 @@ describe('init', () => {
 
     const options = getDefaultBrowserOptions({ dsn: PUBLIC_DSN, defaultIntegrations: DEFAULT_INTEGRATIONS });
 
-    it('should not log a browser extension error if executed inside regular browser environment', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-      init(options);
-
-      expect(consoleErrorSpy).toBeCalledTimes(0);
-
-      consoleErrorSpy.mockRestore();
+    afterEach(() => {
+      Object.defineProperty(WINDOW, 'chrome', { value: undefined, writable: true });
+      Object.defineProperty(WINDOW, 'browser', { value: undefined, writable: true });
     });
 
     it('should log a browser extension error if executed inside a Chrome extension', () => {
@@ -159,15 +154,10 @@ describe('init', () => {
 
       expect(consoleErrorSpy).toBeCalledTimes(1);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+        '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
       );
 
       consoleErrorSpy.mockRestore();
-
-      Object.defineProperty(WINDOW, 'chrome', {
-        value: null,
-        writable: true,
-      });
     });
 
     it('should log a browser extension error if executed inside a Firefox/Safari extension', () => {
@@ -179,12 +169,20 @@ describe('init', () => {
 
       expect(consoleErrorSpy).toBeCalledTimes(1);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[Sentry] You cannot run Sentry this way in an extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
+        '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/troubleshooting/#setting-up-sentry-in-shared-environments-eg-browser-extensions',
       );
 
       consoleErrorSpy.mockRestore();
+    });
 
-      Object.defineProperty(WINDOW, 'browser', { value: null, writable: true });
+    it('should not log a browser extension error if executed inside regular browser environment', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      init(options);
+
+      expect(consoleErrorSpy).toBeCalledTimes(0);
+
+      consoleErrorSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
Prevents initialization inside chrome.* and  browser.* extension environments.
Also refactored init() in browser because of eslint warning about too much complexity.
Fixes https://github.com/getsentry/sentry-javascript/issues/10632
