### PR TITLE
chore(format): Set biome as default VSCode formatter for typescript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,8 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
   },
-  "editor.defaultFormatter": "biomejs.biome"
+  "editor.defaultFormatter": "biomejs.biome",
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }


### PR DESCRIPTION
Since a couple of days, VSCode no longer auto formats my TS files despite me setting biome as the default formatter in my user `settings.json`. Adding the `typescript` entry to the repo's `settings.json` seems to fix the issue for me. 

cc @lforst I think you experienced something similar

I still think we should get rid of biome but for now, this should solve the auto formatting issue