### PR TITLE
feat(v8/svelte): Remove deprecated componentTrackingPreprocessor export

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -350,6 +350,7 @@ To make sure these integrations work properly you'll have to change how you
 - [Astro SDK](./MIGRATION.md#astro-sdk)
 - [AWS Serverless SDK](./MIGRATION.md#aws-serverless-sdk)
 - [Ember SDK](./MIGRATION.md#ember-sdk)
+- [Svelte SDK](./MIGRATION.md#svelte-sdk)
 
 ### General
 
@@ -926,6 +927,42 @@ Removed top-level exports: `InitSentryForEmber`, `StartTransactionFunction`
 
 The `InitSentryForEmber` export has been removed. Instead, you should use the `Sentry.init` method to initialize the
 SDK.
+
+### Svelte SDK
+
+Removed top-level exports: `componentTrackingPreprocessor`
+
+#### Removal of `componentTrackingPreprocessor` export
+
+The `componentTrackingPreprocessor` export has been removed. You should instead use `withSentryConfig` to configure
+component tracking.
+
+```js
+// v7 - svelte.config.js
+import { componentTrackingPreprocessor } from '@sentry/svelte';
+
+const config = {
+  preprocess: [
+    componentTrackingPreprocessor(),
+    // ...
+  ],
+  // ...
+};
+
+export default config;
+```
+
+```js
+// v8 - svelte.config.js
+import { withSentryConfig } from "@sentry/svelte";
+
+const config = {
+  // Your svelte config
+  compilerOptions: {...},
+};
+
+export default withSentryConfig(config);
+```
 
 ## 5. Behaviour Changes
 

--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -33,8 +33,6 @@ export function withSentryConfig(
 
   const shouldTrackComponents = mergedOptions.componentTracking && mergedOptions.componentTracking.trackComponents;
   if (shouldTrackComponents) {
-    // TODO(v8): Remove eslint rule
-    // eslint-disable-next-line deprecation/deprecation
     const firstPassPreproc: SentryPreprocessorGroup = componentTrackingPreprocessor(mergedOptions.componentTracking);
     sentryPreprocessors.set(firstPassPreproc.sentryId || '', firstPassPreproc);
   }

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -7,10 +7,6 @@ export * from '@sentry/browser';
 
 export { init } from './sdk';
 
-// TODO(v8): Remove this export
-// eslint-disable-next-line deprecation/deprecation
-export { componentTrackingPreprocessor } from './preprocessors';
-
 export { trackComponent } from './performance';
 
 export { withSentryConfig } from './config';

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -19,8 +19,10 @@ const defaultTrackComponentOptions: {
 /**
  * Tracks the Svelte component's intialization and mounting operation as well as
  * updates and records them as spans.
+ *
  * This function is injected automatically into your Svelte components' code
- * if you are using the Sentry componentTrackingPreprocessor.
+ * if you are using the withSentryConfig wrapper.
+ *
  * Alternatively, you can call it yourself if you don't want to use the preprocessor.
  */
 export function trackComponent(options?: TrackComponentOptions): void {

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -14,9 +14,6 @@ export const FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID = 'FIRST_PASS_COMPONENT_TR
 /**
  * Svelte Preprocessor to inject Sentry performance monitoring related code
  * into Svelte components.
- *
- * @deprecated Use `withSentryConfig` which is the new way of making compile-time modifications
- *             to Svelte apps going forward.
  */
 export function componentTrackingPreprocessor(options?: ComponentTrackingInitOptions): PreprocessorGroup {
   const mergedOptions = { ...defaultComponentTrackingOptions, ...options };

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -48,7 +48,6 @@ describe('withSentryConfig', () => {
   });
 
   it("doesn't add Sentry preprocessors that were already added by the users", () => {
-    // eslint-disable-next-line deprecation/deprecation
     const sentryPreproc = componentTrackingPreprocessor();
     const originalConfig = {
       compilerOptions: {

--- a/packages/svelte/test/preprocessors.test.ts
+++ b/packages/svelte/test/preprocessors.test.ts
@@ -1,6 +1,5 @@
 import * as svelteCompiler from 'svelte/compiler';
 
-/* eslint-disable deprecation/deprecation */
 import {
   FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
   componentTrackingPreprocessor,


### PR DESCRIPTION
ref ref https://github.com/getsentry/sentry-javascript/issues/10100