### PR TITLE
build(remix): Skip Node 18 & 16 integration tests because they often segfault

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -879,14 +879,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 21]
+        # For whatever reason, these segfault on Node 18, so we are skipping these for now...
+        node: [20, 21]
         remix: [1, 2]
         # Remix v2 only supports Node 18+, so run Node 14, 16 tests separately
         include:
           - node: 14
             remix: 1
-          - node: 16
-            remix: 1
+          # For whatever reason, these segfault on Node 16, so we are skipping these for now...
+          # - node: 16
+          #  remix: 1
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4


### PR DESCRIPTION
E.g. see https://github.com/getsentry/sentry-javascript/actions/runs/8283620197/job/22667464126?pr=11106