### PR TITLE
ref(core): Remove `startTransaction` & `finishTransaction` hooks

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -418,12 +418,6 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   /* eslint-disable @typescript-eslint/unified-signatures */
 
   /** @inheritdoc */
-  public on(hook: 'startTransaction', callback: (transaction: Transaction) => void): void;
-
-  /** @inheritdoc */
-  public on(hook: 'finishTransaction', callback: (transaction: Transaction) => void): void;
-
-  /** @inheritdoc */
   public on(hook: 'spanStart', callback: (span: Span) => void): void;
 
   /** @inheritdoc */
@@ -475,12 +469,6 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     // @ts-expect-error We assue the types are correct
     this._hooks[hook].push(callback);
   }
-
-  /** @inheritdoc */
-  public emit(hook: 'startTransaction', transaction: Transaction): void;
-
-  /** @inheritdoc */
-  public emit(hook: 'finishTransaction', transaction: Transaction): void;
 
   /** @inheritdoc */
   public emit(hook: 'spanStart', span: Span): void;

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -24,7 +24,6 @@ import type {
   SeverityLevel,
   Span,
   StartSpanOptions,
-  Transaction,
   TransactionEvent,
   Transport,
   TransportMakeRequestResponse,

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -416,7 +416,6 @@ function _startTransaction(transactionContext: TransactionContext): Transaction 
     },
   });
   if (client) {
-    client.emit('startTransaction', transaction);
     client.emit('spanStart', transaction);
   }
   return transaction;

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -224,9 +224,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
 
     // eslint-disable-next-line deprecation/deprecation
     const client = this._hub.getClient();
