### PR TITLE
feat(v8/core): Remove getActiveTransaction

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -355,7 +355,7 @@ To make sure these integrations work properly you'll have to change how you
 
 Removed top-level exports: `tracingOrigins`, `MetricsAggregator`, `metricsAggregatorIntegration`, `Severity`,
 `Sentry.configureScope`, `Span`, `spanStatusfromHttpCode`, `makeMain`, `lastEventId`, `pushScope`, `popScope`,
-`addGlobalEventProcessor`, `timestampWithMs`, `addExtensionMethods`, `addGlobalEventProcessor`
+`addGlobalEventProcessor`, `timestampWithMs`, `addExtensionMethods`, `addGlobalEventProcessor`, `getActiveTransaction`
 
 Removed `@sentry/utils` exports: `timestampWithMs`, `addOrUpdateIntegration`, `tracingContextFromHeaders`, `walk`
 

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -70,8 +70,6 @@ export {
   withActiveSpan,
   getSpanDescendants,
   setMeasurement,
-  // eslint-disable-next-line deprecation/deprecation
-  getActiveTransaction,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   makeMultiplexedTransport,

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -3,8 +3,6 @@ export { startIdleSpan, TRACING_DEFAULTS } from './idleSpan';
 export { SentrySpan } from './sentrySpan';
 export { SentryNonRecordingSpan } from './sentryNonRecordingSpan';
 export { Transaction } from './transaction';
-// eslint-disable-next-line deprecation/deprecation
-export { getActiveTransaction } from './utils';
 export {
   setHttpStatus,
   getSpanStatusFromHttpCode,

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,23 +1,6 @@
-import type { Span, Transaction } from '@sentry/types';
+import type { Span } from '@sentry/types';
 import type { Scope } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
-
-import type { Hub } from '../hub';
-import { getCurrentHub } from '../hub';
-
-/**
- * Grabs active transaction off scope.
- *
- * @deprecated You should not rely on the transaction, but just use `startSpan()` APIs instead.
- */
-export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T | undefined {
-  // eslint-disable-next-line deprecation/deprecation
-  const hub = maybeHub || getCurrentHub();
-  // eslint-disable-next-line deprecation/deprecation
-  const scope = hub.getScope();
-  // eslint-disable-next-line deprecation/deprecation
-  return scope.getTransaction() as T | undefined;
-}
 
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -31,8 +31,6 @@ export {
   createTransport,
   flush,
   // eslint-disable-next-line deprecation/deprecation
-  getActiveTransaction,
-  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
   isInitialized,

--- a/packages/tracing-internal/src/exports/index.ts
+++ b/packages/tracing-internal/src/exports/index.ts
@@ -1,6 +1,4 @@
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  getActiveTransaction,
   hasTracingEnabled,
   Transaction,
 } from '@sentry/core';


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10100

more `getCurrentHub` usages bite the dust.