### PR TITLE
test(nextjs): Adjust build validator for newest Next.js canary

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
@@ -31,8 +31,8 @@ const buildStderr = fs.readFileSync('.tmp_build_stderr', 'utf-8');
 assert.match(buildStdout, /○ \/client-component/);
 assert.match(buildStdout, /● \/client-component\/parameter\/\[\.\.\.parameters\]/);
 assert.match(buildStdout, /● \/client-component\/parameter\/\[parameter\]/);
-assert.match(buildStdout, /λ \/server-component/);
-assert.match(buildStdout, /λ \/server-component\/parameter\/\[\.\.\.parameters\]/);
-assert.match(buildStdout, /λ \/server-component\/parameter\/\[parameter\]/);
+assert.match(buildStdout, /(λ|ƒ) \/server-component/);
+assert.match(buildStdout, /(λ|ƒ) \/server-component\/parameter\/\[\.\.\.parameters\]/);
+assert.match(buildStdout, /(λ|ƒ) \/server-component\/parameter\/\[parameter\]/);
 
 export {};


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/11298