### PR TITLE
ci: Fix size limit action base upload

### DIFF
--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -187,7 +187,7 @@ async function run() {
     const githubToken = getInput('github_token');
     const threshold = getInput('threshold');
 
-    if (!comparisonBranch && !pr) {
+    if (comparisonBranch && !pr) {
       throw new Error('No PR found. Only pull_request workflows are supported.');
     }
 


### PR DESCRIPTION
Noticed this is failing e.g. https://github.com/getsentry/sentry-javascript/actions/runs/8294578489/job/22700116991, it was an incorrect check: if there is no comparison branch, we don't need a PR.