### PR TITLE
test(replay): Skip flaky replay integration tests

### DIFF
--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
@@ -8,7 +8,9 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, page, browserName }) => {
+// Skipping because this test is flaky
+// https://github.com/getsentry/sentry-javascript/issues/11062
+sentryTest.skip('handles empty/missing request headers', async ({ getLocalTestPath, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
@@ -8,7 +8,9 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures request body size when body is sent', async ({ getLocalTestPath, page }) => {
+// Skipping because this test is flaky
+// https://github.com/getsentry/sentry-javascript/issues/10395
+sentryTest.skip('captures request body size when body is sent', async ({ getLocalTestPath, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10395
ref https://github.com/getsentry/sentry-javascript/issues/11062