### PR TITLE
ref: Remove more usages of getCurrentHub in the codebase

### DIFF
--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -1,12 +1,4 @@
-import type {
-  ClientOptions,
-  Hub,
-  Scope,
-  Span,
-  SpanTimeInput,
-  StartSpanOptions,
-  TransactionContext,
-} from '@sentry/types';
+import type { ClientOptions, Scope, Span, SpanTimeInput, StartSpanOptions, TransactionContext } from '@sentry/types';
 
 import { propagationContextFromHeaders } from '@sentry/utils';
 import type { AsyncContextStrategy } from '../asyncContext';
@@ -52,14 +44,12 @@ export function startSpan<T>(context: StartSpanOptions, callback: (span: Span) =
 
   return withScope(context.scope, scope => {
     // eslint-disable-next-line deprecation/deprecation
-    const hub = getCurrentHub();
-    // eslint-disable-next-line deprecation/deprecation
     const parentSpan = scope.getSpan() as SentrySpan | undefined;
 
     const shouldSkipSpan = context.onlyIfParent && !parentSpan;
     const activeSpan = shouldSkipSpan
       ? new SentryNonRecordingSpan()
-      : createChildSpanOrTransaction(hub, {
+      : createChildSpanOrTransaction({
           parentSpan,
           spanContext,
           forceTransaction: context.forceTransaction,
@@ -104,14 +94,12 @@ export function startSpanManual<T>(context: StartSpanOptions, callback: (span: S
 
   return withScope(context.scope, scope => {
     // eslint-disable-next-line deprecation/deprecation
-    const hub = getCurrentHub();
-    // eslint-disable-next-line deprecation/deprecation
     const parentSpan = scope.getSpan() as SentrySpan | undefined;
 
     const shouldSkipSpan = context.onlyIfParent && !parentSpan;
     const activeSpan = shouldSkipSpan
       ? new SentryNonRecordingSpan()
-      : createChildSpanOrTransaction(hub, {
+      : createChildSpanOrTransaction({
           parentSpan,
           spanContext,
           forceTransaction: context.forceTransaction,
@@ -155,8 +143,6 @@ export function startInactiveSpan(context: StartSpanOptions): Span {
   }
 
   const spanContext = normalizeContext(context);
-  // eslint-disable-next-line deprecation/deprecation
-  const hub = getCurrentHub();
   const parentSpan = context.scope
     ? // eslint-disable-next-line deprecation/deprecation
       (context.scope.getSpan() as SentrySpan | undefined)
@@ -170,7 +156,7 @@ export function startInactiveSpan(context: StartSpanOptions): Span {
 
   const scope = context.scope || getCurrentScope();
 
-  return createChildSpanOrTransaction(hub, {
+  return createChildSpanOrTransaction({
     parentSpan,
     spanContext,
     forceTransaction: context.forceTransaction,
@@ -225,20 +211,17 @@ export function withActiveSpan<T>(span: Span | null, callback: (scope: Scope) =>
   });
 }
 
-function createChildSpanOrTransaction(
-  hub: Hub,
-  {
-    parentSpan,
-    spanContext,
-    forceTransaction,
-    scope,
-  }: {
-    parentSpan: SentrySpan | undefined;
-    spanContext: TransactionContext;
-    forceTransaction?: boolean;
-    scope: Scope;
-  },
-): Span {
+function createChildSpanOrTransaction({
+  parentSpan,
+  spanContext,
+  forceTransaction,
+  scope,
+}: {
+  parentSpan: SentrySpan | undefined;
+  spanContext: TransactionContext;
+  forceTransaction?: boolean;
+  scope: Scope;
+}): Span {
   if (!hasTracingEnabled()) {
     return new SentryNonRecordingSpan();
   }

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -6,7 +6,6 @@ import { defineIntegration, getIsolationScope, hasTracingEnabled } from '@sentry
 import {
   addBreadcrumb,
   getClient,
-  getCurrentHub,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
   getDynamicSamplingContextFromSpan,
@@ -166,8 +165,7 @@ export class Http implements Integration {
    * @inheritDoc
    */
   public setupOnce(): void {
-    // eslint-disable-next-line deprecation/deprecation
-    const clientOptions = getCurrentHub().getClient<NodeClient>()?.getOptions();
+    const clientOptions = getClient<NodeClient>()?.getOptions();
 
     // If `tracing` is not explicitly set, we default this based on whether or not tracing is enabled.
     // But for compatibility, we only do that if `enableIfHasTracingEnabled` is set.
@@ -275,8 +273,7 @@ function _createWrappedRequestMethodFactory(
     req: http.ClientRequest,
     res?: http.IncomingMessage,
   ): void {
-    // eslint-disable-next-line deprecation/deprecation
-    if (!getCurrentHub().getIntegration(Http)) {
+    if (!getClient()?.getIntegrationByName('Http')) {
       return;
     }
 

--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -53,7 +53,7 @@ function wrapExpressRequestHandler(
           return resolvedBuild.then(resolved => {
             routes = createRoutes(resolved.routes);
 
-            startRequestHandlerTransactionWithRoutes.call(this, origRequestHandler, routes, req, res, next, hub, url);
+            startRequestHandlerTransactionWithRoutes.call(this, origRequestHandler, routes, req, res, next, url);
           });
         } else {
           routes = createRoutes(resolvedBuild.routes);
@@ -64,7 +64,7 @@ function wrapExpressRequestHandler(
         routes = createRoutes(build.routes);
       }
 
-      return startRequestHandlerTransactionWithRoutes.call(this, origRequestHandler, routes, req, res, next, hub, url);
+      return startRequestHandlerTransactionWithRoutes.call(this, origRequestHandler, routes, req, res, next, url);
     });
   };
 }

--- a/packages/replay-internal/README.md
+++ b/packages/replay-internal/README.md
@@ -72,7 +72,7 @@ Sentry.init({
 
 // Sometime later
 const { Replay } = await import('@sentry/browser');
-const client = Sentry.getCurrentHub().getClient<BrowserClient>();
+const client = Sentry.getClient<BrowserClient>();
 
 // Client can be undefined
 client?.addIntegration(Sentry.replayIntegration());
@@ -105,7 +105,7 @@ Sentry.init({
   integrations: [replay]
 });
 
-const client = Sentry.getCurrentHub().getClient<BrowserClient>();
+const client = Sentry.getClient<BrowserClient>();
 
 // Add replay integration, will start recoring
 client?.addIntegration(replay);

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -45,7 +45,7 @@ export declare const defaultStackParser: StackParser;
 export declare const getClient: typeof clientSdk.getClient;
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
-// eslint-disable-next-line deprecation/deprecation
+
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 


### PR DESCRIPTION
The remaining usages are shims + stuff we have for tests. Not sure how much test code we should delete.