### PR TITLE
feat(core): Undeprecate setTransactionName

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -969,10 +969,6 @@ instead now.
 Instead, you can get the currently active span via `Sentry.getActiveSpan()`. Setting a span on the scope happens
 automatically when you use the new performance APIs `startSpan()` and `startSpanManual()`.
 
-## Deprecate `scope.setTransactionName()`
-
-Instead, either set this as attributes or tags, or use an event processor to set `event.transaction`.
-
 ## Deprecate `scope.getTransaction()` and `getActiveTransaction()`
 
 Instead, you should not rely on the active transaction, but just use `startSpan()` APIs, which handle this for you.

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -279,7 +279,6 @@ export class Scope implements ScopeInterface {
 
   /**
    * Sets the transaction name on the scope for future events.
-   * @deprecated Use extra or tags instead.
    */
   public setTransactionName(name?: string): this {
     this._transactionName = name;

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -128,7 +128,6 @@ export interface Scope {
 
   /**
    * Sets the transaction name on the scope for future events.
-   * @deprecated Use extra or tags instead.
    */
   setTransactionName(name?: string): this;
 


### PR DESCRIPTION
This was backported to v7 as part of https://github.com/getsentry/sentry-javascript/pull/10964