### PR TITLE
ref(node-experimental): Refactor usage of `startChild()`

### DIFF
--- a/packages/tracing-internal/src/node/integrations/apollo.ts
+++ b/packages/tracing-internal/src/node/integrations/apollo.ts
@@ -1,6 +1,5 @@
-import type { Hub, SentrySpan } from '@sentry/core';
-import type { EventProcessor } from '@sentry/types';
-import { arrayify, fill, isThenable, loadModule, logger } from '@sentry/utils';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+import { arrayify, fill, loadModule, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../../common/debug-build';
 import type { LazyLoadedIntegration } from './lazy';
@@ -75,7 +74,7 @@ export class Apollo implements LazyLoadedIntegration<GraphQLModule & ApolloModul
   /**
    * @inheritDoc
    */
-  public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+  public setupOnce(): void {
     if (this._useNest) {
       const pkg = this.loadDependency();
 
@@ -99,7 +98,7 @@ export class Apollo implements LazyLoadedIntegration<GraphQLModule & ApolloModul
               return function (this: unknown) {
                 const resolvers = arrayify(orig.call(this));
 
-                const instrumentedResolvers = instrumentResolvers(resolvers, getCurrentHub);
+                const instrumentedResolvers = instrumentResolvers(resolvers);
 
                 return instrumentedResolvers;
               };
@@ -146,7 +145,7 @@ export class Apollo implements LazyLoadedIntegration<GraphQLModule & ApolloModul
 
           const resolvers = arrayify(this.config.resolvers);
 
-          this.config.resolvers = instrumentResolvers(resolvers, getCurrentHub);
+          this.config.resolvers = instrumentResolvers(resolvers);
 
           return orig.call(this);
         };
@@ -155,7 +154,7 @@ export class Apollo implements LazyLoadedIntegration<GraphQLModule & ApolloModul
   }
 }
 
-function instrumentResolvers(resolvers: ApolloModelResolvers[], getCurrentHub: () => Hub): ApolloModelResolvers[] {
+function instrumentResolvers(resolvers: ApolloModelResolvers[]): ApolloModelResolvers[] {
   return resolvers.map(model => {
     Object.keys(model).forEach(resolverGroupName => {
       Object.keys(model[resolverGroupName]).forEach(resolverName => {
@@ -163,7 +162,7 @@ function instrumentResolvers(resolvers: ApolloModelResolvers[], getCurrentHub: (
           return;
         }
 
-        wrapResolver(model, resolverGroupName, resolverName, getCurrentHub);
+        wrapResolver(model, resolverGroupName, resolverName);
       });
     });
 
@@ -174,37 +173,22 @@ function instrumentResolvers(resolvers: ApolloModelResolvers[], getCurrentHub: (
 /**
  * Wrap a single resolver which can be a parent of other resolvers and/or db operations.
  */
-function wrapResolver(
-  model: ApolloModelResolvers,
-  resolverGroupName: string,
-  resolverName: string,
-  getCurrentHub: () => Hub,
-): void {
+function wrapResolver(model: ApolloModelResolvers, resolverGroupName: string, resolverName: string): void {
   fill(model[resolverGroupName], resolverName, function (orig: () => unknown | Promise<unknown>) {
     return function (this: unknown, ...args: unknown[]) {
-      // eslint-disable-next-line deprecation/deprecation
-      const scope = getCurrentHub().getScope();
-      // eslint-disable-next-line deprecation/deprecation
-      const parentSpan = scope.getSpan() as SentrySpan | undefined;
-      // eslint-disable-next-line deprecation/deprecation
-      const span = parentSpan?.startChild({
-        name: `${resolverGroupName}.${resolverName}`,
-        op: 'graphql.resolve',
-        origin: 'auto.graphql.apollo',
-      });
-
-      const rv = orig.call(this, ...args);
-
-      if (isThenable(rv)) {
-        return rv.then((res: unknown) => {
-          span?.end();
-          return res;
-        });
-      }
-
-      span?.end();
-
-      return rv;
+      return startSpan(
+        {
+          onlyIfParent: true,
+          name: `${resolverGroupName}.${resolverName}`,
+          op: 'graphql.resolve',
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.graphql.apollo',
+          },
+        },
+        () => {
+          return orig.call(this, ...args);
+        },
+      );
     };
   });
 }

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import type { Transaction } from '@sentry/core';
+import { startInactiveSpan, withActiveSpan } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
 import type { Integration, PolymorphicRequest } from '@sentry/types';
 import {
@@ -153,11 +154,12 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
       return function (this: NodeJS.Global, req: unknown, res: ExpressResponse & SentryTracingResponse): void {
         const transaction = res.__sentry_transaction;
         if (transaction) {
-          // eslint-disable-next-line deprecation/deprecation
-          const span = transaction.startChild({
-            name: fn.name,
-            op: `middleware.express.${method}`,
-            origin: 'auto.middleware.express',
+          const span = withActiveSpan(transaction, () => {
+            return startInactiveSpan({
+              name: fn.name,
+              op: `middleware.express.${method}`,
+              origin: 'auto.middleware.express',
+            });
           });
           res.once('finish', () => {
             span.end();
@@ -174,12 +176,15 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         next: () => void,
       ): void {
         const transaction = res.__sentry_transaction;
-        // eslint-disable-next-line deprecation/deprecation
-        const span = transaction?.startChild({
-          name: fn.name,
-          op: `middleware.express.${method}`,
-          origin: 'auto.middleware.express',
-        });
+        const span = transaction
+          ? withActiveSpan(transaction, () => {
+              return startInactiveSpan({
+                name: fn.name,
+                op: `middleware.express.${method}`,
+                origin: 'auto.middleware.express',
+              });
+            })
+          : undefined;
         fn.call(this, req, res, function (this: NodeJS.Global, ...args: unknown[]): void {
           span?.end();
           next.call(this, ...args);
@@ -195,12 +200,15 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         next: () => void,
       ): void {
         const transaction = res.__sentry_transaction;
-        // eslint-disable-next-line deprecation/deprecation
-        const span = transaction?.startChild({
-          name: fn.name,
-          op: `middleware.express.${method}`,
-          origin: 'auto.middleware.express',
-        });
+        const span = transaction
+          ? withActiveSpan(transaction, () => {
+              return startInactiveSpan({
+                name: fn.name,
+                op: `middleware.express.${method}`,
+                origin: 'auto.middleware.express',
+              });
+            })
+          : undefined;
         fn.call(this, err, req, res, function (this: NodeJS.Global, ...args: unknown[]): void {
           span?.end();
           next.call(this, ...args);


### PR DESCRIPTION
This refactors the old node integrations to the new syntax, so we can get rid of the public APIs.

This also allows us to get rid of some of the last `getCurrentHub` usage etc.