### PR TITLE
ref(types): sentry API supports breadcrumb as string

### DIFF
--- a/packages/types/src/breadcrumb.ts
+++ b/packages/types/src/breadcrumb.ts
@@ -9,7 +9,7 @@ export interface Breadcrumb {
   category?: string;
   message?: string;
   data?: { [key: string]: any };
-  timestamp?: number;
+  timestamp?: number | string;
 }
 
 /** JSDoc */


### PR DESCRIPTION
Is there a way to backport this change to the 7.x version?

> A timestamp representing when the breadcrumb occurred. The format is either a string as defined in RFC 3339 or a numeric (integer or float) value representing the number of seconds that have elapsed since the Unixepoch.
Breadcrumbs are most useful when they include a timestamp, as it creates a timeline leading up to an event expection/error.

https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/#:~:text=is%20info.-,timestamp,-(recommended)

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Lint fails on unrelated code:
```
lerna ERR! yarn run lint exited 1 in '@sentry/wasm'
```

Tests fails on unrelated code:
```
@sentry/utils:     src/is.ts:4:45 - error TS2307: Cannot find module '@sentry/types'.
```
