### PR TITLE
feat(utils): Use `globalThis`

### DIFF
--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -70,46 +70,8 @@ export interface InternalGlobal {
   _sentryModuleMetadata?: Record<string, any>;
 }
 
-// The code below for 'isGlobalObj' and 'GLOBAL_OBJ' was copied from core-js before modification
-// https://github.com/zloirock/core-js/blob/1b944df55282cdc99c90db5f49eb0b6eda2cc0a3/packages/core-js/internals/global.js
-// core-js has the following licence:
-//
-// Copyright (c) 2014-2022 Denis Pushkarev
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-
-/** Returns 'obj' if it's the global object, otherwise returns undefined */
-function isGlobalObj(obj: { Math?: Math }): any | undefined {
-  return obj && obj.Math == Math ? obj : undefined;
-}
-
 /** Get's the global object for the current JavaScript runtime */
-export const GLOBAL_OBJ: InternalGlobal =
-  (typeof globalThis == 'object' && isGlobalObj(globalThis)) ||
-  // eslint-disable-next-line no-restricted-globals
-  (typeof window == 'object' && isGlobalObj(window)) ||
-  (typeof self == 'object' && isGlobalObj(self)) ||
-  (typeof global == 'object' && isGlobalObj(global)) ||
-  (function (this: any) {
-    return this;
-  })() ||
-  {};
+export const GLOBAL_OBJ = globalThis as unknown as InternalGlobal;
 
 /**
  * @deprecated Use GLOBAL_OBJ instead or WINDOW from @sentry/browser. This will be removed in v8


### PR DESCRIPTION
Now we've dropped Nove v12 we can simplify to `globalThis`:

https://github.com/getsentry/sentry-javascript/issues/5611#issuecomment-1271712639