### PR TITLE
feat(v8/browser): Remove deprecated wrap export

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -567,11 +567,12 @@ interface Transport {
 
 ### Browser SDK (Browser, React, Vue, Angular, Ember, etc.)
 
-Removed top-level exports: `Offline`, `makeXHRTransport`, `BrowserTracing`
+Removed top-level exports: `Offline`, `makeXHRTransport`, `BrowserTracing`, `wrap`
 
 - [Removal of the `BrowserTracing` integration](./MIGRATION.md#removal-of-the-browsertracing-integration)
 - [Removal of Offline integration](./MIGRATION.md#removal-of-the-offline-integration)
 - [Removal of `makeXHRTransport` transport](./MIGRATION.md#removal-of-makexhrtransport-transport)
+- [Removal of `wrap` method](./MIGRATION.md#removal-of-wrap-method)
 
 #### Removal of the `BrowserTracing` integration
 
@@ -588,6 +589,10 @@ The `Offline` integration has been removed in favor of the
 
 The `makeXHRTransport` transport has been removed. Only `makeFetchTransport` is available now. This means that the
 Sentry SDK requires the fetch API to be available in the environment.
+
+#### Removal of `wrap` method
+
+The `wrap` method has been removed. There is no replacement API.
 
 ### Server-side SDKs (Node, Deno, Bun, etc.)
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -93,8 +93,6 @@ export {
   onLoad,
   showReportDialog,
   captureUserFeedback,
-  // eslint-disable-next-line deprecation/deprecation
-  wrap,
 } from './sdk';
 
 export { breadcrumbsIntegration } from './integrations/breadcrumbs';

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -21,7 +21,7 @@ import { dedupeIntegration } from '@sentry/core';
 import type { BrowserClientOptions, BrowserOptions } from './client';
 import { BrowserClient } from './client';
 import { DEBUG_BUILD } from './debug-build';
-import { WINDOW, wrap as internalWrap } from './helpers';
+import { WINDOW } from './helpers';
 import { breadcrumbsIntegration } from './integrations/breadcrumbs';
 import { browserApiErrorsIntegration } from './integrations/browserapierrors';
 import { globalHandlersIntegration } from './integrations/globalhandlers';
@@ -266,23 +266,6 @@ export function forceLoad(): void {
  */
 export function onLoad(callback: () => void): void {
   callback();
-}
-
-/**
- * Wrap code within a try/catch block so the SDK is able to capture errors.
- *
- * @deprecated This function will be removed in v8.
- * It is not part of Sentry's official API and it's easily replaceable by using a try/catch block
- * and calling Sentry.captureException.
- *
- * @param fn A function to wrap.
- *
- * @returns The result of wrapped function call.
- */
-// TODO(v8): Remove this function
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function wrap(fn: (...args: any) => any): any {
-  return internalWrap(fn)();
 }
 
 /**

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -5,7 +5,6 @@ import {
   getReportDialogEndpoint,
   inboundFiltersIntegration,
 } from '@sentry/core';
-import type { WrappedFunction } from '@sentry/types';
 import * as utils from '@sentry/utils';
 
 import type { Event } from '../../src';
@@ -23,7 +22,6 @@ import {
   getCurrentScope,
   init,
   showReportDialog,
-  wrap,
 } from '../../src';
 import { getDefaultBrowserClientOptions } from './helper/browser-client-options';
 import { makeSimpleTransport } from './mocks/simpletransport';
@@ -400,67 +398,5 @@ describe('SentryBrowser initialization', () => {
       expect(sdkData.packages?.[0].version).toBe(SDK_VERSION);
       expect(sdkData.version).toBe(SDK_VERSION);
     });
-  });
-});
-
-describe('wrap()', () => {
-  it('should wrap and call function while capturing error', done => {
-    const options = getDefaultBrowserClientOptions({
-      beforeSend: (event: Event): Event | null => {
-        expect(event.exception!.values![0].type).toBe('TypeError');
-        expect(event.exception!.values![0].value).toBe('mkey');
-        done();
-        return null;
-      },
-      dsn,
-    });
-    setCurrentClient(new BrowserClient(options));
-
-    try {
-      // eslint-disable-next-line deprecation/deprecation
-      wrap(() => {
-        throw new TypeError('mkey');
-      });
-    } catch (e) {
-      // no-empty
-    }
-  });
-
-  it('should return result of a function call', () => {
-    // eslint-disable-next-line deprecation/deprecation
-    const result = wrap(() => 2);
-    expect(result).toBe(2);
-  });
-
-  it('should allow for passing this and arguments through binding', () => {
-    // eslint-disable-next-line deprecation/deprecation
-    const result = wrap(
-      function (this: unknown, a: string, b: number): unknown[] {
-        return [this, a, b];
-      }.bind({ context: 'this' }, 'b', 42),
-    );
-
-    expect((result as unknown[])[0]).toEqual({ context: 'this' });
-    expect((result as unknown[])[1]).toBe('b');
-    expect((result as unknown[])[2]).toBe(42);
-
-    // eslint-disable-next-line deprecation/deprecation
-    const result2 = wrap(
-      function (this: { x: number }): number {
-        return this.x;
-      }.bind({ x: 42 }),
-    );
-
-    expect(result2).toBe(42);
-  });
-
-  it('should ignore frozen functions', () => {
-    const func = Object.freeze(() => 42);
-
-    // eslint-disable-next-line deprecation/deprecation
-    wrap(func);
-
-    expect(func()).toBe(42);
-    expect((func as WrappedFunction).__sentry_wrapped__).toBeUndefined();
   });
 });


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/8927 we deprecated and removed the `wrap` method.

This PR removes the deprecated export from v8.