### PR TITLE
fix(nextjs): Use passthrough `createReduxEnhancer` on server

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/package.json
@@ -13,17 +13,17 @@
     "test:assert": "pnpm test:prod && pnpm test:dev"
   },
   "dependencies": {
+    "@playwright/test": "^1.27.1",
     "@sentry/nextjs": "latest || *",
     "@types/node": "18.11.17",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
-    "next": "14.0.4",
+    "next": "14.1.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "4.9.5",
-    "wait-port": "1.0.4",
     "ts-node": "10.9.1",
-    "@playwright/test": "^1.27.1"
+    "typescript": "4.9.5",
+    "wait-port": "1.0.4"
   },
   "devDependencies": {
     "@sentry/types": "latest || *",

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -30,6 +30,7 @@ export declare const defaultStackParser: StackParser;
 export declare function getSentryRelease(fallback?: string): string | undefined;
 
 export declare const ErrorBoundary: typeof clientSdk.ErrorBoundary;
+export declare const createReduxEnhancer: typeof clientSdk.createReduxEnhancer;
 export declare const showReportDialog: typeof clientSdk.showReportDialog;
 export declare const withErrorBoundary: typeof clientSdk.withErrorBoundary;
 

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -16,7 +16,6 @@ import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegrati
 import { Http } from './httpIntegration';
 import { OnUncaughtException } from './onUncaughtExceptionIntegration';
 
-export { createReduxEnhancer } from '@sentry/react';
 export * from '@sentry/node-experimental';
 export { captureUnderscoreErrorException } from '../common/_error';
 
@@ -46,6 +45,13 @@ export const ErrorBoundary = (props: React.PropsWithChildren<unknown>): React.Re
   // since Next.js >= 10 requires React ^16.6.0 we are allowed to return children like this here
   return props.children as React.ReactNode;
 };
+
+/**
+ * A passthrough redux enhancer for the server that doesn't depend on anything from the `@sentry/react` package.
+ */
+export function createReduxEnhancer() {
+  return (createStore: unknown) => createStore;
+}
 
 /**
  * A passthrough error boundary wrapper for the server that doesn't depend on any react. Error boundaries don't catch


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/10366