### PR TITLE
ref(feedback): Add font family style to actor

### DIFF
--- a/packages/feedback/src/core/components/Actor.css.ts
+++ b/packages/feedback/src/core/components/Actor.css.ts
@@ -25,6 +25,7 @@ export function createActorStyles(): HTMLStyleElement {
   cursor: pointer;
   font-size: 14px;
   font-weight: 600;
+  font-family: inherit;
   padding: 12px 16px;
   text-decoration: none;
   z-index: 9000;


### PR DESCRIPTION
I forgot to apply the font family style to the actor button too

follow up to https://github.com/getsentry/sentry-javascript/pull/11414
ref: https://github.com/getsentry/sentry-javascript/issues/10202
