### PR TITLE
fix(types): Add `AttachmentType` and use for envelope `attachment_type` property

### DIFF
--- a/packages/core/test/lib/transports/base.test.ts
+++ b/packages/core/test/lib/transports/base.test.ts
@@ -22,7 +22,7 @@ const ATTACHMENT_ENVELOPE = createEnvelope<EventEnvelope>(
         length: 20,
         filename: 'test-file.txt',
         content_type: 'text/plain',
-        attachment_type: 'text',
+        attachment_type: 'event.attachment',
       },
       'attachment content',
     ] as AttachmentItem,

--- a/packages/types/src/attachment.ts
+++ b/packages/types/src/attachment.ts
@@ -1,3 +1,10 @@
+export type AttachmentType =
+  | 'event.attachment'
+  | 'event.minidump'
+  | 'event.applecrashreport'
+  | 'unreal.context'
+  | 'unreal.logs';
+
 /**
  * An attachment to an event. This is used to upload arbitrary data to Sentry.
  *
@@ -23,5 +30,5 @@ export interface Attachment {
   /**
    * The type of the attachment. Defaults to `event.attachment` if not specified.
    */
-  attachmentType?: 'event.attachment' | 'event.minidump' | 'event.applecrashreport' | 'unreal.context' | 'unreal.logs';
+  attachmentType?: AttachmentType;
 }

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -1,3 +1,4 @@
+import type { AttachmentType } from './attachment';
 import type { SerializedCheckIn } from './checkin';
 import type { ClientReport } from './clientreport';
 import type { DsnComponents } from './dsn';
@@ -66,7 +67,7 @@ type AttachmentItemHeaders = {
   length: number;
   filename: string;
   content_type?: string;
-  attachment_type?: string;
+  attachment_type?: AttachmentType;
 };
 type UserFeedbackItemHeaders = { type: 'user_report' };
 type FeedbackItemHeaders = { type: 'feedback' };


### PR DESCRIPTION
`Attachment.attachmentType` was changed to use a string union. The `attachment_type` header property should match so I added an extra type for this.