### PR TITLE
fix(node): Send ANR events without scope if event loop blocked indefinitely

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
@@ -1,0 +1,31 @@
+import * as assert from 'assert';
+import * as crypto from 'crypto';
+
+import * as Sentry from '@sentry/node';
+
+setTimeout(() => {
+  process.exit();
+}, 10000);
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  release: '1.0',
+  autoSessionTracking: false,
+  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+});
+
+Sentry.setUser({ email: 'person@home.com' });
+Sentry.addBreadcrumb({ message: 'important message!' });
+
+function longWork() {
+  // This loop will run almost indefinitely
+  for (let i = 0; i < 2000000000; i++) {
+    const salt = crypto.randomBytes(128).toString('base64');
+    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
+    assert.ok(hash);
+  }
+}
+
+setTimeout(() => {
+  longWork();
+}, 1000);

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -1,7 +1,7 @@
 import { conditionalTest } from '../../utils';
 import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
-const EXPECTED_ANR_EVENT = {
+const ANR_EVENT = {
   // Ensure we have context
   contexts: {
     trace: {
@@ -21,15 +21,6 @@ const EXPECTED_ANR_EVENT = {
       timezone: expect.any(String),
     },
   },
-  user: {
-    email: 'person@home.com',
-  },
-  breadcrumbs: [
-    {
-      timestamp: expect.any(Number),
-      message: 'important message!',
-    },
-  ],
   // and an exception that is our ANR
   exception: {
     values: [
@@ -60,24 +51,41 @@ const EXPECTED_ANR_EVENT = {
   },
 };
 
+const ANR_EVENT_WITH_SCOPE = {
+  ...ANR_EVENT,
+  user: {
+    email: 'person@home.com',
+  },
+  breadcrumbs: [
+    {
+      timestamp: expect.any(Number),
+      message: 'important message!',
+    },
+  ],
+};
+
 conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
   test('CJS', done => {
-    createRunner(__dirname, 'basic.js').withMockSentryServer().expect({ event: EXPECTED_ANR_EVENT }).start(done);
+    createRunner(__dirname, 'basic.js').withMockSentryServer().expect({ event: ANR_EVENT_WITH_SCOPE }).start(done);
   });
 
   test('ESM', done => {
-    createRunner(__dirname, 'basic.mjs').withMockSentryServer().expect({ event: EXPECTED_ANR_EVENT }).start(done);
+    createRunner(__dirname, 'basic.mjs').withMockSentryServer().expect({ event: ANR_EVENT_WITH_SCOPE }).start(done);
+  });
+
+  test('blocked indefinitely', done => {
+    createRunner(__dirname, 'indefinite.mjs').withMockSentryServer().expect({ event: ANR_EVENT }).start(done);
   });
 
   test('With --inspect', done => {
     createRunner(__dirname, 'basic.mjs')
       .withMockSentryServer()
       .withFlags('--inspect')
-      .expect({ event: EXPECTED_ANR_EVENT })
+      .expect({ event: ANR_EVENT_WITH_SCOPE })
       .start(done);
   });
 
@@ -108,16 +116,16 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
           abnormal_mechanism: 'anr_foreground',
         },
       })
-      .expect({ event: EXPECTED_ANR_EVENT })
+      .expect({ event: ANR_EVENT_WITH_SCOPE })
       .start(done);
   });
 
   test('from forked process', done => {
-    createRunner(__dirname, 'forker.js').expect({ event: EXPECTED_ANR_EVENT }).start(done);
+    createRunner(__dirname, 'forker.js').expect({ event: ANR_EVENT_WITH_SCOPE }).start(done);
   });
 
   test('worker can be stopped and restarted', done => {
-    createRunner(__dirname, 'stop-and-start.js').expect({ event: EXPECTED_ANR_EVENT }).start(done);
+    createRunner(__dirname, 'stop-and-start.js').expect({ event: ANR_EVENT_WITH_SCOPE }).start(done);
   });
 
   const EXPECTED_ISOLATED_EVENT = {


### PR DESCRIPTION
When experimenting for #11525 I found that `Runtime.evaluate` only returns when the event loop becomes unblocked. This means that we are not sending ANR events if the event loop is blocked indefinitely.

This PR adds a timeout that sends the ANR event if we have not been able to evaluate the scope within 5 seconds.
