### PR TITLE
feat(remix): Skip span creation for `OPTIONS` and `HEAD` requests. [v7]

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -446,6 +446,13 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
       return origRequestHandler.call(this, request, loadContext);
     }
 
+    const upperCaseMethod = request.method.toUpperCase();
+
+    // We don't want to wrap OPTIONS and HEAD requests
+    if (upperCaseMethod === 'OPTIONS' || upperCaseMethod === 'HEAD') {
+      return origRequestHandler.call(this, request, loadContext);
+    }
+
     return runWithAsyncContext(async () => {
       // eslint-disable-next-line deprecation/deprecation
       const hub = getCurrentHub();


### PR DESCRIPTION
Backports #11149 to `v7`
