### PR TITLE
feat(opentelemetry): Export `getRequestSpanData`

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -14,7 +14,7 @@ import {
   setCapturedScopesOnSpan,
   spanToJSON,
 } from '@sentry/core';
-import { _INTERNAL, getClient, getSpanKind } from '@sentry/opentelemetry';
+import { getClient, getRequestSpanData, getSpanKind } from '@sentry/opentelemetry';
 import type { IntegrationFn } from '@sentry/types';
 
 import { stripUrlQueryAndFragment } from '@sentry/utils';
@@ -160,7 +160,7 @@ function _addRequestBreadcrumb(span: Span, response: HTTPModuleRequestIncomingMe
     return;
   }
 
-  const data = _INTERNAL.getRequestSpanData(span);
+  const data = getRequestSpanData(span);
   addBreadcrumb(
     {
       category: 'http',

--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -3,7 +3,7 @@ import { SpanKind } from '@opentelemetry/api';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { addBreadcrumb, defineIntegration } from '@sentry/core';
-import { _INTERNAL, getSpanKind } from '@sentry/opentelemetry';
+import { getRequestSpanData, getSpanKind } from '@sentry/opentelemetry';
 import type { IntegrationFn } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import { DEBUG_BUILD } from '../debug-build';
@@ -88,7 +88,7 @@ function _addRequestBreadcrumb(span: Span): void {
     return;
   }
 
-  const data = _INTERNAL.getRequestSpanData(span);
+  const data = getRequestSpanData(span);
   addBreadcrumb({
     category: 'http',
     data: {

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -39,5 +39,3 @@ export { openTelemetrySetupCheck } from './utils/setupCheck';
 
 // Legacy
 export { getClient } from '@sentry/core';
-
-export { _INTERNAL };

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -1,4 +1,4 @@
-import { getRequestSpanData } from './utils/getRequestSpanData';
+export { getRequestSpanData } from './utils/getRequestSpanData';
 
 export type { OpenTelemetryClient } from './types';
 export { wrapClientClass } from './custom/client';
@@ -39,13 +39,5 @@ export { openTelemetrySetupCheck } from './utils/setupCheck';
 
 // Legacy
 export { getClient } from '@sentry/core';
-
-/**
- * The following internal utils are not considered public API and are subject to change.
- * @hidden
- */
-const _INTERNAL = {
-  getRequestSpanData,
-} as const;
 
 export { _INTERNAL };


### PR DESCRIPTION
Instead of exporting `_INTERNAL` here, it's OK IMHO to export this. The API is stable enough.