### PR TITLE
fix(node): Fix typos in passed `HttpInstrumentation` option properties

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -88,8 +88,8 @@ const _httpIntegration = ((options: HttpOptions = {}) => {
             return false;
           },
 
-          requireParentforOutgoingSpans: true,
-          requireParentforIncomingSpans: false,
+          requireParentForOutgoingSpans: true,
+          requireParentForIncomingSpans: false,
           requestHook: (span, req) => {
             addOriginToSpan(span, 'auto.http.otel.http');
 


### PR DESCRIPTION
Also noticed, that we passed two invalid properties to the Otel `HttpInstrumentation` options:

* `requireParentforOutgoingSpans` -> `requireParentForOutgoingSpans`
* `requireParentforIncomingSpans` -> `requireParentForIncomingSpans`

Not sure how this passes TypeScript but I don't think these options ever had an effect. Let's see what CI has to say