### PR TITLE
 feat(replay/v7): Bump `rrweb` to 2.12.0

### DIFF
--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@sentry-internal/rrweb": "2.11.0"
+    "@sentry-internal/rrweb": "2.12.0"
   },
   "dependencies": {
     "@sentry/core": "7.108.0",

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -54,8 +54,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "7.108.0",
-    "@sentry-internal/rrweb": "2.11.0",
-    "@sentry-internal/rrweb-snapshot": "2.11.0",
+    "@sentry-internal/rrweb": "2.12.0",
+    "@sentry-internal/rrweb-snapshot": "2.12.0",
     "fflate": "^0.8.1",
     "jsdom-worker": "^0.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5554,10 +5554,22 @@
   dependencies:
     "@sentry-internal/rrweb-snapshot" "2.11.0"
 
+"@sentry-internal/rrdom@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.12.0.tgz#d3ca32b1e4b8c5d8cc9bdb44f933fe4b059573a0"
+  integrity sha512-EQ9vmhkTREdtzKp6SmD4GEkwr+RJcaEnbVcDZjbnQnxagskOpqvXjoPMONPf9hZhkULwnrnyFGGp0VpQOGBS0w==
+  dependencies:
+    "@sentry-internal/rrweb-snapshot" "2.12.0"
+
 "@sentry-internal/rrweb-snapshot@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.11.0.tgz#1af79130604afea989d325465b209ac015b27c9a"
   integrity sha512-1nP22QlplMNooSNvTh+L30NSZ+E3UcfaJyxXSMLxUjQHTGPyM1VkndxZMmxlKhyR5X+rLbxi/+RvuAcpM43VoA==
+
+"@sentry-internal/rrweb-snapshot@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.12.0.tgz#2f1f6d4867a07ab757475fb4fa337d7f1aaa6b2d"
+  integrity sha512-AYo8CeDA7qDOKFG75E+bnxrS/qm7l5Ad0ftClA3VzoGV58bNNgv/aKiECtUPk0UPs4EqTQ8z8W/MZ9EYDF6vvA==
 
 "@sentry-internal/rrweb-types@2.11.0":
   version "2.11.0"
@@ -5565,6 +5577,13 @@
   integrity sha512-foCf9DGfN5ffzwykEtIXsV1P5d+XLDVGaQUnKF5ecGn+g5JzKTe/rPC92rL8/gEy2unL5sCTvlYL3DQvUFM4dA==
   dependencies:
     "@sentry-internal/rrweb-snapshot" "2.11.0"
+
+"@sentry-internal/rrweb-types@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.12.0.tgz#f7c57eda7610882c71860437657ffbbcb788184d"
+  integrity sha512-W0iLlTx3HeapBTGjg/uLoKQr1/DGPbkANqwjf4mW0IS4jHAVcxFX/e769aHHKEmd68Lm3+A8b08xdA9UDBXW5w==
+  dependencies:
+    "@sentry-internal/rrweb-snapshot" "2.12.0"
 
 "@sentry-internal/rrweb@2.11.0":
   version "2.11.0"
@@ -5574,6 +5593,20 @@
     "@sentry-internal/rrdom" "2.11.0"
     "@sentry-internal/rrweb-snapshot" "2.11.0"
     "@sentry-internal/rrweb-types" "2.11.0"
+    "@types/css-font-loading-module" "0.0.7"
+    "@xstate/fsm" "^1.4.0"
+    base64-arraybuffer "^1.0.1"
+    fflate "^0.4.4"
+    mitt "^3.0.0"
+
+"@sentry-internal/rrweb@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.12.0.tgz#4becbedf7315f4b4e0ebc35319a848ec6f082dce"
+  integrity sha512-NosAF5f8dXdj6linXpI+e38/eKVtwy3R2rzmMohBCwdhPXgTkTV/Laj/9OsRxARNRyz81mIEGcn/Ivp/De7RaA==
+  dependencies:
+    "@sentry-internal/rrdom" "2.12.0"
+    "@sentry-internal/rrweb-snapshot" "2.12.0"
+    "@sentry-internal/rrweb-types" "2.12.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
Backport of https://github.com/getsentry/sentry-javascript/pull/11314

* fix(canvas): createImageBitmap throws when canvas size is 0
* fix: fixes several cases where we access an undefined value
* fix: Incorrect parsing of functional pseudo class css selector