### PR TITLE
fix(opentelemetry): Avoid weakmap for storing data

### DIFF
--- a/packages/opentelemetry/src/utils/contextData.ts
+++ b/packages/opentelemetry/src/utils/contextData.ts
@@ -1,10 +1,11 @@
 import type { Context } from '@opentelemetry/api';
 import type { Scope } from '@sentry/types';
+import { addNonEnumerableProperty } from '@sentry/utils';
 
 import { SENTRY_SCOPES_CONTEXT_KEY } from '../constants';
 import type { CurrentScopes } from '../types';
 
-const SCOPE_CONTEXT_MAP = new WeakMap<Scope, Context>();
+const SCOPE_CONTEXT_FIELD = '_scopeContext';
 
 /**
  * Try to get the current scopes from the given OTEL context.
@@ -27,7 +28,7 @@ export function setScopesOnContext(context: Context, scopes: CurrentScopes): Con
  * We need this to get the context from the scope in the `trace` functions.
  */
 export function setContextOnScope(scope: Scope, context: Context): void {
-  SCOPE_CONTEXT_MAP.set(scope, context);
+  addNonEnumerableProperty(scope, SCOPE_CONTEXT_FIELD, context);
 }
 
 /**
@@ -35,5 +36,5 @@ export function setContextOnScope(scope: Scope, context: Context): void {
  * TODO v8: Use this for the `trace` functions.
  * */
 export function getContextFromScope(scope: Scope): Context | undefined {
-  return SCOPE_CONTEXT_MAP.get(scope);
+  return (scope as { [SCOPE_CONTEXT_FIELD]?: Context })[SCOPE_CONTEXT_FIELD];
 }

--- a/packages/opentelemetry/src/utils/spanData.ts
+++ b/packages/opentelemetry/src/utils/spanData.ts
@@ -1,17 +1,9 @@
 import type { Scope } from '@sentry/types';
+import { addNonEnumerableProperty } from '@sentry/utils';
 
 import type { AbstractSpan } from '../types';
 
-// We store the parent span, scopes & metadata in separate weakmaps, so we can access them for a given span
-// This way we can enhance the data that an OTEL Span natively gives us
-// and since we are using weakmaps, we do not need to clean up after ourselves
-const SpanScopes = new WeakMap<
-  AbstractSpan,
-  {
-    scope: Scope;
-    isolationScope: Scope;
-  }
->();
+const SPAN_SCOPES_FIELD = '_spanScopes';
 
 /**
  * Set the Sentry scope to be used for finishing a given OTEL span.
@@ -25,7 +17,7 @@ export function setSpanScopes(
     isolationScope: Scope;
   },
 ): void {
-  SpanScopes.set(span, scopes);
+  addNonEnumerableProperty(span, SPAN_SCOPES_FIELD, scopes);
 }
 
 /** Get the Sentry scopes to use for finishing an OTEL span. */
@@ -35,5 +27,5 @@ export function getSpanScopes(span: AbstractSpan):
       isolationScope: Scope;
     }
   | undefined {
-  return SpanScopes.get(span);
+  return (span as { [SPAN_SCOPES_FIELD]?: { scope: Scope; isolationScope: Scope } })[SPAN_SCOPES_FIELD];
 }


### PR DESCRIPTION
It may happen that we have different modules, different versions etc. so the weakmaps may not be in sync. Just storing a non-enumerable property should be the safer choice here.

Partially required for next.js 13.4.19 to work....