### PR TITLE
build: Fix nx cache for real

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -27,12 +27,22 @@
     "build:transpile": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:transpile"],
-      "outputs": ["{projectRoot}/build/{esm,cjs}", "{projectRoot}/build/npm/{esm,cjs}"]
+      "outputs": [
+        "{projectRoot}/build/esm",
+        "{projectRoot}/build/cjs",
+        "{projectRoot}/build/npm/esm",
+        "{projectRoot}/build/npm/cjs"
+      ]
     },
     "build:types": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:types"],
-      "outputs": ["{projectRoot}/build/{types,types-ts3.8}", "{projectRoot}/build/npm/{types,types-ts3.8}"]
+      "outputs": [
+        "{projectRoot}/build/types",
+        "{projectRoot}/build/types-ts3.8",
+        "{projectRoot}/build/npm/types",
+        "{projectRoot}/build/npm/types-ts3.8"
+      ]
     },
     "lint": {
       "inputs": ["default"],


### PR DESCRIPTION
Turns out you cannout use `{xx,yy}` glob syntax for cache outputs, which broke everything. oops....