-    if (client) {
-      client.emit('finishTransaction', this);
-    }
 
     if (this._sampled !== true) {
       // At this point if `sampled !== true` we want to discard the transaction.

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,4 +1,4 @@
-import type { Client, Envelope, Event, Transaction } from '@sentry/types';
+import type { Client, Envelope, Event } from '@sentry/types';
 import { SentryError, SyncPromise, dsnToString, logger } from '@sentry/utils';
 
 import {

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1935,20 +1935,6 @@ describe('BaseClient', () => {
     ] as const;
 
     describe.each(scenarios)('with client %s', (_, client) => {
-      it('should call a startTransaction hook', () => {
-        expect.assertions(1);
-
-        const mockTransaction = {
-          traceId: '86f39e84263a4de99c326acab3bfe3bd',
-        } as Transaction;
-
-        client.on('startTransaction', transaction => {
-          expect(transaction).toEqual(mockTransaction);
-        });
-
-        client.emit('startTransaction', mockTransaction);
-      });
-
       it('should call a beforeEnvelope hook', () => {
         expect.assertions(1);
 

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -23,7 +23,7 @@ import {
   withActiveSpan,
 } from '../../../src/tracing';
 import { SentryNonRecordingSpan } from '../../../src/tracing/sentryNonRecordingSpan';
-import { getActiveSpan, getSpanDescendants } from '../../../src/utils/spanUtils';
+import { getActiveSpan, getRootSpan, getSpanDescendants } from '../../../src/utils/spanUtils';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 beforeAll(() => {
@@ -84,8 +84,8 @@ describe('startSpan', () => {
 
     it('creates a transaction', async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', transaction => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        _span = span;
       });
       try {
         await startSpan({ name: 'GET users/[id]' }, () => {
@@ -102,8 +102,8 @@ describe('startSpan', () => {
 
     it('allows traceparent information to be overriden', async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', transaction => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        _span = span;
       });
       try {
         await startSpan(
@@ -129,8 +129,8 @@ describe('startSpan', () => {
 
     it('allows for transaction to be mutated', async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', transaction => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        _span = span;
       });
       try {
         await startSpan({ name: 'GET users/[id]' }, span => {
@@ -146,8 +146,10 @@ describe('startSpan', () => {
 
     it('creates a span with correct description', async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', transaction => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        if (span === getRootSpan(span)) {
+          _span = span;
+        }
       });
       try {
         await startSpan({ name: 'GET users/[id]', parentSampled: true }, () => {
@@ -170,8 +172,10 @@ describe('startSpan', () => {
 
     it('allows for span to be mutated', async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', transaction => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        if (span === getRootSpan(span)) {
+          _span = span;
+        }
       });
       try {
         await startSpan({ name: 'GET users/[id]', parentSampled: true }, () => {
@@ -200,8 +204,8 @@ describe('startSpan', () => {
       { origin: 'manual', attributes: { 'sentry.origin': 'auto.http.browser' } },
     ])('correctly sets the span origin', async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', transaction => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        _span = span;
       });
       try {
         await startSpan({ name: 'GET users/[id]', origin: 'auto.http.browser' }, () => {

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -5,11 +5,10 @@ import {
   captureException,
   getActiveSpan,
   getClient,
-  getCurrentScope,
   getRootSpan,
   spanToJSON,
 } from '@sentry/core';
-import type { ReplayRecordingMode, Span, Transaction } from '@sentry/types';
+import type { ReplayRecordingMode, Span } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import {

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -3,11 +3,13 @@ import { EventType, record } from '@sentry-internal/rrweb';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   captureException,
+  getActiveSpan,
   getClient,
   getCurrentScope,
+  getRootSpan,
   spanToJSON,
 } from '@sentry/core';
-import type { ReplayRecordingMode, Transaction } from '@sentry/types';
+import type { ReplayRecordingMode, Span, Transaction } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import {
@@ -87,10 +89,10 @@ export class ReplayContainer implements ReplayContainerInterface {
   public recordingMode: ReplayRecordingMode;
 
   /**
-   * The current or last active transcation.
+   * The current or last active span.
    * This is only available when performance is enabled.
    */
-  public lastTransaction?: Transaction;
+  public lastActiveSpan?: Span;
 
   /**
    * These are here so we can overwrite them in tests etc.
@@ -720,16 +722,16 @@ export class ReplayContainer implements ReplayContainerInterface {
    * This is only available if performance is enabled, and if an instrumented router is used.
    */
   public getCurrentRoute(): string | undefined {
-    // eslint-disable-next-line deprecation/deprecation
-    const lastTransaction = this.lastTransaction || getCurrentScope().getTransaction();
+    const lastActiveSpan = this.lastActiveSpan || getActiveSpan();
+    const lastRootSpan = lastActiveSpan && getRootSpan(lastActiveSpan);
 
-    const attributes = (lastTransaction && spanToJSON(lastTransaction).data) || {};
+    const attributes = (lastRootSpan && spanToJSON(lastRootSpan).data) || {};
     const source = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
-    if (!lastTransaction || !source || !['route', 'custom'].includes(source)) {
+    if (!lastRootSpan || !source || !['route', 'custom'].includes(source)) {
       return undefined;
     }
 
-    return spanToJSON(lastTransaction).description;
+    return spanToJSON(lastRootSpan).description;
   }
 
   /**

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -6,7 +6,7 @@ import type {
   ReplayRecordingData,
   ReplayRecordingMode,
   SentryWrappedXMLHttpRequest,
-  Transaction,
+  Span,
   XhrBreadcrumbHint,
 } from '@sentry/types';
 
@@ -478,7 +478,7 @@ export interface ReplayContainer {
   session: Session | undefined;
   recordingMode: ReplayRecordingMode;
   timeouts: Timeouts;
-  lastTransaction?: Transaction;
+  lastActiveSpan?: Span;
   throttledAddEvent: (
     event: RecordingEvent,
     isCheckout?: boolean,

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -44,14 +44,14 @@ export function addGlobalListeners(replay: ReplayContainer): void {
       }
     });
 
-    client.on('startTransaction', transaction => {
-      replay.lastTransaction = transaction;
+    client.on('spanStart', span => {
+      replay.lastActiveSpan = span;
     });
 
-    // We may be missing the initial startTransaction due to timing issues,
+    // We may be missing the initial spanStart due to timing issues,
     // so we capture it on finish again.
-    client.on('finishTransaction', transaction => {
-      replay.lastTransaction = transaction;
+    client.on('spanEnd', span => {
+      replay.lastActiveSpan = span;
     });
 
     // We want to flush replay

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@sentry/core';
 import { NodeClient, setCurrentClient } from '@sentry/node-experimental';
 import * as SentryNode from '@sentry/node-experimental';
-import type { Span, Transaction } from '@sentry/types';
+import type { Span } from '@sentry/types';
 import type { Handle } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
 import { vi } from 'vitest';

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -1,6 +1,7 @@
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   addTracingExtensions,
+  getRootSpan,
   getSpanDescendants,
   spanIsSampled,
   spanToJSON,
@@ -124,8 +125,10 @@ describe('handleSentry', () => {
 
     it("creates a transaction if there's no active span", async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', (transaction: Transaction) => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        if (span === getRootSpan(span)) {
+          _span = span;
+        }
       });
 
       try {
@@ -150,9 +153,11 @@ describe('handleSentry', () => {
     it('creates a child span for nested server calls (i.e. if there is an active span)', async () => {
       let _span: Span | undefined = undefined;
       let txnCount = 0;
-      client.on('finishTransaction', (transaction: Transaction) => {
-        _span = transaction;
-        ++txnCount;
+      client.on('spanEnd', span => {
+        if (span === getRootSpan(span)) {
+          _span = span;
+          ++txnCount;
+        }
       });
 
       try {
@@ -208,8 +213,10 @@ describe('handleSentry', () => {
       });
 
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', (transaction: Transaction) => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        if (span === getRootSpan(span)) {
+          _span = span;
+        }
       });
 
       try {
@@ -248,8 +255,10 @@ describe('handleSentry', () => {
       });
 
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', (transaction: Transaction) => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        if (span === getRootSpan(span)) {
+          _span = span;
+        }
       });
 
       try {
@@ -312,8 +321,10 @@ describe('handleSentry', () => {
 
     it("doesn't create a transaction if there's no route", async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', (transaction: Transaction) => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        if (span === getRootSpan(span)) {
+          _span = span;
+        }
       });
 
       try {
@@ -327,8 +338,10 @@ describe('handleSentry', () => {
 
     it("Creates a transaction if there's no route but `handleUnknownRequests` is true", async () => {
       let _span: Span | undefined = undefined;
-      client.on('finishTransaction', (transaction: Transaction) => {
-        _span = transaction;
+      client.on('spanEnd', span => {
+        if (span === getRootSpan(span)) {
+          _span = span;
+        }
       });
 
       try {

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -16,7 +16,6 @@ import type { Session, SessionAggregates } from './session';
 import type { SeverityLevel } from './severity';
 import type { Span } from './span';
 import type { StartSpanOptions } from './startSpanOptions';
-import type { Transaction } from './transaction';
 import type { Transport, TransportMakeRequestResponse } from './transport';
 
 /**

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -186,18 +186,6 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   /* eslint-disable @typescript-eslint/unified-signatures */
 
   /**
-   * Register a callback for transaction start.
-   * Receives the transaction as argument.
-   */
-  on(hook: 'startTransaction', callback: (transaction: Transaction) => void): void;
-
-  /**
-   * Register a callback for transaction finish.
-   * Receives the transaction as argument.
-   */
-  on(hook: 'finishTransaction', callback: (transaction: Transaction) => void): void;
-
-  /**
    * Register a callback for whenever a span is started.
    * Receives the span as argument.
    */
@@ -277,18 +265,6 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * A hook that is called when the client is closing
    */
   on(hook: 'close', callback: () => void): void;
-
-  /**
-   * Fire a hook event for transaction start.
-   * Expects to be given a transaction as the second argument.
-   */
-  emit(hook: 'startTransaction', transaction: Transaction): void;
-
-  /**
-   * Fire a hook event for transaction finish.
-   * Expects to be given a transaction as the second argument.
-   */
-  emit(hook: 'finishTransaction', transaction: Transaction): void;
 
   /** Fire a hook whener a span starts. */
   emit(hook: 'spanStart', span: Span): void;


### PR DESCRIPTION
This refactors the remaining usage of `startTransaction` and `finishTransaction` hooks (most of it in tests), and removes these hooks.

This is on top of https://github.com/getsentry/sentry-javascript/pull/11007