### PR TITLE
test(node): Use different test server ports for `node` and `node-experimental` packages

### DIFF
--- a/packages/node-experimental/test/transports/http.test.ts
+++ b/packages/node-experimental/test/transports/http.test.ts
@@ -53,14 +53,14 @@ function setupTestServer(
     res.connection?.end();
   });
 
-  testServer.listen(18099);
+  testServer.listen(18100);
 
   return new Promise(resolve => {
     testServer?.on('listening', resolve);
   });
 }
 
-const TEST_SERVER_URL = 'http://localhost:18099';
+const TEST_SERVER_URL = 'http://localhost:18100';
 
 const EVENT_ENVELOPE = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' }, [
   [{ type: 'event' }, { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2' }] as EventItem,

--- a/packages/node-experimental/test/transports/https.test.ts
+++ b/packages/node-experimental/test/transports/https.test.ts
@@ -53,14 +53,14 @@ function setupTestServer(
     res.connection?.end();
   });
 
-  testServer.listen(8099);
+  testServer.listen(8100);
 
   return new Promise(resolve => {
     testServer?.on('listening', resolve);
   });
 }
 
-const TEST_SERVER_URL = 'https://localhost:8099';
+const TEST_SERVER_URL = 'https://localhost:8100';
 
 const EVENT_ENVELOPE = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' }, [
   [{ type: 'event' }, { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2' }] as EventItem,


### PR DESCRIPTION
Fingers crossed.

Fixes https://github.com/getsentry/sentry-javascript/issues/11111

Node and node-experimental used the same port to set up a test-server. I believe it may have flaked depending on whether the tests were ran at the same time or not.