### PR TITLE
ref(node): Remove class based export for local variable integration

### DIFF
--- a/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node-experimental/src/integrations/local-variables/local-variables-sync.ts
@@ -1,5 +1,5 @@
-import { convertIntegrationFnToClass, defineIntegration, getClient } from '@sentry/core';
-import type { Event, Exception, Integration, IntegrationClass, IntegrationFn, StackParser } from '@sentry/types';
+import { defineIntegration, getClient } from '@sentry/core';
+import type { Event, Exception, IntegrationFn, StackParser } from '@sentry/types';
 import { LRUMap, logger } from '@sentry/utils';
 import type { Debugger, InspectorNotification, Runtime } from 'inspector';
 import { Session } from 'inspector';
@@ -384,19 +384,7 @@ const _localVariablesSyncIntegration = ((
   };
 }) satisfies IntegrationFn;
 
-export const localVariablesSyncIntegration = defineIntegration(_localVariablesSyncIntegration);
-
 /**
  * Adds local variables to exception frames.
- * @deprecated Use `localVariablesSyncIntegration()` instead.
  */
-// eslint-disable-next-line deprecation/deprecation
-export const LocalVariablesSync = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  localVariablesSyncIntegration,
-) as IntegrationClass<Integration & { processEvent: (event: Event) => Event; setup: (client: NodeClient) => void }> & {
-  new (options?: LocalVariablesIntegrationOptions, session?: DebugSession): Integration;
-};
-
-// eslint-disable-next-line deprecation/deprecation
-export type LocalVariablesSync = typeof LocalVariablesSync;
+export const localVariablesSyncIntegration = defineIntegration(_localVariablesSyncIntegration);


### PR DESCRIPTION
I think we missed this from removing the other class-based exports.