### PR TITLE
feat(core): Remove `Hub` class export

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,8 +32,6 @@ export {
 export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
-  // eslint-disable-next-line deprecation/deprecation
-  Hub,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
 } from './hub';

--- a/packages/replay-internal/test/unit/session/createSession.test.ts
+++ b/packages/replay-internal/test/unit/session/createSession.test.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/core';
-import type { Hub } from '@sentry/core';
 
+import type { Hub } from '@sentry/types';
 import { WINDOW } from '../../../src/constants';
 import { createSession } from '../../../src/session/createSession';
 import { saveSession } from '../../../src/session/saveSession';


### PR DESCRIPTION
This PR removes the last public export of the `Hub` class. Now that it's gone there are no more breaking changes (🤞). The class still remains in the package because it's still used internally for now but we can remove it (and shave off some well needed bytes) throught the v8 beta cycle.

actually thought this would be more work than just removing the export lol

ref #11482 