### PR TITLE
feat(core): Move more scope globals to `__SENTRY__`

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -17,6 +17,7 @@ import type {
   SeverityLevel,
   User,
 } from '@sentry/types';
+import { getGlobalSingleton } from '@sentry/utils';
 import { GLOBAL_OBJ, consoleSandbox, dateTimestampInSeconds, isThenable, logger, uuid4 } from '@sentry/utils';
 
 import type { AsyncContextStrategy, Carrier } from './asyncContext';
@@ -574,25 +575,14 @@ export function getCurrentHub(): HubInterface {
   return acs.getCurrentHub() || getGlobalHub();
 }
 
-let defaultCurrentScope: Scope | undefined;
-let defaultIsolationScope: Scope | undefined;
-
 /** Get the default current scope. */
 export function getDefaultCurrentScope(): Scope {
-  if (!defaultCurrentScope) {
-    defaultCurrentScope = new Scope();
-  }
-
-  return defaultCurrentScope;
+  return getGlobalSingleton('defaultCurrentScope', () => new Scope());
 }
 
 /** Get the default isolation scope. */
 export function getDefaultIsolationScope(): Scope {
-  if (!defaultIsolationScope) {
-    defaultIsolationScope = new Scope();
-  }
-
-  return defaultIsolationScope;
+  return getGlobalSingleton('defaultIsolationScope', () => new Scope());
 }
 
 /**

--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -55,6 +55,8 @@ export interface InternalGlobal {
       [key: string]: Function;
     };
     globalScope: Scope | undefined;
+    defaultCurrentScope: Scope | undefined;
+    defaultIsolationScope: Scope | undefined;
     globalMetricsAggregators: WeakMap<Client, MetricsAggregator> | undefined;
   };
   /**


### PR DESCRIPTION
This PR moves `defaultCurrentScope` and `defaultIsolationScope` to the `__SENTRY__` global.
