### PR TITLE
ref(v8): Remove deprecated span & transaction properties

### DIFF
--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -1,5 +1,4 @@
 import type {
-  Context,
   Contexts,
   DynamicSamplingContext,
   Hub,
@@ -74,11 +73,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
       ...this._attributes,
     };
 
-    // this is because transactions are also spans, and spans have a transaction pointer
-    // TODO (v8): Replace this with another way to set the root span
-    // eslint-disable-next-line deprecation/deprecation
-    this.transaction = this;
-
     // If Dynamic Sampling Context is provided during the creation of the transaction, we freeze it as it usually means
     // there is incoming Dynamic Sampling Context. (Either through an incoming request, a baggage meta-tag, or other means)
     const incomingDynamicSamplingContext = this._metadata.dynamicSamplingContext;
@@ -125,19 +119,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
   }
 
   /**
-   * Set the context of a transaction event.
-   * @deprecated Use either `.setAttribute()`, or set the context on the scope before creating the transaction.
-   */
-  public setContext(key: string, context: Context | null): void {
-    if (context === null) {
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-      delete this._contexts[key];
-    } else {
-      this._contexts[key] = context;
-    }
-  }
-
-  /**
    * @inheritDoc
    *
    * @deprecated Use top-level `setMeasurement()` instead.
@@ -165,41 +146,6 @@ export class Transaction extends SentrySpan implements TransactionInterface {
     }
     // eslint-disable-next-line deprecation/deprecation
     return this._hub.captureEvent(transaction);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public toContext(): TransactionArguments {
-    // eslint-disable-next-line deprecation/deprecation
-    const spanContext = super.toContext();
-
-    return dropUndefinedKeys({
-      ...spanContext,
-      name: this._name,
-      trimEnd: this._trimEnd,
-    });
-  }
-
-  /**
-   * @inheritdoc
-   *
-   * @experimental
-   *
-   * @deprecated Use top-level `getDynamicSamplingContextFromSpan` instead.
-   */
-  public getDynamicSamplingContext(): Readonly<Partial<DynamicSamplingContext>> {
-    return getDynamicSamplingContextFromSpan(this);
-  }
-
-  /**
-   * Override the current hub with a new one.
-   * Used if you want another hub to finish the transaction.
-   *
-   * @internal
-   */
-  public setHub(hub: Hub): void {
-    this._hub = hub;
   }
 
   /**

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,4 +1,3 @@
-import type { Context } from './context';
 import type { DynamicSamplingContext } from './envelope';
 import type { MeasurementUnit } from './measurement';
 import type { ExtractedNodeRequestData, WorkerLocation } from './misc';
@@ -59,21 +58,10 @@ export interface TraceparentData {
  */
 export interface Transaction extends Omit<TransactionArguments, 'name' | 'op' | 'spanId' | 'traceId'>, Span {
   /**
-   * @inheritDoc
-   */
-  startTimestamp: number;
-
-  /**
    * Metadata about the transaction.
    * @deprecated Use attributes or store data on the scope instead.
    */
   metadata: TransactionMetadata;
-
-  /**
-   * Set the context of a transaction event.
-   * @deprecated Use either `.setAttribute()`, or set the context on the scope before creating the transaction.
-   */
-  setContext(key: string, context: Context): void;
 
   /**
    * Set observed measurement for this transaction.
@@ -87,23 +75,10 @@ export interface Transaction extends Omit<TransactionArguments, 'name' | 'op' | 
   setMeasurement(name: string, value: number, unit: MeasurementUnit): void;
 
   /**
-   * Returns the current transaction properties as a `TransactionArguments`.
-   * @deprecated Use `toJSON()` or access the fields directly instead.
-   */
-  toContext(): TransactionArguments;
-
-  /**
    * Set metadata for this transaction.
    * @deprecated Use attributes or store data on the scope instead.
    */
   setMetadata(newMetadata: Partial<TransactionMetadata>): void;
-
-  /**
-   * Return the current Dynamic Sampling Context of this transaction
-   *
-   * @deprecated Use top-level `getDynamicSamplingContextFromSpan` instead.
-   */
-  getDynamicSamplingContext(): Partial<DynamicSamplingContext>;
 
   /**
    * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.


### PR DESCRIPTION
Removes a bunch of further deprecated properties on span & transaction.