### PR TITLE
feat(node): Do not include `prismaIntegration` by default

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing-experimental/prisma-orm/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/prisma-orm/scenario.js
@@ -9,6 +9,7 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
+  integrations: [Sentry.prismaIntegration()]
 });
 
 // Stop the process from exiting before the transaction is sent

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/prisma-orm/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/prisma-orm/scenario.js
@@ -9,7 +9,7 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  integrations: [Sentry.prismaIntegration()]
+  integrations: [Sentry.prismaIntegration()],
 });
 
 // Stop the process from exiting before the transaction is sent

--- a/packages/astro/src/server/sdk.ts
+++ b/packages/astro/src/server/sdk.ts
@@ -1,6 +1,5 @@
 import { applySdkMetadata } from '@sentry/core';
 import type { NodeOptions } from '@sentry/node';
-import { getDefaultIntegrations } from '@sentry/node';
 import { init as initNodeSdk, setTag } from '@sentry/node';
 
 /**
@@ -10,9 +9,6 @@ import { init as initNodeSdk, setTag } from '@sentry/node';
 export function init(options: NodeOptions): void {
   const opts = {
     ...options,
-    // TODO v8: For now, we disable the Prisma integration, because that has weird esm-cjs interop issues
-    // We should figure these out and fix these before v8 goes stable.
-    defaultIntegrations: getDefaultIntegrations(options).filter(integration => integration.name !== 'Prisma'),
   };
   applySdkMetadata(opts, 'astro', ['astro', 'node']);
 

--- a/packages/node-experimental/src/integrations/tracing/index.ts
+++ b/packages/node-experimental/src/integrations/tracing/index.ts
@@ -11,7 +11,6 @@ import { mysqlIntegration } from './mysql';
 import { mysql2Integration } from './mysql2';
 import { nestIntegration } from './nest';
 import { postgresIntegration } from './postgres';
-import { prismaIntegration } from './prisma';
 
 /**
  * With OTEL, all performance integrations will be added, as OTEL only initializes them when the patched package is actually required.
@@ -26,7 +25,10 @@ export function getAutoPerformanceIntegrations(): Integration[] {
     mysqlIntegration(),
     mysql2Integration(),
     postgresIntegration(),
-    prismaIntegration(),
+    // For now, we do not include prisma by default because it has ESM issues
+    // See https://github.com/prisma/prisma/issues/23410
+    // TODO v8: Figure out a better solution for this, maybe only disable in ESM mode?
+    // prismaIntegration(),
     nestIntegration(),
     hapiIntegration(),
     koaIntegration(),


### PR DESCRIPTION
This seems to have issues in ESM builds (not just in astro, but also saw it in remix), so for now removing this from defaults - users can still add it manually if needed. We may find a better solution for this before v8 is stable.