### PR TITLE
feat(core): Implement `suppressTracing`

### DIFF
--- a/packages/browser-utils/test/browser/metrics/index.test.ts
+++ b/packages/browser-utils/test/browser/metrics/index.test.ts
@@ -32,7 +32,7 @@ const originalLocation = WINDOW.location;
 const resourceEntryName = 'https://example.com/assets/to/css';
 
 describe('_addMeasureSpans', () => {
-  const span = new SentrySpan({ op: 'pageload', name: '/' });
+  const span = new SentrySpan({ op: 'pageload', name: '/', sampled: true });
 
   beforeEach(() => {
     getCurrentScope().clear();
@@ -86,7 +86,7 @@ describe('_addMeasureSpans', () => {
 });
 
 describe('_addResourceSpans', () => {
-  const span = new SentrySpan({ op: 'pageload', name: '/' });
+  const span = new SentrySpan({ op: 'pageload', name: '/', sampled: true });
 
   beforeAll(() => {
     setGlobalLocation(mockWindowLocation);

--- a/packages/browser-utils/test/browser/metrics/utils.test.ts
+++ b/packages/browser-utils/test/browser/metrics/utils.test.ts
@@ -26,7 +26,7 @@ describe('startAndEndSpan()', () => {
   });
 
   it('creates a span with given properties', () => {
-    const parentSpan = new SentrySpan({ name: 'test' });
+    const parentSpan = new SentrySpan({ name: 'test', sampled: true });
     const span = startAndEndSpan(parentSpan, 100, 200, {
       name: 'evaluation',
       op: 'script',
@@ -40,7 +40,7 @@ describe('startAndEndSpan()', () => {
   });
 
   it('adjusts the start timestamp if child span starts before transaction', () => {
-    const parentSpan = new SentrySpan({ name: 'test', startTimestamp: 123 });
+    const parentSpan = new SentrySpan({ name: 'test', startTimestamp: 123, sampled: true });
     const span = startAndEndSpan(parentSpan, 100, 200, {
       name: 'script.js',
       op: 'resource',
@@ -52,7 +52,7 @@ describe('startAndEndSpan()', () => {
   });
 
   it('does not adjust start timestamp if child span starts after transaction', () => {
-    const parentSpan = new SentrySpan({ name: 'test', startTimestamp: 123 });
+    const parentSpan = new SentrySpan({ name: 'test', startTimestamp: 123, sampled: true });
     const span = startAndEndSpan(parentSpan, 150, 200, {
       name: 'script.js',
       op: 'resource',

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@sentry/core": "8.0.0-alpha.9",
     "@sentry/node": "8.0.0-alpha.9",
+    "@sentry/opentelemetry": "8.0.0-alpha.9",
     "@sentry/types": "8.0.0-alpha.9",
     "@sentry/utils": "8.0.0-alpha.9"
   },

--- a/packages/bun/src/transports/index.ts
+++ b/packages/bun/src/transports/index.ts
@@ -1,5 +1,4 @@
-import { createTransport } from '@sentry/core';
-import { suppressTracing } from '@sentry/opentelemetry';
+import { createTransport, suppressTracing } from '@sentry/core';
 import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
 import { rejectedSyncPromise } from '@sentry/utils';
 

--- a/packages/bun/src/transports/index.ts
+++ b/packages/bun/src/transports/index.ts
@@ -1,4 +1,5 @@
 import { createTransport } from '@sentry/core';
+import { suppressTracing } from '@sentry/opentelemetry';
 import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
 import { rejectedSyncPromise } from '@sentry/utils';
 
@@ -19,14 +20,16 @@ export function makeFetchTransport(options: BunTransportOptions): Transport {
     };
 
     try {
-      return fetch(options.url, requestOptions).then(response => {
-        return {
-          statusCode: response.status,
-          headers: {
-            'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
-            'retry-after': response.headers.get('Retry-After'),
-          },
-        };
+      return suppressTracing(() => {
+        return fetch(options.url, requestOptions).then(response => {
+          return {
+            statusCode: response.status,
+            headers: {
+              'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
+              'retry-after': response.headers.get('Retry-After'),
+            },
+          };
+        });
       });
     } catch (e) {
       return rejectedSyncPromise(e);

--- a/packages/core/src/asyncContext.ts
+++ b/packages/core/src/asyncContext.ts
@@ -1,7 +1,7 @@
 import type { Hub, Integration } from '@sentry/types';
 import type { Scope } from '@sentry/types';
 import { GLOBAL_OBJ } from '@sentry/utils';
-import type { startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from './tracing/trace';
+import type { startInactiveSpan, startSpan, startSpanManual, suppressTracing, withActiveSpan } from './tracing/trace';
 import type { getActiveSpan } from './utils/spanUtils';
 
 /**
@@ -62,6 +62,9 @@ export interface AsyncContextStrategy {
 
   /** Make a span the active span in the context of the callback. */
   withActiveSpan?: typeof withActiveSpan;
+
+  /** Suppress tracing in the given callback, ensuring no spans are generated inside of it.  */
+  suppressTracing?: typeof suppressTracing;
 }
 
 /**

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_ENVIRONMENT = 'production';
+
+export const SUPPRESS_TRACING_KEY = '__SENTRY_SUPPRESS_TRACING__';

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,3 +1,1 @@
 export const DEFAULT_ENVIRONMENT = 'production';
-
-export const SUPPRESS_TRACING_KEY = '__SENTRY_SUPPRESS_TRACING__';

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -14,6 +14,7 @@ export {
   startSpanManual,
   continueTrace,
   withActiveSpan,
+  suppressTracing,
 } from './trace';
 export { getDynamicSamplingContextFromClient, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 export { setMeasurement, timedEventsToMeasurements } from './measurement';

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -20,11 +20,12 @@ import {
   startInactiveSpan,
   startSpan,
   startSpanManual,
+  suppressTracing,
   withActiveSpan,
 } from '../../../src/tracing';
 import { SentryNonRecordingSpan } from '../../../src/tracing/sentryNonRecordingSpan';
 import { _setSpanForScope } from '../../../src/utils/spanOnScope';
-import { getActiveSpan, getRootSpan, getSpanDescendants } from '../../../src/utils/spanUtils';
+import { getActiveSpan, getRootSpan, getSpanDescendants, spanIsSampled } from '../../../src/utils/spanUtils';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 beforeAll(() => {
@@ -259,7 +260,7 @@ describe('startSpan', () => {
     const initialScope = getCurrentScope();
 
     const manualScope = initialScope.clone();
-    const parentSpan = new SentrySpan({ spanId: 'parent-span-id' });
+    const parentSpan = new SentrySpan({ spanId: 'parent-span-id', sampled: true });
     _setSpanForScope(manualScope, parentSpan);
 
     startSpan({ name: 'GET users/[id]', scope: manualScope }, span => {
@@ -490,7 +491,7 @@ describe('startSpan', () => {
   });
 
   it('uses implementation from ACS, if it exists', () => {
-    const staticSpan = new SentrySpan({ spanId: 'aha' });
+    const staticSpan = new SentrySpan({ spanId: 'aha', sampled: true });
 
     const carrier = getMainCarrier();
 
@@ -575,7 +576,7 @@ describe('startSpanManual', () => {
     const initialScope = getCurrentScope();
 
     const manualScope = initialScope.clone();
-    const parentSpan = new SentrySpan({ spanId: 'parent-span-id' });
+    const parentSpan = new SentrySpan({ spanId: 'parent-span-id', sampled: true });
     _setSpanForScope(manualScope, parentSpan);
 
     startSpanManual({ name: 'GET users/[id]', scope: manualScope }, (span, finish) => {
@@ -761,7 +762,7 @@ describe('startSpanManual', () => {
   });
 
   it('uses implementation from ACS, if it exists', () => {
-    const staticSpan = new SentrySpan({ spanId: 'aha' });
+    const staticSpan = new SentrySpan({ spanId: 'aha', sampled: true });
 
     const carrier = getMainCarrier();
 
@@ -840,7 +841,7 @@ describe('startInactiveSpan', () => {
     const initialScope = getCurrentScope();
 
     const manualScope = initialScope.clone();
-    const parentSpan = new SentrySpan({ spanId: 'parent-span-id' });
+    const parentSpan = new SentrySpan({ spanId: 'parent-span-id', sampled: true });
     _setSpanForScope(manualScope, parentSpan);
 
     const span = startInactiveSpan({ name: 'GET users/[id]', scope: manualScope });
@@ -994,7 +995,7 @@ describe('startInactiveSpan', () => {
     });
   });
 
-  it('includes the scope at the time the span was started when finished xxx', async () => {
+  it('includes the scope at the time the span was started when finished', async () => {
     const beforeSendTransaction = jest.fn(event => event);
 
     const client = new TestClient(
@@ -1048,7 +1049,7 @@ describe('startInactiveSpan', () => {
   });
 
   it('uses implementation from ACS, if it exists', () => {
-    const staticSpan = new SentrySpan({ spanId: 'aha' });
+    const staticSpan = new SentrySpan({ spanId: 'aha', sampled: true });
 
     const carrier = getMainCarrier();
 
@@ -1206,7 +1207,7 @@ describe('getActiveSpan', () => {
   });
 
   it('works with an active span on the scope', () => {
-    const activeSpan = new SentrySpan({ spanId: 'aha' });
+    const activeSpan = new SentrySpan({ spanId: 'aha', sampled: true });
 
     withActiveSpan(activeSpan, () => {
       const span = getActiveSpan();
@@ -1215,7 +1216,7 @@ describe('getActiveSpan', () => {
   });
 
   it('uses implementation from ACS, if it exists', () => {
-    const staticSpan = new SentrySpan({ spanId: 'aha' });
+    const staticSpan = new SentrySpan({ spanId: 'aha', sampled: true });
 
     const carrier = getMainCarrier();
 
@@ -1285,7 +1286,7 @@ describe('withActiveSpan()', () => {
   });
 
   it('uses implementation from ACS, if it exists', () => {
-    const staticSpan = new SentrySpan({ spanId: 'aha' });
+    const staticSpan = new SentrySpan({ spanId: 'aha', sampled: true });
     const staticScope = new Scope();
 
     const carrier = getMainCarrier();
@@ -1357,5 +1358,68 @@ describe('span hooks', () => {
 
     expect(startedSpans).toEqual(['span1', 'span2', 'span3', 'span5', 'span4']);
     expect(endedSpans).toEqual(['span5', 'span3', 'span2', 'span1']);
+  });
+});
+
+describe('suppressTracing', () => {
+  beforeEach(() => {
+    addTracingExtensions();
+
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
+    setAsyncContextStrategy(undefined);
+
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 1 });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('works for a root span', () => {
+    const span = suppressTracing(() => {
+      return startInactiveSpan({ name: 'span' });
+    });
+
+    expect(span.isRecording()).toBe(false);
+    expect(spanIsSampled(span)).toBe(false);
+  });
+
+  it('works for a child span', () => {
+    startSpan({ name: 'outer' }, span => {
+      expect(span.isRecording()).toBe(true);
+      expect(spanIsSampled(span)).toBe(true);
+
+      const child1 = startInactiveSpan({ name: 'inner1' });
+
+      expect(child1.isRecording()).toBe(true);
+      expect(spanIsSampled(child1)).toBe(true);
+
+      const child2 = suppressTracing(() => {
+        return startInactiveSpan({ name: 'span' });
+      });
+
+      expect(child2.isRecording()).toBe(false);
+      expect(spanIsSampled(child2)).toBe(false);
+    });
+  });
+
+  it('works for a child span with forceTransaction=true', () => {
+    startSpan({ name: 'outer' }, span => {
+      expect(span.isRecording()).toBe(true);
+      expect(spanIsSampled(span)).toBe(true);
+
+      const child = suppressTracing(() => {
+        return startInactiveSpan({ name: 'span', forceTransaction: true });
+      });
+
+      expect(child.isRecording()).toBe(false);
+      expect(spanIsSampled(child)).toBe(false);
+    });
   });
 });

--- a/packages/nextjs/src/common/devErrorSymbolicationEventProcessor.ts
+++ b/packages/nextjs/src/common/devErrorSymbolicationEventProcessor.ts
@@ -1,4 +1,4 @@
-import { suppressTracing } from '@sentry/opentelemetry';
+import { suppressTracing } from '@sentry/core';
 import type { Event, EventHint } from '@sentry/types';
 import { GLOBAL_OBJ } from '@sentry/utils';
 import type { StackFrame } from 'stacktrace-parser';

--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -2,8 +2,7 @@ import * as http from 'node:http';
 import * as https from 'node:https';
 import { Readable } from 'stream';
 import { createGzip } from 'zlib';
-import { createTransport } from '@sentry/core';
-import { suppressTracing } from '@sentry/opentelemetry';
+import { createTransport, suppressTracing } from '@sentry/core';
 import type {
   BaseTransportOptions,
   Transport,

--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -2,9 +2,8 @@ import * as http from 'node:http';
 import * as https from 'node:https';
 import { Readable } from 'stream';
 import { createGzip } from 'zlib';
-import { context } from '@opentelemetry/api';
-import { suppressTracing } from '@opentelemetry/core';
 import { createTransport } from '@sentry/core';
+import { suppressTracing } from '@sentry/opentelemetry';
 import type {
   BaseTransportOptions,
   Transport,
@@ -82,7 +81,7 @@ export function makeNodeTransport(options: NodeTransportOptions): Transport {
     : new nativeHttpModule.Agent({ keepAlive, maxSockets: 30, timeout: 2000 });
 
   // This ensures we do not generate any spans in OpenTelemetry for the transport
-  return context.with(suppressTracing(context.active()), () => {
+  return suppressTracing(() => {
     const requestExecutor = createRequestExecutor(options, options.httpModule ?? nativeHttpModule, agent);
     return createTransport(options, requestExecutor);
   });

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -13,6 +13,7 @@ import { startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from '.
 import type { CurrentScopes } from './types';
 import { getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
+import { suppressTracing } from './utils/suppressTracing';
 
 /**
  * Sets the async context strategy to use follow the OTEL context under the hood.
@@ -122,5 +123,6 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     // The types here don't fully align, because our own `Span` type is narrower
     // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
     withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,
+    suppressTracing: suppressTracing,
   });
 }

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -23,6 +23,8 @@ export { isSentryRequestSpan } from './utils/isSentryRequest';
 export { getActiveSpan } from './utils/getActiveSpan';
 export { startSpan, startSpanManual, startInactiveSpan, withActiveSpan, continueTrace } from './trace';
 
+export { suppressTracing } from './utils/suppressTracing';
+
 // eslint-disable-next-line deprecation/deprecation
 export { setupGlobalHub } from './custom/hub';
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/opentelemetry/src/utils/suppressTracing.ts
+++ b/packages/opentelemetry/src/utils/suppressTracing.ts
@@ -1,0 +1,8 @@
+import { context } from '@opentelemetry/api';
+import { suppressTracing as suppressTracingImpl } from '@opentelemetry/core';
+
+/** Suppress tracing in the given callback, ensuring no spans are generated inside of it. */
+export function suppressTracing<T>(callback: () => T): T {
+  const ctx = suppressTracingImpl(context.active());
+  return context.with(ctx, callback);
+}


### PR DESCRIPTION
This implements a new `suppressTracing` method which can be used to ensure we do not send any spans inside of a callback.

Usage:

```js
await suppressTracing(() => {
  // do not capture any spans for this fetch!
  return fetch(...);
});
```

This also changes the behavior of starting child spans slightly to actually create `NonRecordingSpan` as child spans when not sampled (previously, we'd still create SentrySpans). I choose to continue to create proper spans for unsampled transactions because it makes things like picking name and stuff like this easier for the time being.