### PR TITLE
feat: Export `getSpanDescendants()` everywhere

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -66,6 +66,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
   continueTrace,
   cron,
   parameterize,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -20,6 +20,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
 } from '@sentry/core';
 
 export {

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -20,6 +20,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
 } from '@sentry/core';
 
 export {

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -25,6 +25,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
 } from '@sentry/core';
 
 export {

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -75,6 +75,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
   setMeasurement,
   // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -68,6 +68,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
   continueTrace,
   metricsDefault as metrics,
   functionToStringIntegration,

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -4,7 +4,7 @@ export type { BeforeFinishCallback } from './idletransaction';
 export { SentrySpan } from './sentrySpan';
 export { Transaction } from './transaction';
 // eslint-disable-next-line deprecation/deprecation
-export { getActiveTransaction, getActiveSpan } from './utils';
+export { getActiveTransaction, getActiveSpan, getSpanDescendants } from './utils';
 export {
   setHttpStatus,
   getSpanStatusFromHttpCode,

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -22,7 +22,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE
 import { spanTimeInputToSeconds, spanToJSON, spanToTraceContext } from '../utils/spanUtils';
 import { getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { SentrySpan, SpanRecorder } from './sentrySpan';
-import { getCapturedScopesOnSpan, getSpanTree } from './utils';
+import { getCapturedScopesOnSpan, getSpanDescendants } from './utils';
 
 /** JSDoc */
 export class Transaction extends SentrySpan implements TransactionInterface {
@@ -255,7 +255,7 @@ export class Transaction extends SentrySpan implements TransactionInterface {
     }
 
     // The transaction span itself should be filtered out
-    const finishedSpans = getSpanTree(this).filter(span => span !== this);
+    const finishedSpans = getSpanDescendants(this).filter(span => span !== this);
 
     if (this._trimEnd && finishedSpans.length > 0) {
       const endTimes = finishedSpans.map(span => spanToJSON(span).timestamp).filter(Boolean) as number[];

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -49,9 +49,9 @@ export function addChildSpanToSpan(span: SpanWithPotentialChildren, childSpan: S
 }
 
 /**
- * Obtains the entire span tree, meaning a span + all of its descendants for a particular span.
+ * Returns an array of the given span and all of its descendants.
  */
-export function getSpanTree(span: SpanWithPotentialChildren): Span[] {
+export function getSpanDescendants(span: SpanWithPotentialChildren): Span[] {
   const resultSet = new Set<Span>();
 
   function addSpanChildren(span: SpanWithPotentialChildren): void {

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -19,7 +19,7 @@ import {
   startSpan,
   startSpanManual,
 } from '../../../src/tracing';
-import { getSpanTree } from '../../../src/tracing/utils';
+import { getSpanDescendants } from '../../../src/tracing/utils';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 beforeAll(() => {
@@ -173,7 +173,7 @@ describe('startSpan', () => {
       }
 
       expect(_span).toBeDefined();
-      const spans = getSpanTree(_span!);
+      const spans = getSpanDescendants(_span!);
 
       expect(spans).toHaveLength(2);
       expect(spanToJSON(spans[1]).description).toEqual('SELECT * from users');
@@ -200,7 +200,7 @@ describe('startSpan', () => {
       }
 
       expect(_span).toBeDefined();
-      const spans = getSpanTree(_span!);
+      const spans = getSpanDescendants(_span!);
 
       expect(spans).toHaveLength(2);
       expect(spanToJSON(spans[1]).op).toEqual('db.query');

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -86,6 +86,7 @@ export {
   Scope,
   setMeasurement,
   continueTrace,
+  getSpanDescendants,
   parameterize,
   getCurrentScope,
   getIsolationScope,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -67,6 +67,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
   continueTrace,
   parameterize,
   functionToStringIntegration,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -77,6 +77,7 @@ export {
   startSpanManual,
   startInactiveSpan,
   withActiveSpan,
+  getSpanDescendants,
   continueTrace,
   isInitialized,
   cron,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -70,6 +70,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
   continueTrace,
   parameterize,
   requestDataIntegration,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -67,6 +67,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  getSpanDescendants,
   continueTrace,
   metrics,
   functionToStringIntegration,


### PR DESCRIPTION
This can be used instead of `spanRecorder` going forward.