### PR TITLE
fix(CI): Include CI environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  CI: true
   HEAD_COMMIT: ${{ github.event.inputs.commit || github.sha }}
 
   # WARNING: this disables cross os caching as ~ and


### PR DESCRIPTION
`process.env.CI` is used in quite a few places so lets add it to the build environment.
