### PR TITLE
feat(sveltekit): Update scope transactionName when handling server-side request

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/test/errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/test/errors.server.test.ts
@@ -60,7 +60,6 @@ test.describe('server-side errors', () => {
       }),
     );
 
-    // TODO: Uncomment once we update the scope transaction name on the server side
-    // expect(errorEvent.transaction).toEqual('GET /server-route-error');
+    expect(errorEvent.transaction).toEqual('GET /server-route-error');
   });
 });

--- a/dev-packages/e2e-tests/test-applications/sveltekit/test/errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit/test/errors.server.test.ts
@@ -63,7 +63,6 @@ test.describe('server-side errors', () => {
       }),
     );
 
-    // TODO: Uncomment once we update the scope transaction name on the server side
-    // expect(errorEvent.transaction).toEqual('GET /server-route-error');
+    expect(errorEvent.transaction).toEqual('GET /server-route-error');
   });
 });


### PR DESCRIPTION
This PR updates the scope's `transactionName` in the `sentryHandle` instrumentation that's always invoked when a request is made to the SvelteKit server. 

For now, I opted to not set the transactionName to unknown route URLs by default (i.e. a request that doesn't match a known server endpoint/route). Users can opt into also handling unknown routes at which point we'll also set the transactionName for such routes. 

ref #10846 