### PR TITLE
ref(core): Remove `status` field from Span

### DIFF
--- a/packages/bun/test/integrations/bunserver.test.ts
+++ b/packages/bun/test/integrations/bunserver.test.ts
@@ -24,7 +24,7 @@ describe('Bun Serve Integration', () => {
 
   test('generates a transaction around a request', async () => {
     client.on('finishTransaction', transaction => {
-      expect(transaction.status).toBe('ok');
+      expect(spanToJSON(transaction).status).toBe('ok');
       expect(spanToJSON(transaction).data?.['http.response.status_code']).toEqual(200);
       expect(spanToJSON(transaction).op).toEqual('http.server');
       expect(spanToJSON(transaction).description).toEqual('GET /');
@@ -44,7 +44,7 @@ describe('Bun Serve Integration', () => {
 
   test('generates a post transaction', async () => {
     client.on('finishTransaction', transaction => {
-      expect(transaction.status).toBe('ok');
+      expect(spanToJSON(transaction).status).toBe('ok');
       expect(spanToJSON(transaction).data?.['http.response.status_code']).toEqual(200);
       expect(spanToJSON(transaction).op).toEqual('http.server');
       expect(spanToJSON(transaction).description).toEqual('POST /');

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -135,9 +135,6 @@ export class SentrySpan implements SpanInterface {
     if ('sampled' in spanContext) {
       this._sampled = spanContext.sampled;
     }
-    if (spanContext.status) {
-      this._status = spanContext.status;
-    }
     if (spanContext.endTimestamp) {
       this._endTime = spanContext.endTimestamp;
     }
@@ -258,24 +255,6 @@ export class SentrySpan implements SpanInterface {
    */
   public set endTimestamp(endTime: number | undefined) {
     this._endTime = endTime;
-  }
-
-  /**
-   * The status of the span.
-   *
-   * @deprecated Use `spanToJSON().status` instead to get the status.
-   */
-  public get status(): SpanStatusType | string | undefined {
-    return this._status;
-  }
-
-  /**
-   * The status of the span.
-   *
-   * @deprecated Use `.setStatus()` instead to set or update the status.
-   */
-  public set status(status: SpanStatusType | string | undefined) {
-    this._status = status;
   }
 
   /* eslint-enable @typescript-eslint/member-ordering */

--- a/packages/core/test/lib/tracing/errors.test.ts
+++ b/packages/core/test/lib/tracing/errors.test.ts
@@ -50,18 +50,12 @@ describe('registerErrorHandlers()', () => {
     registerErrorInstrumentation();
 
     const transaction = startInactiveSpan({ name: 'test' })!;
-    // eslint-disable-next-line deprecation/deprecation
-    expect(transaction.status).toBe(undefined);
     expect(spanToJSON(transaction).status).toBe(undefined);
 
     mockErrorCallback({} as HandlerDataError);
-    // eslint-disable-next-line deprecation/deprecation
-    expect(transaction.status).toBe(undefined);
     expect(spanToJSON(transaction).status).toBe(undefined);
 
     mockUnhandledRejectionCallback({});
-    // eslint-disable-next-line deprecation/deprecation
-    expect(transaction.status).toBe(undefined);
     expect(spanToJSON(transaction).status).toBe(undefined);
 
     transaction.end();
@@ -72,8 +66,6 @@ describe('registerErrorHandlers()', () => {
 
     startSpan({ name: 'test' }, span => {
       mockErrorCallback({} as HandlerDataError);
-      // eslint-disable-next-line deprecation/deprecation
-      expect(span!.status).toBe('internal_error');
       expect(spanToJSON(span!).status).toBe('internal_error');
     });
   });
@@ -83,8 +75,6 @@ describe('registerErrorHandlers()', () => {
 
     startSpan({ name: 'test' }, span => {
       mockUnhandledRejectionCallback({});
-      // eslint-disable-next-line deprecation/deprecation
-      expect(span!.status).toBe('internal_error');
       expect(spanToJSON(span!).status).toBe('internal_error');
     });
   });

--- a/packages/core/test/lib/tracing/idletransaction.test.ts
+++ b/packages/core/test/lib/tracing/idletransaction.test.ts
@@ -232,12 +232,12 @@ describe('IdleTransaction', () => {
 
       // Regular SentrySpan - should not modified
       expect(spans[1].spanContext().spanId).toBe(regularSpan.spanContext().spanId);
-      expect(spans[1]['_endTime']).not.toBe(spanToJSON(transaction).timestamp);
+      expect(spanToJSON(spans[1]).timestamp).not.toBe(spanToJSON(transaction).timestamp);
 
       // Cancelled SentrySpan - has endtimestamp of transaction
       expect(spans[2].spanContext().spanId).toBe(cancelledSpan.spanContext().spanId);
-      expect(spans[2].status).toBe('cancelled');
-      expect(spans[2]['_endTime']).toBe(spanToJSON(transaction).timestamp);
+      expect(spanToJSON(spans[2]).status).toBe('cancelled');
+      expect(spanToJSON(spans[2]).timestamp).toBe(spanToJSON(transaction).timestamp);
     }
   });
 
@@ -415,22 +415,22 @@ describe('IdleTransaction', () => {
       const transaction = new IdleTransaction({ name: 'foo' }, getCurrentHub(), 20000);
       const mockFinish = jest.spyOn(transaction, 'end');
 
-      expect(transaction.status).not.toEqual('deadline_exceeded');
+      expect(spanToJSON(transaction).status).not.toEqual('deadline_exceeded');
       expect(mockFinish).toHaveBeenCalledTimes(0);
 
       // Beat 1
       jest.advanceTimersByTime(TRACING_DEFAULTS.heartbeatInterval);
-      expect(transaction.status).not.toEqual('deadline_exceeded');
+      expect(spanToJSON(transaction).status).not.toEqual('deadline_exceeded');
       expect(mockFinish).toHaveBeenCalledTimes(0);
 
       // Beat 2
       jest.advanceTimersByTime(TRACING_DEFAULTS.heartbeatInterval);
-      expect(transaction.status).not.toEqual('deadline_exceeded');
+      expect(spanToJSON(transaction).status).not.toEqual('deadline_exceeded');
       expect(mockFinish).toHaveBeenCalledTimes(0);
 
       // Beat 3
       jest.advanceTimersByTime(TRACING_DEFAULTS.heartbeatInterval);
-      expect(transaction.status).not.toEqual('deadline_exceeded');
+      expect(spanToJSON(transaction).status).not.toEqual('deadline_exceeded');
       expect(mockFinish).toHaveBeenCalledTimes(0);
     });
 

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1,4 +1,4 @@
-import type { Event, Span as SpanType } from '@sentry/types';
+import type { Event, Span } from '@sentry/types';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   addTracingExtensions,
@@ -7,6 +7,7 @@ import {
   getGlobalScope,
   getIsolationScope,
   setCurrentClient,
+  spanIsSampled,
   spanToJSON,
   withScope,
 } from '../../../src';
@@ -18,6 +19,7 @@ import {
   startSpan,
   startSpanManual,
 } from '../../../src/tracing';
+import { getSpanTree } from '../../../src/tracing/utils';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 beforeAll(() => {
@@ -92,9 +94,9 @@ describe('startSpan', () => {
     });
 
     it('creates a transaction', async () => {
-      let ref: any = undefined;
+      let _span: Span | undefined = undefined;
       client.on('finishTransaction', transaction => {
-        ref = transaction;
+        _span = transaction;
       });
       try {
         await startSpan({ name: 'GET users/[id]' }, () => {
@@ -103,16 +105,16 @@ describe('startSpan', () => {
       } catch (e) {
         //
       }
-      expect(ref).toBeDefined();
+      expect(_span).toBeDefined();
 
-      expect(spanToJSON(ref).description).toEqual('GET users/[id]');
-      expect(ref.status).toEqual(isError ? 'internal_error' : undefined);
+      expect(spanToJSON(_span!).description).toEqual('GET users/[id]');
+      expect(spanToJSON(_span!).status).toEqual(isError ? 'internal_error' : undefined);
     });
 
     it('allows traceparent information to be overriden', async () => {
-      let ref: any = undefined;
+      let _span: Span | undefined = undefined;
       client.on('finishTransaction', transaction => {
-        ref = transaction;
+        _span = transaction;
       });
       try {
         await startSpan(
@@ -129,17 +131,17 @@ describe('startSpan', () => {
       } catch (e) {
         //
       }
-      expect(ref).toBeDefined();
+      expect(_span).toBeDefined();
 
-      expect(ref.sampled).toEqual(true);
-      expect(ref.traceId).toEqual('12345678901234567890123456789012');
-      expect(ref.parentSpanId).toEqual('1234567890123456');
+      expect(spanIsSampled(_span!)).toEqual(true);
+      expect(spanToJSON(_span!).trace_id).toEqual('12345678901234567890123456789012');
+      expect(spanToJSON(_span!).parent_span_id).toEqual('1234567890123456');
     });
 
     it('allows for transaction to be mutated', async () => {
-      let ref: any = undefined;
+      let _span: Span | undefined = undefined;
       client.on('finishTransaction', transaction => {
-        ref = transaction;
+        _span = transaction;
       });
       try {
         await startSpan({ name: 'GET users/[id]' }, span => {
@@ -152,13 +154,13 @@ describe('startSpan', () => {
         //
       }
 
-      expect(spanToJSON(ref).op).toEqual('http.server');
+      expect(spanToJSON(_span!).op).toEqual('http.server');
     });
 
     it('creates a span with correct description', async () => {
-      let ref: any = undefined;
+      let _span: Span | undefined = undefined;
       client.on('finishTransaction', transaction => {
-        ref = transaction;
+        _span = transaction;
       });
       try {
         await startSpan({ name: 'GET users/[id]', parentSampled: true }, () => {
@@ -170,16 +172,19 @@ describe('startSpan', () => {
         //
       }
 
-      expect(ref.spanRecorder.spans).toHaveLength(2);
-      expect(spanToJSON(ref.spanRecorder.spans[1]).description).toEqual('SELECT * from users');
-      expect(ref.spanRecorder.spans[1].parentSpanId).toEqual(ref.spanId);
-      expect(ref.spanRecorder.spans[1].status).toEqual(isError ? 'internal_error' : undefined);
+      expect(_span).toBeDefined();
+      const spans = getSpanTree(_span!);
+
+      expect(spans).toHaveLength(2);
+      expect(spanToJSON(spans[1]).description).toEqual('SELECT * from users');
+      expect(spanToJSON(spans[1]).parent_span_id).toEqual(_span!.spanContext().spanId);
+      expect(spanToJSON(spans[1]).status).toEqual(isError ? 'internal_error' : undefined);
     });
 
     it('allows for span to be mutated', async () => {
-      let ref: any = undefined;
+      let _span: Span | undefined = undefined;
       client.on('finishTransaction', transaction => {
-        ref = transaction;
+        _span = transaction;
       });
       try {
         await startSpan({ name: 'GET users/[id]', parentSampled: true }, () => {
@@ -194,8 +199,11 @@ describe('startSpan', () => {
         //
       }
 
-      expect(ref.spanRecorder.spans).toHaveLength(2);
-      expect(spanToJSON(ref.spanRecorder.spans[1]).op).toEqual('db.query');
+      expect(_span).toBeDefined();
+      const spans = getSpanTree(_span!);
+
+      expect(spans).toHaveLength(2);
+      expect(spanToJSON(spans[1]).op).toEqual('db.query');
     });
 
     it.each([
@@ -204,9 +212,9 @@ describe('startSpan', () => {
       // attribute should take precedence over top level origin
       { origin: 'manual', attributes: { 'sentry.origin': 'auto.http.browser' } },
     ])('correctly sets the span origin', async () => {
-      let ref: any = undefined;
+      let _span: Span | undefined = undefined;
       client.on('finishTransaction', transaction => {
-        ref = transaction;
+        _span = transaction;
       });
       try {
         await startSpan({ name: 'GET users/[id]', origin: 'auto.http.browser' }, () => {
@@ -216,7 +224,8 @@ describe('startSpan', () => {
         //
       }
 
-      const jsonSpan = spanToJSON(ref);
+      expect(_span).toBeDefined();
+      const jsonSpan = spanToJSON(_span!);
       expect(jsonSpan).toEqual({
         data: {
           'sentry.origin': 'auto.http.browser',
@@ -944,7 +953,7 @@ describe('startInactiveSpan', () => {
     setCurrentClient(client);
     client.init();
 
-    let span: SpanType | undefined;
+    let span: Span | undefined;
 
     withScope(scope => {
       scope.setTag('scope', 1);

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -67,12 +67,12 @@ describe('spanToJSON', () => {
       op: 'test op',
       parentSpanId: '1234',
       spanId: '5678',
-      status: 'ok',
       traceId: 'abcd',
       origin: 'auto',
       startTimestamp: 123,
       endTimestamp: 456,
     });
+    span.setStatus('ok');
 
     expect(spanToJSON(span)).toEqual({
       description: 'test name',

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -407,8 +407,6 @@ describe('tracingHandler', () => {
 
     setImmediate(() => {
       expect(finishTransaction).toHaveBeenCalled();
-      // eslint-disable-next-line deprecation/deprecation
-      expect(transaction.status).toBe('ok');
       expect(spanToJSON(transaction).status).toBe('ok');
       expect(spanToJSON(transaction).data).toEqual(expect.objectContaining({ 'http.response.status_code': 200 }));
       done();

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -150,7 +150,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       expect(spans.length).toBe(2);
 
       const span = spans[1];
-      expect(span).toEqual(expect.objectContaining({ status: 'internal_error' }));
+      expect(spanToJSON(span).status).toEqual('internal_error');
     });
   });
 

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -361,14 +361,10 @@ describe('SentrySpanProcessor', () => {
     const transaction = getSpanForOtelSpan(otelSpan) as Transaction;
 
     // status is only set after end
-    // eslint-disable-next-line deprecation/deprecation
-    expect(transaction?.status).toBe(undefined);
     expect(spanToJSON(transaction!).status).toBe(undefined);
 
     otelSpan.end();
 
-    // eslint-disable-next-line deprecation/deprecation
-    expect(transaction?.status).toBe('ok');
     expect(spanToJSON(transaction!).status).toBe('ok');
   });
 
@@ -379,14 +375,10 @@ describe('SentrySpanProcessor', () => {
       tracer.startActiveSpan('SELECT * FROM users;', child => {
         const sentrySpan = getSpanForOtelSpan(child);
 
-        // eslint-disable-next-line deprecation/deprecation
-        expect(sentrySpan?.status).toBe(undefined);
         expect(spanToJSON(sentrySpan!).status).toBe(undefined);
 
         child.end();
 
-        // eslint-disable-next-line deprecation/deprecation
-        expect(sentrySpan?.status).toBe('ok');
         expect(spanToJSON(sentrySpan!).status).toBe('ok');
 
         parentOtelSpan.end();
@@ -469,8 +461,6 @@ describe('SentrySpanProcessor', () => {
         }
 
         otelSpan.end();
-        // eslint-disable-next-line deprecation/deprecation
-        expect(transaction?.status).toBe(expected);
         expect(spanToJSON(transaction!).status).toBe(expected);
       },
     );

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -176,7 +176,6 @@ function createTransactionForOtelSpan(span: ReadableSpan): Transaction {
     parentSampled,
     name: description,
     op,
-    status: mapStatus(span),
     startTimestamp: convertOtelTimeToSeconds(span.startTime),
     metadata: {
       ...dropUndefinedKeys({
@@ -189,6 +188,8 @@ function createTransactionForOtelSpan(span: ReadableSpan): Transaction {
     origin,
     sampled: true,
   });
+
+  transaction.setStatus(mapStatus(span));
 
   // We currently don't want to write this to the scope because it would mutate it.
   // In the future we will likely have some sort of transaction payload factory where we can pass this context in directly
@@ -237,11 +238,11 @@ function createAndFinishSpanForOtelSpan(node: SpanNode, sentryParentSpan: Sentry
     name: description,
     op,
     data: allData,
-    status: mapStatus(span),
     startTimestamp: convertOtelTimeToSeconds(span.startTime),
     spanId,
     origin,
   });
+  sentrySpan.setStatus(mapStatus(span));
 
   node.children.forEach(child => {
     createAndFinishSpanForOtelSpan(child, sentrySpan, remaining);

--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -94,7 +94,6 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeId ? 'route' : 'url',
           },
           name: routeId ? routeId : event.url.pathname,
-          status: 'ok',
         },
         () => handleCallbackErrors(() => wrappingTarget.apply(thisArg, [patchedEvent]), sendErrorToSentry),
       );

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -183,7 +183,6 @@ async function instrumentHandle(
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: event.route?.id ? 'route' : 'url',
         },
         name: `${event.request.method} ${event.route?.id || event.url.pathname}`,
-        status: 'ok',
         ...traceparentData,
         metadata: {
           dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -77,7 +77,6 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeId ? 'route' : 'url',
         },
         name: routeId ? routeId : event.url.pathname,
-        status: 'ok',
       };
 
       try {
@@ -144,7 +143,6 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeId ? 'route' : 'url',
         },
         name: routeId ? routeId : event.url.pathname,
-        status: 'ok',
         metadata: {
           dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
         },

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -113,7 +113,6 @@ describe('wrapLoadWithSentry', () => {
           },
           op: 'function.sveltekit.load',
           name: '/users/[id]',
-          status: 'ok',
         },
         expect.any(Function),
       );
@@ -141,7 +140,6 @@ describe('wrapLoadWithSentry', () => {
           },
           op: 'function.sveltekit.load',
           name: '/users/123',
-          status: 'ok',
         },
         expect.any(Function),
       );

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -203,7 +203,6 @@ describe('wrapLoadWithSentry calls trace', () => {
         },
         op: 'function.sveltekit.load',
         name: '/users/[id]',
-        status: 'ok',
       },
       expect.any(Function),
     );
@@ -222,7 +221,6 @@ describe('wrapLoadWithSentry calls trace', () => {
         },
         op: 'function.sveltekit.load',
         name: '/users/123',
-        status: 'ok',
       },
       expect.any(Function),
     );
@@ -258,7 +256,6 @@ describe('wrapServerLoadWithSentry calls trace', () => {
         name: '/users/[id]',
         parentSampled: true,
         parentSpanId: '1234567890abcdef',
-        status: 'ok',
         traceId: '1234567890abcdef1234567890abcdef',
         data: {
           'http.method': 'GET',
@@ -291,7 +288,6 @@ describe('wrapServerLoadWithSentry calls trace', () => {
         },
         op: 'function.sveltekit.server.load',
         name: '/users/[id]',
-        status: 'ok',
         metadata: {},
         data: {
           'http.method': 'GET',
@@ -316,7 +312,6 @@ describe('wrapServerLoadWithSentry calls trace', () => {
         name: '/users/[id]',
         parentSampled: true,
         parentSpanId: '1234567890abcdef',
-        status: 'ok',
         traceId: '1234567890abcdef1234567890abcdef',
         data: {
           'http.method': 'GET',
@@ -347,7 +342,6 @@ describe('wrapServerLoadWithSentry calls trace', () => {
         name: '/users/123',
         parentSampled: true,
         parentSpanId: '1234567890abcdef',
-        status: 'ok',
         traceId: '1234567890abcdef1234567890abcdef',
         data: {
           'http.method': 'GET',

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -110,12 +110,6 @@ export interface SpanContext {
   op?: string | undefined;
 
   /**
-   * Completion status of the Span.
-   * See: {SpanStatusType} for possible values
-   */
-  status?: string | undefined;
-
-  /**
    * Parent Span ID
    */
   parentSpanId?: string | undefined;
@@ -230,15 +224,6 @@ export interface Span extends Omit<SpanContext, 'name' | 'op' | 'status' | 'orig
    * @deprecated Use top level `Sentry.getRootSpan()` instead
    */
   transaction?: Transaction;
-
-  /**
-   * Completion status of the Span.
-   *
-   * See: {SpanStatusType} for possible values
-   *
-   * @deprecated Use `.setStatus` to set or update and `spanToJSON()` to read the status.
-   */
-  status?: string | undefined;
 
   /**
    * Get context data for this span.


### PR DESCRIPTION
This removes the public field to get/set `status` on a span/transaction.