### PR TITLE
feat(fastify): Update scope `transactionName` when handling request

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-fastify-app/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-app/src/app.js
@@ -55,8 +55,8 @@ app.get('/test-error', async function (req, res) {
   res.send({ exceptionId });
 });
 
-app.get('/test-exception', async function (req, res) {
-  throw new Error('This is an exception');
+app.get('/test-exception/:id', async function (req, res) {
+  throw new Error(`This is an exception with id ${req.params.id}`);
 });
 
 app.get('/test-outgoing-fetch-external-allowed', async function (req, res) {

--- a/dev-packages/e2e-tests/test-applications/node-fastify-app/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-app/tests/errors.test.ts
@@ -41,11 +41,11 @@ test('Sends exception to Sentry', async ({ baseURL }) => {
 
 test('Sends correct error event', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-fastify-app', event => {
-    return !event.type && event.exception?.values?.[0]?.value === 'This is an exception';
+    return !event.type && event.exception?.values?.[0]?.value === 'This is an exception with id 123';
   });
 
   try {
-    await axios.get(`${baseURL}/test-exception`);
+    await axios.get(`${baseURL}/test-exception/123`);
   } catch {
     // this results in an error, but we don't care - we want to check the error event
   }
@@ -53,16 +53,16 @@ test('Sends correct error event', async ({ baseURL }) => {
   const errorEvent = await errorEventPromise;
 
   expect(errorEvent.exception?.values).toHaveLength(1);
-  expect(errorEvent.exception?.values?.[0]?.value).toBe('This is an exception');
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('This is an exception with id 123');
 
   expect(errorEvent.request).toEqual({
     method: 'GET',
     cookies: {},
     headers: expect.any(Object),
-    url: 'http://localhost:3030/test-exception',
+    url: 'http://localhost:3030/test-exception/123',
   });
 
-  expect(errorEvent.transaction).toEqual('GET /test-exception');
+  expect(errorEvent.transaction).toEqual('GET /test-exception/:id');
 
   expect(errorEvent.contexts?.trace).toEqual({
     trace_id: expect.any(String),

--- a/dev-packages/e2e-tests/test-applications/node-fastify-app/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-app/tests/transactions.test.ts
@@ -59,6 +59,23 @@ test('Sends an API route transaction', async ({ baseURL }) => {
         {
           data: {
             'plugin.name': 'fastify -> sentry-fastify-error-handler',
+            'fastify.type': 'middleware',
+            'hook.name': 'onRequest',
+            'otel.kind': 'INTERNAL',
+            'sentry.origin': 'manual',
+          },
+          description: 'middleware - fastify -> sentry-fastify-error-handler',
+          parent_span_id: expect.any(String),
+          span_id: expect.any(String),
+          start_timestamp: expect.any(Number),
+          status: 'ok',
+          timestamp: expect.any(Number),
+          trace_id: expect.any(String),
+          origin: 'manual',
+        },
+        {
+          data: {
+            'plugin.name': 'fastify -> sentry-fastify-error-handler',
             'fastify.type': 'request_handler',
             'http.route': '/test-transaction',
             'otel.kind': 'INTERNAL',

--- a/packages/node/src/integrations/tracing/fastify.ts
+++ b/packages/node/src/integrations/tracing/fastify.ts
@@ -1,6 +1,6 @@
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify';
-import { captureException, defineIntegration, getCurrentScope, getIsolationScope } from '@sentry/core';
+import { captureException, defineIntegration, getIsolationScope } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/types';
 
 import { addOriginToSpan } from '../../utils/addOriginToSpan';


### PR DESCRIPTION
This PR updates the isolation scope's `transactionName` ~whenever the `requestHook` Otel instrumentation hook is invoked and we have a recording span (non-recording spans don't have a attributes :( )~ 

Update: Changed the transactionName updating mechanism to adding another hook callback in our `setupFastifyErrorHandler` fastify plugin. This is better than accessing the otel span for two reasons:

1. We can always update the transactionName, not just when a span is sampled and recording
2. The `onRequest` hook is executed earlier in the lifecycle than the `preHandler` hook that Otel uses to trigger the `requestHook` callback.

Also, we now access the same fields to read the route name [as Otel](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/fe18e2fbb2a6535cb72f314fdb1550a3a4160403/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts#L94-L96).

adjusted existing e2e slightly to cover a paramterized route and to account for the additional span caused by our new `onRequest` handler.

ref #10846 
