### PR TITLE
feat(core): Filter out noisy GoogleTag error by default

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -10,6 +10,7 @@ const DEFAULT_IGNORE_ERRORS = [
   /^Script error\.?$/,
   /^Javascript error: Script error\.? on line 0$/,
   /^ResizeObserver loop completed with undelivered notifications.$/,
+  /^Cannot redefine property: googletag$/,
 ];
 
 /** Options for the InboundFilters integration */

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -198,6 +198,17 @@ const RESIZEOBSERVER_EVENT: Event = {
   },
 };
 
+const GOOGLETAG_EVENT: Event = {
+  exception: {
+    values: [
+      {
+        type: 'TypeError',
+        value: 'Cannot redefine property: googletag',
+      },
+    ],
+  },
+};
+
 const MALFORMED_EVENT: Event = {
   exception: {
     values: [
@@ -299,14 +310,19 @@ describe('InboundFilters', () => {
       expect(eventProcessor(EXCEPTION_EVENT, {})).toBe(null);
     });
 
-    it('uses default filters', () => {
+    it('uses default filters (script error)', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(null);
     });
 
-    it('uses default filters ResizeObserver', () => {
+    it('uses default filters (ResizeObserver)', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(RESIZEOBSERVER_EVENT, {})).toBe(null);
+    });
+
+    it('uses default filters (googletag)', () => {
+      const eventProcessor = createInboundFiltersEventProcessor();
+      expect(eventProcessor(GOOGLETAG_EVENT, {})).toBe(null);
     });
 
     it('filters on last exception when multiple present', () => {


### PR DESCRIPTION
We received reports about this error

```
TypeError: Cannot redefine property: googletag
```

being thrown and reported to Sentry. It's a noisy error where we strongly suspect that browser extensions interfere with our users' apps. In an effort to quickly reduce noise, this PR adds the error message to our SDK `inboundFilters` integration. 

Side-note: In my opinion we cannot continue adding such filters SDK-side long-term. For the moment we have to because other SDK areas like Replay or spans would incorrectly change their state on an error we first send to Sentry but later on drop in Relay. However, long-term, I strongly think connecting (and sampling) has to happen server side. Otherwise our SDK grows and bundlesize inevitably increases. 