### PR TITLE
feat(core): Update `continueTrace` to be callback-only

### DIFF
--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -86,13 +86,12 @@ function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]
 
         return continueTrace(
           { sentryTrace: request.headers.get('sentry-trace') || '', baggage: request.headers.get('baggage') },
-          ctx => {
+          () => {
             return startSpan(
               {
                 attributes,
                 op: 'http.server',
                 name: `${request.method} ${parsedUrl.path || '/'}`,
-                ...ctx,
               },
               async span => {
                 try {

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1112,18 +1112,9 @@ describe('continueTrace', () => {
   });
 
   it('works without trace & baggage data', () => {
-    const expectedContext = {
-      metadata: {},
-    };
-
-    const result = continueTrace({ sentryTrace: undefined, baggage: undefined }, ctx => {
-      expect(ctx).toEqual(expectedContext);
-      return ctx;
+    const scope = continueTrace({ sentryTrace: undefined, baggage: undefined }, () => {
+      return getCurrentScope();
     });
-
-    expect(result).toEqual(expectedContext);
-
-    const scope = getCurrentScope();
 
     expect(scope.getPropagationContext()).toEqual({
       sampled: undefined,
@@ -1135,29 +1126,15 @@ describe('continueTrace', () => {
   });
 
   it('works with trace data', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {},
-      },
-      parentSampled: false,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    const result = continueTrace(
+    const scope = continueTrace(
       {
         sentryTrace: '12312012123120121231201212312012-1121201211212012-0',
         baggage: undefined,
       },
-      ctx => {
-        expect(ctx).toEqual(expectedContext);
-        return ctx;
+      () => {
+        return getCurrentScope();
       },
     );
-
-    expect(result).toEqual(expectedContext);
-
-    const scope = getCurrentScope();
 
     expect(scope.getPropagationContext()).toEqual({
       dsc: {}, // DSC should be an empty object (frozen), because there was an incoming trace
@@ -1171,32 +1148,15 @@ describe('continueTrace', () => {
   });
 
   it('works with trace & baggage data', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {
-          environment: 'production',
-          version: '1.0',
-        },
-      },
-      parentSampled: true,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    const result = continueTrace(
+    const scope = continueTrace(
       {
         sentryTrace: '12312012123120121231201212312012-1121201211212012-1',
         baggage: 'sentry-version=1.0,sentry-environment=production',
       },
-      ctx => {
-        expect(ctx).toEqual(expectedContext);
-        return ctx;
+      () => {
+        return getCurrentScope();
       },
     );
-
-    expect(result).toEqual(expectedContext);
-
-    const scope = getCurrentScope();
 
     expect(scope.getPropagationContext()).toEqual({
       dsc: {
@@ -1213,32 +1173,15 @@ describe('continueTrace', () => {
   });
 
   it('works with trace & 3rd party baggage data', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {
-          environment: 'production',
-          version: '1.0',
-        },
-      },
-      parentSampled: true,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    const result = continueTrace(
+    const scope = continueTrace(
       {
         sentryTrace: '12312012123120121231201212312012-1121201211212012-1',
         baggage: 'sentry-version=1.0,sentry-environment=production,dogs=great,cats=boring',
       },
-      ctx => {
-        expect(ctx).toEqual(expectedContext);
-        return ctx;
+      () => {
+        return getCurrentScope();
       },
     );
-
-    expect(result).toEqual(expectedContext);
-
-    const scope = getCurrentScope();
 
     expect(scope.getPropagationContext()).toEqual({
       dsc: {
@@ -1255,45 +1198,17 @@ describe('continueTrace', () => {
   });
 
   it('returns response of callback', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {},
-      },
-      parentSampled: false,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
     const result = continueTrace(
       {
         sentryTrace: '12312012123120121231201212312012-1121201211212012-0',
         baggage: undefined,
       },
-      ctx => {
-        return { ctx };
+      () => {
+        return 'aha';
       },
     );
 
-    expect(result).toEqual({ ctx: expectedContext });
-  });
-
-  it('works without a callback', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {},
-      },
-      parentSampled: false,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    // eslint-disable-next-line deprecation/deprecation
-    const ctx = continueTrace({
-      sentryTrace: '12312012123120121231201212312012-1121201211212012-0',
-      baggage: undefined,
-    });
-
-    expect(ctx).toEqual(expectedContext);
+    expect(result).toEqual('aha');
   });
 });
 

--- a/packages/node/src/integrations/hapi/index.ts
+++ b/packages/node/src/integrations/hapi/index.ts
@@ -81,9 +81,8 @@ export const hapiTracingPlugin = {
           sentryTrace: request.headers['sentry-trace'] || undefined,
           baggage: request.headers['baggage'] || undefined,
         },
-        transactionContext => {
+        () => {
           return startInactiveSpan({
-            ...transactionContext,
             op: 'hapi.request',
             name: `${request.route.method} ${request.path}`,
             forceTransaction: true,

--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -282,6 +282,9 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         const propagationContextBefore = scope.getPropagationContext();
 
         activeSpan = continueTrace({ sentryTrace, baggage }, () => {
+          // We update the outer current scope to have the correct propagation context...
+          scope.setPropagationContext(getCurrentScope().getPropagationContext());
+
           // Ensure we are on the original current scope again, so the span is set as active on it
           return withScope(scope, () => {
             return _createRouteSpan(client, {
@@ -291,6 +294,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
           });
         });
 
+        // Reset this back to what it was before
         scope.setPropagationContext(propagationContextBefore);
       });
 


### PR DESCRIPTION
Also update it to only update the propagation context in the callback. In some places (old node...) we need the legacy behaviour, but for now we can do that in-place.