### PR TITLE
feat(remix): Skip span creation for `OPTIONS` and `HEAD` requests.

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -430,6 +430,13 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
       return origRequestHandler.call(this, request, loadContext);
     }
 
+    const upperCaseMethod = request.method.toUpperCase();
+
+    // We don't want to wrap OPTIONS and HEAD requests
+    if (upperCaseMethod === 'OPTIONS' || upperCaseMethod === 'HEAD') {
+      return origRequestHandler.call(this, request, loadContext);
+    }
+
     return withIsolationScope(async isolationScope => {
       const options = getClient()?.getOptions();
 


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/11105

Skips span creation for `OPTIONS` and `HEAD` requests in `wrapRequestHandler`, which apparently are the unwanted requests mentioned in #11105. We can also implement a more precise filtering but this seems to resolve it on my local test application.