### PR TITLE
feat(v8/core): Remove deprecated integration classes

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -75,8 +75,6 @@ export {
   getSpanStatusFromHttpCode,
   setHttpStatus,
   makeMultiplexedTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  ModuleMetadata,
   moduleMetadataIntegration,
 } from '@sentry/core';
 export type { Span } from '@sentry/types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,9 +94,6 @@ export {
 } from './utils/spanUtils';
 export { applySdkMetadata } from './utils/sdkMetadata';
 export { DEFAULT_ENVIRONMENT } from './constants';
-/* eslint-disable deprecation/deprecation */
-export { ModuleMetadata } from './integrations/metadata';
-export { RequestData } from './integrations/requestdata';
 export { addBreadcrumb } from './breadcrumbs';
 export { functionToStringIntegration } from './integrations/functiontostring';
 export { inboundFiltersIntegration } from './integrations/inboundfilters';

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -1,7 +1,7 @@
-import type { Client, Integration, IntegrationClass, IntegrationFn, WrappedFunction } from '@sentry/types';
+import type { Client, IntegrationFn, WrappedFunction } from '@sentry/types';
 import { getOriginalFunction } from '@sentry/utils';
 import { getClient } from '../currentScopes';
-import { convertIntegrationFnToClass, defineIntegration } from '../integration';
+import { defineIntegration } from '../integration';
 
 let originalFunctionToString: () => void;
 
