### PR TITLE
fix(node): Export spotlightIntegration from OTEL node

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -85,6 +85,7 @@ export {
   prismaIntegration,
   hapiIntegration,
   setupHapiErrorHandler,
+  spotlightIntegration,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -21,6 +21,7 @@ export { nestIntegration } from './integrations/tracing/nest';
 export { postgresIntegration } from './integrations/tracing/postgres';
 export { prismaIntegration } from './integrations/tracing/prisma';
 export { hapiIntegration, setupHapiErrorHandler } from './integrations/tracing/hapi';
+export { spotlightIntegration } from './integrations/spotlight';
 
 export { init, getDefaultIntegrations } from './sdk/init';
 export { getAutoPerformanceIntegrations } from './integrations/tracing';


### PR DESCRIPTION
Unblocks converting more packages to using OpenTelemetry.