### PR TITLE
ref(opentelemetry): Remove span metadata handling

### DIFF
--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -1,11 +1,11 @@
-import type { ClientRequest, ServerResponse } from 'http';
+import type { ServerResponse } from 'http';
 import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 
 import { addBreadcrumb, defineIntegration, getIsolationScope, isSentryRequestUrl } from '@sentry/core';
-import { _INTERNAL, getClient, getSpanKind, setSpanMetadata } from '@sentry/opentelemetry';
+import { _INTERNAL, getClient, getSpanKind } from '@sentry/opentelemetry';
 import type { IntegrationFn } from '@sentry/types';
 
 import type { NodeClient } from '../sdk/client';
@@ -81,7 +81,7 @@ const _httpIntegration = ((options: HttpOptions = {}) => {
           requireParentforOutgoingSpans: true,
           requireParentforIncomingSpans: false,
           requestHook: (span, req) => {
-            _updateSpan(span, req);
+            _updateSpan(span);
 
             // Update the isolation scope, isolate this request
             if (getSpanKind(span) === SpanKind.SERVER) {
@@ -124,12 +124,8 @@ const _httpIntegration = ((options: HttpOptions = {}) => {
 export const httpIntegration = defineIntegration(_httpIntegration);
 
 /** Update the span with data we need. */
-function _updateSpan(span: Span, request: ClientRequest | HTTPModuleRequestIncomingMessage): void {
+function _updateSpan(span: Span): void {
   addOriginToSpan(span, 'auto.http.otel.http');
-
-  if (getSpanKind(span) === SpanKind.SERVER) {
-    setSpanMetadata(span, { request: request as HTTPModuleRequestIncomingMessage });
-  }
 }
 
 /** Add a breadcrumb for outgoing requests. */

--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -37,7 +37,6 @@ describe('Integration | Transactions', () => {
         op: 'test op',
         name: 'test name',
         origin: 'auto.test',
-        metadata: { requestPath: 'test-path' },
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
         },
@@ -109,7 +108,6 @@ describe('Integration | Transactions', () => {
     });
 
     expect(transaction.sdkProcessingMetadata?.sampleRate).toEqual(1);
-    expect(transaction.sdkProcessingMetadata?.requestPath).toEqual('test-path');
     expect(transaction.sdkProcessingMetadata?.dynamicSamplingContext).toEqual({
       environment: 'production',
       public_key: expect.any(String),

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -7,9 +7,7 @@ export { wrapClientClass } from './custom/client';
 
 export { getSpanKind } from './utils/getSpanKind';
 export {
-  getSpanMetadata,
   getSpanParent,
-  setSpanMetadata,
   getSpanScopes,
 } from './utils/spanData';
 

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -24,7 +24,7 @@ import type { SpanNode } from './utils/groupSpansWithParents';
 import { groupSpansWithParents } from './utils/groupSpansWithParents';
 import { mapStatus } from './utils/mapStatus';
 import { parseSpanDescription } from './utils/parseSpanDescription';
-import { getSpanMetadata, getSpanScopes } from './utils/spanData';
+import { getSpanScopes } from './utils/spanData';
 
 type SpanNodeCompleted = SpanNode & { span: ReadableSpan };
 
@@ -153,7 +153,6 @@ function parseSpan(span: ReadableSpan): { op?: string; origin?: SpanOrigin; sour
 
 function createTransactionForOtelSpan(span: ReadableSpan): TransactionEvent {
   const { op, description, data, origin = 'manual', source } = getSpanData(span);
-  const metadata = getSpanMetadata(span);
   const capturedSpanScopes = getSpanScopes(span);
 
   const sampleRate = span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] as number | undefined;
@@ -197,11 +196,10 @@ function createTransactionForOtelSpan(span: ReadableSpan): TransactionEvent {
     transaction: description,
     type: 'transaction',
     sdkProcessingMetadata: {
-      sampleRate,
-      ...metadata,
-      capturedSpanScope: capturedSpanScopes?.scope,
-      capturedSpanIsolationScope: capturedSpanScopes?.isolationScope,
       ...dropUndefinedKeys({
+        capturedSpanScope: capturedSpanScopes?.scope,
+        capturedSpanIsolationScope: capturedSpanScopes?.isolationScope,
+        sampleRate,
         dynamicSamplingContext: getDynamicSamplingContextFromSpan(span),
       }),
     },

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -20,7 +20,6 @@ import { SENTRY_TRACE_STATE_DSC } from './constants';
 import type { OpenTelemetryClient, OpenTelemetrySpanContext } from './types';
 import { getContextFromScope } from './utils/contextData';
 import { getDynamicSamplingContextFromSpan } from './utils/dynamicSamplingContext';
-import { setSpanMetadata } from './utils/spanData';
 
 /**
  * Wraps a function with a transaction/span and finishes the span after the function is done.
@@ -144,7 +143,7 @@ function getTracer(): Tracer {
 
 function _applySentryAttributesToSpan(span: Span, options: OpenTelemetrySpanContext): void {
   // eslint-disable-next-line deprecation/deprecation
-  const { origin, op, source, metadata } = options;
+  const { origin, op, source } = options;
 
   if (origin) {
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
@@ -156,10 +155,6 @@ function _applySentryAttributesToSpan(span: Span, options: OpenTelemetrySpanCont
 
   if (source) {
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
-  }
-
-  if (metadata) {
-    setSpanMetadata(span, metadata);
   }
 }
 

--- a/packages/opentelemetry/src/utils/spanData.ts
+++ b/packages/opentelemetry/src/utils/spanData.ts
@@ -1,5 +1,5 @@
 import type { Span } from '@opentelemetry/api';
-import type { Scope, TransactionMetadata } from '@sentry/types';
+import type { Scope } from '@sentry/types';
 
 import type { AbstractSpan } from '../types';
 
@@ -14,7 +14,6 @@ const SpanScopes = new WeakMap<
   }
 >();
 const SpanParent = new WeakMap<AbstractSpan, Span>();
-const SpanMetadata = new WeakMap<AbstractSpan, Partial<TransactionMetadata>>();
 
 /** Set the parent OTEL span on an OTEL span. */
 export function setSpanParent(span: AbstractSpan, parentSpan: Span): void {
@@ -24,16 +23,6 @@ export function setSpanParent(span: AbstractSpan, parentSpan: Span): void {
 /** Get the parent OTEL span of an OTEL span. */
 export function getSpanParent(span: AbstractSpan): Span | undefined {
   return SpanParent.get(span);
-}
-
-/** Set metadata for an OTEL span. */
-export function setSpanMetadata(span: AbstractSpan, metadata: Partial<TransactionMetadata>): void {
-  SpanMetadata.set(span, metadata);
-}
-
-/** Get metadata for an OTEL span. */
-export function getSpanMetadata(span: AbstractSpan): Partial<TransactionMetadata> | undefined {
-  return SpanMetadata.get(span);
 }
 
 /**

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -43,7 +43,6 @@ describe('Integration | Transactions', () => {
         op: 'test op',
         name: 'test name',
         origin: 'auto.test',
-        metadata: { requestPath: 'test-path' },
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
         },
@@ -115,7 +114,6 @@ describe('Integration | Transactions', () => {
     });
 
     expect(transaction.sdkProcessingMetadata?.sampleRate).toEqual(1);
-    expect(transaction.sdkProcessingMetadata?.requestPath).toEqual('test-path');
     expect(transaction.sdkProcessingMetadata?.dynamicSamplingContext).toEqual({
       environment: 'production',
       public_key: expect.any(String),

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -20,7 +20,6 @@ import { startInactiveSpan, startSpan, startSpanManual } from '../src/trace';
 import type { AbstractSpan } from '../src/types';
 import { getActiveSpan } from '../src/utils/getActiveSpan';
 import { getSpanKind } from '../src/utils/getSpanKind';
-import { getSpanMetadata } from '../src/utils/spanData';
 import { spanHasAttributes, spanHasName } from '../src/utils/spanTypes';
 import { cleanupOtel, mockSdkInit } from './helpers/mockSdkInit';
 
@@ -216,8 +215,6 @@ describe('trace', () => {
           expect(getSpanAttributes(span)).toEqual({
             [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           });
-
-          expect(getSpanMetadata(span)).toEqual(undefined);
         },
       );
 
@@ -226,7 +223,6 @@ describe('trace', () => {
           name: 'outer',
           op: 'my-op',
           origin: 'auto.test.origin',
-          metadata: { requestPath: 'test-path' },
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
           },
@@ -239,8 +235,6 @@ describe('trace', () => {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'my-op',
             [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           });
-
-          expect(getSpanMetadata(span)).toEqual({ requestPath: 'test-path' });
         },
       );
     });
@@ -478,8 +472,6 @@ describe('trace', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
       });
 
-      expect(getSpanMetadata(span)).toEqual(undefined);
-
       const span2 = startInactiveSpan({
         name: 'outer',
         op: 'my-op',
@@ -497,8 +489,6 @@ describe('trace', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test.origin',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'my-op',
       });
-
-      expect(getSpanMetadata(span2)).toEqual({ requestPath: 'test-path' });
     });
 
     it('allows to pass base SpanOptions', () => {


### PR DESCRIPTION
This is not used anymore (and deprecated), so we can remove the custom handling for this.

We put the request on the isolation scope, where it should be picked up anyhow.