### PR TITLE
feat: Ensure `withActiveSpan` is exported everywhere [v7]

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -90,6 +90,7 @@ export {
   startActiveSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   cron,
   parameterize,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -56,6 +56,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   SDK_VERSION,
   setContext,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -81,6 +81,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   metrics,
   functionToStringIntegration,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -82,6 +82,7 @@ export {
   startActiveSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   parameterize,
   metrics,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -92,6 +92,7 @@ export {
   startSpan,
   startSpanManual,
   startInactiveSpan,
+  withActiveSpan,
   continueTrace,
   isInitialized,
   cron,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -82,6 +82,7 @@ export {
   startActiveSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   parameterize,
   requestDataIntegration,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -88,6 +88,7 @@ export {
   startActiveSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   cron,
   parameterize,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -80,6 +80,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   metrics,
   functionToStringIntegration,


### PR DESCRIPTION
We forgot to re-export this everywhere, oops.