### PR TITLE
feat(v8/nextjs): Remove usage of class integrations

### DIFF
--- a/packages/nextjs/src/server/httpIntegration.ts
+++ b/packages/nextjs/src/server/httpIntegration.ts
@@ -1,13 +1,12 @@
-import { Integrations } from '@sentry/node-experimental';
+import { defineIntegration } from '@sentry/core';
+import { httpIntegration as originalHttpIntegration } from '@sentry/node-experimental';
+import type { IntegrationFn } from '@sentry/types';
 
-/**
- * A custom HTTP integration where we always enable tracing.
- */
-export class Http extends Integrations.Http {
-  public constructor(options?: ConstructorParameters<typeof Integrations.Http>[0]) {
-    super({
-      ...options,
-      tracing: true,
-    });
-  }
-}
+export const customHttpIntegration = ((options?: Parameters<typeof originalHttpIntegration>[0]) => {
+  return originalHttpIntegration({
+    ...options,
+    tracing: true,
+  });
+}) satisfies IntegrationFn;
+
+export const httpIntegration = defineIntegration(customHttpIntegration);

--- a/packages/nextjs/src/server/httpIntegration.ts
+++ b/packages/nextjs/src/server/httpIntegration.ts
@@ -1,12 +1,5 @@
-import { defineIntegration } from '@sentry/core';
 import { httpIntegration as originalHttpIntegration } from '@sentry/node-experimental';
-import type { IntegrationFn } from '@sentry/types';
 
-export const customHttpIntegration = ((options?: Parameters<typeof originalHttpIntegration>[0]) => {
-  return originalHttpIntegration({
-    ...options,
-    tracing: true,
-  });
-}) satisfies IntegrationFn;
-
-export const httpIntegration = defineIntegration(customHttpIntegration);
+export const httpIntegration: typeof originalHttpIntegration = options => {
+  return originalHttpIntegration({ ...options, tracing: true });
+};

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -13,16 +13,14 @@ import { devErrorSymbolicationEventProcessor } from '../common/devErrorSymbolica
 import { getVercelEnv } from '../common/getVercelEnv';
 import { isBuild } from '../common/utils/isBuild';
 import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegration';
-import { Http } from './httpIntegration';
-import { OnUncaughtException } from './onUncaughtExceptionIntegration';
+import { httpIntegration } from './httpIntegration';
+import { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration';
 
 export * from '@sentry/node-experimental';
 export { captureUnderscoreErrorException } from '../common/_error';
 
 export const Integrations = {
   ...OriginalIntegrations,
-  Http,
-  OnUncaughtException,
 };
 
 const globalWithInjectedValues = global as typeof global & {
@@ -85,8 +83,8 @@ export function init(options: NodeOptions): void {
     ...getDefaultIntegrations(options).filter(
       integration => !['Http', 'OnUncaughtException'].includes(integration.name),
     ),
-    new Http(),
-    new OnUncaughtException(),
+    httpIntegration(),
+    onUncaughtExceptionIntegration(),
   ];
 
   // This value is injected at build time, based on the output directory specified in the build config. Though a default

--- a/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
+++ b/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
@@ -1,12 +1,5 @@
-import { defineIntegration } from '@sentry/core';
-import { onUncaughtExceptionIntegration as originalOnUncaughtExceptionIntegration } from '@sentry/node-experimental';
-import type { IntegrationFn } from '@sentry/types';
+import { onUncaughtExceptionIntegration as originalOnUncaughtExceptionIntegration } from '@sentry/node';
 
-export const customOnUncaughtException = ((options?: Parameters<typeof originalOnUncaughtExceptionIntegration>[0]) => {
-  return originalOnUncaughtExceptionIntegration({
-    exitEvenIfOtherHandlersAreRegistered: false,
-    ...options,
-  });
-}) satisfies IntegrationFn;
-
-export const onUncaughtExceptionIntegration = defineIntegration(customOnUncaughtException);
+export const onUncaughtExceptionIntegration: typeof originalOnUncaughtExceptionIntegration = options => {
+  return originalOnUncaughtExceptionIntegration({ ...options, exitEvenIfOtherHandlersAreRegistered: false });
+};

--- a/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
+++ b/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
@@ -1,13 +1,12 @@
-import { Integrations } from '@sentry/node-experimental';
+import { defineIntegration } from '@sentry/core';
+import { onUncaughtExceptionIntegration as originalOnUncaughtExceptionIntegration } from '@sentry/node-experimental';
+import type { IntegrationFn } from '@sentry/types';
 
-/**
- * A custom OnUncaughtException integration that does not exit by default.
- */
-export class OnUncaughtException extends Integrations.OnUncaughtException {
-  public constructor(options?: ConstructorParameters<typeof Integrations.OnUncaughtException>[0]) {
-    super({
-      exitEvenIfOtherHandlersAreRegistered: false,
-      ...options,
-    });
-  }
-}
+export const customOnUncaughtException = ((options?: Parameters<typeof originalOnUncaughtExceptionIntegration>[0]) => {
+  return originalOnUncaughtExceptionIntegration({
+    exitEvenIfOtherHandlersAreRegistered: false,
+    ...options,
+  });
+}) satisfies IntegrationFn;
+
+export const onUncaughtExceptionIntegration = defineIntegration(customOnUncaughtException);

--- a/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
+++ b/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
@@ -1,4 +1,4 @@
-import { onUncaughtExceptionIntegration as originalOnUncaughtExceptionIntegration } from '@sentry/node';
+import { onUncaughtExceptionIntegration as originalOnUncaughtExceptionIntegration } from '@sentry/node-experimental';
 
 export const onUncaughtExceptionIntegration: typeof originalOnUncaughtExceptionIntegration = options => {
   return originalOnUncaughtExceptionIntegration({ ...options, exitEvenIfOtherHandlersAreRegistered: false });

--- a/packages/nextjs/test/serverSdk.test.ts
+++ b/packages/nextjs/test/serverSdk.test.ts
@@ -151,18 +151,6 @@ describe('Server init()', () => {
         expect(httpIntegration).toBeDefined();
         expect(httpIntegration).toEqual(expect.objectContaining({ _tracing: {} }));
       });
-
-      it('forces `_tracing = true` even if set to false', () => {
-        init({
-          integrations: [new Integrations.Http({ tracing: false })],
-        });
-
-        const nodeInitOptions = nodeInit.mock.calls[0][0] as ModifiedInitOptions;
-        const httpIntegration = findIntegrationByName(nodeInitOptions.integrations, 'Http');
-
-        expect(httpIntegration).toBeDefined();
-        expect(httpIntegration).toEqual(expect.objectContaining({ _tracing: {} }));
-      });
     });
   });
 });


### PR DESCRIPTION
In order to proceed with removing `Sentry.Integrations.X` as per https://github.com/getsentry/sentry-javascript/issues/8844, there's still some places to clean up.

This does conflict with https://github.com/getsentry/sentry-javascript/pull/11016, but not sure when that merges in, so opening this in the meantime to unblock the integrations cleanup work. if we think the OTEL nextjs work will merge in sooner then the next 1-2 days, I'm happy to leave this alone for now!