### PR TITLE
feat: Add `trpcMiddleware` back to serverside SDKs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -571,7 +571,7 @@ Sentry.getGlobalScope().addEventProcessor(event => {
 
 The `lastEventId` function has been removed. See [below](./MIGRATION.md#deprecate-lasteventid) for more details.
 
-#### Remove `void` from transport return types
+#### Removal of `void` from transport return types
 
 The `send` method on the `Transport` interface now always requires a `TransportMakeRequestResponse` to be returned in
 the promise. This means that the `void` return type is no longer allowed.
@@ -590,7 +590,7 @@ interface Transport {
 }
 ```
 
-#### Remove `addGlobalEventProcessor` in favor of `addEventProcessor`
+#### Removal of `addGlobalEventProcessor` in favor of `addEventProcessor`
 
 In v8, we are removing the `addGlobalEventProcessor` function in favor of `addEventProcessor`.
 
@@ -608,6 +608,23 @@ addEventProcessor(event => {
   delete event.extra;
   return event;
 });
+```
+
+#### Removal of `Sentry.Handlers.trpcMiddleware()` in favor of `Sentry.trpcMiddleware()`
+
+The Sentry tRPC middleware got moved from `Sentry.Handlers.trpcMiddleware()` to `Sentry.trpcMiddleware()`. Functionally
+they are the same:
+
+```js
+// v7
+import * as Sentry from '@sentry/node';
+Sentry.Handlers.trpcMiddleware();
+```
+
+```js
+// v8
+import * as Sentry from '@sentry/node';
+Sentry.trpcMiddleware();
 ```
 
 ### Browser SDK (Browser, React, Vue, Angular, Ember, etc.)

--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -99,7 +99,7 @@ for (const dependent of dependentsToCheck) {
 }
 
 if (Object.keys(missingExports).length > 0) {
-  console.error('\n❌ Found missing exports from @sentry/node in the following packages:\n');
+  console.log('\n❌ Found missing exports from @sentry/node in the following packages:\n');
   console.log(JSON.stringify(missingExports, null, 2));
   process.exit(1);
 }

--- a/dev-packages/e2e-tests/test-applications/node-express-app/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-app/package.json
@@ -11,12 +11,16 @@
     "test:assert": "pnpm test"
   },
   "dependencies": {
+    "@sentry/core": "latest || *",
     "@sentry/node": "latest || *",
     "@sentry/types": "latest || *",
-    "express": "4.19.2",
+    "@trpc/server": "10.45.2",
+    "@trpc/client": "10.45.2",
     "@types/express": "4.17.17",
     "@types/node": "18.15.1",
-    "typescript": "4.9.5"
+    "express": "4.19.2",
+    "typescript": "4.9.5",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@playwright/test": "^1.27.1",

--- a/dev-packages/e2e-tests/test-applications/node-express-app/tests/server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-app/tests/server.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from '@playwright/test';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import { waitForError } from '../event-proxy-server';
+import { waitForError, waitForTransaction } from '../event-proxy-server';
+import type { AppRouter } from '../src/app';
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
@@ -129,4 +131,97 @@ test('Should record uncaught exceptions with local variable', async ({ baseURL }
   const frames = routehandlerError!.exception!.values![0]!.stacktrace!.frames!;
 
   expect(frames[frames.length - 1].vars?.randomVariableToRecord).toBeDefined();
+});
+
+test('Should record transaction for trpc query', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('node-express-app', transactionEvent => {
+    return transactionEvent.transaction === 'trpc/getSomething';
+  });
+
+  const trpcClient = createTRPCProxyClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${baseURL}/trpc`,
+      }),
+    ],
+  });
+
+  await trpcClient.getSomething.query('foobar');
+
+  await expect(transactionEventPromise).resolves.toBeDefined();
+  const transaction = await transactionEventPromise;
+
+  expect(transaction.contexts?.trpc).toMatchObject({
+    procedure_type: 'query',
+    input: 'foobar',
+  });
+});
+
+test('Should record transaction for trpc mutation', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('node-express-app', transactionEvent => {
+    return transactionEvent.transaction === 'trpc/createSomething';
+  });
+
+  const trpcClient = createTRPCProxyClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${baseURL}/trpc`,
+      }),
+    ],
+  });
+
+  await trpcClient.createSomething.mutate();
+
+  await expect(transactionEventPromise).resolves.toBeDefined();
+  const transaction = await transactionEventPromise;
+
+  expect(transaction.contexts?.trpc).toMatchObject({
+    procedure_type: 'mutation',
+  });
+});
+
+test('Should record transaction and error for a crashing trpc handler', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('node-express-app', transactionEvent => {
+    return transactionEvent.transaction === 'trpc/crashSomething';
+  });
+
+  const errorEventPromise = waitForError('node-express-app', errorEvent => {
+    return !!errorEvent?.exception?.values?.some(exception => exception.value?.includes('I crashed in a trpc handler'));
+  });
+
+  const trpcClient = createTRPCProxyClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${baseURL}/trpc`,
+      }),
+    ],
+  });
+
+  await expect(trpcClient.crashSomething.mutate()).rejects.toBeDefined();
+
+  await expect(transactionEventPromise).resolves.toBeDefined();
+  await expect(errorEventPromise).resolves.toBeDefined();
+});
+
+test('Should record transaction and error for a trpc handler that returns a status code', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('node-express-app', transactionEvent => {
+    return transactionEvent.transaction === 'trpc/dontFindSomething';
+  });
+
+  const errorEventPromise = waitForError('node-express-app', errorEvent => {
+    return !!errorEvent?.exception?.values?.some(exception => exception.value?.includes('Page not found'));
+  });
+
+  const trpcClient = createTRPCProxyClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${baseURL}/trpc`,
+      }),
+    ],
+  });
+
+  await expect(trpcClient.dontFindSomething.mutate()).rejects.toBeDefined();
+
+  await expect(transactionEventPromise).resolves.toBeDefined();
+  await expect(errorEventPromise).resolves.toBeDefined();
 });

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -90,6 +90,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  trpcMiddleware,
 } from '@sentry/node';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -111,6 +111,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  trpcMiddleware,
 } from '@sentry/node';
 
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,3 +107,4 @@ export { metricsDefault } from './metrics/exports-default';
 export { BrowserMetricsAggregator } from './metrics/browser-aggregator';
 export { getMetricSummaryJsonForSpan } from './metrics/metric-summary';
 export { addTracingHeadersToFetchRequest, instrumentFetchRequest } from './fetch';
