### PR TITLE
feat(core): Allow to pass scope to `withIsolationScope()`

### DIFF
--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -5,6 +5,7 @@ import {
   getGlobalScope,
   getIsolationScope,
   withIsolationScope,
+  withScope,
 } from '../../src';
 
 import { Scope } from '../../src/scope';
@@ -853,40 +854,135 @@ describe('Scope', () => {
   });
 });
 
-describe('isolation scope', () => {
-  describe('withIsolationScope()', () => {
-    it('will pass an isolation scope without Sentry.init()', done => {
-      expect.assertions(1);
-      withIsolationScope(scope => {
-        expect(scope).toBeDefined();
+describe('withScope()', () => {
+  beforeEach(() => {
+    getIsolationScope().clear();
+    getCurrentScope().clear();
+    getGlobalScope().clear();
+  });
+
+  it('will make the passed scope the active scope within the callback', done => {
+    withScope(scope => {
+      expect(getCurrentScope()).toBe(scope);
+      done();
+    });
+  });
+
+  it('will pass a scope that is different from the current active isolation scope', done => {
+    withScope(scope => {
+      expect(getIsolationScope()).not.toBe(scope);
+      done();
+    });
+  });
+
+  it('will always make the inner most passed scope the current isolation scope when nesting calls', done => {
+    withIsolationScope(_scope1 => {
+      withIsolationScope(scope2 => {
+        expect(getIsolationScope()).toBe(scope2);
         done();
       });
     });
+  });
 
-    it('will make the passed isolation scope the active isolation scope within the callback', done => {
-      expect.assertions(1);
-      withIsolationScope(scope => {
-        expect(getIsolationScope()).toBe(scope);
+  it('forks the scope when not passing any scope', done => {
+    const initialScope = getCurrentScope();
+    initialScope.setTag('aa', 'aa');
+
+    withScope(scope => {
+      expect(getCurrentScope()).toBe(scope);
+      scope.setTag('bb', 'bb');
+      expect(scope).not.toBe(initialScope);
+      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+      done();
+    });
+  });
+
+  it('forks the scope when passing undefined', done => {
+    const initialScope = getCurrentScope();
+    initialScope.setTag('aa', 'aa');
+
+    withScope(undefined, scope => {
+      expect(getCurrentScope()).toBe(scope);
+      scope.setTag('bb', 'bb');
+      expect(scope).not.toBe(initialScope);
+      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+      done();
+    });
+  });
+
+  it('sets the passed in scope as active scope', done => {
+    const initialScope = getCurrentScope();
+    initialScope.setTag('aa', 'aa');
+
+    const customScope = new Scope();
+
+    withScope(customScope, scope => {
+      expect(getCurrentScope()).toBe(customScope);
+      expect(scope).toBe(customScope);
+      done();
+    });
+  });
+});
+
+describe('withIsolationScope()', () => {
+  beforeEach(() => {
+    getIsolationScope().clear();
+    getCurrentScope().clear();
+    getGlobalScope().clear();
+  });
+
+  it('will make the passed isolation scope the active isolation scope within the callback', done => {
+    withIsolationScope(scope => {
+      expect(getIsolationScope()).toBe(scope);
+      done();
+    });
+  });
+
+  it('will pass an isolation scope that is different from the current active scope', done => {
+    withIsolationScope(scope => {
+      expect(getCurrentScope()).not.toBe(scope);
+      done();
+    });
+  });
+
+  it('will always make the inner most passed scope the current scope when nesting calls', done => {
+    withIsolationScope(_scope1 => {
+      withIsolationScope(scope2 => {
+        expect(getIsolationScope()).toBe(scope2);
         done();
       });
     });
+  });
 
-    it('will pass an isolation scope that is different from the current active scope', done => {
-      expect.assertions(1);
-      withIsolationScope(scope => {
-        expect(getCurrentScope()).not.toBe(scope);
-        done();
-      });
+  // Note: This is expected! In browser, we do not actually fork this
+  it('does not fork isolation scope when not passing any isolation scope', done => {
+    const isolationScope = getIsolationScope();
+
+    withIsolationScope(scope => {
+      expect(getIsolationScope()).toBe(scope);
+      expect(scope).toBe(isolationScope);
+      done();
     });
+  });
 
-    it('will always make the inner most passed scope the current scope when nesting calls', done => {
-      expect.assertions(1);
-      withIsolationScope(_scope1 => {
-        withIsolationScope(scope2 => {
-          expect(getIsolationScope()).toBe(scope2);
-          done();
-        });
-      });
+  it('does not fork isolation scope when passing undefined', done => {
+    const isolationScope = getIsolationScope();
+
+    withIsolationScope(undefined, scope => {
+      expect(getIsolationScope()).toBe(scope);
+      expect(scope).toBe(isolationScope);
+      done();
+    });
+  });
+
+  it('ignores passed in isolation scope', done => {
+    const isolationScope = getIsolationScope();
+    const customIsolationScope = new Scope();
+
+    withIsolationScope(customIsolationScope, scope => {
+      expect(getIsolationScope()).toBe(isolationScope);
+      expect(scope).toBe(isolationScope);
+      done();
     });
   });
 });

--- a/packages/opentelemetry/test/asyncContextStrategy.test.ts
+++ b/packages/opentelemetry/test/asyncContextStrategy.test.ts
@@ -1,5 +1,6 @@
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import {
+  Scope as ScopeClass,
   getCurrentScope,
   getIsolationScope,
   setAsyncContextStrategy,
@@ -295,6 +296,134 @@ describe('asyncContextStrategy', () => {
           aa: 'aa',
           bb2: 'bb',
         });
+      });
+    });
+  });
+
+  describe('withScope()', () => {
+    it('will make the passed scope the active scope within the callback', done => {
+      withScope(scope => {
+        expect(getCurrentScope()).toBe(scope);
+        done();
+      });
+    });
+
+    it('will pass a scope that is different from the current active isolation scope', done => {
+      withScope(scope => {
+        expect(getIsolationScope()).not.toBe(scope);
+        done();
+      });
+    });
+
+    it('will always make the inner most passed scope the current scope when nesting calls', done => {
+      withIsolationScope(_scope1 => {
+        withIsolationScope(scope2 => {
+          expect(getIsolationScope()).toBe(scope2);
+          done();
+        });
+      });
+    });
+
+    it('forks the scope when not passing any scope', done => {
+      const initialScope = getCurrentScope();
+      initialScope.setTag('aa', 'aa');
+
+      withScope(scope => {
+        expect(getCurrentScope()).toBe(scope);
+        scope.setTag('bb', 'bb');
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+        done();
+      });
+    });
+
+    it('forks the scope when passing undefined', done => {
+      const initialScope = getCurrentScope();
+      initialScope.setTag('aa', 'aa');
+
+      withScope(undefined, scope => {
+        expect(getCurrentScope()).toBe(scope);
+        scope.setTag('bb', 'bb');
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+        done();
+      });
+    });
+
+    it('sets the passed in scope as active scope', done => {
+      const initialScope = getCurrentScope();
+      initialScope.setTag('aa', 'aa');
+
+      const customScope = new ScopeClass();
+
+      withScope(customScope, scope => {
+        expect(getCurrentScope()).toBe(customScope);
+        expect(scope).toBe(customScope);
+        done();
+      });
+    });
+  });
+
+  describe('withIsolationScope()', () => {
+    it('will make the passed isolation scope the active isolation scope within the callback', done => {
+      withIsolationScope(scope => {
+        expect(getIsolationScope()).toBe(scope);
+        done();
+      });
+    });
+
+    it('will pass an isolation scope that is different from the current active scope', done => {
+      withIsolationScope(scope => {
+        expect(getCurrentScope()).not.toBe(scope);
+        done();
+      });
+    });
+
+    it('will always make the inner most passed scope the current scope when nesting calls', done => {
+      withIsolationScope(_scope1 => {
+        withIsolationScope(scope2 => {
+          expect(getIsolationScope()).toBe(scope2);
+          done();
+        });
+      });
+    });
+
+    it('forks the isolation scope when not passing any isolation scope', done => {
+      const initialScope = getIsolationScope();
+      initialScope.setTag('aa', 'aa');
+
+      withIsolationScope(scope => {
+        expect(getIsolationScope()).toBe(scope);
+        scope.setTag('bb', 'bb');
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+        done();
+      });
+    });
+
+    it('forks the isolation scope when passing undefined', done => {
+      const initialScope = getIsolationScope();
+      initialScope.setTag('aa', 'aa');
+
+      withIsolationScope(undefined, scope => {
+        expect(getIsolationScope()).toBe(scope);
+        scope.setTag('bb', 'bb');
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+        done();
+      });
+    });
+
+    it('sets the passed in isolation scope as active isolation scope', done => {
+      const initialScope = getIsolationScope();
+      initialScope.setTag('aa', 'aa');
+
+      const customScope = new ScopeClass();
+
+      withIsolationScope(customScope, scope => {
+        expect(getIsolationScope()).toBe(customScope);
+        expect(scope).toBe(customScope);
+        done();
       });
     });
   });

--- a/packages/vercel-edge/src/async.ts
+++ b/packages/vercel-edge/src/async.ts
@@ -11,15 +11,15 @@ interface AsyncLocalStorage<T> {
   run<R, TArgs extends any[]>(store: T, callback: (...args: TArgs) => R, ...args: TArgs): R;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-const MaybeGlobalAsyncLocalStorage = (GLOBAL_OBJ as any).AsyncLocalStorage;
-
 let asyncStorage: AsyncLocalStorage<Hub>;
 
 /**
  * Sets the async context strategy to use AsyncLocalStorage which should be available in the edge runtime.
  */
 export function setAsyncLocalStorageAsyncContextStrategy(): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+  const MaybeGlobalAsyncLocalStorage = (GLOBAL_OBJ as any).AsyncLocalStorage;
+
   if (!MaybeGlobalAsyncLocalStorage) {
     DEBUG_BUILD &&
       logger.warn(

--- a/packages/vercel-edge/test/async.test.ts
+++ b/packages/vercel-edge/test/async.test.ts
@@ -1,0 +1,150 @@
+import { Scope, getCurrentScope, getGlobalScope, getIsolationScope, withIsolationScope, withScope } from '@sentry/core';
+import { GLOBAL_OBJ } from '@sentry/utils';
+import { AsyncLocalStorage } from 'async_hooks';
+import { setAsyncLocalStorageAsyncContextStrategy } from '../src/async';
+
+describe('withScope()', () => {
+  beforeEach(() => {
+    getIsolationScope().clear();
+    getCurrentScope().clear();
+    getGlobalScope().clear();
+
+    (GLOBAL_OBJ as any).AsyncLocalStorage = AsyncLocalStorage;
+    setAsyncLocalStorageAsyncContextStrategy();
+  });
+
+  it('will make the passed scope the active scope within the callback', done => {
+    withScope(scope => {
+      expect(getCurrentScope()).toBe(scope);
+      done();
+    });
+  });
+
+  it('will pass a scope that is different from the current active isolation scope', done => {
+    withScope(scope => {
+      expect(getIsolationScope()).not.toBe(scope);
+      done();
+    });
+  });
+
+  it('will always make the inner most passed scope the current scope when nesting calls', done => {
+    withIsolationScope(_scope1 => {
+      withIsolationScope(scope2 => {
+        expect(getIsolationScope()).toBe(scope2);
+        done();
+      });
+    });
+  });
+
+  it('forks the scope when not passing any scope', done => {
+    const initialScope = getCurrentScope();
+    initialScope.setTag('aa', 'aa');
+
+    withScope(scope => {
+      expect(getCurrentScope()).toBe(scope);
+      scope.setTag('bb', 'bb');
+      expect(scope).not.toBe(initialScope);
+      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+      done();
+    });
+  });
+
+  it('forks the scope when passing undefined', done => {
+    const initialScope = getCurrentScope();
+    initialScope.setTag('aa', 'aa');
+
+    withScope(undefined, scope => {
+      expect(getCurrentScope()).toBe(scope);
+      scope.setTag('bb', 'bb');
+      expect(scope).not.toBe(initialScope);
+      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+      done();
+    });
+  });
+
+  it('sets the passed in scope as active scope', done => {
+    const initialScope = getCurrentScope();
+    initialScope.setTag('aa', 'aa');
+
+    const customScope = new Scope();
+
+    withScope(customScope, scope => {
+      expect(getCurrentScope()).toBe(customScope);
+      expect(scope).toBe(customScope);
+      done();
+    });
+  });
+});
+
+describe('withIsolationScope()', () => {
+  beforeEach(() => {
+    getIsolationScope().clear();
+    getCurrentScope().clear();
+    getGlobalScope().clear();
+    (GLOBAL_OBJ as any).AsyncLocalStorage = AsyncLocalStorage;
+
+    setAsyncLocalStorageAsyncContextStrategy();
+  });
+
+  it('will make the passed isolation scope the active isolation scope within the callback', done => {
+    withIsolationScope(scope => {
+      expect(getIsolationScope()).toBe(scope);
+      done();
+    });
+  });
+
+  it('will pass an isolation scope that is different from the current active scope', done => {
+    withIsolationScope(scope => {
+      expect(getCurrentScope()).not.toBe(scope);
+      done();
+    });
+  });
+
+  it('will always make the inner most passed scope the current scope when nesting calls', done => {
+    withIsolationScope(_scope1 => {
+      withIsolationScope(scope2 => {
+        expect(getIsolationScope()).toBe(scope2);
+        done();
+      });
+    });
+  });
+
+  it('forks the isolation scope when not passing any isolation scope', done => {
+    const initialScope = getIsolationScope();
+    initialScope.setTag('aa', 'aa');
+
+    withIsolationScope(scope => {
+      expect(getIsolationScope()).toBe(scope);
+      scope.setTag('bb', 'bb');
+      expect(scope).not.toBe(initialScope);
+      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+      done();
+    });
+  });
+
+  it('forks the isolation scope when passing undefined', done => {
+    const initialScope = getIsolationScope();
+    initialScope.setTag('aa', 'aa');
+
+    withIsolationScope(undefined, scope => {
+      expect(getIsolationScope()).toBe(scope);
+      scope.setTag('bb', 'bb');
+      expect(scope).not.toBe(initialScope);
+      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+      done();
+    });
+  });
+
+  it('sets the passed in isolation scope as active isolation scope', done => {
+    const initialScope = getIsolationScope();
+    initialScope.setTag('aa', 'aa');
+
+    const customScope = new Scope();
+
+    withIsolationScope(customScope, scope => {
+      expect(getIsolationScope()).toBe(customScope);
+      expect(scope).toBe(customScope);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Also adds tests for this for core, vercel-edge and opentelemetry.

NOTE: In core, this does not do anything, as we cannot actually update the isolation scope in browser.