### PR TITLE
fix(nextjs): Remove Http integration from Next.js

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/tests/request-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/tests/request-instrumentation.test.ts
@@ -19,16 +19,15 @@ test('Should send a transaction with a fetch span', async ({ page }) => {
     }),
   );
 
-  // TODO: Uncomment the below when fixed. For whatever reason that we now have accepted, spans created with Node.js' http.get() will not attach themselves to transactions.
-  // More info: https://github.com/getsentry/sentry-javascript/pull/11016/files#diff-10fa195789425786c6e5e769380be18790768f0b76319ee41bbb488d9fe50405R4
-  // expect((await transactionPromise).spans).toContainEqual(
-  //   expect.objectContaining({
-  //     data: expect.objectContaining({
-  //       'http.method': 'GET',
-  //       'sentry.op': 'http.client',
-  //       'sentry.origin': 'auto.http.otel.http',
-  //     }),
-  //     description: 'GET http://example.com/',
-  //   }),
-  // );
+  expect((await transactionPromise).spans).toContainEqual(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        'http.method': 'GET',
+        'sentry.op': 'http.client',
+        // todo: without the HTTP integration in the Next.js SDK, this is set to 'manual' -> we could rename this to be more specific
+        'sentry.origin': 'manual',
+      }),
+      description: 'GET http://example.com/',
+    }),
+  );
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
@@ -20,7 +20,7 @@
     "@types/node": "18.11.17",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
-    "next": "14.0.0",
+    "next": "14.0.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "4.9.5",

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
@@ -20,7 +20,7 @@
     "@types/node": "18.11.17",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