@@ -48,17 +48,3 @@ const _functionToStringIntegration = (() => {
  * ```
  */
 export const functionToStringIntegration = defineIntegration(_functionToStringIntegration);
-
-/**
- * Patch toString calls to return proper name for wrapped functions.
- *
- * @deprecated Use `functionToStringIntegration()` instead.
- */
-// eslint-disable-next-line deprecation/deprecation
-export const FunctionToString = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  functionToStringIntegration,
-) as IntegrationClass<Integration & { setupOnce: () => void }>;
-
-// eslint-disable-next-line deprecation/deprecation
-export type FunctionToString = typeof FunctionToString;

--- a/packages/core/src/integrations/metadata.ts
+++ b/packages/core/src/integrations/metadata.ts
@@ -1,6 +1,6 @@
-import type { Client, Event, EventHint, EventItem, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
+import type { EventItem, IntegrationFn } from '@sentry/types';
 import { forEachEnvelopeItem } from '@sentry/utils';
-import { convertIntegrationFnToClass, defineIntegration } from '../integration';
+import { defineIntegration } from '../integration';
 
 import { addMetadataToStackFrames, stripMetadataFromStackFrames } from '../metadata';
 
@@ -33,8 +33,6 @@ const _moduleMetadataIntegration = (() => {
   };
 }) satisfies IntegrationFn;
 
-export const moduleMetadataIntegration = defineIntegration(_moduleMetadataIntegration);
-
 /**
  * Adds module metadata to stack frames.
  *
@@ -43,16 +41,5 @@ export const moduleMetadataIntegration = defineIntegration(_moduleMetadataIntegr
  * When this integration is added, the metadata passed to the bundler plugin is added to the stack frames of all events
  * under the `module_metadata` property. This can be used to help in tagging or routing of events from different teams
  * our sources
- *
- * @deprecated Use `moduleMetadataIntegration()` instead.
  */
-// eslint-disable-next-line deprecation/deprecation
-export const ModuleMetadata = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  moduleMetadataIntegration,
-) as IntegrationClass<
-  Integration & {
-    setup: (client: Client) => void;
-    processEvent: (event: Event, hint: EventHint, client: Client) => Event;
-  }
->;
+export const moduleMetadataIntegration = defineIntegration(_moduleMetadataIntegration);

--- a/packages/core/src/integrations/requestdata.ts
+++ b/packages/core/src/integrations/requestdata.ts
@@ -1,15 +1,7 @@
-import type {
-  Client,
-  Event,
-  EventHint,
-  Integration,
-  IntegrationClass,
-  IntegrationFn,
-  Transaction,
-} from '@sentry/types';
+import type { Client, IntegrationFn, Transaction } from '@sentry/types';
 import type { AddRequestDataToEventOptions, TransactionNamingScheme } from '@sentry/utils';
 import { addRequestDataToEvent, extractPathForTransaction } from '@sentry/utils';
-import { convertIntegrationFnToClass, defineIntegration } from '../integration';
+import { defineIntegration } from '../integration';
 import { spanToJSON } from '../utils/spanUtils';
 
 export type RequestDataIntegrationOptions = {
@@ -127,41 +119,11 @@ const _requestDataIntegration = ((options: RequestDataIntegrationOptions = {}) =
   };
 }) satisfies IntegrationFn;
 
-export const requestDataIntegration = defineIntegration(_requestDataIntegration);
-
 /**
  * Add data about a request to an event. Primarily for use in Node-based SDKs, but included in `@sentry/core`
  * so it can be used in cross-platform SDKs like `@sentry/nextjs`.
- * @deprecated Use `requestDataIntegration()` instead.
  */
-// eslint-disable-next-line deprecation/deprecation
-export const RequestData = convertIntegrationFnToClass(INTEGRATION_NAME, requestDataIntegration) as IntegrationClass<
-  Integration & { processEvent: (event: Event, hint: EventHint, client: Client) => Event }
-> & {
-  new (options?: {
-    /**
-     * Controls what data is pulled from the request and added to the event
-     */
-    include?: {
-      cookies?: boolean;
-      data?: boolean;
-      headers?: boolean;
-      ip?: boolean;
-      query_string?: boolean;
-      url?: boolean;
-      user?:
-        | boolean
-        | {
-            id?: boolean;
-            username?: boolean;
-            email?: boolean;
-          };
-    };
-
-    /** Whether to identify transactions by parameterized path, parameterized path with method, or handler name */
-    transactionNamingScheme?: TransactionNamingScheme;
-  }): Integration;
-};
+export const requestDataIntegration = defineIntegration(_requestDataIntegration);
 
 /** Convert this integration's options to match what `addRequestDataToEvent` expects */
 /** TODO: Can possibly be deleted once https://github.com/getsentry/sentry-javascript/issues/5718 is fixed */

--- a/packages/core/test/lib/integrations/metadata.test.ts
+++ b/packages/core/test/lib/integrations/metadata.test.ts
@@ -1,7 +1,7 @@
 import type { Event } from '@sentry/types';
 import { GLOBAL_OBJ, createStackParser, nodeStackLineParser, parseEnvelope } from '@sentry/utils';
 
-import { ModuleMetadata, captureException, createTransport, setCurrentClient } from '../../../src';
+import { captureException, createTransport, moduleMetadataIntegration, setCurrentClient } from '../../../src';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 const stackParser = createStackParser(nodeStackLineParser());
@@ -26,8 +26,7 @@ describe('ModuleMetadata integration', () => {
       dsn: 'https://username@domain/123',
       enableSend: true,
       stackParser,
-      // eslint-disable-next-line deprecation/deprecation
-      integrations: [new ModuleMetadata()],
+      integrations: [moduleMetadataIntegration()],
       beforeSend: (event, _hint) => {
         // copy the frames since reverse in in-place
         const lastFrame = [...(event.exception?.values?.[0].stacktrace?.frames || [])].reverse()[0];

--- a/packages/core/test/lib/integrations/requestdata.test.ts
+++ b/packages/core/test/lib/integrations/requestdata.test.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage } from 'http';
 import type { Event, EventProcessor } from '@sentry/types';
 import * as sentryUtils from '@sentry/utils';
 import type { RequestDataIntegrationOptions } from '../../../src';
-import { RequestData, setCurrentClient } from '../../../src';
+import { requestDataIntegration, setCurrentClient } from '../../../src';
 
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
@@ -16,15 +16,14 @@ const path = '/by/the/trees/';
 const queryString = 'chase=me&please=thankyou';
 
 function initWithRequestDataIntegrationOptions(integrationOptions: RequestDataIntegrationOptions): EventProcessor {
-  // eslint-disable-next-line deprecation/deprecation
-  const requestDataIntegration = new RequestData({
+  const integration = requestDataIntegration({
     ...integrationOptions,
   });
 
   const client = new TestClient(
     getDefaultTestClientOptions({
       dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
-      integrations: [requestDataIntegration],
+      integrations: [integration],
     }),
   );
 

--- a/packages/node/src/integrations/index.ts
+++ b/packages/node/src/integrations/index.ts
@@ -5,7 +5,6 @@ export { OnUncaughtException } from './onuncaughtexception';
 export { OnUnhandledRejection } from './onunhandledrejection';
 export { Modules } from './modules';
 export { Context } from './context';
-export { RequestData } from '@sentry/core';
 export { Undici } from './undici';
 export { Spotlight } from './spotlight';
 export { Hapi } from './hapi';


### PR DESCRIPTION
Removes exports for `ModuleMetadata` and `RequestData`