### PR TITLE
fix(node):  Export `initOpenTelemetry`

### DIFF
--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -88,6 +88,7 @@ export {
   hapiIntegration,
   setupHapiErrorHandler,
   spotlightIntegration,
+  initOpenTelemetry,
 } from '@sentry/node';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -109,6 +109,7 @@ export {
   hapiIntegration,
   setupHapiErrorHandler,
   spotlightIntegration,
+  initOpenTelemetry,
 } from '@sentry/node';
 
 export {

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -88,6 +88,7 @@ export {
   hapiIntegration,
   setupHapiErrorHandler,
   spotlightIntegration,
+  initOpenTelemetry,
 } from '@sentry/node';
 
 export {

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -24,6 +24,7 @@ export { hapiIntegration, setupHapiErrorHandler } from './integrations/tracing/h
 export { spotlightIntegration } from './integrations/spotlight';
 
 export { init, getDefaultIntegrations } from './sdk/init';
+export { initOpenTelemetry } from './sdk/initOtel';
 export { getAutoPerformanceIntegrations } from './integrations/tracing';
 export { getSentryRelease, defaultStackParser } from './sdk/api';
 export { createGetModuleFromFilename } from './utils/module';

--- a/packages/node-experimental/src/sdk/init.ts
+++ b/packages/node-experimental/src/sdk/init.ts
@@ -37,7 +37,7 @@ import { makeNodeTransport } from '../transports';
 import type { NodeClientOptions, NodeOptions } from '../types';
 import { defaultStackParser, getSentryRelease } from './api';
 import { NodeClient } from './client';
-import { initOtel } from './initOtel';
+import { initOpenTelemetry } from './initOtel';
 
 function getCjsOnlyIntegrations(isCjs = typeof require !== 'undefined'): Integration[] {
   return isCjs ? [modulesIntegration()] : [];
@@ -122,7 +122,7 @@ export function init(options: NodeOptions | undefined = {}): void {
   // If users opt-out of this, they _have_ to set up OpenTelemetry themselves
   // There is no way to use this SDK without OpenTelemetry!
   if (!options.skipOpenTelemetrySetup) {
-    initOtel();
+    initOpenTelemetry(client);
   }
 
   validateOpenTelemetrySetup();

--- a/packages/node-experimental/src/sdk/initOtel.ts
+++ b/packages/node-experimental/src/sdk/initOtel.ts
@@ -2,28 +2,17 @@ import { DiagLogLevel, diag } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { SDK_VERSION, getClient } from '@sentry/core';
+import { SDK_VERSION } from '@sentry/core';
 import { SentryPropagator, SentrySampler, SentrySpanProcessor, setupEventContextTrace } from '@sentry/opentelemetry';
 import { logger } from '@sentry/utils';
 
-import { DEBUG_BUILD } from '../debug-build';
 import { SentryContextManager } from '../otel/contextManager';
 import type { NodeClient } from './client';
 
 /**
  * Initialize OpenTelemetry for Node.
  */
-export function initOtel(): void {
-  const client = getClient<NodeClient>();
-
-  if (!client) {
-    DEBUG_BUILD &&
-      logger.warn(
-        'No client available, skipping OpenTelemetry setup. This probably means that `Sentry.init()` was not called before `initOtel()`.',
-      );
-    return;
-  }
-
+export function initOpenTelemetry(client: NodeClient): void {
   if (client.getOptions().debug) {
     const otelLogger = new Proxy(logger as typeof logger & { verbose: (typeof logger)['debug'] }, {
       get(target, prop, receiver) {

--- a/packages/node-experimental/test/sdk/client.test.ts
+++ b/packages/node-experimental/test/sdk/client.test.ts
@@ -13,8 +13,7 @@ import type { Event, EventHint } from '@sentry/types';
 import type { Scope } from '@sentry/types';
 
 import { setOpenTelemetryContextAsyncContextStrategy } from '@sentry/opentelemetry';
-import { NodeClient } from '../../src/sdk/client';
-import { initOtel } from '../../src/sdk/initOtel';
+import { NodeClient, initOpenTelemetry } from '../../src';
 import { getDefaultNodeClientOptions } from '../helpers/getDefaultNodeClientOptions';
 import { cleanupOtel } from '../helpers/mockSdkInit';
 
@@ -79,7 +78,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       withIsolationScope(isolationScope => {
         isolationScope.setRequestSession({ status: 'ok' });
@@ -96,7 +95,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
       // by the`requestHandler`)
@@ -117,7 +116,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
       // by the`requestHandler`)
@@ -138,7 +137,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
       // by the`requestHandler`)
@@ -159,7 +158,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
       // by the`requestHandler`)
@@ -187,7 +186,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
       // by the`requestHandler`)
@@ -223,7 +222,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
       // by the`requestHandler`)
@@ -244,7 +243,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
       // by the`requestHandler`)
@@ -263,7 +262,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
       // by the`requestHandler`)
@@ -284,7 +283,7 @@ describe('NodeClient', () => {
       const client = new NodeClient(options);
       setCurrentClient(client);
       client.init();
-      initOtel();
+      initOpenTelemetry(client);
 
       withIsolationScope(isolationScope => {
         isolationScope.setRequestSession({ status: 'ok' });


### PR DESCRIPTION
Closes #11118

This PR exports what used to be called `initOtel` so that the `NodeClient` can be used without calling `init`.

If OpenTelemetry is only required for performance feature, we should also only enable it if the sample rate is above zero to save memory.
