### PR TITLE
fix(node): Add missing core re-exports

### DIFF
--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -100,6 +100,11 @@ export {
   extraErrorDataIntegration,
   rewriteFramesIntegration,
   sessionTimingIntegration,
+  metricsDefault as metrics,
+  startSession,
+  captureSession,
+  endSession,
+  addIntegration,
 } from '@sentry/core';
 
 export type {


### PR DESCRIPTION
These exports were lost on the migration from the experimental package
