### PR TITLE
fix(spans): Allow zero exclusive time for INP spans

### DIFF
--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -167,7 +167,7 @@ export class Span implements SpanInterface {
     if (spanContext.endTimestamp) {
       this._endTime = spanContext.endTimestamp;
     }
-    if (spanContext.exclusiveTime) {
+    if (spanContext.exclusiveTime !== undefined) {
       this._exclusiveTime = spanContext.exclusiveTime;
     }
     this._measurements = spanContext.measurements ? { ...spanContext.measurements } : {};

--- a/packages/core/test/lib/tracing/span.test.ts
+++ b/packages/core/test/lib/tracing/span.test.ts
@@ -56,6 +56,21 @@ describe('span', () => {
       expect(span.name).toEqual('new name');
       expect(span.description).toEqual('new name');
     });
+
+    it('allows exclusiveTime to be set', () => {
+      const span = new Span({ name: 'span name', exclusiveTime: 100 });
+      expect(spanToJSON(span).exclusive_time).toEqual(100);
+    });
+
+    it('allows exclusiveTime to be zero', () => {
+      const span = new Span({ name: 'span name', exclusiveTime: 0 });
+      expect(spanToJSON(span).exclusive_time).toEqual(0);
+    });
+
+    it('drops undefined exclusiveTime', () => {
+      const span = new Span({ name: 'span name', exclusiveTime: undefined });
+      expect(Object.keys(spanToJSON(span)).includes('exclusive_time')).toBe(false);
+    });
   });
   /* eslint-enable deprecation/deprecation */
 

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -57,6 +57,7 @@ export interface SpanJSON {
   trace_id: string;
   origin?: SpanOrigin;
   _metrics_summary?: Record<string, Array<MetricSummary>>;
+  exclusive_time?: number;
 }
 
 // These are aligned with OpenTelemetry trace flags


### PR DESCRIPTION
Allows exclusive time for spans to be 0, including inp spans.