### PR TITLE
ci: Re-add size limit action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,34 @@ jobs:
       # `job_build` can't see `job_install_deps` and what it returned)
       dependency_cache_key: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
 
+  job_size_check:
+    name: Size Check
+    needs: [job_get_metadata, job_build]
+    timeout-minutes: 15
+    runs-on: ubuntu-20.04
+    if:
+      github.event_name == 'pull_request' || needs.job_get_metadata.outputs.is_develop == 'true' ||
+      needs.job_get_metadata.outputs.is_release == 'true'
+    steps:
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.HEAD_COMMIT }}
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        env:
+          DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check bundle sizes
+        uses: ./dev-packages/size-limit-gh-action
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Only run comparison against develop if this is a PR
+          comparison_branch: ${{ (github.event_name == 'pull_request' && github.base_ref) ||  ''}}
+
   job_lint:
     name: Lint
     # Even though the linter only checks source code, not built code, it needs the built code in order check that all

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -45,21 +45,21 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, browserTracingIntegration }',
     gzip: true,
-    limit: '35 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. browserTracingIntegration) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, browserTracingIntegration }',
     gzip: true,
-    limit: '35 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. feedbackIntegration) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, feedbackIntegration }',
     gzip: true,
-    limit: '50 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. feedbackModalIntegration) - Webpack (gzipped)',
@@ -80,14 +80,14 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, sendFeedback }',
     gzip: true,
-    limit: '50 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init }',
     gzip: true,
-    limit: '28 KB',
+    limit: '90 KB',
   },
 
   // Browser CDN bundles
@@ -107,13 +107,13 @@ module.exports = [
     name: '@sentry/browser (incl. Tracing) - CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.tracing.min.js',
     gzip: true,
-    limit: '37 KB',
+    limit: '40 KB',
   },
   {
     name: '@sentry/browser - CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.min.js',
     gzip: true,
-    limit: '28 KB',
+    limit: '30 KB',
   },
 
   // browser CDN bundles (non-gzipped)
