### PR TITLE
fix(metrics): use correct statsd data category

### DIFF
--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -26,7 +26,9 @@ export type DataCategory =
   | 'monitor'
   // Feedback type event (v2)
   | 'feedback'
-  // Unknown data category
-  | 'unknown'
+  // Statsd type event for metrics
+  | 'statsd'
   // Span
-  | 'span';
+  | 'span'
+  // Unknown data category
+  | 'unknown';

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -210,8 +210,7 @@ const ITEM_TYPE_TO_DATA_CATEGORY_MAP: Record<EnvelopeItemType, DataCategory> = {
   check_in: 'monitor',
   feedback: 'feedback',
   span: 'span',
-  // TODO: This is a temporary workaround until we have a proper data category for metrics
-  statsd: 'unknown',
+  statsd: 'statsd',
 };
 
 /**


### PR DESCRIPTION
As per https://github.com/getsentry/relay/blob/2f49cfeb4ed44068e4556ac6ad234f35ee3fde88/relay-server/src/envelope.rs#L166C30-L166C36

Backport for https://github.com/getsentry/sentry-javascript/pull/11184