### PR TITLE
test(e2e-nextjs): Check NextJS client error `transaction` field

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/exceptions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/exceptions.test.ts
@@ -19,6 +19,8 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
   const errorEvent = await errorEventPromise;
   const exceptionEventId = errorEvent.event_id;
 
+  expect(errorEvent.transaction).toBe('/');
+
   await expect
     .poll(
       async () => {


### PR DESCRIPTION
Super small PR to check that an error event has a valid `transaction` field in NextJS. 
Besides testing, there was nothing specifically to do for NextJS since as far as I can tell we never update a pageload or navigation span name. 

ref #10846 