### PR TITLE
feat(browser): Remove IE parser from the default stack parsers

### DIFF
--- a/packages/browser/src/stack-parsers.ts
+++ b/packages/browser/src/stack-parsers.ts
@@ -153,7 +153,7 @@ const opera11: StackLineParserFn = line => {
 
 export const opera11StackLineParser: StackLineParser = [OPERA11_PRIORITY, opera11];
 
-export const defaultStackLineParsers = [chromeStackLineParser, geckoStackLineParser, winjsStackLineParser];
+export const defaultStackLineParsers = [chromeStackLineParser, geckoStackLineParser];
 
 export const defaultStackParser = createStackParser(...defaultStackLineParsers);
 

--- a/packages/browser/test/unit/tracekit/ie.test.ts
+++ b/packages/browser/test/unit/tracekit/ie.test.ts
@@ -1,5 +1,8 @@
+import { createStackParser } from '@sentry/utils';
 import { exceptionFromError } from '../../../src/eventbuilder';
-import { defaultStackParser as parser } from '../../../src/stack-parsers';
+import { chromeStackLineParser, geckoStackLineParser, winjsStackLineParser } from '../../../src/stack-parsers';
+
+const parser = createStackParser(chromeStackLineParser, geckoStackLineParser, winjsStackLineParser);
 
 describe('Tracekit - IE Tests', () => {
   it('should parse IE 10 error', () => {


### PR DESCRIPTION
We no longer support IE so we don't need it's parser in the default stack parsers!