### PR TITLE
feat(v8/vercel-edge): Remove vercel-edge sdk deprecations

### DIFF
--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -21,8 +21,6 @@ export type { AddRequestDataToEventOptions } from '@sentry/utils';
 export type { VercelEdgeOptions } from './types';
 
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  addGlobalEventProcessor,
   addEventProcessor,
   addBreadcrumb,
   addIntegration,
@@ -32,22 +30,14 @@ export {
   close,
   createTransport,
   flush,
-  // eslint-disable-next-line deprecation/deprecation
-  getActiveTransaction,
-  // eslint-disable-next-line deprecation/deprecation
-  getCurrentHub,
   getClient,
   isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
   Hub,
-  // eslint-disable-next-line deprecation/deprecation
-  makeMain,
   setCurrentClient,
   Scope,
-  // eslint-disable-next-line deprecation/deprecation
-  startTransaction,
   SDK_VERSION,
   setContext,
   setExtra,
@@ -86,13 +76,5 @@ export {
   init,
 } from './sdk';
 
-import { RequestData } from '@sentry/core';
-
-import { WinterCGFetch } from './integrations/wintercg-fetch';
 export { winterCGFetchIntegration } from './integrations/wintercg-fetch';
 
-/** @deprecated Import the integration function directly, e.g. `inboundFiltersIntegration()` instead of `new Integrations.InboundFilter(). */
-export const Integrations = {
-  WinterCGFetch,
-  RequestData,
-};

--- a/packages/vercel-edge/src/integrations/wintercg-fetch.ts
+++ b/packages/vercel-edge/src/integrations/wintercg-fetch.ts
@@ -1,6 +1,5 @@
 import {
   addBreadcrumb,
-  convertIntegrationFnToClass,
   defineIntegration,
   getClient,
   instrumentFetchRequest,
@@ -11,8 +10,6 @@ import type {
   FetchBreadcrumbData,
   FetchBreadcrumbHint,
   HandlerDataFetch,
-  Integration,
-  IntegrationClass,
   IntegrationFn,
   Span,
 } from '@sentry/types';
@@ -117,23 +114,10 @@ const _winterCGFetch = ((options: Partial<Options> = {}) => {
   };
 }) satisfies IntegrationFn;
 
-export const winterCGFetchIntegration = defineIntegration(_winterCGFetch);
-
 /**
  * Creates spans and attaches tracing headers to fetch requests on WinterCG runtimes.
- *
- * @deprecated Use `winterCGFetchIntegration()` instead.
  */
-// eslint-disable-next-line deprecation/deprecation
-export const WinterCGFetch = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  winterCGFetchIntegration,
-) as IntegrationClass<Integration & { setupOnce: () => void }> & {
-  new (options?: Partial<Options>): Integration;
-};
-
-// eslint-disable-next-line deprecation/deprecation
-export type WinterCGFetch = typeof WinterCGFetch;
+export const winterCGFetchIntegration = defineIntegration(_winterCGFetch);
 
 function createBreadcrumb(handlerData: HandlerDataFetch): void {
   const { startTimestamp, endTimestamp } = handlerData;


### PR DESCRIPTION
Only keep around async local storage strategy code - tbd on what happens with that.

ref https://github.com/getsentry/sentry-javascript/issues/10100