### PR TITLE
feat(node): Remove unnecessary URL imports

### DIFF
--- a/packages/node-experimental/src/integrations/anr/index.ts
+++ b/packages/node-experimental/src/integrations/anr/index.ts
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import { defineIntegration, getCurrentScope } from '@sentry/core';
 import type { Contexts, Event, EventHint, IntegrationFn } from '@sentry/types';
 import { logger } from '@sentry/utils';

--- a/packages/node-experimental/src/integrations/spotlight.ts
+++ b/packages/node-experimental/src/integrations/spotlight.ts
@@ -1,5 +1,4 @@
 import * as http from 'http';
-import { URL } from 'url';
 import { defineIntegration } from '@sentry/core';
 import type { Client, Envelope, IntegrationFn } from '@sentry/types';
 import { logger, serializeEnvelope } from '@sentry/utils';

--- a/packages/node-experimental/src/integrations/tracing/hapi/types.ts
+++ b/packages/node-experimental/src/integrations/tracing/hapi/types.ts
@@ -19,7 +19,6 @@
 //   https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c73060bd14bb74a2f1906ccfc714d385863bc07d/types/boom/v4/index.d.ts
 
 import type * as stream from 'stream';
-import type * as url from 'url';
 
 interface Podium {
   new (events?: Events[]): Podium;
@@ -214,7 +213,7 @@ interface Request extends Podium {
   readonly path: string;
   response: ResponseObject | Boom | null;
   readonly route: RequestRoute;
-  readonly url: url.Url;
+  readonly url: URL;
 }
 
 interface ResponseObjectHeaderOptions {

--- a/packages/node-experimental/src/proxy/helpers.ts
+++ b/packages/node-experimental/src/proxy/helpers.ts
@@ -30,8 +30,6 @@
 import * as http from 'http';
 import * as https from 'https';
 import type { Readable } from 'stream';
-// TODO (v8): Remove this when Node < 12 is no longer supported
-import type { URL } from 'url';
 
 export type ThenableRequest = http.ClientRequest & {
   then: Promise<http.IncomingMessage>['then'];

--- a/packages/node-experimental/src/proxy/index.ts
+++ b/packages/node-experimental/src/proxy/index.ts
@@ -33,8 +33,6 @@ import type * as http from 'http';
 import type { OutgoingHttpHeaders } from 'http';
 import * as net from 'net';
 import * as tls from 'tls';
-// TODO (v8): Remove this when Node < 12 is no longer supported
-import { URL } from 'url';
 import { logger } from '@sentry/utils';
 import { Agent } from './base';
 import type { AgentConnectOpts } from './base';

--- a/packages/node-experimental/src/transports/http-module.ts
+++ b/packages/node-experimental/src/transports/http-module.ts
@@ -1,6 +1,5 @@
 import type { ClientRequest, IncomingHttpHeaders, RequestOptions as HTTPRequestOptions } from 'http';
 import type { RequestOptions as HTTPSRequestOptions } from 'https';
-import type { URL } from 'url';
 
 export type HTTPModuleRequestOptions = HTTPRequestOptions | HTTPSRequestOptions | string | URL;
 

--- a/packages/node-experimental/src/transports/http.ts
+++ b/packages/node-experimental/src/transports/http.ts
@@ -1,7 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
 import { Readable } from 'stream';
-import { URL } from 'url';
 import { createGzip } from 'zlib';
 import { createTransport } from '@sentry/core';
 import type {


### PR DESCRIPTION
Now we will no longer be supporting Node v8, these imports are no longer required