### PR TITLE
feat(hapi): Update scope `transactionName` when handling request

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-hapi-app/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-hapi-app/src/app.js
@@ -46,6 +46,15 @@ const init = async () => {
 
   server.route({
     method: 'GET',
+    path: '/test-error/{id}',
+    handler: function (request) {
+      console.log('This is an error with id', request.params.id);
+      throw new Error(`This is an error with id ${request.params.id}`);
+    },
+  });
+
+  server.route({
+    method: 'GET',
     path: '/test-failure',
     handler: async function (request, h) {
       throw new Error('This is an error');

--- a/dev-packages/e2e-tests/test-applications/node-hapi-app/tests/server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-hapi-app/tests/server.test.ts
@@ -121,6 +121,20 @@ test('Sends successful transactions to Sentry', async ({ baseURL }) => {
     .toBe(200);
 });
 
+test('sends error with parameterized transaction name', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('node-hapi-app', errorEvent => {
+    return errorEvent?.exception?.values?.[0]?.value === 'This is an error with id 123';
+  });
+
+  try {
+    await axios.get(`${baseURL}/test-error/123`);
+  } catch {}
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent?.transaction).toBe('GET /test-error/{id}');
+});
+
 test('Sends parameterized transactions to Sentry', async ({ baseURL }) => {
   const pageloadTransactionEventPromise = waitForTransaction('node-hapi-app', transactionEvent => {
     return (

--- a/dev-packages/node-integration-tests/suites/tracing/hapi/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing/hapi/scenario.js
@@ -37,6 +37,14 @@ const init = async () => {
 
   server.route({
     method: 'GET',
+    path: '/error/{id}',
+    handler: (_request, _h) => {
+      return new Error('Sentry Test Error');
+    },
+  });
+
+  server.route({
+    method: 'GET',
     path: '/boom-error',
     handler: (_request, _h) => {
       return new Boom.Boom('Sentry Test Error');

--- a/dev-packages/node-integration-tests/suites/tracing/hapi/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/hapi/test.ts
@@ -56,6 +56,20 @@ describe('hapi auto-instrumentation', () => {
       .makeRequest('get', '/error');
   });
 
+  test('CJS - should assign parameterized transactionName to error.', done => {
+    createRunner(__dirname, 'scenario.js')
+      .expect({
+        event: {
+          ...EXPECTED_ERROR_EVENT,
+          transaction: 'GET /error/{id}',
+        },
+      })
+      .ignore('transaction')
+      .expectError()
+      .start(done)
+      .makeRequest('get', '/error/123');
+  });
+
   test('CJS - should handle returned Boom errors in routes.', done => {
     createRunner(__dirname, 'scenario.js')
       .expect({

--- a/packages/node/src/integrations/tracing/hapi/index.ts
+++ b/packages/node/src/integrations/tracing/hapi/index.ts
@@ -6,7 +6,6 @@ import {
   captureException,
   defineIntegration,
   getActiveSpan,
-  getCurrentScope,
   getDefaultIsolationScope,
   getIsolationScope,
   getRootSpan,

--- a/packages/node/src/integrations/tracing/hapi/index.ts
+++ b/packages/node/src/integrations/tracing/hapi/index.ts
@@ -6,6 +6,7 @@ import {
   captureException,
   defineIntegration,
   getActiveSpan,
+  getCurrentScope,
   getRootSpan,
 } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/types';
@@ -58,6 +59,11 @@ export const hapiErrorPlugin = {
     const server = serverArg as unknown as Server;
 
     server.events.on('request', (request, event) => {
+      const route = request.route;
+      if (route && route.path) {
+        getCurrentScope().setTransactionName(`${route.method?.toUpperCase() || 'GET'} ${route.path}`);
+      }
+
       const activeSpan = getActiveSpan();
       const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
 


### PR DESCRIPTION
This PR updates the scope's `transactionName` in our Hapi error handler. Conveniently, we can access the parameterized route within our Hapi plugin, meaning we're not constrained by reading route info from a potential non-recording span. 

ref #10846 
