### PR TITLE
meta: CHANGELOG for 7.108.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 7.108.0
+
+This release fixes issues with Time to First Byte (TTFB) calculation in the SDK that was introduced with `7.95.0`. It
+also fixes some bugs with Interaction to First Paint (INP) instrumentation. This may impact your Sentry Performance
+Score calculation.
+
+- feat(serverless): Add Node.js 20 to compatible runtimes (#11104)
+- feat(core): Backport `ResizeObserver` and `googletag` default filters (#11210)
+- feat(webvitals): Adds event entry names for INP handler. Also guard against empty metric value
+- fix(metrics): use correct statsd data category (#11187)
+- fix(node): Record local variables with falsy values (v7) (#11190)
+- fix(node): Use unique variable for ANR context transfer (v7) (#11162)
+- fix(node): Time zone handling for `cron` (#11225)
+- fix(tracing): use web-vitals ttfb calculation (#11231)
+- fix(types): Fix incorrect `sampled` type on `Transaction` (#11146)
+- fix(webvitals): Fix mapping not being maintained properly and sometimes not sending INP spans (#11183)
+
+Work in this release contributed by @quisido and @joshkel. Thank you for your contributions!
+
 ## 7.107.0
 
 This release fixes issues with INP instrumentation with the Next.js SDK and adds support for the `enableInp` option in

--- a/packages/node/src/cron/cron.ts
+++ b/packages/node/src/cron/cron.ts
@@ -100,7 +100,7 @@ export function instrumentCron<T>(lib: T & CronJobConstructor, monitorSlug: stri
           },
           {
             schedule: { type: 'crontab', value: cronString },
-            ...(timeZone ? { timeZone } : {}),
+            timezone: timeZone || undefined,
           },
         );
       }
@@ -132,7 +132,7 @@ export function instrumentCron<T>(lib: T & CronJobConstructor, monitorSlug: stri
               },
               {
                 schedule: { type: 'crontab', value: cronString },
-                ...(timeZone ? { timeZone } : {}),
+                timezone: timeZone || undefined,
               },
             );
           };

--- a/packages/node/test/cron.test.ts
+++ b/packages/node/test/cron.test.ts
@@ -53,13 +53,20 @@ describe('cron check-ins', () => {
 
       const CronJobWithCheckIn = cron.instrumentCron(CronJobMock, 'my-cron-job');
 
-      new CronJobWithCheckIn('* * * Jan,Sep Sun', () => {
-        expect(withMonitorSpy).toHaveBeenCalledTimes(1);
-        expect(withMonitorSpy).toHaveBeenLastCalledWith('my-cron-job', expect.anything(), {
-          schedule: { type: 'crontab', value: '* * * 1,9 0' },
-        });
-        done();
-      });
+      new CronJobWithCheckIn(
+        '* * * Jan,Sep Sun',
+        () => {
+          expect(withMonitorSpy).toHaveBeenCalledTimes(1);
+          expect(withMonitorSpy).toHaveBeenLastCalledWith('my-cron-job', expect.anything(), {
+            schedule: { type: 'crontab', value: '* * * 1,9 0' },
+            timezone: 'America/Los_Angeles',
+          });
+          done();
+        },
+        undefined,
+        true,
+        'America/Los_Angeles',
+      );
     });
 
     test('CronJob.from()', done => {


### PR DESCRIPTION
This is a CHANGELOG for `7.107.0`, and ports https://github.com/getsentry/sentry-javascript/pull/11225 to the v7 branch.