### PR TITLE
feat(v8/profiling-node): Use OTEL powered node package

### DIFF
--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@sentry/core": "8.0.0-alpha.2",
-    "@sentry/node-experimental": "8.0.0-alpha.2",
+    "@sentry/node": "8.0.0-alpha.2",
     "@sentry/types": "8.0.0-alpha.2",
     "@sentry/utils": "8.0.0-alpha.2",
     "@types/node": "16.18.70",

--- a/packages/profiling-node/rollup.npm.config.mjs
+++ b/packages/profiling-node/rollup.npm.config.mjs
@@ -2,11 +2,12 @@ import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import { makeBaseNPMConfig } from '@sentry-internal/rollup-utils';
+import { makeJsonPlugin } from '@sentry-internal/rollup-utils/plugins/index.mjs';
 
 export default makeBaseNPMConfig({
   packageSpecificConfig: {
     input: 'src/index.ts',
     output: { file: 'lib/index.js', format: 'cjs', dir: undefined, preserveModules: false },
-    plugins: [resolve(), commonjs(), typescript({ tsconfig: './tsconfig.json' })],
+    plugins: [resolve(), makeJsonPlugin(), commonjs(), typescript({ tsconfig: './tsconfig.json' })],
   },
 });

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -1,5 +1,5 @@
 import { defineIntegration, getCurrentScope, getRootSpan, spanToJSON } from '@sentry/core';
-import type { NodeClient } from '@sentry/node-experimental';
+import type { NodeClient } from '@sentry/node';
 import type { IntegrationFn, Span } from '@sentry/types';
 
 import { logger } from '@sentry/utils';

--- a/packages/profiling-node/src/spanProfileUtils.ts
+++ b/packages/profiling-node/src/spanProfileUtils.ts
@@ -1,5 +1,5 @@
 import { spanIsSampled, spanToJSON } from '@sentry/core';
-import type { NodeClient } from '@sentry/node-experimental';
+import type { NodeClient } from '@sentry/node';
 import type { CustomSamplingContext, Span } from '@sentry/types';
 import { logger, uuid4 } from '@sentry/utils';
 

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -3,7 +3,7 @@ import type { Context, Envelope, Event, StackFrame, StackParser } from '@sentry/
 import { env, versions } from 'process';
 import { isMainThread, threadId } from 'worker_threads';
 
-import * as Sentry from '@sentry/node-experimental';
+import { getCurrentHub } from '@sentry/node';
 import { GLOBAL_OBJ, forEachEnvelopeItem, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
@@ -318,7 +318,7 @@ export function applyDebugMetadata(resource_paths: ReadonlyArray<string>): Debug
   }
 
   // eslint-disable-next-line deprecation/deprecation
-  const hub = Sentry.getCurrentHub();
+  const hub = getCurrentHub();
   // eslint-disable-next-line deprecation/deprecation
   const client = hub.getClient();
   const options = client && client.getOptions();

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 
 import type { Transport } from '@sentry/types';
 
-import type { NodeClient } from '@sentry/node-experimental';
+import type { NodeClient } from '@sentry/node';
 import { _nodeProfilingIntegration } from '../src/integration';
 
 describe('ProfilingIntegration', () => {

--- a/packages/profiling-node/test/spanProfileUtils.test.ts
+++ b/packages/profiling-node/test/spanProfileUtils.test.ts
@@ -1,6 +1,13 @@
-import { NodeClient, defaultStackParser, flush, makeNodeTransport, setCurrentClient, startInactiveSpan } from '@sentry/node';
+import {
+  NodeClient,
+  defaultStackParser,
+  flush,
+  makeNodeTransport,
+  setCurrentClient,
+  startInactiveSpan,
+} from '@sentry/node';
 
-import { getMainCarrier,  } from '@sentry/core';
+import { getMainCarrier } from '@sentry/core';
 import type { Transport } from '@sentry/types';
 import { GLOBAL_OBJ, createEnvelope, logger } from '@sentry/utils';
 import { CpuProfilerBindings } from '../src/cpu_profiler';


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/9956

Switch from relying on `@sentry/node-experimental` to `@sentry/node`.