### PR TITLE
test(ci): Remove code coverage logs on CI

### DIFF
--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -19,4 +19,11 @@ module.exports = {
     __DEBUG_BUILD__: true,
   },
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
+
+  // On CI, we do not need the pretty CLI output, as it makes logs harder to parse
+  ...(process.env.CI
+    ? {
+        coverageReporters: ['json', 'lcov', 'clover'],
+      }
+    : {}),
 };


### PR DESCRIPTION
This makes parsing logs for errors etc. harder than it needs to be.

I already added this for node integration tests, but IMHO it makes sense for all jest tests on CI.
