### PR TITLE
fix(node): Use `suppressTracing` to avoid capturing otel spans

### DIFF
--- a/packages/node-experimental/src/transports/http.ts
+++ b/packages/node-experimental/src/transports/http.ts
@@ -2,6 +2,8 @@ import * as http from 'node:http';
 import * as https from 'node:https';
 import { Readable } from 'stream';
 import { createGzip } from 'zlib';
+import { context } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
 import { createTransport } from '@sentry/core';
 import type {
   BaseTransportOptions,
@@ -12,7 +14,6 @@ import type {
 } from '@sentry/types';
 import { consoleSandbox } from '@sentry/utils';
 import { HttpsProxyAgent } from '../proxy';
-
 import type { HTTPModule } from './http-module';
 
 export interface NodeTransportOptions extends BaseTransportOptions {
@@ -80,8 +81,11 @@ export function makeNodeTransport(options: NodeTransportOptions): Transport {
     ? (new HttpsProxyAgent(proxy) as http.Agent)
     : new nativeHttpModule.Agent({ keepAlive, maxSockets: 30, timeout: 2000 });
 
-  const requestExecutor = createRequestExecutor(options, options.httpModule ?? nativeHttpModule, agent);
-  return createTransport(options, requestExecutor);
+  // This ensures we do not generate any spans in OpenTelemetry for the transport
+  return context.with(suppressTracing(context.active()), () => {
+    const requestExecutor = createRequestExecutor(options, options.httpModule ?? nativeHttpModule, agent);
+    return createTransport(options, requestExecutor);
+  });
 }
 
 /**


### PR DESCRIPTION
I leave the other checks (e.g. in http integration) in there, for now (where we check if the url is sentry URL), but this should ensure we are also not picked up by any other OTEL instrumentation etc.