+export { trpcMiddleware } from './trpc';

--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -26,7 +26,8 @@ const trpcCaptureContext = { mechanism: { handled: false, data: { function: 'trp
  * Sentry tRPC middleware that captures errors and creates spans for tRPC procedures.
  */
 export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
-  return function <T>({ path, type, next, rawInput }: SentryTrpcMiddlewareArguments<T>): T {
+  return function <T>(opts: SentryTrpcMiddlewareArguments<T>): T {
+    const { path, type, next, rawInput } = opts;
     const client = getClient();
     const clientOptions = client && client.getOptions();
 
@@ -69,9 +70,8 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
           maybePromiseResult = next();
         } catch (e) {
           captureException(e, trpcCaptureContext);
-          throw e;
-        } finally {
           span.end();
+          throw e;
         }
 
         if (isThenable(maybePromiseResult)) {

--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -1,0 +1,98 @@
+import { isThenable, normalize } from '@sentry/utils';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  captureException,
+  setContext,
+  startSpanManual,
+} from '.';
+import { getClient } from './currentScopes';
+
+interface SentryTrpcMiddlewareOptions {
+  /** Whether to include procedure inputs in reported events. Defaults to `false`. */
+  attachRpcInput?: boolean;
+}
+
+export interface SentryTrpcMiddlewareArguments<T> {
+  path?: unknown;
+  type?: unknown;
+  next: () => T;
+  rawInput?: unknown;
+}
+
+const trpcCaptureContext = { mechanism: { handled: false, data: { function: 'trpcMiddleware' } } };
+
+/**
+ * Sentry tRPC middleware that captures errors and creates spans for tRPC procedures.
+ */
+export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
+  return function <T>({ path, type, next, rawInput }: SentryTrpcMiddlewareArguments<T>): T {
+    const client = getClient();
+    const clientOptions = client && client.getOptions();
+
+    const trpcContext: Record<string, unknown> = {
+      procedure_type: type,
+    };
+
+    if (options.attachRpcInput !== undefined ? options.attachRpcInput : clientOptions && clientOptions.sendDefaultPii) {
+      trpcContext.input = normalize(rawInput);
+    }
+
+    setContext('trpc', trpcContext);
+
+    function captureIfError(nextResult: unknown): void {
+      // TODO: Set span status based on what TRPCError was encountered
+      if (
+        typeof nextResult === 'object' &&
+        nextResult !== null &&
+        'ok' in nextResult &&
+        !nextResult.ok &&
+        'error' in nextResult
+      ) {
+        captureException(nextResult.error, trpcCaptureContext);
+      }
+    }
+
+    return startSpanManual(
+      {
+        name: `trpc/${path}`,
+        op: 'rpc.server',
+        forceTransaction: true,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.rpc.trpc',
+        },
+      },
+      span => {
+        let maybePromiseResult;
+        try {
+          maybePromiseResult = next();
+        } catch (e) {
+          captureException(e, trpcCaptureContext);
+          throw e;
+        } finally {
+          span.end();
+        }
+
+        if (isThenable(maybePromiseResult)) {
+          return maybePromiseResult.then(
+            nextResult => {
+              captureIfError(nextResult);
+              span.end();
+              return nextResult;
+            },
+            e => {
+              captureException(e, trpcCaptureContext);
+              span.end();
+              throw e;
+            },
+          ) as T;
+        } else {
+          captureIfError(maybePromiseResult);
+          span.end();
+          return maybePromiseResult;
+        }
+      },
+    );
+  };
+}

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -90,6 +90,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  trpcMiddleware,
 } from '@sentry/node';
 
 export {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -105,6 +105,7 @@ export {
   withActiveSpan,
   getRootSpan,
   spanToJSON,
+  trpcMiddleware,
 } from '@sentry/core';
 
 export type {

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -94,6 +94,7 @@ export {
   setupHapiErrorHandler,
   spotlightIntegration,
   setupFastifyErrorHandler,
+  trpcMiddleware,
 } from '@sentry/node';
 
 // Keeping the `*` exports for backwards compatibility and types

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -69,6 +69,7 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  trpcMiddleware,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -69,6 +69,7 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  trpcMiddleware,
 } from '@sentry/core';
 
 export { VercelEdgeClient } from './client';


### PR DESCRIPTION
Adds back the `trpcMiddleware` we accidentally removed when removing the old `@sentry/node` package.