### PR TITLE
fix(node): Correct SDK name

### DIFF
--- a/packages/node-experimental/src/sdk/client.ts
+++ b/packages/node-experimental/src/sdk/client.ts
@@ -19,7 +19,7 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
       serverName: options.serverName || global.process.env.SENTRY_NAME || os.hostname(),
     };
 
-    applySdkMetadata(clientOptions, 'node-experimental');
+    applySdkMetadata(clientOptions, 'node');
 
     super(clientOptions);
   }
@@ -30,7 +30,7 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
       return this._tracer;
     }
 
-    const name = '@sentry/node-experimental';
+    const name = '@sentry/node';
     const version = SDK_VERSION;
     const tracer = trace.getTracer(name, version);
     this._tracer = tracer;

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -82,7 +82,7 @@ export function getCurrentHub(): Hub {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): any {
       // eslint-disable-next-line no-console
-      console.warn('startTransaction is a noop in @sentry/node-experimental. Use `startSpan` instead.');
+      console.warn('startTransaction is a noop in @sentry/node. Use `startSpan` instead.');
       // We return an object here as hub.ts checks for the result of this
       // and renders a different warning if this is empty
       return {};

--- a/packages/node-experimental/src/sdk/initOtel.ts
+++ b/packages/node-experimental/src/sdk/initOtel.ts
@@ -48,7 +48,7 @@ export function setupOtel(client: NodeClient): BasicTracerProvider {
   const provider = new BasicTracerProvider({
     sampler: new SentrySampler(client),
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'node-experimental',
+      [SemanticResourceAttributes.SERVICE_NAME]: 'node',
       [SemanticResourceAttributes.SERVICE_NAMESPACE]: 'sentry',
       [SemanticResourceAttributes.SERVICE_VERSION]: SDK_VERSION,
     }),

--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -75,7 +75,7 @@ describe('Integration | Transactions', () => {
               'sentry.source': 'task',
             },
             resource: {
-              'service.name': 'node-experimental',
+              'service.name': 'node',
               'service.namespace': 'sentry',
               'service.version': expect.any(String),
               'telemetry.sdk.language': 'nodejs',

--- a/packages/node-experimental/test/sdk/client.test.ts
+++ b/packages/node-experimental/test/sdk/client.test.ts
@@ -43,10 +43,10 @@ describe('NodeClient', () => {
       stackParser: options.stackParser,
       _metadata: {
         sdk: {
-          name: 'sentry.javascript.node-experimental',
+          name: 'sentry.javascript.node',
           packages: [
             {
-              name: 'npm:@sentry/node-experimental',
+              name: 'npm:@sentry/node',
               version: SDK_VERSION,
             },
           ],


### PR DESCRIPTION
The SDK is now called `@sentry/node`!
