### PR TITLE
meta: Update changelog for 7.107.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 7.107.0
+
+This release fixes issues with INP instrumentation with the Next.js SDK and adds support for the `enableInp` option in
+the deprecated `BrowserTracing` integration for backwards compatibility.
+
+- feat(performance): Port INP span instrumentation to old browser tracing (#11085)
+- fix(ember): Ensure browser tracing is correctly lazy loaded (#11027)
+- fix(node): Do not assert in vendored proxy code (v7 backport) (#11009)
+- fix(react): Set `handled` value in ErrorBoundary depending on fallback [v7] (#11037)
+
 ## 7.106.1
 
 - fix(nextjs/v7): Use passthrough `createReduxEnhancer` on server (#11010)


### PR DESCRIPTION
Backport issue: https://github.com/getsentry/sentry-javascript/issues/10996

This backport previously was going to contain https://github.com/getsentry/sentry-javascript/pull/10970, but given the priority of getting out the INP related change in https://github.com/getsentry/sentry-javascript/pull/11085 we decided to release this now. We can get to the fix in #10970 at a later point, or even move it to v8 entirely.

