### PR TITLE
ref(browser): Update `scope.transactionName` on pageload and navigation span creation

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/error/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/error/subject.js
@@ -1,0 +1,3 @@
+setTimeout(() => {
+  throw new Error('Error during pageload');
+}, 100);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/error/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/error/test.ts
@@ -1,0 +1,30 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+import { sentryTest } from '../../../../utils/fixtures';
+import { getMultipleSentryEnvelopeRequests, shouldSkipTracingTest } from '../../../../utils/helpers';
+
+sentryTest(
+  'should put the pageload transaction name onto an error event caught during pageload',
+  async ({ getLocalTestPath, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    await page.goto(url);
+
+    const [e1, e2] = await getMultipleSentryEnvelopeRequests<Event>(page, 2);
+
+    const pageloadTxnEvent = e1.type === 'transaction' ? e1 : e2;
+    const errorEvent = e1.type === 'transaction' ? e2 : e1;
+
+    expect(pageloadTxnEvent.contexts?.trace?.op).toEqual('pageload');
+    expect(pageloadTxnEvent.spans?.length).toBeGreaterThan(0);
+    expect(errorEvent.exception?.values?.[0]).toBeDefined();
+
+    expect(pageloadTxnEvent.transaction?.endsWith('index.html')).toBe(true);
+
+    expect(errorEvent.transaction).toEqual(pageloadTxnEvent.transaction);
+  },
+);

--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -364,6 +364,8 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
 export function startBrowserTracingPageLoadSpan(client: Client, spanOptions: StartSpanOptions): Span | undefined {
   client.emit('startPageLoadSpan', spanOptions);
 
+  getCurrentScope().setTransactionName(spanOptions.name);
+
   const span = getActiveSpan();
   const op = span && spanToJSON(span).op;
   return op === 'pageload' ? span : undefined;
@@ -375,6 +377,8 @@ export function startBrowserTracingPageLoadSpan(client: Client, spanOptions: Sta
  */
 export function startBrowserTracingNavigationSpan(client: Client, spanOptions: StartSpanOptions): Span | undefined {
   client.emit('startNavigationSpan', spanOptions);
+
+  getCurrentScope().setTransactionName(spanOptions.name);
 
   const span = getActiveSpan();
   const op = span && spanToJSON(span).op;

--- a/packages/tracing-internal/test/browser/browserTracingIntegration.test.ts
+++ b/packages/tracing-internal/test/browser/browserTracingIntegration.test.ts
@@ -374,6 +374,20 @@ describe('browserTracingIntegration', () => {
 
       expect(spanToJSON(pageloadSpan!).op).toBe('test op');
     });
+
+    it('sets the pageload span name on `scope.transactionName`', () => {
+      const client = new TestClient(
+        getDefaultClientOptions({
+          integrations: [browserTracingIntegration()],
+        }),
+      );
+      setCurrentClient(client);
+      client.init();
+
+      startBrowserTracingPageLoadSpan(client, { name: 'test pageload span' });
+
+      expect(getCurrentScope().getScopeData().transactionName).toBe('test pageload span');
+    });
   });
 
   it('sets source to "custom" if name is changed in beforeStartSpan', () => {
@@ -583,6 +597,20 @@ describe('browserTracingIntegration', () => {
 
       expect(spanToJSON(pageloadSpan!).description).toBe('changed');
       expect(spanToJSON(pageloadSpan!).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+    });
+
+    it('sets the pageload span name on `scope.transactionName`', () => {
+      const client = new TestClient(
+        getDefaultClientOptions({
+          integrations: [browserTracingIntegration()],
+        }),
+      );
+      setCurrentClient(client);
+      client.init();
+
+      startBrowserTracingPageLoadSpan(client, { name: 'test navigation span' });
+
+      expect(getCurrentScope().getScopeData().transactionName).toBe('test navigation span');
     });
   });
 


### PR DESCRIPTION
_Builds on top of https://github.com/getsentry/sentry-javascript/pull/10991_

This PR updates the transaction name on the scope in the default `browserTracingIntegration` and whenever `startBrowserTracingNavigationSpan` and `startBrowserTracingPageLoadSpan` are called from higher-level SDKs' integrations. 

In a follow-up PR, I'm going to make the same update in our individual `browserTracingIntegration`s whenever we have access to a parameterized transaction name.

ref https://github.com/getsentry/sentry-javascript/issues/10846
