### PR TITLE
feat(sveltekit): Update scope `transactionName` when pageload route name is updated

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/test/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/test/errors.client.test.ts
@@ -27,6 +27,8 @@ test.describe('client-side errors', () => {
     );
 
     expect(errorEvent.tags).toMatchObject({ runtime: 'browser' });
+
+    expect(errorEvent.transaction).toEqual('client-error');
   });
 
   test('captures universal load error', async ({ page }) => {
@@ -52,5 +54,6 @@ test.describe('client-side errors', () => {
     );
 
     expect(errorEvent.tags).toMatchObject({ runtime: 'browser' });
+    expect(errorEvent.transaction).toEqual('universal-load-error');
   });
 });

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/test/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/test/errors.client.test.ts
@@ -28,7 +28,7 @@ test.describe('client-side errors', () => {
 
     expect(errorEvent.tags).toMatchObject({ runtime: 'browser' });
 
-    expect(errorEvent.transaction).toEqual('client-error');
+    expect(errorEvent.transaction).toEqual('/client-error');
   });
 
   test('captures universal load error', async ({ page }) => {
@@ -54,6 +54,6 @@ test.describe('client-side errors', () => {
     );
 
     expect(errorEvent.tags).toMatchObject({ runtime: 'browser' });
-    expect(errorEvent.transaction).toEqual('universal-load-error');
+    expect(errorEvent.transaction).toEqual('/universal-load-error');
   });
 });

--- a/packages/opentelemetry/test/propagator.test.ts
+++ b/packages/opentelemetry/test/propagator.test.ts
@@ -203,7 +203,7 @@ describe('SentryPropagator', () => {
             spanId: '6e0c63257de34c92',
             sampled: true,
             dsc: {
-              transaction: 'sampled-transaction',
+              transaction: 'users/123',
               sampled: 'false',
               trace_id: 'dsc_trace_id',
               public_key: 'dsc_public_key',

--- a/packages/opentelemetry/test/propagator.test.ts
+++ b/packages/opentelemetry/test/propagator.test.ts
@@ -203,7 +203,7 @@ describe('SentryPropagator', () => {
             spanId: '6e0c63257de34c92',
             sampled: true,
             dsc: {
-              transaction: 'users/123',
+              transaction: 'sampled-transaction',
               sampled: 'false',
               trace_id: 'dsc_trace_id',
               public_key: 'dsc_public_key',

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -3,6 +3,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } fr
 import {
   WINDOW,
   browserTracingIntegration as originalBrowserTracingIntegration,
+  getCurrentScope,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
   startInactiveSpan,
@@ -65,6 +66,7 @@ function _instrumentPageload(client: Client): void {
     if (routeId) {
       pageloadSpan.updateName(routeId);
       pageloadSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
+      getCurrentScope().setTransactionName(routeId);
     }
   });
 }

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -206,7 +206,6 @@ describe('browserTracingIntegration', () => {
       },
     });
 
-    // eslint-disable-next-line deprecation/deprecation
     expect(startInactiveSpanSpy).toHaveBeenCalledWith({
       op: 'ui.sveltekit.routing',
       name: 'SvelteKit Route Change',
@@ -269,7 +268,6 @@ describe('browserTracingIntegration', () => {
         },
       });
 
-      // eslint-disable-next-line deprecation/deprecation
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         op: 'ui.sveltekit.routing',
         name: 'SvelteKit Route Change',

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -40,7 +40,6 @@ describe('browserTracingIntegration', () => {
         ...txnCtx,
         updateName: vi.fn(),
         setAttribute: vi.fn(),
-        setTag: vi.fn(),
       };
       return createdRootSpan;
     });
@@ -52,7 +51,6 @@ describe('browserTracingIntegration', () => {
         ...txnCtx,
         updateName: vi.fn(),
         setAttribute: vi.fn(),
-        setTag: vi.fn(),
       };
       return createdRootSpan;
     });
@@ -136,6 +134,29 @@ describe('browserTracingIntegration', () => {
     integration.afterAllSetup(fakeClient);
 
     expect(startBrowserTracingPageLoadSpanSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("updates the current scope's transactionName once it's resolved during pageload", () => {
+    const scopeSetTransactionNameSpy = vi.fn();
+
+    // @ts-expect-error - only returning a partial scope here, that's fine
+    vi.spyOn(SentrySvelte, 'getCurrentScope').mockImplementation(() => {
+      return {
+        setTransactionName: scopeSetTransactionNameSpy,
+      };
+    });
+
+    const integration = browserTracingIntegration();
+    // @ts-expect-error - the fakeClient doesn't satisfy Client but that's fine
+    integration.afterAllSetup(fakeClient);
+
+    // We emit an update to the `page` store to simulate the SvelteKit router lifecycle
+    // @ts-expect-error - page is a writable but the types say it's just readable
+    page.set({ route: { id: 'testRoute/:id' } });
+
+    // This should update the transaction name with the parameterized route:
+    expect(scopeSetTransactionNameSpy).toHaveBeenCalledTimes(3);
+    expect(scopeSetTransactionNameSpy).toHaveBeenLastCalledWith('testRoute/:id');
   });
 
   it("doesn't start a navigation span when `instrumentNavigation` is false", () => {


### PR DESCRIPTION
Our SvelteKit routing instrumentation updates the pageload rootspan name once we obtain the parameterized route id. This PR now also updates the scope's `transactionName` at this point.

ref #10846 