### PR TITLE
test(node): Allow passing of http headers for node integration tests

### DIFF
--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -106,13 +106,13 @@ async function runDockerCompose(options: DockerOptions): Promise<VoidFunction> {
 
 type Expected =
   | {
-      event: Partial<Event> | ((event: Event) => void);
+      event: Partial<Event> | ((event: Event, headers?: Record<string, string>) => void);
     }
   | {
-      transaction: Partial<Event> | ((event: Event) => void);
+      transaction: Partial<Event> | ((event: Event, headers?: Record<string, string>) => void);
     }
   | {
-      session: Partial<SerializedSession> | ((event: SerializedSession) => void);
+      session: Partial<SerializedSession> | ((event: SerializedSession, headers?: Record<string, string>) => void);
     };
 
 /** Creates a test runner */
@@ -182,7 +182,7 @@ export function createRunner(...paths: string[]) {
         }
       }
 
-      function newEnvelope(envelope: Envelope): void {
+      function newEnvelope(envelope: Envelope, headers?: Record<string, string>): void {
         for (const item of envelope[1]) {
           const envelopeItemType = item[0].type;
 
@@ -207,7 +207,7 @@ export function createRunner(...paths: string[]) {
             if ('event' in expected) {
               const event = item[1] as Event;
               if (typeof expected.event === 'function') {
-                expected.event(event);
+                expected.event(event, headers);
               } else {
                 assertSentryEvent(event, expected.event);
               }
@@ -218,7 +218,7 @@ export function createRunner(...paths: string[]) {
             if ('transaction' in expected) {
               const event = item[1] as Event;
               if (typeof expected.transaction === 'function') {
-                expected.transaction(event);
+                expected.transaction(event, headers);
               } else {
                 assertSentryTransaction(event, expected.transaction);
               }
@@ -229,7 +229,7 @@ export function createRunner(...paths: string[]) {
             if ('session' in expected) {
               const session = item[1] as SerializedSession;
               if (typeof expected.session === 'function') {
-                expected.session(session);
+                expected.session(session, headers);
               } else {
                 assertSentrySession(session, expected.session);
               }

--- a/dev-packages/node-integration-tests/utils/server.ts
+++ b/dev-packages/node-integration-tests/utils/server.ts
@@ -9,13 +9,15 @@ import express from 'express';
  * This does no checks on the envelope, it just calls the callback if it managed to parse an envelope from the raw POST
  * body data.
  */
-export function createBasicSentryServer(onEnvelope: (env: Envelope) => void): Promise<number> {
+export function createBasicSentryServer(
+  onEnvelope: (env: Envelope, headers: Record<string, string>) => void,
+): Promise<number> {
   const app = express();
   app.use(express.raw({ type: () => true, inflate: true, limit: '100mb' }));
   app.post('/api/:id/envelope/', (req, res) => {
     try {
       const env = parseEnvelope(req.body as Buffer);
-      onEnvelope(env);
+      onEnvelope(env, req.headers);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e);


### PR DESCRIPTION
This PR adds the ability to test request headers for Node integration tests.

Configure your test to use the mock Sentry server and then pass a callback which will be passed the event/transaction/session along with the request headers:
```ts
  createRunner(__dirname, 'basic.js')
    .withMockSentryServer()
    .expect({
       event: (event, headers) => {
         // assert whatever here, you can use `assertSentryEvent` to check the event
       }
    })
    .start(done);
```

When using `withMockSentryServer`, the DSN to use is passed to the test scenario as `process.env.SENTRY_DSN`.