### PR TITLE
fix(nextjs): Client code should not use Node `global`

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -2,6 +2,7 @@ import { addEventProcessor, applySdkMetadata, hasTracingEnabled, setTag } from '
 import type { BrowserOptions } from '@sentry/react';
 import { getDefaultIntegrations as getReactDefaultIntegrations, init as reactInit } from '@sentry/react';
 import type { EventProcessor, Integration } from '@sentry/types';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { devErrorSymbolicationEventProcessor } from '../common/devErrorSymbolicationEventProcessor';
 import { getVercelEnv } from '../common/getVercelEnv';
@@ -13,7 +14,7 @@ export * from '@sentry/react';
 
 export { captureUnderscoreErrorException } from '../common/_error';
 
-const globalWithInjectedValues = global as typeof global & {
+const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   __rewriteFramesAssetPrefixPath__: string;
 };
 

--- a/packages/nextjs/src/client/tunnelRoute.ts
+++ b/packages/nextjs/src/client/tunnelRoute.ts
@@ -1,9 +1,9 @@
 import type { BrowserOptions } from '@sentry/react';
-import { dsnFromString, logger } from '@sentry/utils';
+import { GLOBAL_OBJ, dsnFromString, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../common/debug-build';
 
-const globalWithInjectedValues = global as typeof global & {
+const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   __sentryRewritesTunnelPath__?: string;
 };
 


### PR DESCRIPTION
Found while working through ESM issues in #10833.

For whatever reason this passes all the integration tests until ESM is used 🤯