### PR TITLE
ref(nextjs): Remove last internal deprecations

### DIFF
--- a/packages/nextjs/src/edge/rewriteFramesIntegration.ts
+++ b/packages/nextjs/src/edge/rewriteFramesIntegration.ts
@@ -37,11 +37,7 @@ export const customRewriteFramesIntegration = ((options?: RewriteFramesOptions) 
 
   // Do nothing if we can't find a distDirName
   return {
-    // eslint-disable-next-line deprecation/deprecation
     name: 'RewriteFrames',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    setupOnce: () => {},
-    processEvent: event => event,
   };
 }) satisfies IntegrationFn;
 

--- a/packages/nextjs/src/server/rewriteFramesIntegration.ts
+++ b/packages/nextjs/src/server/rewriteFramesIntegration.ts
@@ -37,11 +37,7 @@ export const customRewriteFramesIntegration = ((options?: RewriteFramesOptions) 
 
   // Do nothing if we can't find a distDirName
   return {
-    // eslint-disable-next-line deprecation/deprecation
     name: 'RewriteFrames',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    setupOnce: () => {},
-    processEvent: event => event,
   };
 }) satisfies IntegrationFn;
 

--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -91,10 +91,9 @@ describe('Client init()', () => {
     const transportSend = jest.spyOn(getClient()!.getTransport()!, 'send');
 
     // Ensure we have no current span, so our next span is a transaction
-    // eslint-disable-next-line deprecation/deprecation
-    getCurrentScope().setSpan(undefined);
-
-    SentryReact.startInactiveSpan({ name: '/404' })?.end();
+    SentryReact.withActiveSpan(null, () => {
+      SentryReact.startInactiveSpan({ name: '/404' })?.end();
+    });
 
     expect(transportSend).not.toHaveBeenCalled();
     expect(captureEvent.mock.results[0].value).toBeUndefined();


### PR DESCRIPTION
Removes the last internally used deprecated APIs (that are ignored with an eslint comment at least)