### PR TITLE
feat: Ignore ResizeObserver and undefined error

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -6,7 +6,11 @@ import { convertIntegrationFnToClass, defineIntegration } from '../integration';
 
 // "Script error." is hard coded into browsers for errors that it can't read.
 // this is the result of a script being pulled in from an external domain and CORS.
-const DEFAULT_IGNORE_ERRORS = [/^Script error\.?$/, /^Javascript error: Script error\.? on line 0$/, /^ResizeObserver loop completed with undelivered notifications.$/];
+const DEFAULT_IGNORE_ERRORS = [
+  /^Script error\.?$/,
+  /^Javascript error: Script error\.? on line 0$/,
+  /^ResizeObserver loop completed with undelivered notifications.$/,
+];
 
 /** Options for the InboundFilters integration */
 export interface InboundFiltersOptions {

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -6,7 +6,7 @@ import { convertIntegrationFnToClass, defineIntegration } from '../integration';
 
 // "Script error." is hard coded into browsers for errors that it can't read.
 // this is the result of a script being pulled in from an external domain and CORS.
-const DEFAULT_IGNORE_ERRORS = [/^Script error\.?$/, /^Javascript error: Script error\.? on line 0$/, /^ResizeObserver loop completed with undelivered notifications.$/, /^undefined$/];
+const DEFAULT_IGNORE_ERRORS = [/^Script error\.?$/, /^Javascript error: Script error\.? on line 0$/, /^ResizeObserver loop completed with undelivered notifications.$/];
 
 /** Options for the InboundFilters integration */
 export interface InboundFiltersOptions {

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -6,7 +6,7 @@ import { convertIntegrationFnToClass, defineIntegration } from '../integration';
 
 // "Script error." is hard coded into browsers for errors that it can't read.
 // this is the result of a script being pulled in from an external domain and CORS.
-const DEFAULT_IGNORE_ERRORS = [/^Script error\.?$/, /^Javascript error: Script error\.? on line 0$/];
+const DEFAULT_IGNORE_ERRORS = [/^Script error\.?$/, /^Javascript error: Script error\.? on line 0$/, /^ResizeObserver loop completed with undelivered notifications.$/, /^undefined$/];
 
 /** Options for the InboundFilters integration */
 export interface InboundFiltersOptions {

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -177,12 +177,35 @@ const SENTRY_EVENT: Event = {
   },
 };
 
+const BOGUS_EVENT: Event = {
+  message: '',
+  exception: {
+    values: [
+      {
+        type: 'Error',
+        value: 'undefined',
+      },
+    ],
+  },
+};
+
 const SCRIPT_ERROR_EVENT: Event = {
   exception: {
     values: [
       {
         type: '[undefined]',
         value: 'Script error.',
+      },
+    ],
+  },
+};
+
+const RESIZEOBSERVER_EVENT: Event = {
+  exception: {
+    values: [
+      {
+        type: 'Error',
+        value: 'ResizeObserver loop completed with undelivered notifications.',
       },
     ],
   },
@@ -292,6 +315,16 @@ describe('InboundFilters', () => {
     it('uses default filters', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(null);
+    });
+
+    it('uses default filters Resize', () => {
+      const eventProcessor = createInboundFiltersEventProcessor();
+      expect(eventProcessor(RESIZEOBSERVER_EVENT, {})).toBe(null);
+    });
+
+    it('uses default filters Empty', () => {
+      const eventProcessor = createInboundFiltersEventProcessor();
+      expect(eventProcessor(BOGUS_EVENT, {})).toBe(null);
     });
 
     it('filters on last exception when multiple present', () => {

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -177,18 +177,6 @@ const SENTRY_EVENT: Event = {
   },
 };
 
-const BOGUS_EVENT: Event = {
-  message: '',
-  exception: {
-    values: [
-      {
-        type: 'Error',
-        value: 'undefined',
-      },
-    ],
-  },
-};
-
 const SCRIPT_ERROR_EVENT: Event = {
   exception: {
     values: [
@@ -317,14 +305,9 @@ describe('InboundFilters', () => {
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(null);
     });
 
-    it('uses default filters Resize', () => {
+    it('uses default filters ResizeObserver', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(RESIZEOBSERVER_EVENT, {})).toBe(null);
-    });
-
-    it('uses default filters Empty', () => {
-      const eventProcessor = createInboundFiltersEventProcessor();
-      expect(eventProcessor(BOGUS_EVENT, {})).toBe(null);
     });
 
     it('filters on last exception when multiple present', () => {


### PR DESCRIPTION
We want to filter out `ResizeObserver` error since they are not actionable and have no stacktrace and break transaction status. ref https://stackoverflow.com/a/77680580/1139707

Also, I added to filter out undefined errors - here are two events to Sentry to represent this.

undefined: 
https://sentry.sentry.io/issues/3611187513/events/46ed8c398c234ff89baee87c5c341844/

ResizeObserver: 
https://sentry.sentry.io/issues/3611187513/events/48f25ea9dfbf4bd0b84a18982ee73362/