### PR TITLE
test(vue): Use vitest

### DIFF
--- a/packages/vue/.eslintrc.js
+++ b/packages/vue/.eslintrc.js
@@ -3,4 +3,12 @@ module.exports = {
     browser: true,
   },
   extends: ['../../.eslintrc.js'],
+  overrides: [
+    {
+      files: ['vite.config.ts'],
+      parserOptions: {
+        project: ['tsconfig.test.json'],
+      },
+    },
+  ]
 };

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -69,8 +69,8 @@
     "clean": "rimraf build coverage sentry-vue-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
     "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push --sig"
   },
   "volta": {

--- a/packages/vue/test/errorHandler.test.ts
+++ b/packages/vue/test/errorHandler.test.ts
@@ -1,4 +1,5 @@
 import { setCurrentClient } from '@sentry/browser';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { attachErrorHandler } from '../src/errorhandler';
 import type { Operation, Options, ViewModel, Vue } from '../src/types';
@@ -7,7 +8,7 @@ import { generateComponentTrace } from '../src/vendor/components';
 describe('attachErrorHandler', () => {
   describe('attachProps', () => {
     afterEach(() => {
-      jest.resetAllMocks();
+      vi.resetAllMocks();
     });
 
     describe("given I don't want to `attachProps`", () => {
@@ -325,13 +326,13 @@ const testHarness = ({
   enableConsole,
   vm,
 }: TestHarnessOpts) => {
-  jest.useFakeTimers();
-  const providedErrorHandlerSpy = jest.fn();
-  const warnHandlerSpy = jest.fn();
-  const consoleErrorSpy = jest.fn();
+  vi.useFakeTimers();
+  const providedErrorHandlerSpy = vi.fn();
+  const warnHandlerSpy = vi.fn();
+  const consoleErrorSpy = vi.fn();
 
   const client: any = {
-    captureException: jest.fn(async () => Promise.resolve()),
+    captureException: vi.fn(async () => Promise.resolve()),
   };
   setCurrentClient(client);
 
@@ -339,7 +340,7 @@ const testHarness = ({
     config: {
       silent: !!silent,
     },
-    mixin: jest.fn(),
+    mixin: vi.fn(),
   };
 
   if (enableErrorHandler) {
@@ -380,7 +381,7 @@ const testHarness = ({
       app.config.errorHandler(new DummyError(), vm, 'stub-lifecycle-hook');
 
       // and waits for internal timers
-      jest.runAllTimers();
+      vi.runAllTimers();
     },
     expect: {
       errorHandlerSpy: expect(providedErrorHandlerSpy),

--- a/packages/vue/test/integration/VueIntegration.test.ts
+++ b/packages/vue/test/integration/VueIntegration.test.ts
@@ -1,5 +1,6 @@
 import type { Client } from '@sentry/types';
 import { logger } from '@sentry/utils';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createApp } from 'vue';
 
 import * as Sentry from '../../src';
@@ -15,10 +16,11 @@ describe('Sentry.VueIntegration', () => {
   const globalRequest = globalThis.Request;
 
   beforeAll(() => {
-    globalThis.fetch = jest.fn();
     // @ts-expect-error This is a mock
-    globalThis.Response = jest.fn();
-    globalThis.Request = jest.fn();
+    globalThis.fetch = vi.fn();
+    // @ts-expect-error This is a mock
+    globalThis.Response = vi.fn();
+    globalThis.Request = vi.fn();
   });
 
   afterAll(() => {
@@ -31,17 +33,17 @@ describe('Sentry.VueIntegration', () => {
     warnings = [];
     loggerWarnings = [];
 
-    jest.spyOn(logger, 'warn').mockImplementation((message: unknown) => {
+    vi.spyOn(logger, 'warn').mockImplementation((message: unknown) => {
       loggerWarnings.push(message);
     });
 
-    jest.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+    vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
       warnings.push(message);
     });
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
   });
 
   it('allows to initialize integration later', () => {

--- a/packages/vue/test/integration/init.test.ts
+++ b/packages/vue/test/integration/init.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createApp } from 'vue';
 
 import type { Options } from '../../src/types';
@@ -10,13 +11,13 @@ describe('Sentry.init', () => {
 
   beforeEach(() => {
     warnings = [];
-    jest.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+    vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
       warnings.push(message);
     });
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('does not warn when correctly setup (Vue 3)', () => {

--- a/packages/vue/test/vendor/components.test.ts
+++ b/packages/vue/test/vendor/components.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from 'vitest';
 import { formatComponentName } from '../../src/vendor/components';
 
 describe('formatComponentName', () => {

--- a/packages/vue/tsconfig.test.json
+++ b/packages/vue/tsconfig.test.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["test/**/*"],
+  "include": ["test/**/*", "vite.config.ts"],
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["jest"]
+    "types": []
 
     // other package-specific, test-specific options
   }

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -1,0 +1,13 @@
+import type { UserConfig } from 'vitest';
+
+import baseConfig from '../../vite/vite.config';
+
+export default {
+  ...baseConfig,
+  test: {
+    // test exists, no idea why TS doesn't recognize it
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(baseConfig as UserConfig & { test: any }).test,
+    environment: 'jsdom',
+  },
+};


### PR DESCRIPTION
An example draft PR of us using vitest in the repo. We probably get way better time savings on the bigger test suites, I think it's worthwhile for us to give this a roll.

```
# Before
Test Suites: 5 passed, 5 total
Tests:       51 passed, 51 total
Snapshots:   0 total
Time:        2.972 s

# After
Test Files  5 passed (5)
Tests  51 passed (51)
Start at  23:25:50
Duration  1.76s (transform 303ms, setup 0ms, collect 3.18s, tests 76ms)
```

