### PR TITLE
feat(node): Support `tunnel` option for ANR

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1,4 +1,4 @@
-import type { ClientOptions, DsnComponents, DsnLike, SdkInfo } from '@sentry/types';
+import type { DsnComponents, DsnLike, SdkInfo } from '@sentry/types';
 import { dsnToString, makeDsn, urlEncode } from '@sentry/utils';
 
 const SENTRY_API_VERSION = '7';

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -31,20 +31,7 @@ function _encodedAuth(dsn: DsnComponents, sdkInfo: SdkInfo | undefined): string 
  *
  * Sending auth as part of the query string and not as custom HTTP headers avoids CORS preflight requests.
  */
-export function getEnvelopeEndpointWithUrlEncodedAuth(
-  dsn: DsnComponents,
-  // TODO (v8): Remove `tunnelOrOptions` in favor of `options`, and use the substitute code below
-  // options: ClientOptions = {} as ClientOptions,
-  tunnelOrOptions: string | ClientOptions = {} as ClientOptions,
-): string {
-  // TODO (v8): Use this code instead
-  // const { tunnel, _metadata = {} } = options;
-  // return tunnel ? tunnel : `${_getIngestEndpoint(dsn)}?${_encodedAuth(dsn, _metadata.sdk)}`;
-
-  const tunnel = typeof tunnelOrOptions === 'string' ? tunnelOrOptions : tunnelOrOptions.tunnel;
-  const sdkInfo =
-    typeof tunnelOrOptions === 'string' || !tunnelOrOptions._metadata ? undefined : tunnelOrOptions._metadata.sdk;
-
+export function getEnvelopeEndpointWithUrlEncodedAuth(dsn: DsnComponents, tunnel?: string, sdkInfo?: SdkInfo): string {
   return tunnel ? tunnel : `${_getIngestEndpoint(dsn)}?${_encodedAuth(dsn, sdkInfo)}`;
 }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -135,7 +135,11 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     }
 
     if (this._dsn) {
-      const url = getEnvelopeEndpointWithUrlEncodedAuth(this._dsn, options);
+      const url = getEnvelopeEndpointWithUrlEncodedAuth(
+        this._dsn,
+        options.tunnel,
+        options._metadata ? options._metadata.sdk : undefined,
+      );
       this._transport = options.transport({
         recordDroppedEvent: this.recordDroppedEvent.bind(this),
         ...options.transportOptions,

--- a/packages/node-experimental/src/integrations/anr/common.ts
+++ b/packages/node-experimental/src/integrations/anr/common.ts
@@ -37,6 +37,7 @@ export interface WorkerStartData extends AnrIntegrationOptions {
   debug: boolean;
   sdkMetadata: SdkMetadata;
   dsn: DsnComponents;
+  tunnel: string | undefined
   release: string | undefined;
   environment: string;
   dist: string | undefined;

--- a/packages/node-experimental/src/integrations/anr/common.ts
+++ b/packages/node-experimental/src/integrations/anr/common.ts
@@ -37,7 +37,7 @@ export interface WorkerStartData extends AnrIntegrationOptions {
   debug: boolean;
   sdkMetadata: SdkMetadata;
   dsn: DsnComponents;
-  tunnel: string | undefined
+  tunnel: string | undefined;
   release: string | undefined;
   environment: string;
   dist: string | undefined;

--- a/packages/node-experimental/src/integrations/anr/index.ts
+++ b/packages/node-experimental/src/integrations/anr/index.ts
@@ -73,6 +73,7 @@ async function _startWorker(client: NodeClient, _options: Partial<AnrIntegration
   const options: WorkerStartData = {
     debug: logger.isEnabled(),
     dsn,
+    tunnel: initOptions.tunnel,
     environment: initOptions.environment || 'production',
     release: initOptions.release,
     dist: initOptions.dist,

--- a/packages/node-experimental/src/integrations/anr/worker.ts
+++ b/packages/node-experimental/src/integrations/anr/worker.ts
@@ -33,7 +33,7 @@ function log(msg: string): void {
   }
 }
 
-const url = getEnvelopeEndpointWithUrlEncodedAuth(options.dsn);
+const url = getEnvelopeEndpointWithUrlEncodedAuth(options.dsn, options.tunnel, options.sdkMetadata.sdk);
 const transport = makeNodeTransport({
   url,
   recordDroppedEvent: () => {
@@ -47,7 +47,7 @@ async function sendAbnormalSession(): Promise<void> {
     log('Sending abnormal session');
     updateSession(session, { status: 'abnormal', abnormal_mechanism: 'anr_foreground' });
 
-    const envelope = createSessionEnvelope(session, options.dsn, options.sdkMetadata);
+    const envelope = createSessionEnvelope(session, options.dsn, options.sdkMetadata, options.tunnel);
     // Log the envelope so to aid in testing
     log(JSON.stringify(envelope));
 
@@ -119,15 +119,15 @@ async function sendAnrEvent(frames?: StackFrame[], traceContext?: TraceContext):
     tags: options.staticTags,
   };
 
-  const envelope = createEventEnvelope(event, options.dsn, options.sdkMetadata);
-  // Log the envelope so to aid in testing
+  const envelope = createEventEnvelope(event, options.dsn, options.sdkMetadata, options.tunnel);
+  // Log the envelope to aid in testing
   log(JSON.stringify(envelope));
 
   await transport.send(envelope);
   await transport.flush(2000);
 
-  // Delay for 5 seconds so that stdio can flush in the main event loop ever restarts.
-  // This is mainly for the benefit of logging/debugging issues.
+  // Delay for 5 seconds so that stdio can flush if the main event loop ever restarts.
+  // This is mainly for the benefit of logging or debugging.
   setTimeout(() => {
     process.exit(0);
   }, 5_000);


### PR DESCRIPTION
Closes #11159

This PR also modifies `getEnvelopeEndpointWithUrlEncodedAuth` which had a suggested simplification for v8.

I ignored the suggestion because `{ tunnel, _metadata }` feels like a very "internal" API. Sure, this is convenient because it lets you pass the client options directly but it doesn't sit right as a user facing API.

