### PR TITLE
ref(v8): Remove `metadata` on transaction

### DIFF
--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -121,9 +121,7 @@ export function makeTerserPlugin() {
           // These are used by instrument.ts in utils for identifying HTML elements & events
           '_sentryCaptured',
           '_sentryId',
-          // For v7 backwards-compatibility we need to access txn._frozenDynamicSamplingContext
-          // TODO (v8): Remove this reserved word
-          '_frozenDynamicSamplingContext',
+          '_frozenDsc',
           // These are used to keep span & scope relationships
           '_sentryRootSpan',
           '_sentryChildSpans',

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -1,10 +1,28 @@
-import type { Client, DynamicSamplingContext, Span, Transaction } from '@sentry/types';
-import { dropUndefinedKeys } from '@sentry/utils';
+import type { Client, DynamicSamplingContext, Span } from '@sentry/types';
+import { addNonEnumerableProperty, dropUndefinedKeys } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from '../constants';
 import { getClient } from '../currentScopes';
-import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../semanticAttributes';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../semanticAttributes';
 import { getRootSpan, spanIsSampled, spanToJSON } from '../utils/spanUtils';
+
+/**
+ * If you change this value, also update the terser plugin config to
+ * avoid minification of the object property!
+ */
+const FROZEN_DSC_FIELD = '_frozenDsc';
+
+type SpanWithMaybeDsc = Span & {
+  [FROZEN_DSC_FIELD]?: Partial<DynamicSamplingContext> | undefined;
+};
+
+/**
+ * Freeze the given DSC on the given span.
+ */
+export function freezeDscOnSpan(span: Span, dsc: Partial<DynamicSamplingContext>): void {
+  const spanWithMaybeDsc = span as SpanWithMaybeDsc;
+  addNonEnumerableProperty(spanWithMaybeDsc, FROZEN_DSC_FIELD, dsc);
+}
 
 /**
  * Creates a dynamic sampling context from a client.
@@ -29,11 +47,6 @@ export function getDynamicSamplingContextFromClient(trace_id: string, client: Cl
 }
 
 /**
- * A Span with a frozen dynamic sampling context.
- */
-type TransactionWithV7FrozenDsc = Transaction & { _frozenDynamicSamplingContext?: DynamicSamplingContext };
-
-/**
  * Creates a dynamic sampling context from a span (and client and scope)
  *
  * @param span the span from which a few values like the root span name and sample rate are extracted.
@@ -48,32 +61,26 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
 
   const dsc = getDynamicSamplingContextFromClient(spanToJSON(span).trace_id || '', client);
 
-  // TODO (v8): Remove v7FrozenDsc as a Transaction will no longer have _frozenDynamicSamplingContext
   const rootSpan = getRootSpan(span);
   if (!rootSpan) {
     return dsc;
   }
 
-  // TODO (v8): Remove v7FrozenDsc as a Transaction will no longer have _frozenDynamicSamplingContext
-  // For now we need to avoid breaking users who directly created a txn with a DSC, where this field is still set.
-  // @see Transaction class constructor
-  const v7FrozenDsc = rootSpan && (rootSpan as TransactionWithV7FrozenDsc)._frozenDynamicSamplingContext;
-  if (v7FrozenDsc) {
-    return v7FrozenDsc;
+  const frozenDsc = (rootSpan as SpanWithMaybeDsc)[FROZEN_DSC_FIELD];
+  if (frozenDsc) {
+    return frozenDsc;
   }
 
-  // TODO (v8): Replace txn.metadata with txn.attributes[]
-  // We can't do this yet because attributes aren't always set yet.
-  // eslint-disable-next-line deprecation/deprecation
-  const { sampleRate: maybeSampleRate } = (rootSpan as TransactionWithV7FrozenDsc).metadata || {};
+  const jsonSpan = spanToJSON(rootSpan);
+  const attributes = jsonSpan.data || {};
+  const maybeSampleRate = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE];
+
   if (maybeSampleRate != null) {
     dsc.sample_rate = `${maybeSampleRate}`;
   }
 
   // We don't want to have a transaction name in the DSC if the source is "url" because URLs might contain PII
-  const jsonSpan = spanToJSON(rootSpan);
-
-  const source = (jsonSpan.data || {})[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+  const source = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
 
   // after JSON conversion, txn.name becomes jsonSpan.description
   if (source && source !== 'url') {

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -92,30 +92,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
   }
 
   /**
-   * @inheritDoc
-   */
-  public toContext(): TransactionArguments {
-    // eslint-disable-next-line deprecation/deprecation
-    const spanContext = super.toContext();
-
-    return dropUndefinedKeys({
-      ...spanContext,
-      name: this._name,
-      trimEnd: this._trimEnd,
-    });
-  }
-
-  /**
-   * Override the current hub with a new one.
-   * Used if you want another hub to finish the transaction.
-   *
-   * @internal
-   */
-  public setHub(hub: Hub): void {
-    this._hub = hub;
-  }
-
-  /**
    * Finish the transaction & prepare the event to send to Sentry.
    */
   protected _finishTransaction(endTimestamp?: number): TransactionEvent | undefined {

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -10,6 +10,7 @@ import {
   getDynamicSamplingContextFromSpan,
   startInactiveSpan,
 } from '../../../src/tracing';
+import { freezeDscOnSpan } from '../../../src/tracing/dynamicSamplingContext';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 describe('getDynamicSamplingContextFromSpan', () => {
@@ -25,12 +26,14 @@ describe('getDynamicSamplingContextFromSpan', () => {
     jest.resetAllMocks();
   });
 
-  test('returns the DSC provided during transaction creation', () => {
+  test('uses frozen DSC from span', () => {
     // eslint-disable-next-line deprecation/deprecation -- using old API on purpose
     const transaction = new Transaction({
       name: 'tx',
-      metadata: { dynamicSamplingContext: { environment: 'myEnv' } },
+      sampled: true,
     });
+
+    freezeDscOnSpan(transaction, { environment: 'myEnv' });
 
     const dynamicSamplingContext = getDynamicSamplingContextFromSpan(transaction);
 
@@ -77,10 +80,8 @@ describe('getDynamicSamplingContextFromSpan', () => {
     // eslint-disable-next-line deprecation/deprecation -- using old API on purpose
     const transaction = new Transaction({
       name: 'tx',
-      metadata: {
-        sampleRate: 0.56,
-      },
       attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 0.56,
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
       },
       sampled: true,
@@ -103,11 +104,9 @@ describe('getDynamicSamplingContextFromSpan', () => {
       // eslint-disable-next-line deprecation/deprecation -- using old API on purpose
       const transaction = new Transaction({
         name: 'tx',
-        metadata: {
-          sampleRate: 0.56,
-        },
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+          [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 0.56,
         },
       });
 

--- a/packages/core/test/lib/tracing/transaction.test.ts
+++ b/packages/core/test/lib/tracing/transaction.test.ts
@@ -1,10 +1,4 @@
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
-  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  Transaction,
-  spanToJSON,
-} from '../../../src';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, Transaction, spanToJSON } from '../../../src';
 
 describe('transaction', () => {
   describe('name', () => {
@@ -25,55 +19,6 @@ describe('transaction', () => {
       expect(spanToJSON(transaction).description).toEqual('new name');
       expect(spanToJSON(transaction).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
     });
-    /* eslint-enable deprecation/deprecation */
-  });
-
-  describe('metadata', () => {
-    /* eslint-disable deprecation/deprecation */
-    it('works with defaults', () => {
-      const transaction = new Transaction({ name: 'span name' });
-      expect(transaction.metadata).toEqual({});
-    });
-
-    it('allows to set metadata in constructor', () => {
-      const transaction = new Transaction({ name: 'span name', metadata: { request: {} } });
-      expect(transaction.metadata).toEqual({
-        request: {},
-      });
-    });
-
-    it('allows to set source & sample rate data in constructor', () => {
-      const transaction = new Transaction({
-        name: 'span name',
-        metadata: { request: {} },
-        attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
-          [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 0.5,
-        },
-      });
-
-      expect(transaction.metadata).toEqual({
-        sampleRate: 0.5,
-        request: {},
-      });
-
-      expect(spanToJSON(transaction).data).toEqual({
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
-        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
-        [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 0.5,
-      });
-    });
-
-    it('allows to update metadata via setMetadata', () => {
-      const transaction = new Transaction({ name: 'span name', metadata: {} });
-
-      transaction.setMetadata({ request: {} });
-
-      expect(transaction.metadata).toEqual({
-        request: {},
-      });
-    });
-
     /* eslint-enable deprecation/deprecation */
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -111,7 +111,6 @@ export type {
   TraceparentData,
   Transaction,
   TransactionArguments,
-  TransactionMetadata,
   TransactionSource,
 } from './transaction';
 export type {

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,7 +1,5 @@
-import type { DynamicSamplingContext } from './envelope';
 import type { MeasurementUnit } from './measurement';
 import type { ExtractedNodeRequestData, WorkerLocation } from './misc';
-import type { PolymorphicRequest } from './polymorphics';
 import type { SentrySpanArguments, Span } from './span';
 
 /**

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -99,27 +99,6 @@ export interface SamplingContext extends CustomSamplingContext {
   request?: ExtractedNodeRequestData;
 }
 
-export interface TransactionMetadata {
-  /**
-   * The sample rate used when sampling this transaction.
-   * @deprecated Use `SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE` attribute instead.
-   */
-  sampleRate?: number;
-
-  /**
-   * The Dynamic Sampling Context of a transaction. If provided during transaction creation, its Dynamic Sampling
-   * Context Will be frozen
-   */
-  dynamicSamplingContext?: Partial<DynamicSamplingContext>;
-
-  /** For transactions tracing server-side request handling, the request being tracked. */
-  request?: PolymorphicRequest;
-
-  /** For transactions tracing server-side request handling, the path of the request being tracked. */
-  /** TODO: If we rm -rf `instrumentServer`, this can go, too */
-  requestPath?: string;
-}
-
 /**
  * Contains information about how the name of the transaction was determined. This will be used by the server to decide
  * whether or not to scrub identifiers from the transaction name, or replace the entire name with a placeholder.

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -25,12 +25,6 @@ export interface TransactionArguments extends SentrySpanArguments {
    * If this transaction has a parent, the parent's sampling decision
    */
   parentSampled?: boolean | undefined;
-
-  /**
-   * Metadata associated with the transaction, for internal SDK use.
-   * @deprecated Use attributes or store data on the scope instead.
-   */
-  metadata?: Partial<TransactionMetadata>;
 }
 
 /**
@@ -58,12 +52,7 @@ export interface TraceparentData {
  */
 export interface Transaction extends Omit<TransactionArguments, 'name' | 'op' | 'spanId' | 'traceId'>, Span {
   /**
-   * Metadata about the transaction.
-   * @deprecated Use attributes or store data on the scope instead.
-   */
-  metadata: TransactionMetadata;
 
-  /**
    * Set observed measurement for this transaction.
    *
    * @param name Name of the measurement

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -62,12 +62,6 @@ export interface Transaction extends Omit<TransactionArguments, 'name' | 'op' | 
    * @deprecated Use top-level `setMeasurement()` instead.
    */
   setMeasurement(name: string, value: number, unit: MeasurementUnit): void;
-
-  /**
-   * Set metadata for this transaction.
-   * @deprecated Use attributes or store data on the scope instead.
-   */
-  setMetadata(newMetadata: Partial<TransactionMetadata>): void;
 }
 
 /**


### PR DESCRIPTION
Instead, we freeze the DSC explicitly onto the transaction now.