### PR TITLE
feat(node): Send ANR events from main thread

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -10,7 +10,7 @@ setTimeout(() => {
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
   autoSessionTracking: true,
 });
 

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 Sentry.setUser({ email: 'person@home.com' });

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 Sentry.setUser({ email: 'person@home.com' });

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -8,11 +8,11 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
-  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
   debug: true,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 Sentry.setUser({ email: 'person@home.com' });

--- a/dev-packages/node-integration-tests/suites/anr/forker.js
+++ b/dev-packages/node-integration-tests/suites/anr/forker.js
@@ -1,7 +1,7 @@
 const { fork } = require('child_process');
 const { join } = require('path');
 
-const child = fork(join(__dirname, 'forked.js'), { stdio: 'inherit', env: process.env});
+const child = fork(join(__dirname, 'forked.js'), { stdio: 'inherit', env: process.env });
 child.on('exit', () => {
   process.exit();
 });

--- a/dev-packages/node-integration-tests/suites/anr/forker.js
+++ b/dev-packages/node-integration-tests/suites/anr/forker.js
@@ -1,7 +1,7 @@
 const { fork } = require('child_process');
 const { join } = require('path');
 
-const child = fork(join(__dirname, 'forked.js'), { stdio: 'inherit' });
+const child = fork(join(__dirname, 'forked.js'), { stdio: 'inherit', env: process.env});
 child.on('exit', () => {
   process.exit();
 });

