### PR TITLE
feat(browser): Exclude span exports from non-performance CDN bundles

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -45,10 +45,6 @@ export {
   Scope,
   // eslint-disable-next-line deprecation/deprecation
   startTransaction,
-  getActiveSpan,
-  startSpan,
-  startInactiveSpan,
-  startSpanManual,
   continueTrace,
   SDK_VERSION,
   setContext,
@@ -59,7 +55,6 @@ export {
   setUser,
   withScope,
   withIsolationScope,
-  withActiveSpan,
   functionToStringIntegration,
   inboundFiltersIntegration,
   dedupeIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -15,6 +15,14 @@ Sentry.Integrations.Replay = Replay;
 addTracingExtensions();
 
 export {
+  getActiveSpan,
+  startSpan,
+  startInactiveSpan,
+  startSpanManual,
+  withActiveSpan,
+} from '@sentry/core';
+
+export {
   // eslint-disable-next-line deprecation/deprecation
   Feedback,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -15,6 +15,14 @@ Sentry.Integrations.Replay = Replay;
 addTracingExtensions();
 
 export {
+  getActiveSpan,
+  startSpan,
+  startInactiveSpan,
+  startSpanManual,
+  withActiveSpan,
+} from '@sentry/core';
+
+export {
   // eslint-disable-next-line deprecation/deprecation
   FeedbackShim as Feedback,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -20,6 +20,14 @@ Sentry.Integrations.Replay = ReplayShim;
 addTracingExtensions();
 
 export {
+  getActiveSpan,
+  startSpan,
+  startInactiveSpan,
+  startSpanManual,
+  withActiveSpan,
+} from '@sentry/core';
+
+export {
   // eslint-disable-next-line deprecation/deprecation
   FeedbackShim as Feedback,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -70,6 +70,11 @@ export {
 export type { RequestInstrumentationOptions } from '@sentry-internal/tracing';
 export {
   addTracingExtensions,
+  getActiveSpan,
+  startSpan,
+  startInactiveSpan,
+  startSpanManual,
+  withActiveSpan,
   setMeasurement,
   // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,


### PR DESCRIPTION
I figured we don't actually need to expor these (e.g. `startSpan`, etc.) in non-performance CDN bundles.

We can think about providing shims for these, but honestly not so sure 🤔 