### PR TITLE
ci(tests): Use `docker compose` instead of `docker-compose`

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/package.json
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/package.json
@@ -7,7 +7,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "db-up": "docker-compose up -d",
+    "db-up": "docker compose up -d",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev -n sentry-test",
     "setup": "run-s --silent db-up generate migrate"


### PR DESCRIPTION
Seems like GitHub got rid of `docker-compose` on April 2 so we need to use `docker compose` instead now:

- https://github.com/actions/runner-images/issues/9557
- https://github.com/orgs/community/discussions/116610