### PR TITLE
fix(tracing-internal/v7): Guard for missing navigation performance entries

### DIFF
--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -674,7 +674,12 @@ function setResourceEntrySizeData(
  * ttfb information is added via vendored web vitals library.
  */
 function _addTtfbRequestTimeToMeasurements(_measurements: Measurements): void {
-  const navEntry = getNavigationEntry() as TTFBMetric['entries'][number];
+  const navEntry = getNavigationEntry();
+
+  if (!navEntry) {
+    return;
+  }
+
   const { responseStart, requestStart } = navEntry;
 
   if (requestStart <= responseStart) {

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -32,7 +32,6 @@ import { _startChild, isMeasurementValue } from './utils';
 
 import { createSpanEnvelope } from '@sentry/core';
 import { getNavigationEntry } from '../web-vitals/lib/getNavigationEntry';
-import type { TTFBMetric } from '../web-vitals/types/ttfb';
 
 const MAX_INT_AS_BYTES = 2147483647;
 


### PR DESCRIPTION
Backport https://github.com/getsentry/sentry-javascript/pull/11329

Fixes https://github.com/getsentry/sentry-javascript/issues/11326