### PR TITLE
test(replay): Ensure we don't run replay-worker tests as node unit tests

### DIFF
--- a/scripts/node-unit-tests.ts
+++ b/scripts/node-unit-tests.ts
@@ -19,6 +19,7 @@ const DEFAULT_SKIP_TESTS_PACKAGES = [
   '@sentry/profiling-node',
   '@sentry/replay',
   '@sentry-internal/replay-canvas',
+  '@sentry-internal/replay-worker',
   '@sentry-internal/feedback',
   '@sentry/wasm',
   '@sentry/bun',


### PR DESCRIPTION
Noticed we seem to have forgotten this, we can skip this there (this runs as browser unit test).