### PR TITLE
ref(node): Use new performance APIs in legacy `http` & `undici`

### DIFF
--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -1,9 +1,8 @@
-import type { SentrySpan } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
 import {
   SPAN_STATUS_ERROR,
   addBreadcrumb,
   defineIntegration,
-  getActiveSpan,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
@@ -14,7 +13,14 @@ import {
   setHttpStatus,
   spanToTraceHeader,
 } from '@sentry/core';
-import type { EventProcessor, Integration, IntegrationFn, IntegrationFnResult, Span } from '@sentry/types';
+import type {
+  EventProcessor,
+  Integration,
+  IntegrationFn,
+  IntegrationFnResult,
+  Span,
+  SpanAttributes,
+} from '@sentry/types';
 import {
   LRUMap,
   dynamicSamplingContextToSentryBaggageHeader,
@@ -185,9 +191,8 @@ export class Undici implements Integration {
     const clientOptions = client.getOptions();
     const scope = getCurrentScope();
     const isolationScope = getIsolationScope();
-    const parentSpan = getActiveSpan() as SentrySpan;
 
-    const span = this._shouldCreateSpan(stringUrl) ? createRequestSpan(parentSpan, request, stringUrl) : undefined;
+    const span = this._shouldCreateSpan(stringUrl) ? createRequestSpan(request, stringUrl) : undefined;
     if (span) {
       request.__sentry_span__ = span;
     }
@@ -326,28 +331,24 @@ function setHeadersOnRequest(
   }
 }
 
-function createRequestSpan(
-  activeSpan: SentrySpan | undefined,
-  request: RequestWithSentry,
-  stringUrl: string,
-): Span | undefined {
+function createRequestSpan(request: RequestWithSentry, stringUrl: string): Span {
   const url = parseUrl(stringUrl);
 
   const method = request.method || 'GET';
-  const data: Record<string, unknown> = {
+  const attributes: SpanAttributes = {
     'http.method': method,
+    [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.node.undici',
   };
   if (url.search) {
-    data['http.query'] = url.search;
+    attributes['http.query'] = url.search;
   }
   if (url.hash) {
-    data['http.fragment'] = url.hash;
+    attributes['http.fragment'] = url.hash;
   }
-  // eslint-disable-next-line deprecation/deprecation
-  return activeSpan?.startChild({
+  return startInactiveSpan({
+    onlyIfParent: true,
     op: 'http.client',
-    origin: 'auto.http.node.undici',
     name: `${method} ${getSanitizedUrlString(url)}`,
-    data,
+    attributes,
   });
 }


### PR DESCRIPTION
Extraced this out from https://github.com/getsentry/sentry-javascript/pull/11051, as it's actually not fully related.