### PR TITLE
feat(koa): Update scope `transactionName` when creating router span

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-koa-app/index.js
+++ b/dev-packages/e2e-tests/test-applications/node-koa-app/index.js
@@ -75,6 +75,10 @@ router1.get('/test-exception', async ctx => {
   throw new Error('This is an exception');
 });
 
+router1.get('/test-exception/:id', async ctx => {
+  throw new Error(`This is an exception with id ${ctx.params.id}`);
+});
+
 router1.get('/test-outgoing-fetch-external-allowed', async ctx => {
   const fetchResponse = await fetch(`http://localhost:${port2}/external-allowed`);
   const data = await fetchResponse.json();

--- a/dev-packages/e2e-tests/test-applications/node-koa-app/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-koa-app/tests/errors.test.ts
@@ -41,11 +41,11 @@ test('Sends exception to Sentry', async ({ baseURL }) => {
 
 test('Sends correct error event', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-koa-app', event => {
-    return !event.type && event.exception?.values?.[0]?.value === 'This is an exception';
+    return !event.type && event.exception?.values?.[0]?.value === 'This is an exception with id 123';
   });
 
   try {
-    await axios.get(`${baseURL}/test-exception`);
+    await axios.get(`${baseURL}/test-exception/123`);
   } catch {
     // this results in an error, but we don't care - we want to check the error event
   }
@@ -53,16 +53,16 @@ test('Sends correct error event', async ({ baseURL }) => {
   const errorEvent = await errorEventPromise;
 
   expect(errorEvent.exception?.values).toHaveLength(1);
-  expect(errorEvent.exception?.values?.[0]?.value).toBe('This is an exception');
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('This is an exception with id 123');
 
   expect(errorEvent.request).toEqual({
     method: 'GET',
     cookies: {},
     headers: expect.any(Object),
-    url: 'http://localhost:3030/test-exception',
+    url: 'http://localhost:3030/test-exception/123',
   });
 
-  expect(errorEvent.transaction).toEqual('GET /test-exception');
+  expect(errorEvent.transaction).toEqual('GET /test-exception/:id');
 
   expect(errorEvent.contexts?.trace).toEqual({
     trace_id: expect.any(String),


### PR DESCRIPTION
This PR updates the current scope's `transactionName` in our Koa integration. Unfortunately, I didn't find a reliable way to get the parameterized route in our error handler/via `app.use` because similarly to Express, koa doesn't seem to expose this information before going through the actual route layers. A couple of stackoverflow posts suggest a way if potentially [obtaining a routename](https://stackoverflow.com/questions/53398808/how-to-get-the-path-of-a-route-inside-middleware-in-koa) via a private `ctx` variable but in my testing this didn't work. Seems like there are multiple versions of `koa-router`/`@koa/router` where some support this and others don't... 

Consequence: In case of a negative sampling decision for the span, we can't update the scope's transaction name which most likely will be the unparameterized route set by our Http integration. 

ref #10846 