### PR TITLE
build(ci): Run dependabot for opentelemetry dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
     allow:
       - dependency-name: "@sentry/cli"
       - dependency-name: "@sentry/vite-plugin"
+      - dependency-name: "@opentelemetry/*"
+      - dependency-name: "@prisma/instrumentation"
+      - dependency-name: "opentelemetry-instrumentation-fetch-node"
     versioning-strategy: increase
     commit-message:
       prefix: feat


### PR DESCRIPTION
These are deps we may want to keep more up to date than we usually do, so generating update PRs for them may be helpful.
