### PR TITLE
feat(serverless/v7): Add Node.js 20 to compatible runtimes

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -156,6 +156,7 @@ targets:
           - nodejs14.x
           - nodejs16.x
           - nodejs18.x
+          - nodejs20.x
     license: MIT
 
   # CDN Bundle Target


### PR DESCRIPTION
Backport of https://github.com/getsentry/sentry-javascript/pull/11103