### PR TITLE
ref(integrations): Delete deprecated class integrations

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.breadcrumbsIntegration()],
+  integrations: [Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.Integrations.Breadcrumbs()],
+  integrations: [new Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.breadcrumbsIntegration()],
+  integrations: [Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.Integrations.Breadcrumbs()],
+  integrations: [new Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.breadcrumbsIntegration()],
+  integrations: [Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.Integrations.Breadcrumbs()],
+  integrations: [new Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/manual-client/browser-context/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/browser-context/init.js
@@ -1,23 +1,23 @@
 import {
-  Breadcrumbs,
   BrowserClient,
-  FunctionToString,
-  HttpContext,
   Hub,
-  InboundFilters,
-  LinkedErrors,
+  breadcrumbsIntegration,
   dedupeIntegration,
   defaultStackParser,
+  functionToStringIntegration,
+  httpContextIntegration,
+  inboundFiltersIntegration,
+  linkedErrorsIntegration,
   makeFetchTransport,
 } from '@sentry/browser';
 
 const integrations = [
-  new Breadcrumbs(),
-  new FunctionToString(),
+  breadcrumbsIntegration(),
+  functionToStringIntegration(),
   dedupeIntegration(),
-  new HttpContext(),
-  new InboundFilters(),
-  new LinkedErrors(),
+  httpContextIntegration(),
+  inboundFiltersIntegration(),
+  linkedErrorsIntegration(),
 ];
 
 const client = new BrowserClient({

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -60,10 +60,6 @@ export {
   withScope,
   withIsolationScope,
   withActiveSpan,
-  // eslint-disable-next-line deprecation/deprecation
-  FunctionToString,
-  // eslint-disable-next-line deprecation/deprecation
-  InboundFilters,
   functionToStringIntegration,
   inboundFiltersIntegration,
   dedupeIntegration,
@@ -113,6 +109,3 @@ export { globalHandlersIntegration } from './integrations/globalhandlers';
 export { httpContextIntegration } from './integrations/httpcontext';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
 export { browserApiErrorsIntegration } from './integrations/browserapierrors';
-
-// eslint-disable-next-line deprecation/deprecation
-export { Breadcrumbs, LinkedErrors, HttpContext } from './integrations';

--- a/packages/browser/src/index.bundle.base.ts
+++ b/packages/browser/src/index.bundle.base.ts
@@ -2,11 +2,9 @@ import type { IntegrationFn } from '@sentry/types/src';
 
 export * from './exports';
 
-import { Integrations as CoreIntegrations } from '@sentry/core';
 import type { Integration } from '@sentry/types';
 
 import { WINDOW } from './helpers';
-import * as BrowserIntegrations from './integrations';
 
 let windowIntegrations = {};
 
@@ -18,9 +16,6 @@ if (WINDOW.Sentry && WINDOW.Sentry.Integrations) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const INTEGRATIONS: Record<string, (new (...args: any[]) => Integration) | IntegrationFn> = {
   ...windowIntegrations,
-  // eslint-disable-next-line deprecation/deprecation
-  ...CoreIntegrations,
-  ...BrowserIntegrations,
 };
 
 export { INTEGRATIONS as Integrations };

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,9 +1,6 @@
 export * from './exports';
 
-import { Integrations as CoreIntegrations } from '@sentry/core';
-
 import { WINDOW } from './helpers';
-import * as BrowserIntegrations from './integrations';
 
 let windowIntegrations = {};
 
@@ -15,9 +12,6 @@ if (WINDOW.Sentry && WINDOW.Sentry.Integrations) {
 /** @deprecated Import the integration function directly, e.g. `inboundFiltersIntegration()` instead of `new Integrations.InboundFilter(). */
 const INTEGRATIONS = {
   ...windowIntegrations,
-  // eslint-disable-next-line deprecation/deprecation
-  ...CoreIntegrations,
-  ...BrowserIntegrations,
 };
 
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { addBreadcrumb, convertIntegrationFnToClass, defineIntegration, getClient } from '@sentry/core';
+import { addBreadcrumb, defineIntegration, getClient } from '@sentry/core';
 import type {
   Client,
   Event as SentryEvent,
@@ -8,8 +8,6 @@ import type {
   HandlerDataFetch,
   HandlerDataHistory,
   HandlerDataXhr,
-  Integration,
-  IntegrationClass,
   IntegrationFn,
 } from '@sentry/types';
 import type {
@@ -94,32 +92,6 @@ const _breadcrumbsIntegration = ((options: Partial<BreadcrumbsOptions> = {}) => 
 }) satisfies IntegrationFn;
 
 export const breadcrumbsIntegration = defineIntegration(_breadcrumbsIntegration);
-
-/**
- * Default Breadcrumbs instrumentations
- *
- * @deprecated Use `breadcrumbsIntegration()` instead.
- */
-// eslint-disable-next-line deprecation/deprecation
-export const Breadcrumbs = convertIntegrationFnToClass(INTEGRATION_NAME, breadcrumbsIntegration) as IntegrationClass<
-  Integration & { setup: (client: Client) => void }
-> & {
-  new (
-    options?: Partial<{
-      console: boolean;
-      dom:
-        | boolean
-        | {
-            serializeAttribute?: string | string[];
-            maxStringLength?: number;
-          };
-      fetch: boolean;
-      history: boolean;
-      sentry: boolean;
-      xhr: boolean;
-    }>,
-  ): Integration;
-};
 
 /**
  * Adds a breadcrumb for Sentry events or transactions if this option is enabled.

--- a/packages/browser/src/integrations/index.ts
+++ b/packages/browser/src/integrations/index.ts
@@ -1,4 +1,0 @@
-/* eslint-disable deprecation/deprecation */
-export { Breadcrumbs } from './breadcrumbs';
-export { LinkedErrors } from './linkederrors';
-export { HttpContext } from './httpcontext';

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -270,7 +270,7 @@ describe('SentryBrowser', () => {
 
       expect(localBeforeSend).toHaveBeenCalledTimes(2);
     });
-    il;
+
     it('should use inboundfilter rules of bound client', async () => {
       const localBeforeSend = jest.fn();
       const options = getDefaultBrowserClientOptions({

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -1,4 +1,10 @@
-import { InboundFilters, SDK_VERSION, getGlobalScope, getIsolationScope, getReportDialogEndpoint } from '@sentry/core';
+import {
+  SDK_VERSION,
+  getGlobalScope,
+  getIsolationScope,
+  getReportDialogEndpoint,
+  inboundFiltersIntegration,
+} from '@sentry/core';
 import type { WrappedFunction } from '@sentry/types';
 import * as utils from '@sentry/utils';
 
@@ -264,16 +270,13 @@ describe('SentryBrowser', () => {
 
       expect(localBeforeSend).toHaveBeenCalledTimes(2);
     });
-
+    il;
     it('should use inboundfilter rules of bound client', async () => {
       const localBeforeSend = jest.fn();
       const options = getDefaultBrowserClientOptions({
         beforeSend: localBeforeSend,
         dsn,
-        integrations: [
-          // eslint-disable-next-line deprecation/deprecation
-          new InboundFilters({ ignoreErrors: ['capture'] }),
-        ],
+        integrations: [inboundFiltersIntegration({ ignoreErrors: ['capture'] })],
       });
       const client = new BrowserClient(options);
       setCurrentClient(client);

--- a/packages/browser/test/unit/integrations/breadcrumbs.test.ts
+++ b/packages/browser/test/unit/integrations/breadcrumbs.test.ts
@@ -1,6 +1,6 @@
 import * as SentryCore from '@sentry/core';
 
-import { Breadcrumbs, BrowserClient, flush } from '../../../src';
+import { BrowserClient, breadcrumbsIntegration, flush } from '../../../src';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
 
 describe('Breadcrumbs', () => {
@@ -8,8 +8,7 @@ describe('Breadcrumbs', () => {
     const client = new BrowserClient({
       ...getDefaultBrowserClientOptions(),
       dsn: 'https://username@domain/123',
-      // eslint-disable-next-line deprecation/deprecation
-      integrations: [new Breadcrumbs()],
+      integrations: [breadcrumbsIntegration()],
     });
 
     SentryCore.setCurrentClient(client);

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -119,14 +119,11 @@ export {
   init,
 } from './sdk';
 
-import { Integrations as CoreIntegrations } from '@sentry/core';
 import { Integrations as NodeIntegrations } from '@sentry/node-experimental';
 import { BunServer } from './integrations/bunserver';
 export { bunServerIntegration } from './integrations/bunserver';
 
 const INTEGRATIONS = {
-  // eslint-disable-next-line deprecation/deprecation
-  ...CoreIntegrations,
   ...NodeIntegrations,
   BunServer,
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,12 +97,7 @@ export { DEFAULT_ENVIRONMENT } from './constants';
 /* eslint-disable deprecation/deprecation */
 export { ModuleMetadata } from './integrations/metadata';
 export { RequestData } from './integrations/requestdata';
-export { InboundFilters } from './integrations/inboundfilters';
-export { FunctionToString } from './integrations/functiontostring';
-export { LinkedErrors } from './integrations/linkederrors';
 export { addBreadcrumb } from './breadcrumbs';
-/* eslint-enable deprecation/deprecation */
-import * as INTEGRATIONS from './integrations';
 export { functionToStringIntegration } from './integrations/functiontostring';
 export { inboundFiltersIntegration } from './integrations/inboundfilters';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
@@ -118,9 +113,3 @@ export { metrics } from './metrics/exports';
 export type { MetricData } from './metrics/exports';
 export { metricsDefault } from './metrics/exports-default';
 export { BrowserMetricsAggregator } from './metrics/browser-aggregator';
-
-/** @deprecated Import the integration function directly, e.g. `inboundFiltersIntegration()` instead of `new Integrations.InboundFilter(). */
-const Integrations = INTEGRATIONS;
-
-// eslint-disable-next-line deprecation/deprecation
-export { Integrations };

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -1,8 +1,8 @@
-import type { Client, Event, EventHint, Integration, IntegrationClass, IntegrationFn, StackFrame } from '@sentry/types';
+import type { Event, IntegrationFn, StackFrame } from '@sentry/types';
 import { getEventDescription, logger, stringMatchesSomePattern } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
-import { convertIntegrationFnToClass, defineIntegration } from '../integration';
+import { defineIntegration } from '../integration';
 
 // "Script error." is hard coded into browsers for errors that it can't read.
 // this is the result of a script being pulled in from an external domain and CORS.
@@ -35,28 +35,6 @@ const _inboundFiltersIntegration = ((options: Partial<InboundFiltersOptions> = {
 }) satisfies IntegrationFn;
 
 export const inboundFiltersIntegration = defineIntegration(_inboundFiltersIntegration);
-
-/**
- * Inbound filters configurable by the user.
- * @deprecated Use `inboundFiltersIntegration()` instead.
- */
-// eslint-disable-next-line deprecation/deprecation
-export const InboundFilters = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  inboundFiltersIntegration,
-) as IntegrationClass<Integration & { preprocessEvent: (event: Event, hint: EventHint, client: Client) => void }> & {
-  new (
-    options?: Partial<{
-      allowUrls: Array<string | RegExp>;
-      denyUrls: Array<string | RegExp>;
-      ignoreErrors: Array<string | RegExp>;
-      ignoreTransactions: Array<string | RegExp>;
-      ignoreInternal: boolean;
-      disableErrorDefaults: boolean;
-      disableTransactionDefaults: boolean;
-    }>,
-  ): Integration;
-};
 
 function _mergeOptions(
   internalOptions: Partial<InboundFiltersOptions> = {},

--- a/packages/core/src/integrations/index.ts
+++ b/packages/core/src/integrations/index.ts
@@ -1,4 +1,0 @@
-/* eslint-disable deprecation/deprecation */
-export { FunctionToString } from './functiontostring';
-export { InboundFilters } from './inboundfilters';
-export { LinkedErrors } from './linkederrors';

--- a/packages/core/src/integrations/linkederrors.ts
+++ b/packages/core/src/integrations/linkederrors.ts
@@ -1,6 +1,6 @@
-import type { Client, Event, EventHint, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
+import type { IntegrationFn } from '@sentry/types';
 import { applyAggregateErrorsToEvent, exceptionFromError } from '@sentry/utils';
-import { convertIntegrationFnToClass, defineIntegration } from '../integration';
+import { defineIntegration } from '../integration';
 
 interface LinkedErrorsOptions {
   key?: string;
@@ -35,12 +35,3 @@ const _linkedErrorsIntegration = ((options: LinkedErrorsOptions = {}) => {
 }) satisfies IntegrationFn;
 
 export const linkedErrorsIntegration = defineIntegration(_linkedErrorsIntegration);
-
-/**
- * Adds SDK info to an event.
- * @deprecated Use `linkedErrorsIntegration()` instead.
- */
-// eslint-disable-next-line deprecation/deprecation
-export const LinkedErrors = convertIntegrationFnToClass(INTEGRATION_NAME, linkedErrorsIntegration) as IntegrationClass<
-  Integration & { preprocessEvent: (event: Event, hint: EventHint, client: Client) => void }
-> & { new (options?: { key?: string; limit?: number }): Integration };

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -1,7 +1,7 @@
 import type { Event, EventProcessor } from '@sentry/types';
 
 import type { InboundFiltersOptions } from '../../../src/integrations/inboundfilters';
-import { InboundFilters } from '../../../src/integrations/inboundfilters';
+import { inboundFiltersIntegration } from '../../../src/integrations/inboundfilters';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 const PUBLIC_DSN = 'https://username@domain/123';
@@ -33,8 +33,7 @@ function createInboundFiltersEventProcessor(
       dsn: PUBLIC_DSN,
       ...clientOptions,
       defaultIntegrations: false,
-      // eslint-disable-next-line deprecation/deprecation
-      integrations: [new InboundFilters(options)],
+      integrations: [inboundFiltersIntegration(options)],
     }),
   );
 

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -95,8 +95,6 @@ export {
   init,
 } from './sdk';
 
-import { Integrations as CoreIntegrations } from '@sentry/core';
-
 export { denoContextIntegration } from './integrations/context';
 export { globalHandlersIntegration } from './integrations/globalhandlers';
 export { normalizePathsIntegration } from './integrations/normalizepaths';
@@ -108,7 +106,5 @@ import * as DenoIntegrations from './integrations';
 
 /** @deprecated Import the integration function directly, e.g. `inboundFiltersIntegration()` instead of `new Integrations.InboundFilter(). */
 export const Integrations = {
-  // eslint-disable-next-line deprecation/deprecation
-  ...CoreIntegrations,
   ...DenoIntegrations,
 };

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -102,16 +102,12 @@ export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from
 
 export { createGetModuleFromFilename } from './module';
 
-import { Integrations as CoreIntegrations } from '@sentry/core';
-
 import * as Handlers from './handlers';
 import * as NodeIntegrations from './integrations';
 import * as TracingIntegrations from './tracing/integrations';
 
 // TODO: Deprecate this once we migrated tracing integrations
 export const Integrations = {
-  // eslint-disable-next-line deprecation/deprecation
-  ...CoreIntegrations,
   ...NodeIntegrations,
   ...TracingIntegrations,
 };

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'fs';
-import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
-import type { Event, Integration, IntegrationClass, IntegrationFn, StackFrame } from '@sentry/types';
+import { defineIntegration } from '@sentry/core';
+import type { Event, IntegrationFn, StackFrame } from '@sentry/types';
 import { LRUMap, addContextToFrame } from '@sentry/utils';
 
 const FILE_CONTENT_CACHE = new LRUMap<string, string[] | null>(100);
@@ -47,15 +47,6 @@ const _contextLinesIntegration = ((options: ContextLinesOptions = {}) => {
 }) satisfies IntegrationFn;
 
 export const contextLinesIntegration = defineIntegration(_contextLinesIntegration);
-
-/**
- * Add node modules / packages to the event.
- * @deprecated Use `contextLinesIntegration()` instead.
- */
-// eslint-disable-next-line deprecation/deprecation
-export const ContextLines = convertIntegrationFnToClass(INTEGRATION_NAME, contextLinesIntegration) as IntegrationClass<
-  Integration & { processEvent: (event: Event) => Promise<Event> }
-> & { new (options?: { frameContextLines?: number }): Integration };
 
 async function addSourceContext(event: Event, contextLines: number): Promise<Event> {
   // keep a lookup map of which files we've already enqueued to read,
@@ -121,9 +112,6 @@ function addSourceContextToFrames(frames: StackFrame[], contextLines: number): v
     }
   }
 }
-
-// eslint-disable-next-line deprecation/deprecation
-export type ContextLines = typeof ContextLines;
 
 /**
  * Reads file contents and caches them in a global LRU cache.

--- a/packages/node/src/integrations/index.ts
+++ b/packages/node/src/integrations/index.ts
@@ -4,7 +4,6 @@ export { Http } from './http';
 export { OnUncaughtException } from './onuncaughtexception';
 export { OnUnhandledRejection } from './onunhandledrejection';
 export { Modules } from './modules';
-export { ContextLines } from './contextlines';
 export { Context } from './context';
 export { RequestData } from '@sentry/core';
 export { Undici } from './undici';

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -1,5 +1,4 @@
 import {
-  LinkedErrors,
   SDK_VERSION,
   getGlobalScope,
   getIsolationScope,
@@ -11,7 +10,7 @@ import {
 import type { EventHint, Integration } from '@sentry/types';
 
 import type { Event } from '../src';
-import { contextLinesIntegration } from '../src';
+import { contextLinesIntegration, linkedErrorsIntegration } from '../src';
 import {
   NodeClient,
   addBreadcrumb,
@@ -24,7 +23,6 @@ import {
   init,
 } from '../src';
 import { setNodeAsyncContextStrategy } from '../src/async';
-import { ContextLines } from '../src/integrations';
 import { defaultStackParser, getDefaultIntegrations } from '../src/sdk';
 import { getDefaultNodeClientOptions } from './helper/node-client-options';
 
@@ -217,8 +215,7 @@ describe('SentryNode', () => {
       expect.assertions(15);
       const options = getDefaultNodeClientOptions({
         stackParser: defaultStackParser,
-        // eslint-disable-next-line deprecation/deprecation
-        integrations: [new ContextLines(), new LinkedErrors()],
+        integrations: [contextLinesIntegration(), linkedErrorsIntegration()],
         beforeSend: (event: Event) => {
           expect(event.exception).not.toBeUndefined();
           expect(event.exception!.values![1]).not.toBeUndefined();

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -86,15 +86,13 @@ export {
   init,
 } from './sdk';
 
-import { Integrations as CoreIntegrations, RequestData } from '@sentry/core';
+import { RequestData } from '@sentry/core';
 
 import { WinterCGFetch } from './integrations/wintercg-fetch';
 export { winterCGFetchIntegration } from './integrations/wintercg-fetch';
 
 /** @deprecated Import the integration function directly, e.g. `inboundFiltersIntegration()` instead of `new Integrations.InboundFilter(). */
 export const Integrations = {
-  // eslint-disable-next-line deprecation/deprecation
-  ...CoreIntegrations,
   WinterCGFetch,
   RequestData,
 };


### PR DESCRIPTION
Deletes `FunctionToString`, `Breadcrumbs`, `InboundFilters`and `LinkedErrors`
ref https://github.com/getsentry/sentry-javascript/issues/8844