### PR TITLE
fix(opentelemetry): Ensure DSC propagation works correctly

### DIFF
--- a/packages/opentelemetry/src/constants.ts
+++ b/packages/opentelemetry/src/constants.ts
@@ -3,9 +3,7 @@ import { createContextKey } from '@opentelemetry/api';
 export const SENTRY_TRACE_HEADER = 'sentry-trace';
 export const SENTRY_BAGGAGE_HEADER = 'baggage';
 export const SENTRY_TRACE_STATE_DSC = 'sentry.trace';
-
-/** Context Key to hold a PropagationContext. */
-export const SENTRY_PROPAGATION_CONTEXT_CONTEXT_KEY = createContextKey('SENTRY_PROPAGATION_CONTEXT_CONTEXT_KEY');
+export const SENTRY_TRACE_STATE_PARENT_SPAN_ID = 'sentry.parent_span_id';
 
 /** Context Key to hold a Hub. */
 export const SENTRY_HUB_CONTEXT_KEY = createContextKey('sentry_hub');

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -14,11 +14,7 @@ export {
   getSpanScopes,
 } from './utils/spanData';
 
-export {
-  getPropagationContextFromContext,
-  setPropagationContextOnContext,
-  getScopesFromContext,
-} from './utils/contextData';
+export { getScopesFromContext } from './utils/contextData';
 
 export {
   spanHasAttributes,

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -1,7 +1,7 @@
 import type { Baggage, Context, SpanContext, TextMapGetter, TextMapSetter } from '@opentelemetry/api';
 import { TraceFlags, propagation, trace } from '@opentelemetry/api';
 import { TraceState, W3CBaggagePropagator, isTracingSuppressed } from '@opentelemetry/core';
-import { getClient, getDynamicSamplingContextFromClient } from '@sentry/core';
+import { getClient, getCurrentScope, getDynamicSamplingContextFromClient, getIsolationScope } from '@sentry/core';
 import type { DynamicSamplingContext, PropagationContext } from '@sentry/types';
 import {
   SENTRY_BAGGAGE_KEY_PREFIX,
@@ -11,28 +11,30 @@ import {
   propagationContextFromHeaders,
 } from '@sentry/utils';
 
-import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER, SENTRY_TRACE_STATE_DSC } from './constants';
-import { getPropagationContextFromContext, setPropagationContextOnContext } from './utils/contextData';
+import {
+  SENTRY_BAGGAGE_HEADER,
+  SENTRY_TRACE_HEADER,
+  SENTRY_TRACE_STATE_DSC,
+  SENTRY_TRACE_STATE_PARENT_SPAN_ID,
+} from './constants';
+import { getScopesFromContext, setScopesOnContext } from './utils/contextData';
 
-function getDynamicSamplingContextFromContext(context: Context): Partial<DynamicSamplingContext> | undefined {
-  // If possible, we want to take the DSC from the active span
-  // That should take precedence over the DSC from the propagation context
-  const activeSpan = trace.getSpan(context);
-  const traceStateDsc = activeSpan?.spanContext().traceState?.get(SENTRY_TRACE_STATE_DSC);
-  const dscOnSpan = traceStateDsc ? baggageHeaderToDynamicSamplingContext(traceStateDsc) : undefined;
+/** Get the Sentry propagation context from a span context. */
+export function getPropagationContextFromSpanContext(spanContext: SpanContext): PropagationContext {
+  const { traceId, spanId, traceFlags, traceState } = spanContext;
 
-  if (dscOnSpan) {
-    return dscOnSpan;
-  }
+  const dscString = traceState ? traceState.get(SENTRY_TRACE_STATE_DSC) : undefined;
+  const dsc = dscString ? baggageHeaderToDynamicSamplingContext(dscString) : undefined;
+  const parentSpanId = traceState ? traceState.get(SENTRY_TRACE_STATE_PARENT_SPAN_ID) : undefined;
+  const sampled = traceFlags === TraceFlags.SAMPLED;
 
-  const propagationContext = getPropagationContextFromContext(context);
-
-  if (propagationContext) {
-    const { traceId } = getSentryTraceData(context, propagationContext);
-    return getDynamicSamplingContext(propagationContext, traceId);
-  }
-
-  return undefined;
+  return {
+    traceId,
+    spanId,
+    sampled,
+    parentSpanId,
+    dsc,
+  };
 }
 
 /**
@@ -49,10 +51,7 @@ export class SentryPropagator extends W3CBaggagePropagator {
 
     let baggage = propagation.getBaggage(context) || propagation.createBaggage({});
 
-    const propagationContext = getPropagationContextFromContext(context);
-    const { spanId, traceId, sampled } = getSentryTraceData(context, propagationContext);
-
-    const dynamicSamplingContext = getDynamicSamplingContextFromContext(context);
+    const { dynamicSamplingContext, traceId, spanId, sampled } = getInjectionData(context);
 
     if (dynamicSamplingContext) {
       baggage = Object.entries(dynamicSamplingContext).reduce<Baggage>((b, [dscKey, dscValue]) => {
@@ -83,15 +82,11 @@ export class SentryPropagator extends W3CBaggagePropagator {
 
     const propagationContext = propagationContextFromHeaders(sentryTraceHeader, maybeBaggageHeader);
 
-    // Add propagation context to context
-    const contextWithPropagationContext = setPropagationContextOnContext(context, propagationContext);
-
     // We store the DSC as OTEL trace state on the span context
-    const dscString = propagationContext.dsc
-      ? dynamicSamplingContextToSentryBaggageHeader(propagationContext.dsc)
-      : undefined;
-
-    const traceState = dscString ? new TraceState().set(SENTRY_TRACE_STATE_DSC, dscString) : undefined;
+    const traceState = makeTraceState({
+      parentSpanId: propagationContext.parentSpanId,
+      dsc: propagationContext.dsc,
+    });
 
     const spanContext: SpanContext = {
       traceId: propagationContext.traceId,
@@ -101,8 +96,18 @@ export class SentryPropagator extends W3CBaggagePropagator {
       traceState,
     };
 
-    // Add remote parent span context
-    return trace.setSpanContext(contextWithPropagationContext, spanContext);
+    // Add remote parent span context,
+    const ctxWithSpanContext = trace.setSpanContext(context, spanContext);
+
+    // Also update the scope on the context (to be sure this is picked up everywhere)
+    const scopes = getScopesFromContext(ctxWithSpanContext);
+    const newScopes = {
+      scope: scopes ? scopes.scope.clone() : getCurrentScope().clone(),
+      isolationScope: scopes ? scopes.isolationScope : getIsolationScope(),
+    };
+    newScopes.scope.setPropagationContext(propagationContext);
+
+    return setScopesOnContext(ctxWithSpanContext, newScopes);
   }
 
   /**
@@ -113,13 +118,91 @@ export class SentryPropagator extends W3CBaggagePropagator {
   }
 }
 
-/** Get the DSC. */
+/** Exported for tests. */
+export function makeTraceState({
+  parentSpanId,
+  dsc,
+}: { parentSpanId?: string; dsc?: Partial<DynamicSamplingContext> }): TraceState | undefined {
+  if (!parentSpanId && !dsc) {
+    return undefined;
+  }
+
+  // We store the DSC as OTEL trace state on the span context
+  const dscString = dsc ? dynamicSamplingContextToSentryBaggageHeader(dsc) : undefined;
+
+  const traceStateBase = parentSpanId
+    ? new TraceState().set(SENTRY_TRACE_STATE_PARENT_SPAN_ID, parentSpanId)
+    : new TraceState();
+
+  return dscString ? traceStateBase.set(SENTRY_TRACE_STATE_DSC, dscString) : traceStateBase;
+}
+
+function getInjectionData(context: Context): {
+  dynamicSamplingContext: Partial<DynamicSamplingContext> | undefined;
+  traceId: string | undefined;
+  spanId: string | undefined;
+  sampled: boolean | undefined;
+} {
+  const span = trace.getSpan(context);
+  const spanIsRemote = span?.spanContext().isRemote;
+
+  // If we have a local span, we can just pick everything from it
+  if (span && !spanIsRemote) {
+    const spanContext = span.spanContext();
+    const propagationContext = getPropagationContextFromSpanContext(spanContext);
+    const dynamicSamplingContext = getDynamicSamplingContext(propagationContext, spanContext.traceId);
+    return {
+      dynamicSamplingContext,
+      traceId: spanContext.traceId,
+      spanId: spanContext.spanId,
+      sampled: spanContext.traceFlags === TraceFlags.SAMPLED,
+    };
+  }
+
+  // Else we try to use the propagation context from the scope
+  const scope = getScopesFromContext(context)?.scope;
+  if (scope) {
+    const propagationContext = scope.getPropagationContext();
+    const dynamicSamplingContext = getDynamicSamplingContext(propagationContext, propagationContext.traceId);
+    return {
+      dynamicSamplingContext,
+      traceId: propagationContext.traceId,
+      spanId: propagationContext.spanId,
+      sampled: propagationContext.sampled,
+    };
+  }
+
+  // Else, we look at the remote span context
+  const spanContext = trace.getSpanContext(context);
+  if (spanContext) {
+    const propagationContext = getPropagationContextFromSpanContext(spanContext);
+    const dynamicSamplingContext = getDynamicSamplingContext(propagationContext, spanContext.traceId);
+
+    return {
+      dynamicSamplingContext,
+      traceId: spanContext.traceId,
+      spanId: spanContext.spanId,
+      sampled: spanContext.traceFlags === TraceFlags.SAMPLED,
+    };
+  }
+
+  // If we have neither, there is nothing much we can do, but that should not happen usually
+  // Unless there is a detached OTEL context being passed around
+  return {
+    dynamicSamplingContext: undefined,
+    traceId: undefined,
+    spanId: undefined,
+    sampled: undefined,
+  };
+}
+
+/** Get the DSC from a context, or fall back to use the one from the client. */
 function getDynamicSamplingContext(
   propagationContext: PropagationContext,
   traceId: string | undefined,
 ): Partial<DynamicSamplingContext> | undefined {
   // If we have a DSC on the propagation context, we just use it
-  if (propagationContext.dsc) {
+  if (propagationContext?.dsc) {
     return propagationContext.dsc;
   }
 
@@ -131,31 +214,4 @@ function getDynamicSamplingContext(
   }
 
   return undefined;
-}
-
-/** Get the trace data for propagation. */
-function getSentryTraceData(
-  context: Context,
-  propagationContext: PropagationContext | undefined,
-): {
-  spanId: string | undefined;
-  traceId: string | undefined;
-  sampled: boolean | undefined;
-} {
-  const span = trace.getSpan(context);
-  const spanContext = span && span.spanContext();
-
-  const traceId = spanContext ? spanContext.traceId : propagationContext?.traceId;
-
-  // We have a few scenarios here:
-  // If we have an active span, and it is _not_ remote, we just use the span's ID
-  // If we have an active span that is remote, we do not want to use the spanId, as we don't want to attach it to the parent span
-  // If `isRemote === true`, the span is bascially virtual
-  // If we don't have a local active span, we use the generated spanId from the propagationContext
-  const spanId = spanContext && !spanContext.isRemote ? spanContext.spanId : propagationContext?.spanId;
-
-  // eslint-disable-next-line no-bitwise
-  const sampled = spanContext ? Boolean(spanContext.traceFlags & TraceFlags.SAMPLED) : propagationContext?.sampled;
-
-  return { traceId, spanId, sampled };
 }

--- a/packages/opentelemetry/src/utils/contextData.ts
+++ b/packages/opentelemetry/src/utils/contextData.ts
@@ -1,30 +1,10 @@
 import type { Context } from '@opentelemetry/api';
-import type { Hub, PropagationContext, Scope } from '@sentry/types';
+import type { Hub, Scope } from '@sentry/types';
 
-import {
-  SENTRY_HUB_CONTEXT_KEY,
-  SENTRY_PROPAGATION_CONTEXT_CONTEXT_KEY,
-  SENTRY_SCOPES_CONTEXT_KEY,
-} from '../constants';
+import { SENTRY_HUB_CONTEXT_KEY, SENTRY_SCOPES_CONTEXT_KEY } from '../constants';
 import type { CurrentScopes } from '../types';
 
 const SCOPE_CONTEXT_MAP = new WeakMap<Scope, Context>();
-
-/**
- * Try to get the Propagation Context from the given OTEL context.
- * This requires the SentryPropagator to be registered.
- */
-export function getPropagationContextFromContext(context: Context): PropagationContext | undefined {
-  return context.getValue(SENTRY_PROPAGATION_CONTEXT_CONTEXT_KEY) as PropagationContext | undefined;
-}
-
-/**
- * Set a Propagation Context on an OTEL context..
- * This will return a forked context with the Propagation Context set.
- */
-export function setPropagationContextOnContext(context: Context, propagationContext: PropagationContext): Context {
-  return context.setValue(SENTRY_PROPAGATION_CONTEXT_CONTEXT_KEY, propagationContext);
-}
 
 /**
  * Try to get the Hub from the given OTEL context.

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -1,8 +1,9 @@
 import type { SpanContext } from '@opentelemetry/api';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 import { TraceFlags, context, trace } from '@opentelemetry/api';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, addBreadcrumb, getClient, setTag, withIsolationScope } from '@sentry/core';
-import type { Event, PropagationContext, TransactionEvent } from '@sentry/types';
+import type { Event, TransactionEvent } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { TraceState } from '@opentelemetry/core';
@@ -10,7 +11,6 @@ import { spanToJSON } from '@sentry/core';
 import { SENTRY_TRACE_STATE_DSC } from '../../src/constants';
 import { SentrySpanProcessor } from '../../src/spanProcessor';
 import { startInactiveSpan, startSpan } from '../../src/trace';
-import { setPropagationContextOnContext } from '../../src/utils/contextData';
 import type { TestClientInterface } from '../helpers/TestClient';
 import { cleanupOtel, getProvider, mockSdkInit } from '../helpers/mockSdkInit';
 
@@ -343,29 +343,19 @@ describe('Integration | Transactions', () => {
       traceFlags: TraceFlags.SAMPLED,
     };
 
-    const propagationContext: PropagationContext = {
-      traceId,
-      parentSpanId,
-      spanId: '6e0c63257de34c93',
-      sampled: true,
-    };
-
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
     const client = getClient() as TestClientInterface;
 
     // We simulate the correct context we'd normally get from the SentryPropagator
-    context.with(
-      trace.setSpanContext(setPropagationContextOnContext(context.active(), propagationContext), spanContext),
-      () => {
-        startSpan({ op: 'test op', name: 'test name', source: 'task', origin: 'auto.test' }, () => {
-          const subSpan = startInactiveSpan({ name: 'inner span 1' });
-          subSpan.end();
+    context.with(trace.setSpanContext(ROOT_CONTEXT, spanContext), () => {
+      startSpan({ op: 'test op', name: 'test name', source: 'task', origin: 'auto.test' }, () => {
+        const subSpan = startInactiveSpan({ name: 'inner span 1' });
+        subSpan.end();
 
-          startSpan({ name: 'inner span 2' }, () => {});
-        });
-      },
-    );
+        startSpan({ name: 'inner span 2' }, () => {});
+      });
+    });
 
     await client.flush();
 
@@ -554,36 +544,26 @@ describe('Integration | Transactions', () => {
       traceState: new TraceState().set(SENTRY_TRACE_STATE_DSC, dscString),
     };
 
-    const propagationContext: PropagationContext = {
-      traceId,
-      parentSpanId,
-      spanId: '6e0c63257de34c93',
-      sampled: true,
-    };
-
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
     const client = getClient() as TestClientInterface;
 
     // We simulate the correct context we'd normally get from the SentryPropagator
-    context.with(
-      trace.setSpanContext(setPropagationContextOnContext(context.active(), propagationContext), spanContext),
-      () => {
-        startSpan({ op: 'test op', name: 'test name', source: 'task', origin: 'auto.test' }, span => {
-          expect(span.spanContext().traceState?.get(SENTRY_TRACE_STATE_DSC)).toEqual(dscString);
+    context.with(trace.setSpanContext(ROOT_CONTEXT, spanContext), () => {
+      startSpan({ op: 'test op', name: 'test name', source: 'task', origin: 'auto.test' }, span => {
+        expect(span.spanContext().traceState?.get(SENTRY_TRACE_STATE_DSC)).toEqual(dscString);
 
-          const subSpan = startInactiveSpan({ name: 'inner span 1' });
+        const subSpan = startInactiveSpan({ name: 'inner span 1' });
 
+        expect(subSpan.spanContext().traceState?.get(SENTRY_TRACE_STATE_DSC)).toEqual(dscString);
+
+        subSpan.end();
+
+        startSpan({ name: 'inner span 2' }, subSpan => {
           expect(subSpan.spanContext().traceState?.get(SENTRY_TRACE_STATE_DSC)).toEqual(dscString);
-
-          subSpan.end();
-
-          startSpan({ name: 'inner span 2' }, subSpan => {
-            expect(subSpan.spanContext().traceState?.get(SENTRY_TRACE_STATE_DSC)).toEqual(dscString);
-          });
         });
-      },
-    );
+      });
+    });
 
     await client.flush();
 

--- a/packages/opentelemetry/test/propagator.test.ts
+++ b/packages/opentelemetry/test/propagator.test.ts
@@ -1,18 +1,19 @@
 import {
   ROOT_CONTEXT,
   TraceFlags,
+  context,
   defaultTextMapGetter,
   defaultTextMapSetter,
   propagation,
   trace,
 } from '@opentelemetry/api';
-import { TraceState, suppressTracing } from '@opentelemetry/core';
-import { addTracingExtensions, setCurrentClient } from '@sentry/core';
-import type { Client, PropagationContext } from '@sentry/types';
+import { suppressTracing } from '@opentelemetry/core';
+import { addTracingExtensions, withScope } from '@sentry/core';
 
-import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER, SENTRY_TRACE_STATE_DSC } from '../src/constants';
-import { SentryPropagator } from '../src/propagator';
-import { getPropagationContextFromContext, setPropagationContextOnContext } from '../src/utils/contextData';
+import { SENTRY_BAGGAGE_HEADER, SENTRY_SCOPES_CONTEXT_KEY, SENTRY_TRACE_HEADER } from '../src/constants';
+import { SentryPropagator, makeTraceState } from '../src/propagator';
+import { getScopesFromContext } from '../src/utils/contextData';
+import { cleanupOtel, mockSdkInit } from './helpers/mockSdkInit';
 
 beforeAll(() => {
   addTracingExtensions();
@@ -24,6 +25,16 @@ describe('SentryPropagator', () => {
 
   beforeEach(() => {
     carrier = {};
+    mockSdkInit({
+      environment: 'production',
+      release: '1.0.0',
+      enableTracing: true,
+      dsn: 'https://abc@domain/123',
+    });
+  });
+
+  afterEach(() => {
+    cleanupOtel();
   });
 
   it('returns fields set', () => {
@@ -31,289 +42,454 @@ describe('SentryPropagator', () => {
   });
 
   describe('inject', () => {
-    const client = {
-      getOptions: () => ({
-        environment: 'production',
-        release: '1.0.0',
-      }),
-      getDsn: () => ({
-        publicKey: 'abc',
-      }),
-      emit: () => {},
-    } as unknown as Client;
-
-    setCurrentClient(client);
-
-    describe('with active span', () => {
+    describe('without active local span', () => {
       it.each([
         [
-          'works with a sampled propagation context',
-          {
-            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c92',
-            traceFlags: TraceFlags.SAMPLED,
-          },
-          {
-            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c94',
-            parentSpanId: '6e0c63257de34c93',
-            sampled: true,
-            dsc: {
-              transaction: 'sampled-transaction',
-              trace_id: 'd4cda95b652f4a1592b449d5929fda1b',
-              sampled: 'true',
-              public_key: 'abc',
-              environment: 'production',
-              release: '1.0.0',
-            },
-          },
-          [
-            'sentry-environment=production',
-            'sentry-release=1.0.0',
-            'sentry-public_key=abc',
-            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
-            'sentry-transaction=sampled-transaction',
-            'sentry-sampled=true',
-          ],
-          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1',
-        ],
-        [
-          'works with a DSC on the span trace state',
-          {
-            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c92',
-            traceFlags: TraceFlags.SAMPLED,
-            traceState: new TraceState().set(
-              SENTRY_TRACE_STATE_DSC,
-              'sentry-transaction=other-transaction,sentry-environment=other,sentry-release=8.0.0,sentry-public_key=public,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-sampled=true',
-            ),
-          },
-          {
-            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c94',
-            parentSpanId: '6e0c63257de34c93',
-            sampled: true,
-          },
-          [
-            'sentry-environment=other',
-            'sentry-release=8.0.0',
-            'sentry-public_key=public',
-            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
-            'sentry-transaction=other-transaction',
-            'sentry-sampled=true',
-          ],
-          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1',
-        ],
-        [
-          'works with an unsampled propagation context',
-          {
-            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c92',
-            traceFlags: TraceFlags.NONE,
-          },
-          {
-            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c94',
-            parentSpanId: '6e0c63257de34c93',
-            sampled: false,
-            dsc: {
-              transaction: 'not-sampled-transaction',
-              trace_id: 'd4cda95b652f4a1592b449d5929fda1b',
-              sampled: 'false',
-              public_key: 'abc',
-              environment: 'production',
-              release: '1.0.0',
-            },
-          },
-          [
-            'sentry-environment=production',
-            'sentry-release=1.0.0',
-            'sentry-public_key=abc',
-            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
-            'sentry-transaction=not-sampled-transaction',
-            'sentry-sampled=false',
-          ],
-          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-0',
-        ],
-        [
-          'creates a new DSC if none exists yet',
-          {
-            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c92',
-            traceFlags: TraceFlags.SAMPLED,
-          },
-          {
-            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c94',
-            parentSpanId: '6e0c63257de34c93',
-            sampled: true,
-            dsc: undefined,
-          },
-          [
-            'sentry-environment=production',
-            'sentry-public_key=abc',
-            'sentry-release=1.0.0',
-            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
-          ],
-          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1',
-        ],
-        [
-          'works with a remote parent span',
+          'uses remote spanContext without DSC for sampled remote span',
           {
             traceId: 'd4cda95b652f4a1592b449d5929fda1b',
             spanId: '6e0c63257de34c92',
             traceFlags: TraceFlags.SAMPLED,
             isRemote: true,
           },
+          [
+            'sentry-environment=production',
+            'sentry-release=1.0.0',
+            'sentry-public_key=abc',
+            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
+          ],
+          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1',
+        ],
+        [
+          'uses remote spanContext without DSC for unsampled remote span',
           {
             traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-            spanId: '6e0c63257de34c94',
-            parentSpanId: '6e0c63257de34c93',
-            sampled: true,
-            dsc: {
-              transaction: 'sampled-transaction',
-              trace_id: 'd4cda95b652f4a1592b449d5929fda1b',
-              sampled: 'true',
-              public_key: 'abc',
-              environment: 'production',
-              release: '1.0.0',
-            },
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.NONE,
+            isRemote: true,
           },
           [
             'sentry-environment=production',
             'sentry-release=1.0.0',
             'sentry-public_key=abc',
             'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
+          ],
+          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-0',
+        ],
+        [
+          'uses remote spanContext with DSC for sampled remote span',
+          {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.SAMPLED,
+            traceState: makeTraceState({
+              parentSpanId: '6e0c63257de34c92',
+              dsc: {
+                transaction: 'sampled-transaction',
+                sampled: 'true',
+                trace_id: 'dsc_trace_id',
+                public_key: 'dsc_public_key',
+                environment: 'dsc_environment',
+                release: 'dsc_release',
+                sample_rate: '0.5',
+                replay_id: 'dsc_replay_id',
+              },
+            }),
+            isRemote: true,
+          },
+          [
+            'sentry-environment=dsc_environment',
+            'sentry-release=dsc_release',
+            'sentry-public_key=dsc_public_key',
+            'sentry-trace_id=dsc_trace_id',
             'sentry-transaction=sampled-transaction',
             'sentry-sampled=true',
+            'sentry-sample_rate=0.5',
+            'sentry-replay_id=dsc_replay_id',
           ],
-          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c94-1',
+          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1',
         ],
-      ])('%s', (_name, spanContext, propagationContext, baggage, sentryTrace) => {
-        const context = trace.setSpanContext(
-          setPropagationContextOnContext(ROOT_CONTEXT, propagationContext),
-          spanContext,
-        );
-        propagator.inject(context, carrier, defaultTextMapSetter);
+        [
+          'uses remote spanContext with DSC for unsampled remote span',
+          {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.NONE,
+            traceState: makeTraceState({
+              parentSpanId: '6e0c63257de34c92',
+              dsc: {
+                transaction: 'sampled-transaction',
+                sampled: 'false',
+                trace_id: 'dsc_trace_id',
+                public_key: 'dsc_public_key',
+                environment: 'dsc_environment',
+                release: 'dsc_release',
+                sample_rate: '0.5',
+                replay_id: 'dsc_replay_id',
+              },
+            }),
+            isRemote: true,
+          },
+          [
+            'sentry-environment=dsc_environment',
+            'sentry-release=dsc_release',
+            'sentry-public_key=dsc_public_key',
+            'sentry-trace_id=dsc_trace_id',
+            'sentry-transaction=sampled-transaction',
+            'sentry-sampled=false',
+            'sentry-sample_rate=0.5',
+            'sentry-replay_id=dsc_replay_id',
+          ],
+          'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-0',
+        ],
+      ])('%s', (_name, spanContext, baggage, sentryTrace) => {
+        const ctx = trace.setSpanContext(ROOT_CONTEXT, spanContext);
+        propagator.inject(ctx, carrier, defaultTextMapSetter);
+
         expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(baggage.sort());
         expect(carrier[SENTRY_TRACE_HEADER]).toBe(sentryTrace);
       });
 
-      it('should include existing baggage', () => {
-        const propagationContext: PropagationContext = {
-          traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-          spanId: '6e0c63257de34c92',
-          parentSpanId: '6e0c63257de34c93',
-          sampled: true,
-          dsc: {
-            transaction: 'sampled-transaction',
-            trace_id: 'd4cda95b652f4a1592b449d5929fda1b',
-            sampled: 'true',
-            public_key: 'abc',
-            environment: 'production',
-            release: '1.0.0',
-          },
-        };
+      it('uses scope propagation context without DSC if no span is found', () => {
+        withScope(scope => {
+          scope.setPropagationContext({
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            parentSpanId: '6e0c63257de34c93',
+            spanId: '6e0c63257de34c92',
+            sampled: true,
+          });
 
-        const spanContext = {
-          traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-          spanId: '6e0c63257de34c92',
-          traceFlags: TraceFlags.SAMPLED,
-        };
-        const context = trace.setSpanContext(
-          setPropagationContextOnContext(ROOT_CONTEXT, propagationContext),
-          spanContext,
-        );
-        const baggage = propagation.createBaggage({ foo: { value: 'bar' } });
-        propagator.inject(propagation.setBaggage(context, baggage), carrier, defaultTextMapSetter);
-        expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(
-          [
-            'foo=bar',
-            'sentry-transaction=sampled-transaction',
-            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
-            'sentry-sampled=true',
-            'sentry-public_key=abc',
-            'sentry-environment=production',
-            'sentry-release=1.0.0',
-          ].sort(),
+          propagator.inject(context.active(), carrier, defaultTextMapSetter);
+
+          expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(
+            [
+              'sentry-environment=production',
+              'sentry-release=1.0.0',
+              'sentry-public_key=abc',
+              'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
+            ].sort(),
+          );
+          expect(carrier[SENTRY_TRACE_HEADER]).toBe('d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1');
+        });
+      });
+
+      it('uses scope propagation context with DSC if no span is found', () => {
+        withScope(scope => {
+          scope.setPropagationContext({
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            parentSpanId: '6e0c63257de34c93',
+            spanId: '6e0c63257de34c92',
+            sampled: true,
+            dsc: {
+              transaction: 'sampled-transaction',
+              sampled: 'false',
+              trace_id: 'dsc_trace_id',
+              public_key: 'dsc_public_key',
+              environment: 'dsc_environment',
+              release: 'dsc_release',
+              sample_rate: '0.5',
+              replay_id: 'dsc_replay_id',
+            },
+          });
+
+          propagator.inject(context.active(), carrier, defaultTextMapSetter);
+
+          expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(
+            [
+              'sentry-environment=dsc_environment',
+              'sentry-release=dsc_release',
+              'sentry-public_key=dsc_public_key',
+              'sentry-trace_id=dsc_trace_id',
+              'sentry-transaction=sampled-transaction',
+              'sentry-sampled=false',
+              'sentry-sample_rate=0.5',
+              'sentry-replay_id=dsc_replay_id',
+            ].sort(),
+          );
+          expect(carrier[SENTRY_TRACE_HEADER]).toBe('d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1');
+        });
+      });
+
+      it('uses scope propagation context over remote spanContext', () => {
+        context.with(
+          trace.setSpanContext(ROOT_CONTEXT, {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.NONE,
+            isRemote: true,
+          }),
+          () => {
+            withScope(scope => {
+              scope.setPropagationContext({
+                traceId: 'TRACE_ID',
+                parentSpanId: 'PARENT_SPAN_ID',
+                spanId: 'SPAN_ID',
+                sampled: true,
+              });
+
+              propagator.inject(context.active(), carrier, defaultTextMapSetter);
+
+              expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(
+                [
+                  'sentry-environment=production',
+                  'sentry-release=1.0.0',
+                  'sentry-public_key=abc',
+                  'sentry-trace_id=TRACE_ID',
+                ].sort(),
+              );
+              expect(carrier[SENTRY_TRACE_HEADER]).toBe('TRACE_ID-SPAN_ID-1');
+            });
+          },
         );
       });
 
-      it('should create baggage without propagation context', () => {
-        const spanContext = {
-          traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-          spanId: '6e0c63257de34c92',
-          traceFlags: TraceFlags.SAMPLED,
-        };
-        const context = trace.setSpanContext(ROOT_CONTEXT, spanContext);
-        const baggage = propagation.createBaggage({ foo: { value: 'bar' } });
-        propagator.inject(propagation.setBaggage(context, baggage), carrier, defaultTextMapSetter);
-        expect(carrier[SENTRY_BAGGAGE_HEADER]).toBe('foo=bar');
-      });
+      it('creates random traceId & spanId if no scope & span is found', () => {
+        const ctx = trace.deleteSpan(ROOT_CONTEXT).deleteValue(SENTRY_SCOPES_CONTEXT_KEY);
+        propagator.inject(ctx, carrier, defaultTextMapSetter);
 
-      it('should NOT set baggage and sentry-trace header if instrumentation is supressed', () => {
-        const spanContext = {
-          traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-          spanId: '6e0c63257de34c92',
-          traceFlags: TraceFlags.SAMPLED,
-        };
-        const propagationContext: PropagationContext = {
-          traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-          spanId: '6e0c63257de34c92',
-          parentSpanId: '6e0c63257de34c93',
-          sampled: true,
-          dsc: {
-            transaction: 'sampled-transaction',
-            trace_id: 'd4cda95b652f4a1592b449d5929fda1b',
-            sampled: 'true',
-            public_key: 'abc',
-            environment: 'production',
-            release: '1.0.0',
-          },
-        };
-        const context = suppressTracing(
-          trace.setSpanContext(setPropagationContextOnContext(ROOT_CONTEXT, propagationContext), spanContext),
-        );
-        propagator.inject(context, carrier, defaultTextMapSetter);
-        expect(carrier[SENTRY_TRACE_HEADER]).toBe(undefined);
-        expect(carrier[SENTRY_BAGGAGE_HEADER]).toBe(undefined);
+        expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual([]);
+        expect(carrier[SENTRY_TRACE_HEADER]).toMatch(/^\w{32}-\w{16}$/);
       });
     });
 
-    it('should take span from propagationContext id if no active span is found', () => {
-      const propagationContext: PropagationContext = {
-        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-        parentSpanId: '6e0c63257de34c93',
-        spanId: '6e0c63257de34c92',
-        sampled: true,
-        dsc: {
-          transaction: 'sampled-transaction',
-          trace_id: 'd4cda95b652f4a1592b449d5929fda1b',
-          sampled: 'true',
-          public_key: 'abc',
-          environment: 'production',
-          release: '1.0.0',
-        },
-      };
+    describe('with active span', () => {
+      it.each([
+        [
+          'continues a remote trace without dsc',
+          {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.SAMPLED,
+            isRemote: true,
+          },
+          [
+            'sentry-environment=production',
+            'sentry-release=1.0.0',
+            'sentry-public_key=abc',
+            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
+          ],
+          'd4cda95b652f4a1592b449d5929fda1b-{{spanId}}-1',
+        ],
+        [
+          'continues a remote trace with dsc',
+          {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.SAMPLED,
+            isRemote: true,
+            traceState: makeTraceState({
+              parentSpanId: '6e0c63257de34c92',
+              dsc: {
+                transaction: 'sampled-transaction',
+                sampled: 'true',
+                trace_id: 'dsc_trace_id',
+                public_key: 'dsc_public_key',
+                environment: 'dsc_environment',
+                release: 'dsc_release',
+                sample_rate: '0.5',
+                replay_id: 'dsc_replay_id',
+              },
+            }),
+          },
+          [
+            'sentry-environment=dsc_environment',
+            'sentry-release=dsc_release',
+            'sentry-public_key=dsc_public_key',
+            'sentry-trace_id=dsc_trace_id',
+            'sentry-transaction=sampled-transaction',
+            'sentry-sampled=true',
+            'sentry-sample_rate=0.5',
+            'sentry-replay_id=dsc_replay_id',
+          ],
+          'd4cda95b652f4a1592b449d5929fda1b-{{spanId}}-1',
+        ],
+        [
+          'continues an unsampled remote trace without dsc',
+          {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.NONE,
+            isRemote: true,
+          },
+          [
+            'sentry-environment=production',
+            'sentry-release=1.0.0',
+            'sentry-public_key=abc',
+            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
+          ],
+          'd4cda95b652f4a1592b449d5929fda1b-{{spanId}}-0',
+        ],
+        [
+          'continues an unsampled remote trace with dsc',
+          {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.NONE,
+            isRemote: true,
+            traceState: makeTraceState({
+              parentSpanId: '6e0c63257de34c92',
+              dsc: {
+                transaction: 'sampled-transaction',
+                sampled: 'false',
+                trace_id: 'dsc_trace_id',
+                public_key: 'dsc_public_key',
+                environment: 'dsc_environment',
+                release: 'dsc_release',
+                sample_rate: '0.5',
+                replay_id: 'dsc_replay_id',
+              },
+            }),
+          },
+          [
+            'sentry-environment=dsc_environment',
+            'sentry-release=dsc_release',
+            'sentry-public_key=dsc_public_key',
+            'sentry-trace_id=dsc_trace_id',
+            'sentry-transaction=sampled-transaction',
+            'sentry-sampled=false',
+            'sentry-sample_rate=0.5',
+            'sentry-replay_id=dsc_replay_id',
+          ],
+          'd4cda95b652f4a1592b449d5929fda1b-{{spanId}}-0',
+        ],
+        [
+          'starts a new trace without existing dsc',
+          {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.SAMPLED,
+          },
+          [
+            'sentry-environment=production',
+            'sentry-release=1.0.0',
+            'sentry-public_key=abc',
+            'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
+          ],
+          'd4cda95b652f4a1592b449d5929fda1b-{{spanId}}-1',
+        ],
+      ])('%s', (_name, spanContext, baggage, sentryTrace) => {
+        context.with(trace.setSpanContext(ROOT_CONTEXT, spanContext), () => {
+          trace.getTracer('test').startActiveSpan('test', span => {
+            propagator.inject(context.active(), carrier, defaultTextMapSetter);
 
-      const context = setPropagationContextOnContext(ROOT_CONTEXT, propagationContext);
-      propagator.inject(context, carrier, defaultTextMapSetter);
+            expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(baggage.sort());
+            expect(carrier[SENTRY_TRACE_HEADER]).toBe(sentryTrace.replace('{{spanId}}', span.spanContext().spanId));
+          });
+        });
+      });
+
+      it('uses local span over propagation context', () => {
+        context.with(
+          trace.setSpanContext(ROOT_CONTEXT, {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.SAMPLED,
+            isRemote: true,
+          }),
+          () => {
+            trace.getTracer('test').startActiveSpan('test', span => {
+              withScope(scope => {
+                scope.setPropagationContext({
+                  traceId: 'TRACE_ID',
+                  parentSpanId: 'PARENT_SPAN_ID',
+                  spanId: 'SPAN_ID',
+                  sampled: true,
+                });
+
+                propagator.inject(context.active(), carrier, defaultTextMapSetter);
+
+                expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(
+                  [
+                    'sentry-environment=production',
+                    'sentry-release=1.0.0',
+                    'sentry-public_key=abc',
+                    'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
+                  ].sort(),
+                );
+                expect(carrier[SENTRY_TRACE_HEADER]).toBe(
+                  `d4cda95b652f4a1592b449d5929fda1b-${span.spanContext().spanId}-1`,
+                );
+              });
+            });
+          },
+        );
+
+        context.with(
+          trace.setSpanContext(ROOT_CONTEXT, {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.NONE,
+            isRemote: true,
+          }),
+          () => {
+            withScope(scope => {
+              scope.setPropagationContext({
+                traceId: 'TRACE_ID',
+                parentSpanId: 'PARENT_SPAN_ID',
+                spanId: 'SPAN_ID',
+                sampled: true,
+              });
+
+              propagator.inject(context.active(), carrier, defaultTextMapSetter);
+
+              expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(
+                [
+                  'sentry-environment=production',
+                  'sentry-release=1.0.0',
+                  'sentry-public_key=abc',
+                  'sentry-trace_id=TRACE_ID',
+                ].sort(),
+              );
+              expect(carrier[SENTRY_TRACE_HEADER]).toBe('TRACE_ID-SPAN_ID-1');
+            });
+          },
+        );
+      });
+    });
+
+    it('should include existing baggage', () => {
+      const spanContext = {
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        spanId: '6e0c63257de34c92',
+        traceFlags: TraceFlags.SAMPLED,
+      };
+      const context = trace.setSpanContext(ROOT_CONTEXT, spanContext);
+      const baggage = propagation.createBaggage({ foo: { value: 'bar' } });
+      propagator.inject(propagation.setBaggage(context, baggage), carrier, defaultTextMapSetter);
       expect(baggageToArray(carrier[SENTRY_BAGGAGE_HEADER])).toEqual(
         [
-          'sentry-transaction=sampled-transaction',
+          'foo=bar',
           'sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b',
-          'sentry-sampled=true',
           'sentry-public_key=abc',
           'sentry-environment=production',
           'sentry-release=1.0.0',
         ].sort(),
       );
-      expect(carrier[SENTRY_TRACE_HEADER]).toBe('d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1');
+    });
+
+    it('should create baggage without propagation context', () => {
+      const context = ROOT_CONTEXT;
+      const baggage = propagation.createBaggage({ foo: { value: 'bar' } });
+      propagator.inject(propagation.setBaggage(context, baggage), carrier, defaultTextMapSetter);
+      expect(carrier[SENTRY_BAGGAGE_HEADER]).toBe('foo=bar');
+    });
+
+    it('should NOT set baggage and sentry-trace header if instrumentation is supressed', () => {
+      const spanContext = {
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        spanId: '6e0c63257de34c92',
+        traceFlags: TraceFlags.SAMPLED,
+      };
+
+      const context = suppressTracing(trace.setSpanContext(ROOT_CONTEXT, spanContext));
+      propagator.inject(context, carrier, defaultTextMapSetter);
+      expect(carrier[SENTRY_TRACE_HEADER]).toBe(undefined);
+      expect(carrier[SENTRY_BAGGAGE_HEADER]).toBe(undefined);
     });
   });
 
   describe('extract', () => {
-    it('sets sentry span context on the context', () => {
+    it('sets data from sentry trace header on span context', () => {
       const sentryTraceHeader = 'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1';
       carrier[SENTRY_TRACE_HEADER] = sentryTraceHeader;
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
@@ -322,66 +498,98 @@ describe('SentryPropagator', () => {
         spanId: '6e0c63257de34c92',
         traceFlags: TraceFlags.SAMPLED,
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        traceState: makeTraceState({ parentSpanId: '6e0c63257de34c92' }),
       });
     });
 
-    it('sets defined sentry trace header on context', () => {
+    it('sets data from sentry trace header on scope', () => {
       const sentryTraceHeader = 'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1';
       carrier[SENTRY_TRACE_HEADER] = sentryTraceHeader;
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
 
-      const propagationContext = getPropagationContextFromContext(context);
-      expect(propagationContext).toEqual({
-        sampled: true,
-        parentSpanId: '6e0c63257de34c92',
-        spanId: expect.any(String),
-        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-        dsc: {}, // Frozen DSC
-      });
+      const scopes = getScopesFromContext(context);
 
-      // Ensure spanId !== parentSpanId - it should be a new random ID
-      expect(propagationContext?.spanId).not.toBe('6e0c63257de34c92');
+      expect(scopes).toBeDefined();
+      expect(scopes?.scope.getPropagationContext()).toEqual({
+        spanId: expect.any(String),
+        sampled: true,
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        parentSpanId: '6e0c63257de34c92',
+        dsc: {},
+      });
     });
 
-    it('sets undefined sentry trace header on context', () => {
+    it('handles undefined sentry trace header', () => {
       const sentryTraceHeader = undefined;
       carrier[SENTRY_TRACE_HEADER] = sentryTraceHeader;
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
-      expect(getPropagationContextFromContext(context)).toEqual({
+      expect(trace.getSpanContext(context)).toEqual({
+        isRemote: true,
         spanId: expect.any(String),
+        traceFlags: TraceFlags.NONE,
         traceId: expect.any(String),
       });
     });
 
-    it('sets defined dynamic sampling context on context', () => {
+    it('sets data from baggage header on span context', () => {
       const sentryTraceHeader = 'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1';
       const baggage =
         'sentry-environment=production,sentry-release=1.0.0,sentry-public_key=abc,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-transaction=dsc-transaction';
       carrier[SENTRY_TRACE_HEADER] = sentryTraceHeader;
       carrier[SENTRY_BAGGAGE_HEADER] = baggage;
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
-      expect(getPropagationContextFromContext(context)).toEqual({
-        sampled: true,
-        parentSpanId: expect.any(String),
+      expect(trace.getSpanContext(context)).toEqual({
+        isRemote: true,
+        spanId: '6e0c63257de34c92',
+        traceFlags: TraceFlags.SAMPLED,
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        traceState: makeTraceState({
+          parentSpanId: '6e0c63257de34c92',
+          dsc: {
+            environment: 'production',
+            release: '1.0.0',
+            public_key: 'abc',
+            trace_id: 'd4cda95b652f4a1592b449d5929fda1b',
+            transaction: 'dsc-transaction',
+          },
+        }),
+      });
+    });
+
+    it('sets data from baggage header on scope', () => {
+      const sentryTraceHeader = 'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1';
+      const baggage =
+        'sentry-environment=production,sentry-release=1.0.0,sentry-public_key=abc,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-transaction=dsc-transaction';
+      carrier[SENTRY_TRACE_HEADER] = sentryTraceHeader;
+      carrier[SENTRY_BAGGAGE_HEADER] = baggage;
+      const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
+
+      const scopes = getScopesFromContext(context);
+
+      expect(scopes).toBeDefined();
+      expect(scopes?.scope.getPropagationContext()).toEqual({
         spanId: expect.any(String),
-        traceId: expect.any(String), // Note: This is not automatically taken from the DSC (in reality, this should be aligned)
+        sampled: true,
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        parentSpanId: '6e0c63257de34c92',
         dsc: {
           environment: 'production',
-          public_key: 'abc',
           release: '1.0.0',
+          public_key: 'abc',
           trace_id: 'd4cda95b652f4a1592b449d5929fda1b',
           transaction: 'dsc-transaction',
         },
       });
     });
 
-    it('sets undefined dynamic sampling context on context', () => {
+    it('handles empty dsc baggage header', () => {
       const baggage = '';
       carrier[SENTRY_BAGGAGE_HEADER] = baggage;
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
-      expect(getPropagationContextFromContext(context)).toEqual({
-        sampled: undefined,
+      expect(trace.getSpanContext(context)).toEqual({
+        isRemote: true,
         spanId: expect.any(String),
+        traceFlags: TraceFlags.NONE,
         traceId: expect.any(String),
       });
     });
@@ -389,9 +597,10 @@ describe('SentryPropagator', () => {
     it('handles when sentry-trace is an empty array', () => {
       carrier[SENTRY_TRACE_HEADER] = [];
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
-      expect(getPropagationContextFromContext(context)).toEqual({
-        sampled: undefined,
+      expect(trace.getSpanContext(context)).toEqual({
+        isRemote: true,
         spanId: expect.any(String),
+        traceFlags: TraceFlags.NONE,
         traceId: expect.any(String),
       });
     });


### PR DESCRIPTION
This updates the propagation handling in OTEL to the following:
1. If there is an active (local) span, we always pick up propagation context/DSC data from it.
2. Else, we try to pick it from the current scope
3. If we can't find this (e.g. a detached otel context is used), we try to pick it from the remote span context
4. Finally, if that also fails, we have no DSC

Closes https://github.com/getsentry/sentry-javascript/issues/10899