### PR TITLE
feat(profiling-node): Expose `nodeProfilingIntegration`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -740,46 +740,48 @@ The following list shows how integrations should be migrated:
 
 ### List of integrations and their replacements
 
-| Old                          | New                                 | Packages                                                                                                |
-| ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `new BrowserTracing()`       | `browserTracingIntegration()`       | `@sentry/browser`                                                                                       |
-| `new InboundFilters()`       | `inboundFiltersIntegration()`       | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |
-| `new FunctionToString()`     | `functionToStringIntegration()`     | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |
-| `new LinkedErrors()`         | `linkedErrorsIntegration()`         | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |
-| `new ModuleMetadata()`       | `moduleMetadataIntegration()`       | `@sentry/core`, `@sentry/browser`                                                                       |
-| `new RequestData()`          | `requestDataIntegration()`          | `@sentry/core`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge`                    |
-| `new Wasm() `                | `wasmIntegration()`                 | `@sentry/wasm`                                                                                          |
-| `new Replay()`               | `replayIntegration()`               | `@sentry/browser`                                                                                       |
-| `new ReplayCanvas()`         | `replayCanvasIntegration()`         | `@sentry/browser`                                                                                       |
-| `new Feedback()`             | `feedbackIntegration()`             | `@sentry/browser`                                                                                       |
-| `new CaptureConsole()`       | `captureConsoleIntegration()`       | `@sentry/integrations`                                                                                  |
-| `new Debug()`                | `debugIntegration()`                | `@sentry/integrations`                                                                                  |
-| `new Dedupe()`               | `dedupeIntegration()`               | `@sentry/browser`, `@sentry/integrations`, `@sentry/deno`                                               |
-| `new ExtraErrorData()`       | `extraErrorDataIntegration()`       | `@sentry/integrations`                                                                                  |
-| `new ReportingObserver()`    | `reportingObserverIntegration()`    | `@sentry/integrations`                                                                                  |
-| `new RewriteFrames()`        | `rewriteFramesIntegration()`        | `@sentry/integrations`                                                                                  |
-| `new SessionTiming()`        | `sessionTimingIntegration()`        | `@sentry/integrations`                                                                                  |
-| `new HttpClient()`           | `httpClientIntegration()`           | `@sentry/integrations`                                                                                  |
-| `new ContextLines()`         | `contextLinesIntegration()`         | `@sentry/integrations`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`                                   |
-| `new Breadcrumbs()`          | `breadcrumbsIntegration()`          | `@sentry/browser`, `@sentry/deno`                                                                       |
-| `new GlobalHandlers()`       | `globalHandlersIntegration()`       | `@sentry/browser` , `@sentry/deno`                                                                      |
-| `new HttpContext()`          | `httpContextIntegration()`          | `@sentry/browser`                                                                                       |
-| `new TryCatch()`             | `browserApiErrorsIntegration()`     | `@sentry/browser`, `@sentry/deno`                                                                       |
-| `new VueIntegration()`       | `vueIntegration()`                  | `@sentry/vue`                                                                                           |
-| `new DenoContext()`          | `denoContextIntegration()`          | `@sentry/deno`                                                                                          |
-| `new DenoCron()`             | `denoCronIntegration()`             | `@sentry/deno`                                                                                          |
-| `new NormalizePaths()`       | `normalizePathsIntegration()`       | `@sentry/deno`                                                                                          |
-| `new Console()`              | `consoleIntegration()`              | `@sentry/node`                                                                                          |
-| `new Context()`              | `nodeContextIntegration()`          | `@sentry/node`                                                                                          |
-| `new Modules()`              | `modulesIntegration()`              | `@sentry/node`                                                                                          |
-| `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  | `@sentry/node`                                                                                          |
-| `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` | `@sentry/node`                                                                                          |
-| `new LocalVariables()`       | `localVariablesIntegration()`       | `@sentry/node`                                                                                          |
-| `new Spotlight()`            | `spotlightIntegration()`            | `@sentry/node`                                                                                          |
-| `new Anr()`                  | `anrIntegration()`                  | `@sentry/node`                                                                                          |
-| `new Hapi()`                 | `hapiIntegration()`                 | `@sentry/node`                                                                                          |
-| `new Undici()`               | `nativeNodeFetchIntegration()`      | `@sentry/node`                                                                                          |
-| `new Http()`                 | `httpIntegration()`                 | `@sentry/node`                                                                                          |
+| Old                                 | New                                 | Packages                                                                                                |
+| ----------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `new BrowserTracing()`              | `browserTracingIntegration()`       | `@sentry/browser`                                                                                       |
+| `new InboundFilters()`              | `inboundFiltersIntegration()`       | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |
+| `new FunctionToString()`            | `functionToStringIntegration()`     | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |
+| `new LinkedErrors()`                | `linkedErrorsIntegration()`         | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |
+| `new ModuleMetadata()`              | `moduleMetadataIntegration()`       | `@sentry/core`, `@sentry/browser`                                                                       |
+| `new RequestData()`                 | `requestDataIntegration()`          | `@sentry/core`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge`                    |
+| `new Wasm() `                       | `wasmIntegration()`                 | `@sentry/wasm`                                                                                          |
+| `new Replay()`                      | `replayIntegration()`               | `@sentry/browser`                                                                                       |
+| `new ReplayCanvas()`                | `replayCanvasIntegration()`         | `@sentry/browser`                                                                                       |
+| `new Feedback()`                    | `feedbackIntegration()`             | `@sentry/browser`                                                                                       |
+| `new CaptureConsole()`              | `captureConsoleIntegration()`       | `@sentry/integrations`                                                                                  |
+| `new Debug()`                       | `debugIntegration()`                | `@sentry/integrations`                                                                                  |
+| `new Dedupe()`                      | `dedupeIntegration()`               | `@sentry/browser`, `@sentry/integrations`, `@sentry/deno`                                               |
+| `new ExtraErrorData()`              | `extraErrorDataIntegration()`       | `@sentry/integrations`                                                                                  |
+| `new ReportingObserver()`           | `reportingObserverIntegration()`    | `@sentry/integrations`                                                                                  |
+| `new RewriteFrames()`               | `rewriteFramesIntegration()`        | `@sentry/integrations`                                                                                  |
+| `new SessionTiming()`               | `sessionTimingIntegration()`        | `@sentry/integrations`                                                                                  |
+| `new HttpClient()`                  | `httpClientIntegration()`           | `@sentry/integrations`                                                                                  |
+| `new ContextLines()`                | `contextLinesIntegration()`         | `@sentry/integrations`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`                                   |
+| `new Breadcrumbs()`                 | `breadcrumbsIntegration()`          | `@sentry/browser`, `@sentry/deno`                                                                       |
+| `new GlobalHandlers()`              | `globalHandlersIntegration()`       | `@sentry/browser` , `@sentry/deno`                                                                      |
+| `new HttpContext()`                 | `httpContextIntegration()`          | `@sentry/browser`                                                                                       |
+| `new TryCatch()`                    | `browserApiErrorsIntegration()`     | `@sentry/browser`, `@sentry/deno`                                                                       |
+| `new VueIntegration()`              | `vueIntegration()`                  | `@sentry/vue`                                                                                           |
+| `new DenoContext()`                 | `denoContextIntegration()`          | `@sentry/deno`                                                                                          |
+| `new DenoCron()`                    | `denoCronIntegration()`             | `@sentry/deno`                                                                                          |
+| `new NormalizePaths()`              | `normalizePathsIntegration()`       | `@sentry/deno`                                                                                          |
+| `new Console()`                     | `consoleIntegration()`              | `@sentry/node`                                                                                          |
+| `new Context()`                     | `nodeContextIntegration()`          | `@sentry/node`                                                                                          |
+| `new Modules()`                     | `modulesIntegration()`              | `@sentry/node`                                                                                          |
+| `new OnUncaughtException()`         | `onUncaughtExceptionIntegration()`  | `@sentry/node`                                                                                          |
+| `new OnUnhandledRejection()`        | `onUnhandledRejectionIntegration()` | `@sentry/node`                                                                                          |
+| `new LocalVariables()`              | `localVariablesIntegration()`       | `@sentry/node`                                                                                          |
+| `new Spotlight()`                   | `spotlightIntegration()`            | `@sentry/node`                                                                                          |
+| `new Anr()`                         | `anrIntegration()`                  | `@sentry/node`                                                                                          |
+| `new Hapi()`                        | `hapiIntegration()`                 | `@sentry/node`                                                                                          |
+| `new Undici()`                      | `nativeNodeFetchIntegration()`      | `@sentry/node`                                                                                          |
+| `new Http()`                        | `httpIntegration()`                 | `@sentry/node`                                                                                          |
+| `new ProfilingIntegration()`        | `nodeProfilingIntegration()`        | `@sentry/profiling-node`                                                                                |
+| `new BrowserProfilingIntegration()` | `browserProfilingIntegration()`     | `@sentry/browser`                                                                                       |
 
 ## Deprecate `hub.bindClient()` and `makeMain()`
 

--- a/packages/profiling-node/README.md
+++ b/packages/profiling-node/README.md
@@ -27,14 +27,14 @@ npm install --save @sentry/node @sentry/profiling-node
 
 ```javascript
 import * as Sentry from '@sentry/node';
