### PR TITLE
feat(v7): Deprecate and relocate `trpcMiddleware`

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing-new/prisma-orm/package.json
+++ b/dev-packages/node-integration-tests/suites/tracing-new/prisma-orm/package.json
@@ -7,7 +7,7 @@
     "node": ">=12"
   },
   "scripts": {
-    "db-up": "docker-compose up -d",
+    "db-up": "docker compose up -d",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev -n sentry-test",
     "setup": "run-s --silent db-up generate migrate"

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/package.json
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/package.json
@@ -7,7 +7,7 @@
     "node": ">=12"
   },
   "scripts": {
-    "db-up": "docker-compose up -d",
+    "db-up": "docker compose up -d",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev -n sentry-test",
     "setup": "run-s --silent db-up generate migrate"

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -83,6 +83,7 @@ export {
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   Handlers,
+  trpcMiddleware,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -125,6 +125,7 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  trpcMiddleware,
 } from '@sentry/node';
 
 export { BunClient } from './client';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -167,6 +167,8 @@ export type { AnrIntegrationOptions } from './integrations/anr/common';
 
 export { Handlers };
 
+export { trpcMiddleware } from './trpc';
+
 export { hapiErrorPlugin } from './integrations/hapi';
 
 import { instrumentCron } from './cron/cron';

--- a/packages/node/src/trpc.ts
+++ b/packages/node/src/trpc.ts
@@ -1,0 +1,77 @@
+import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, captureException, getClient, getCurrentScope } from '@sentry/core';
+import { isThenable, normalize } from '@sentry/utils';
+
+interface SentryTrpcMiddlewareOptions {
+  /** Whether to include procedure inputs in reported events. Defaults to `false`. */
+  attachRpcInput?: boolean;
+}
+
+interface TrpcMiddlewareArguments<T> {
+  path: string;
+  type: string;
+  next: () => T;
+  rawInput: unknown;
+}
+
+/**
+ * Sentry tRPC middleware that names the handling transaction after the called procedure.
+ *
+ * Use the Sentry tRPC middleware in combination with the Sentry server integration,
+ * e.g. Express Request Handlers or Next.js SDK.
+ */
+export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
+  return function <T>({ path, type, next, rawInput }: TrpcMiddlewareArguments<T>): T {
+    const clientOptions = getClient()?.getOptions();
+    // eslint-disable-next-line deprecation/deprecation
+    const sentryTransaction = getCurrentScope().getTransaction();
+
+    if (sentryTransaction) {
+      sentryTransaction.updateName(`trpc/${path}`);
+      sentryTransaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
+      sentryTransaction.op = 'rpc.server';
+
+      const trpcContext: Record<string, unknown> = {
+        procedure_type: type,
+      };
+
+      if (options.attachRpcInput !== undefined ? options.attachRpcInput : clientOptions?.sendDefaultPii) {
+        trpcContext.input = normalize(rawInput);
+      }
+
+      // TODO: Can we rewrite this to an attribute? Or set this on the scope?
+      // eslint-disable-next-line deprecation/deprecation
+      sentryTransaction.setContext('trpc', trpcContext);
+    }
+
+    function captureIfError(nextResult: { ok: false; error?: Error } | { ok: true }): void {
+      if (!nextResult.ok) {
+        captureException(nextResult.error, { mechanism: { handled: false, data: { function: 'trpcMiddleware' } } });
+      }
+    }
+
+    let maybePromiseResult;
+    try {
+      maybePromiseResult = next();
+    } catch (e) {
+      captureException(e, { mechanism: { handled: false, data: { function: 'trpcMiddleware' } } });
+      throw e;
+    }
+
+    if (isThenable(maybePromiseResult)) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      Promise.resolve(maybePromiseResult).then(
+        nextResult => {
+          captureIfError(nextResult as any);
+        },
+        e => {
+          captureException(e, { mechanism: { handled: false, data: { function: 'trpcMiddleware' } } });
+        },
+      );
+    } else {
+      captureIfError(maybePromiseResult as any);
+    }
+
+    // We return the original promise just to be safe.
+    return maybePromiseResult;
+  };
+}

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -87,6 +87,7 @@ export {
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   Handlers,
+  trpcMiddleware,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -73,6 +73,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   deepReadDirSync,
   Handlers,
+  trpcMiddleware,
   // eslint-disable-next-line deprecation/deprecation
   Integrations,
   setMeasurement,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -81,6 +81,7 @@ export {
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   Handlers,
+  trpcMiddleware,
   setMeasurement,
   getActiveSpan,
   startSpan,


### PR DESCRIPTION
The `trpcMiddleware` export will move from `Handlers` to a top level export in v8. This is more or less backporting https://github.com/getsentry/sentry-javascript/pull/11374 to v7.