### PR TITLE
feat(v8): Remove addGlobalEventProcessor

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -355,7 +355,7 @@ To make sure these integrations work properly you'll have to change how you
 
 Removed top-level exports: `tracingOrigins`, `MetricsAggregator`, `metricsAggregatorIntegration`, `Severity`,
 `Sentry.configureScope`, `Span`, `spanStatusfromHttpCode`, `makeMain`, `lastEventId`, `pushScope`, `popScope`,
-`addGlobalEventProcessor`, `timestampWithMs`, `addExtensionMethods`
+`addGlobalEventProcessor`, `timestampWithMs`, `addExtensionMethods`, `addGlobalEventProcessor`
 
 Removed `@sentry/utils` exports: `timestampWithMs`, `addOrUpdateIntegration`, `tracingContextFromHeaders`, `walk`
 
@@ -370,6 +370,7 @@ Removed `@sentry/utils` exports: `timestampWithMs`, `addOrUpdateIntegration`, `t
 - [Removal of `addGlobalEventProcessor` in favour of `addEventProcessor`](./MIGRATION.md#removal-of-addglobaleventprocessor-in-favour-of-addeventprocessor)
 - [Removal of `lastEventId()` method](./MIGRATION.md#deprecate-lasteventid)
 - [Remove `void` from transport return types](./MIGRATION.md#remove-void-from-transport-return-types)
+- [Remove `addGlobalEventProcessor` in favor of `addEventProcessor`](./MIGRATION.md#remove-addglobaleventprocessor-in-favor-of-addeventprocessor)
 
 #### Deprecation of `Hub` and `getCurrentHub()`
 
@@ -540,7 +541,7 @@ addGlobalEventProcessor(event => {
 
 ```js
 // v8
-addEventProcessor(event => {
+Sentry.getGlobalScope().addEventProcessor(event => {
   delete event.extra;
   return event;
 });
@@ -567,6 +568,26 @@ interface Transport {
 interface Transport {
   send(event: Event): Promise<TransportMakeRequestResponse>;
 }
+```
+
+#### Remove `addGlobalEventProcessor` in favor of `addEventProcessor`
+
+In v8, we are removing the `addGlobalEventProcessor` function in favor of `addEventProcessor`.
+
+```js
+// v7
+addGlobalEventProcessor(event => {
+  delete event.extra;
+  return event;
+});
+```
+
+```js
+// v8
+addEventProcessor(event => {
+  delete event.extra;
+  return event;
+});
 ```
 
 ### Browser SDK (Browser, React, Vue, Angular, Ember, etc.)

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -20,8 +20,6 @@ export type { BrowserOptions } from './client';
 export type { ReportDialogOptions } from './sdk';
 
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  addGlobalEventProcessor,
   addEventProcessor,
   addBreadcrumb,
   addIntegration,

--- a/packages/core/src/eventProcessors.ts
+++ b/packages/core/src/eventProcessors.ts
@@ -1,24 +1,7 @@
 import type { Event, EventHint, EventProcessor } from '@sentry/types';
-import { SyncPromise, getGlobalSingleton, isThenable, logger } from '@sentry/utils';
+import { SyncPromise, isThenable, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
-
-/**
- * Returns the global event processors.
- * @deprecated Global event processors will be removed in v8.
- */
-export function getGlobalEventProcessors(): EventProcessor[] {
-  return getGlobalSingleton<EventProcessor[]>('globalEventProcessors', () => []);
-}
-
-/**
- * Add a EventProcessor to be kept globally.
- * @deprecated Use `addEventProcessor` instead. Global event processors will be removed in v8.
- */
-export function addGlobalEventProcessor(callback: EventProcessor): void {
-  // eslint-disable-next-line deprecation/deprecation
-  getGlobalEventProcessors().push(callback);
-}
 
 /**
  * Process an array of event processors, returning the processed event (or `null` if the event was dropped).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,11 +54,7 @@ export {
 export { makeSession, closeSession, updateSession } from './session';
 export { SessionFlusher } from './sessionflusher';
 export { Scope } from './scope';
-export {
-  notifyEventProcessors,
-  // eslint-disable-next-line deprecation/deprecation
-  addGlobalEventProcessor,
-} from './eventProcessors';
+export { notifyEventProcessors } from './eventProcessors';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
 export { BaseClient } from './baseclient';
 export { ServerRuntimeClient } from './server-runtime-client';

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -13,7 +13,7 @@ import { GLOBAL_OBJ, addExceptionMechanism, dateTimestampInSeconds, normalize, t
 
 import { DEFAULT_ENVIRONMENT } from '../constants';
 import { getGlobalScope } from '../currentScopes';
-import { getGlobalEventProcessors, notifyEventProcessors } from '../eventProcessors';
+import { notifyEventProcessors } from '../eventProcessors';
 import { Scope } from '../scope';
 import { applyScopeDataToEvent, mergeScopeData } from './applyScopeDataToEvent';
 
@@ -34,8 +34,6 @@ export type ExclusiveEventHintOrCaptureContext =
  *
  * Information that is already present in the event is never overwritten. For
  * nested objects, such as the context, keys are merged.
- *
- * Note: This also triggers callbacks for `addGlobalEventProcessor`, but not `beforeSend`.
  *
  * @param event The original event.
  * @param hint May contain additional information about the original exception.
@@ -99,11 +97,8 @@ export function prepareEvent(
 
   applyScopeDataToEvent(prepared, data);
 
-  // TODO (v8): Update this order to be: Global > Client > Scope
   const eventProcessors = [
     ...clientEventProcessors,
-    // eslint-disable-next-line deprecation/deprecation
-    ...getGlobalEventProcessors(),
     // Run scope event processors _after_ all other processors
     ...data.eventProcessors,
   ];

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -21,8 +21,6 @@ export type { AddRequestDataToEventOptions, TransactionNamingScheme } from '@sen
 export type { NodeOptions } from './types';
 
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  addGlobalEventProcessor,
   addEventProcessor,
   addBreadcrumb,
   addIntegration,

--- a/packages/replay-internal/test/mocks/resetSdkMock.ts
+++ b/packages/replay-internal/test/mocks/resetSdkMock.ts
@@ -1,5 +1,4 @@
-import type { EventProcessor } from '@sentry/types';
-import { getGlobalSingleton, resetInstrumentationHandlers } from '@sentry/utils';
+import { resetInstrumentationHandlers } from '@sentry/utils';
 
 import type { Replay as ReplayIntegration } from '../../src/integration';
 import type { ReplayContainer } from '../../src/replay';
@@ -23,7 +22,6 @@ export async function resetSdkMock({ replayOptions, sentryOptions, autoStart }: 
 
   // Clear all handlers that have been registered
   resetInstrumentationHandlers();
-  getGlobalSingleton<EventProcessor[]>('globalEventProcessors', () => []).length = 0;
 
   const SentryUtils = await import('@sentry/utils');
   jest.spyOn(SentryUtils, 'addClickKeypressInstrumentationHandler').mockImplementation(handler => {

--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -46,7 +46,6 @@ export interface InternalGlobal {
    */
   _sentryDebugIds?: Record<string, string>;
   __SENTRY__: {
-    globalEventProcessors: any;
     hub: any;
     logger: any;
     extensions?: {


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10100

Removes `addGlobalEventProcessor` and adds migration guide.