### PR TITLE
fix: Remove `@sentry/node-experimental` from craft config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -125,11 +125,6 @@ targets:
     id: '@sentry-internal/eslint-config-sdk'
     includeNames: /^sentry-internal-eslint-config-sdk-\d.*\.tgz$/
 
-  ## 8. Experimental packages
-  - name: npm
-    id: '@sentry/node-experimental'
-    includeNames: /^sentry-node-experimental-\d.*\.tgz$/
-
   # AWS Lambda Layer target
   - name: aws-lambda-layer
     includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha)\.\d+)?\.zip$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 8.0.0-alpha.9
+
+This is a re-release of version `8.0.0-alpha.8` needed to be done for technical purposes.
+
 ## 8.0.0-alpha.8
 
 This is the eighth alpha release of Sentry JavaScript SDK v8, which includes a variety of breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 ## 8.0.0-alpha.9
 
-This is a re-release of version `8.0.0-alpha.8` needed to be done for technical purposes.
-
-## 8.0.0-alpha.8
-
 This is the eighth alpha release of Sentry JavaScript SDK v8, which includes a variety of breaking changes.
 
 Read the [in-depth migration guide](./MIGRATION.md) to find out how to address any breaking changes in your code.
@@ -92,6 +88,10 @@ monitoring.
 - ref(feedback): Add font family to buttons (#11414)
 - ref(gcp-serverless): Remove setting `.__sentry_transaction` (#11346)
 - ref(nextjs): Replace multiplexer with conditional exports (#11442)
+
+## 8.0.0-alpha.8
+
+This is a partially broken release and was superseded by version `8.0.0-alpha.9`.
 
 ## 8.0.0-alpha.7
 


### PR DESCRIPTION
Fixes botched release: https://github.com/getsentry/publish/issues/3661