### PR TITLE
feat(tracing): Adds span envelope and datacategory

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export {
 export { applyScopeDataToEvent, mergeScopeData } from './utils/applyScopeDataToEvent';
 export { prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';
+export { createSpanEnvelope } from './span';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';
 export { isSentryRequestUrl } from './utils/isSentryRequestUrl';
 export { handleCallbackErrors } from './utils/handleCallbackErrors';

--- a/packages/core/src/span.ts
+++ b/packages/core/src/span.ts
@@ -1,0 +1,22 @@
+import type { SpanEnvelope, SpanItem } from '@sentry/types';
+import type { Span } from '@sentry/types';
+import { createEnvelope } from '@sentry/utils';
+
+/**
+ * Create envelope from Span item.
+ */
+export function createSpanEnvelope(spans: Span[]): SpanEnvelope {
+  const headers: SpanEnvelope[0] = {
+    sent_at: new Date().toISOString(),
+  };
+
+  const items = spans.map(createSpanItem);
+  return createEnvelope<SpanEnvelope>(headers, items);
+}
+
+function createSpanItem(span: Span): SpanItem {
+  const spanHeaders: SpanItem[0] = {
+    type: 'span',
+  };
+  return [spanHeaders, span];
+}

--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -29,4 +29,6 @@ export type DataCategory =
   // Statsd type event for metrics
   | 'statsd'
   // Unknown data category
-  | 'unknown';
+  | 'unknown'
+  // Span
+  | 'span';

--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -28,7 +28,7 @@ export type DataCategory =
   | 'feedback'
   // Statsd type event for metrics
   | 'statsd'
-  // Unknown data category
-  | 'unknown'
   // Span
-  | 'span';
+  | 'span'
+  // Unknown data category
+  | 'unknown';

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -8,6 +8,7 @@ import type { Profile } from './profiling';
 import type { ReplayEvent, ReplayRecordingData } from './replay';
 import type { SdkInfo } from './sdkinfo';
 import type { SerializedSession, Session, SessionAggregates } from './session';
+import type { Span } from './span';
 
 // Based on: https://develop.sentry.dev/sdk/envelopes/
 
@@ -36,7 +37,8 @@ export type EnvelopeItemType =
   | 'replay_event'
   | 'replay_recording'
   | 'check_in'
-  | 'statsd';
+  | 'statsd'
+  | 'span';
 
 export type BaseEnvelopeHeaders = {
   [key: string]: unknown;
@@ -77,6 +79,7 @@ type ReplayRecordingItemHeaders = { type: 'replay_recording'; length: number };
 type CheckInItemHeaders = { type: 'check_in' };
 type StatsdItemHeaders = { type: 'statsd'; length: number };
 type ProfileItemHeaders = { type: 'profile' };
+type SpanItemHeaders = { type: 'span' };
 
 // TODO (v8): Replace `Event` with `SerializedEvent`
 export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event>;
@@ -93,6 +96,7 @@ type ReplayRecordingItem = BaseEnvelopeItem<ReplayRecordingItemHeaders, ReplayRe
 export type StatsdItem = BaseEnvelopeItem<StatsdItemHeaders, string>;
 export type FeedbackItem = BaseEnvelopeItem<FeedbackItemHeaders, FeedbackEvent>;
 export type ProfileItem = BaseEnvelopeItem<ProfileItemHeaders, Profile>;
+export type SpanItem = BaseEnvelopeItem<SpanItemHeaders, Span>;
 
 export type EventEnvelopeHeaders = { event_id: string; sent_at: string; trace?: DynamicSamplingContext };
 type SessionEnvelopeHeaders = { sent_at: string };
@@ -100,6 +104,7 @@ type CheckInEnvelopeHeaders = { trace?: DynamicSamplingContext };
 type ClientReportEnvelopeHeaders = BaseEnvelopeHeaders;
 type ReplayEnvelopeHeaders = BaseEnvelopeHeaders;
 type StatsdEnvelopeHeaders = BaseEnvelopeHeaders;
+type SpanEnvelopeHeaders = BaseEnvelopeHeaders;
 
 export type EventEnvelope = BaseEnvelope<
   EventEnvelopeHeaders,
@@ -110,6 +115,7 @@ export type ClientReportEnvelope = BaseEnvelope<ClientReportEnvelopeHeaders, Cli
 export type ReplayEnvelope = [ReplayEnvelopeHeaders, [ReplayEventItem, ReplayRecordingItem]];
 export type CheckInEnvelope = BaseEnvelope<CheckInEnvelopeHeaders, CheckInItem>;
 export type StatsdEnvelope = BaseEnvelope<StatsdEnvelopeHeaders, StatsdItem>;
+export type SpanEnvelope = BaseEnvelope<SpanEnvelopeHeaders, SpanItem>;
 
 export type Envelope =
   | EventEnvelope
@@ -117,5 +123,6 @@ export type Envelope =
   | ClientReportEnvelope
   | ReplayEnvelope
   | CheckInEnvelope
-  | StatsdEnvelope;
+  | StatsdEnvelope
+  | SpanEnvelope;
 export type EnvelopeItem = Envelope[1][number];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -45,6 +45,8 @@ export type {
   StatsdItem,
   StatsdEnvelope,
   ProfileItem,
+  SpanEnvelope,
+  SpanItem,
 } from './envelope';
 export type { ExtendedError } from './error';
 export type { Event, EventHint, EventType, ErrorEvent, TransactionEvent } from './event';

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -208,7 +208,9 @@ const ITEM_TYPE_TO_DATA_CATEGORY_MAP: Record<EnvelopeItemType, DataCategory> = {
   replay_recording: 'replay',
   check_in: 'monitor',
   feedback: 'feedback',
-  statsd: 'statsd',
+  span: 'span',
+  // TODO: This is a temporary workaround until we have a proper data category for metrics
+  statsd: 'unknown',
 };
 
 /**


### PR DESCRIPTION
Adds span envelopes and datacategory. For use with standalone inp spans

Forward port of https://github.com/getsentry/sentry-javascript/pull/10706