### PR TITLE
feat(node): Do not exit process by default when other `onUncaughtException` handlers are registered in `onUncaughtExceptionIntegration`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1118,6 +1118,7 @@ Sentry.init({
 - [Updated behaviour of `extraErrorDataIntegration`](./MIGRATION.md#extraerrordataintegration-changes)
 - [Updated behaviour of `transactionContext` passed to `tracesSampler`](./MIGRATION.md#transactioncontext-no-longer-passed-to-tracessampler)
 - [Updated behaviour of `getClient()`](./MIGRATION.md#getclient-always-returns-a-client)
+- [Updated behaviour of the SDK in combination with `onUncaughtException` handlers in Node.js](./MIGRATION.md#behaviour-in-combination-with-onuncaughtexception-handlers-in-node.js)
 - [Removal of Client-Side health check transaction filters](./MIGRATION.md#removal-of-client-side-health-check-transaction-filters)
 - [Change of Replay default options (`unblock` and `unmask`)](./MIGRATION.md#change-of-replay-default-options-unblock-and-unmask)
 - [Angular Tracing Decorator renaming](./MIGRATION.md#angular-tracing-decorator-renaming)
@@ -1167,6 +1168,16 @@ some attributes may only be set later during the span lifecycle (and thus not be
 `getClient()` now always returns a client if `Sentry.init()` was called. For cases where this may be used to check if
 Sentry was actually initialized, using `getClient()` will thus not work anymore. Instead, you should use the new
 `Sentry.isInitialized()` utility to check this.
+
+#### Behaviour in combination with `onUncaughtException` handlers in Node.js
+
+Previously the SDK exited the process by default, even though additional `onUncaughtException` may have been registered,
+that would have prevented the process from exiting. You could opt out of this behaviour by setting the
+`exitEvenIfOtherHandlersAreRegistered: false` in the `onUncaughtExceptionIntegration` options. Up until now the value
+for this option defaulted to `true`.
+
+Going forward, the default value for `exitEvenIfOtherHandlersAreRegistered` will be `false`, meaning that the SDK will
+not exit your process when you have registered other `onUncaughtException` handlers.
 
 #### Removal of Client-Side health check transaction filters
 

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -15,15 +15,14 @@ describe('OnUncaughtException integration', () => {
     });
   });
 
-  test('should close process on uncaught error when additional listeners are registered', done => {
-    expect.assertions(3);
+  test('should not close process on uncaught error when additional listeners are registered', done => {
+    expect.assertions(2);
 
     const testScriptPath = path.resolve(__dirname, 'additional-listener-test-script.js');
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
-      expect(err).not.toBeNull();
-      expect(err?.code).toBe(1);
-      expect(stdout).not.toBe("I'm alive!");
+      expect(err).toBeNull();
+      expect(stdout).toBe("I'm alive!");
       done();
     });
   });

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -8,14 +8,12 @@ import { devErrorSymbolicationEventProcessor } from '../common/devErrorSymbolica
 import { getVercelEnv } from '../common/getVercelEnv';
 import { isBuild } from '../common/utils/isBuild';
 import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegration';
-import { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration';
 
 export * from '@sentry/node';
 import type { EventProcessor } from '@sentry/types';
 import { requestIsolationScopeIntegration } from './requestIsolationScopeIntegration';
 
 export { captureUnderscoreErrorException } from '../common/_error';
-export { onUncaughtExceptionIntegration } from './onUncaughtExceptionIntegration';
 
 const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   __rewriteFramesDistDir__?: string;
@@ -75,13 +73,11 @@ export function init(options: NodeOptions): void {
   const customDefaultIntegrations = [
     ...getDefaultIntegrations(options).filter(
       integration =>
-        integration.name !== 'OnUncaughtException' &&
         // Next.js comes with its own Node-Fetch instrumentation, so we shouldn't add ours on-top
         integration.name !== 'NodeFetch' &&
         // Next.js comes with its own Http instrumentation for OTel which lead to double spans for route handler requests
         integration.name !== 'Http',
     ),
-    onUncaughtExceptionIntegration(),
     requestIsolationScopeIntegration(),
   ];
 

--- a/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
+++ b/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
@@ -1,5 +1,0 @@
-import { onUncaughtExceptionIntegration as originalOnUncaughtExceptionIntegration } from '@sentry/node';
-
-export const onUncaughtExceptionIntegration: typeof originalOnUncaughtExceptionIntegration = options => {
-  return originalOnUncaughtExceptionIntegration({ ...options, exitEvenIfOtherHandlersAreRegistered: false });
-};


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/1661
Ref: https://github.com/getsentry/sentry-javascript/issues/6146

This PR sets the default for the `exitEvenIfOtherHandlersAreRegistered` option of the `onUncaughtExceptionIntegration` to `false`. Effectively this means that going forward, by default, Sentry will not try to exit the process when there are other `onUncaughtException` handlers attached.

In the Next.js SDK we needed to override the option for this integration to `false`, so now it will be in line with the global default.