### PR TITLE
test: Re-enable flaky replay tests

### DIFF
--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
@@ -252,9 +252,7 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
   ]);
 });
 
-// This test is flaky.
-// See https://github.com/getsentry/sentry-javascript/pull/11110
-sentryTest.skip('captures request headers as Headers instance', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers as Headers instance', async ({ getLocalTestPath, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
@@ -95,9 +95,7 @@ sentryTest.skip('captures request body size when body is sent', async ({ getLoca
   ]);
 });
 
-// This test is flaky.
-// See https://github.com/getsentry/sentry-javascript/pull/11110
-sentryTest.skip('captures request size from non-text request body', async ({ getLocalTestPath, page }) => {
+sentryTest('captures request size from non-text request body', async ({ getLocalTestPath, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
@@ -157,9 +157,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
   ]);
 });
 
-// This test is flaky so it's skipped for now
-// See https://github.com/getsentry/sentry-javascript/issues/11139
-sentryTest.skip('does not capture response headers if URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest('does not capture response headers if URL does not match', async ({ getLocalTestPath, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
@@ -188,9 +188,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
   ]);
 });
 
-// This test is flaky so it's skipped for now
-// See https://github.com/getsentry/sentry-javascript/issues/11137
-sentryTest.skip('captures response size from non-text response body', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response size from non-text response body', async ({ getLocalTestPath, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/handlers-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/handlers-lcp/test.ts
@@ -7,9 +7,7 @@ import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../.
 
 const bundle = process.env.PW_BUNDLE || '';
 
-// This test is flaky so it's skipped for now
-// See https://github.com/getsentry/sentry-javascript/issues/11138
-sentryTest.skip(
+sentryTest(
   'should capture metrics for LCP instrumentation handlers',
   async ({ browserName, getLocalTestPath, page }) => {
     // This uses a utility that is not exported in CDN bundles


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/11136
closes https://github.com/getsentry/sentry-javascript/issues/11062
closes https://github.com/getsentry/sentry-javascript/issues/11137
closes https://github.com/getsentry/sentry-javascript/issues/11138
closes https://github.com/getsentry/sentry-javascript/issues/11139

In https://github.com/getsentry/sentry-javascript/pull/11134 we changed the playwright tests use a larger GH runner. This should hopefully fix the flaky replay playwright tests. Validating that here.

Note that `Detect flaky tests / Check tests for flakiness` runs on the smaller workers, so it'll experience the same issues we had before.