### PR TITLE
fix(opentelemetry): Do not stomp span status when `startSpan` callback throws

### DIFF
--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -85,12 +85,10 @@ function ensureTimestampInSeconds(timestamp: number): number {
 
 /**
  * Convert a span to a JSON representation.
- * Note that all fields returned here are optional and need to be guarded against.
- *
- * Note: Because of this, we currently have a circular type dependency (which we opted out of in package.json).
- * This is not avoidable as we need `spanToJSON` in `spanUtils.ts`, which in turn is needed by `span.ts` for backwards compatibility.
- * And `spanToJSON` needs the Span class from `span.ts` to check here.
  */
+// Note: Because of this, we currently have a circular type dependency (which we opted out of in package.json).
+// This is not avoidable as we need `spanToJSON` in `spanUtils.ts`, which in turn is needed by `span.ts` for backwards compatibility.
+// And `spanToJSON` needs the Span class from `span.ts` to check here.
 export function spanToJSON(span: Span): Partial<SpanJSON> {
   if (spanIsSentrySpan(span)) {
     return span.getSpanJSON();

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -178,7 +178,7 @@ function createTransactionForOtelSpan(span: ReadableSpan): TransactionEvent {
     data: attributes,
     origin,
     op,
-    status: getStatusMessage(status),
+    status: getStatusMessage(status), // As per protocol, span status is allowed to be undefined
   });
 
   const transactionEvent: TransactionEvent = {
@@ -252,7 +252,7 @@ function createAndFinishSpanForOtelSpan(node: SpanNode, spans: SpanJSON[], remai
     start_timestamp: convertOtelTimeToSeconds(startTime),
     // This is [0,0] by default in OTEL, in which case we want to interpret this as no end time
     timestamp: convertOtelTimeToSeconds(endTime) || undefined,
-    status: getStatusMessage(status),
+    status: getStatusMessage(status), // As per protocol, span status is allowed to be undefined
     op,
     origin,
     _metrics_summary: getMetricSummaryJsonForSpan(span as unknown as Span),

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -12,6 +12,7 @@ import {
   getDynamicSamplingContextFromClient,
   getRootSpan,
   handleCallbackErrors,
+  spanToJSON,
 } from '@sentry/core';
 import type { Client, Scope } from '@sentry/types';
 import { continueTraceAsRemoteSpan, getSamplingDecision, makeTraceState } from './propagator';
@@ -46,7 +47,9 @@ export function startSpan<T>(options: OpenTelemetrySpanContext, callback: (span:
     return handleCallbackErrors(
       () => callback(span),
       () => {
-        span.setStatus({ code: SpanStatusCode.ERROR });
+        if (spanToJSON(span).status === undefined) {
+          span.setStatus({ code: SpanStatusCode.ERROR });
+        }
       },
       () => span.end(),
     );
@@ -82,7 +85,9 @@ export function startSpanManual<T>(
     return handleCallbackErrors(
       () => callback(span, () => span.end()),
       () => {
-        span.setStatus({ code: SpanStatusCode.ERROR });
+        if (spanToJSON(span).status === undefined) {
+          span.setStatus({ code: SpanStatusCode.ERROR });
+        }
       },
     );
   });

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -47,6 +47,7 @@ export function startSpan<T>(options: OpenTelemetrySpanContext, callback: (span:
     return handleCallbackErrors(
       () => callback(span),
       () => {
+        // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses
         if (spanToJSON(span).status === undefined) {
           span.setStatus({ code: SpanStatusCode.ERROR });
         }
@@ -85,6 +86,7 @@ export function startSpanManual<T>(
     return handleCallbackErrors(
       () => callback(span, () => span.end()),
       () => {
+        // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses
         if (spanToJSON(span).status === undefined) {
           span.setStatus({ code: SpanStatusCode.ERROR });
         }


### PR DESCRIPTION
This PR fixes span status stomping in the Otel `starSpan` and `startSpanManual` implementations.

When the callbacks threw, we didn't check whether there was already a more useful status on there and just stomped it with an `ERROR` status. Now we only set the status to `ERROR` when it wasn't defined already.