### PR TITLE
fix(processing): Only mark aggregate errors as exception groups

### DIFF
--- a/packages/utils/src/aggregate-errors.ts
+++ b/packages/utils/src/aggregate-errors.ts
@@ -57,6 +57,7 @@ function aggregateExceptionsFromError(
 
   let newExceptions = [...prevExceptions];
 
+  // Recursively call this function in order to walk down a chain of errors
   if (isInstanceOf(error[key], Error)) {
     applyExceptionGroupFieldsForParentException(exception, exceptionId);
     const newException = exceptionFromErrorImplementation(parser, error[key]);
@@ -106,7 +107,7 @@ function applyExceptionGroupFieldsForParentException(exception: Exception, excep
 
   exception.mechanism = {
     ...exception.mechanism,
-    is_exception_group: true,
+    ...(exception.type === 'AggregateError' && { is_exception_group: true }),
     exception_id: exceptionId,
   };
 }

--- a/packages/utils/test/aggregate-errors.test.ts
+++ b/packages/utils/test/aggregate-errors.test.ts
@@ -4,7 +4,7 @@ import { applyAggregateErrorsToEvent, createStackParser } from '../src/index';
 
 const stackParser = createStackParser([0, line => ({ filename: line })]);
 const exceptionFromError = (_stackParser: StackParser, ex: Error): Exception => {
-  return { value: ex.message, mechanism: { type: 'instrument', handled: true } };
+  return { value: ex.message, type: ex.name, mechanism: { type: 'instrument', handled: true } };
 };
 
 describe('applyAggregateErrorsToEvent()', () => {
@@ -57,6 +57,7 @@ describe('applyAggregateErrorsToEvent()', () => {
       exception: {
         values: [
           {
+            type: 'Error',
             value: 'Nested Error 2',
             mechanism: {
               exception_id: 2,
@@ -67,6 +68,7 @@ describe('applyAggregateErrorsToEvent()', () => {
             },
           },
           {
+            type: 'Error',
             value: 'Nested Error 1',
             mechanism: {
               exception_id: 1,
@@ -78,6 +80,7 @@ describe('applyAggregateErrorsToEvent()', () => {
             },
           },
           {
+            type: 'Error',
             value: 'Root Error',
             mechanism: {
               exception_id: 0,
@@ -123,6 +126,7 @@ describe('applyAggregateErrorsToEvent()', () => {
 
     // Last exception in list should be the root exception
     expect(event.exception?.values?.[event.exception?.values.length - 1]).toStrictEqual({
+      type: 'Error',
       value: 'Root Error',
       mechanism: {
         exception_id: 0,
@@ -167,6 +171,7 @@ describe('applyAggregateErrorsToEvent()', () => {
               source: 'cause',
               type: 'chained',
             },
+            type: 'Error',
             value: 'Nested Error 4',
           },
           {
@@ -178,6 +183,7 @@ describe('applyAggregateErrorsToEvent()', () => {
               source: 'errors[1]',
               type: 'chained',
             },
+            type: 'Error',
             value: 'Nested Error 3',
           },
           {
@@ -188,6 +194,7 @@ describe('applyAggregateErrorsToEvent()', () => {
               source: 'errors[0]',
               type: 'chained',
             },
+            type: 'Error',
             value: 'Nested Error 2',
           },
           {
@@ -199,6 +206,7 @@ describe('applyAggregateErrorsToEvent()', () => {
               source: 'errors[1]',
               type: 'chained',
             },
+            type: 'Error',
             value: 'AggregateError2',
           },
           {
@@ -209,6 +217,7 @@ describe('applyAggregateErrorsToEvent()', () => {
               source: 'errors[0]',
               type: 'chained',
             },
+            type: 'Error',
             value: 'Nested Error 1',
           },
           {
@@ -218,6 +227,7 @@ describe('applyAggregateErrorsToEvent()', () => {
               is_exception_group: true,
               type: 'instrument',
             },
+            type: 'Error',
             value: 'AggregateError1',
           },
         ],
@@ -239,6 +249,7 @@ describe('applyAggregateErrorsToEvent()', () => {
       exception: {
         values: [
           {
+            type: 'Error',
             value: 'Nested Error 2',
             mechanism: {
               exception_id: 2,
@@ -249,6 +260,7 @@ describe('applyAggregateErrorsToEvent()', () => {
             },
           },
           {
+            type: 'Error',
             value: 'Nested Error 1',
             mechanism: {
               exception_id: 1,
@@ -260,6 +272,7 @@ describe('applyAggregateErrorsToEvent()', () => {
             },
           },
           {
+            type: 'Error',
             value: 'Root Error',
             mechanism: {
               exception_id: 0,
@@ -287,6 +300,7 @@ describe('applyAggregateErrorsToEvent()', () => {
       exception: {
         values: [
           {
+            type: 'Error',
             value: 'Nested Error 2 ...',
             mechanism: {
               exception_id: 2,
@@ -297,6 +311,7 @@ describe('applyAggregateErrorsToEvent()', () => {
             },
           },
           {
+            type: 'Error',
             value: 'Nested Error 1 ...',
             mechanism: {
               exception_id: 1,
@@ -308,6 +323,7 @@ describe('applyAggregateErrorsToEvent()', () => {
             },
           },
           {
+            type: 'Error',
             value: 'Root Error with...',
             mechanism: {
               exception_id: 0,

--- a/packages/utils/test/aggregate-errors.test.ts
+++ b/packages/utils/test/aggregate-errors.test.ts
@@ -83,7 +83,6 @@ describe('applyAggregateErrorsToEvent()', () => {
               exception_id: 1,
               handled: true,
               parent_id: 0,
-              is_exception_group: true,
               source: 'cause',
               type: 'chained',
             },
@@ -94,7 +93,6 @@ describe('applyAggregateErrorsToEvent()', () => {
             mechanism: {
               exception_id: 0,
               handled: true,
-              is_exception_group: true,
               type: 'instrument',
             },
           },
@@ -140,7 +138,6 @@ describe('applyAggregateErrorsToEvent()', () => {
       mechanism: {
         exception_id: 0,
         handled: true,
-        is_exception_group: true,
         type: 'instrument',
       },
     });
@@ -191,7 +188,6 @@ describe('applyAggregateErrorsToEvent()', () => {
             mechanism: {
               exception_id: 4,
               handled: true,
-              is_exception_group: true,
               parent_id: 2,
               source: 'errors[1]',
               type: 'chained',
@@ -279,7 +275,6 @@ describe('applyAggregateErrorsToEvent()', () => {
               exception_id: 1,
               handled: true,
               parent_id: 0,
-              is_exception_group: true,
               source: 'cause',
               type: 'chained',
             },
@@ -290,7 +285,6 @@ describe('applyAggregateErrorsToEvent()', () => {
             mechanism: {
               exception_id: 0,
               handled: true,
-              is_exception_group: true,
               type: 'instrument',
             },
           },
@@ -330,7 +324,6 @@ describe('applyAggregateErrorsToEvent()', () => {
               exception_id: 1,
               handled: true,
               parent_id: 0,
-              is_exception_group: true,
               source: 'cause',
               type: 'chained',
             },
@@ -341,7 +334,6 @@ describe('applyAggregateErrorsToEvent()', () => {
             mechanism: {
               exception_id: 0,
               handled: true,
-              is_exception_group: true,
               type: 'instrument',
             },
           },


### PR DESCRIPTION
When Sentry started supporting the idea of exception groups, two changes happened. In the SDK, we adapted our logic for handling linked errors to also handle `AggregateError`s. And in our ingest pipeline, we began looking for an `is_exception_group` flag on the last entry in `event.exception.values; when we found it, we'd then ignore that entry when grouping and titling events, under the assumption that it was just a container and therefore wasn't meaningful.

When it came to instances of `AggregateError`, this worked great. For linked errors, however, this caused us to focus on the `cause` error rather than the error which was actually caught, with the result that it both threw off grouping and made for some very unhelpful titling of issues. (See the screenshot below, in which the first three errors are, respectively, an `UndefinedResponseBodyError`, a `RequestError`, and an `InternalServerError`, though you'd be hard pressed to figure that out without opening them up.)

This fixes those problems by restricting the use of the `is_exception_group` flag to `AggregateError`s.

Note: In order to update the tests to work with this change, I had add in consideration of the error `name` property and the corresponding event `type` property, to match what we do in real life. To keep things readable, there's a new mock `AggregateError` class, which I adapted all the tests to use.

Fixes https://github.com/getsentry/sentry/issues/59679.

_These issues all look the same, but they are not, in fact, the same_
![image](https://github.com/getsentry/sentry-javascript/assets/14812505/e36e7dc1-52b0-4eb3-be27-7d18853350b6)
