### PR TITLE
chore(tests): Remove `--detectOpenHandles` from Jest config.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -906,16 +906,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # For whatever reason, these segfault on Node 18, so we are skipping these for now...
-        node: [20, 21]
+        node: [18, 20, 21]
         remix: [1, 2]
         # Remix v2 only supports Node 18+, so run Node 14, 16 tests separately
         include:
           - node: 14
             remix: 1
-          # For whatever reason, these segfault on Node 16, so we are skipping these for now...
-          # - node: 16
-          #  remix: 1
+          - node: 16
+            remix: 1
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4

--- a/packages/nextjs/test/integration/jest.config.js
+++ b/packages/nextjs/test/integration/jest.config.js
@@ -4,7 +4,6 @@ module.exports = {
   ...baseConfig,
   testMatch: [`${__dirname}/test/server/**/*.test.ts`],
   testPathIgnorePatterns: [`${__dirname}/test/client`],
-  detectOpenHandles: true,
   forceExit: true,
   testTimeout: 30000,
   setupFilesAfterEnv: [`${__dirname}/jest.setup.js`],

--- a/packages/nextjs/test/integration/package.json
+++ b/packages/nextjs/test/integration/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "pretest": "yarn build",
     "test:client": "playwright test",
-    "test:server": "jest --detectOpenHandles --forceExit --runInBand"
+    "test:server": "jest --forceExit --runInBand"
   },
   "dependencies": {
     "@sentry/nextjs": "file:../../",

--- a/packages/remix/test/integration/jest.config.js
+++ b/packages/remix/test/integration/jest.config.js
@@ -4,6 +4,5 @@ module.exports = {
   ...baseConfig,
   testMatch: [`${__dirname}/test/server/**/*.test.ts`],
   testPathIgnorePatterns: [`${__dirname}/test/client`],
-  detectOpenHandles: true,
   forceExit: true,
 };


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/pull/11107/

Removes `--detectOpenHandles` from Jest configurations of Remix and Next.JS which apparently causes segfault.

Re-enables Remix Node 16 and Node 18 integration tests on CI