### PR TITLE
feat(vue): Update scope's `transactionName` when resolving a route

### DIFF
--- a/dev-packages/e2e-tests/test-applications/vue-3/src/router/index.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/src/router/index.ts
@@ -17,6 +17,10 @@ const router = createRouter({
       path: '/users/:id',
       component: () => import('../views/UserIdView.vue'),
     },
+    {
+      path: '/users-error/:id',
+      component: () => import('../views/UserIdView.vue'),
+    },
   ],
 });
 

--- a/dev-packages/e2e-tests/test-applications/vue-3/src/router/index.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/src/router/index.ts
@@ -19,7 +19,7 @@ const router = createRouter({
     },
     {
       path: '/users-error/:id',
-      component: () => import('../views/UserIdView.vue'),
+      component: () => import('../views/UserIdErrorView.vue'),
     },
   ],
 });

--- a/dev-packages/e2e-tests/test-applications/vue-3/src/views/UserIdErrorView.vue
+++ b/dev-packages/e2e-tests/test-applications/vue-3/src/views/UserIdErrorView.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+  function throwError() {
+    throw new Error('This is a Vue test error');
+  }
+</script>
+
+<template>
+  <h1>(Error) User ID: {{ $route.params.id }}</h1>
+  <button id="userErrorBtn" @click="throwError">Throw Error</button>
+</template>

--- a/dev-packages/e2e-tests/test-applications/vue-3/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/tests/errors.test.ts
@@ -25,5 +25,34 @@ test('sends an error', async ({ page }) => {
         },
       ],
     },
+    transaction: '/',
+  });
+});
+
+test('sends an error with a parameterized transaction name', async ({ page }) => {
+  const errorPromise = waitForError('vue-3', async errorEvent => {
+    return !errorEvent.type;
+  });
+
+  await page.goto(`/users-error/456`);
+
+  await page.locator('#userErrorBtn').click();
+
+  const error = await errorPromise;
+
+  expect(error).toMatchObject({
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'This is a Vue test error',
+          mechanism: {
+            type: 'generic',
+            handled: false,
+          },
+        },
+      ],
+    },
+    transaction: '/users-error/:id',
   });
 });

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -3,6 +3,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   getActiveSpan,
+  getCurrentScope,
   getRootSpan,
   spanToJSON,
 } from '@sentry/core';
@@ -77,22 +78,24 @@ export function instrumentVueRouter(
     }
 
     // Determine a name for the routing transaction and where that name came from
-    let transactionName: string = to.path;
+    let spanName: string = to.path;
     let transactionSource: TransactionSource = 'url';
     if (to.name && options.routeLabel !== 'path') {
-      transactionName = to.name.toString();
+      spanName = to.name.toString();
       transactionSource = 'custom';
     } else if (to.matched[0] && to.matched[0].path) {
-      transactionName = to.matched[0].path;
+      spanName = to.matched[0].path;
       transactionSource = 'route';
     }
+
+    getCurrentScope().setTransactionName(spanName);
 
     if (options.instrumentPageLoad && isPageLoadNavigation) {
       const activeRootSpan = getActiveRootSpan();
       if (activeRootSpan) {
         const existingAttributes = spanToJSON(activeRootSpan).data || {};
         if (existingAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] !== 'custom') {
-          activeRootSpan.updateName(transactionName);
+          activeRootSpan.updateName(spanName);
           activeRootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, transactionSource);
         }
         // Set router attributes on the existing pageload transaction
@@ -108,7 +111,7 @@ export function instrumentVueRouter(
       attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] = transactionSource;
       attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] = 'auto.navigation.vue';
       startNavigationSpanFn({
-        name: transactionName,
+        name: spanName,
         op: 'navigation',
         attributes,
       });


### PR DESCRIPTION
This PR updates the current scope's `transactionName` when our Vue router instrumentation resolves the parameterized route name. 

ref #10846 