### PR TITLE
ref(v8): Remove deprecated `scope.getTransaction()`

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/metric-summaries/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/metric-summaries/test.ts
@@ -11,6 +11,7 @@ const EXPECTED_TRANSACTION = {
         sum: 1,
         tags: {
           release: '1.0',
+          transaction: 'Test Transaction',
           email: 'jon.doe@example.com',
         },
       },
@@ -21,6 +22,7 @@ const EXPECTED_TRANSACTION = {
         sum: 1,
         tags: {
           release: '1.0',
+          transaction: 'Test Transaction',
           email: 'jane.doe@example.com',
         },
       },
@@ -39,6 +41,7 @@ const EXPECTED_TRANSACTION = {
             sum: 4,
             tags: {
               release: '1.0',
+              transaction: 'Test Transaction',
             },
           },
         ],
@@ -50,6 +53,7 @@ const EXPECTED_TRANSACTION = {
             sum: 2,
             tags: {
               release: '1.0',
+              transaction: 'Test Transaction',
             },
           },
         ],
@@ -61,6 +65,7 @@ const EXPECTED_TRANSACTION = {
             sum: 62,
             tags: {
               release: '1.0',
+              transaction: 'Test Transaction',
             },
           },
         ],
@@ -72,6 +77,7 @@ const EXPECTED_TRANSACTION = {
             sum: 62,
             tags: {
               release: '1.0',
+              transaction: 'Test Transaction',
             },
           },
         ],

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -19,13 +19,11 @@ import type {
   ScopeData,
   Session,
   SeverityLevel,
-  Transaction,
   User,
 } from '@sentry/types';
 import { dateTimestampInSeconds, isPlainObject, logger, uuid4 } from '@sentry/utils';
 
 import { updateSession } from './session';
-import type { SentrySpan } from './tracing/sentrySpan';
 import { _getSpanForScope, _setSpanForScope } from './utils/spanOnScope';
 
 /**
@@ -292,25 +290,6 @@ export class Scope implements ScopeInterface {
 
     this._notifyScopeListeners();
     return this;
-  }
-
-  /**
-   * Returns the `Transaction` attached to the scope (if there is one).
-   * @deprecated You should not rely on the transaction, but just use `startSpan()` APIs instead.
-   */
-  public getTransaction(): Transaction | undefined {
-    // Often, this span (if it exists at all) will be a transaction, but it's not guaranteed to be. Regardless, it will
-    // have a pointer to the currently-active transaction.
-    const span = _getSpanForScope(this);
-
-    // Cannot replace with getRootSpan because getRootSpan returns a span, not a transaction
-    // Also, this method will be removed anyway.
-    // eslint-disable-next-line deprecation/deprecation
-    if (span && (span as SentrySpan).transaction) {
-      // eslint-disable-next-line deprecation/deprecation
-      return (span as SentrySpan).transaction;
-    }
-    return undefined;
   }
 
   /**

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -10,7 +10,6 @@ import type { RequestSession, Session } from './session';
 import type { SeverityLevel } from './severity';
 import type { Span } from './span';
 import type { PropagationContext } from './tracing';
-import type { Transaction } from './transaction';
 import type { User } from './user';
 
 /** JSDocs */
@@ -144,12 +143,6 @@ export interface Scope {
    * @param context an object containing context data. This data will be normalized. Pass `null` to unset the context.
    */
   setContext(name: string, context: Context | null): this;
-
-  /**
-   * Returns the `Transaction` attached to the scope (if there is one).
-   * @deprecated You should not rely on the transaction, but just use `startSpan()` APIs instead.
-   */
-  getTransaction(): Transaction | undefined;
 
   /**
    * Returns the `Session` if there is one


### PR DESCRIPTION
This depends on https://github.com/getsentry/sentry-javascript/pull/11363 being merged first...