### PR TITLE
ci(canary): Fix canary tests

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -12,6 +12,13 @@ on:
 env:
   HEAD_COMMIT: ${{ github.event.inputs.commit || github.sha }}
 
+  CACHED_BUILD_PATHS: |
+    ${{ github.workspace }}/packages/*/*.tgz
+    ${{ github.workspace }}/dev-packages/event-proxy-server/build
+    ${{ github.workspace }}/node_modules
+    ${{ github.workspace }}/packages/*/node_modules
+    ${{ github.workspace }}/dev-packages/*/node_modules
+
 permissions:
   contents: read
   issues: write
@@ -33,10 +40,7 @@ jobs:
       - name: Check canary cache
         uses: actions/cache@v4
         with:
-          path: |
-            ${{ github.workspace }}/packages/*/*.tgz
-            ${{ github.workspace }}/node_modules
-            ${{ github.workspace }}/packages/*/node_modules
+          path: ${{ env.CACHED_BUILD_PATHS }}
           key: canary-${{ env.HEAD_COMMIT }}
       - name: Install dependencies
         run: yarn install
@@ -94,24 +98,22 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 8.3.1
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'package.json'
+          node-version-file: 'dev-packages/e2e-tests/package.json'
 
       - name: Restore canary cache
         uses: actions/cache/restore@v4
         with:
-          path: |
-            ${{ github.workspace }}/packages/*/*.tgz
-            ${{ github.workspace }}/node_modules
-            ${{ github.workspace }}/packages/*/node_modules
+          path: ${{ env.CACHED_BUILD_PATHS }}
           key: canary-${{ env.HEAD_COMMIT }}
 
       - name: Get node version
         id: versions
         run: |
-          echo "echo node=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
+          echo "echo node=$(jq -r '.volta.node' dev-packages/e2e-tests/package.json)" >> $GITHUB_OUTPUT
 
       - name: Validate Verdaccio
         run: yarn test:validate

--- a/dev-packages/event-proxy-server/package.json
+++ b/dev-packages/event-proxy-server/package.json
@@ -39,7 +39,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "rimraf -g ./node_modules ./build"
   },
-  "dependencies": {
+  "devDependencies": {
     "@sentry/types": "8.0.0-alpha.9",
     "@sentry/utils": "8.0.0-alpha.9"
   },


### PR DESCRIPTION
Fixes the Canary tests by ensuring we cache node modules and files in dev-packages as well.

In the debugging process, I also moved a few things around - e.g. the playwright dependency stuff now happens in CI, not in the build commands everywhere.