### PR TITLE
ref: Remove deprecated `origin` field on span start options

### DIFF
--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -75,7 +75,7 @@ export class SentrySpan implements Span {
 
     this._attributes = {};
     this.setAttributes({
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: spanContext.origin || 'manual',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: spanContext.op,
       ...spanContext.attributes,
     });

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1,6 +1,7 @@
 import type { Event, Span, StartSpanOptions } from '@sentry/types';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   Scope,
   addTracingExtensions,
   getCurrentScope,
@@ -197,20 +198,21 @@ describe('startSpan', () => {
       expect(spanToJSON(spans[1]).op).toEqual('db.query');
     });
 
-    it.each([
-      { origin: 'auto.http.browser' },
-      { attributes: { 'sentry.origin': 'auto.http.browser' } },
-      // attribute should take precedence over top level origin
-      { origin: 'manual', attributes: { 'sentry.origin': 'auto.http.browser' } },
-    ])('correctly sets the span origin', async () => {
+    it('correctly sets the span origin', async () => {
       let _span: Span | undefined = undefined;
       client.on('spanEnd', span => {
         _span = span;
       });
       try {
-        await startSpan({ name: 'GET users/[id]', origin: 'auto.http.browser' }, () => {
-          return callback();
-        });
+        await startSpan(
+          {
+            name: 'GET users/[id]',
+            attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser' },
+          },
+          () => {
+            return callback();
+          },
+        );
       } catch (e) {
         //
       }

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -85,9 +85,11 @@ describe('spanToJSON', () => {
         parentSpanId: '1234',
         spanId: '5678',
         traceId: 'abcd',
-        origin: 'auto',
         startTimestamp: 123,
         endTimestamp: 456,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto',
+        },
       });
       span.setStatus({ code: SPAN_STATUS_OK });
 

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -122,9 +122,9 @@ export function _instrumentEmberRouter(
     const routeInfo = routerService.recognize(url);
     activeRootSpan = startBrowserTracingPageLoadSpan(client, {
       name: `route:${routeInfo.name}`,
-      origin: 'auto.pageload.ember',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.ember',
         url,
         toRoute: routeInfo.name,
       },
@@ -149,9 +149,9 @@ export function _instrumentEmberRouter(
 
     activeRootSpan = startBrowserTracingNavigationSpan(client, {
       name: `route:${toRoute}`,
-      origin: 'auto.navigation.ember',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.ember',
         fromRoute,
         toRoute,
       },
@@ -295,8 +295,10 @@ function processComponentRenderAfter(
     startInactiveSpan({
       name: payload.containerKey || payload.object,
       op,
-      origin: 'auto.ui.ember',
       startTimestamp: begin.now,
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.ember',
+      },
     })?.end(now);
   }
 }

--- a/packages/node-experimental/src/utils/addOriginToSpan.ts
+++ b/packages/node-experimental/src/utils/addOriginToSpan.ts
@@ -1,8 +1,8 @@
 import type { Span } from '@opentelemetry/api';
-import { _INTERNAL } from '@sentry/opentelemetry';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import type { SpanOrigin } from '@sentry/types';
 
 /** Adds an origin to an OTEL Span. */
 export function addOriginToSpan(span: Span, origin: SpanOrigin): void {
-  _INTERNAL.addOriginToSpan(span, origin);
+  span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
 }

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,6 +1,7 @@
 import type * as http from 'http';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Transaction } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -68,10 +69,10 @@ export function tracingHandler(): (
       return startInactiveSpan({
         name,
         op: 'http.server',
-        origin: 'auto.http.node.tracingHandler',
         forceTransaction: true,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.node.tracingHandler',
         },
         metadata: {
           // The request should already have been stored in `scope.sdkProcessingMetadata` (which will become

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -1,4 +1,3 @@
-import { addOriginToSpan } from './utils/addOriginToSpan';
 import { maybeCaptureExceptionForTimedEvent } from './utils/captureExceptionForTimedEvent';
 import { getRequestSpanData } from './utils/getRequestSpanData';
 
@@ -46,7 +45,6 @@ export { getClient } from '@sentry/core';
  * @hidden
  */
 const _INTERNAL = {
-  addOriginToSpan,
   maybeCaptureExceptionForTimedEvent,
   getRequestSpanData,
 } as const;

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -6,7 +6,6 @@ import { TraceState, suppressTracing } from '@opentelemetry/core';
 import {
   SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   getClient,
   getCurrentScope,
@@ -143,11 +142,7 @@ function getTracer(): Tracer {
 
 function _applySentryAttributesToSpan(span: Span, options: OpenTelemetrySpanContext): void {
   // eslint-disable-next-line deprecation/deprecation
-  const { origin, op, source } = options;
-
-  if (origin) {
-    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
-  }
+  const { op, source } = options;
 
   if (op) {
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, op);

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -222,9 +222,9 @@ describe('trace', () => {
         {
           name: 'outer',
           op: 'my-op',
-          origin: 'auto.test.origin',
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test.origin',
           },
         },
         span => {
@@ -475,9 +475,9 @@ describe('trace', () => {
       const span2 = startInactiveSpan({
         name: 'outer',
         op: 'my-op',
-        origin: 'auto.test.origin',
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test.origin',
         },
         metadata: { requestPath: 'test-path' },
       });

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -249,9 +249,9 @@ function makeWrappedDataFunction(
     return startSpan(
       {
         op: `function.remix.${name}`,
-        origin: 'auto.ui.remix',
         name: id,
         attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.remix',
           name,
         },
       },

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
-import { getActiveSpan, startInactiveSpan } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, getActiveSpan, startInactiveSpan } from '@sentry/core';
 import { setMeasurement } from '@sentry/core';
-import type { Measurements, Span, StartSpanOptions } from '@sentry/types';
+import type { Measurements, Span, SpanAttributes, StartSpanOptions } from '@sentry/types';
 import { browserPerformanceTimeOrigin, getComponentName, htmlTreeAsString, logger, parseUrl } from '@sentry/utils';
 
 import { spanToJSON } from '@sentry/core';
@@ -80,8 +80,10 @@ export function startTrackingLongTasks(): void {
       const span = startInactiveSpan({
         name: 'Main UI thread blocked',
         op: 'ui.long-task',
-        origin: 'auto.ui.browser.metrics',
         startTime,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
+        },
       });
       if (span) {
         span.end(startTime + duration);
@@ -107,8 +109,10 @@ export function startTrackingInteractions(): void {
         const spanOptions: StartSpanOptions = {
           name: htmlTreeAsString(entry.target),
           op: `ui.interaction.${entry.name}`,
-          origin: 'auto.ui.browser.metrics',
           startTime: startTime,
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
+          },
         };
 
         const componentName = getComponentName(entry.target);
@@ -264,7 +268,9 @@ export function addPerformanceEntries(span: Span): void {
       startAndEndSpan(span, fidMark.value, fidMark.value + msToSec(_measurements['fid'].value), {
         name: 'first input delay',
         op: 'ui.action',
-        origin: 'auto.ui.browser.metrics',
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
+        },
       });
 
       // Delete mark.fid as we don't want it to be part of final payload
@@ -304,7 +310,9 @@ export function _addMeasureSpans(
   startAndEndSpan(span, measureStartTimestamp, measureEndTimestamp, {
     name: entry.name as string,
     op: entry.entryType as string,
-    origin: 'auto.resource.browser.metrics',
+    attributes: {
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
+    },
   });
 
   return measureStartTimestamp;
@@ -339,8 +347,10 @@ function _addPerformanceNavigationTiming(
   }
   startAndEndSpan(span, timeOrigin + msToSec(start), timeOrigin + msToSec(end), {
     op: 'browser',
-    origin: 'auto.browser.browser.metrics',
     name: name || event,
+    attributes: {
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
+    },
   });
 }
 
@@ -358,8 +368,10 @@ function _addRequest(span: Span, entry: Record<string, any>, timeOrigin: number)
       timeOrigin + msToSec(entry.responseEnd as number),
       {
         op: 'browser',
-        origin: 'auto.browser.browser.metrics',
         name: 'request',
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
+        },
       },
     );
 
@@ -369,8 +381,10 @@ function _addRequest(span: Span, entry: Record<string, any>, timeOrigin: number)
       timeOrigin + msToSec(entry.responseEnd as number),
       {
         op: 'browser',
-        origin: 'auto.browser.browser.metrics',
         name: 'response',
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
+        },
       },
     );
   }
@@ -401,24 +415,25 @@ export function _addResourceSpans(
 
   const parsedUrl = parseUrl(resourceUrl);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const data: Record<string, any> = {};
-  setResourceEntrySizeData(data, entry, 'transferSize', 'http.response_transfer_size');
-  setResourceEntrySizeData(data, entry, 'encodedBodySize', 'http.response_content_length');
-  setResourceEntrySizeData(data, entry, 'decodedBodySize', 'http.decoded_response_content_length');
+  const attributes: SpanAttributes = {
+    [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
+  };
+  setResourceEntrySizeData(attributes, entry, 'transferSize', 'http.response_transfer_size');
+  setResourceEntrySizeData(attributes, entry, 'encodedBodySize', 'http.response_content_length');
+  setResourceEntrySizeData(attributes, entry, 'decodedBodySize', 'http.decoded_response_content_length');
 
   if ('renderBlockingStatus' in entry) {
-    data['resource.render_blocking_status'] = entry.renderBlockingStatus;
+    attributes['resource.render_blocking_status'] = entry.renderBlockingStatus;
   }
   if (parsedUrl.protocol) {
-    data['url.scheme'] = parsedUrl.protocol.split(':').pop(); // the protocol returned by parseUrl includes a :, but OTEL spec does not, so we remove it.
+    attributes['url.scheme'] = parsedUrl.protocol.split(':').pop(); // the protocol returned by parseUrl includes a :, but OTEL spec does not, so we remove it.
   }
 
   if (parsedUrl.host) {
-    data['server.address'] = parsedUrl.host;
+    attributes['server.address'] = parsedUrl.host;
   }
 
-  data['url.same_origin'] = resourceUrl.includes(WINDOW.location.origin);
+  attributes['url.same_origin'] = resourceUrl.includes(WINDOW.location.origin);
 
   const startTimestamp = timeOrigin + startTime;
   const endTimestamp = startTimestamp + duration;
@@ -426,8 +441,7 @@ export function _addResourceSpans(
   startAndEndSpan(span, startTimestamp, endTimestamp, {
     name: resourceUrl.replace(WINDOW.location.origin, ''),
     op: entry.initiatorType ? `resource.${entry.initiatorType}` : 'resource.other',
-    origin: 'auto.resource.browser.metrics',
-    data,
+    attributes,
   });
 }
 

--- a/packages/tracing-internal/src/browser/router.ts
+++ b/packages/tracing-internal/src/browser/router.ts
@@ -1,4 +1,4 @@
-import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
 import type { Transaction, TransactionContext } from '@sentry/types';
 import { addHistoryInstrumentationHandler, browserPerformanceTimeOrigin, logger } from '@sentry/utils';
 
@@ -27,9 +27,9 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
       // pageload should always start at timeOrigin (and needs to be in s, not ms)
       startTimestamp: browserPerformanceTimeOrigin ? browserPerformanceTimeOrigin / 1000 : undefined,
       op: 'pageload',
-      origin: 'auto.pageload.browser',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
       },
     });
   }
@@ -61,9 +61,9 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
         activeTransaction = customStartTransaction({
           name: WINDOW.location.pathname,
           op: 'navigation',
-          origin: 'auto.navigation.browser',
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
           },
         });
       }

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import type { Transaction } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { startInactiveSpan, withActiveSpan } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
 import type { Integration, PolymorphicRequest } from '@sentry/types';
@@ -158,7 +159,9 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
             return startInactiveSpan({
               name: fn.name,
               op: `middleware.express.${method}`,
-              origin: 'auto.middleware.express',
+              attributes: {
+                [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.middleware.express',
+              },
             });
           });
           res.once('finish', () => {
@@ -181,7 +184,9 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
               return startInactiveSpan({
                 name: fn.name,
                 op: `middleware.express.${method}`,
-                origin: 'auto.middleware.express',
+                attributes: {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.middleware.express',
+                },
               });
             })
           : undefined;
@@ -205,7 +210,9 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
               return startInactiveSpan({
                 name: fn.name,
                 op: `middleware.express.${method}`,
-                origin: 'auto.middleware.express',
+                attributes: {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.middleware.express',
+                },
               });
             })
           : undefined;

--- a/packages/tracing-internal/test/browser/browserTracingIntegration.test.ts
+++ b/packages/tracing-internal/test/browser/browserTracingIntegration.test.ts
@@ -301,8 +301,10 @@ describe('browserTracingIntegration', () => {
 
       const span = startBrowserTracingPageLoadSpan(client, {
         name: 'test span',
-        origin: 'auto.test',
-        attributes: { testy: 'yes' },
+        attributes: {
+          testy: 'yes',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
+        },
       });
 
       expect(span).toBeDefined();
@@ -492,8 +494,10 @@ describe('browserTracingIntegration', () => {
 
       const span = startBrowserTracingNavigationSpan(client, {
         name: 'test span',
-        origin: 'auto.test',
-        attributes: { testy: 'yes' },
+        attributes: {
+          testy: 'yes',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
+        },
       });
 
       expect(span).toBeDefined();

--- a/packages/tracing-internal/test/browser/router.test.ts
+++ b/packages/tracing-internal/test/browser/router.test.ts
@@ -1,4 +1,4 @@
-import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import type { HandlerDataHistory } from '@sentry/types';
 import { JSDOM } from 'jsdom';
 import { conditionalTest } from '../../../node/test/utils';
@@ -45,8 +45,10 @@ conditionalTest({ min: 16 })('instrumentRoutingWithDefaults', () => {
     expect(customStartTransaction).toHaveBeenLastCalledWith({
       name: 'blank',
       op: 'pageload',
-      origin: 'auto.pageload.browser',
-      attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url' },
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
+      },
       startTimestamp: expect.any(Number),
     });
   });
@@ -63,12 +65,7 @@ conditionalTest({ min: 16 })('instrumentRoutingWithDefaults', () => {
 
     it('it is not created automatically', () => {
       instrumentRoutingWithDefaults(customStartTransaction);
-      expect(customStartTransaction).not.toHaveBeenLastCalledWith({
-        name: 'blank',
-        op: 'navigation',
-        origin: 'auto.navigation.browser',
-        metadata: { source: 'url' },
-      });
+      expect(customStartTransaction).not.toHaveBeenCalledWith(expect.objectContaining({ op: 'navigation' }));
     });
 
     it('is created on location change', () => {
@@ -80,8 +77,10 @@ conditionalTest({ min: 16 })('instrumentRoutingWithDefaults', () => {
       expect(customStartTransaction).toHaveBeenLastCalledWith({
         name: 'blank',
         op: 'navigation',
-        origin: 'auto.navigation.browser',
-        attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url' },
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
+        },
       });
     });
 

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -189,11 +189,6 @@ export interface SpanContext {
    * Timestamp in seconds (epoch time) indicating when the span ended.
    */
   endTimestamp?: number | undefined;
-
-  /**
-   * The origin of the span, giving context about what created the span.
-   */
-  origin?: SpanOrigin | undefined;
 }
 
 /**

--- a/packages/types/src/startSpanOptions.ts
+++ b/packages/types/src/startSpanOptions.ts
@@ -1,6 +1,6 @@
 import type { Primitive } from './misc';
 import type { Scope } from './scope';
-import type { SpanAttributes, SpanOrigin, SpanTimeInput } from './span';
+import type { SpanAttributes, SpanTimeInput } from './span';
 import type { TransactionContext, TransactionMetadata, TransactionSource } from './transaction';
 
 export interface StartSpanOptions extends TransactionContext {
@@ -25,13 +25,6 @@ export interface StartSpanOptions extends TransactionContext {
    * It is not guaranteed that a span started with this flag set to `true` will be sent as a transaction.
    */
   forceTransaction?: boolean;
-
-  /**
-   * The origin of the span - if it comes from auto instrumentation or manual instrumentation.
-   *
-   * @deprecated Set `attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]` instead.
-   */
-  origin?: SpanOrigin;
 
   /** Attributes for the span. */
   attributes?: SpanAttributes;


### PR DESCRIPTION
This is now always set as attribute.