### PR TITLE
feat(v7/types): Deprecate `Hub` interface

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -115,6 +115,7 @@ export interface Carrier {
  * themselves and will also be removed in version 8. More information:
  * - [Migration Guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub)
  */
+// eslint-disable-next-line deprecation/deprecation
 export class Hub implements HubInterface {
   /** Is a {@link Layer}[] containing the client and scope */
   private readonly _stack: Layer[];

--- a/packages/core/src/utils/isSentryRequestUrl.ts
+++ b/packages/core/src/utils/isSentryRequestUrl.ts
@@ -6,6 +6,7 @@ import type { Client, DsnComponents, Hub } from '@sentry/types';
  *
  * TODO(v8): Remove Hub fallback type
  */
+// eslint-disable-next-line deprecation/deprecation
 export function isSentryRequestUrl(url: string, hubOrClient: Hub | Client | undefined): boolean {
   const client =
     hubOrClient && isHub(hubOrClient)
@@ -34,6 +35,7 @@ function removeTrailingSlash(str: string): string {
   return str[str.length - 1] === '/' ? str.slice(0, -1) : str;
 }
 
+// eslint-disable-next-line deprecation/deprecation
 function isHub(hubOrClient: Hub | Client | undefined): hubOrClient is Hub {
   // eslint-disable-next-line deprecation/deprecation
   return (hubOrClient as Hub).getClient !== undefined;

--- a/packages/core/test/lib/utils/isSentryRequestUrl.test.ts
+++ b/packages/core/test/lib/utils/isSentryRequestUrl.test.ts
@@ -21,6 +21,7 @@ describe('isSentryRequestUrl', () => {
       getClient: () => {
         return client;
       },
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     // Works with hub passed

--- a/packages/integrations/test/reportingobserver.test.ts
+++ b/packages/integrations/test/reportingobserver.test.ts
@@ -14,6 +14,7 @@ const withScope = jest.fn(callback => {
 
 const captureMessage = jest.fn();
 
+// eslint-disable-next-line deprecation/deprecation
 const mockHub = {} as unknown as Hub;
 
 const mockReportingObserverConstructor = jest.fn();

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -173,6 +173,7 @@ export class Http implements Integration {
   /**
    * @inheritDoc
    */
+  // eslint-disable-next-line deprecation/deprecation
   public setupOnce(_addGlobalEventProcessor: (callback: EventProcessor) => void, _getCurrentHub: () => Hub): void {
     // No need to instrument if we don't want to track anything
     if (!this._breadcrumbs && this._spans === false) {

--- a/packages/node-experimental/src/sdk/globals.ts
+++ b/packages/node-experimental/src/sdk/globals.ts
@@ -27,7 +27,7 @@ export function getGlobalCarrier(): SentryCarrier {
  * Calls global extension method and binding current instance to the function call
  */
 // @ts-expect-error Function lacks ending return statement and return type does not include 'undefined'. ts(2366)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any,deprecation/deprecation
 export function callExtensionMethod<T>(hub: Hub, method: string, ...args: any[]): T {
   const carrier = getGlobalCarrier();
 

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -40,6 +40,7 @@ export function setupGlobalHub(): void {
 /**
  * This is for legacy reasons, and returns a proxy object instead of a hub to be used.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function getCurrentHub(): Hub {
   return {
     isOlderThan(_version: number): boolean {
@@ -88,6 +89,7 @@ export function getCurrentHub(): Hub {
     // eslint-disable-next-line deprecation/deprecation
     configureScope: configureScope,
 
+    // eslint-disable-next-line deprecation/deprecation
     run(callback: (hub: Hub) => void): void {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return withScope(() => callback(this as any));
@@ -142,6 +144,7 @@ export function getCurrentHub(): Hub {
  *
  * @returns The old replaced hub
  */
+// eslint-disable-next-line deprecation/deprecation
 export function makeMain(hub: Hub): Hub {
   // eslint-disable-next-line no-console
   console.warn('makeMain is a noop in @sentry/node-experimental. Use `setCurrentClient` instead.');

--- a/packages/node-experimental/src/sdk/types.ts
+++ b/packages/node-experimental/src/sdk/types.ts
@@ -54,6 +54,7 @@ export interface AsyncContextStrategy {
   getScopes: () => CurrentScopes | undefined;
 
   /** This is here for legacy reasons. */
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub: () => Hub;
 
   /**
@@ -67,6 +68,7 @@ export interface SentryCarrier {
   acs?: AsyncContextStrategy;
 
   // hub is here for legacy reasons
+  // eslint-disable-next-line deprecation/deprecation
   hub?: Hub;
 
   extensions?: {

--- a/packages/node/test/eventbuilders.test.ts
+++ b/packages/node/test/eventbuilders.test.ts
@@ -69,6 +69,7 @@ describe('eventFromUnknownInput', () => {
             return { normalizeDepth: 6 };
           },
         }),
+        // eslint-disable-next-line deprecation/deprecation
       } as unknown as Hub;
     });
 

--- a/packages/opentelemetry-node/src/utils/captureExceptionForTimedEvent.ts
+++ b/packages/opentelemetry-node/src/utils/captureExceptionForTimedEvent.ts
@@ -7,6 +7,7 @@ import { isString } from '@sentry/utils';
  * Maybe capture a Sentry exception for an OTEL timed event.
  * This will check if the event is exception-like and in that case capture it as an exception.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function maybeCaptureExceptionForTimedEvent(hub: Hub, event: TimedEvent, otelSpan?: OtelSpan): void {
   if (event.name !== 'exception') {
     return;

--- a/packages/opentelemetry-node/test/utils/captureExceptionForTimedEvent.test.ts
+++ b/packages/opentelemetry-node/test/utils/captureExceptionForTimedEvent.test.ts
@@ -14,6 +14,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event);
@@ -30,6 +31,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event);
@@ -49,6 +51,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event);
@@ -76,6 +79,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event);
@@ -119,6 +123,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event, span);

--- a/packages/opentelemetry/src/custom/transaction.ts
+++ b/packages/opentelemetry/src/custom/transaction.ts
@@ -7,6 +7,7 @@ import { uuid4 } from '@sentry/utils';
  * This is a fork of core's tracing/hubextensions.ts _startTransaction,
  * with some OTEL specifics.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function startTransaction(hub: HubInterface, transactionContext: TransactionContext): Transaction {
   // eslint-disable-next-line deprecation/deprecation
   const client = hub.getClient();

--- a/packages/opentelemetry/src/utils/captureExceptionForTimedEvent.ts
+++ b/packages/opentelemetry/src/utils/captureExceptionForTimedEvent.ts
@@ -7,6 +7,7 @@ import { isString } from '@sentry/utils';
  * Maybe capture a Sentry exception for an OTEL timed event.
  * This will check if the event is exception-like and in that case capture it as an exception.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function maybeCaptureExceptionForTimedEvent(hub: Hub, event: TimedEvent, otelSpan?: OtelSpan): void {
   if (event.name !== 'exception') {
     return;

--- a/packages/opentelemetry/src/utils/contextData.ts
+++ b/packages/opentelemetry/src/utils/contextData.ts
@@ -23,7 +23,9 @@ export function setPropagationContextOnContext(context: Context, propagationCont
  * Try to get the Hub from the given OTEL context.
  * This requires a Context Manager that was wrapped with getWrappedContextManager.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function getHubFromContext(context: Context): Hub | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return context.getValue(SENTRY_HUB_CONTEXT_KEY) as Hub | undefined;
 }
 
@@ -31,6 +33,7 @@ export function getHubFromContext(context: Context): Hub | undefined {
  * Set a Hub on an OTEL context..
  * This will return a forked context with the Propagation Context set.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function setHubOnContext(context: Context, hub: Hub): Context {
   return context.setValue(SENTRY_HUB_CONTEXT_KEY, hub);
 }

--- a/packages/opentelemetry/src/utils/spanData.ts
+++ b/packages/opentelemetry/src/utils/spanData.ts
@@ -8,6 +8,7 @@ import type { AbstractSpan } from '../types';
 // and since we are using weakmaps, we do not need to clean up after ourselves
 const SpanScope = new WeakMap<AbstractSpan, Scope>();
 const SpanFinishScope = new WeakMap<AbstractSpan, Scope>();
+// eslint-disable-next-line deprecation/deprecation
 const SpanHub = new WeakMap<AbstractSpan, Hub>();
 const SpanParent = new WeakMap<AbstractSpan, Span>();
 const SpanMetadata = new WeakMap<AbstractSpan, Partial<TransactionMetadata>>();
@@ -23,11 +24,13 @@ export function getSpanScope(span: AbstractSpan): Scope | undefined {
 }
 
 /** Set the Sentry hub on an OTEL span. */
+// eslint-disable-next-line deprecation/deprecation
 export function setSpanHub(span: AbstractSpan, hub: Hub): void {
   SpanHub.set(span, hub);
 }
 
 /** Get the Sentry hub of an OTEL span. */
+// eslint-disable-next-line deprecation/deprecation
 export function getSpanHub(span: AbstractSpan): Hub | undefined {
   return SpanHub.get(span);
 }

--- a/packages/opentelemetry/test/utils/captureExceptionForTimedEvent.test.ts
+++ b/packages/opentelemetry/test/utils/captureExceptionForTimedEvent.test.ts
@@ -14,6 +14,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event);
@@ -30,6 +31,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event);
@@ -49,6 +51,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event);
@@ -76,6 +79,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event);
@@ -119,6 +123,7 @@ describe('maybeCaptureExceptionForTimedEvent', () => {
     const captureException = jest.fn();
     const hub = {
       captureException,
+      // eslint-disable-next-line deprecation/deprecation
     } as unknown as Hub;
 
     maybeCaptureExceptionForTimedEvent(hub, event, span);

--- a/packages/profiling-node/src/hubextensions.ts
+++ b/packages/profiling-node/src/hubextensions.ts
@@ -10,6 +10,7 @@ import { isValidSampleRate } from './utils';
 export const MAX_PROFILE_DURATION_MS = 30 * 1000;
 
 type StartTransaction = (
+  // eslint-disable-next-line deprecation/deprecation
   this: Hub,
   transactionContext: TransactionContext,
   customSamplingContext?: CustomSamplingContext,
@@ -142,6 +143,7 @@ export function stopTransactionProfile(
  */
 export function __PRIVATE__wrapStartTransactionWithProfiling(startTransaction: StartTransaction): StartTransaction {
   return function wrappedStartTransaction(
+    // eslint-disable-next-line deprecation/deprecation
     this: Hub,
     transactionContext: TransactionContext,
     customSamplingContext?: CustomSamplingContext,

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -55,6 +55,7 @@ export class ProfilingIntegration implements Integration {
    * @inheritDoc
    */
   public readonly name: string;
+  // eslint-disable-next-line deprecation/deprecation
   public getCurrentHub?: () => Hub;
 
   public constructor() {
@@ -64,6 +65,7 @@ export class ProfilingIntegration implements Integration {
   /**
    * @inheritDoc
    */
+  // eslint-disable-next-line deprecation/deprecation
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     this.getCurrentHub = getCurrentHub;
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/profiling-node/test/hubextensions.test.ts
+++ b/packages/profiling-node/test/hubextensions.test.ts
@@ -47,6 +47,7 @@ function makeHubMock({
 }: {
   profilesSampleRate: number | undefined;
   client?: Partial<NodeClient>;
+  // eslint-disable-next-line deprecation/deprecation
 }): Hub {
   return {
     getClient: jest.fn().mockImplementation(() => {
@@ -59,6 +60,7 @@ function makeHubMock({
         ...(client ?? {}),
       };
     }),
+    // eslint-disable-next-line deprecation/deprecation
   } as unknown as Hub;
 }
 

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -71,6 +71,7 @@ describe('ProfilingIntegration', () => {
       // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
+      // eslint-disable-next-line deprecation/deprecation
       const getCurrentHub = jest.fn((): Hub => {
         return {
           getClient: () => {
@@ -86,6 +87,7 @@ describe('ProfilingIntegration', () => {
               getTransport: () => transport,
             };
           },
+          // eslint-disable-next-line deprecation/deprecation
         } as Hub;
       });
       const addGlobalEventProcessor = () => void 0;
@@ -106,7 +108,9 @@ describe('ProfilingIntegration', () => {
       // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
+      // eslint-disable-next-line deprecation/deprecation
       const getCurrentHub = jest.fn((): Hub => {
+        // eslint-disable-next-line deprecation/deprecation
         return { getClient: () => undefined } as Hub;
       });
       const addGlobalEventProcessor = () => void 0;
@@ -122,6 +126,7 @@ describe('ProfilingIntegration', () => {
       // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
+      // eslint-disable-next-line deprecation/deprecation
       const getCurrentHub = jest.fn((): Hub => {
         return {
           getClient: () => {
@@ -129,6 +134,7 @@ describe('ProfilingIntegration', () => {
               getDsn: () => undefined,
             };
           },
+          // eslint-disable-next-line deprecation/deprecation
         } as Hub;
       });
       const addGlobalEventProcessor = () => void 0;
@@ -144,6 +150,7 @@ describe('ProfilingIntegration', () => {
       // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
+      // eslint-disable-next-line deprecation/deprecation
       const getCurrentHub = jest.fn((): Hub => {
         return {
           getClient: () => {
@@ -154,6 +161,7 @@ describe('ProfilingIntegration', () => {
               getTransport: () => undefined,
             };
           },
+          // eslint-disable-next-line deprecation/deprecation
         } as Hub;
       });
       const addGlobalEventProcessor = () => void 0;
@@ -174,6 +182,7 @@ describe('ProfilingIntegration', () => {
       // eslint-disable-next-line deprecation/deprecation
       const integration = new ProfilingIntegration();
 
+      // eslint-disable-next-line deprecation/deprecation
       const getCurrentHub = jest.fn((): Hub => {
         return {
           getClient: () => {
@@ -189,6 +198,7 @@ describe('ProfilingIntegration', () => {
               getTransport: () => transport,
             };
           },
+          // eslint-disable-next-line deprecation/deprecation
         } as Hub;
       });
       const addGlobalEventProcessor = () => void 0;
@@ -209,6 +219,7 @@ describe('ProfilingIntegration', () => {
       const integration = new ProfilingIntegration();
       const emitter = new EventEmitter();
 
+      // eslint-disable-next-line deprecation/deprecation
       const getCurrentHub = jest.fn((): Hub => {
         return {
           getClient: () => {
@@ -226,6 +237,7 @@ describe('ProfilingIntegration', () => {
               getTransport: () => transport,
             } as any;
           },
+          // eslint-disable-next-line deprecation/deprecation
         } as Hub;
       });
 
@@ -245,6 +257,7 @@ describe('ProfilingIntegration', () => {
       const integration = new ProfilingIntegration();
       const emitter = new EventEmitter();
 
+      // eslint-disable-next-line deprecation/deprecation
       const getCurrentHub = jest.fn((): Hub => {
         return {
           getClient: () => {
@@ -262,6 +275,7 @@ describe('ProfilingIntegration', () => {
               getTransport: () => transport,
             } as any;
           },
+          // eslint-disable-next-line deprecation/deprecation
         } as Hub;
       });
 

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -119,6 +119,7 @@ export class Express implements Integration {
   /**
    * @inheritDoc
    */
+  // eslint-disable-next-line deprecation/deprecation
   public setupOnce(_: unknown, getCurrentHub: () => Hub): void {
     if (!this._router) {
       DEBUG_BUILD && logger.error('ExpressIntegration is missing an Express instance');

--- a/packages/tracing-internal/src/node/integrations/utils/node-utils.ts
+++ b/packages/tracing-internal/src/node/integrations/utils/node-utils.ts
@@ -6,6 +6,7 @@ import type { Hub } from '@sentry/types';
  * @param getCurrentHub A method to fetch the current hub
  * @returns boolean
  */
+// eslint-disable-next-line deprecation/deprecation
 export function shouldDisableAutoInstrumentation(getCurrentHub: () => Hub): boolean {
   // eslint-disable-next-line deprecation/deprecation
   const clientOptions = getCurrentHub().getClient()?.getOptions();

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -13,6 +13,12 @@ import type { User } from './user';
 /**
  * Internal class used to make sure we always have the latest internal functions
  * working in case we have a version conflict.
+ *
+ * @deprecated The `Hub` interface will be removed in a future major version of the SDK in favour of
+ * `Scope` and `Client` objects and APIs.
+ *
+ * Most APIs referencing `Hub` are themselves and will be removed in version 8 of the SDK. More information:
+ * - [Migration Guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub)
  */
 export interface Hub {
   /**
@@ -226,6 +232,7 @@ export interface Hub {
    *
    * TODO v8: This will be merged with `withScope()`
    */
+  // eslint-disable-next-line deprecation/deprecation
   run(callback: (hub: Hub) => void): void;
 
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -53,6 +53,7 @@ export type { Event, EventHint, EventType, ErrorEvent, TransactionEvent, Seriali
 export type { EventProcessor } from './eventprocessor';
 export type { Exception } from './exception';
 export type { Extra, Extras } from './extra';
+// eslint-disable-next-line deprecation/deprecation
 export type { Hub } from './hub';
 export type { Integration, IntegrationClass, IntegrationFn, IntegrationFnResult } from './integration';
 export type { Mechanism } from './mechanism';
@@ -153,9 +154,5 @@ export type {
 
 export type { BrowserClientReplayOptions, BrowserClientProfilingOptions } from './browseroptions';
 export type { CheckIn, MonitorConfig, FinishedCheckIn, InProgressCheckIn, SerializedCheckIn } from './checkin';
-export type {
-  MetricsAggregator,
-  MetricBucketItem,
-  MetricInstance,
-} from './metrics';
+export type { MetricsAggregator, MetricBucketItem, MetricInstance } from './metrics';
 export type { ParameterizedString } from './parameterize';

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -77,6 +77,7 @@ export interface Integration {
    *
    * NOTE: In v8, this will become optional, and not receive any arguments anymore.
    */
+  // eslint-disable-next-line deprecation/deprecation
   setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void;
 
   /**

--- a/packages/utils/src/eventbuilder.ts
+++ b/packages/utils/src/eventbuilder.ts
@@ -69,6 +69,7 @@ function getMessageForObject(exception: object): string {
  * @hidden
  */
 export function eventFromUnknownInput(
+  // eslint-disable-next-line deprecation/deprecation
   getHubOrClient: (() => Hub) | Client | undefined,
   stackParser: StackParser,
   exception: unknown,

--- a/packages/utils/test/eventbuilder.test.ts
+++ b/packages/utils/test/eventbuilder.test.ts
@@ -2,6 +2,7 @@ import type { Hub, Scope } from '@sentry/types';
 
 import { createStackParser, eventFromUnknownInput, nodeStackLineParser } from '../src';
 
+// eslint-disable-next-line deprecation/deprecation
 function getCurrentHub(): Hub {
   // Some fake hub to get us through
   return {
@@ -11,6 +12,7 @@ function getCurrentHub(): Hub {
         setExtra: () => {},
       } as unknown as Scope;
     },
+    // eslint-disable-next-line deprecation/deprecation
   } as unknown as Hub;
 }
 


### PR DESCRIPTION
This PR deprecates the `Hub` interface as a continuation of #11528 where we deprecated the Hub class.

The difference here is that the interface will stay deprecated throughout v8 so that we can shim the infamous `getCurrentHub` API. Most other usages of the interface should already be removed in v8/`develop` 🤞  

ref #11482 