### PR TITLE
feat(core): Allow custom tracing implementations

### DIFF
--- a/packages/core/src/asyncContext.ts
+++ b/packages/core/src/asyncContext.ts
@@ -1,6 +1,8 @@
 import type { Hub, Integration } from '@sentry/types';
 import type { Scope } from '@sentry/types';
 import { GLOBAL_OBJ } from '@sentry/utils';
+import type { startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from './tracing/trace';
+import type { getActiveSpan } from './utils/spanUtils';
 
 /**
  * @private Private API with no semver guarantees!
@@ -42,6 +44,24 @@ export interface AsyncContextStrategy {
    * Get the currently active isolation scope.
    */
   getIsolationScope: () => Scope;
+
+  // OPTIONAL: Custom tracing methods
+  // These are used so that we can provide OTEL-based implementations
+
+  /** Start an active span. */
+  startSpan?: typeof startSpan;
+
+  /** Start an inactive span. */
+  startInactiveSpan?: typeof startInactiveSpan;
+
+  /** Start an active manual span. */
+  startSpanManual?: typeof startSpanManual;
+
+  /** Get the currently active span. */
+  getActiveSpan?: typeof getActiveSpan;
+
+  /** Make a span the active span in the context of the callback. */
+  withActiveSpan?: typeof withActiveSpan;
 }
 
 /**

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -10,18 +10,16 @@ import type {
   FinishedCheckIn,
   MonitorConfig,
   Primitive,
-  Scope as ScopeInterface,
   Session,
   SessionContext,
   SeverityLevel,
-  Span,
   TransactionContext,
   User,
 } from '@sentry/types';
 import { GLOBAL_OBJ, isThenable, logger, timestampInSeconds, uuid4 } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from './constants';
-import { getClient, getCurrentScope, getIsolationScope, withScope } from './currentScopes';
+import { getClient, getCurrentScope, getIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { Hub } from './hub';
 import { getCurrentHub } from './hub';
@@ -124,23 +122,6 @@ export function setTag(key: string, value: Primitive): ReturnType<Hub['setTag']>
  */
 export function setUser(user: User | null): ReturnType<Hub['setUser']> {
   getIsolationScope().setUser(user);
-}
-
-/**
- * Forks the current scope and sets the provided span as active span in the context of the provided callback. Can be
- * passed `null` to start an entirely new span tree.
- *
- * @param span Spans started in the context of the provided callback will be children of this span. If `null` is passed,
- * spans started within the callback will not be attached to a parent span.
- * @param callback Execution context in which the provided span will be active. Is passed the newly forked scope.
- * @returns the value returned from the provided callback function.
- */
-export function withActiveSpan<T>(span: Span | null, callback: (scope: ScopeInterface) => T): T {
-  return withScope(scope => {
-    // eslint-disable-next-line deprecation/deprecation
-    scope.setSpan(span || undefined);
-    return callback(scope);
-  });
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,7 +29,6 @@ export {
   startSession,
   endSession,
   captureSession,
-  withActiveSpan,
   addEventProcessor,
 } from './exports';
 export {
@@ -93,6 +92,7 @@ export {
   getSpanDescendants,
   getStatusMessage,
   getRootSpan,
+  getActiveSpan,
 } from './utils/spanUtils';
 export { applySdkMetadata } from './utils/sdkMetadata';
 export { DEFAULT_ENVIRONMENT } from './constants';

--- a/packages/core/src/metrics/aggregator.ts
+++ b/packages/core/src/metrics/aggregator.ts
@@ -1,9 +1,9 @@
 import type { Client, MeasurementUnit, MetricsAggregator as MetricsAggregatorBase, Primitive } from '@sentry/types';
 import { timestampInSeconds } from '@sentry/utils';
+import { updateMetricSummaryOnActiveSpan } from '../utils/spanUtils';
 import { DEFAULT_FLUSH_INTERVAL, MAX_WEIGHT, NAME_AND_TAG_KEY_NORMALIZATION_REGEX, SET_METRIC_TYPE } from './constants';
 import { captureAggregateMetrics } from './envelope';
 import { METRIC_MAP } from './instance';
-import { updateMetricSummaryOnActiveSpan } from './metric-summary';
 import type { MetricBucket, MetricType } from './types';
 import { getBucketKey, sanitizeTags } from './utils';
 

--- a/packages/core/src/metrics/browser-aggregator.ts
+++ b/packages/core/src/metrics/browser-aggregator.ts
@@ -1,9 +1,9 @@
 import type { Client, MeasurementUnit, MetricsAggregator, Primitive } from '@sentry/types';
 import { timestampInSeconds } from '@sentry/utils';
+import { updateMetricSummaryOnActiveSpan } from '../utils/spanUtils';
 import { DEFAULT_BROWSER_FLUSH_INTERVAL, NAME_AND_TAG_KEY_NORMALIZATION_REGEX, SET_METRIC_TYPE } from './constants';
 import { captureAggregateMetrics } from './envelope';
 import { METRIC_MAP } from './instance';
-import { updateMetricSummaryOnActiveSpan } from './metric-summary';
 import type { MetricBucket, MetricType } from './types';
 import { getBucketKey, sanitizeTags } from './utils';
 

--- a/packages/core/src/tracing/errors.ts
+++ b/packages/core/src/tracing/errors.ts
@@ -5,9 +5,8 @@ import {
 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
-import { getRootSpan } from '../utils/spanUtils';
+import { getActiveSpan, getRootSpan } from '../utils/spanUtils';
 import { SPAN_STATUS_ERROR } from './spanstatus';
-import { getActiveSpan } from './utils';
 
 let errorsInstrumented = false;
 

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -5,11 +5,16 @@ import { getClient, getCurrentScope } from '../currentScopes';
 import { DEBUG_BUILD } from '../debug-build';
 import { SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON } from '../semanticAttributes';
 import { hasTracingEnabled } from '../utils/hasTracingEnabled';
-import { getSpanDescendants, removeChildSpanFromSpan, spanTimeInputToSeconds, spanToJSON } from '../utils/spanUtils';
+import {
+  getActiveSpan,
+  getSpanDescendants,
+  removeChildSpanFromSpan,
+  spanTimeInputToSeconds,
+  spanToJSON,
+} from '../utils/spanUtils';
 import { SentryNonRecordingSpan } from './sentryNonRecordingSpan';
 import { SPAN_STATUS_ERROR } from './spanstatus';
 import { startInactiveSpan } from './trace';
-import { getActiveSpan } from './utils';
 
 export const TRACING_DEFAULTS = {
   idleTimeout: 1_000,

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -4,7 +4,7 @@ export { SentrySpan } from './sentrySpan';
 export { SentryNonRecordingSpan } from './sentryNonRecordingSpan';
 export { Transaction } from './transaction';
 // eslint-disable-next-line deprecation/deprecation
-export { getActiveTransaction, getActiveSpan } from './utils';
+export { getActiveTransaction } from './utils';
 export {
   setHttpStatus,
   getSpanStatusFromHttpCode,
@@ -15,6 +15,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   continueTrace,
+  withActiveSpan,
 } from './trace';
 export { getDynamicSamplingContextFromClient, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 export { setMeasurement } from './measurement';

--- a/packages/core/src/tracing/measurement.ts
+++ b/packages/core/src/tracing/measurement.ts
@@ -1,7 +1,5 @@
 import type { MeasurementUnit, Span, Transaction } from '@sentry/types';
-import { getRootSpan } from '../utils/spanUtils';
-
-import { getActiveSpan } from './utils';
+import { getActiveSpan, getRootSpan } from '../utils/spanUtils';
 
 /**
  * Adds a measurement to the current active transaction.

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,7 +1,6 @@
 import type { Span, Transaction } from '@sentry/types';
 import type { Scope } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
-import { getCurrentScope } from '../currentScopes';
 
 import type { Hub } from '../hub';
 import { getCurrentHub } from '../hub';
@@ -22,14 +21,6 @@ export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T |
 
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';
-
-/**
- * Returns the currently active span.
- */
-export function getActiveSpan(): Span | undefined {
-  // eslint-disable-next-line deprecation/deprecation
-  return getCurrentScope().getSpan();
-}
 
 const SCOPE_ON_START_SPAN_FIELD = '_sentryScope';
 const ISOLATION_SCOPE_ON_START_SPAN_FIELD = '_sentryIsolationScope';

--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -1,20 +1,13 @@
 import type { Attachment, Breadcrumb, Client, Event, RequestSessionStatus } from '@sentry/types';
 import {
-  addTracingExtensions,
   applyScopeDataToEvent,
-  getActiveSpan,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  setCurrentClient,
   setGlobalScope,
-  spanToJSON,
-  startInactiveSpan,
-  startSpan,
   withIsolationScope,
 } from '../../src';
 
-import { withActiveSpan } from '../../src/exports';
 import { Scope } from '../../src/scope';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
@@ -933,51 +926,6 @@ describe('isolation scope', () => {
           expect(getIsolationScope()).toBe(scope2);
           done();
         });
-      });
-    });
-  });
-});
-
-describe('withActiveSpan()', () => {
-  beforeAll(() => {
-    addTracingExtensions();
-  });
-
-  beforeEach(() => {
-    const options = getDefaultTestClientOptions({ enableTracing: true });
-    const client = new TestClient(options);
-    setCurrentClient(client);
-    client.init();
-  });
-
-  it('should set the active span within the callback', () => {
-    expect.assertions(2);
-    const inactiveSpan = startInactiveSpan({ name: 'inactive-span' });
-
-    expect(getActiveSpan()).not.toBe(inactiveSpan);
-
-    withActiveSpan(inactiveSpan, () => {
-      expect(getActiveSpan()).toBe(inactiveSpan);
-    });
-  });
-
-  it('should create child spans when calling startSpan within the callback', () => {
-    const inactiveSpan = startInactiveSpan({ name: 'inactive-span' });
-
-    const parentSpanId = withActiveSpan(inactiveSpan, () => {
-      return startSpan({ name: 'child-span' }, childSpan => {
-        return spanToJSON(childSpan).parent_span_id;
-      });
-    });
-
-    expect(parentSpanId).toBe(inactiveSpan.spanContext().spanId);
-  });
-
-  it('when `null` is passed, no span should be active within the callback', () => {
-    expect.assertions(1);
-    startSpan({ name: 'parent-span' }, () => {
-      withActiveSpan(null, () => {
-        expect(getActiveSpan()).toBeUndefined();
       });
     });
   });

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -4,8 +4,12 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setCurrentClient,
 } from '../../../src';
-import { Transaction, getDynamicSamplingContextFromSpan, startInactiveSpan } from '../../../src/tracing';
-import { addTracingExtensions } from '../../../src/tracing';
+import {
+  Transaction,
+  addTracingExtensions,
+  getDynamicSamplingContextFromSpan,
+  startInactiveSpan,
+} from '../../../src/tracing';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 describe('getDynamicSamplingContextFromSpan', () => {

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -39,16 +39,9 @@ export { NodeClient } from './sdk/client';
 export { getCurrentHub } from './sdk/hub';
 export { cron } from './cron';
 
-export type { Span, NodeOptions } from './types';
+export type { NodeOptions } from './types';
 
-export {
-  startSpan,
-  startSpanManual,
-  startInactiveSpan,
-  getActiveSpan,
-  getRootSpan,
-  withActiveSpan,
-} from '@sentry/opentelemetry';
+export { getRootSpan } from '@sentry/opentelemetry';
 
 export {
   addRequestDataToEvent,
@@ -108,6 +101,11 @@ export {
   captureSession,
   endSession,
   addIntegration,
+  startSpan,
+  startSpanManual,
+  startInactiveSpan,
+  getActiveSpan,
+  withActiveSpan,
 } from '@sentry/core';
 
 export type {
@@ -126,4 +124,5 @@ export type {
   Thread,
   Transaction,
   User,
+  Span,
 } from '@sentry/types';

--- a/packages/node-experimental/src/types.ts
+++ b/packages/node-experimental/src/types.ts
@@ -1,6 +1,6 @@
 import type { Span as WriteableSpan } from '@opentelemetry/api';
-import type { ReadableSpan, Span } from '@opentelemetry/sdk-trace-base';
-import type { ClientOptions, Options, SamplingContext, Scope, TracePropagationTargets } from '@sentry/types';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import type { ClientOptions, Options, SamplingContext, Scope, Span, TracePropagationTargets } from '@sentry/types';
 
 import type { NodeTransportOptions } from './transports';
 
@@ -104,6 +104,4 @@ export interface CurrentScopes {
  * Note that technically, the `Span` exported from `@opentelemwetry/sdk-trace-base` matches this,
  * but we cannot be 100% sure that we are actually getting such a span, so this type is more defensive.
  */
-export type AbstractSpan = WriteableSpan | ReadableSpan;
-
-export type { Span };
+export type AbstractSpan = WriteableSpan | ReadableSpan | Span;

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,5 +1,6 @@
 import * as api from '@opentelemetry/api';
 import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
+import type { withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
 import type { Hub, Scope } from '@sentry/types';
 
 import {
@@ -8,8 +9,10 @@ import {
   SENTRY_FORK_SET_SCOPE_CONTEXT_KEY,
 } from './constants';
 import { getCurrentHub as _getCurrentHub } from './custom/getCurrentHub';
+import { startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from './trace';
 import type { CurrentScopes } from './types';
 import { getScopesFromContext } from './utils/contextData';
+import { getActiveSpan } from './utils/getActiveSpan';
 
 /**
  * Sets the async context strategy to use follow the OTEL context under the hood.
@@ -112,5 +115,12 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     withIsolationScope,
     getCurrentScope,
     getIsolationScope,
+    startSpan,
+    startSpanManual,
+    startInactiveSpan,
+    getActiveSpan,
+    // The types here don't fully align, because our own `Span` type is narrower
+    // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
+    withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,
   });
 }

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -64,7 +64,10 @@ export function startSpan<T>(options: OpenTelemetrySpanContext, callback: (span:
  *
  * Note that you'll always get a span passed to the callback, it may just be a NonRecordingSpan if the span is not sampled.
  */
-export function startSpanManual<T>(options: OpenTelemetrySpanContext, callback: (span: Span) => T): T {
+export function startSpanManual<T>(
+  options: OpenTelemetrySpanContext,
+  callback: (span: Span, finish: () => void) => T,
+): T {
   const tracer = getTracer();
 
   const { name } = options;
@@ -79,7 +82,7 @@ export function startSpanManual<T>(options: OpenTelemetrySpanContext, callback: 
     _applySentryAttributesToSpan(span, options);
 
     return handleCallbackErrors(
-      () => callback(span),
+      () => callback(span, () => span.end()),
       () => {
         span.setStatus({ code: SpanStatusCode.ERROR });
       },

--- a/packages/opentelemetry/src/types.ts
+++ b/packages/opentelemetry/src/types.ts
@@ -1,6 +1,6 @@
 import type { Span as WriteableSpan, SpanKind, Tracer } from '@opentelemetry/api';
-import type { BasicTracerProvider, ReadableSpan, Span } from '@opentelemetry/sdk-trace-base';
-import type { Scope, StartSpanOptions } from '@sentry/types';
+import type { BasicTracerProvider, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import type { Scope, Span, StartSpanOptions } from '@sentry/types';
 
 export interface OpenTelemetryClient {
   tracer: Tracer;
@@ -21,9 +21,7 @@ export interface OpenTelemetrySpanContext extends StartSpanOptions {
  * Note that technically, the `Span` exported from `@opentelemwetry/sdk-trace-base` matches this,
  * but we cannot be 100% sure that we are actually getting such a span, so this type is more defensive.
  */
-export type AbstractSpan = WriteableSpan | ReadableSpan;
-
-export type { Span };
+export type AbstractSpan = WriteableSpan | ReadableSpan | Span;
 
 export interface CurrentScopes {
   scope: Scope;

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -61,6 +61,44 @@ type TraceFlagNone = 0;
 type TraceFlagSampled = 1;
 export type TraceFlag = TraceFlagNone | TraceFlagSampled;
 
+export interface TraceState {
+  /**
+   * Create a new TraceState which inherits from this TraceState and has the
+   * given key set.
+   * The new entry will always be added in the front of the list of states.
+   *
+   * @param key key of the TraceState entry.
+   * @param value value of the TraceState entry.
+   */
+  set(key: string, value: string): TraceState;
+  /**
+   * Return a new TraceState which inherits from this TraceState but does not
+   * contain the given key.
+   *
+   * @param key the key for the TraceState entry to be removed.
+   */
+  unset(key: string): TraceState;
+  /**
+   * Returns the value to which the specified key is mapped, or `undefined` if
+   * this map contains no mapping for the key.
+   *
+   * @param key with which the specified value is to be associated.
+   * @returns the value to which the specified key is mapped, or `undefined` if
+   *     this map contains no mapping for the key.
+   */
+  get(key: string): string | undefined;
+  /**
+   * Serializes the TraceState to a `list` as defined below. The `list` is a
+   * series of `list-members` separated by commas `,`, and a list-member is a
+   * key/value pair separated by an equals sign `=`. Spaces and horizontal tabs
+   * surrounding `list-members` are ignored. There can be a maximum of 32
+   * `list-members` in a `list`.
+   *
+   * @returns the serialized string.
+   */
+  serialize(): string;
+}
+
 export interface SpanContextData {
   /**
    * The ID of the trace that this span belongs to. It is worldwide unique
@@ -80,7 +118,7 @@ export interface SpanContextData {
   /**
    * Only true if the SpanContext was propagated from a remote parent.
    */
-  isRemote?: boolean;
+  isRemote?: boolean | undefined;
 
   /**
    * Trace flags to propagate.
@@ -89,11 +127,11 @@ export interface SpanContextData {
    * sampled or not. When set, the least significant bit documents that the
    * caller may have recorded trace data. A caller who does not record trace
    * data out-of-band leaves this flag unset.
-   * We allow number here because otel also does, so we can't be stricter than them.
    */
   traceFlags: TraceFlag | number;
 
-  // Note: we do not have traceState here, but this is optional in OpenTelemetry anyhow
+  /** In OpenTelemetry, this can be used to store trace state, which are basically key-value pairs. */
+  traceState?: TraceState | undefined;
 }
 
 /**


### PR DESCRIPTION
And do this for opentelemetry, instead of relying on extra exports.

Also needed to move things around a bit to avoid circular dependency build issues.

Missing is `getRootSpan` which is still different, I will update this in a follow up to actually use the same non-enumerable property under the hood so we can use the same implementation there!

## Reasoning

Until now, we had a core implementation of tracing APIs in `@sentry/core`. In `@sentry/opentelemetry`, we had some alternative implementations, which where instead re-exported in `@sentry/node` - so if you do e.g. this:

```js
import { startSpan } from '@sentry/node';
```

You'll get the correct, OTEL-powered performance API - great!

However, if any code would internally do e.g. this:

```js
import { getActiveSpan } from '@sentry/core'; // import from core, not node
```

It would not work, because it would use the non-OTEL-powered API. 

This PR addresses this by ensuring we use the same API everywhere when `@sentry/node` is being used.