### PR TITLE
feat: Ensure `withActiveSpan` is exported everywhere

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -65,6 +65,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   cron,
   parameterize,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -67,6 +67,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   metricsDefault as metrics,
   functionToStringIntegration,
@@ -83,7 +84,6 @@ export {
   startSession,
   captureSession,
   endSession,
-  withActiveSpan,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 export {

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -40,9 +40,19 @@ export { cron } from './cron';
 
 export type { Span, NodeOptions } from './types';
 
-export { startSpan, startSpanManual, startInactiveSpan, getActiveSpan, withActiveSpan } from '@sentry/opentelemetry';
+export {
+  startSpan,
+  startSpanManual,
+  startInactiveSpan,
+  getActiveSpan,
+  withActiveSpan,
+} from '@sentry/opentelemetry';
 
-export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from '@sentry/utils';
+export {
+  addRequestDataToEvent,
+  DEFAULT_USER_INCLUDES,
+  extractRequestData,
+} from '@sentry/utils';
 
 export {
   addBreadcrumb,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -66,6 +66,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   parameterize,
   functionToStringIntegration,
@@ -76,7 +77,6 @@ export {
   startSession,
   captureSession,
   endSession,
-  withActiveSpan,
 } from '@sentry/core';
 
 export {

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -76,6 +76,7 @@ export {
   startSpan,
   startSpanManual,
   startInactiveSpan,
+  withActiveSpan,
   continueTrace,
   isInitialized,
   cron,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -69,6 +69,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   parameterize,
   requestDataIntegration,
@@ -96,7 +97,6 @@ export {
   startSession,
   captureSession,
   endSession,
-  withActiveSpan,
 } from '@sentry/node-experimental';
 
 export {

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -71,6 +71,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   cron,
   parameterize,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -66,6 +66,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  withActiveSpan,
   continueTrace,
   metrics,
   functionToStringIntegration,


### PR DESCRIPTION
We forgot to do that, apparently :grimace:
