### PR TITLE
ref(v8/replay): Deprecate `@sentry/replay` exports

### DIFF
--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,18 +1,41 @@
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
 export { replayIntegration } from './integration';
 
-export type {
-  ReplayConfiguration,
-  ReplayEventType,
-  ReplayEventWithTime,
-  ReplayBreadcrumbFrame,
-  ReplayBreadcrumbFrameEvent,
-  ReplayOptionFrameEvent,
-  ReplayFrame,
-  ReplayFrameEvent,
-  ReplaySpanFrame,
-  ReplaySpanFrameEvent,
-  CanvasManagerInterface,
-  CanvasManagerOptions,
-} from './types';
-
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
 export { getReplay } from './util/getReplay';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayConfiguration } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayEventType } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayEventWithTime } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayBreadcrumbFrame } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayBreadcrumbFrameEvent } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayOptionFrameEvent } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayFrame } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplayFrameEvent } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplaySpanFrame } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { ReplaySpanFrameEvent } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { CanvasManagerInterface } from './types';
+
+/** @deprecated Use the export from `@sentry/replay` or from framework-specific SDKs like `@sentry/react` or `@sentry/vue` */
+export type { CanvasManagerOptions } from './types';


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/pull/11200
on v7 https://github.com/getsentry/sentry-javascript/pull/11242
