### PR TITLE
ref(angular): Don't include BrowserApiErrors in bundle

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -2,7 +2,7 @@ export type { ErrorHandlerOptions } from './errorhandler';
 
 export * from '@sentry/browser';
 
-export { init } from './sdk';
+export { init, getDefaultIntegrations } from './sdk';
 export { createErrorHandler, SentryErrorHandler } from './errorhandler';
 export {
   browserTracingIntegration,

--- a/packages/angular/test/sdk.test.ts
+++ b/packages/angular/test/sdk.test.ts
@@ -1,6 +1,6 @@
 import * as SentryBrowser from '@sentry/browser';
 import { vi } from 'vitest';
-import { getDefaultIntegrations, init } from '../src/index';
+import { getDefaultIntegrations, init } from '../src/sdk';
 
 describe('init', () => {
   it('sets the Angular version (if available) in the global scope', () => {
@@ -14,39 +14,16 @@ describe('init', () => {
     expect(setContextSpy).toHaveBeenCalledWith('angular', { version: 14 });
   });
 
-  describe('filtering out the `BrowserApiErrors` integration', () => {
-    const browserInitSpy = vi.spyOn(SentryBrowser, 'init');
+  it('does not include the BrowserApiErrors integration', () => {
+    const browserDefaultIntegrationsWithoutBrowserApiErrors = SentryBrowser.getDefaultIntegrations()
+      .filter(i => i.name !== 'BrowserApiErrors')
+      .map(i => i.name)
+      .sort();
 
-    beforeEach(() => {
-      browserInitSpy.mockClear();
-    });
+    const angularDefaultIntegrations = getDefaultIntegrations()
+      .map(i => i.name)
+      .sort();
 
-    it('filters if `defaultIntegrations` is not set', () => {
-      init({});
-
-      expect(browserInitSpy).toHaveBeenCalledTimes(1);
-
-      const options = browserInitSpy.mock.calls[0][0] || {};
-      expect(options.defaultIntegrations).not.toContainEqual(expect.objectContaining({ name: 'BrowserApiErrors' }));
-    });
-
-    it("doesn't filter if `defaultIntegrations` is set to `false`", () => {
-      init({ defaultIntegrations: false });
-
-      expect(browserInitSpy).toHaveBeenCalledTimes(1);
-
-      const options = browserInitSpy.mock.calls[0][0] || {};
-      expect(options.defaultIntegrations).toEqual(false);
-    });
-
-    it("doesn't filter if `defaultIntegrations` is overwritten", () => {
-      const defaultIntegrations = getDefaultIntegrations({});
-      init({ defaultIntegrations });
-
-      expect(browserInitSpy).toHaveBeenCalledTimes(1);
-
-      const options = browserInitSpy.mock.calls[0][0] || {};
-      expect(options.defaultIntegrations).toEqual(defaultIntegrations);
-    });
+    expect(angularDefaultIntegrations).toEqual(browserDefaultIntegrationsWithoutBrowserApiErrors);
   });
 });

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -32,6 +32,10 @@ import { makeFetchTransport } from './transports/fetch';
 
 /** Get the default integrations for the browser SDK. */
 export function getDefaultIntegrations(_options: Options): Integration[] {
+  /**
+   * Note: Please make sure this stays in sync with Angular SDK, which re-exports
+   * `getDefaultIntegrations` but with an adjusted set of integrations.
+   */
   return [
     inboundFiltersIntegration(),
     functionToStringIntegration(),


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/9508

The `BrowserApiErrors` integration interfers with Angular error handler, so don't include it in the default integrations.