### PR TITLE
test(browser): Add async span example test

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/init.js
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/subject.js
@@ -1,0 +1,30 @@
+import { getActiveSpan, startSpan } from '@sentry/browser';
+
+const waitForSeconds = seconds => new Promise(res => setTimeout(res, seconds * 1000));
+
+startSpan({ name: 'span 1' }, async () => {
+  await waitForSeconds(1);
+  window.firstWaitingSpan = getActiveSpan();
+});
+
+startSpan({ name: 'span 2' }, async () => {
+  await waitForSeconds(2);
+  window.secondWaitingSpan = getActiveSpan();
+});
+
+startSpan({ name: 'span 3' }, async () => {
+  await waitForSeconds(0.5);
+  window.thirdWaitingSpan = getActiveSpan();
+});
+
+/**
+ * This is what happens here:
+ * 1. span 1 starts
+ * 2. span 2 starts
+ * 3. span 3 starts (span 3 is active now)
+ * 4. waiting time in span 3 is over and 'span 3' is stored in variable
+ * 5. span 3 ends (2 is active now)
+ * 6. waiting time in span 1 is over and 'span 2' is stored in variable
+ * 7. span 2 ends (1 is active now)
+ * 8. waiting time in span 2 is over and 'span 1' is stored in variable
+ */

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/subject.js
@@ -1,20 +1,20 @@
-import { getActiveSpan, startSpan } from '@sentry/browser';
+import { getActiveSpan, spanToJSON, startSpan } from '@sentry/browser';
 
 const waitForSeconds = seconds => new Promise(res => setTimeout(res, seconds * 1000));
 
 startSpan({ name: 'span 1' }, async () => {
   await waitForSeconds(1);
-  window.firstWaitingSpan = getActiveSpan();
+  window.firstWaitingSpan = spanToJSON(getActiveSpan());
 });
 
 startSpan({ name: 'span 2' }, async () => {
   await waitForSeconds(2);
-  window.secondWaitingSpan = getActiveSpan();
+  window.secondWaitingSpan = spanToJSON(getActiveSpan());
 });
 
 startSpan({ name: 'span 3' }, async () => {
   await waitForSeconds(0.5);
-  window.thirdWaitingSpan = getActiveSpan();
+  window.thirdWaitingSpan = spanToJSON(getActiveSpan());
 });
 
 /**

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
@@ -1,0 +1,37 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../utils/fixtures';
+
+type WindowWithSpan = Window & {
+  firstWaitingSpan: any;
+  secondWaitingSpan: any;
+  thirdWaitingSpan: any;
+};
+
+sentryTest(
+  'async spans with different durations lead to unexpected behavior in browser (no "asynchronous context tracking")',
+  async ({ getLocalTestPath, page }) => {
+    const url = await getLocalTestPath({ testDir: __dirname });
+    page.goto(url);
+
+    await page.waitForFunction(
+      () =>
+        (window as unknown as WindowWithSpan).firstWaitingSpan &&
+        (window as unknown as WindowWithSpan).secondWaitingSpan &&
+        (window as unknown as WindowWithSpan).thirdWaitingSpan,
+    );
+
+    const firstWaitingSpanValue = await page.evaluate(
+      () => (window as unknown as WindowWithSpan).firstWaitingSpan._name,
+    );
+    const secondWaitingSpanName = await page.evaluate(
+      () => (window as unknown as WindowWithSpan).secondWaitingSpan._name,
+    );
+    const thirdWaitingSpanName = await page.evaluate(
+      () => (window as unknown as WindowWithSpan).thirdWaitingSpan._name,
+    );
+
+    expect(firstWaitingSpanValue).toBe('span 2');
+    expect(secondWaitingSpanName).toBe('span 1');
+    expect(thirdWaitingSpanName).toBe('span 3');
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
@@ -1,5 +1,7 @@
 import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 type WindowWithSpan = Window & {
   firstWaitingSpan: any;
@@ -13,13 +15,8 @@ sentryTest(
     const url = await getLocalTestPath({ testDir: __dirname });
     await page.goto(url);
 
-    await page.waitForFunction(
-      () =>
-        typeof window !== 'undefined' &&
-        (window as unknown as WindowWithSpan).firstWaitingSpan &&
-        (window as unknown as WindowWithSpan).secondWaitingSpan &&
-        (window as unknown as WindowWithSpan).thirdWaitingSpan,
-    );
+    const envelope = await getFirstSentryEnvelopeRequest<Event>(page);
+    expect(envelope).toBeDefined();
 
     const firstWaitingSpanValue = await page.evaluate(
       () => (window as unknown as WindowWithSpan).firstWaitingSpan._name,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
@@ -11,10 +11,11 @@ sentryTest(
   'async spans with different durations lead to unexpected behavior in browser (no "asynchronous context tracking")',
   async ({ getLocalTestPath, page }) => {
     const url = await getLocalTestPath({ testDir: __dirname });
-    page.goto(url);
+    await page.goto(url);
 
     await page.waitForFunction(
       () =>
+        typeof window !== 'undefined' &&
         (window as unknown as WindowWithSpan).firstWaitingSpan &&
         (window as unknown as WindowWithSpan).secondWaitingSpan &&
         (window as unknown as WindowWithSpan).thirdWaitingSpan,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
 type WindowWithSpan = Window & {
   firstWaitingSpan: any;
@@ -12,6 +12,10 @@ type WindowWithSpan = Window & {
 sentryTest(
   'async spans with different durations lead to unexpected behavior in browser (no "asynchronous context tracking")',
   async ({ getLocalTestPath, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
     const url = await getLocalTestPath({ testDir: __dirname });
     await page.goto(url);
 
@@ -19,13 +23,13 @@ sentryTest(
     expect(envelope).toBeDefined();
 
     const firstWaitingSpanValue = await page.evaluate(
-      () => (window as unknown as WindowWithSpan).firstWaitingSpan._name,
+      () => (window as unknown as WindowWithSpan).firstWaitingSpan.description,
     );
     const secondWaitingSpanName = await page.evaluate(
-      () => (window as unknown as WindowWithSpan).secondWaitingSpan._name,
+      () => (window as unknown as WindowWithSpan).secondWaitingSpan.description,
     );
     const thirdWaitingSpanName = await page.evaluate(
-      () => (window as unknown as WindowWithSpan).thirdWaitingSpan._name,
+      () => (window as unknown as WindowWithSpan).thirdWaitingSpan.description,
     );
 
     expect(firstWaitingSpanValue).toBe('span 2');


### PR DESCRIPTION
For showing current behavior with using differently timed async spans in browser
ref https://github.com/getsentry/sentry-javascript/pull/10986
ref https://github.com/getsentry/sentry-javascript/issues/10944