-    "next": "14.0.2",
+    "next": "14.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "4.9.5",

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/route-handlers.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/route-handlers.test.ts
@@ -56,6 +56,7 @@ test('Should record exceptions and transactions for faulty route handlers', asyn
 
   expect(routehandlerTransaction.contexts?.trace?.status).toBe('unknown_error');
   expect(routehandlerTransaction.contexts?.trace?.op).toBe('http.server');
+  expect(routehandlerTransaction.contexts?.trace?.origin).toBe('auto.function.nextjs');
 
   expect(routehandlerError.exception?.values?.[0].value).toBe('route-handler-error');
   // TODO: Uncomment once we update the scope transaction name on the server side

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -65,12 +65,14 @@
     "access": "public"
   },
   "dependencies": {
+    "@opentelemetry/api": "1.7.0",
     "@rollup/plugin-commonjs": "24.0.0",
     "@sentry/core": "8.0.0-alpha.9",
     "@sentry/node": "8.0.0-alpha.9",
     "@sentry/react": "8.0.0-alpha.9",
     "@sentry/types": "8.0.0-alpha.9",
     "@sentry/utils": "8.0.0-alpha.9",
+    "@sentry/opentelemetry": "8.0.0-alpha.9",
     "@sentry/vercel-edge": "8.0.0-alpha.9",
     "@sentry/webpack-plugin": "2.16.0",
     "chalk": "3.0.0",

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -20,7 +20,7 @@ import { flushQueue } from './utils/responseEnd';
 import { withIsolationScopeOrReuseFromRootSpan } from './utils/withIsolationScopeOrReuseFromRootSpan';
 
 /** As our own HTTP integration is disabled (src/server/index.ts) the rootSpan comes from Next.js.
- * In case there is not root span, we start a new span. */
+ * In case there is no root span, we start a new span. */
 function startOrUpdateSpan(spanName: string, cb: (rootSpan: Span) => Promise<Response>): Promise<Response> {
   const activeSpan = getActiveSpan();
   const rootSpan = activeSpan && getRootSpan(activeSpan);

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -22,10 +22,7 @@ import { withIsolationScopeOrReuseFromRootSpan } from './utils/withIsolationScop
 
 /** As our own HTTP integration is disabled (src/server/index.ts) the rootSpan comes from Next.js.
  * In case there is not root span, we start a new span. */
-function startOrUpdateSpan(
-  spanName: string,
-  handleResponseErrors: (rootSpan: Span) => Promise<Response>,
-): Promise<Response> {
+function startOrUpdateSpan(spanName: string, cb: (rootSpan: Span) => Promise<Response>): Promise<Response> {
   const activeSpan = getActiveSpan();
   const rootSpan = activeSpan && getRootSpan(activeSpan);
 
@@ -35,7 +32,7 @@ function startOrUpdateSpan(
     rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'http.server');
     rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.function.nextjs');
 
-    return handleResponseErrors(rootSpan);
+    return cb(rootSpan);
   } else {
     return startSpan(
       {
@@ -48,7 +45,7 @@ function startOrUpdateSpan(
         },
       },
       (span: Span) => {
-        return handleResponseErrors(span);
+        return cb(span);
       },
     );
   }

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -1,4 +1,6 @@
 import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SPAN_STATUS_ERROR,
   addTracingExtensions,
   captureException,
@@ -6,14 +8,54 @@ import {
   getRootSpan,
   handleCallbackErrors,
   setHttpStatus,
+  startSpan,
   withIsolationScope,
 } from '@sentry/core';
+import type { Span } from '@sentry/types';
 import { winterCGHeadersToDict } from '@sentry/utils';
 import { isNotFoundNavigationError, isRedirectNavigationError } from './nextNavigationErrorUtils';
 import type { RouteHandlerContext } from './types';
 import { platformSupportsStreaming } from './utils/platformSupportsStreaming';
 import { flushQueue } from './utils/responseEnd';
 import { withIsolationScopeOrReuseFromRootSpan } from './utils/withIsolationScopeOrReuseFromRootSpan';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function addSpanAttributes<F extends (...args: any[]) => any>(
+  originalFunction: F,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  thisArg: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any[],
+  rootSpan?: Span,
+): Promise<Response> {
+  const response: Response = await handleCallbackErrors(
+    () => originalFunction.apply(thisArg, args),
+    error => {
+      // Next.js throws errors when calling `redirect()`. We don't wanna report these.
+      if (isRedirectNavigationError(error)) {
+        // Don't do anything
+      } else if (isNotFoundNavigationError(error) && rootSpan) {
+        rootSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'not_found' });
+      } else {
+        captureException(error, {
+          mechanism: {
+            handled: false,
+          },
+        });
+      }
+    },
+  );
+
+  try {
+    if (rootSpan && response.status) {
+      setHttpStatus(rootSpan, response.status);
+    }
+  } catch {
+    // best effort - response may be undefined?
+  }
+
+  return response;
+}
 
 /**
  * Wraps a Next.js route handler with performance and error instrumentation.
@@ -25,10 +67,10 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
 ): (...args: Parameters<F>) => ReturnType<F> extends Promise<unknown> ? ReturnType<F> : Promise<ReturnType<F>> {
   addTracingExtensions();
 
-  const { headers } = context;
+  const { method, parameterizedRoute, headers } = context;
 
   return new Proxy(routeHandler, {
-    apply: async (originalFunction, thisArg, args) => {
+    apply: (originalFunction, thisArg, args) => {
       return withIsolationScope(async isolationScope => {
         isolationScope.setSDKProcessingMetadata({
           request: {
@@ -40,33 +82,24 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
           const activeSpan = getActiveSpan();
           const rootSpan = activeSpan && getRootSpan(activeSpan);
 
-          const response: Response = await handleCallbackErrors(
-            () => originalFunction.apply(thisArg, args),
-            error => {
-              // Next.js throws errors when calling `redirect()`. We don't wanna report these.
-              if (isRedirectNavigationError(error)) {
-                // Don't do anything
-              } else if (isNotFoundNavigationError(error) && rootSpan) {
-                rootSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'not_found' });
-              } else {
-                captureException(error, {
-                  mechanism: {
-                    handled: false,
-                  },
-                });
-              }
-            },
-          );
-
-          try {
-            if (rootSpan && response.status) {
-              setHttpStatus(rootSpan, response.status);
-            }
-          } catch {
-            // best effort - response may be undefined?
+          if (rootSpan) {
+            return await addSpanAttributes<F>(originalFunction, thisArg, args, rootSpan);
+          } else {
+            /** As our own HTTP integration is disabled (src/server/index.ts) the rootSpan comes from Next.js.
+             * In case there is not root span, we start a new one. */
+            return await startSpan(
+              {
+                op: 'http.server',
+                name: `${method} ${parameterizedRoute}`,
+                forceTransaction: true,
+                attributes: {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.nextjs',
+                },
+              },
+              async span => addSpanAttributes(originalFunction, thisArg, args, span),
+            );
           }
