### PR TITLE
feat: Set required node version to >=14.18.0 for all packages

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,9 +20,9 @@ stable release of `8.x` comes out).
 
 ## 1. Version Support changes:
 
-**Node.js**: We now official support Node 14.8+ for our CJS package, and Node 18.8+ for our ESM package. This applies to
-`@sentry/node` and all of our node-based server-side sdks (`@sentry/nextjs`, `@sentry/serverless`, etc.). We no longer
-test against Node 8, 10, or 12 and cannot guarantee that the SDK will work as expected on these versions.
+**Node.js**: We now official support Node 14.18+ for our CJS package, and Node 18.8+ for our ESM package. This applies
+to `@sentry/node` and all of our node-based server-side sdks (`@sentry/nextjs`, `@sentry/serverless`, etc.). We no
+longer test against Node 8, 10, or 12 and cannot guarantee that the SDK will work as expected on these versions.
 
 **Browser**: Our browser SDKs (`@sentry/browser`, `@sentry/react`, `@sentry/vue`, etc.) now require ES2017+ compatible
 browsers. This means that we no longer support IE11 (end of an era). This also means that the Browser SDK requires the

--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "private": true,
   "scripts": {

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/package.json
@@ -30,7 +30,7 @@
     "typescript": "^5.0.4"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0-alpha.2",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "private": true,
   "main": "build/cjs/index.js",

--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "main": "build/bundles/sentry-angular.umd.js",
   "module": "build/fesm2015/sentry-angular.js",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "main": "build/bundles/sentry-angular.umd.js",
   "module": "build/fesm2015/sentry-angular.js",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/ember/README.md
+++ b/packages/ember/README.md
@@ -173,7 +173,7 @@ ENV['@sentry/ember'] = {
 ### Supported Versions
 
 * **Ember.js**: v4.0 or above
-* **Node**: v14.8 or above
+* **Node**: v14.18 or above
 
 ### Previous Integration
 

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -83,7 +83,7 @@
     "webpack": "~5.74.0"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "ember": {
     "edition": "octane"

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -12,7 +12,7 @@
     "sentry"
   ],
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "src"

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -12,7 +12,7 @@
     "sentry"
   ],
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "src"

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin"
   ],
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/integration-shims/package.json
+++ b/packages/integration-shims/package.json
@@ -44,7 +44,7 @@
     "@sentry/utils": "8.0.0-alpha.2"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "main": "build/cjs/index.server.js",
   "module": "build/esm/index.server.js",

--- a/packages/node-experimental/package.json
+++ b/packages/node-experimental/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -19,7 +19,7 @@
     "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -10,7 +10,7 @@
     "sentry-upload-sourcemaps": "scripts/sentry-upload-sourcemaps.js"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -39,6 +39,6 @@
     "@vanilla-extract/integration": "6.2.4"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   }
 }

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -65,7 +65,7 @@
     "@sentry/utils": "8.0.0-alpha.2"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/replay-worker/package.json
+++ b/packages/replay-worker/package.json
@@ -52,7 +52,7 @@
     "fflate": "0.8.1"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -66,7 +66,7 @@
     "@sentry/utils": "8.0.0-alpha.2"
   },
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/tracing-internal/package.json
+++ b/packages/tracing-internal/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=14.8"
+    "node": ">=14.18"
   },
   "files": [
     "cjs",


### PR DESCRIPTION
we would like to start using node protocol imports in the SDK to unblock https://github.com/getsentry/sentry-javascript/pull/10960 and https://github.com/getsentry/sentry-javascript/pull/10928

This requires us to have a minimum supported Node version of `14.18.0` as per https://2ality.com/2021/12/node-protocol-imports.html