### PR TITLE
fix(types): Fix incorrect `sampled` type on `Transaction`

### DIFF
--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -66,7 +66,7 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
    * Was this transaction chosen to be sent as part of the sample?
    * @deprecated Use `spanIsSampled(transaction)` instead.
    */
-  sampled?: boolean;
+  sampled?: boolean | undefined;
 
   /**
    * @inheritDoc


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

`@sentry/types` does not align with `@sentry/core`, and it causes build errors when `exactOptionalPropertyTypes` is `true`.

Example error below:

```
.../Yarn/Berry/cache/@sentry-core-npm-7.107.0-d7aa1d2661-10c0.zip/node_modules/@sentry/core/types/tracing/transaction.d.ts:5:22 - error TS2420: Class 'import(".../Yarn/Berry/cache/@sentry-core-npm-7.107.0-d7aa1d2661-10c0.zip/node_modules/@sentry/core/types/tracing/transaction").Transaction' incorrectly implements interface 'import(".../Yarn/Berry/cache/@sentry-types-npm-7.107.0-a994f84978-10c0.zip/node_modules/@sentry/types/types/transaction").Transaction'.
  Types of property 'sampled' are incompatible.
    Type 'boolean | undefined' is not assignable to type 'boolean'.
      Type 'undefined' is not assignable to type 'boolean'.

5 export declare class Transaction extends SpanClass implements TransactionInterface {
                       ~~~~~~~~~~~


Found 1 error in .../Yarn/Berry/cache/@sentry-core-npm-7.107.0-d7aa1d2661-10c0.zip/node_modules/@sentry/core/types/tracing/transaction.d.ts:5
```

This change fixes this.