### PR TITLE
fix(opentelemetry): Fix span & sampling propagation

### DIFF
--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -28,11 +28,8 @@ export declare const getActiveSpan: typeof clientSdk.getActiveSpan;
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
 export declare const getClient: typeof clientSdk.getClient;
-export declare const startSpan: typeof clientSdk.startSpan;
-export declare const startInactiveSpan: typeof clientSdk.startInactiveSpan;
-export declare const startSpanManual: typeof clientSdk.startSpanManual;
-export declare const withActiveSpan: typeof clientSdk.withActiveSpan;
-export declare const getRootSpan: typeof clientSdk.getRootSpan;
+export declare const continueTrace: typeof clientSdk.continueTrace;
+
 export declare const Span: clientSdk.Span;
 
 export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -162,8 +162,7 @@ export function spanIsSampled(span: Span): boolean {
   // We align our trace flags with the ones OpenTelemetry use
   // So we also check for sampled the same way they do.
   const { traceFlags } = span.spanContext();
-  // eslint-disable-next-line no-bitwise
-  return Boolean(traceFlags & TRACE_FLAG_SAMPLED);
+  return traceFlags === TRACE_FLAG_SAMPLED;
 }
 
 /** Get the status message to use for a JSON representation of a span. */

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -47,6 +47,10 @@ export {
   extractRequestData,
 } from '@sentry/utils';
 
+// These are custom variants that need to be used instead of the core one
+// As they have slightly different implementations
+export { continueTrace } from '@sentry/opentelemetry';
+
 export {
   addBreadcrumb,
   isInitialized,
@@ -78,7 +82,6 @@ export {
   setCurrentClient,
   Scope,
   setMeasurement,
-  continueTrace,
   getSpanDescendants,
   parameterize,
   getCurrentScope,

--- a/packages/node-experimental/test/integration/scope.test.ts
+++ b/packages/node-experimental/test/integration/scope.test.ts
@@ -65,6 +65,8 @@ describe('Integration | Scope', () => {
               trace: {
                 span_id: spanId,
                 trace_id: traceId,
+                // local span ID from propagation context
+                ...(enableTracing ? { parent_span_id: expect.any(String) } : undefined),
               },
             }),
           }),
@@ -110,6 +112,8 @@ describe('Integration | Scope', () => {
                 status: 'ok',
                 trace_id: traceId,
                 origin: 'manual',
+                // local span ID from propagation context
+                parent_span_id: expect.any(String),
               },
             }),
             spans: [],
@@ -194,7 +198,8 @@ describe('Integration | Scope', () => {
               ? {
                   span_id: spanId1,
                   trace_id: traceId1,
-                  parent_span_id: undefined,
+                  // local span ID from propagation context
+                  ...(enableTracing ? { parent_span_id: expect.any(String) } : undefined),
                 }
               : expect.any(Object),
           }),
@@ -220,7 +225,8 @@ describe('Integration | Scope', () => {
               ? {
                   span_id: spanId2,
                   trace_id: traceId2,
-                  parent_span_id: undefined,
+                  // local span ID from propagation context
+                  ...(enableTracing ? { parent_span_id: expect.any(String) } : undefined),
                 }
               : expect.any(Object),
           }),

--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -267,6 +267,8 @@ describe('Integration | Transactions', () => {
             status: 'ok',
             trace_id: expect.any(String),
             origin: 'auto.test',
+            // local span ID from propagation context
+            parent_span_id: expect.any(String),
           },
         }),
         spans: [expect.any(Object), expect.any(Object)],
@@ -312,6 +314,8 @@ describe('Integration | Transactions', () => {
             status: 'ok',
             trace_id: expect.any(String),
             origin: 'manual',
+            // local span ID from propagation context
+            parent_span_id: expect.any(String),
           },
         }),
         spans: [expect.any(Object), expect.any(Object)],

--- a/packages/opentelemetry/src/constants.ts
+++ b/packages/opentelemetry/src/constants.ts
@@ -2,8 +2,10 @@ import { createContextKey } from '@opentelemetry/api';
 
 export const SENTRY_TRACE_HEADER = 'sentry-trace';
 export const SENTRY_BAGGAGE_HEADER = 'baggage';
-export const SENTRY_TRACE_STATE_DSC = 'sentry.trace';
+
+export const SENTRY_TRACE_STATE_DSC = 'sentry.dsc';
 export const SENTRY_TRACE_STATE_PARENT_SPAN_ID = 'sentry.parent_span_id';
