### PR TITLE
feat(core): Remove most Hub class exports

### DIFF
--- a/dev-packages/browser-integration-tests/suites/manual-client/browser-context/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/browser-context/init.js
@@ -1,6 +1,6 @@
 import {
   BrowserClient,
-  Hub,
+  Scope,
   breadcrumbsIntegration,
   dedupeIntegration,
   defaultStackParser,
@@ -31,6 +31,9 @@ const client = new BrowserClient({
   integrations,
 });
 
-const hub = new Hub(client);
+const scope = new Scope();
+scope.setClient(client);
 
-hub.captureException(new Error('test client'));
+client.init();
+
+scope.captureException(new Error('test client'));

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -23,7 +23,6 @@ export {
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  Hub,
   setCurrentClient,
   Scope,
   SDK_VERSION,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -18,7 +18,6 @@ export {
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  Hub,
   setCurrentClient,
   Scope,
   SDK_VERSION,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -35,7 +35,6 @@ export {
   getCurrentScope,
   getIsolationScope,
   getGlobalScope,
-  Hub,
   setCurrentClient,
   Scope,
   continueTrace,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -37,7 +37,6 @@ export {
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  Hub,
   setCurrentClient,
   Scope,
   SDK_VERSION,

--- a/packages/core/src/asyncContext.ts
+++ b/packages/core/src/asyncContext.ts
@@ -13,6 +13,7 @@ export interface AsyncContextStrategy {
   /**
    * Gets the currently active hub.
    */
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub: () => Hub;
 
   /**

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -19,7 +19,6 @@ import { GLOBAL_OBJ, isThenable, logger, timestampInSeconds, uuid4 } from '@sent
 import { DEFAULT_ENVIRONMENT } from './constants';
 import { getClient, getCurrentScope, getIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
-import type { Hub } from './hub';
 import { closeSession, makeSession, updateSession } from './session';
 import type { ExclusiveEventHintOrCaptureContext } from './utils/prepareEvent';
 import { parseEventHintOrCaptureContext } from './utils/prepareEvent';
@@ -71,7 +70,7 @@ export function captureEvent(event: Event, hint?: EventHint): string {
  * @param context Any kind of data. This data will be normalized.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function setContext(name: string, context: { [key: string]: any } | null): ReturnType<Hub['setContext']> {
+export function setContext(name: string, context: { [key: string]: any } | null): void {
   getIsolationScope().setContext(name, context);
 }
 
@@ -79,7 +78,7 @@ export function setContext(name: string, context: { [key: string]: any } | null)
  * Set an object that will be merged sent as extra data with the event.
  * @param extras Extras object to merge into current context.
  */
-export function setExtras(extras: Extras): ReturnType<Hub['setExtras']> {
+export function setExtras(extras: Extras): void {
   getIsolationScope().setExtras(extras);
 }
 
@@ -88,7 +87,7 @@ export function setExtras(extras: Extras): ReturnType<Hub['setExtras']> {
  * @param key String of extra
  * @param extra Any kind of data. This data will be normalized.
  */
-export function setExtra(key: string, extra: Extra): ReturnType<Hub['setExtra']> {
+export function setExtra(key: string, extra: Extra): void {
   getIsolationScope().setExtra(key, extra);
 }
 
@@ -96,7 +95,7 @@ export function setExtra(key: string, extra: Extra): ReturnType<Hub['setExtra']>
  * Set an object that will be merged sent as tags data with the event.
  * @param tags Tags context object to merge into current context.
  */
-export function setTags(tags: { [key: string]: Primitive }): ReturnType<Hub['setTags']> {
+export function setTags(tags: { [key: string]: Primitive }): void {
   getIsolationScope().setTags(tags);
 }
 
@@ -108,7 +107,7 @@ export function setTags(tags: { [key: string]: Primitive }): ReturnType<Hub['set
  * @param key String key of tag
  * @param value Value of tag
  */
-export function setTag(key: string, value: Primitive): ReturnType<Hub['setTag']> {
+export function setTag(key: string, value: Primitive): void {
   getIsolationScope().setTag(key, value);
 }
 
@@ -117,7 +116,7 @@ export function setTag(key: string, value: Primitive): ReturnType<Hub['setTag']>
  *
  * @param user User context object to be set in the current context. Pass `null` to unset the user.
  */
-export function setUser(user: User | null): ReturnType<Hub['setUser']> {
+export function setUser(user: User | null): void {
   getIsolationScope().setUser(user);
 }
 

--- a/packages/core/src/getCurrentHubShim.ts
+++ b/packages/core/src/getCurrentHubShim.ts
@@ -16,8 +16,12 @@ import {
 /**
  * This is for legacy reasons, and returns a proxy object instead of a hub to be used.
  *
- * @deprecated Use the methods directly.
+ * @deprecated Use the methods directly from the top level Sentry API (e.g. `Sentry.withScope`)
+ * For more information see our migration guide for
+ * [replacing `getCurrentHub` and `Hub`](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub)
+ * usage
  */
+// eslint-disable-next-line deprecation/deprecation
 export function getCurrentHubShim(): Hub {
   return {
     bindClient(client: Client): void {

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -55,7 +55,9 @@ export interface Layer {
 
 /**
  * @inheritDoc
+ * @deprecated This class will be removed in v8 (tmp-deprecating so we're aware of where this is a problem)
  */
+// eslint-disable-next-line deprecation/deprecation
 export class Hub implements HubInterface {
   /** Is a {@link Layer}[] containing the client and scope */
   private readonly _stack: Layer[];
@@ -503,6 +505,7 @@ export class Hub implements HubInterface {
  *
  * @deprecated Use the respective replacement method directly instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function getCurrentHub(): HubInterface {
   // Get main carrier (global for every environment)
   const carrier = getMainCarrier();
@@ -525,8 +528,10 @@ export function getDefaultIsolationScope(): Scope {
  * Get the global hub.
  * This will be removed during the v8 cycle and is only here to make migration easier.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function getGlobalHub(): HubInterface {
   const registry = getMainCarrier();
+  // eslint-disable-next-line deprecation/deprecation
   const sentry = getSentryCarrier(registry) as { hub?: HubInterface };
 
   // If there's no hub, or its an old API, assign a new one
@@ -560,6 +565,7 @@ function withScope<T>(callback: (scope: ScopeInterface) => T): T {
 }
 
 function withSetScope<T>(scope: ScopeInterface, callback: (scope: ScopeInterface) => T): T {
+  // eslint-disable-next-line deprecation/deprecation
   const hub = getGlobalHub() as Hub;
   // eslint-disable-next-line deprecation/deprecation
   return hub.withScope(() => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export {
 export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
+  // eslint-disable-next-line deprecation/deprecation
   Hub,
   getGlobalHub,
   getDefaultCurrentScope,

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -55,6 +55,7 @@ export function setCurrentClient(client: Client): void {
   }
 }
 
+// eslint-disable-next-line deprecation/deprecation
 function isHubClass(hub: HubInterface): hub is Hub {
   // eslint-disable-next-line deprecation/deprecation
   return !!(hub as Hub).getStackTop;

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -34,7 +34,6 @@ export {
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  Hub,
   setCurrentClient,
   Scope,
   SDK_VERSION,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -18,7 +18,6 @@ export {
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  Hub,
   setCurrentClient,
   Scope,
   SDK_VERSION,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -48,7 +48,6 @@ export {
   close,
   createTransport,
   flush,
-  Hub,
   SDK_VERSION,
   getSpanStatusFromHttpCode,
   setHttpStatus,

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -40,6 +40,7 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     };
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   function getCurrentHub(): Hub {
     // eslint-disable-next-line deprecation/deprecation
     const hub = getCurrentHubShim();

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -25,7 +25,6 @@ export {
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  Hub,
   setCurrentClient,
   NodeClient,
   Scope,

--- a/packages/replay-internal/test/unit/session/createSession.test.ts
+++ b/packages/replay-internal/test/unit/session/createSession.test.ts
@@ -24,6 +24,7 @@ describe('Unit | session | createSession', () => {
     jest.spyOn(Sentry, 'getCurrentHub').mockImplementation(() => {
       return {
         captureEvent: captureEventMock,
+        // eslint-disable-next-line deprecation/deprecation
       } as unknown as Hub;
     });
   });

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -18,7 +18,6 @@ export {
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  Hub,
   NodeClient,
   setCurrentClient,
   Scope,

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -12,6 +12,13 @@ import type { User } from './user';
 /**
  * Internal class used to make sure we always have the latest internal functions
  * working in case we have a version conflict.
+ *
+ * @deprecated This interface will be removed in a future major version of the SDK in favour of
+ * `Scope` and `Client` objects and APIs.
+ *
+ * Most APIs referencing `Hub` are themselves and will be removed in version 8 of the SDK. More information:
+ * - [Migration Guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub)
+ *
  */
 export interface Hub {
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -53,6 +53,7 @@ export type { Event, EventHint, EventType, ErrorEvent, TransactionEvent } from '
 export type { EventProcessor } from './eventprocessor';
 export type { Exception } from './exception';
 export type { Extra, Extras } from './extra';
+// eslint-disable-next-line deprecation/deprecation
 export type { Hub } from './hub';
 export type { Integration, IntegrationClass, IntegrationFn } from './integration';
 export type { Mechanism } from './mechanism';

--- a/packages/vercel-edge/src/async.ts
+++ b/packages/vercel-edge/src/async.ts
@@ -51,6 +51,7 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     };
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   function getCurrentHub(): Hub {
     // eslint-disable-next-line deprecation/deprecation
     const hub = getCurrentHubShim();

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -34,7 +34,6 @@ export {
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
-  Hub,
   setCurrentClient,
   Scope,
   SDK_VERSION,


### PR DESCRIPTION
This PR removes top-level exports of the `Hub` class from all SDK packages. The only package that still exports it is core for now because we temporarily still need the class until we shimmed the return value of `getCurrentHub`. Decided to deprecate the class for now as well, to be aware of where we still use it.

Furthermore, this PR also deprecated the `Hub` interface. However, this interface will not be removed in v8 (prob v9) to keep support for `getCurrentHub` during the v8 life cycle. 

ref #11482 

