### PR TITLE
test(e2e/react): Add e2e tests for Scope `transactionName` changes

### DIFF
--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/event-proxy-server.ts
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/event-proxy-server.ts
@@ -1,0 +1,253 @@
+import * as fs from 'fs';
+import * as http from 'http';
+import * as https from 'https';
+import type { AddressInfo } from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import * as util from 'util';
+import * as zlib from 'zlib';
+import type { Envelope, EnvelopeItem, Event } from '@sentry/types';
+import { parseEnvelope } from '@sentry/utils';
+
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+
+interface EventProxyServerOptions {
+  /** Port to start the event proxy server at. */
+  port: number;
+  /** The name for the proxy server used for referencing it with listener functions */
+  proxyServerName: string;
+}
+
+interface SentryRequestCallbackData {
+  envelope: Envelope;
+  rawProxyRequestBody: string;
+  rawSentryResponseBody: string;
+  sentryResponseStatusCode?: number;
+}
+
+/**
+ * Starts an event proxy server that will proxy events to sentry when the `tunnel` option is used. Point the `tunnel`
+ * option to this server (like this `tunnel: http://localhost:${port option}/`).
+ */
+export async function startEventProxyServer(options: EventProxyServerOptions): Promise<void> {
+  const eventCallbackListeners: Set<(data: string) => void> = new Set();
+
+  const proxyServer = http.createServer((proxyRequest, proxyResponse) => {
+    const proxyRequestChunks: Uint8Array[] = [];
+
+    proxyRequest.addListener('data', (chunk: Buffer) => {
+      proxyRequestChunks.push(chunk);
+    });
+
+    proxyRequest.addListener('error', err => {
+      throw err;
+    });
+
+    proxyRequest.addListener('end', () => {
+      const proxyRequestBody =
+        proxyRequest.headers['content-encoding'] === 'gzip'
+          ? zlib.gunzipSync(Buffer.concat(proxyRequestChunks)).toString()
+          : Buffer.concat(proxyRequestChunks).toString();
+
+      let envelopeHeader = JSON.parse(proxyRequestBody.split('\n')[0]);
+
+      if (!envelopeHeader.dsn) {
+        throw new Error('[event-proxy-server] No dsn on envelope header. Please set tunnel option.');
+      }
+
+      const { origin, pathname, host } = new URL(envelopeHeader.dsn);
+
+      const projectId = pathname.substring(1);
+      const sentryIngestUrl = `${origin}/api/${projectId}/envelope/`;
+
+      proxyRequest.headers.host = host;
+
+      const sentryResponseChunks: Uint8Array[] = [];
+
+      const sentryRequest = https.request(
+        sentryIngestUrl,
+        { headers: proxyRequest.headers, method: proxyRequest.method },
+        sentryResponse => {
+          sentryResponse.addListener('data', (chunk: Buffer) => {
+            proxyResponse.write(chunk, 'binary');
+            sentryResponseChunks.push(chunk);
+          });
+
+          sentryResponse.addListener('end', () => {
+            eventCallbackListeners.forEach(listener => {
+              const rawSentryResponseBody = Buffer.concat(sentryResponseChunks).toString();
+
+              const data: SentryRequestCallbackData = {
+                envelope: parseEnvelope(proxyRequestBody),
+                rawProxyRequestBody: proxyRequestBody,
+                rawSentryResponseBody,
+                sentryResponseStatusCode: sentryResponse.statusCode,
+              };
+
+              listener(Buffer.from(JSON.stringify(data)).toString('base64'));
+            });
+            proxyResponse.end();
+          });
+
+          sentryResponse.addListener('error', err => {
+            throw err;
+          });
+
+          proxyResponse.writeHead(sentryResponse.statusCode || 500, sentryResponse.headers);
+        },
+      );
+
+      sentryRequest.write(Buffer.concat(proxyRequestChunks), 'binary');
+      sentryRequest.end();
+    });
+  });
+
+  const proxyServerStartupPromise = new Promise<void>(resolve => {
+    proxyServer.listen(options.port, () => {
+      resolve();
+    });
+  });
+
+  const eventCallbackServer = http.createServer((eventCallbackRequest, eventCallbackResponse) => {
+    eventCallbackResponse.statusCode = 200;
+    eventCallbackResponse.setHeader('connection', 'keep-alive');
+
+    const callbackListener = (data: string): void => {
+      eventCallbackResponse.write(data.concat('\n'), 'utf8');
+    };
+
+    eventCallbackListeners.add(callbackListener);
+
+    eventCallbackRequest.on('close', () => {
+      eventCallbackListeners.delete(callbackListener);
+    });
+
+    eventCallbackRequest.on('error', () => {
+      eventCallbackListeners.delete(callbackListener);
+    });
+  });
+
+  const eventCallbackServerStartupPromise = new Promise<void>(resolve => {
+    eventCallbackServer.listen(0, () => {
+      const port = String((eventCallbackServer.address() as AddressInfo).port);
+      void registerCallbackServerPort(options.proxyServerName, port).then(resolve);
+    });
+  });
+
+  await eventCallbackServerStartupPromise;
+  await proxyServerStartupPromise;
+  return;
+}
+
+export async function waitForRequest(
+  proxyServerName: string,
+  callback: (eventData: SentryRequestCallbackData) => Promise<boolean> | boolean,
+): Promise<SentryRequestCallbackData> {
+  const eventCallbackServerPort = await retrieveCallbackServerPort(proxyServerName);
+
+  return new Promise<SentryRequestCallbackData>((resolve, reject) => {
+    const request = http.request(`http://localhost:${eventCallbackServerPort}/`, {}, response => {
+      let eventContents = '';
+
+      response.on('error', err => {
+        reject(err);
+      });
+
+      response.on('data', (chunk: Buffer) => {
+        const chunkString = chunk.toString('utf8');
+        chunkString.split('').forEach(char => {
+          if (char === '\n') {
+            const eventCallbackData: SentryRequestCallbackData = JSON.parse(
+              Buffer.from(eventContents, 'base64').toString('utf8'),
+            );
+            const callbackResult = callback(eventCallbackData);
+            if (typeof callbackResult !== 'boolean') {
+              callbackResult.then(
+                match => {
+                  if (match) {
+                    response.destroy();
+                    resolve(eventCallbackData);
+                  }
+                },
+                err => {
+                  throw err;
+                },
+              );
+            } else if (callbackResult) {
+              response.destroy();
+              resolve(eventCallbackData);
+            }
+            eventContents = '';
+          } else {
+            eventContents = eventContents.concat(char);
+          }
+        });
+      });
+    });
+
+    request.end();
+  });
+}
+
+export function waitForEnvelopeItem(
+  proxyServerName: string,
+  callback: (envelopeItem: EnvelopeItem) => Promise<boolean> | boolean,
+): Promise<EnvelopeItem> {
+  return new Promise((resolve, reject) => {
+    waitForRequest(proxyServerName, async eventData => {
+      const envelopeItems = eventData.envelope[1];
+      for (const envelopeItem of envelopeItems) {
+        if (await callback(envelopeItem)) {
+          resolve(envelopeItem);
+          return true;
+        }
+      }
+      return false;
+    }).catch(reject);
+  });
+}
+
+export function waitForError(
+  proxyServerName: string,
+  callback: (transactionEvent: Event) => Promise<boolean> | boolean,
+): Promise<Event> {
+  return new Promise((resolve, reject) => {
+    waitForEnvelopeItem(proxyServerName, async envelopeItem => {
+      const [envelopeItemHeader, envelopeItemBody] = envelopeItem;
+      if (envelopeItemHeader.type === 'event' && (await callback(envelopeItemBody as Event))) {
+        resolve(envelopeItemBody as Event);
+        return true;
+      }
+      return false;
+    }).catch(reject);
+  });
+}
+
+export function waitForTransaction(
+  proxyServerName: string,
+  callback: (transactionEvent: Event) => Promise<boolean> | boolean,
+): Promise<Event> {
+  return new Promise((resolve, reject) => {
+    waitForEnvelopeItem(proxyServerName, async envelopeItem => {
+      const [envelopeItemHeader, envelopeItemBody] = envelopeItem;
+      if (envelopeItemHeader.type === 'transaction' && (await callback(envelopeItemBody as Event))) {
+        resolve(envelopeItemBody as Event);
+        return true;
+      }
+      return false;
+    }).catch(reject);
+  });
+}
+
+const TEMP_FILE_PREFIX = 'event-proxy-server-';
+
+async function registerCallbackServerPort(serverName: string, port: string): Promise<void> {
+  const tmpFilePath = path.join(os.tmpdir(), `${TEMP_FILE_PREFIX}${serverName}`);
+  await writeFile(tmpFilePath, port, { encoding: 'utf8' });
+}
+
+function retrieveCallbackServerPort(serverName: string): Promise<string> {
+  const tmpFilePath = path.join(os.tmpdir(), `${TEMP_FILE_PREFIX}${serverName}`);
+  return readFile(tmpFilePath, 'utf8');
+}

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/package.json
@@ -47,9 +47,11 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "1.26.1",
+    "@playwright/test": "1.41.2",
     "axios": "1.6.0",