-import { ProfilingIntegration } from '@sentry/profiling-node';
+import { nodeProfilingIntegration } from '@sentry/profiling-node';
 
 Sentry.init({
   dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
   debug: true,
   tracesSampleRate: 1,
   profilesSampleRate: 1, // Set profiling sampling rate.
-  integrations: [new ProfilingIntegration()],
+  integrations: [nodeProfilingIntegration()],
 });
 ```
 

--- a/packages/profiling-node/src/index.ts
+++ b/packages/profiling-node/src/index.ts
@@ -1,1 +1,5 @@
-export { ProfilingIntegration } from './integration';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  ProfilingIntegration,
+  nodeProfilingIntegration,
+} from './integration';

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -1,6 +1,14 @@
 import { spanToJSON } from '@sentry/core';
 import type { NodeClient } from '@sentry/node-experimental';
-import type { Event, EventProcessor, Hub, Integration, Transaction } from '@sentry/types';
+import type {
+  Event,
+  EventProcessor,
+  Hub,
+  Integration,
+  IntegrationFn,
+  IntegrationFnResult,
+  Transaction,
+} from '@sentry/types';
 
 import { logger } from '@sentry/utils';
 
@@ -40,6 +48,8 @@ function addToProfileQueue(profile: RawThreadCpuProfile): void {
  * and inspect each event to see if it is a transaction event and if that transaction event
  * contains a profile on it's metadata. If that is the case, we create a profiling event envelope
  * and delete the profile from the transaction metadata.
+ *
+ * @deprecated Use `nodeProfilingIntegration` instead.
  */
 export class ProfilingIntegration implements Integration {
   /**
@@ -245,3 +255,14 @@ export class ProfilingIntegration implements Integration {
     return maybeRemoveProfileFromSdkMetadata(event);
   }
 }
+
+/**
+ * We need this integration in order to send data to Sentry. We hook into the event processor
+ * and inspect each event to see if it is a transaction event and if that transaction event
+ * contains a profile on it's metadata. If that is the case, we create a profiling event envelope
+ * and delete the profile from the transaction metadata.
+ */
+export const nodeProfilingIntegration = (() => {
+  // eslint-disable-next-line deprecation/deprecation
+  return new ProfilingIntegration() as unknown as IntegrationFnResult;
+}) satisfies IntegrationFn;

--- a/packages/profiling-node/test/hubextensions.hub.test.ts
+++ b/packages/profiling-node/test/hubextensions.hub.test.ts
@@ -7,6 +7,7 @@ import { CpuProfilerBindings } from '../src/cpu_profiler';
 import { ProfilingIntegration } from '../src/index';
 
 function makeClientWithoutHooks(): [Sentry.NodeClient, Transport] {
+  // eslint-disable-next-line deprecation/deprecation
   const integration = new ProfilingIntegration();
   const transport = Sentry.makeNodeTransport({
     url: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
@@ -41,6 +42,7 @@ function makeClientWithoutHooks(): [Sentry.NodeClient, Transport] {
 }
 
 function makeClientWithHooks(): [Sentry.NodeClient, Transport] {
+  // eslint-disable-next-line deprecation/deprecation
   const integration = new ProfilingIntegration();
   const client = new Sentry.NodeClient({
     stackParser: Sentry.defaultStackParser,

--- a/packages/profiling-node/test/index.test.ts
+++ b/packages/profiling-node/test/index.test.ts
@@ -23,6 +23,7 @@ function makeStaticTransport(): MockTransport {
 }
 
 function makeClientWithoutHooks(): [Sentry.NodeClient, MockTransport] {
+  // eslint-disable-next-line deprecation/deprecation
   const integration = new ProfilingIntegration();
   const transport = makeStaticTransport();
   const client = new Sentry.NodeClient({

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -43,10 +43,12 @@ describe('ProfilingIntegration', () => {
     jest.clearAllMocks();
   });
   it('has a name', () => {
+    // eslint-disable-next-line deprecation/deprecation
     expect(new ProfilingIntegration().name).toBe('ProfilingIntegration');
   });
 
   it('stores a reference to getCurrentHub', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const integration = new ProfilingIntegration();
 
     const getCurrentHub = jest.fn().mockImplementation(() => {
@@ -66,6 +68,7 @@ describe('ProfilingIntegration', () => {
         send: jest.fn().mockImplementation(() => Promise.resolve()),
         flush: jest.fn().mockImplementation(() => Promise.resolve()),
       };
+      // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
       const getCurrentHub = jest.fn((): Hub => {
@@ -100,6 +103,7 @@ describe('ProfilingIntegration', () => {
 
     it('when Hub.getClient returns undefined', async () => {
       const logSpy = jest.spyOn(logger, 'log');
+      // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
       const getCurrentHub = jest.fn((): Hub => {
@@ -115,6 +119,7 @@ describe('ProfilingIntegration', () => {
     });
     it('when getDsn returns undefined', async () => {
       const logSpy = jest.spyOn(logger, 'log');
+      // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
       const getCurrentHub = jest.fn((): Hub => {
@@ -136,6 +141,7 @@ describe('ProfilingIntegration', () => {
     });
     it('when getTransport returns undefined', async () => {
       const logSpy = jest.spyOn(logger, 'log');
+      // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
       const getCurrentHub = jest.fn((): Hub => {
@@ -165,6 +171,7 @@ describe('ProfilingIntegration', () => {
         send: jest.fn().mockImplementation(() => Promise.resolve()),
         flush: jest.fn().mockImplementation(() => Promise.resolve()),
       };
+      // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
       const getCurrentHub = jest.fn((): Hub => {
@@ -198,6 +205,7 @@ describe('ProfilingIntegration', () => {
         send: jest.fn().mockImplementation(() => Promise.resolve()),
         flush: jest.fn().mockImplementation(() => Promise.resolve()),
       };
+      // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
       const emitter = new EventEmitter();
 
@@ -233,6 +241,7 @@ describe('ProfilingIntegration', () => {
         send: jest.fn().mockImplementation(() => Promise.resolve()),
         flush: jest.fn().mockImplementation(() => Promise.resolve()),
       };
+      // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
       const emitter = new EventEmitter();
 


### PR DESCRIPTION
@JonasBa when you got some time, could you look into actually rewriting this to the new style? Right now a lot of the tests depend on the non-hook based version etc. and I'm not 100% clear on what can/cannot be removed there 😅 

The end result should be just having a single `nodeProfilingIntegration` that receives the client in `setup(client)` and sets up hooks etc in there!