### PR TITLE
feat(nextjs): Allow omitting `client.(server|client).config.ts` and nudge towards using `instrumentation.ts`

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -43,6 +43,10 @@ export type NextConfigObject = {
         fallback?: NextRewrite[];
       }
   >;
+  // Next.js experimental options
+  experimental?: {
+    instrumentationHook?: boolean;
+  };
 };
 
 export type SentryBuildOptions = {

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -545,24 +545,19 @@ async function addSentryToEntryProperty(
  * @returns The name of the relevant file. If the server or client file is not found, this method throws an error. The
  * edge file is optional, if it is not found this function will return `undefined`.
  */
-export function getUserConfigFile(projectDir: string, platform: 'server' | 'client' | 'edge'): string | undefined {
+export function getUserConfigFile(projectDir: string, platform: 'server' | 'client' | 'edge'): string | void {
   const possibilities = [`sentry.${platform}.config.ts`, `sentry.${platform}.config.js`];
 
   for (const filename of possibilities) {
     if (fs.existsSync(path.resolve(projectDir, filename))) {
+      if (platform === 'server' || platform === 'edge') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[@sentry/nextjs] It seems you have configured a \`${filename}\` file. It is recommended to put this file's content into a Next.js instrumentation hook instead! Read more: https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation`,
+        );
+      }
       return filename;
     }
-  }
-
-  // Edge config file is optional
-  if (platform === 'edge') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      '[@sentry/nextjs] You are using Next.js features that run on the Edge Runtime. Please add a "sentry.edge.config.js" or a "sentry.edge.config.ts" file to your project root in which you initialize the Sentry SDK with "Sentry.init()".',
-    );
-    return;
-  } else {
-    throw new Error(`Cannot find '${possibilities[0]}' or '${possibilities[1]}' in '${projectDir}'.`);
   }
 }
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -69,6 +69,18 @@ function getFinalConfigObject(
     }
   }
 
+  // We need to enable `instrumentation.ts` for users because we tell them to put their `Sentry.init()` calls inside of it.
+  if (incomingUserNextConfigObject.experimental?.instrumentationHook === false) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[@sentry/nextjs] You turned off the `instrumentationHook` option. Note that Sentry will not be initialized if you set it up inside `instrumentation.ts`.',
+    );
+  }
+  incomingUserNextConfigObject.experimental = {
+    instrumentationHook: true,
+    ...incomingUserNextConfigObject.experimental,
+  };
+
   return {
     ...incomingUserNextConfigObject,
     webpack: constructWebpackConfigFunction(incomingUserNextConfigObject, userSentryOptions),


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/11042
Ref https://github.com/getsentry/sentry-javascript/issues/11046

Because Next.js OTEL implementations requires tracers to be set up in `instrumentation.ts` (not doing so breaks parent child relationships between spans for some reason) we need to change how we tell users to configure the SDK.

We aleviate all te restrictions around having to set up config files (`sentry.*.config.ts`) and instead nudge users towards using `instrumentation.ts`.