### PR TITLE
feat(node): Add scope to ANR events

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -15,6 +15,9 @@ Sentry.init({
   autoSessionTracking: true,
 });
 
+Sentry.setUser({ email: 'person@home.com' });
+Sentry.addBreadcrumb({ message: 'important message!' });
+
 function longWork() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -15,6 +15,9 @@ Sentry.init({
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 
+Sentry.setUser({ email: 'person@home.com' });
+Sentry.addBreadcrumb({ message: 'important message!' });
+
 function longWork() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -15,6 +15,9 @@ Sentry.init({
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 
+Sentry.setUser({ email: 'person@home.com' });
+Sentry.addBreadcrumb({ message: 'important message!' });
+
 function longWork() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -15,6 +15,9 @@ Sentry.init({
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 
+Sentry.setUser({ email: 'person@home.com' });
+Sentry.addBreadcrumb({ message: 'important message!' });
+
 function longWork() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');

--- a/dev-packages/node-integration-tests/suites/anr/isolated.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/isolated.mjs
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+import * as crypto from 'crypto';
+
+import * as Sentry from '@sentry/node';
+
+setTimeout(() => {
+  process.exit();
+}, 10000);
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  debug: true,
+  autoSessionTracking: false,
+  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+});
+
+function longWork() {
+  for (let i = 0; i < 20; i++) {
+    const salt = crypto.randomBytes(128).toString('base64');
+    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
+    assert.ok(hash);
+  }
+}
+
+const fns = [
+  () => {},
+  () => {},
+  () => {},
+  () => {},
+  () => {},
+  () => longWork(), // [5]
+  () => {},
+  () => {},
+  () => {},
+  () => {},
+];
+
+for (let id = 0; id < 10; id++) {
+  Sentry.withIsolationScope(() => {
+    Sentry.setUser({ id });
+
+    setTimeout(() => {
+      fns[id]();
+    }, 1000);
+  });
+}

--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -17,6 +17,9 @@ Sentry.init({
   integrations: [anr],
 });
 
+Sentry.setUser({ email: 'person@home.com' });
+Sentry.addBreadcrumb({ message: 'important message!' });
+
 function longWorkIgnored() {
   for (let i = 0; i < 20; i++) {
     const salt = crypto.randomBytes(128).toString('base64');

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -114,4 +114,34 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
   test('worker can be stopped and restarted', done => {
     createRunner(__dirname, 'stop-and-start.js').expect({ event: EXPECTED_ANR_EVENT }).start(done);
   });
+
+  const EXPECTED_ISOLATED_EVENT = {
+    user: {
+      id: 5,
+    },
+    exception: {
+      values: [
+        {
+          type: 'ApplicationNotResponding',
+          value: 'Application Not Responding for at least 100 ms',
+          mechanism: { type: 'ANR' },
+          stacktrace: {
+            frames: expect.arrayContaining([
+              {
+                colno: 25,
+                lineno: 21,
+                filename: expect.stringMatching(/isolated.mjs$/),
+                function: 'longWork',
+                in_app: true,
+              },
+            ]),
+          },
+        },
+      ],
+    },
+  };
+
+  test('fetches correct isolated scope', done => {
+    createRunner(__dirname, 'isolated.mjs').expect({ event: EXPECTED_ISOLATED_EVENT }).start(done);
+  });
 });

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -128,8 +128,8 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
           stacktrace: {
             frames: expect.arrayContaining([
               {
-                colno: 25,
-                lineno: 21,
+                colno: expect.any(Number),
+                lineno: expect.any(Number),
                 filename: expect.stringMatching(/isolated.mjs$/),
                 function: 'longWork',
                 in_app: true,

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -21,6 +21,15 @@ const EXPECTED_ANR_EVENT = {
       timezone: expect.any(String),
     },
   },
+  user: {
+    email: 'person@home.com',
+  },
+  breadcrumbs: [
+    {
+      timestamp: expect.any(Number),
+      message: 'important message!',
+    },
+  ],
   // and an exception that is our ANR
   exception: {
     values: [

--- a/packages/node-experimental/src/integrations/anr/index.ts
+++ b/packages/node-experimental/src/integrations/anr/index.ts
@@ -26,9 +26,9 @@ function getScopeData(): ScopeData {
   mergeScopeData(scope, getIsolationScope().getScopeData());
   mergeScopeData(scope, getCurrentScope().getScopeData());
 
-  // We remove attachments because they likely won't serialize well
+  // We remove attachments because they likely won't serialize well as json
   scope.attachments = [];
-  // We can serialize event processors
+  // We can't serialize event processor functions
   scope.eventProcessors = [];
 
   return scope;

--- a/packages/node-experimental/src/integrations/anr/worker.ts
+++ b/packages/node-experimental/src/integrations/anr/worker.ts
@@ -1,11 +1,12 @@
 import {
+  applyScopeDataToEvent,
   createEventEnvelope,
   createSessionEnvelope,
   getEnvelopeEndpointWithUrlEncodedAuth,
   makeSession,
   updateSession,
 } from '@sentry/core';
-import type { Event, Session, StackFrame, TraceContext } from '@sentry/types';
+import type { Event, ScopeData, Session, StackFrame } from '@sentry/types';
 import {
   callFrameToStackFrame,
   normalizeUrlToBase,
@@ -86,7 +87,23 @@ function prepareStackFrames(stackFrames: StackFrame[] | undefined): StackFrame[]
   return strippedFrames;
 }
 
-async function sendAnrEvent(frames?: StackFrame[], traceContext?: TraceContext): Promise<void> {
+function applyScopeToEvent(event: Event, scope: ScopeData): void {
+  applyScopeDataToEvent(event, scope);
+
+  if (!event.contexts?.trace) {
+    const { traceId: trace_id, spanId, parentSpanId } = scope.propagationContext;
+    event.contexts = {
+      trace: {
+        trace_id,
+        span_id: spanId,
+        parent_span_id: parentSpanId,
+      },
+      ...event.contexts,
+    };
+  }
+}
+
+async function sendAnrEvent(frames?: StackFrame[], scope?: ScopeData): Promise<void> {
   if (hasSentAnrEvent) {
     return;
   }
@@ -99,7 +116,7 @@ async function sendAnrEvent(frames?: StackFrame[], traceContext?: TraceContext):
 
   const event: Event = {
     event_id: uuid4(),
-    contexts: { ...options.contexts, trace: traceContext },
+    contexts: options.contexts,
     release: options.release,
     environment: options.environment,
     dist: options.dist,
@@ -118,6 +135,10 @@ async function sendAnrEvent(frames?: StackFrame[], traceContext?: TraceContext):
     },
     tags: options.staticTags,
   };
+
+  if (scope) {
+    applyScopeToEvent(event, scope);
+  }
 
   const envelope = createEventEnvelope(event, options.dsn, options.sdkMetadata, options.tunnel);
   // Log the envelope to aid in testing
@@ -171,20 +192,23 @@ if (options.captureStackTrace) {
         'Runtime.evaluate',
         {
           // Grab the trace context from the current scope
-          expression:
-            'var __sentry_ctx = __SENTRY__.acs?.getCurrentScope().getPropagationContext() || {}; __sentry_ctx.traceId + "-" + __sentry_ctx.spanId + "-" + __sentry_ctx.parentSpanId',
+          expression: 'global.__SENTRY_GET_SCOPES__();',
           // Don't re-trigger the debugger if this causes an error
           silent: true,
+          // Serialize the result to json otherwise only primitives are supported
+          returnByValue: true,
         },
-        (_, param) => {
-          const traceId = param && param.result ? (param.result.value as string) : '--';
-          const [trace_id, span_id, parent_span_id] = traceId.split('-') as (string | undefined)[];
+        (err, param) => {
+          if (err) {
+            log(`Error executing script: '${err.message}'`);
+          }
+
+          const scopes = param && param.result ? (param.result.value as ScopeData) : undefined;
 
           session.post('Debugger.resume');
           session.post('Debugger.disable');
 
-          const context = trace_id?.length && span_id?.length ? { trace_id, span_id, parent_span_id } : undefined;
-          sendAnrEvent(stackFrames, context).then(null, () => {
+          sendAnrEvent(stackFrames, scopes).then(null, () => {
             log('Sending ANR event failed.');
           });
         },

--- a/packages/node-experimental/src/integrations/anr/worker.ts
+++ b/packages/node-experimental/src/integrations/anr/worker.ts
@@ -91,10 +91,10 @@ function applyScopeToEvent(event: Event, scope: ScopeData): void {
   applyScopeDataToEvent(event, scope);
 
   if (!event.contexts?.trace) {
-    const { traceId: trace_id, spanId, parentSpanId } = scope.propagationContext;
+    const { traceId, spanId, parentSpanId } = scope.propagationContext;
     event.contexts = {
       trace: {
-        trace_id,
+        trace_id: traceId,
         span_id: spanId,
         parent_span_id: parentSpanId,
       },


### PR DESCRIPTION
Closes #10668

Rather than inject large unchecked JavaScript strings to run via `Runtime.evaluate`, when the ANR integration is enabled, we add a function to `global.__SENTRY_GET_SCOPES__` which can then be called via the debugger when the event loop is suspended. 