### PR TITLE
feat: Implement timed events & remove `transaction.measurements`

### DIFF
--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'dev-packages/browser-integration-tests/suites/**'
+      - 'dev-packages/browser-integration-tests/suites/**/test.ts'
     branches-ignore:
       - master
 

--- a/dev-packages/node-integration-tests/suites/public-api/setMeasurement/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setMeasurement/scenario.ts
@@ -1,3 +1,13 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1,
+  transport: loggingTransport,
+});
+
 Sentry.startSpan({ name: 'some_transaction' }, () => {
   Sentry.setMeasurement('metric.foo', 42, 'ms');
   Sentry.setMeasurement('metric.bar', 1337, 'nanoseconds');

--- a/dev-packages/node-integration-tests/suites/public-api/setMeasurement/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setMeasurement/test.ts
@@ -1,0 +1,20 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+test('should attach measurement to transaction', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .expect({
+      transaction: {
+        transaction: 'some_transaction',
+        measurements: {
+          'metric.foo': { value: 42, unit: 'ms' },
+          'metric.bar': { value: 1337, unit: 'nanoseconds' },
+          'metric.baz': { value: 1, unit: '' },
+        },
+      },
+    })
+    .start(done);
+});

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -18,6 +18,7 @@ export {
   startSpanManual,
   withActiveSpan,
   getSpanDescendants,
+  setMeasurement,
 } from '@sentry/core';
 
 export {

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -18,6 +18,7 @@ export {
   startSpanManual,
   withActiveSpan,
   getSpanDescendants,
+  setMeasurement,
 } from '@sentry/core';
 
 export {

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -18,6 +18,7 @@ export {
   startSpanManual,
   withActiveSpan,
   getSpanDescendants,
+  setMeasurement,
 } from '@sentry/core';
 
 export {

--- a/packages/core/src/semanticAttributes.ts
+++ b/packages/core/src/semanticAttributes.ts
@@ -22,3 +22,9 @@ export const SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN = 'sentry.origin';
 
 /** The reason why an idle span finished. */
 export const SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON = 'sentry.idle_span_finish_reason';
+
+/** The unit of a measurement, which may be stored as a TimedEvent. */
+export const SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_UNIT = 'sentry.measurement_unit';
+
+/** The value of a measurement, which may be stored as a TimedEvent. */
+export const SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_VALUE = 'sentry.measurement_value';

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -16,6 +16,6 @@ export {
   withActiveSpan,
 } from './trace';
 export { getDynamicSamplingContextFromClient, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
-export { setMeasurement } from './measurement';
+export { setMeasurement, timedEventsToMeasurements } from './measurement';
 export { sampleSpan } from './sampling';
 export { logSpanEnd, logSpanStart } from './logSpans';

--- a/packages/core/src/tracing/sentryNonRecordingSpan.ts
+++ b/packages/core/src/tracing/sentryNonRecordingSpan.ts
@@ -59,4 +59,13 @@ export class SentryNonRecordingSpan implements Span {
   public isRecording(): boolean {
     return false;
   }
+
+  /** @inheritdoc */
+  public addEvent(
+    _name: string,
+    _attributesOrStartTime?: SpanAttributes | SpanTimeInput,
+    _startTime?: SpanTimeInput,
+  ): this {
+    return this;
+  }
 }

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -175,9 +175,7 @@ export class SentrySpan implements Span {
     attributesOrStartTime?: SpanAttributes | SpanTimeInput,
     startTime?: SpanTimeInput,
   ): this {
-    if (this._endTime) {
-      return this;
-    }
+    DEBUG_BUILD && logger.log('[Tracing] Adding an event to span:', name);
 
     const time = isSpanTimeInput(attributesOrStartTime) ? attributesOrStartTime : startTime || timestampInSeconds();
     const attributes = isSpanTimeInput(attributesOrStartTime) ? {} : attributesOrStartTime || {};

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -10,8 +10,9 @@ import type {
   SpanTimeInput,
   TimedEvent,
 } from '@sentry/types';
-import { dropUndefinedKeys, timestampInSeconds, uuid4 } from '@sentry/utils';
+import { dropUndefinedKeys, logger, timestampInSeconds, uuid4 } from '@sentry/utils';
 import { getClient } from '../currentScopes';
+import { DEBUG_BUILD } from '../debug-build';
 
 import { getMetricSummaryJsonForSpan } from '../metrics/metric-summary';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../semanticAttributes';

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -2,7 +2,7 @@ import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { captureEvent, getMetricSummaryJsonForSpan } from '@sentry/core';
+import { captureEvent, getMetricSummaryJsonForSpan, timedEventsToMeasurements } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -138,7 +138,10 @@ function maybeSend(spans: ReadableSpan[]): ReadableSpan[] {
 
     transactionEvent.spans = spans;
 
-    // TODO Measurements are not yet implemented in OTEL
+    const measurements = timedEventsToMeasurements(span.events);
+    if (Object.keys(measurements).length) {
+      transactionEvent.measurements = measurements;
+    }
 
     captureEvent(transactionEvent);
   });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -101,6 +101,7 @@ export type {
   MetricSummary,
 } from './span';
 export type { SpanStatus } from './spanStatus';
+export type { TimedEvent } from './timedEvent';
 export type { StackFrame } from './stackframe';
 export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
 export type { PropagationContext, TracePropagationTargets } from './tracing';

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -227,4 +227,9 @@ export interface Span {
    * This will return false if tracing is disabled, this span was not sampled or if the span is already finished.
    */
   isRecording(): boolean;
+
+  /**
+   * Adds an event to the Span.
+   */
+  addEvent(name: string, attributesOrStartTime?: SpanAttributes | SpanTimeInput, startTime?: SpanTimeInput): this;
 }

--- a/packages/types/src/timedEvent.ts
+++ b/packages/types/src/timedEvent.ts
@@ -1,0 +1,7 @@
+import type { SpanAttributes, SpanTimeInput } from './span';
+
+export interface TimedEvent {
+  name: string;
+  time: SpanTimeInput;
+  attributes?: SpanAttributes;
+}

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,4 +1,3 @@
-import type { MeasurementUnit } from './measurement';
 import type { ExtractedNodeRequestData, WorkerLocation } from './misc';
 import type { SentrySpanArguments, Span } from './span';
 
@@ -48,19 +47,7 @@ export interface TraceparentData {
 /**
  * Transaction "Class", inherits Span only has `setName`
  */
-export interface Transaction extends Omit<TransactionArguments, 'name' | 'op' | 'spanId' | 'traceId'>, Span {
-  /**
-
-   * Set observed measurement for this transaction.
-   *
-   * @param name Name of the measurement
-   * @param value Value of the measurement
-   * @param unit Unit of the measurement. (Defaults to an empty string)
-   *
-   * @deprecated Use top-level `setMeasurement()` instead.
-   */
-  setMeasurement(name: string, value: number, unit: MeasurementUnit): void;
-}
+export interface Transaction extends Omit<TransactionArguments, 'name' | 'op' | 'spanId' | 'traceId'>, Span {}
 
 /**
  * Context data passed by the user when starting a transaction, to be used by the tracesSampler method.


### PR DESCRIPTION
Now, we interpret timed events with special attributes as timed events.

For now, we ignore all other timed events.