### PR TITLE
chore(google-cloud): Fix yalc:publish command

### DIFF
--- a/packages/google-cloud/package.json
+++ b/packages/google-cloud/package.json
@@ -77,7 +77,7 @@
     "lint": "eslint . --format stylish",
     "test": "jest",
     "test:watch": "jest --watch",
-    "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push --sig"
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push --sig"
   },
   "volta": {
     "extends": "../../package.json"


### PR DESCRIPTION
We don't publish bundles from google cloud package, fixing yalc command accordingly.