### PR TITLE
docs: Fix paths in readme to point to proper files

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -35,7 +35,7 @@ Sentry.init({
 
 Note that it is necessary to initialize Sentry **before you import any package that may be instrumented by us**.
 
-[More information on how to set up Sentry for Node in v8.](./../../docs/v8-node.md)
+[More information on how to set up Sentry for Node in v8.](https://github.com/getsentry/sentry-javascript/blob/develop/docs/v8-node.md)
 
 ### ESM Support
 

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -86,7 +86,7 @@ function setupSentry() {
 }
 ```
 
-A full setup example can be found in [node-experimental](./../node-experimental).
+A full setup example can be found in [node-experimental](https://github.com/getsentry/sentry-javascript/blob/develop/packages/node-experimental).
 
 ## Links
 


### PR DESCRIPTION
This was noticed here: https://github.com/getsentry/sentry-javascript/issues/11337#issuecomment-2027402882, when viewed on e.g. npmjs.org the relative links to do not work, so we should have full URLs only in the readme files.

It would be _nicer_ if we could replace this with a proper full URL at release time to point to the correct version of the file, but that's more work and probably not worth it...