### PR TITLE
ref(v7/replay): Deprecate `@sentry/replay` exports

### DIFF
--- a/dev-packages/browser-integration-tests/suites/replay/bufferMode/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferMode/test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import type { Replay } from '@sentry/replay';
+import type { InternalReplay } from '@sentry/replay';
 import type { ReplayContainer } from '@sentry/replay/build/npm/types/types';
 
 import { sentryTest } from '../../../utils/fixtures';
@@ -68,7 +68,8 @@ sentryTest(
     expect(
       await page.evaluate(() => {
         // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof Replay> }).Replay;
+        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof InternalReplay> })
+          .Replay;
         // @ts-expect-error private
         const replay = replayIntegration._replay;
         replayIntegration.startBuffering();
@@ -89,7 +90,7 @@ sentryTest(
       reqPromise0,
       page.evaluate(async () => {
         // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
+        const replayIntegration = (window as unknown as Window & { Replay: InternalReplay }).Replay;
         await replayIntegration.flush();
       }),
     ]);
@@ -213,7 +214,8 @@ sentryTest(
     expect(
       await page.evaluate(() => {
         // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof Replay> }).Replay;
+        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof InternalReplay> })
+          .Replay;
         // @ts-expect-error private
         const replay = replayIntegration._replay;
         replayIntegration.startBuffering();
@@ -234,7 +236,7 @@ sentryTest(
       reqPromise0,
       page.evaluate(async () => {
         // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
+        const replayIntegration = (window as unknown as Window & { Replay: InternalReplay }).Replay;
         await replayIntegration.flush({ continueRecording: false });
       }),
     ]);
@@ -329,7 +331,8 @@ sentryTest(
     expect(
       await page.evaluate(() => {
         // eslint-disable-next-line deprecation/deprecation
-        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof Replay> }).Replay;
+        const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof InternalReplay> })
+          .Replay;
         const replay = replayIntegration['_replay'];
         replayIntegration.startBuffering();
         return replay.isEnabled();
@@ -348,7 +351,7 @@ sentryTest(
 
     await page.evaluate(async () => {
       // eslint-disable-next-line deprecation/deprecation
-      const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
+      const replayIntegration = (window as unknown as Window & { Replay: InternalReplay }).Replay;
       replayIntegration['_replay'].getOptions().errorSampleRate = 1.0;
     });
 

--- a/packages/browser/src/index.bundle.replay.ts
+++ b/packages/browser/src/index.bundle.replay.ts
@@ -6,13 +6,13 @@ import {
   browserTracingIntegration,
   feedbackIntegration,
 } from '@sentry-internal/integration-shims';
-import { Replay, replayIntegration } from '@sentry/replay';
+import { InternalReplay, internalReplayIntegration } from '@sentry/replay';
 
 import * as Sentry from './index.bundle.base';
 
 // TODO (v8): Remove this as it was only needed for backwards compatibility
 // eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = Replay;
+Sentry.Integrations.Replay = InternalReplay;
 
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
@@ -24,8 +24,8 @@ export {
   browserTracingIntegration,
   addTracingExtensions,
   // eslint-disable-next-line deprecation/deprecation
-  Replay,
-  replayIntegration,
+  InternalReplay as Replay,
+  internalReplayIntegration as replayIntegration,
   // eslint-disable-next-line deprecation/deprecation
   Feedback,
   feedbackIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -1,6 +1,6 @@
 import { Feedback, feedbackIntegration } from '@sentry-internal/feedback';
 import { BrowserTracing, Span, addExtensionMethods } from '@sentry-internal/tracing';
-import { Replay, replayIntegration } from '@sentry/replay';
+import { InternalReplay, internalReplayIntegration } from '@sentry/replay';
 import { bundleBrowserTracingIntegration as browserTracingIntegration } from './helpers';
 
 import * as Sentry from './index.bundle.base';
@@ -9,7 +9,7 @@ import * as Sentry from './index.bundle.base';
 // We want replay to be available under Sentry.Replay, to be consistent
 // with the NPM package version.
 // eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = Replay;
+Sentry.Integrations.Replay = InternalReplay;
 
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
@@ -21,9 +21,9 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   Feedback,
   // eslint-disable-next-line deprecation/deprecation
-  Replay,
+  InternalReplay as Replay,
   feedbackIntegration,
-  replayIntegration,
+  internalReplayIntegration as replayIntegration,
   // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -1,6 +1,6 @@
 import { Feedback, feedbackIntegration } from '@sentry-internal/integration-shims';
 import { BrowserTracing, Span, addExtensionMethods } from '@sentry-internal/tracing';
-import { Replay, replayIntegration } from '@sentry/replay';
+import { InternalReplay, internalReplayIntegration } from '@sentry/replay';
 import { bundleBrowserTracingIntegration as browserTracingIntegration } from './helpers';
 
 import * as Sentry from './index.bundle.base';
@@ -9,7 +9,7 @@ import * as Sentry from './index.bundle.base';
 // We want replay to be available under Sentry.Replay, to be consistent
 // with the NPM package version.
 // eslint-disable-next-line deprecation/deprecation
-Sentry.Integrations.Replay = Replay;
+Sentry.Integrations.Replay = InternalReplay;
 
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
@@ -21,8 +21,8 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   Feedback,
   // eslint-disable-next-line deprecation/deprecation
-  Replay,
-  replayIntegration,
+  InternalReplay as Replay,
+  internalReplayIntegration as replayIntegration,
   feedbackIntegration,
   // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -25,20 +25,20 @@ export { INTEGRATIONS as Integrations };
 
 export {
   // eslint-disable-next-line deprecation/deprecation
-  Replay,
-  replayIntegration,
-  getReplay,
+  InternalReplay as Replay,
+  internalReplayIntegration as replayIntegration,
+  internalGetReplay as getReplay,
 } from '@sentry/replay';
 export type {
-  ReplayEventType,
-  ReplayEventWithTime,
-  ReplayBreadcrumbFrame,
-  ReplayBreadcrumbFrameEvent,
-  ReplayOptionFrameEvent,
-  ReplayFrame,
-  ReplayFrameEvent,
-  ReplaySpanFrame,
-  ReplaySpanFrameEvent,
+  InternalReplayEventType as ReplayEventType,
+  InternalReplayEventWithTime as ReplayEventWithTime,
+  InternalReplayBreadcrumbFrame as ReplayBreadcrumbFrame,
+  InternalReplayBreadcrumbFrameEvent as ReplayBreadcrumbFrameEvent,
+  InternalReplayOptionFrameEvent as ReplayOptionFrameEvent,
+  InternalReplayFrame as ReplayFrame,
+  InternalReplayFrameEvent as ReplayFrameEvent,
+  InternalReplaySpanFrame as ReplaySpanFrame,
+  InternalReplaySpanFrameEvent as ReplaySpanFrameEvent,
 } from '@sentry/replay';
 
 export {

--- a/packages/replay-canvas/src/canvas.ts
+++ b/packages/replay-canvas/src/canvas.ts
@@ -1,6 +1,6 @@
 import { CanvasManager } from '@sentry-internal/rrweb';
 import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
-import type { CanvasManagerInterface, CanvasManagerOptions } from '@sentry/replay';
+import type { InternalCanvasManagerInterface, InternalCanvasManagerOptions } from '@sentry/replay';
 import type { Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
 
 interface ReplayCanvasOptions {
@@ -8,7 +8,7 @@ interface ReplayCanvasOptions {
   quality: 'low' | 'medium' | 'high';
 }
 
-type GetCanvasManager = (options: CanvasManagerOptions) => CanvasManagerInterface;
+type GetCanvasManager = (options: InternalCanvasManagerOptions) => InternalCanvasManagerInterface;
 export interface ReplayCanvasIntegrationOptions {
   enableManualSnapshot?: boolean;
   recordCanvas: true;
@@ -74,7 +74,7 @@ export const _replayCanvasIntegration = ((options: Partial<ReplayCanvasOptions> 
       return {
         enableManualSnapshot,
         recordCanvas: true,
-        getCanvasManager: (options: CanvasManagerOptions) => {
+        getCanvasManager: (options: InternalCanvasManagerOptions) => {
           const manager = new CanvasManager({
             ...options,
             enableManualSnapshot,

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -24,7 +24,7 @@ const replayIntegration = internalReplayIntegration;
 
 /** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
 // eslint-disable-next-line deprecation/deprecation
-const Replay = InternalReplay;
+class Replay extends InternalReplay {}
 
 // eslint-disable-next-line deprecation/deprecation
 export { replayIntegration, getReplay, Replay, internalReplayIntegration, internalGetReplay, InternalReplay };

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,50 +1,108 @@
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export { replayIntegration } from './integration';
+// eslint-disable-next-line deprecation/deprecation
+import { Replay as InternalReplay, replayIntegration as internalReplayIntegration } from './integration';
+import type {
+  CanvasManagerInterface as InternalCanvasManagerInterface,
+  CanvasManagerOptions as InternalCanvasManagerOptions,
+  ReplayBreadcrumbFrame as InternalReplayBreadcrumbFrame,
+  ReplayBreadcrumbFrameEvent as InternalReplayBreadcrumbFrameEvent,
+  ReplayConfiguration as InternalReplayConfiguration,
+  ReplayEventType as InternalReplayEventType,
+  ReplayEventWithTime as InternalReplayEventWithTime,
+  ReplayFrame as InternalReplayFrame,
+  ReplayFrameEvent as InternalReplayFrameEvent,
+  ReplayOptionFrameEvent as InternalReplayOptionFrameEvent,
+  ReplaySpanFrame as InternalReplaySpanFrame,
+  ReplaySpanFrameEvent as InternalReplaySpanFrameEvent,
+} from './types';
+import { getReplay as internalGetReplay } from './util/getReplay';
 
 /** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export {
+const getReplay = internalGetReplay;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+const replayIntegration = internalReplayIntegration;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+// eslint-disable-next-line deprecation/deprecation
+const Replay = InternalReplay;
+
+// eslint-disable-next-line deprecation/deprecation
+export { replayIntegration, getReplay, Replay, internalReplayIntegration, internalGetReplay, InternalReplay };
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplayConfiguration = InternalReplayConfiguration;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplayEventType = InternalReplayEventType;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplayEventWithTime = InternalReplayEventWithTime;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplayBreadcrumbFrame = InternalReplayBreadcrumbFrame;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplayBreadcrumbFrameEvent = InternalReplayBreadcrumbFrameEvent;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplayOptionFrameEvent = InternalReplayOptionFrameEvent;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplayFrame = InternalReplayFrame;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplayFrameEvent = InternalReplayFrameEvent;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplaySpanFrame = InternalReplaySpanFrame;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type ReplaySpanFrameEvent = InternalReplaySpanFrameEvent;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type CanvasManagerInterface = InternalCanvasManagerInterface;
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+type CanvasManagerOptions = InternalCanvasManagerOptions;
+
+export type {
   // eslint-disable-next-line deprecation/deprecation
-  Replay,
-} from './integration';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export { getReplay } from './util/getReplay';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplayConfiguration } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplayEventType } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplayEventWithTime } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplayBreadcrumbFrame } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplayBreadcrumbFrameEvent } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplayOptionFrameEvent } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplayFrame } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplayFrameEvent } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplaySpanFrame } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { ReplaySpanFrameEvent } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { CanvasManagerInterface } from './types';
-
-/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
-export type { CanvasManagerOptions } from './types';
+  CanvasManagerInterface,
+  // eslint-disable-next-line deprecation/deprecation
+  CanvasManagerOptions,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplayBreadcrumbFrame,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplayBreadcrumbFrameEvent,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplayConfiguration,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplayEventType,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplayEventWithTime,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplayFrame,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplayFrameEvent,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplayOptionFrameEvent,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplaySpanFrame,
+  // eslint-disable-next-line deprecation/deprecation
+  ReplaySpanFrameEvent,
+  InternalCanvasManagerInterface,
+  InternalCanvasManagerOptions,
+  InternalReplayBreadcrumbFrame,
+  InternalReplayBreadcrumbFrameEvent,
+  InternalReplayConfiguration,
+  InternalReplayEventType,
+  InternalReplayEventWithTime,
+  InternalReplayFrame,
+  InternalReplayFrameEvent,
+  InternalReplayOptionFrameEvent,
+  InternalReplaySpanFrame,
+  InternalReplaySpanFrameEvent,
+};
 
 // TODO (v8): Remove deprecated types
 export * from './types/deprecated';

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,25 +1,50 @@
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export { replayIntegration } from './integration';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
 export {
   // eslint-disable-next-line deprecation/deprecation
   Replay,
-  replayIntegration,
 } from './integration';
 
-export type {
-  ReplayConfiguration,
-  ReplayEventType,
-  ReplayEventWithTime,
-  ReplayBreadcrumbFrame,
-  ReplayBreadcrumbFrameEvent,
-  ReplayOptionFrameEvent,
-  ReplayFrame,
-  ReplayFrameEvent,
-  ReplaySpanFrame,
-  ReplaySpanFrameEvent,
-  CanvasManagerInterface,
-  CanvasManagerOptions,
-} from './types';
-
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
 export { getReplay } from './util/getReplay';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayConfiguration } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayEventType } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayEventWithTime } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayBreadcrumbFrame } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayBreadcrumbFrameEvent } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayOptionFrameEvent } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayFrame } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayFrameEvent } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplaySpanFrame } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplaySpanFrameEvent } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { CanvasManagerInterface } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { CanvasManagerOptions } from './types';
 
 // TODO (v8): Remove deprecated types
 export * from './types/deprecated';

--- a/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
+++ b/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
@@ -2,6 +2,7 @@ import * as SentryCore from '@sentry/core';
 import type { Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
 
+// eslint-disable-next-line deprecation/deprecation
 import type { Replay } from '../../src';
 import type { ReplayContainer } from '../../src/replay';
 import { clearSession } from '../../src/session/clearSession';

--- a/packages/replay/test/integration/stop.test.ts
+++ b/packages/replay/test/integration/stop.test.ts
@@ -1,5 +1,6 @@
 import * as SentryUtils from '@sentry/utils';
 
+// eslint-disable-next-line deprecation/deprecation
 import type { Replay } from '../../src';
 import { WINDOW } from '../../src/constants';
 import type { ReplayContainer } from '../../src/replay';

--- a/packages/replay/test/mocks/mockSdk.ts
+++ b/packages/replay/test/mocks/mockSdk.ts
@@ -1,5 +1,6 @@
 import type { Envelope, Transport, TransportMakeRequestResponse } from '@sentry/types';
 
+// eslint-disable-next-line deprecation/deprecation
 import type { Replay as ReplayIntegration } from '../../src';
 import type { ReplayContainer } from '../../src/replay';
 import type { ReplayConfiguration } from '../../src/types';

--- a/packages/replay/test/utils/getTestEvent.ts
+++ b/packages/replay/test/utils/getTestEvent.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line deprecation/deprecation
 import type { ReplayEventType, ReplayEventWithTime } from '../../src';
 import { ReplayEventTypeFullSnapshot, ReplayEventTypeIncrementalSnapshot } from '../../src/types';
 
@@ -8,7 +9,9 @@ export function getTestEvent({
 }: {
   timestamp: number;
   data?: any;
+  // eslint-disable-next-line deprecation/deprecation
   type: ReplayEventType;
+  // eslint-disable-next-line deprecation/deprecation
 }): ReplayEventWithTime {
   return {
     data: data || {},
@@ -17,10 +20,12 @@ export function getTestEvent({
   };
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export function getTestEventCheckout({ timestamp, data }: { timestamp: number; data?: any }): ReplayEventWithTime {
   return getTestEvent({ timestamp, data, type: ReplayEventTypeFullSnapshot });
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export function getTestEventIncremental({ timestamp, data }: { timestamp: number; data?: any }): ReplayEventWithTime {
   return getTestEvent({ timestamp, data, type: ReplayEventTypeIncrementalSnapshot });
 }


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/pull/11200
ref issue https://github.com/getsentry/sentry-javascript/issues/8864