-
-          return response;
         } finally {
           if (!platformSupportsStreaming() || process.env.NEXT_RUNTIME === 'edge') {
             // 1. Edge transport requires manual flushing

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -10,7 +10,6 @@ import {
   handleCallbackErrors,
   setHttpStatus,
   startSpan,
-  withIsolationScope,
 } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { winterCGHeadersToDict } from '@sentry/utils';
@@ -22,10 +21,7 @@ import { withIsolationScopeOrReuseFromRootSpan } from './utils/withIsolationScop
 
 /** As our own HTTP integration is disabled (src/server/index.ts) the rootSpan comes from Next.js.
  * In case there is not root span, we start a new span. */
-function startOrUpdateSpan(
-  spanName: string,
-  handleResponseErrors: (rootSpan: Span) => Promise<Response>,
-): Promise<Response> {
+function startOrUpdateSpan(spanName: string, cb: (rootSpan: Span) => Promise<Response>): Promise<Response> {
   const activeSpan = getActiveSpan();
   const rootSpan = activeSpan && getRootSpan(activeSpan);
 
@@ -35,7 +31,7 @@ function startOrUpdateSpan(
     rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'http.server');
     rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.function.nextjs');
 
-    return handleResponseErrors(rootSpan);
+    return cb(rootSpan);
   } else {
     return startSpan(
       {
@@ -48,7 +44,7 @@ function startOrUpdateSpan(
         },
       },
       (span: Span) => {
-        return handleResponseErrors(span);
+        return cb(span);
       },
     );
   }
@@ -68,7 +64,7 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
 
   return new Proxy(routeHandler, {
     apply: (originalFunction, thisArg, args) => {
-      return withIsolationScope(async isolationScope => {
+      return withIsolationScopeOrReuseFromRootSpan(async isolationScope => {
         isolationScope.setSDKProcessingMetadata({
           request: {
             headers: headers ? winterCGHeadersToDict(headers) : undefined,

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -27,9 +27,11 @@ function startOrUpdateSpan(spanName: string, cb: (rootSpan: Span) => Promise<Res
 
   if (rootSpan) {
     rootSpan.updateName(spanName);
-    rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
-    rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'http.server');
-    rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.function.nextjs');
+    rootSpan.setAttributes({
+      [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.nextjs',
+    });
 
     return cb(rootSpan);
   } else {

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -40,6 +40,7 @@ function startOrUpdateSpan(spanName: string, cb: (rootSpan: Span) => Promise<Res
         forceTransaction: true,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.nextjs',
         },
       },

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -3,10 +3,10 @@ import {
   addTracingExtensions,
   captureException,
   getActiveSpan,
-  getIsolationScope,
   getRootSpan,
   handleCallbackErrors,
   setHttpStatus,
+  withIsolationScope,
 } from '@sentry/core';
 import { winterCGHeadersToDict } from '@sentry/utils';
 import { isNotFoundNavigationError, isRedirectNavigationError } from './nextNavigationErrorUtils';
@@ -29,50 +29,52 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
 
   return new Proxy(routeHandler, {
     apply: async (originalFunction, thisArg, args) => {
-      getIsolationScope().setSDKProcessingMetadata({
-        request: {
-          headers: headers ? winterCGHeadersToDict(headers) : undefined,
-        },
-      });
-
-      try {
-        const activeSpan = getActiveSpan();
-        const rootSpan = activeSpan && getRootSpan(activeSpan);
-
-        const response: Response = await handleCallbackErrors(
-          () => originalFunction.apply(thisArg, args),
-          error => {
-            // Next.js throws errors when calling `redirect()`. We don't wanna report these.
-            if (isRedirectNavigationError(error)) {
-              // Don't do anything
-            } else if (isNotFoundNavigationError(error) && rootSpan) {
-              rootSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'not_found' });
-            } else {
-              captureException(error, {
-                mechanism: {
-                  handled: false,
-                },
-              });
-            }
+      return withIsolationScope(async isolationScope => {
+        isolationScope.setSDKProcessingMetadata({
+          request: {
+            headers: headers ? winterCGHeadersToDict(headers) : undefined,
           },
-        );
+        });
 
         try {
-          if (rootSpan && response.status) {
-            setHttpStatus(rootSpan, response.status);
-          }
-        } catch {
-          // best effort - response may be undefined?
-        }
+          const activeSpan = getActiveSpan();
+          const rootSpan = activeSpan && getRootSpan(activeSpan);
 
-        return response;
-      } finally {
-        if (!platformSupportsStreaming() || process.env.NEXT_RUNTIME === 'edge') {
-          // 1. Edge transport requires manual flushing
-          // 2. Lambdas require manual flushing to prevent execution freeze before the event is sent
-          await flushQueue();
+          const response: Response = await handleCallbackErrors(
+            () => originalFunction.apply(thisArg, args),
+            error => {
+              // Next.js throws errors when calling `redirect()`. We don't wanna report these.
+              if (isRedirectNavigationError(error)) {
+                // Don't do anything
+              } else if (isNotFoundNavigationError(error) && rootSpan) {
+                rootSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'not_found' });
+              } else {
+                captureException(error, {
+                  mechanism: {
+                    handled: false,
+                  },
+                });
+              }
+            },
+          );
+
+          try {
+            if (rootSpan && response.status) {
+              setHttpStatus(rootSpan, response.status);
+            }
+          } catch {
+            // best effort - response may be undefined?
+          }
+
+          return response;
+        } finally {
+          if (!platformSupportsStreaming() || process.env.NEXT_RUNTIME === 'edge') {
+            // 1. Edge transport requires manual flushing
+            // 2. Lambdas require manual flushing to prevent execution freeze before the event is sent
+            await flushQueue();
+          }
         }
-      }
+      });
     },
   });
 }

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -12,7 +12,6 @@ import { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration
 
 export * from '@sentry/node';
 import type { EventProcessor } from '@sentry/types';
-import { requestIsolationScopeIntegration } from './requestIsolationScopeIntegration';
 
 export { captureUnderscoreErrorException } from '../common/_error';
 export { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration';
@@ -82,7 +81,7 @@ export function init(options: NodeOptions): void {
         integration.name !== 'Http',
     ),
     onUncaughtExceptionIntegration(),
-    requestIsolationScopeIntegration(),
+    // requestIsolationScopeIntegration(),
   ];
 
   // This value is injected at build time, based on the output directory specified in the build config. Though a default

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -75,8 +75,9 @@ export function init(options: NodeOptions): void {
     ...getDefaultIntegrations(options).filter(
       integration =>
         integration.name !== 'OnUncaughtException' &&
-        // Next.js comes with its own Node-Fetch and Http instrumentation, so we shouldn't add ours on-top
+        // Next.js comes with its own Node-Fetch instrumentation, so we shouldn't add ours on-top
         integration.name !== 'NodeFetch' &&
+        // Next.js comes with its own Http instrumentation for OTel which lead to double spans for route handler requests
         integration.name !== 'Http',
     ),
     onUncaughtExceptionIntegration(),

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -75,8 +75,9 @@ export function init(options: NodeOptions): void {
     ...getDefaultIntegrations(options).filter(
       integration =>
         integration.name !== 'OnUncaughtException' &&
-        // Next.js comes with its own Node-Fetch instrumentation so we shouldn't add ours on-top
-        integration.name !== 'NodeFetch',
+        // Next.js comes with its own Node-Fetch and Http instrumentation, so we shouldn't add ours on-top
+        integration.name !== 'NodeFetch' &&
+        integration.name !== 'Http',
     ),
     onUncaughtExceptionIntegration(),
   ];

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -12,6 +12,7 @@ import { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration
 
 export * from '@sentry/node';
 import type { EventProcessor } from '@sentry/types';
+import { requestIsolationScopeIntegration } from './requestIsolationScopeIntegration';
 
 export { captureUnderscoreErrorException } from '../common/_error';
 export { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration';
@@ -81,7 +82,7 @@ export function init(options: NodeOptions): void {
         integration.name !== 'Http',
     ),
     onUncaughtExceptionIntegration(),
-    // requestIsolationScopeIntegration(),
+    requestIsolationScopeIntegration(),
   ];
 
   // This value is injected at build time, based on the output directory specified in the build config. Though a default

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -12,6 +12,7 @@ import { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration
 
 export * from '@sentry/node';
 import type { EventProcessor } from '@sentry/types';
+import { requestIsolationScopeIntegration } from './requestIsolationScopeIntegration';
 
 export { captureUnderscoreErrorException } from '../common/_error';
 export { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration';
@@ -81,6 +82,7 @@ export function init(options: NodeOptions): void {
         integration.name !== 'Http',
     ),
     onUncaughtExceptionIntegration(),
+    requestIsolationScopeIntegration(),
   ];
 
   // This value is injected at build time, based on the output directory specified in the build config. Though a default

--- a/packages/nextjs/src/server/requestIsolationScopeIntegration.ts
+++ b/packages/nextjs/src/server/requestIsolationScopeIntegration.ts
@@ -26,7 +26,10 @@ export const requestIsolationScopeIntegration = defineIntegration(() => {
         const data = spanJson.data || {};
 
         // The following check is a heuristic to determine whether the started span is a span that tracks an incoming HTTP request
-        if ((getSpanKind(span) === SpanKind.SERVER && data['http.method']) || (span === getRootSpan(span) && data['next.route'])) {
+        if (
+          (getSpanKind(span) === SpanKind.SERVER && data['http.method']) ||
+          (span === getRootSpan(span) && data['next.route'])
+        ) {
           const scopes = getCapturedScopesOnSpan(span);
 
           // Update the isolation scope, isolate this request

--- a/packages/nextjs/src/server/requestIsolationScopeIntegration.ts
+++ b/packages/nextjs/src/server/requestIsolationScopeIntegration.ts
@@ -1,0 +1,29 @@
+import { SpanKind } from '@opentelemetry/api';
+import { defineIntegration, spanToJSON } from '@sentry/core';
+import { getSpanKind, getSpanScopes } from '@sentry/opentelemetry';
+
+/**
+ * This integration is responsible for creating isolation scopes for incoming Http requests.
+ * We do so by waiting for http spans to be created and then forking the isolation scope.
+ *
+ * Normally the isolation scopes would be created by our Http instrumentation, however Next.js brings it's own Http
+ * instrumentation so we had to disable ours.
+ */
+export const requestIsolationScopeIntegration = defineIntegration(() => {
+  return {
+    name: 'RequestIsolationScope',
+    setup(client) {
+      client.on('spanStart', span => {
+        const spanJson = spanToJSON(span);
+
+        // The following check is a heuristic to determine whether the started span is a span that tracks an incoming HTTP request
+        if (getSpanKind(span) === SpanKind.SERVER && spanJson.data && 'http.method' in spanJson.data) {
+          const scopes = getSpanScopes(span);
+          if (scopes) {
+            scopes.isolationScope = scopes.isolationScope.clone();
+          }
+        }
+      });
+    },
+  };
+});

--- a/packages/nextjs/src/server/requestIsolationScopeIntegration.ts
+++ b/packages/nextjs/src/server/requestIsolationScopeIntegration.ts
@@ -4,6 +4,7 @@ import {
   getCapturedScopesOnSpan,
   getCurrentScope,
   getIsolationScope,
+  getRootSpan,
   setCapturedScopesOnSpan,
   spanToJSON,
 } from '@sentry/core';
@@ -25,7 +26,7 @@ export const requestIsolationScopeIntegration = defineIntegration(() => {
         const data = spanJson.data || {};
 
         // The following check is a heuristic to determine whether the started span is a span that tracks an incoming HTTP request
-        if ((getSpanKind(span) === SpanKind.SERVER && data['http.method']) || data['next.route']) {
+        if ((getSpanKind(span) === SpanKind.SERVER && data['http.method']) || (span === getRootSpan(span) && data['next.route'])) {
           const scopes = getCapturedScopesOnSpan(span);
 
           // Update the isolation scope, isolate this request


### PR DESCRIPTION
Next.js provides their own OTel http integration, which conflicts with ours
ref https://github.com/getsentry/sentry-javascript/pull/11016
added commit from this PR: https://github.com/getsentry/sentry-javascript/pull/11319
