### PR TITLE
feat(sveltekit): Export `unstable_sentryVitePluginOptions` for full Vite plugin customization

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -254,6 +254,7 @@ We now support the following integrations out of the box:
 - [Browser SDK](./MIGRATION.md#browser-sdk-browser-react-vue-angular-ember-etc)
 - [Server-side SDKs (Node, Deno, Bun)](./MIGRATION.md#server-side-sdks-node-deno-bun-etc)
 - [Next.js SDK](./MIGRATION.md#nextjs-sdk)
+- [SvelteKit SDK](./MIGRATION.md#sveltekit-sdk)
 - [Astro SDK](./MIGRATION.md#astro-sdk)
 
 ### General
@@ -542,8 +543,8 @@ Sentry.init({
 #### Breaking `sentrySvelteKit()` changes
 
 We upgraded the `@sentry/vite-plugin` which is a dependency of the SvelteKit SDK from version 0.x to 2.x. With this
-change, resolving uploaded source maps should work out of the box much more often than before (read more about this
-[here](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/)).
+change, resolving uploaded source maps should work out of the box much more often than before
+([more information](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/artifact-bundles/)).
 
 To allow future upgrades of the Vite plugin without breaking stable and public APIs in `sentrySvelteKit`, we modified
 the `sourceMapsUploadOptions` to remove the hard dependency on the API of the plugin. While you previously could specify
@@ -606,8 +607,8 @@ sentrySvelteKit({
 }),
 ```
 
-Please note, that we DO NOT guarantee stability of `unstable_vitePluginOptions`. They can be removed or updated at any
-time, including breaking changes within the same major version of the SDK.
+Important: we DO NOT guarantee stability of `unstable_vitePluginOptions`. They can be removed or updated at any time,
+including breaking changes within the same major version of the SDK.
 
 ## 5. Behaviour Changes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,8 +12,6 @@ The main goal of version 8 is to improve our performance monitoring APIs, integr
 version is breaking because we removed deprecated APIs, restructured npm package contents, and introduced new
 dependencies on OpenTelemetry. Below we will outline the steps you need to take to tackle to deprecated methods.
 
-## Removal of Client-Side health check transaction filters
-
 Before updating to `8.x` of the SDK, we recommend upgrading to the latest version of `7.x`. You can then follow
 [these steps](./MIGRATION.md#deprecations-in-7x) remove deprecated methods in `7.x` before upgrading to `8.x`.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -587,7 +587,7 @@ sentrySvelteKit({
 
 In the future, we might add additional [options](https://www.npmjs.com/package/@sentry/vite-plugin/v/2.14.2#options)
 from the Vite plugin but if you would like to specify some of them directly, you can do this by passing in an
-`unstable_vitePluginOptions` object:
+`unstable_sentryVitePluginOptions` object:
 
 ```js
 sentrySvelteKit({
@@ -596,7 +596,7 @@ sentrySvelteKit({
     release: {
 	    name: '1.0.1',
     },
-    unstable_vitePluginOptions: {
+    unstable_sentryVitePluginOptions: {
       release: {
         setCommits: {
           auto: true
@@ -607,8 +607,8 @@ sentrySvelteKit({
 }),
 ```
 
-Important: we DO NOT guarantee stability of `unstable_vitePluginOptions`. They can be removed or updated at any time,
-including breaking changes within the same major version of the SDK.
+Important: we DO NOT guarantee stability of `unstable_sentryVitePluginOptions`. They can be removed or updated at any
+time, including breaking changes within the same major version of the SDK.
 
 ## 5. Behaviour Changes
 

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -129,7 +129,7 @@ type SourceMapsUploadOptions = {
      *
      * Furthermore, some options are untested with SvelteKit specifically. Use with caution.
      */
-    unstable_vitePluginOptions?: Partial<SentryVitePluginOptions>;
+    unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>;
   };
 };
 
@@ -212,12 +212,13 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
   }
 
   if (mergedOptions.autoUploadSourceMaps && process.env.NODE_ENV !== 'development') {
-    const { unstable_vitePluginOptions, ...sourceMapsUploadOptions } = mergedOptions.sourceMapsUploadOptions || {};
+    const { unstable_sentryVitePluginOptions, ...sourceMapsUploadOptions } =
+      mergedOptions.sourceMapsUploadOptions || {};
 
     const sentryVitePluginsOptions = {
       ...sourceMapsUploadOptions,
 
-      ...unstable_vitePluginOptions,
+      ...unstable_sentryVitePluginOptions,
 
       adapter: mergedOptions.adapter,
       // override the plugin's debug flag with the one from the top-level options
@@ -227,14 +228,14 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
     if (sentryVitePluginsOptions.sourcemaps) {
       sentryVitePluginsOptions.sourcemaps = {
         ...sourceMapsUploadOptions?.sourcemaps,
-        ...unstable_vitePluginOptions?.sourcemaps,
+        ...unstable_sentryVitePluginOptions?.sourcemaps,
       };
     }
 
     if (sentryVitePluginsOptions.release) {
       sentryVitePluginsOptions.release = {
         ...sourceMapsUploadOptions?.release,
-        ...unstable_vitePluginOptions?.release,
+        ...unstable_sentryVitePluginOptions?.release,
       };
     }
 

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite';
 
-import { SentryVitePluginOptions } from '@sentry/vite-plugin';
+import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 import type { AutoInstrumentSelection } from './autoInstrument';
 import { makeAutoInstrumentationPlugin } from './autoInstrument';
 import type { SupportedSvelteKitAdapters } from './detectAdapter';
@@ -214,25 +214,32 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
   if (mergedOptions.autoUploadSourceMaps && process.env.NODE_ENV !== 'development') {
     const { unstable_vitePluginOptions, ...sourceMapsUploadOptions } = mergedOptions.sourceMapsUploadOptions || {};
 
-    const sentryVitePlugins = await makeCustomSentryVitePlugins({
+    const sentryVitePluginsOptions = {
       ...sourceMapsUploadOptions,
 
       ...unstable_vitePluginOptions,
 
-      sourcemaps: {
-        ...sourceMapsUploadOptions?.sourcemaps,
-        ...unstable_vitePluginOptions?.sourcemaps,
-      },
-
-      release: {
-        ...sourceMapsUploadOptions?.release,
-        ...unstable_vitePluginOptions?.release,
-      },
-
       adapter: mergedOptions.adapter,
       // override the plugin's debug flag with the one from the top-level options
       debug: mergedOptions.debug,
-    });
+    };
+
+    if (sentryVitePluginsOptions.sourcemaps) {
+      sentryVitePluginsOptions.sourcemaps = {
+        ...sourceMapsUploadOptions?.sourcemaps,
+        ...unstable_vitePluginOptions?.sourcemaps,
+      };
+    }
+
+    if (sentryVitePluginsOptions.release) {
+      sentryVitePluginsOptions.release = {
+        ...sourceMapsUploadOptions?.release,
+        ...unstable_vitePluginOptions?.release,
+      };
+    }
+
+    const sentryVitePlugins = await makeCustomSentryVitePlugins(sentryVitePluginsOptions);
+
     sentryPlugins.push(...sentryVitePlugins);
   }
 

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -113,6 +113,32 @@ describe('sentrySvelteKit()', () => {
     });
   });
 
+  it('passes user-specified vite plugin options to the custom sentry source maps plugin', async () => {
+    const makePluginSpy = vi.spyOn(sourceMaps, 'makeCustomSentryVitePlugins');
+    await getSentrySvelteKitPlugins({
+      debug: true,
+      sourceMapsUploadOptions: {
+        sourcemaps: {
+          assets: ['foo/*.js'],
+          ignore: ['bar/*.js'],
+          filesToDeleteAfterUpload: ['baz/*.js'],
+        },
+      },
+      autoInstrument: false,
+      adapter: 'vercel',
+    });
+
+    expect(makePluginSpy).toHaveBeenCalledWith({
+      debug: true,
+      sourcemaps: {
+        assets: ['foo/*.js'],
+        ignore: ['bar/*.js'],
+        filesToDeleteAfterUpload: ['baz/*.js'],
+      },
+      adapter: 'vercel',
+    });
+  });
+
   it('passes user-specified options to the auto instrument plugin', async () => {
     const makePluginSpy = vi.spyOn(autoInstrument, 'makeAutoInstrumentationPlugin');
     const plugins = await getSentrySvelteKitPlugins({

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -118,10 +118,30 @@ describe('sentrySvelteKit()', () => {
     await getSentrySvelteKitPlugins({
       debug: true,
       sourceMapsUploadOptions: {
+        org: 'my-org',
         sourcemaps: {
-          assets: ['foo/*.js'],
-          ignore: ['bar/*.js'],
+          assets: ['nope/*.js'],
           filesToDeleteAfterUpload: ['baz/*.js'],
+        },
+        release: {
+          inject: false,
+          name: '2.0.0',
+        },
+        unstable_vitePluginOptions: {
+          org: 'other-org',
+          sourcemaps: {
+            assets: ['foo/*.js'],
+            ignore: ['bar/*.js'],
+          },
+          release: {
+            name: '3.0.0',
+            setCommits: {
+              auto: true,
+            },
+          },
+          headers: {
+            'X-My-Header': 'foo',
+          },
         },
       },
       autoInstrument: false,
@@ -130,10 +150,21 @@ describe('sentrySvelteKit()', () => {
 
     expect(makePluginSpy).toHaveBeenCalledWith({
       debug: true,
+      org: 'other-org',
       sourcemaps: {
         assets: ['foo/*.js'],
         ignore: ['bar/*.js'],
         filesToDeleteAfterUpload: ['baz/*.js'],
+      },
+      release: {
+        inject: false,
+        name: '3.0.0',
+        setCommits: {
+          auto: true,
+        },
+      },
+      headers: {
+        'X-My-Header': 'foo',
       },
       adapter: 'vercel',
     });

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -127,7 +127,7 @@ describe('sentrySvelteKit()', () => {
           inject: false,
           name: '2.0.0',
         },
-        unstable_vitePluginOptions: {
+        unstable_sentryVitePluginOptions: {
           org: 'other-org',
           sourcemaps: {
             assets: ['foo/*.js'],


### PR DESCRIPTION
As discussed with @lforst last week, we decided to provide an escape hatch to the reduced (but therefore version-agnostic) Vite plugin option API in the SvelteKit version of the plugin (`sentrySvelteKit()`). By specifying options in `unstable_vitePluginOptions`, users can still set and override all options the Vite plugin can take. We explicitly warn that  keys in `unstable_vitePluginOptions` do not follow semver and might be removed or changed at any time. This allows
users to do whatever they need to and us to still bump Vite plugin major versions whenever we need to.

This PR now also adds an MIGRATION entry, which I previously forgot in #10813

builds on #10813 
ref https://github.com/getsentry/sentry-javascript/issues/9835