+export const SENTRY_TRACE_STATE_SAMPLED_NOT_RECORDING = 'sentry.sampled_not_recording';
 
 export const SENTRY_SCOPES_CONTEXT_KEY = createContextKey('sentry_scopes');
 

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -21,7 +21,7 @@ export {
 export { isSentryRequestSpan } from './utils/isSentryRequest';
 
 export { getActiveSpan } from './utils/getActiveSpan';
-export { startSpan, startSpanManual, startInactiveSpan, withActiveSpan } from './trace';
+export { startSpan, startSpanManual, startInactiveSpan, withActiveSpan, continueTrace } from './trace';
 
 // eslint-disable-next-line deprecation/deprecation
 export { setupGlobalHub } from './custom/hub';

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -20,7 +20,7 @@ function onSpanStart(span: Span, parentContext: Context): void {
   let scopes = getScopesFromContext(parentContext);
 
   // We need access to the parent span in order to be able to move up the span tree for breadcrumbs
-  if (parentSpan) {
+  if (parentSpan && !parentSpan.spanContext().isRemote) {
     addChildSpanToSpan(parentSpan, span);
   }
 

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -2,21 +2,22 @@ import type { Context, Span, SpanContext, SpanOptions, Tracer } from '@opentelem
 import { TraceFlags } from '@opentelemetry/api';
 import { context } from '@opentelemetry/api';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
-import { TraceState, suppressTracing } from '@opentelemetry/core';
+import { suppressTracing } from '@opentelemetry/core';
 import {
   SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  continueTrace as baseContinueTrace,
   getClient,
   getCurrentScope,
+  getDynamicSamplingContextFromClient,
   getRootSpan,
   handleCallbackErrors,
 } from '@sentry/core';
 import type { Client, Scope } from '@sentry/types';
-import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
-import { SENTRY_TRACE_STATE_DSC } from './constants';
+import { continueTraceAsRemoteSpan, getSamplingDecision, makeTraceState } from './propagator';
 
 import type { OpenTelemetryClient, OpenTelemetrySpanContext } from './types';
-import { getContextFromScope } from './utils/contextData';
+import { getContextFromScope, getScopesFromContext } from './utils/contextData';
 import { getDynamicSamplingContextFromSpan } from './utils/dynamicSamplingContext';
 
 /**
@@ -167,33 +168,65 @@ function ensureTimestampInMilliseconds(timestamp: number): number {
 
 function getContext(scope: Scope | undefined, forceTransaction: boolean | undefined): Context {
   const ctx = getContextForScope(scope);
+  const actualScope = getScopesFromContext(ctx)?.scope;
 
+  const parentSpan = trace.getSpan(ctx);
+
+  // In the case that we have no parent span, we need to "simulate" one to ensure the propagation context is correct
+  if (!parentSpan) {
+    const client = getClient();
+
+    if (actualScope && client) {
+      const propagationContext = actualScope.getPropagationContext();
+      const dynamicSamplingContext =
+        propagationContext.dsc || getDynamicSamplingContextFromClient(propagationContext.traceId, client);
+
+      // We store the DSC as OTEL trace state on the span context
+      const traceState = makeTraceState({
+        parentSpanId: propagationContext.parentSpanId,
+        dsc: dynamicSamplingContext,
+        sampled: propagationContext.sampled,
+      });
+
+      const spanContext: SpanContext = {
+        traceId: propagationContext.traceId,
+        spanId: propagationContext.parentSpanId || propagationContext.spanId,
+        isRemote: true,
+        traceFlags: propagationContext.sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
+        traceState,
+      };
+
+      // Add remote parent span context,
+      return trace.setSpanContext(ctx, spanContext);
+    }
+
+    // if we have no scope or client, we just return the context as-is
+    return ctx;
+  }
+
+  // If we don't want to force a transaction, and we have a parent span, all good, we just return as-is!
   if (!forceTransaction) {
     return ctx;
   }
 
-  // Else we need to "fix" the context to have no parent span
-  const parentSpan = trace.getSpan(ctx);
-
-  // If there is no parent span, all good, nothing to do!
-  if (!parentSpan) {
-    return ctx;
-  }
+  // Else, if we do have a parent span but want to force a transaction, we have to simulate a "root" context
 
   // Else, we need to do two things:
   // 1. Unset the parent span from the context, so we'll create a new root span
   // 2. Ensure the propagation context is correct, so we'll continue from the parent span
   const ctxWithoutSpan = trace.deleteSpan(ctx);
 
-  const { spanId, traceId, traceFlags } = parentSpan.spanContext();
-  // eslint-disable-next-line no-bitwise
-  const sampled = Boolean(traceFlags & TraceFlags.SAMPLED);
+  const { spanId, traceId } = parentSpan.spanContext();
+  const sampled = getSamplingDecision(parentSpan.spanContext());
 
   const rootSpan = getRootSpan(parentSpan);
   const dsc = getDynamicSamplingContextFromSpan(rootSpan);
-  const dscString = dynamicSamplingContextToSentryBaggageHeader(dsc);
 
-  const traceState = dscString ? new TraceState().set(SENTRY_TRACE_STATE_DSC, dscString) : undefined;
+  const traceState = makeTraceState({
+    dsc,
+    parentSpanId: spanId,
+    sampled,
+  });
 
   const spanContext: SpanContext = {
     traceId,
@@ -217,4 +250,14 @@ function getContextForScope(scope?: Scope): Context {
   }
 
   return context.active();
+}
+
+/**
+ * This is a custom version of `continueTrace` that is used in OTEL-powered environments.
+ * It propagates the trace as a remote span, in addition to setting it on the propagation context.
+ */
+export function continueTrace<T>(options: Parameters<typeof baseContinueTrace>[0], callback: () => T): T {
+  return baseContinueTrace(options, () => {
+    return continueTraceAsRemoteSpan(context.active(), options, callback);
+  });
 }

--- a/packages/opentelemetry/src/utils/dynamicSamplingContext.ts
+++ b/packages/opentelemetry/src/utils/dynamicSamplingContext.ts
@@ -1,4 +1,3 @@
-import { TraceFlags } from '@opentelemetry/api';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -8,6 +7,7 @@ import {
 import type { DynamicSamplingContext } from '@sentry/types';
 import { baggageHeaderToDynamicSamplingContext } from '@sentry/utils';
 import { SENTRY_TRACE_STATE_DSC } from '../constants';
+import { getSamplingDecision } from '../propagator';
 import type { AbstractSpan } from '../types';
 import { spanHasAttributes, spanHasName } from './spanTypes';
 
@@ -51,10 +51,10 @@ export function getDynamicSamplingContextFromSpan(span: AbstractSpan): Readonly<
     dsc.transaction = name;
   }
 
-  // TODO: Once we aligned span types, use spanIsSampled() from core instead
-  // eslint-disable-next-line no-bitwise
-  const sampled = Boolean(span.spanContext().traceFlags & TraceFlags.SAMPLED);
-  dsc.sampled = String(sampled);
+  const sampled = getSamplingDecision(span.spanContext());
+  if (sampled != null) {
+    dsc.sampled = String(sampled);
+  }
 
   client.emit('createDsc', dsc);
 

--- a/packages/opentelemetry/test/integration/scope.test.ts
+++ b/packages/opentelemetry/test/integration/scope.test.ts
@@ -72,6 +72,8 @@ describe('Integration | Scope', () => {
               trace: {
                 span_id: spanId,
                 trace_id: traceId,
+                // local span ID from propagation context
+                ...(enableTracing ? { parent_span_id: expect.any(String) } : undefined),
               },
             },
           }),
@@ -117,6 +119,8 @@ describe('Integration | Scope', () => {
                 status: 'ok',
                 trace_id: traceId,
                 origin: 'manual',
+                // local span ID from propagation context
+                parent_span_id: expect.any(String),
               },
             }),
             spans: [],
@@ -211,6 +215,8 @@ describe('Integration | Scope', () => {
               ? {
                   span_id: spanId1,
                   trace_id: traceId1,
+                  // local span ID from propagation context
+                  ...(enableTracing ? { parent_span_id: expect.any(String) } : undefined),
                 }
               : expect.any(Object),
           }),
@@ -236,7 +242,8 @@ describe('Integration | Scope', () => {
               ? {
                   span_id: spanId2,
                   trace_id: traceId2,
-                  parent_span_id: undefined,
+                  // local span ID from propagation context
+                  ...(enableTracing ? { parent_span_id: expect.any(String) } : undefined),
                 }
               : expect.any(Object),
           }),
@@ -327,16 +334,21 @@ describe('Integration | Scope', () => {
 
       await client.flush();
 
+      expect(spanId1).toBeDefined();
+      expect(spanId2).toBeDefined();
+      expect(traceId1).toBeDefined();
+      expect(traceId2).toBeDefined();
+
       expect(beforeSend).toHaveBeenCalledTimes(2);
       expect(beforeSend).toHaveBeenCalledWith(
         expect.objectContaining({
           contexts: expect.objectContaining({
-            trace: spanId1
-              ? {
-                  span_id: spanId1,
-                  trace_id: traceId1,
-                }
-              : expect.any(Object),
+            trace: {
+              span_id: spanId1,
+              trace_id: traceId1,
+              // local span ID from propagation context
+              ...(enableTracing ? { parent_span_id: expect.any(String) } : undefined),
+            },
           }),
           tags: {
             tag1: 'val1',
@@ -358,13 +370,12 @@ describe('Integration | Scope', () => {
       expect(beforeSend).toHaveBeenCalledWith(
         expect.objectContaining({
           contexts: expect.objectContaining({
-            trace: spanId2
-              ? {
-                  span_id: spanId2,
-                  trace_id: traceId2,
-                  parent_span_id: undefined,
-                }
-              : expect.any(Object),
+            trace: {
+              span_id: spanId2,
+              trace_id: traceId2,
+              // local span ID from propagation context
+              ...(enableTracing ? { parent_span_id: expect.any(String) } : undefined),
+            },
           }),
           tags: {
             tag1: 'val1',

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -280,6 +280,8 @@ describe('Integration | Transactions', () => {
             status: 'ok',
             trace_id: expect.any(String),
             origin: 'auto.test',
+            // local span ID from propagation context
+            parent_span_id: expect.any(String),
           },
         }),
         spans: [expect.any(Object), expect.any(Object)],
@@ -325,6 +327,8 @@ describe('Integration | Transactions', () => {
             status: 'ok',
             trace_id: expect.any(String),
             origin: 'manual',
+            // local span ID from propagation context
+            parent_span_id: expect.any(String),
           },
         }),
         spans: [expect.any(Object), expect.any(Object)],


### PR DESCRIPTION
OK, this was a tricky one, but I _think_ it now works as expected.

This PR fixes to fundamental issues with sampling & propagation that were uncovered by @Lms24 & myself while trying to use OTEL for remix & sveltekit:

1. `continueTrace` updates the propagation context, but if there is an active parent span (even a remote one) this is ignored.
2. Sampling inheritance did not work as expected, due to the fact that OTEL spans cannot differentiate between `sampled=false` (sampled to be not recorded) and `sampled=undefined` (no sampling decision yet).

## Update to `continueTrace` & trace propagation

While my first instinct was to ensure that in the trace methods, if we have remote span we ignore it and look at the propagation context, this has a bunch of problems - because it means we can run out of sync, if this is set from outside, etc.

So instead, I now provide a custom `continueTrace` method from `@sentry/opentelemetry` & `@sentry/node` which should be used instead of the core one in meta SDKs. This method will, in addition to updating the propagation context, _also_ create a remote span with the passed in data, and make it the active span in the callback.

Then, I updated the otel start span APIs to always use that, if it exists (which was already the behavior we had), PLUS also added behavior that if there is no active span at all (not even a remote one), _then_ we look at the propagation context.

## Update to sampling inheritance

Previously, we basically did the following:

```ts
const sampled: Boolean | undefined = spanContext.traceFlags === TraceFlags.SAMPLED; 
// this will always be true or false, never undefined
```

Which means that if we create a remote span from a minimal propagation context:

```ts
// This could be a generated propagation context from a scope
const propagationContext = { spanId: 'xxx', traceId: 'yyy' };

const spanContext: SpanContext = {
  sampled: propagationContext.sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
}
```

We would later always get `sampled: false`, and inherit this decision for all downstream spans - instead of treating it as `undefined`, and going through the sampler, as we actually want it to.

In order to "solve" this, I added a new trace state `SENTRY_TRACE_STATE_SAMPLED_NOT_RECORDING`, which we set if we _know_ this is actually `sampled: false`, and not just unset.

Then, based on this we can interpret `sampled` as being `false` or `undefined`, respectively.

This is a bit hacky but should work - it means that if we get a sampling decision from outside we'll treat it as `undefined`, which is OK I would say. Our own sampler will set this correctly so we inherit correctly as well, and our propagator does so too.
