### PR TITLE
ref(v8): Remove deprecated `_reportAllChanges` option

### DIFF
--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -108,20 +108,6 @@ export interface BrowserTracingOptions {
   enableHTTPTimings: boolean;
 
   /**
-   * _metricOptions allows the user to send options to change how metrics are collected.
-   *
-   * _metricOptions is currently experimental.
-   *
-   * Default: undefined
-   */
-  _metricOptions?: Partial<{
-    /**
-     * @deprecated This property no longer has any effect and will be removed in v8.
-     */
-    _reportAllChanges: boolean;
-  }>;
-
-  /**
    * _experiments allows the user to send options to define how this integration works.
    *
    * Default: undefined


### PR DESCRIPTION
This is not used anymore.