### PR TITLE
feat(remix): Refactor to use new performance APIs

### DIFF
--- a/packages/remix/test/integration/common/routes/manual-tracing.$id.tsx
+++ b/packages/remix/test/integration/common/routes/manual-tracing.$id.tsx
@@ -1,7 +1,10 @@
 import * as Sentry from '@sentry/remix';
 
 export default function ManualTracing() {
-  const transaction = Sentry.startTransaction({ name: 'test_transaction_1' });
-  transaction.end();
+  const span = Sentry.startInactiveSpan({
+    name: 'test_transaction_1',
+    forceTransaction: true,
+  });
+  span.end();
   return <div />;
 }

--- a/packages/remix/test/integration/test/client/manualtracing.test.ts
+++ b/packages/remix/test/integration/test/client/manualtracing.test.ts
@@ -7,6 +7,7 @@ const useV2 = process.env.REMIX_VERSION === '2';
 test('should report a manually created / finished transaction.', async ({ page }) => {
   const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 2, {
     url: '/manual-tracing/0',
+    envelopeType: 'transaction',
   });
 
   const [manualTransactionEnvelope, pageloadEnvelope] = envelopes;


### PR DESCRIPTION
This removes all usage of `startTransaction` and `span.startChild()` in remix.

Instead, we now use `startSpan`, which works reasonably well as we always have callbacks anyhow.
I also updated it to use `continueTrace` for trace propagation.