### PR TITLE
test(e2e/sveltekit): Unflake client error test by waiting for hydration

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/test/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/test/errors.client.test.ts
@@ -4,7 +4,7 @@ import { waitForInitialPageload } from './utils';
 
 test.describe('client-side errors', () => {
   test('captures error thrown on click', async ({ page }) => {
-    await page.goto('/client-error');
+    await waitForInitialPageload(page, { route: '/client-error' });
 
     const errorEventPromise = waitForError('sveltekit-2', errorEvent => {
       return errorEvent?.exception?.values?.[0]?.value === 'Click Error';

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/test/utils.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/test/utils.ts
@@ -18,7 +18,7 @@ import { waitForTransaction } from '@sentry-internal/event-proxy-server';
  */
 export async function waitForInitialPageload(
   page: Page,
-  opts?: { route?: string; parameterizedRoute?: string; debug: boolean },
+  opts?: { route?: string; parameterizedRoute?: string; debug?: boolean },
 ) {
   const route = opts?.route ?? '/';
   const txnName = opts?.parameterizedRoute ?? route;

--- a/dev-packages/e2e-tests/test-applications/sveltekit/test/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit/test/errors.client.test.ts
@@ -4,7 +4,7 @@ import { waitForInitialPageload } from '../utils';
 
 test.describe('client-side errors', () => {
   test('captures error thrown on click', async ({ page }) => {
-    await page.goto('/client-error');
+    await waitForInitialPageload(page, { route: '/client-error' });
 
     const errorEventPromise = waitForError('sveltekit', errorEvent => {
       return errorEvent?.exception?.values?.[0]?.value === 'Click Error';

--- a/dev-packages/e2e-tests/test-applications/sveltekit/utils.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit/utils.ts
@@ -18,7 +18,7 @@ import { waitForTransaction } from '@sentry-internal/event-proxy-server';
  */
 export async function waitForInitialPageload(
   page: Page,
-  opts?: { route?: string; parameterizedRoute?: string; debug: boolean },
+  opts?: { route?: string; parameterizedRoute?: string; debug?: boolean },
 ) {
   const route = opts?.route ?? '/';
   const txnName = opts?.parameterizedRoute ?? route;


### PR DESCRIPTION
Both SvelteKit e2e test apps have a flaky test that checks for a client-side error to be caught by the SDK. Looks like Kit hydration takes too long in the Playwright env to kick in, leading to our test clicking the error-triggering button before the onclick handler code is registered. 

The PR attempts to fix the the flakiness by awaiting the initial pageload, meaning we await
- going to the specified route
- a custom hydration flag being set
- the pageload transaction being sent

This will prolong the test for a couple of ms but I think that's acceptable.