### PR TITLE
ref(v7): Deprecate `addRequestDataToTransaction`

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -105,6 +105,7 @@ export function tracingHandler(): (
       // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction
       // closes
       setImmediate(() => {
+        // eslint-disable-next-line deprecation/deprecation
         addRequestDataToTransaction(transaction, req);
         setHttpStatus(transaction, res.statusCode);
         transaction.end();

--- a/packages/utils/src/requestdata.ts
+++ b/packages/utils/src/requestdata.ts
@@ -64,7 +64,9 @@ export type TransactionNamingScheme = 'path' | 'methodPath' | 'handler';
 
 /**
  * Sets parameterized route as transaction name e.g.: `GET /users/:id`
- * Also adds more context data on the transaction from the request
+ * Also adds more context data on the transaction from the request.
+ *
+ * @deprecated This utility will be removed in v8.
  */
 export function addRequestDataToTransaction(
   transaction: Transaction | undefined,


### PR DESCRIPTION
This is not used/needed anymore in v8, and also is coupled to transactions.

Not sure if we need to add this to migration docs, as this is from utils and was more internally used...? (Also, I guess if so we need to add it to migration docs in a separate PR on develop...?)