### PR TITLE
build(replay): Ensure replay package has `publishConfig`

### DIFF
--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -32,6 +32,9 @@
     "types-ts3.8"
   ],
   "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "run-p build:transpile build:types build:bundle",
     "build:transpile": "rollup -c rollup.npm.config.mjs",


### PR DESCRIPTION
Let's see if that fixes the publishing issue... (Note that this was never there, but maybe this is a problem...)