--- a/dev-packages/node-integration-tests/suites/anr/isolated.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/isolated.mjs
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 async function longWork() {

--- a/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
@@ -2,11 +2,11 @@ const Sentry = require('@sentry/node');
 
 function configureSentry() {
   Sentry.init({
-    dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    dsn: process.env.SENTRY_DSN,
     release: '1.0',
     autoSessionTracking: false,
     debug: true,
-    integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
+    integrations: [Sentry.anrIntegration()],
   });
 }
 

--- a/dev-packages/node-integration-tests/suites/anr/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit.js
@@ -2,11 +2,11 @@ const Sentry = require('@sentry/node');
 
 function configureSentry() {
   Sentry.init({
-    dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    dsn: process.env.SENTRY_DSN,
     release: '1.0',
     autoSessionTracking: false,
     debug: true,
-    integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
+    integrations: [Sentry.anrIntegration()],
   });
 }
 

--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -7,10 +7,10 @@ setTimeout(() => {
   process.exit();
 }, 10000);
 
-const anr = Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 });
+const anr = Sentry.anrIntegration({ anrThreshold: 100 });
 
 Sentry.init({
-  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  dsn: process.env.SENTRY_DSN,
   release: '1.0',
   debug: true,
   autoSessionTracking: false,

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -39,20 +39,20 @@ const EXPECTED_ANR_EVENT = {
         mechanism: { type: 'ANR' },
         stacktrace: {
           frames: expect.arrayContaining([
-            {
+            expect.objectContaining({
               colno: expect.any(Number),
               lineno: expect.any(Number),
               filename: expect.any(String),
               function: '?',
               in_app: true,
-            },
-            {
+            }),
+            expect.objectContaining({
               colno: expect.any(Number),
               lineno: expect.any(Number),
               filename: expect.any(String),
               function: 'longWork',
               in_app: true,
-            },
+            }),
           ]),
         },
       },
@@ -82,7 +82,7 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
   });
 
   test('should exit', done => {
-    const runner = createRunner(__dirname, 'should-exit.js').start();
+    const runner = createRunner(__dirname, 'should-exit.js').withMockSentryServer().start();
 
     setTimeout(() => {
       expect(runner.childHasExited()).toBe(true);
@@ -91,7 +91,7 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
   });
 
   test('should exit forced', done => {
-    const runner = createRunner(__dirname, 'should-exit-forced.js').start();
+    const runner = createRunner(__dirname, 'should-exit-forced.js').withMockSentryServer().start();
 
     setTimeout(() => {
       expect(runner.childHasExited()).toBe(true);
@@ -113,11 +113,14 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
   });
 
   test('from forked process', done => {
-    createRunner(__dirname, 'forker.js').expect({ event: EXPECTED_ANR_EVENT }).start(done);
+    createRunner(__dirname, 'forker.js').withMockSentryServer().expect({ event: EXPECTED_ANR_EVENT }).start(done);
   });
 
   test('worker can be stopped and restarted', done => {
-    createRunner(__dirname, 'stop-and-start.js').expect({ event: EXPECTED_ANR_EVENT }).start(done);
+    createRunner(__dirname, 'stop-and-start.js')
+      .withMockSentryServer()
+      .expect({ event: EXPECTED_ANR_EVENT })
+      .start(done);
   });
 
   const EXPECTED_ISOLATED_EVENT = {
@@ -132,13 +135,13 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
           mechanism: { type: 'ANR' },
           stacktrace: {
             frames: expect.arrayContaining([
-              {
+              expect.objectContaining({
                 colno: expect.any(Number),
                 lineno: expect.any(Number),
                 filename: expect.stringMatching(/isolated.mjs$/),
                 function: 'longWork',
                 in_app: true,
-              },
+              }),
             ]),
           },
         },

--- a/packages/node/src/integrations/anr/common.ts
+++ b/packages/node/src/integrations/anr/common.ts
@@ -1,4 +1,4 @@
-import type { Contexts, DsnComponents, Primitive, SdkMetadata } from '@sentry/types';
+import type { Primitive } from '@sentry/types';
 
 export interface AnrIntegrationOptions {
   /**
@@ -14,14 +14,6 @@ export interface AnrIntegrationOptions {
    */
   anrThreshold: number;
   /**
-   * Whether to capture a stack trace when the ANR event is triggered.
-   *
-   * Defaults to `false`.
-   *
-   * This uses the node debugger which enables the inspector API and opens the required ports.
-   */
-  captureStackTrace: boolean;
-  /**
    * Tags to include with ANR events.
    */
   staticTags: { [key: string]: Primitive };
@@ -35,11 +27,4 @@ export interface AnrIntegrationOptions {
 
 export interface WorkerStartData extends AnrIntegrationOptions {
   debug: boolean;
-  sdkMetadata: SdkMetadata;
-  dsn: DsnComponents;
-  tunnel: string | undefined;
-  release: string | undefined;
-  environment: string;
-  dist: string | undefined;
-  contexts: Contexts;
 }

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -17,7 +17,7 @@ function log(message: string, ...args: unknown[]): void {
 }
 
 function globalWithScopeFetchFn(): typeof GLOBAL_OBJ & {
-  __SENTRY_SEND_ANR__?: (frames: StackFrame[]) => Promise<void>;
+  __SENTRY_SEND_ANR__?: (frames: StackFrame[]) => void;
 } {
   return GLOBAL_OBJ;
 }
@@ -64,7 +64,7 @@ const _anrIntegration = ((integrationOptions: Partial<AnrIntegrationOptions> = {
     return strippedFrames;
   }
 
-  async function sendAnrEvent(frames?: StackFrame[]): Promise<void> {
+  function sendAnrEvent(frames?: StackFrame[]): void {
     const session = getIsolationScope().getSession();
     if (session) {
       log('Sending abnormal session');

--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -51,11 +51,9 @@ session.on('Debugger.paused', event => {
       'Runtime.evaluate',
       {
         // Send the stack frames to the main thread to be sent by the SDK
-        expression: `await global.__SENTRY_SEND_ANR__(${JSON.stringify(stackFrames)});`,
+        expression: `global.__SENTRY_SEND_ANR__(${JSON.stringify(stackFrames)});`,
         // Don't re-trigger the debugger if this causes an error
         silent: true,
-        // Serialize the result to json otherwise only primitives are supported
-        returnByValue: true,
       },
       err => {
         if (err) {


### PR DESCRIPTION
This PR modifies the ANR integration to send ANR events from the main thread via the debugger interface.

### Negatives
- `captureStackTrace` option is removed as it's we require the debugger to send the events to the main thread. ANR without stack traces are not very actionable anyway [BREAKING!]

### Positives
- Minified ANR worker code goes from 42KB to 4KB
- Events now include context lines and more up-to-date context
- Dedupe/`beforeSend` now work

### Still TODO
- Test that events are still sent if the event loop is blocked indefinitely! 