### PR TITLE
feat: Export `spanToJSON` and `spanToTraceHeader` from all relevant packages

### DIFF
--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -93,6 +93,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  spanToTraceHeader,
   trpcMiddleware,
 } from '@sentry/node';
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -56,6 +56,7 @@ export {
   captureSession,
   endSession,
   spanToJSON,
+  spanToTraceHeader,
 } from '@sentry/core';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -113,6 +113,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  spanToTraceHeader,
   trpcMiddleware,
 } from '@sentry/node';
 

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -74,6 +74,8 @@ export {
   startSession,
   captureSession,
   endSession,
+  spanToJSON,
+  spanToTraceHeader,
 } from '@sentry/core';
 
 export { DenoClient } from './client';

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -93,6 +93,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  spanToTraceHeader,
   trpcMiddleware,
 } from '@sentry/node';
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -102,6 +102,7 @@ export {
   withActiveSpan,
   getRootSpan,
   spanToJSON,
+  spanToTraceHeader,
   trpcMiddleware,
 } from '@sentry/core';
 

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -96,6 +96,8 @@ export {
   spotlightIntegration,
   setupFastifyErrorHandler,
   trpcMiddleware,
+  spanToJSON,
+  spanToTraceHeader,
 } from '@sentry/node';
 
 // Keeping the `*` exports for backwards compatibility and types

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -70,6 +70,8 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   trpcMiddleware,
+  spanToJSON,
+  spanToTraceHeader,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -69,6 +69,8 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   trpcMiddleware,
+  spanToJSON,
+  spanToTraceHeader,
 } from '@sentry/core';
 
 export { VercelEdgeClient } from './client';


### PR DESCRIPTION
I was looking to bump the [docs to v8](https://github.com/getsentry/sentry-docs/pull/9628), but it seems like `spanToJSON` and `spanToTraceHeader` were missed in a few packages (including Next.js).