### PR TITLE
fix(ci): Fix root directory for size limit result upload

### DIFF
--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -219,7 +219,7 @@ async function run() {
       });
       const files = await globber.glob();
 
-      await artifactClient.uploadArtifact(ARTIFACT_NAME, files, process.env);
+      await artifactClient.uploadArtifact(ARTIFACT_NAME, files, __dirname);
 
       return;
     }


### PR DESCRIPTION
Currently, [CI is failing](https://github.com/getsentry/sentry-javascript/actions/runs/8295328564/job/22702264264#step:5:195) on `develop` because we specified the `process.env` object instead of a `rootDir` string as the third argument of the octokit `uploadArtifact` function.  This PR fixes that by setting the directory of the results file as its [root dir](https://github.com/actions/toolkit/tree/%40actions/artifact%401.1.1/packages/artifact#upload-an-artifact). I'm not a 100% convinced that this is correct but we'll see 🤞 

(Also primes example why TypeScript is ❤️ )