### PR TITLE
build: Cache aws serverless package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ env:
     ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/gatsby/*.d.ts
     ${{ github.workspace }}/packages/core/src/version.ts
-    ${{ github.workspace }}/packages/serverless
+    ${{ github.workspace }}/packages/aws-serverless
     ${{ github.workspace }}/packages/utils/cjs
     ${{ github.workspace }}/packages/utils/esm
 


### PR DESCRIPTION
Publish failed in https://github.com/getsentry/publish/actions/runs/8288609418/job/22683485973 for https://github.com/getsentry/publish/issues/3567

```
 [info] ==============================================
[info] === Publishing to target: aws-lambda-layer ===
[info] ==============================================
[debug] [[target/aws-lambda-layer]] Fetching artifact list...
[debug] [[target/aws-lambda-layer]] Getting artifact list for revision "b91e35220b7ad3d84fd3c9fdba32cac98bfdd42a", filtering options: ***includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha)\.\d+)?\.zip$/, excludeNames:undefined***
[debug] [[artifact-provider/github]] Fetching artifact list for revision `b91e35220b7ad3d84fd3c9fdba32cac98bfdd42a`.
[debug] [[artifact-provider/github]] Found list in cache.
[debug] [[artifact-provider/github]] Found 134 artifacts.
Error:  Cannot publish AWS Lambda Layer: no packages found
  at ct (/usr/local/bin/craft:552:13801)
  at SB.publish (/usr/local/bin/craft:617:768)
  at async wCt (/usr/local/bin/craft:634:1990)
  at async /usr/local/bin/craft:637:89
  at async Fr (/usr/local/bin/craft:559:659)
  at async pxe (/usr/local/bin/craft:637:29)
  at async Object.qB [as handler] (/usr/local/bin/craft:639:73)
```

I never touched any of this code with the changes in https://github.com/getsentry/sentry-javascript/pull/11052, so I suspect it's some artifact caching issue. Trying this to see if that works, but not sure :/