### PR TITLE
feat(interactions): Add interactions sample rate to browser tracing integrations

### DIFF
--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -115,6 +115,15 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
   enableInp: boolean;
 
   /**
+   * Sample rate to determine interaction span sampling.
+   * interactionsSampleRate is applied on top of the global tracesSampleRate.
+   * ie a tracesSampleRate of 0.1 and interactionsSampleRate of 0.5 will result in a 0.05 sample rate for interactions.
+   *
+   * Default: 1
+   */
+  interactionsSampleRate: number;
+
+  /**
    * _metricOptions allows the user to send options to change how metrics are collected.
    *
    * _metricOptions is currently experimental.
@@ -154,6 +163,7 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   markBackgroundSpan: true,
   enableLongTask: true,
   enableInp: false,
+  interactionsSampleRate: 1,
   _experiments: {},
   ...defaultRequestInstrumentationOptions,
 };
@@ -196,7 +206,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
   /** Stores a mapping of interactionIds from PerformanceEventTimings to the origin interaction path */
   const interactionIdToRouteNameMapping: InteractionRouteNameMapping = {};
   if (options.enableInp) {
-    startTrackingINP(interactionIdToRouteNameMapping);
+    startTrackingINP(interactionIdToRouteNameMapping, options.interactionsSampleRate);
   }
 
   if (options.enableLongTask) {

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -99,6 +99,15 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
   enableInp: boolean;
 
   /**
+   * Sample rate to determine interaction span sampling.
+   * interactionsSampleRate is applied on top of the global tracesSampleRate.
+   * ie a tracesSampleRate of 0.1 and interactionsSampleRate of 0.5 will result in a 0.05 sample rate for interactions.
+   *
+   * Default: 1
+   */
+  interactionsSampleRate: number;
+
+  /**
    * _metricOptions allows the user to send options to change how metrics are collected.
    *
    * _metricOptions is currently experimental.
@@ -158,6 +167,7 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   startTransactionOnPageLoad: true,
   enableLongTask: true,
   enableInp: false,
+  interactionsSampleRate: 1,
   _experiments: {},
   ...defaultRequestInstrumentationOptions,
 };
@@ -238,7 +248,7 @@ export class BrowserTracing implements Integration {
     this._interactionIdToRouteNameMapping = {};
 
     if (this.options.enableInp) {
-      startTrackingINP(this._interactionIdToRouteNameMapping);
+      startTrackingINP(this._interactionIdToRouteNameMapping, this.options.interactionsSampleRate);
     }
     if (this.options.enableLongTask) {
       startTrackingLongTasks();

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -299,8 +299,8 @@ function _trackINP(
     });
 
     /** Check to see if the span should be sampled */
-    const tracesSampleRate = getTracesSampleRate(parentContext, options);
-    const sampleRate = interactionsSampleRate * tracesSampleRate;
+    const sampleRate = getSampleRate(parentContext, options, interactionsSampleRate);
+
     if (!sampleRate) {
       return;
     }
@@ -697,9 +697,10 @@ function _addTtfbRequestTimeToMeasurements(_measurements: Measurements): void {
 }
 
 /** Taken from @sentry/core sampling.ts */
-function getTracesSampleRate(
+function getSampleRate(
   transactionContext: TransactionContext | undefined,
   options: ClientOptions,
+  interactionsSampleRate: number,
 ): number | boolean {
   if (!hasTracingEnabled(options)) {
     return false;
@@ -728,5 +729,10 @@ function getTracesSampleRate(
     DEBUG_BUILD && logger.warn('[Tracing] Discarding interaction span because of invalid sample rate.');
     return false;
   }
-  return sampleRate;
+  if (sampleRate === true) {
+    return interactionsSampleRate;
+  } else if (sampleRate === false) {
+    return 0;
+  }
+  return sampleRate * interactionsSampleRate;
 }

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -92,6 +92,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
 
     expect(browserTracing.options).toEqual({
       enableInp: false,
+      interactionsSampleRate: 1,
       enableLongTask: true,
       _experiments: {},
       ...TRACING_DEFAULTS,
@@ -112,6 +113,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
 
     expect(browserTracing.options).toEqual({
       enableInp: false,
+      interactionsSampleRate: 1,
       enableLongTask: false,
       ...TRACING_DEFAULTS,
       markBackgroundTransactions: true,
@@ -132,6 +134,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
 
     expect(browserTracing.options).toEqual({
       enableInp: false,
+      interactionsSampleRate: 1,
       enableLongTask: false,
       _experiments: {},
       ...TRACING_DEFAULTS,


### PR DESCRIPTION
Adds a `interactionsSampleRate` option to browser tracing integrations to allow users to apply an additional sample rate filter on interaction spans.

`interactionsSampleRate` is applied on top of the global `tracesSampleRate`.
Therefore if `interactionsSampleRate` is `0.5` and `tracesSampleRate` is `0.1`, then the actual sample rate for interactions is `0.05`