### PR TITLE
fix(opentelemetry): Do not stomp span error status

### DIFF
--- a/packages/core/src/tracing/spanstatus.ts
+++ b/packages/core/src/tracing/spanstatus.ts
@@ -10,6 +10,7 @@ export const SPAN_STATUS_ERROR = 2;
  * @param httpStatus The HTTP response status code.
  * @returns The span status or unknown_error.
  */
+// https://develop.sentry.dev/sdk/event-payloads/span/
 export function getSpanStatusFromHttpCode(httpStatus: number): SpanStatus {
   if (httpStatus < 400 && httpStatus >= 100) {
     return { code: SPAN_STATUS_OK };
@@ -29,6 +30,8 @@ export function getSpanStatusFromHttpCode(httpStatus: number): SpanStatus {
         return { code: SPAN_STATUS_ERROR, message: 'failed_precondition' };
       case 429:
         return { code: SPAN_STATUS_ERROR, message: 'resource_exhausted' };
+      case 499:
+        return { code: SPAN_STATUS_ERROR, message: 'cancelled' };
       default:
         return { code: SPAN_STATUS_ERROR, message: 'invalid_argument' };
     }

--- a/packages/opentelemetry/test/utils/mapStatus.test.ts
+++ b/packages/opentelemetry/test/utils/mapStatus.test.ts
@@ -6,79 +6,94 @@ import { mapStatus } from '../../src/utils/mapStatus';
 import { createSpan } from '../helpers/createSpan';
 
 describe('mapStatus', () => {
-  const statusTestTable: [number, undefined | number | string, undefined | string, SpanStatus][] = [
-    [-1, undefined, undefined, { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
-    [3, undefined, undefined, { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
-    [0, undefined, undefined, { code: SPAN_STATUS_OK }],
-    [1, undefined, undefined, { code: SPAN_STATUS_OK }],
-    [2, undefined, undefined, { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
-
+  const statusTestTable: [undefined | number | string, undefined | string, SpanStatus][] = [
     // http codes
-    [2, 400, undefined, { code: SPAN_STATUS_ERROR, message: 'failed_precondition' }],
-    [2, 401, undefined, { code: SPAN_STATUS_ERROR, message: 'unauthenticated' }],
-    [2, 403, undefined, { code: SPAN_STATUS_ERROR, message: 'permission_denied' }],
-    [2, 404, undefined, { code: SPAN_STATUS_ERROR, message: 'not_found' }],
-    [2, 409, undefined, { code: SPAN_STATUS_ERROR, message: 'aborted' }],
-    [2, 429, undefined, { code: SPAN_STATUS_ERROR, message: 'resource_exhausted' }],
-    [2, 499, undefined, { code: SPAN_STATUS_ERROR, message: 'cancelled' }],
-    [2, 500, undefined, { code: SPAN_STATUS_ERROR, message: 'internal_error' }],
-    [2, 501, undefined, { code: SPAN_STATUS_ERROR, message: 'unimplemented' }],
-    [2, 503, undefined, { code: SPAN_STATUS_ERROR, message: 'unavailable' }],
-    [2, 504, undefined, { code: SPAN_STATUS_ERROR, message: 'deadline_exceeded' }],
-    [2, 999, undefined, { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
+    [400, undefined, { code: SPAN_STATUS_ERROR, message: 'invalid_argument' }],
+    [401, undefined, { code: SPAN_STATUS_ERROR, message: 'unauthenticated' }],
+    [403, undefined, { code: SPAN_STATUS_ERROR, message: 'permission_denied' }],
+    [404, undefined, { code: SPAN_STATUS_ERROR, message: 'not_found' }],
+    [409, undefined, { code: SPAN_STATUS_ERROR, message: 'already_exists' }],
+    [429, undefined, { code: SPAN_STATUS_ERROR, message: 'resource_exhausted' }],
+    [499, undefined, { code: SPAN_STATUS_ERROR, message: 'cancelled' }],
+    [500, undefined, { code: SPAN_STATUS_ERROR, message: 'internal_error' }],
+    [501, undefined, { code: SPAN_STATUS_ERROR, message: 'unimplemented' }],
+    [503, undefined, { code: SPAN_STATUS_ERROR, message: 'unavailable' }],
+    [504, undefined, { code: SPAN_STATUS_ERROR, message: 'deadline_exceeded' }],
+    [999, undefined, { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
 
-    [2, '400', undefined, { code: SPAN_STATUS_ERROR, message: 'failed_precondition' }],
-    [2, '401', undefined, { code: SPAN_STATUS_ERROR, message: 'unauthenticated' }],
-    [2, '403', undefined, { code: SPAN_STATUS_ERROR, message: 'permission_denied' }],
-    [2, '404', undefined, { code: SPAN_STATUS_ERROR, message: 'not_found' }],
-    [2, '409', undefined, { code: SPAN_STATUS_ERROR, message: 'aborted' }],
-    [2, '429', undefined, { code: SPAN_STATUS_ERROR, message: 'resource_exhausted' }],
-    [2, '499', undefined, { code: SPAN_STATUS_ERROR, message: 'cancelled' }],
-    [2, '500', undefined, { code: SPAN_STATUS_ERROR, message: 'internal_error' }],
-    [2, '501', undefined, { code: SPAN_STATUS_ERROR, message: 'unimplemented' }],
-    [2, '503', undefined, { code: SPAN_STATUS_ERROR, message: 'unavailable' }],
-    [2, '504', undefined, { code: SPAN_STATUS_ERROR, message: 'deadline_exceeded' }],
-    [2, '999', undefined, { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
+    ['400', undefined, { code: SPAN_STATUS_ERROR, message: 'invalid_argument' }],
+    ['401', undefined, { code: SPAN_STATUS_ERROR, message: 'unauthenticated' }],
+    ['403', undefined, { code: SPAN_STATUS_ERROR, message: 'permission_denied' }],
+    ['404', undefined, { code: SPAN_STATUS_ERROR, message: 'not_found' }],
+    ['409', undefined, { code: SPAN_STATUS_ERROR, message: 'already_exists' }],
+    ['429', undefined, { code: SPAN_STATUS_ERROR, message: 'resource_exhausted' }],
+    ['499', undefined, { code: SPAN_STATUS_ERROR, message: 'cancelled' }],
+    ['500', undefined, { code: SPAN_STATUS_ERROR, message: 'internal_error' }],
+    ['501', undefined, { code: SPAN_STATUS_ERROR, message: 'unimplemented' }],
+    ['503', undefined, { code: SPAN_STATUS_ERROR, message: 'unavailable' }],
+    ['504', undefined, { code: SPAN_STATUS_ERROR, message: 'deadline_exceeded' }],
+    ['999', undefined, { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
 
     // grpc codes
-    [2, undefined, '1', { code: SPAN_STATUS_ERROR, message: 'cancelled' }],
-    [2, undefined, '2', { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
-    [2, undefined, '3', { code: SPAN_STATUS_ERROR, message: 'invalid_argument' }],
-    [2, undefined, '4', { code: SPAN_STATUS_ERROR, message: 'deadline_exceeded' }],
-    [2, undefined, '5', { code: SPAN_STATUS_ERROR, message: 'not_found' }],
-    [2, undefined, '6', { code: SPAN_STATUS_ERROR, message: 'already_exists' }],
-    [2, undefined, '7', { code: SPAN_STATUS_ERROR, message: 'permission_denied' }],
-    [2, undefined, '8', { code: SPAN_STATUS_ERROR, message: 'resource_exhausted' }],
-    [2, undefined, '9', { code: SPAN_STATUS_ERROR, message: 'failed_precondition' }],
-    [2, undefined, '10', { code: SPAN_STATUS_ERROR, message: 'aborted' }],
-    [2, undefined, '11', { code: SPAN_STATUS_ERROR, message: 'out_of_range' }],
-    [2, undefined, '12', { code: SPAN_STATUS_ERROR, message: 'unimplemented' }],
-    [2, undefined, '13', { code: SPAN_STATUS_ERROR, message: 'internal_error' }],
-    [2, undefined, '14', { code: SPAN_STATUS_ERROR, message: 'unavailable' }],
-    [2, undefined, '15', { code: SPAN_STATUS_ERROR, message: 'data_loss' }],
-    [2, undefined, '16', { code: SPAN_STATUS_ERROR, message: 'unauthenticated' }],
-    [2, undefined, '999', { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
+    [undefined, '1', { code: SPAN_STATUS_ERROR, message: 'cancelled' }],
+    [undefined, '2', { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
+    [undefined, '3', { code: SPAN_STATUS_ERROR, message: 'invalid_argument' }],
+    [undefined, '4', { code: SPAN_STATUS_ERROR, message: 'deadline_exceeded' }],
+    [undefined, '5', { code: SPAN_STATUS_ERROR, message: 'not_found' }],
+    [undefined, '6', { code: SPAN_STATUS_ERROR, message: 'already_exists' }],
+    [undefined, '7', { code: SPAN_STATUS_ERROR, message: 'permission_denied' }],
+    [undefined, '8', { code: SPAN_STATUS_ERROR, message: 'resource_exhausted' }],
+    [undefined, '9', { code: SPAN_STATUS_ERROR, message: 'failed_precondition' }],
+    [undefined, '10', { code: SPAN_STATUS_ERROR, message: 'aborted' }],
+    [undefined, '11', { code: SPAN_STATUS_ERROR, message: 'out_of_range' }],
+    [undefined, '12', { code: SPAN_STATUS_ERROR, message: 'unimplemented' }],
+    [undefined, '13', { code: SPAN_STATUS_ERROR, message: 'internal_error' }],
+    [undefined, '14', { code: SPAN_STATUS_ERROR, message: 'unavailable' }],
+    [undefined, '15', { code: SPAN_STATUS_ERROR, message: 'data_loss' }],
+    [undefined, '16', { code: SPAN_STATUS_ERROR, message: 'unauthenticated' }],
+    [undefined, '999', { code: SPAN_STATUS_ERROR, message: 'unknown_error' }],
 
     // http takes precedence over grpc
-    [2, '400', '2', { code: SPAN_STATUS_ERROR, message: 'failed_precondition' }],
+    ['400', '2', { code: SPAN_STATUS_ERROR, message: 'invalid_argument' }],
   ];
 
-  it.each(statusTestTable)(
-    'works with otelStatus=%i, httpCode=%s, grpcCode=%s',
-    (otelStatus, httpCode, grpcCode, expected) => {
-      const span = createSpan();
-      span.setStatus({ code: otelStatus });
+  it.each(statusTestTable)('works with httpCode=%s, grpcCode=%s', (httpCode, grpcCode, expected) => {
+    const span = createSpan();
+    span.setStatus({ code: 0 }); // UNSET
 
-      if (httpCode) {
-        span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpCode);
-      }
+    if (httpCode) {
+      span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpCode);
+    }
 
-      if (grpcCode) {
-        span.setAttribute(SemanticAttributes.RPC_GRPC_STATUS_CODE, grpcCode);
-      }
+    if (grpcCode) {
+      span.setAttribute(SemanticAttributes.RPC_GRPC_STATUS_CODE, grpcCode);
+    }
 
-      const actual = mapStatus(span);
-      expect(actual).toEqual(expected);
-    },
-  );
+    const actual = mapStatus(span);
+    expect(actual).toEqual(expected);
+  });
+
+  it('returns ok span status when is UNSET present on span', () => {
+    const span = createSpan();
+    span.setStatus({ code: 0 }); // UNSET
+    expect(mapStatus(span)).toEqual({ code: SPAN_STATUS_OK });
+  });
+
+  it('returns ok span status when already present on span', () => {
+    const span = createSpan();
+    span.setStatus({ code: 1 }); // OK
+    expect(mapStatus(span)).toEqual({ code: SPAN_STATUS_OK });
+  });
+
+  it('returns error status when span already has error status', () => {
+    const span = createSpan();
+    span.setStatus({ code: 2, message: 'invalid_argument' }); // ERROR
+    expect(mapStatus(span)).toEqual({ code: SPAN_STATUS_ERROR, message: 'invalid_argument' });
+  });
+
+  it('returns unknown error status when code is unknown', () => {
+    const span = createSpan();
+    span.setStatus({ code: -1 as 0 });
+    expect(mapStatus(span)).toEqual({ code: SPAN_STATUS_ERROR, message: 'unknown_error' });
+  });
 });


### PR DESCRIPTION
This fixes a bug I noticed when attempting to port the Next.js SDK to OTEL.

The behaviour of `mapStatus()` (which is called when we serialize spans & transactions to set the span and transaction status) previously always looked at the HTTP and GRPC status attributes first when determining the status of a span, stomping any previously set status in the process. Additionally, and arguably worse, when there was no HTTP and GRPC status attribute on the span, and the span status was `ERROR`, we completely stomped the error message with `unknown_error`. 

This PR changes the implementation so that we first prefer the status code that is already set on the span when it is `OK` and `ERROR`, otherwise we try to infer the span status from the HTTP and GRPC codes, we default to setting the span status to `OK` when the otel span status is `UNSET`, and we default to `ERROR` when we see an unknown otel span status.