### PR TITLE
feat(replay/v8): Delete deprecated `replaySession` and `errorSampleRates`

### DIFF
--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -11,6 +11,7 @@ import {
 } from './constants';
 import { ReplayContainer } from './replay';
 import type {
+  InitialReplayPluginOptions,
   RecordingOptions,
   ReplayCanvasIntegrationOptions,
   ReplayConfiguration,
@@ -26,9 +27,6 @@ const MEDIA_SELECTORS =
 const DEFAULT_NETWORK_HEADERS = ['content-length', 'content-type', 'accept'];
 
 let _initialized = false;
-
-type InitialReplayPluginOptions = Omit<ReplayPluginOptions, 'sessionSampleRate' | 'errorSampleRate'> &
-  Partial<Pick<ReplayPluginOptions, 'sessionSampleRate' | 'errorSampleRate'>>;
 
 /**
  * Sentry integration for [Session Replay](https://sentry.io/for/session-replay/).
@@ -90,8 +88,6 @@ export class Replay implements Integration {
     useCompression = true,
     workerUrl,
     _experiments = {},
-    sessionSampleRate,
-    errorSampleRate,
     maskAllText = true,
     maskAllInputs = true,
     blockAllMedia = true,
@@ -189,8 +185,6 @@ export class Replay implements Integration {
       minReplayDuration: Math.min(minReplayDuration, MIN_REPLAY_DURATION_LIMIT),
       maxReplayDuration: Math.min(maxReplayDuration, MAX_REPLAY_DURATION),
       stickySession,
-      sessionSampleRate,
-      errorSampleRate,
       useCompression,
       workerUrl,
       blockAllMedia,
@@ -210,30 +204,6 @@ export class Replay implements Integration {
 
       _experiments,
     };
-
-    if (typeof sessionSampleRate === 'number') {
-      // eslint-disable-next-line
-      console.warn(
-        `[Replay] You are passing \`sessionSampleRate\` to the Replay integration.
-This option is deprecated and will be removed soon.
-Instead, configure \`replaysSessionSampleRate\` directly in the SDK init options, e.g.:
-Sentry.init({ replaysSessionSampleRate: ${sessionSampleRate} })`,
-      );
-
-      this._initialOptions.sessionSampleRate = sessionSampleRate;
-    }
-
-    if (typeof errorSampleRate === 'number') {
-      // eslint-disable-next-line
-      console.warn(
-        `[Replay] You are passing \`errorSampleRate\` to the Replay integration.
-This option is deprecated and will be removed soon.
-Instead, configure \`replaysOnErrorSampleRate\` directly in the SDK init options, e.g.:
-Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
-      );
-
-      this._initialOptions.errorSampleRate = errorSampleRate;
-    }
 
     if (this._initialOptions.blockAllMedia) {
       // `blockAllMedia` is a more user friendly option to configure blocking
@@ -401,7 +371,11 @@ function loadReplayOptionsFromClient(initialOptions: InitialReplayPluginOptions)
   const client = getClient();
   const opt = client && (client.getOptions() as BrowserClientReplayOptions);
 
-  const finalOptions = { sessionSampleRate: 0, errorSampleRate: 0, ...dropUndefinedKeys(initialOptions) };
+  const finalOptions: ReplayPluginOptions = {
+    sessionSampleRate: 0,
+    errorSampleRate: 0,
+    ...dropUndefinedKeys(initialOptions),
+  };
 
   if (!opt) {
     consoleSandbox(() => {
@@ -411,12 +385,7 @@ function loadReplayOptionsFromClient(initialOptions: InitialReplayPluginOptions)
     return finalOptions;
   }
 
-  if (
-    initialOptions.sessionSampleRate == null && // TODO remove once deprecated rates are removed
-    initialOptions.errorSampleRate == null && // TODO remove once deprecated rates are removed
-    opt.replaysSessionSampleRate == null &&
-    opt.replaysOnErrorSampleRate == null
-  ) {
+  if (opt.replaysSessionSampleRate == null && opt.replaysOnErrorSampleRate == null) {
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
       console.warn(

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -236,6 +236,20 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
 }
 
 /**
+ * The options that can be set in the plugin options. `sessionSampleRate` and `errorSampleRate` are added
+ * in the root level of the SDK options as `replaysSessionSampleRate` and `replaysOnErrorSampleRate`.
+ */
+export type InitialReplayPluginOptions = Omit<ReplayPluginOptions, 'sessionSampleRate' | 'errorSampleRate'>;
+
+// These are optional for ReplayPluginOptions because the plugin sets default values
+type OptionalReplayPluginOptions = Partial<InitialReplayPluginOptions> & {
+  /**
+   * Mask element attributes that are contained in list
+   */
+  maskAttributes?: string[];
+};
+
+/**
  * Session options that are configurable by the integration configuration
  */
 export interface SessionOptions extends Pick<ReplayPluginOptions, 'sessionSampleRate' | 'stickySession'> {
@@ -279,14 +293,6 @@ export interface ReplayIntegrationPrivacyOptions {
    */
   maskFn?: (s: string) => string;
 }
-
-// These are optional for ReplayPluginOptions because the plugin sets default values
-type OptionalReplayPluginOptions = Partial<ReplayPluginOptions> & {
-  /**
-   * Mask element attributes that are contained in list
-   */
-  maskAttributes?: string[];
-};
 
 export interface DeprecatedPrivacyOptions {
   /**

--- a/packages/replay/test/integration/integrationSettings.test.ts
+++ b/packages/replay/test/integration/integrationSettings.test.ts
@@ -42,26 +42,6 @@ describe('Integration | integrationSettings', () => {
       mockConsole.mockRestore();
     });
 
-    it('works with defining settings in integration', async () => {
-      const { replay } = await mockSdk({
-        replayOptions: { sessionSampleRate: 0.5 },
-        sentryOptions: { replaysSessionSampleRate: undefined },
-      });
-
-      expect(replay.getOptions().sessionSampleRate).toBe(0.5);
-      expect(mockConsole).toBeCalledTimes(1);
-    });
-
-    it('works with defining 0 in integration but logs warnings', async () => {
-      const { replay } = await mockSdk({
-        replayOptions: { sessionSampleRate: 0 },
-        sentryOptions: { replaysSessionSampleRate: undefined },
-      });
-
-      expect(replay.getOptions().sessionSampleRate).toBe(0);
-      expect(mockConsole).toBeCalledTimes(1);
-    });
-
     it('works with defining settings in SDK', async () => {
       const { replay } = await mockSdk({ sentryOptions: { replaysSessionSampleRate: 0.5 }, replayOptions: {} });
 
@@ -74,26 +54,6 @@ describe('Integration | integrationSettings', () => {
 
       expect(replay.getOptions().sessionSampleRate).toBe(0);
       expect(mockConsole).toBeCalledTimes(0);
-    });
-
-    it('SDK option takes precedence', async () => {
-      const { replay } = await mockSdk({
-        sentryOptions: { replaysSessionSampleRate: 0.5 },
-        replayOptions: { sessionSampleRate: 0.1 },
-      });
-
-      expect(replay.getOptions().sessionSampleRate).toBe(0.5);
-      expect(mockConsole).toBeCalledTimes(1);
-    });
-
-    it('SDK option takes precedence even when 0', async () => {
-      const { replay } = await mockSdk({
-        sentryOptions: { replaysSessionSampleRate: 0 },
-        replayOptions: { sessionSampleRate: 0.1 },
-      });
-
-      expect(replay.getOptions().sessionSampleRate).toBe(0);
-      expect(mockConsole).toBeCalledTimes(1);
     });
   });
 
@@ -108,26 +68,6 @@ describe('Integration | integrationSettings', () => {
       mockConsole.mockRestore();
     });
 
-    it('works with defining settings in integration', async () => {
-      const { replay } = await mockSdk({
-        replayOptions: { errorSampleRate: 0.5 },
-        sentryOptions: { replaysOnErrorSampleRate: undefined },
-      });
-
-      expect(replay.getOptions().errorSampleRate).toBe(0.5);
-      expect(mockConsole).toBeCalledTimes(1);
-    });
-
-    it('works with defining 0 in integration', async () => {
-      const { replay } = await mockSdk({
-        replayOptions: { errorSampleRate: 0 },
-        sentryOptions: { replaysOnErrorSampleRate: undefined },
-      });
-
-      expect(replay.getOptions().errorSampleRate).toBe(0);
-      expect(mockConsole).toBeCalledTimes(1);
-    });
-
     it('works with defining settings in SDK', async () => {
       const { replay } = await mockSdk({ sentryOptions: { replaysOnErrorSampleRate: 0.5 }, replayOptions: {} });
 
@@ -140,26 +80,6 @@ describe('Integration | integrationSettings', () => {
 
       expect(replay.getOptions().errorSampleRate).toBe(0);
       expect(mockConsole).toBeCalledTimes(0);
-    });
-
-    it('SDK option takes precedence', async () => {
-      const { replay } = await mockSdk({
-        sentryOptions: { replaysOnErrorSampleRate: 0.5 },
-        replayOptions: { errorSampleRate: 0.1 },
-      });
-
-      expect(replay.getOptions().errorSampleRate).toBe(0.5);
-      expect(mockConsole).toBeCalledTimes(1);
-    });
-
-    it('SDK option takes precedence even when 0', async () => {
-      const { replay } = await mockSdk({
-        sentryOptions: { replaysOnErrorSampleRate: 0 },
-        replayOptions: { errorSampleRate: 0.1 },
-      });
-
-      expect(replay.getOptions().errorSampleRate).toBe(0);
-      expect(mockConsole).toBeCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
Options can be configured with `replaysSessionSampleRate` and `replaysOnErrorSampleRate`.
closes https://github.com/getsentry/sentry-javascript/issues/6958