@@ -129,7 +129,7 @@ module.exports = [
     path: 'packages/browser/build/bundles/bundle.tracing.min.js',
     gzip: false,
     brotli: false,
-    limit: '105 KB',
+    limit: '120 KB',
   },
   {
     name: '@sentry/browser - CDN Bundle (minified & uncompressed)',
@@ -145,18 +145,19 @@ module.exports = [
     path: 'packages/react/build/esm/index.js',
     import: '{ init, browserTracingIntegration, replayIntegration }',
     gzip: true,
-    limit: '75 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/react - Webpack (gzipped)',
     path: 'packages/react/build/esm/index.js',
     import: '{ init }',
     gzip: true,
-    limit: '30 KB',
+    limit: '90 KB',
   },
 
   // Next.js
-  {
+  // TODO: Re-enable these, when we figure out why they break...
+  /*  {
     name: '@sentry/nextjs Client (incl. Tracing, Replay) - Webpack (gzipped)',
     path: 'packages/nextjs/build/esm/client/index.js',
     import: '{ init, browserTracingIntegration, replayIntegration }',
@@ -169,12 +170,5 @@ module.exports = [
     import: '{ init }',
     gzip: true,
     limit: '57 KB',
-  },
-  {
-    name: '@sentry-internal/feedback - Webpack (gzipped)',
-    path: 'packages/feedback/build/npm/esm/index.js',
-    import: '{ feedbackIntegration }',
-    gzip: true,
-    limit: '25 KB',
-  },
+  }, */
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -12,7 +12,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, replayIntegration, browserTracingIntegration }',
     gzip: true,
-    limit: '75 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay with Canvas) - Webpack (gzipped)',
@@ -101,7 +101,7 @@ module.exports = [
     name: '@sentry/browser (incl. Tracing, Replay) - CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.tracing.replay.min.js',
     gzip: true,
-    limit: '75 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing) - CDN Bundle (gzipped)',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -66,14 +66,14 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, feedbackIntegration, feedbackModalIntegration }',
     gzip: true,
-    limit: '50 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. feedbackScreenshotIntegration) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, feedbackIntegration, feedbackModalIntegration, feedbackScreenshotIntegration }',
     gzip: true,
-    limit: '50 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. sendFeedback) - Webpack (gzipped)',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,28 +1,28 @@
 module.exports = [
   // Main browser webpack builds
   {
-    name: '@sentry/browser (incl. Tracing, Replay, Feedback) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. Tracing, Replay, Feedback)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, replayIntegration, browserTracingIntegration, feedbackIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. Tracing, Replay) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. Tracing, Replay)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, replayIntegration, browserTracingIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. Tracing, Replay with Canvas) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. Tracing, Replay with Canvas)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, replayIntegration, browserTracingIntegration, replayCanvasIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. Tracing, Replay) - Webpack with treeshaking flags (gzipped)',
+    name: '@sentry/browser (incl. Tracing, Replay) - with treeshaking flags',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, replayIntegration, browserTracingIntegration }',
     gzip: true,
@@ -41,49 +41,49 @@ module.exports = [
     },
   },
   {
-    name: '@sentry/browser (incl. Tracing) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. Tracing)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, browserTracingIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. browserTracingIntegration) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. browserTracingIntegration)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, browserTracingIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. feedbackIntegration) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. feedbackIntegration)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, feedbackIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. feedbackModalIntegration) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. feedbackModalIntegration)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, feedbackIntegration, feedbackModalIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. feedbackScreenshotIntegration) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. feedbackScreenshotIntegration)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, feedbackIntegration, feedbackModalIntegration, feedbackScreenshotIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. sendFeedback) - Webpack (gzipped)',
+    name: '@sentry/browser (incl. sendFeedback)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, sendFeedback }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser - Webpack (gzipped)',
+    name: '@sentry/browser',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init }',
     gzip: true,
@@ -92,25 +92,25 @@ module.exports = [
 
   // Browser CDN bundles
   {
-    name: '@sentry/browser (incl. Tracing, Replay, Feedback) - CDN Bundle (gzipped)',
+    name: 'CDN Bundle (incl. Tracing, Replay, Feedback)',
     path: 'packages/browser/build/bundles/bundle.tracing.replay.feedback.min.js',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. Tracing, Replay) - CDN Bundle (gzipped)',
+    name: 'CDN Bundle (incl. Tracing, Replay)',
     path: 'packages/browser/build/bundles/bundle.tracing.replay.min.js',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/browser (incl. Tracing) - CDN Bundle (gzipped)',
+    name: 'CDN Bundle (incl. Tracing)',
     path: 'packages/browser/build/bundles/bundle.tracing.min.js',
     gzip: true,
     limit: '40 KB',
   },
   {
-    name: '@sentry/browser - CDN Bundle (gzipped)',
+    name: 'CDN Bundle',
     path: 'packages/browser/build/bundles/bundle.min.js',
     gzip: true,
     limit: '30 KB',
@@ -118,21 +118,21 @@ module.exports = [
 
   // browser CDN bundles (non-gzipped)
   {
-    name: '@sentry/browser (incl. Tracing, Replay) - CDN Bundle (minified & uncompressed)',
+    name: 'CDN Bundle (incl. Tracing, Replay) - uncompressed',
     path: 'packages/browser/build/bundles/bundle.tracing.replay.min.js',
     gzip: false,
     brotli: false,
     limit: '260 KB',
   },
   {
-    name: '@sentry/browser (incl. Tracing) - CDN Bundle (minified & uncompressed)',
+    name: 'CDN Bundle (incl. Tracing) - uncompressed',
     path: 'packages/browser/build/bundles/bundle.tracing.min.js',
     gzip: false,
     brotli: false,
     limit: '120 KB',
   },
   {
-    name: '@sentry/browser - CDN Bundle (minified & uncompressed)',
+    name: 'CDN Bundle - uncompressed',
     path: 'packages/browser/build/bundles/bundle.min.js',
     gzip: false,
     brotli: false,
@@ -141,14 +141,14 @@ module.exports = [
 
   // React
   {
-    name: '@sentry/react (incl. Tracing, Replay) - Webpack (gzipped)',
+    name: '@sentry/react (incl. Tracing, Replay)',
     path: 'packages/react/build/esm/index.js',
     import: '{ init, browserTracingIntegration, replayIntegration }',
     gzip: true,
     limit: '90 KB',
   },
   {
-    name: '@sentry/react - Webpack (gzipped)',
+    name: '@sentry/react',
     path: 'packages/react/build/esm/index.js',
     import: '{ init }',
     gzip: true,
@@ -158,14 +158,14 @@ module.exports = [
   // Next.js
   // TODO: Re-enable these, when we figure out why they break...
   /*  {
-    name: '@sentry/nextjs Client (incl. Tracing, Replay) - Webpack (gzipped)',
+    name: '@sentry/nextjs Client (incl. Tracing, Replay)',
     path: 'packages/nextjs/build/esm/client/index.js',
     import: '{ init, browserTracingIntegration, replayIntegration }',
     gzip: true,
     limit: '110 KB',
   },
   {
-    name: '@sentry/nextjs Client - Webpack (gzipped)',
+    name: '@sentry/nextjs Client',
     path: 'packages/nextjs/build/esm/client/index.js',
     import: '{ init }',
     gzip: true,

--- a/dev-packages/size-limit-gh-action/.eslintrc.cjs
+++ b/dev-packages/size-limit-gh-action/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: ['../../.eslintrc.js'],
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+  },
+
+  overrides: [
+    {
+      files: ['*.mjs'],
+      extends: ['@sentry-internal/sdk/src/base'],
+    },
+  ],
+};

--- a/dev-packages/size-limit-gh-action/action.yml
+++ b/dev-packages/size-limit-gh-action/action.yml
@@ -1,0 +1,17 @@
+name: 'size-limit-gh-action'
+description: 'Run size-limit comparison'
+inputs:
+  github_token:
+    required: true
+    description: 'a github access token'
+  comparison_branch:
+    required: false
+    default: ""
+    description: "If set, compare the current branch with this branch"
+  threshold:
+    required: false
+    default: "0.0125"
+    description: "The percentage threshold for size changes before posting a comment"
+runs:
+  using: 'node20'
+  main: 'index.mjs'

--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -1,0 +1,298 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as artifact from '@actions/artifact';
+import * as core from '@actions/core';
+import { exec } from '@actions/exec';
+import { context, getOctokit } from '@actions/github';
+import * as glob from '@actions/glob';
+import bytes from 'bytes';
+import { markdownTable } from 'markdown-table';
+
+import download from 'github-fetch-workflow-artifact';
+
+const SIZE_LIMIT_HEADING = '## size-limit report 📦 ';
+const ARTIFACT_NAME = 'size-limit-action';
+const RESULTS_FILE = 'size-limit-results.json';
+
+async function fetchPreviousComment(octokit, repo, pr) {
+  const { data: commentList } = await octokit.rest.issues.listComments({
+    ...repo,
+    issue_number: pr.number,
+  });
+
+  const sizeLimitComment = commentList.find(comment => comment.body.startsWith(SIZE_LIMIT_HEADING));
+  return !sizeLimitComment ? null : sizeLimitComment;
+}
+
+class SizeLimit {
+  formatBytes(size) {
+    return bytes.format(size, { unitSeparator: ' ' });
+  }
+
+  formatTime(seconds) {
+    if (seconds >= 1) {
+      return `${Math.ceil(seconds * 10) / 10} s`;
+    }
+
+    return `${Math.ceil(seconds * 1000)} ms`;
+  }
+
+  formatChange(base = 0, current = 0) {
+    if (base === 0) {
+      return 'added';
+    }
+
+    if (current === 0) {
+      return 'removed';
+    }
+
+    const value = ((current - base) / base) * 100;
+    const formatted = (Math.sign(value) * Math.ceil(Math.abs(value) * 100)) / 100;
+
+    if (value > 0) {
+      return `+${formatted}% 🔺`;
+    }
+
+    if (value === 0) {
+      return `${formatted}%`;
+    }
+
+    return `${formatted}% 🔽`;
+  }
+
+  formatLine(value, change) {
+    return `${value} (${change})`;
+  }
+
+  formatSizeResult(name, base, current) {
+    return [name, this.formatLine(this.formatBytes(current.size), this.formatChange(base.size, current.size))];
+  }
+
+  formatTimeResult(name, base, current) {
+    return [
+      name,
+      this.formatLine(this.formatBytes(current.size), this.formatChange(base.size, current.size)),
+      this.formatLine(this.formatTime(current.loading), this.formatChange(base.loading, current.loading)),
+      this.formatLine(this.formatTime(current.running), this.formatChange(base.running, current.running)),
+      this.formatTime(current.total),
+    ];
+  }
+
+  parseResults(output) {
+    const results = JSON.parse(output);
+
+    return results.reduce((current, result) => {
+      let time = {};
+
+      if (result.loading !== undefined && result.running !== undefined) {
+        const loading = +result.loading;
+        const running = +result.running;
+
+        time = {
+          running,
+          loading,
+          total: loading + running,
+        };
+      }
+
+      return {
+        // biome-ignore lint/performance/noAccumulatingSpread: <explanation>
+        ...current,
+        [result.name]: {
+          name: result.name,
+          size: +result.size,
+          ...time,
+        },
+      };
+    }, {});
+  }
+
+  hasSizeChanges(base, current, threshold = 0) {
+    const names = [...new Set([...(base ? Object.keys(base) : []), ...Object.keys(current)])];
+    const isSize = names.some(name => current[name] && current[name].total === undefined);
+
+    // Always return true if time results are present
+    if (!isSize) {
+      return true;
+    }
+
+    return !!names.find(name => {
+      const baseResult = base?.[name] || EmptyResult;
+      const currentResult = current[name] || EmptyResult;
+
+      if (baseResult.size === 0 && currentResult.size === 0) {
+        return true;
+      }
+
+      return Math.abs((currentResult.size - baseResult.size) / baseResult.size) * 100 > threshold;
+    });
+  }
+
+  formatResults(base, current) {
+    const names = [...new Set([...(base ? Object.keys(base) : []), ...Object.keys(current)])];
+    const isSize = names.some(name => current[name] && current[name].total === undefined);
+    const header = isSize ? SIZE_RESULTS_HEADER : TIME_RESULTS_HEADER;
+    const fields = names.map(name => {
+      const baseResult = base?.[name] || EmptyResult;
+      const currentResult = current[name] || EmptyResult;
+
+      if (isSize) {
+        return this.formatSizeResult(name, baseResult, currentResult);
+      }
+      return this.formatTimeResult(name, baseResult, currentResult);
+    });
+
+    return [header, ...fields];
+  }
+}
+
+async function execSizeLimit() {
+  let output = '';
+
+  const status = await exec('yarn run --silent size-limit --json', [], {
+    windowsVerbatimArguments: false,
+    ignoreReturnCode: true,
+    cwd: process.cwd(),
+    listeners: {
+      stdout: data => {
+        output += data.toString();
+      },
+    },
+  });
+
+  return { status, output };
+}
+
+const SIZE_RESULTS_HEADER = ['Path', 'Size'];
+const TIME_RESULTS_HEADER = ['Path', 'Size', 'Loading time (3g)', 'Running time (snapdragon)', 'Total time'];
+
+const EmptyResult = {
+  name: '-',
+  size: 0,
+  running: 0,
+  loading: 0,
+  total: 0,
+};
+
+async function run() {
+  const { getInput, setFailed } = core;
+
+  try {
+    const { payload, repo } = context;
+    const pr = payload.pull_request;
+
+    const comparisonBranch = getInput('comparison_branch');
+    const githubToken = getInput('github_token');
+    const threshold = getInput('threshold');
+
+    if (!comparisonBranch && !pr) {
+      throw new Error('No PR found. Only pull_request workflows are supported.');
+    }
+
+    const octokit = getOctokit(githubToken);
+    const limit = new SizeLimit();
+    const artifactClient = artifact.create();
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const resultsFilePath = path.resolve(__dirname, RESULTS_FILE);
+
+    // If we have no comparison branch, we just run size limit & store the result as artifact
+    if (!comparisonBranch) {
+      let base;
+      const { output: baseOutput } = await execSizeLimit();
+
+      try {
+        base = limit.parseResults(baseOutput);
+      } catch (error) {
+        core.error('Error parsing size-limit output. The output should be a json.');
+        throw error;
+      }
+
+      try {
+        await fs.writeFile(resultsFilePath, JSON.stringify(base), 'utf8');
+      } catch (err) {
+        core.error(err);
+      }
+      const globber = await glob.create(resultsFilePath, {
+        followSymbolicLinks: false,
+      });
+      const files = await globber.glob();
+
+      await artifactClient.uploadArtifact(ARTIFACT_NAME, files, process.env);
+
+      return;
+    }
+
+    // Else, we run size limit for the current branch, AND fetch it for the comparison branch
+    let base;
+    let current;
+
+    try {
+      // Ignore failures here as it is likely that this only happens when introducing size-limit
+      // and this has not been run on the main branch yet
+      await download(octokit, {
+        ...repo,
+        artifactName: ARTIFACT_NAME,
+        branch: comparisonBranch,
+        downloadPath: __dirname,
+        workflowEvent: 'push',
+        workflowName: `${process.env.GITHUB_WORKFLOW || ''}`,
+      });
+      base = JSON.parse(await fs.readFile(resultsFilePath, { encoding: 'utf8' }));
+    } catch (error) {
+      core.startGroup('Warning, unable to find base results');
+      core.debug(error);
+      core.endGroup();
+    }
+
+    const { status, output } = await execSizeLimit();
+    try {
+      current = limit.parseResults(output);
+    } catch (error) {
+      core.error('Error parsing size-limit output. The output should be a json.');
+      throw error;
+    }
+
+    const thresholdNumber = Number(threshold);
+
+    // @ts-ignore
+    const sizeLimitComment = await fetchPreviousComment(octokit, repo, pr);
+
+    const shouldComment =
+      isNaN(thresholdNumber) || limit.hasSizeChanges(base, current, thresholdNumber) || sizeLimitComment;
+
+    if (shouldComment) {
+      const body = [SIZE_LIMIT_HEADING, markdownTable(limit.formatResults(base, current))].join('\r\n');
+
+      try {
+        if (!sizeLimitComment) {
+          await octokit.rest.issues.createComment({
+            ...repo,
+            issue_number: pr.number,
+            body,
+          });
+        } else {
+          await octokit.rest.issues.updateComment({
+            ...repo,
+            comment_id: sizeLimitComment.id,
+            body,
+          });
+        }
+      } catch (error) {
+        core.error(
+          "Error updating comment. This can happen for PR's originating from a fork without write permissions.",
+        );
+      }
+    }
+
+    if (status > 0) {
+      setFailed('Size limit has been exceeded.');
+    }
+  } catch (error) {
+    core.error(error);
+    setFailed(error.message);
+  }
+}
+
+run();

--- a/dev-packages/size-limit-gh-action/package.json
+++ b/dev-packages/size-limit-gh-action/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@sentry-internal/size-limit-gh-action",
+  "description": "An internal Github Action to compare the current size of a PR against the one on develop.",
+  "version": "8.0.0-alpha.2",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "private": true,
+  "main": "index.mjs",
+  "type": "module",
+  "scripts": {
+    "lint": "eslint . --format stylish",
+    "fix": "eslint . --format stylish --fix"
+  },
+  "dependencies": {
+    "@actions/core": "1.10.1",
+    "@actions/exec": "1.1.1",
+    "@actions/github": "6.0.0",
+    "@actions/artifact": "1.1.2",
+    "@actions/glob": "0.4.0",
+    "markdown-table": "3.0.3",
+    "github-fetch-workflow-artifact": "2.0.0",
+    "bytes": "3.1.2"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "dev-packages/e2e-tests",
     "dev-packages/node-integration-tests",
     "dev-packages/overhead-metrics",
+    "dev-packages/size-limit-gh-action",
     "dev-packages/rollup-utils"
   ],
   "devDependencies": {
@@ -93,8 +94,8 @@
     "@rollup/plugin-sucrase": "^5.0.2",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
-    "@size-limit/file": "~11.0.1",
-    "@size-limit/webpack": "~11.0.1",
+    "@size-limit/file": "~11.1.0",
+    "@size-limit/webpack": "~11.1.0",
     "@strictsoftware/typedoc-plugin-monorepo": "^0.3.1",
     "@types/chai": "^4.1.3",
     "@types/jest": "^27.4.1",
@@ -125,7 +126,7 @@
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-license": "^3.3.1",
     "sinon": "^7.3.2",
-    "size-limit": "~11.0.1",
+    "size-limit": "~11.1.0",
     "ts-jest": "^27.1.4",
     "ts-node": "10.9.1",
     "typedoc": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,72 @@
 # yarn lockfile v1
 
 
+"@actions/artifact@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@actions/artifact/-/artifact-1.1.2.tgz#13e796ce35214bd6486508f97b29b4b8e44f5a35"
+  integrity sha512-1gLONA4xw3/Q/9vGxKwkFdV9u1LE2RWGx/IpAqg28ZjprCnJFjwn4pA7LtShqg5mg5WhMek2fjpyH1leCmOlQQ==
+  dependencies:
+    "@actions/core" "^1.9.1"
+    "@actions/http-client" "^2.0.1"
+    tmp "^0.2.1"
+    tmp-promise "^3.0.2"
+
+"@actions/core@1.10.1", "@actions/core@^1.6.0", "@actions/core@^1.9.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.10.1.tgz#61108e7ac40acae95ee36da074fa5850ca4ced8a"
+  integrity sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==
+  dependencies:
+    "@actions/http-client" "^2.0.1"
+    uuid "^8.3.2"
+
+"@actions/exec@1.1.1", "@actions/exec@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.1.1.tgz#2e43f28c54022537172819a7cf886c844221a611"
+  integrity sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==
+  dependencies:
+    "@actions/io" "^1.0.1"
+
+"@actions/github@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@actions/github/-/github-6.0.0.tgz#65883433f9d81521b782a64cc1fd45eef2191ea7"
+  integrity sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==
+  dependencies:
+    "@actions/http-client" "^2.2.0"
+    "@octokit/core" "^5.0.1"
+    "@octokit/plugin-paginate-rest" "^9.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "^10.0.0"
+
+"@actions/github@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@actions/github/-/github-5.1.1.tgz#40b9b9e1323a5efcf4ff7dadd33d8ea51651bbcb"
+  integrity sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==
+  dependencies:
+    "@actions/http-client" "^2.0.1"
+    "@octokit/core" "^3.6.0"
+    "@octokit/plugin-paginate-rest" "^2.17.0"
+    "@octokit/plugin-rest-endpoint-methods" "^5.13.0"
+
+"@actions/glob@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@actions/glob/-/glob-0.4.0.tgz#b169b1c1c72f41e5df7b3d9349539c88fa68403c"
+  integrity sha512-+eKIGFhsFa4EBwaf/GMyzCdWrXWymGXfFmZU3FHQvYS8mPcHtTtZONbkcqqUMzw9mJ/pImEBFET1JNifhqGsAQ==
+  dependencies:
+    "@actions/core" "^1.9.1"
+    minimatch "^3.0.4"
+
+"@actions/http-client@^2.0.1", "@actions/http-client@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-2.2.1.tgz#ed3fe7a5a6d317ac1d39886b0bb999ded229bb38"
+  integrity sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==
+  dependencies:
+    tunnel "^0.0.6"
+    undici "^5.25.4"
+
+"@actions/io@^1.0.1", "@actions/io@^1.1.1":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.1.3.tgz#4cdb6254da7962b07473ff5c335f3da485d94d71"
+  integrity sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==
+
 "@ampproject/remapping@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-1.0.1.tgz#1398e73e567c2a7992df6554c15bb94a89b68ba2"
@@ -4488,6 +4554,14 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jridgewell/trace-mapping@^0.3.20":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@jsdevtools/coverage-istanbul-loader@3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@jsdevtools/coverage-istanbul-loader/-/coverage-istanbul-loader-3.0.5.tgz#2a4bc65d0271df8d4435982db4af35d81754ee26"
@@ -4869,12 +4943,37 @@
   resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.4.1.tgz#d48b2b6f9762dcda5ae51b4f4ecd354479f42605"
   integrity sha512-MAy719VC8hCPkYJ6j5Gl+s4pevWL0dxbzcXtQDstC0Y7XWPFmHS+CDgK8zHWfaN8mK6Sebv+nTQ+e/ptEu1+TA==
 
+"@octokit/auth-token@^2.4.4":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.5.0.tgz#27c37ea26c205f28443402477ffd261311f21e36"
+  integrity sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+
 "@octokit/auth-token@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-3.0.2.tgz#a0fc8de149fd15876e1ac78f6525c1c5ab48435f"
   integrity sha512-pq7CwIMV1kmzkFTimdwjAINCXKTajZErLB4wMLYapR2nuB/Jpr66+05wOTZMSCBXP6n4DdDWT2W19Bm17vU69Q==
   dependencies:
     "@octokit/types" "^8.0.0"
+
+"@octokit/auth-token@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-4.0.0.tgz#40d203ea827b9f17f42a29c6afb93b7745ef80c7"
+  integrity sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==
+
+"@octokit/core@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.6.0.tgz#3376cb9f3008d9b3d110370d90e0a1fcd5fe6085"
+  integrity sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.3"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
 
 "@octokit/core@^4.1.0":
   version "4.2.0"
@@ -4902,6 +5001,28 @@
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/core@^5.0.1":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-5.1.0.tgz#81dacf0197ed7855e6413f128bd6dd9e121e7d2f"
+  integrity sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==
+  dependencies:
+    "@octokit/auth-token" "^4.0.0"
+    "@octokit/graphql" "^7.0.0"
+    "@octokit/request" "^8.0.2"
+    "@octokit/request-error" "^5.0.0"
+    "@octokit/types" "^12.0.0"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.12"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.12.tgz#3b4d47a4b0e79b1027fb8d75d4221928b2d05658"
+  integrity sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/endpoint@^7.0.0":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-7.0.3.tgz#0b96035673a9e3bedf8bab8f7335de424a2147ed"
@@ -4909,6 +5030,23 @@
   dependencies:
     "@octokit/types" "^8.0.0"
     is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^9.0.0":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-9.0.4.tgz#8afda5ad1ffc3073d08f2b450964c610b821d1ea"
+  integrity sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==
+  dependencies:
+    "@octokit/types" "^12.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.5.8":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
+  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
+  dependencies:
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
 "@octokit/graphql@^5.0.0":
@@ -4919,6 +5057,20 @@
     "@octokit/request" "^6.0.0"
     "@octokit/types" "^8.0.0"
     universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^7.0.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-7.0.2.tgz#3df14b9968192f9060d94ed9e3aa9780a76e7f99"
+  integrity sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==
+  dependencies:
+    "@octokit/request" "^8.0.1"
+    "@octokit/types" "^12.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^12.11.0":
+  version "12.11.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-12.11.0.tgz#da5638d64f2b919bca89ce6602d059f1b52d3ef0"
+  integrity sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==
 
 "@octokit/openapi-types@^14.0.0":
   version "14.0.0"
@@ -4935,10 +5087,22 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-18.0.0.tgz#f43d765b3c7533fd6fb88f3f25df079c24fccf69"
   integrity sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==
 
+"@octokit/openapi-types@^20.0.0":
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-20.0.0.tgz#9ec2daa0090eeb865ee147636e0c00f73790c6e5"
+  integrity sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==
+
 "@octokit/plugin-enterprise-rest@6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz#e07896739618dab8da7d4077c658003775f95437"
   integrity sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==
+
+"@octokit/plugin-paginate-rest@^2.17.0":
+  version "2.21.3"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz#7f12532797775640dbb8224da577da7dc210c87e"
+  integrity sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==
+  dependencies:
+    "@octokit/types" "^6.40.0"
 
 "@octokit/plugin-paginate-rest@^6.0.0":
   version "6.0.0"
@@ -4955,10 +5119,32 @@
     "@octokit/tsconfig" "^1.0.2"
     "@octokit/types" "^9.2.3"
 
+"@octokit/plugin-paginate-rest@^9.0.0":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz#2e2a2f0f52c9a4b1da1a3aa17dabe3c459b9e401"
+  integrity sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==
+  dependencies:
+    "@octokit/types" "^12.6.0"
+
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
   integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
+
+"@octokit/plugin-rest-endpoint-methods@^10.0.0":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz#41ba478a558b9f554793075b2e20cd2ef973be17"
+  integrity sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==
+  dependencies:
+    "@octokit/types" "^12.6.0"
+
+"@octokit/plugin-rest-endpoint-methods@^5.13.0":
+  version "5.16.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz#7ee8bf586df97dd6868cf68f641354e908c25342"
+  integrity sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==
+  dependencies:
+    "@octokit/types" "^6.39.0"
+    deprecation "^2.3.1"
 
 "@octokit/plugin-rest-endpoint-methods@^7.0.0":
   version "7.0.1"
@@ -4975,6 +5161,15 @@
   dependencies:
     "@octokit/types" "^10.0.0"
 
+"@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
 "@octokit/request-error@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-3.0.2.tgz#f74c0f163d19463b87528efe877216c41d6deb0a"
@@ -4983,6 +5178,27 @@
     "@octokit/types" "^8.0.0"
     deprecation "^2.0.0"
     once "^1.4.0"
+
+"@octokit/request-error@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-5.0.1.tgz#277e3ce3b540b41525e07ba24c5ef5e868a72db9"
+  integrity sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==
+  dependencies:
+    "@octokit/types" "^12.0.0"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.6.0", "@octokit/request@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
+  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.7"
+    universal-user-agent "^6.0.0"
 
 "@octokit/request@^6.0.0":
   version "6.2.2"
@@ -4994,6 +5210,16 @@
     "@octokit/types" "^8.0.0"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.7"
+    universal-user-agent "^6.0.0"
+
+"@octokit/request@^8.0.1", "@octokit/request@^8.0.2":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-8.2.0.tgz#125c547bc3f4c0e2dfa38c6829a1cf00027fbd98"
+  integrity sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==
+  dependencies:
+    "@octokit/endpoint" "^9.0.0"
+    "@octokit/request-error" "^5.0.0"
+    "@octokit/types" "^12.0.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@19.0.11":
@@ -5027,6 +5253,20 @@
   integrity sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
+
+"@octokit/types@^12.0.0", "@octokit/types@^12.6.0":
+  version "12.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-12.6.0.tgz#8100fb9eeedfe083aae66473bd97b15b62aedcb2"
+  integrity sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==
+  dependencies:
+    "@octokit/openapi-types" "^20.0.0"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.39.0", "@octokit/types@^6.40.0":
+  version "6.41.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.41.0.tgz#e58ef78d78596d2fb7df9c6259802464b5f84a04"
+  integrity sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==
+  dependencies:
+    "@octokit/openapi-types" "^12.11.0"
 
 "@octokit/types@^8.0.0":
   version "8.0.0"
@@ -6086,10 +6326,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sindresorhus/merge-streams@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz#9cd84cc15bc865a5ca35fcaae198eb899f7b5c90"
-  integrity sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==
+"@sindresorhus/merge-streams@^2.1.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz#719df7fb41766bc143369eaa0dd56d8dc87c9958"
+  integrity sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.7.0":
   version "1.8.2"
@@ -6157,18 +6397,18 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@size-limit/file@~11.0.1":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/@size-limit/file/-/file-11.0.1.tgz#882ca942341f58fea048aa2f403e73a8a34cd882"
-  integrity sha512-ioSYJ1WY66kc9+3dgTHi5mT/gcaNNCJ22xU87cjzfKiNxmol+lGsNKbplmrJf+QezvPH9kRIFOWxBjGY+DOt3g==
+"@size-limit/file@~11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@size-limit/file/-/file-11.1.0.tgz#9fe6497f5782cf4d887439b2ded1daf2ad2da620"
+  integrity sha512-C7Tr9dvw8Jx8If2xyGt0OprB+t03tAf259QJYi4WSl3IRMxH7l8k9qyITa/KCFcmH7tVBduNRSnHAL8Cf90EfQ==
 
-"@size-limit/webpack@~11.0.1":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/@size-limit/webpack/-/webpack-11.0.1.tgz#dd7bd770314e6c017724c34659481d62fbbd39e2"
-  integrity sha512-aQLzpXpp0Xx/AqijgpXnxJGQ3bypLo0acLt8ar3OH83w4cKE1choYROxBsqGFpPSMlwXjCIAwLxLmU98pClPzA==
+"@size-limit/webpack@~11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@size-limit/webpack/-/webpack-11.1.0.tgz#955fa23defae08697caa924c11df4e510dd03884"
+  integrity sha512-Tijbk9hgr2fPDz6M7ig7K4AbD8sacEljO+1c0bVVEr0JdbO7fv5dWsjS0lzKt+EM3GiuGPUVPZ4f381t/FzTSw==
   dependencies:
-    nanoid "^5.0.4"
-    webpack "^5.89.0"
+    nanoid "^5.0.6"
+    webpack "^5.90.3"
 
 "@socket.io/base64-arraybuffer@~1.0.2":
   version "1.0.2"
@@ -6335,6 +6575,13 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz#5433a141730f8e1d7a8e7486458ceb8144ee5edc"
   integrity sha512-JOvNJUU/zjfJWcA1aHDnCKHwQjZ7VQ3UNfbcMKXrkQKKyMkJHrQ9vpSVMhgsztrtsbIRJKazMDvg2QggFVwJqw==
+
+"@types/async-retry@^1.4.3":
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.8.tgz#eb32df13aceb9ba1a8a80e7fe518ff4e3fe46bb3"
+  integrity sha512-Qup/B5PWLe86yI5I3av6ePGaeQrIHNKCwbsQotD6aHQ6YkHsMUxVZkZsmx/Ry3VZQ6uysHwTjQ7666+k6UjVJA==
+  dependencies:
+    "@types/retry" "*"
 
 "@types/aws-lambda@^8.10.62":
   version "8.10.73"
@@ -6707,7 +6954,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/estree@1.0.5", "@types/estree@^1.0.1":
+"@types/estree@1.0.5", "@types/estree@^1.0.1", "@types/estree@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -7271,6 +7518,11 @@
   version "1.20.3"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.3.tgz#066742d69a0bbba8c5d7d517f82e1140ddeb3c3c"
   integrity sha512-NH5oErHOtHZYcjCtg69t26aXEk4BN2zLWqf7wnDZ+dpe0iR7Rds1SPGEItl3fca21oOe0n3OCnZ4W7jBxu7FOw==
+
+"@types/retry@*":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.5.tgz#f090ff4bd8d2e5b940ff270ab39fd5ca1834a07e"
+  integrity sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==
 
 "@types/rimraf@^2.0.2", "@types/rimraf@^2.0.3":
   version "2.0.4"
@@ -9212,7 +9464,7 @@ async-promise-queue@^1.0.3, async-promise-queue@^1.0.5:
     async "^2.4.1"
     debug "^2.6.8"
 
-async-retry@^1.2.1:
+async-retry@^1.2.1, async-retry@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
   integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
@@ -11043,6 +11295,16 @@ browserslist@^4.16.1, browserslist@^4.21.5, browserslist@^4.6.4:
     node-releases "^2.0.8"
     update-browserslist-db "^1.0.10"
 
+browserslist@^4.21.10, browserslist@^4.22.2:
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.0.tgz#8f3acc2bbe73af7213399430890f86c63a5674ab"
+  integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
+  dependencies:
+    caniuse-lite "^1.0.30001587"
+    electron-to-chromium "^1.4.668"
+    node-releases "^2.0.14"
+    update-browserslist-db "^1.0.13"
+
 browserslist@^4.21.9:
   version "4.22.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.1.tgz#ba91958d1a59b87dab6fed8dfbcb3da5e2e9c619"
@@ -11051,16 +11313,6 @@ browserslist@^4.21.9:
     caniuse-lite "^1.0.30001541"
     electron-to-chromium "^1.4.535"
     node-releases "^2.0.13"
-    update-browserslist-db "^1.0.13"
-
-browserslist@^4.22.2:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.0.tgz#8f3acc2bbe73af7213399430890f86c63a5674ab"
-  integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
-  dependencies:
-    caniuse-lite "^1.0.30001587"
-    electron-to-chromium "^1.4.668"
-    node-releases "^2.0.14"
     update-browserslist-db "^1.0.13"
 
 browserstack-local@^1.3.7:
@@ -11763,6 +12015,21 @@ chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
+
+chokidar@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
   version "1.1.4"
@@ -17180,6 +17447,18 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
+github-fetch-workflow-artifact@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/github-fetch-workflow-artifact/-/github-fetch-workflow-artifact-2.0.0.tgz#0d763aec2fb3c6d81a165695892c4cda5892f2ac"
+  integrity sha512-FexZF1gRVKvbzVzOiHXDPFOkGkuqw7XqFoPc084WRBAj7juQqqMi4tCokaBof5I7N49kHYzsHpOVtIkvd/N5cQ==
+  dependencies:
+    "@actions/core" "^1.6.0"
+    "@actions/exec" "^1.1.0"
+    "@actions/github" "^5.0.0"
+    "@actions/io" "^1.1.1"
+    "@types/async-retry" "^1.4.3"
+    async-retry "^1.3.3"
+
 github-from-package@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
@@ -17445,12 +17724,12 @@ globby@^13.1.2:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
-globby@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.0.tgz#ea9c062a3614e33f516804e778590fcf055256b9"
-  integrity sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==
+globby@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.1.tgz#a1b44841aa7f4c6d8af2bc39951109d77301959b"
+  integrity sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==
   dependencies:
-    "@sindresorhus/merge-streams" "^1.0.0"
+    "@sindresorhus/merge-streams" "^2.1.0"
     fast-glob "^3.3.2"
     ignore "^5.2.4"
     path-type "^5.0.0"
@@ -20173,6 +20452,11 @@ jest@^27.5.1:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
+jiti@^1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
+  integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
+
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
@@ -21031,10 +21315,10 @@ lilconfig@^2.0.3:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
   integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
 
-lilconfig@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.0.0.tgz#f8067feb033b5b74dab4602a5f5029420be749bc"
-  integrity sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==
+lilconfig@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.1.tgz#9d8a246fa753106cfc205fd2d77042faca56e5e3"
+  integrity sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==
 
 line-column@^1.0.2:
   version "1.0.2"
@@ -21899,7 +22183,7 @@ markdown-it@^8.3.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-markdown-table@^3.0.0:
+markdown-table@3.0.3, markdown-table@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.3.tgz#e6331d30e493127e031dd385488b5bd326e4a6bd"
   integrity sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==
@@ -23320,10 +23604,10 @@ nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
-nanoid@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.4.tgz#d2b608d8169d7da669279127615535705aa52edf"
-  integrity sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==
+nanoid@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.6.tgz#7f99a033aa843e4dcf9778bdaec5eb02f4dc44d5"
+  integrity sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -29282,15 +29566,16 @@ sisteransi@^1.0.5:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
-size-limit@~11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/size-limit/-/size-limit-11.0.1.tgz#e34ab3302b83833843d578e70a2bf3c6da29f123"
-  integrity sha512-6L80ocVspWPrhIRg8kPl41VypqTGH8/lu9e6TJiSJpkNLtOR2h/EEqdAO/wNJOv/sUVtjX+lVEWrzBpItGP+gQ==
+size-limit@~11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/size-limit/-/size-limit-11.1.0.tgz#f0386fac40bfc26f4d8940e9d4824135e8391691"
+  integrity sha512-HvqVEUDJ3y/XL69pR3vxTavPr6s4S9ScJhHjLEjpctF0Ymgo1StmHgFeQoyQYb/1ip7olkWxJG3wRcZk1hZcPg==
   dependencies:
     bytes-iec "^3.1.1"
-    chokidar "^3.5.3"
-    globby "^14.0.0"
-    lilconfig "^3.0.0"
+    chokidar "^3.6.0"
+    globby "^14.0.1"
+    jiti "^1.21.0"
+    lilconfig "^3.1.1"
     nanospinner "^1.1.0"
     picocolors "^1.0.0"
 
@@ -30838,16 +31123,16 @@ terser-webpack-plugin@^5.1.3:
     source-map "^0.6.1"
     terser "^5.7.2"
 
-terser-webpack-plugin@^5.3.7:
-  version "5.3.9"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
-  integrity sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==
+terser-webpack-plugin@^5.3.10:
+  version "5.3.10"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
+  integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.17"
+    "@jridgewell/trace-mapping" "^0.3.20"
     jest-worker "^27.4.5"
     schema-utils "^3.1.1"
     serialize-javascript "^6.0.1"
-    terser "^5.16.8"
+    terser "^5.26.0"
 
 terser@5.14.2:
   version "5.14.2"
@@ -30886,17 +31171,7 @@ terser@^5.0.0, terser@^5.10.0, terser@^5.7.2:
     source-map "~0.7.2"
     source-map-support "~0.5.20"
 
-terser@^5.16.8:
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.26.0.tgz#ee9f05d929f4189a9c28a0feb889d96d50126fe1"
-  integrity sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==
-  dependencies:
-    "@jridgewell/source-map" "^0.3.3"
-    acorn "^8.8.2"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
-
-terser@^5.17.4:
+terser@^5.17.4, terser@^5.26.0:
   version "5.29.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.29.1.tgz#44e58045b70c09792ba14bfb7b4e14ca8755b9fa"
   integrity sha512-lZQ/fyaIGxsbGxApKmoPTODIzELy3++mXhS5hOqaAWZjQtpq/hFHAc+rm29NND1rYRxRWKcjuARNwULNXa5RtQ==
@@ -31095,6 +31370,13 @@ tinyspy@^1.0.2:
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.1.1.tgz#0cb91d5157892af38cb2d217f5c7e8507a5bf092"
   integrity sha512-UVq5AXt/gQlti7oxoIg5oi/9r0WpF7DGEVwXgqWSMmyN16+e3tl5lIvTaOpJ3TAtu5xFzWccFRM4R5NaWHF+4g==
 
+tmp-promise@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@0.0.28:
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.28.tgz#172735b7f614ea7af39664fa84cf0de4e515d120"
@@ -31115,6 +31397,11 @@ tmp@^0.1.0:
   integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
   dependencies:
     rimraf "^2.6.3"
+
+tmp@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 tmp@^0.2.1, tmp@~0.2.1:
   version "0.2.1"
@@ -31439,6 +31726,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -31669,6 +31961,13 @@ undici@^5.21.0:
   version "5.26.2"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.26.2.tgz#fa61bfe40f732540d15e58b0c1271872d8e3c995"
   integrity sha512-a4PDLQgLTPHVzOK+x3F79/M4GtyYPl+aX9AAK7aQxpwxDwCqkeZCScy7Gk5kWT3JtdFq1uhO3uZJdLtHI4dK9A==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
+
+undici@^5.25.4:
+  version "5.28.3"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.3.tgz#a731e0eff2c3fcfd41c1169a869062be222d1e5b"
+  integrity sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
@@ -32942,19 +33241,19 @@ webpack@^5.52.0, webpack@~5.74.0:
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
-webpack@^5.89.0:
-  version "5.89.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.89.0.tgz#56b8bf9a34356e93a6625770006490bf3a7f32dc"
-  integrity sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==
+webpack@^5.90.3:
+  version "5.90.3"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.90.3.tgz#37b8f74d3ded061ba789bb22b31e82eed75bd9ac"
+  integrity sha512-h6uDYlWCctQRuXBs1oYpVe6sFcWedl0dpcVaTf/YF67J9bKvwJajFulMVSYKHrksMB3I/pIagRzDxwxkebuzKA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.0"
+    "@types/estree" "^1.0.5"
     "@webassemblyjs/ast" "^1.11.5"
     "@webassemblyjs/wasm-edit" "^1.11.5"
     "@webassemblyjs/wasm-parser" "^1.11.5"
     acorn "^8.7.1"
     acorn-import-assertions "^1.9.0"
-    browserslist "^4.14.5"
+    browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
     enhanced-resolve "^5.15.0"
     es-module-lexer "^1.2.1"
@@ -32968,7 +33267,7 @@ webpack@^5.89.0:
     neo-async "^2.6.2"
     schema-utils "^3.2.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.7"
+    terser-webpack-plugin "^5.3.10"
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 


### PR DESCRIPTION
Size seems to be much increased, let's figure this out in follow ups.

Also there is some issue with it reading next.js sizes, also something we can look at in follow ups... I disabled these size checks for now.

The action is now inlined as a package in the monorepo, as our fork has been archived and the upstream package is not really maintained and works pretty different from what we need. Now we at least have full control over this.