### PR TITLE
feat(core): Remove `getGlobalHub` export

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,7 +34,6 @@ export {
   getCurrentHub,
   // eslint-disable-next-line deprecation/deprecation
   Hub,
-  getGlobalHub,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
 } from './hub';


### PR DESCRIPTION
Just noticed we export this API from core but it's not used in packages outside of `@sentry/core` (anymore?). Let's remove it while we can.

ref #11482 