### PR TITLE
fix(node): Skip capturing Hapi Boom error responses.

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/scenario.js
@@ -26,6 +26,14 @@ const init = async () => {
     },
   });
 
+  server.route({
+    method: 'GET',
+    path: '/error',
+    handler: (_request, _h) => {
+      throw new Error('Sentry Test Error');
+    },
+  });
+
   await Sentry.setupHapiErrorHandler(server);
   await server.start();
 

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/scenario.js
@@ -43,6 +43,14 @@ const init = async () => {
     },
   });
 
+  server.route({
+    method: 'GET',
+    path: '/promise-error',
+    handler: async (_request, _h) => {
+      return Promise.reject(new Error('Sentry Test Error'));
+    },
+  });
+
   await Sentry.setupHapiErrorHandler(server);
   await server.start();
 

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/scenario.js
@@ -9,6 +9,7 @@ Sentry.init({
 });
 
 const Hapi = require('@hapi/hapi');
+const Boom = require('@hapi/boom');
 
 const port = 5999;
 
@@ -30,7 +31,15 @@ const init = async () => {
     method: 'GET',
     path: '/error',
     handler: (_request, _h) => {
-      throw new Error('Sentry Test Error');
+      return new Error('Sentry Test Error');
+    },
+  });
+
+  server.route({
+    method: 'GET',
+    path: '/boom-error',
+    handler: (_request, _h) => {
+      return new Boom.Boom('Sentry Test Error');
     },
   });
 

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/test.ts
@@ -25,10 +25,29 @@ describe('hapi auto-instrumentation', () => {
     ]),
   };
 
+  const EXPECTED_ERROR_EVENT = {
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'Sentry Test Error',
+        },
+      ],
+    },
+  };
+
   test('CJS - should auto-instrument `@hapi/hapi` package.', done => {
     createRunner(__dirname, 'scenario.js')
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start(done)
       .makeRequest('get', '/');
+  });
+
+  test('CJS - should handle errors in routes.', done => {
+    createRunner(__dirname, 'scenario.js')
+      .expect({ event: EXPECTED_ERROR_EVENT })
+      .expectError()
+      .start(done)
+      .makeRequest('get', '/error');
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/test.ts
@@ -43,11 +43,19 @@ describe('hapi auto-instrumentation', () => {
       .makeRequest('get', '/');
   });
 
-  test('CJS - should handle errors in routes.', done => {
+  test('CJS - should handle returned plain errors in routes.', done => {
     createRunner(__dirname, 'scenario.js')
       .expect({ event: EXPECTED_ERROR_EVENT })
       .expectError()
       .start(done)
       .makeRequest('get', '/error');
+  });
+
+  test('CJS - should handle returned Boom errors in routes.', done => {
+    createRunner(__dirname, 'scenario.js')
+      .expect({ event: EXPECTED_ERROR_EVENT })
+      .expectError()
+      .start(done)
+      .makeRequest('get', '/boom-error');
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/hapi/test.ts
@@ -58,4 +58,12 @@ describe('hapi auto-instrumentation', () => {
       .start(done)
       .makeRequest('get', '/boom-error');
   });
+
+  test('CJS - should handle promise rejections in routes.', done => {
+    createRunner(__dirname, 'scenario.js')
+      .expect({ event: EXPECTED_ERROR_EVENT })
+      .expectError()
+      .start(done)
+      .makeRequest('get', '/promise-error');
+  });
 });

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -126,6 +126,7 @@ export function createRunner(...paths: string[]) {
   let withSentryServer = false;
   let dockerOptions: DockerOptions | undefined;
   let ensureNoErrorOutput = false;
+  let expectError = false;
 
   if (testPath.endsWith('.ts')) {
     flags.push('-r', 'ts-node/register');
@@ -134,6 +135,10 @@ export function createRunner(...paths: string[]) {
   return {
     expect: function (expected: Expected) {
       expectedEnvelopes.push(expected);
+      return this;
+    },
+    expectError: function () {
+      expectError = true;
       return this;
     },
     withFlags: function (...args: string[]) {
@@ -347,7 +352,18 @@ export function createRunner(...paths: string[]) {
           }
 
           const url = `http://localhost:${scenarioServerPort}${path}`;
-          if (method === 'get') {
+          if (expectError) {
+            try {
+              if (method === 'get') {
+                await axios.get(url, { headers });
+              } else {
+                await axios.post(url, { headers });
+              }
+            } catch (e) {
+              return;
+            }
+            return;
+          } else if (method === 'get') {
             return (await axios.get(url, { headers })).data;
           } else {
             return (await axios.post(url, { headers })).data;

--- a/packages/node/src/integrations/hapi/index.ts
+++ b/packages/node/src/integrations/hapi/index.ts
@@ -23,10 +23,6 @@ function isResponseObject(response: ResponseObject | Boom): response is Response
   return response && (response as ResponseObject).statusCode !== undefined;
 }
 
-function isBoomObject(response: ResponseObject | Boom): response is Boom {
-  return response && (response as Boom).isBoom !== undefined;
-}
-
 function isErrorEvent(event: RequestEvent): event is RequestEvent {
   return event && (event as RequestEvent).error !== undefined;
 }
@@ -54,9 +50,7 @@ export const hapiErrorPlugin = {
       const activeSpan = getActiveSpan();
       const rootSpan = activeSpan && getRootSpan(activeSpan);
 
-      if (request.response && isBoomObject(request.response)) {
-        sendErrorToSentry(request.response);
-      } else if (isErrorEvent(event)) {
+      if (isErrorEvent(event)) {
         sendErrorToSentry(event.error);
       }
 


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-javascript/issues/11069

After checking the behaviour, it seems to me that we don't need to capture any Boom responses, as the errors that may cause a `5xx` response are already captured by the core logic. To add an option to control this behaviour, we need to update the usage of `hapiErrorPlugin`, converting it to a function signature, which IMO may not worth doing, as I'm not sure if users in general would need to use it.

This also adds `expectError()` to the `node-integration-tests` runner to allow `5xx` responses to be tested.