### PR TITLE
feat(feedback): Add `getFeedback` utility to get typed feedback instance

### DIFF
--- a/packages/browser/src/index.bundle.feedback.ts
+++ b/packages/browser/src/index.bundle.feedback.ts
@@ -1,5 +1,5 @@
 // This is exported so the loader does not fail when switching off Replay/Tracing
-import { feedbackIntegration } from '@sentry-internal/feedback';
+import { feedbackIntegration, getFeedback } from '@sentry-internal/feedback';
 import {
   addTracingExtensionsShim,
   browserTracingIntegrationShim,
@@ -12,5 +12,6 @@ export {
   addTracingExtensionsShim as addTracingExtensions,
   replayIntegrationShim as replayIntegration,
   feedbackIntegration,
+  getFeedback,
 };
 // Note: We do not export a shim for `Span` here, as that is quite complex and would blow up the bundle

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -1,4 +1,4 @@
-import { feedbackIntegration } from '@sentry-internal/feedback';
+import { feedbackIntegration, getFeedback } from '@sentry-internal/feedback';
 import { replayIntegration } from '@sentry-internal/replay';
 import {
   browserTracingIntegration,
@@ -27,6 +27,7 @@ export {
   addTracingExtensions,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
+  getFeedback,
 };
 
 export * from './index.bundle.base';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -49,6 +49,7 @@ export { replayCanvasIntegration } from '@sentry-internal/replay-canvas';
 
 export {
   feedbackIntegration,
+  getFeedback,
   sendFeedback,
 } from '@sentry-internal/feedback';
 

--- a/packages/feedback/src/core/getFeedback.test.ts
+++ b/packages/feedback/src/core/getFeedback.test.ts
@@ -1,0 +1,40 @@
+import { getCurrentScope } from '@sentry/core';
+import { getFeedback } from './getFeedback';
+import { feedbackIntegration } from './integration';
+import { mockSdk } from './mockSdk';
+
+describe('getFeedback', () => {
+  beforeEach(() => {
+    getCurrentScope().setClient(undefined);
+  });
+
+  it('works without a client', () => {
+    const actual = getFeedback();
+    expect(actual).toBeUndefined();
+  });
+
+  it('works with a client without Feedback', () => {
+    mockSdk({
+      sentryOptions: {
+        integrations: [],
+      },
+    });
+
+    const actual = getFeedback();
+    expect(actual).toBeUndefined();
+  });
+
+  it('works with a client with Feedback', () => {
+    const feedback = feedbackIntegration();
+
+    mockSdk({
+      sentryOptions: {
+        integrations: [feedback],
+      },
+    });
+
+    const actual = getFeedback();
+    expect(actual).toBeDefined();
+    expect(actual === feedback).toBe(true);
+  });
+});

--- a/packages/feedback/src/core/getFeedback.ts
+++ b/packages/feedback/src/core/getFeedback.ts
@@ -1,0 +1,10 @@
+import { getClient } from '@sentry/core';
+import type { feedbackIntegration } from './integration';
+
+/**
+ * This is a small utility to get a type-safe instance of the Feedback integration.
+ */
+export function getFeedback(): ReturnType<typeof feedbackIntegration> | undefined {
+  const client = getClient();
+  return client && client.getIntegrationByName<ReturnType<typeof feedbackIntegration>>('Feedback');
+}

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -1,4 +1,4 @@
-import { defineIntegration, getClient } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type { Integration, IntegrationFn } from '@sentry/types';
 import { isBrowser, logger } from '@sentry/utils';
 import {
@@ -45,7 +45,10 @@ interface PublicFeedbackIntegration {
 }
 export type IFeedbackIntegration = Integration & PublicFeedbackIntegration;
 
-export const _feedbackIntegration = (({
+/**
+ * Allow users to capture user feedback and send it to Sentry.
+ */
+export const feedbackIntegration = (({
   // FeedbackGeneralConfiguration
   id = 'sentry-feedback',
   showBranding = true,
@@ -279,5 +282,3 @@ export const _feedbackIntegration = (({
     },
   };
 }) satisfies IntegrationFn;
-
-export const feedbackIntegration = defineIntegration(_feedbackIntegration);

--- a/packages/feedback/src/index.ts
+++ b/packages/feedback/src/index.ts
@@ -1,6 +1,7 @@
 export { sendFeedback } from './core/sendFeedback';
 export { feedbackIntegration } from './core/integration';
 export { feedbackModalIntegration } from './modal/integration';
+export { getFeedback } from './core/getFeedback';
 export { feedbackScreenshotIntegration } from './screenshot/integration';
 
 export type { OptionalFeedbackConfiguration } from './types';


### PR DESCRIPTION
Also ensure the `feedbackIntegration` returns a properly typed response.

This should make it easier to manually interact with feedbacks.
