### PR TITLE
ref: remove node-experimental references

### DIFF
--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -66,7 +66,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
  * @example
  * ```
  *
- * const { addBreadcrumb } = require('@sentry/node-experimental');
+ * const { addBreadcrumb } = require('@sentry/node');
  * addBreadcrumb({
  *   message: 'My Breadcrumb',
  *   // ...
@@ -76,7 +76,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
  * @example
  * ```
  *
- * const Sentry = require('@sentry/node-experimental');
+ * const Sentry = require('@sentry/node');
  * Sentry.captureMessage('Hello, world!');
  * Sentry.captureException(new Error('Good bye'));
  * Sentry.captureEvent({

--- a/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
+++ b/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
@@ -4,7 +4,7 @@ import { BigQuery } from '@google-cloud/bigquery';
 import * as nock from 'nock';
 
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
-import { NodeClient, createTransport, setCurrentClient } from '@sentry/node-experimental';
+import { NodeClient, createTransport, setCurrentClient } from '@sentry/node';
 import { googleCloudHttpIntegration } from '../../src/integrations/google-cloud-http';
 
 const mockSpanEnd = jest.fn();


### PR DESCRIPTION
With this change, there are two remaining references to node-experimental.

1. nextjs, which is handled by https://github.com/getsentry/sentry-javascript/pull/11016
2. express integration tests, which I will address after https://github.com/getsentry/sentry-javascript/pull/11285 gets merged

Once those two are done, we can remove the old node packages entirely!