### PR TITLE
ref(feedback): Move UserFeedback type into feedback.ts

### DIFF
--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -3,12 +3,12 @@ import type { ClientReport } from './clientreport';
 import type { DsnComponents } from './dsn';
 import type { Event } from './event';
 import type { FeedbackEvent } from './feedback';
+import type { UserFeedback } from './feedback';
 import type { Profile } from './profiling';
 import type { ReplayEvent, ReplayRecordingData } from './replay';
 import type { SdkInfo } from './sdkinfo';
 import type { SerializedSession, Session, SessionAggregates } from './session';
 import type { Transaction } from './transaction';
-import type { UserFeedback } from './user';
 
 // Based on: https://develop.sentry.dev/sdk/envelopes/
 

--- a/packages/types/src/feedback.ts
+++ b/packages/types/src/feedback.ts
@@ -1,6 +1,17 @@
 import type { Event } from './event';
+import type { User } from './user';
 
-export interface FeedbackContext extends Record<string, unknown> {
+/**
+ * Crash report feedback object
+ */
+export interface UserFeedback {
+  event_id: string;
+  email: User['email'];
+  name: string;
+  comments: string;
+}
+
+interface FeedbackContext extends Record<string, unknown> {
   message: string;
   contact_email?: string;
   name?: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -69,7 +69,7 @@ export type {
   Profile,
 } from './profiling';
 export type { ReplayEvent, ReplayRecordingData, ReplayRecordingMode } from './replay';
-export type { FeedbackEvent } from './feedback';
+export type { FeedbackEvent, UserFeedback } from './feedback';
 export type { QueryParams, Request, SanitizedRequestData } from './request';
 export type { Runtime } from './runtime';
 export type { CaptureContext, Scope, ScopeContext, ScopeData } from './scope';
@@ -131,7 +131,7 @@ export type {
   BaseTransportOptions,
   TransportRequestExecutor,
 } from './transport';
-export type { User, UserFeedback } from './user';
+export type { User } from './user';
 export type { WebFetchHeaders, WebFetchRequest } from './webfetchapi';
 export type { WrappedFunction } from './wrappedfunction';
 export type {

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -8,10 +8,3 @@ export interface User {
   email?: string;
   username?: string;
 }
-
-export interface UserFeedback {
-  event_id: string;
-  email: User['email'];
-  name: string;
-  comments: string;
-}


### PR DESCRIPTION
Moving the UserFeedback type into the feedback file. It's a better place for it, especially as there will be more related things coming soon (related to the feedback widget)