### PR TITLE
fix(node): Clear ANR timer on stop

### DIFF
--- a/packages/node-experimental/src/integrations/anr/index.ts
+++ b/packages/node-experimental/src/integrations/anr/index.ts
@@ -175,5 +175,6 @@ async function _startWorker(
   return () => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     worker.terminate();
+    clearInterval(timer);
   };
 }


### PR DESCRIPTION
This was missed from the original PR #11214 but is already included in the backport #11228