-    "serve": "14.0.1"
+    "serve": "14.0.1",
+    "ts-node": "10.9.1",
+    "wait-port": "1.0.4"
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/src/index.tsx
@@ -13,11 +13,13 @@ import {
 import Index from './pages/Index';
 import User from './pages/User';
 
-const replay = Sentry.replayIntegration();
+const replay = Sentry.replayIntegration({ useCompression: false });
 
 Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
+  tunnel: `http://localhost:3031/`, // proxy server
+  debug: true,
   integrations: [
     Sentry.reactRouterV6BrowserTracingIntegration({
       useEffect: React.useEffect,

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/src/pages/User.tsx
@@ -2,7 +2,19 @@
 import * as React from 'react';
 
 const User = () => {
-  return <p>I am a blank page :)</p>;
+  return (
+    <>
+      <p>I am a blank page :)</p>
+      <button
+        id="userErrorBtn"
+        onClick={() => {
+          throw new Error('User page error');
+        }}
+      >
+        Throw error
+      </button>
+    </>
+  );
 };
 
 export default User;

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/start-event-proxy.ts
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/start-event-proxy.ts
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from './event-proxy-server';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'standard-frontend-react',
+});

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/tests/error-test.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/tests/error-test.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+import { waitForError, waitForTransaction } from '../event-proxy-server';
+
+test('Sends an exception to Sentry after a pageload and attaches the transaction info', async ({ page }) => {
+  const errorPromise = waitForError('standard-frontend-react', async errorEvent => {
+    return !errorEvent.type;
+  });
+
+  await page.goto(`/`);
+
+  const [, error] = await Promise.all([page.locator('#exception-button').click(), errorPromise]);
+
+  expect(error).toMatchObject({
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'I am an error!',
+          mechanism: {
+            type: 'generic',
+            handled: true, // called via captureException, this makes sense
+          },
+        },
+      ],
+    },
+    transaction: '/',
+    contexts: {
+      trace: {
+        data: {
+          'sentry.source': 'route',
+          'sentry.origin': 'auto.pageload.react.reactrouter_v6',
+          'sentry.op': 'pageload',
+          'sentry.sample_rate': 1,
+        },
+        op: 'pageload',
+        span_id: expect.any(String),
+        trace_id: expect.any(String),
+        origin: 'auto.pageload.react.reactrouter_v6',
+      },
+    },
+  });
+});
+
+test('Sends an exception to Sentry after a navigation and attaches the transaction info', async ({ page }) => {
+  const pageloadTxnPromise = waitForTransaction('standard-frontend-react', async txnEvent => {
+    return txnEvent.type === 'transaction' && txnEvent.contexts?.trace?.op === 'pageload';
+  });
+
+  const errorPromise = waitForError('standard-frontend-react', async errorEvent => {
+    return !errorEvent.type;
+  });
+
+  await page.goto(`/`);
+
+  await pageloadTxnPromise;
+
+  await page.locator('#navigation').click();
+
+  const [, error] = await Promise.all([page.locator('#userErrorBtn').click(), errorPromise]);
+
+  console.log(JSON.stringify(error, null, 2));
+  expect(error).toMatchObject({
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'User page error',
+          mechanism: {
+            type: 'instrument',
+            handled: false,
+          },
+        },
+      ],
+    },
+    transaction: '/user/:id',
+    contexts: {
+      trace: {
+        data: {
+          'sentry.source': 'route',
+          'sentry.origin': 'auto.navigation.react.reactrouter_v6',
+          'sentry.op': 'navigation',
+          'sentry.sample_rate': 1,
+        },
+        op: 'navigation',
+        span_id: expect.any(String),
+        trace_id: expect.any(String),
+        origin: 'auto.navigation.react.reactrouter_v6',
+      },
+    },
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/tests/fixtures/ReplayRecordingData.ts
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/tests/fixtures/ReplayRecordingData.ts
@@ -20,7 +20,7 @@ export const ReplayRecordingData = [
         sessionSampleRate: 1,
         shouldRecordCanvas: false,
         useCompression: false,
-        useCompressionOption: true,
+        useCompressionOption: false,
       },
       tag: 'options',
     },

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/tests/fixtures/ReplayRecordingData.ts
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/tests/fixtures/ReplayRecordingData.ts
@@ -175,6 +175,7 @@ export const ReplayRecordingData = [
           decodedBodySize: expect.any(Number),
           encodedBodySize: expect.any(Number),
           size: expect.any(Number),
+          statusCode: expect.any(Number),
         },
       },
     },

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/tsconfig.json
@@ -16,5 +16,10 @@
     "noEmit": true,
     "jsx": "react"
   },
-  "include": ["src", "tests"]
+  "include": ["src", "tests"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  }
 }


### PR DESCRIPTION
This PR adds two React `standard-frontend-react` e2e tests to cover the changes made in #11048. To avoid adding tests that poll the Sentry API and potentially cause timeouts, I added our event proxy e2e testing stragegy to the `standard-frontend-react` test app. 

ref #10846 