### PR TITLE
feat(core): Deprecate `addTracingExtensions`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -65,7 +65,7 @@ We've removed the following packages:
 `@sentry/tracing` has been removed and will no longer be published. See
 [below](./MIGRATION.md/#3-removal-of-deprecated-apis) for more details.
 
-For Browser SDKs you can import `BrowserTracing` from the SDK directly:
+For Browser SDKs you can import `browserTracingIntegration` from the SDK directly:
 
 ```js
 // v7
@@ -86,12 +86,13 @@ import * as Sentry from '@sentry/browser';
 Sentry.init({
   dsn: '__DSN__',
   tracesSampleRate: 1.0,
-  integrations: [new Sentry.BrowserTracing()],
+  integrations: [Sentry.browserTracingIntegration()],
 });
 ```
 
-If you were importing `@sentry/tracing` for the side effect, you can now use `Sentry.addTracingExtensions()` to add the
-tracing extensions to the SDK. `addTracingExtensions` replaces the `addExtensionMethods` method from `@sentry/tracing`.
+If you don't want to use `browserTracingIntegration` but still manually start spans, you can now use
+`Sentry.registerSpanErrorInstrumentation()` to setup handlers for span instrumentation.
+`registerSpanErrorInstrumentation` replaces the `addExtensionMethods` method from `@sentry/tracing`.
 
 ```js
 // v7
@@ -108,7 +109,7 @@ Sentry.init({
 // v8
 import * as Sentry from '@sentry/browser';
 
-Sentry.addTracingExtensions();
+Sentry.registerSpanErrorInstrumentation();
 
 Sentry.init({
   dsn: '__DSN__',

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/init.js
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 
-Sentry.addTracingExtensions();
-
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,

--- a/packages/browser-utils/test/browser/utils.test.ts
+++ b/packages/browser-utils/test/browser/utils.test.ts
@@ -1,18 +1,9 @@
-import {
-  SentrySpan,
-  addTracingExtensions,
-  getCurrentScope,
-  getIsolationScope,
-  setCurrentClient,
-  spanToJSON,
-} from '@sentry/core';
+import { SentrySpan, getCurrentScope, getIsolationScope, setCurrentClient, spanToJSON } from '@sentry/core';
 import { startAndEndSpan } from '../../src/metrics/utils';
 import { TestClient, getDefaultClientOptions } from '../utils/TestClient';
 
 describe('startAndEndSpan()', () => {
   beforeEach(() => {
-    addTracingExtensions();
-
     getCurrentScope().clear();
     getIsolationScope().clear();
 

--- a/packages/browser/src/index.bundle.feedback.ts
+++ b/packages/browser/src/index.bundle.feedback.ts
@@ -1,9 +1,4 @@
-// This is exported so the loader does not fail when switching off Replay/Tracing
-import {
-  addTracingExtensionsShim,
-  browserTracingIntegrationShim,
-  replayIntegrationShim,
-} from '@sentry-internal/integration-shims';
+import { browserTracingIntegrationShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
 
@@ -14,8 +9,4 @@ export {
   getFeedback,
 } from '@sentry-internal/feedback';
 
-export {
-  browserTracingIntegrationShim as browserTracingIntegration,
-  addTracingExtensionsShim as addTracingExtensions,
-  replayIntegrationShim as replayIntegration,
-};
+export { browserTracingIntegrationShim as browserTracingIntegration, replayIntegrationShim as replayIntegration };

--- a/packages/browser/src/index.bundle.replay.ts
+++ b/packages/browser/src/index.bundle.replay.ts
@@ -1,6 +1,4 @@
-// This is exported so the loader does not fail when switching off Replay/Tracing
 import {
-  addTracingExtensionsShim,
   browserTracingIntegrationShim,
   feedbackIntegrationShim,
   feedbackModalIntegrationShim,
@@ -13,7 +11,6 @@ export { replayIntegration } from '@sentry-internal/replay';
 
 export {
   browserTracingIntegrationShim as browserTracingIntegration,
-  addTracingExtensionsShim as addTracingExtensions,
   feedbackIntegrationShim as feedbackIntegration,
   feedbackModalIntegrationShim as feedbackModalIntegration,
   feedbackScreenshotIntegrationShim as feedbackScreenshotIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -1,7 +1,6 @@
-import { addTracingExtensions } from '@sentry/core';
+import { registerSpanErrorInstrumentation } from '@sentry/core';
 
-// We are patching the global object with our hub extension methods
-addTracingExtensions();
+registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
@@ -14,7 +13,6 @@ export {
   withActiveSpan,
   getSpanDescendants,
   setMeasurement,
-  addTracingExtensions,
 } from '@sentry/core';
 
 export {

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -3,10 +3,9 @@ import {
   feedbackModalIntegrationShim,
   feedbackScreenshotIntegrationShim,
 } from '@sentry-internal/integration-shims';
-import { addTracingExtensions } from '@sentry/core';
+import { registerSpanErrorInstrumentation } from '@sentry/core';
 
-// We are patching the global object with our hub extension methods
-addTracingExtensions();
+registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
@@ -19,7 +18,6 @@ export {
   withActiveSpan,
   getSpanDescendants,
   setMeasurement,
-  addTracingExtensions,
 } from '@sentry/core';
 
 export {

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -1,14 +1,12 @@
-// This is exported so the loader does not fail when switching off Replay
 import {
   feedbackIntegrationShim,
   feedbackModalIntegrationShim,
   feedbackScreenshotIntegrationShim,
   replayIntegrationShim,
 } from '@sentry-internal/integration-shims';
-import { addTracingExtensions } from '@sentry/core';
+import { registerSpanErrorInstrumentation } from '@sentry/core';
 
-// We are patching the global object with our hub extension methods
-addTracingExtensions();
+registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
@@ -21,7 +19,6 @@ export {
   withActiveSpan,
   getSpanDescendants,
   setMeasurement,
-  addTracingExtensions,
 } from '@sentry/core';
 
 export {

--- a/packages/browser/src/index.bundle.ts
+++ b/packages/browser/src/index.bundle.ts
@@ -1,6 +1,4 @@
-// This is exported so the loader does not fail when switching off Replay/Tracing
 import {
-  addTracingExtensionsShim,
   browserTracingIntegrationShim,
   feedbackIntegrationShim,
   feedbackModalIntegrationShim,
@@ -11,7 +9,6 @@ import {
 export * from './index.bundle.base';
 
 export {
-  addTracingExtensionsShim as addTracingExtensions,
   browserTracingIntegrationShim as browserTracingIntegration,
   feedbackIntegrationShim as feedbackIntegration,
   feedbackModalIntegrationShim as feedbackModalIntegration,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -49,7 +49,9 @@ export {
 } from './tracing/browserTracingIntegration';
 export type { RequestInstrumentationOptions } from './tracing/request';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addTracingExtensions,
+  registerSpanErrorInstrumentation,
   getActiveSpan,
   getRootSpan,
   startSpan,

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -10,13 +10,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   TRACING_DEFAULTS,
-  addTracingExtensions,
   continueTrace,
   getActiveSpan,
   getClient,
   getCurrentScope,
   getIsolationScope,
   getRootSpan,
+  registerSpanErrorInstrumentation,
   spanToJSON,
   startIdleSpan,
   withScope,
@@ -153,7 +153,7 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
  * We explicitly export the proper type here, as this has to be extended in some cases.
  */
 export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptions> = {}) => {
-  addTracingExtensions();
+  registerSpanErrorInstrumentation();
 
   const options = {
     ...DEFAULT_BROWSER_TRACING_OPTIONS,

--- a/packages/browser/test/unit/tracing/backgroundtab.test.ts
+++ b/packages/browser/test/unit/tracing/backgroundtab.test.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, getCurrentScope } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
 import { setCurrentClient } from '@sentry/core';
 
 import { TextDecoder, TextEncoder } from 'util';
@@ -29,8 +29,6 @@ describe('registerBackgroundTabDetection', () => {
     const client = new BrowserClient(options);
     setCurrentClient(client);
     client.init();
-
-    addTracingExtensions();
 
     global.document.addEventListener = jest.fn((event, callback) => {
       events[event] = callback;

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -20,9 +20,9 @@ import { DEBUG_BUILD } from './debug-build';
 import type { Scope } from './scope';
 import { SessionFlusher } from './sessionflusher';
 import {
-  addTracingExtensions,
   getDynamicSamplingContextFromClient,
   getDynamicSamplingContextFromSpan,
+  registerSpanErrorInstrumentation,
 } from './tracing';
 import { _getSpanForScope } from './utils/spanOnScope';
 import { getRootSpan, spanToTraceContext } from './utils/spanUtils';
@@ -47,7 +47,7 @@ export class ServerRuntimeClient<
    */
   public constructor(options: O) {
     // Server clients always support tracing
-    addTracingExtensions();
+    registerSpanErrorInstrumentation();
 
     super(options);
   }

--- a/packages/core/src/tracing/errors.ts
+++ b/packages/core/src/tracing/errors.ts
@@ -16,9 +16,9 @@ export function _resetErrorsInstrumented(): void {
 }
 
 /**
- * Configures global error listeners
+ * Ensure that global errors automatically set the active span status.
  */
-export function registerErrorInstrumentation(): void {
+export function registerSpanErrorInstrumentation(): void {
   if (errorsInstrumented) {
     return;
   }

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -1,9 +1,8 @@
-import { registerErrorInstrumentation } from './errors';
+import { registerSpanErrorInstrumentation } from './errors';
 
 /**
- * Adds tracing extensions.
- * TODO (v8): Do we still need this?? Can we solve this differently?
+ * @deprecated Use `registerSpanErrorInstrumentation()` instead. In v9, this function will be removed. Note that you don't need to call this in Node-based SDKs or when using `browserTracingIntegration`.
  */
 export function addTracingExtensions(): void {
-  registerErrorInstrumentation();
+  registerSpanErrorInstrumentation();
 }

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -1,4 +1,6 @@
+export { registerSpanErrorInstrumentation } from './errors';
 export { setCapturedScopesOnSpan, getCapturedScopesOnSpan } from './utils';
+// eslint-disable-next-line deprecation/deprecation
 export { addTracingExtensions } from './hubextensions';
 export { startIdleSpan, TRACING_DEFAULTS } from './idleSpan';
 export { SentrySpan } from './sentrySpan';

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -4,12 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setCurrentClient,
 } from '../../../src';
-import {
-  SentrySpan,
-  addTracingExtensions,
-  getDynamicSamplingContextFromSpan,
-  startInactiveSpan,
-} from '../../../src/tracing';
+import { SentrySpan, getDynamicSamplingContextFromSpan, startInactiveSpan } from '../../../src/tracing';
 import { freezeDscOnSpan } from '../../../src/tracing/dynamicSamplingContext';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
@@ -19,7 +14,6 @@ describe('getDynamicSamplingContextFromSpan', () => {
     const client = new TestClient(options);
     setCurrentClient(client);
     client.init();
-    addTracingExtensions();
   });
 
   afterEach(() => {

--- a/packages/core/test/lib/tracing/errors.test.ts
+++ b/packages/core/test/lib/tracing/errors.test.ts
@@ -1,7 +1,7 @@
 import type { HandlerDataError, HandlerDataUnhandledRejection } from '@sentry/types';
-import { addTracingExtensions, setCurrentClient, spanToJSON, startInactiveSpan, startSpan } from '../../../src';
+import { setCurrentClient, spanToJSON, startInactiveSpan, startSpan } from '../../../src';
 
-import { _resetErrorsInstrumented, registerErrorInstrumentation } from '../../../src/tracing/errors';
+import { _resetErrorsInstrumented, registerSpanErrorInstrumentation } from '../../../src/tracing/errors';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 const mockAddGlobalErrorInstrumentationHandler = jest.fn();
@@ -25,10 +25,6 @@ jest.mock('@sentry/utils', () => {
   };
 });
 
-beforeAll(() => {
-  addTracingExtensions();
-});
-
 describe('registerErrorHandlers()', () => {
   beforeEach(() => {
     mockAddGlobalErrorInstrumentationHandler.mockClear();
@@ -41,7 +37,7 @@ describe('registerErrorHandlers()', () => {
   });
 
   it('registers error instrumentation', () => {
-    registerErrorInstrumentation();
+    registerSpanErrorInstrumentation();
     expect(mockAddGlobalErrorInstrumentationHandler).toHaveBeenCalledTimes(1);
     expect(mockAddGlobalUnhandledRejectionInstrumentationHandler).toHaveBeenCalledTimes(1);
     expect(mockAddGlobalErrorInstrumentationHandler).toHaveBeenCalledWith(expect.any(Function));
@@ -49,7 +45,7 @@ describe('registerErrorHandlers()', () => {
   });
 
   it('does not set status if transaction is not on scope', () => {
-    registerErrorInstrumentation();
+    registerSpanErrorInstrumentation();
 
     const transaction = startInactiveSpan({ name: 'test' })!;
     expect(spanToJSON(transaction).status).toBe(undefined);
@@ -64,7 +60,7 @@ describe('registerErrorHandlers()', () => {
   });
 
   it('sets status for transaction on scope on error', () => {
-    registerErrorInstrumentation();
+    registerSpanErrorInstrumentation();
 
     startSpan({ name: 'test' }, span => {
       mockErrorCallback({} as HandlerDataError);
@@ -73,7 +69,7 @@ describe('registerErrorHandlers()', () => {
   });
 
   it('sets status for transaction on scope on unhandledrejection', () => {
-    registerErrorInstrumentation();
+    registerSpanErrorInstrumentation();
 
     startSpan({ name: 'test' }, span => {
       mockUnhandledRejectionCallback({});

--- a/packages/core/test/lib/tracing/idleSpan.test.ts
+++ b/packages/core/test/lib/tracing/idleSpan.test.ts
@@ -5,7 +5,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON,
   SentryNonRecordingSpan,
   SentrySpan,
-  addTracingExtensions,
   getActiveSpan,
   getClient,
   getCurrentScope,
@@ -24,7 +23,6 @@ const dsn = 'https://123@sentry.io/42';
 describe('startIdleSpan', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    addTracingExtensions();
 
     getCurrentScope().clear();
     getIsolationScope().clear();

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -3,7 +3,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   Scope,
-  addTracingExtensions,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
@@ -17,6 +16,7 @@ import { getAsyncContextStrategy } from '../../../src/hub';
 import {
   SentrySpan,
   continueTrace,
+  registerSpanErrorInstrumentation,
   startInactiveSpan,
   startSpan,
   startSpanManual,
@@ -28,10 +28,6 @@ import { _setSpanForScope } from '../../../src/utils/spanOnScope';
 import { getActiveSpan, getRootSpan, getSpanDescendants, spanIsSampled } from '../../../src/utils/spanUtils';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
-beforeAll(() => {
-  addTracingExtensions();
-});
-
 const enum Type {
   Sync = 'sync',
   Async = 'async',
@@ -41,7 +37,7 @@ let client: TestClient;
 
 describe('startSpan', () => {
   beforeEach(() => {
-    addTracingExtensions();
+    registerSpanErrorInstrumentation();
 
     getCurrentScope().clear();
     getIsolationScope().clear();
@@ -559,7 +555,7 @@ describe('startSpan', () => {
 
 describe('startSpanManual', () => {
   beforeEach(() => {
-    addTracingExtensions();
+    registerSpanErrorInstrumentation();
 
     getCurrentScope().clear();
     getIsolationScope().clear();
@@ -878,7 +874,7 @@ describe('startSpanManual', () => {
 
 describe('startInactiveSpan', () => {
   beforeEach(() => {
-    addTracingExtensions();
+    registerSpanErrorInstrumentation();
 
     getCurrentScope().clear();
     getIsolationScope().clear();
@@ -1218,8 +1214,6 @@ describe('startInactiveSpan', () => {
 
 describe('continueTrace', () => {
   beforeEach(() => {
-    addTracingExtensions();
-
     getCurrentScope().clear();
     getIsolationScope().clear();
     getGlobalScope().clear();
@@ -1335,8 +1329,6 @@ describe('continueTrace', () => {
 
 describe('getActiveSpan', () => {
   beforeEach(() => {
-    addTracingExtensions();
-
     getCurrentScope().clear();
     getIsolationScope().clear();
     getGlobalScope().clear();
@@ -1384,10 +1376,6 @@ describe('getActiveSpan', () => {
 });
 
 describe('withActiveSpan()', () => {
-  beforeAll(() => {
-    addTracingExtensions();
-  });
-
   beforeEach(() => {
     getCurrentScope().clear();
     getIsolationScope().clear();
@@ -1460,8 +1448,6 @@ describe('withActiveSpan()', () => {
 
 describe('span hooks', () => {
   beforeEach(() => {
-    addTracingExtensions();
-
     getCurrentScope().clear();
     getIsolationScope().clear();
     getGlobalScope().clear();
@@ -1511,8 +1497,6 @@ describe('span hooks', () => {
 
 describe('suppressTracing', () => {
   beforeEach(() => {
-    addTracingExtensions();
-
     getCurrentScope().clear();
     getIsolationScope().clear();
     getGlobalScope().clear();

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -7,7 +7,6 @@ import {
   SPAN_STATUS_OK,
   SPAN_STATUS_UNSET,
   SentrySpan,
-  addTracingExtensions,
   setCurrentClient,
   spanToTraceHeader,
   startInactiveSpan,
@@ -224,7 +223,6 @@ describe('getRootSpan', () => {
   beforeEach(() => {
     const client = new TestClient(getDefaultTestClientOptions({ tracesSampleRate: 1 }));
     setCurrentClient(client);
-    addTracingExtensions();
   });
 
   it('returns the root span of a span that is a root span', () => {

--- a/packages/integration-shims/src/BrowserTracing.ts
+++ b/packages/integration-shims/src/BrowserTracing.ts
@@ -16,8 +16,3 @@ export const browserTracingIntegrationShim = defineIntegration((_options?: unkno
     name: 'BrowserTracing',
   };
 });
-
-/** Shim function */
-export function addTracingExtensionsShim(): void {
-  // noop
-}

--- a/packages/integration-shims/src/index.ts
+++ b/packages/integration-shims/src/index.ts
@@ -4,7 +4,4 @@ export {
   feedbackScreenshotIntegrationShim,
 } from './Feedback';
 export { replayIntegrationShim } from './Replay';
-export {
-  browserTracingIntegrationShim,
-  addTracingExtensionsShim,
-} from './BrowserTracing';
+export { browserTracingIntegrationShim } from './BrowserTracing';

--- a/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
@@ -2,7 +2,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SPAN_STATUS_OK,
-  addTracingExtensions,
   captureException,
   continueTrace,
   getIsolationScope,
@@ -23,7 +22,6 @@ export function withEdgeWrapping<H extends EdgeRouteHandler>(
   options: { spanDescription: string; spanOp: string; mechanismFunctionName: string },
 ): (...params: Parameters<H>) => Promise<ReturnType<H>> {
   return async function (this: unknown, ...args) {
-    addTracingExtensions();
     const req: unknown = args[0];
 
     let sentryTrace;

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -1,12 +1,5 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, SPAN_STATUS_ERROR, getIsolationScope } from '@sentry/core';
-import {
-  addTracingExtensions,
-  captureException,
-  continueTrace,
-  getClient,
-  handleCallbackErrors,
-  startSpan,
-} from '@sentry/core';
+import { captureException, continueTrace, getClient, handleCallbackErrors, startSpan } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
@@ -57,7 +50,6 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
   options: Options,
   callback: A,
 ): Promise<ReturnType<A>> {
-  addTracingExtensions();
   return withIsolationScopeOrReuseFromRootSpan(isolationScope => {
     const sendDefaultPii = getClient()?.getOptions().sendDefaultPii;
 

--- a/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
@@ -1,6 +1,5 @@
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  addTracingExtensions,
   captureException,
   continueTrace,
   setHttpStatus,
@@ -51,8 +50,6 @@ export function wrapApiHandlerWithSentry(apiHandler: NextApiHandler, parameteriz
         return wrappingTarget.apply(thisArg, args);
       }
       req.__withSentry_applied__ = true;
-
-      addTracingExtensions();
 
       return withIsolationScopeOrReuseFromRootSpan(isolationScope => {
         return continueTrace(

--- a/packages/nextjs/src/common/wrapApiHandlerWithSentryVercelCrons.ts
+++ b/packages/nextjs/src/common/wrapApiHandlerWithSentryVercelCrons.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, captureCheckIn } from '@sentry/core';
+import { captureCheckIn } from '@sentry/core';
 import type { NextApiRequest } from 'next';
 
 import type { VercelCronsConfig } from './types';
@@ -25,7 +25,6 @@ export function wrapApiHandlerWithSentryVercelCrons<F extends (...args: any[]) =
           return originalFunction.apply(thisArg, args);
         }
 
-        addTracingExtensions();
         const [req] = args as [NextApiRequest | EdgeRequest];
 
         let maybePromiseResult;

--- a/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
@@ -1,10 +1,4 @@
-import {
-  addTracingExtensions,
-  getActiveSpan,
-  getDynamicSamplingContextFromSpan,
-  getRootSpan,
-  spanToTraceHeader,
-} from '@sentry/core';
+import { getActiveSpan, getDynamicSamplingContextFromSpan, getRootSpan, spanToTraceHeader } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type App from 'next/app';
 
@@ -27,8 +21,6 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
       if (isBuild()) {
         return wrappingTarget.apply(thisArg, args);
       }
-
-      addTracingExtensions();
 
       const [context] = args;
       const { req, res } = context.ctx;

--- a/packages/nextjs/src/common/wrapDocumentGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapDocumentGetInitialPropsWithSentry.ts
@@ -1,4 +1,3 @@
-import { addTracingExtensions } from '@sentry/core';
 import type Document from 'next/document';
 
 import { isBuild } from './utils/isBuild';
@@ -22,8 +21,6 @@ export function wrapDocumentGetInitialPropsWithSentry(
       if (isBuild()) {
         return wrappingTarget.apply(thisArg, args);
       }
-
-      addTracingExtensions();
 
       const [context] = args;
       const { req, res } = context;

--- a/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
@@ -1,10 +1,4 @@
-import {
-  addTracingExtensions,
-  getActiveSpan,
-  getDynamicSamplingContextFromSpan,
-  getRootSpan,
-  spanToTraceHeader,
-} from '@sentry/core';
+import { getActiveSpan, getDynamicSamplingContextFromSpan, getRootSpan, spanToTraceHeader } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPageContext } from 'next';
 import type { ErrorProps } from 'next/error';
@@ -30,8 +24,6 @@ export function wrapErrorGetInitialPropsWithSentry(
       if (isBuild()) {
         return wrappingTarget.apply(thisArg, args);
       }
-
-      addTracingExtensions();
 
       const [context] = args;
       const { req, res } = context;

--- a/packages/nextjs/src/common/wrapGenerationFunctionWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGenerationFunctionWithSentry.ts
@@ -2,7 +2,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
-  addTracingExtensions,
   captureException,
   getClient,
   getCurrentScope,
@@ -26,7 +25,6 @@ export function wrapGenerationFunctionWithSentry<F extends (...args: any[]) => a
   generationFunction: F,
   context: GenerationFunctionContext,
 ): F {
-  addTracingExtensions();
   const { requestAsyncStorage, componentRoute, componentType, generationFunctionIdentifier } = context;
   return new Proxy(generationFunction, {
     apply: (originalFunction, thisArg, args) => {

--- a/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
@@ -1,10 +1,4 @@
-import {
-  addTracingExtensions,
-  getActiveSpan,
-  getDynamicSamplingContextFromSpan,
-  getRootSpan,
-  spanToTraceHeader,
-} from '@sentry/core';
+import { getActiveSpan, getDynamicSamplingContextFromSpan, getRootSpan, spanToTraceHeader } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPage } from 'next';
 
@@ -26,8 +20,6 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
       if (isBuild()) {
         return wrappingTarget.apply(thisArg, args);
       }
-
-      addTracingExtensions();
 
       const [context] = args;
       const { req, res } = context;

--- a/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
@@ -1,10 +1,4 @@
-import {
-  addTracingExtensions,
-  getActiveSpan,
-  getDynamicSamplingContextFromSpan,
-  getRootSpan,
-  spanToTraceHeader,
-} from '@sentry/core';
+import { getActiveSpan, getDynamicSamplingContextFromSpan, getRootSpan, spanToTraceHeader } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { GetServerSideProps } from 'next';
 
@@ -27,8 +21,6 @@ export function wrapGetServerSidePropsWithSentry(
       if (isBuild()) {
         return wrappingTarget.apply(thisArg, args);
       }
-
-      addTracingExtensions();
 
       const [context] = args;
       const { req, res } = context;

--- a/packages/nextjs/src/common/wrapGetStaticPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetStaticPropsWithSentry.ts
@@ -1,4 +1,3 @@
-import { addTracingExtensions } from '@sentry/core';
 import type { GetStaticProps } from 'next';
 
 import { isBuild } from './utils/isBuild';
@@ -22,8 +21,6 @@ export function wrapGetStaticPropsWithSentry(
       if (isBuild()) {
         return wrappingTarget.apply(thisArg, args);
       }
-
-      addTracingExtensions();
 
       const errorWrappedGetStaticProps = withErrorInstrumentation(wrappingTarget);
       return callDataFetcherTraced(errorWrappedGetStaticProps, args, {

--- a/packages/nextjs/src/common/wrapPageComponentWithSentry.ts
+++ b/packages/nextjs/src/common/wrapPageComponentWithSentry.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, captureException, getCurrentScope } from '@sentry/core';
+import { captureException, getCurrentScope } from '@sentry/core';
 import { extractTraceparentData } from '@sentry/utils';
 import { withIsolationScopeOrReuseFromRootSpan } from './utils/withIsolationScopeOrReuseFromRootSpan';
 
@@ -22,7 +22,6 @@ function isReactClassComponent(target: unknown): target is ClassComponent {
  * Wraps a page component with Sentry error instrumentation.
  */
 export function wrapPageComponentWithSentry(pageComponent: FunctionComponent | ClassComponent): unknown {
-  addTracingExtensions();
   if (isReactClassComponent(pageComponent)) {
     return class SentryWrappedPageComponent extends pageComponent {
       public render(...args: unknown[]): unknown {

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -3,7 +3,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SPAN_STATUS_ERROR,
-  addTracingExtensions,
   captureException,
   getActiveSpan,
   getRootSpan,
@@ -61,8 +60,6 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
   routeHandler: F,
   context: RouteHandlerContext,
 ): (...args: Parameters<F>) => ReturnType<F> extends Promise<unknown> ? ReturnType<F> : Promise<ReturnType<F>> {
-  addTracingExtensions();
-
   const { method, parameterizedRoute, headers } = context;
 
   return new Proxy(routeHandler, {

--- a/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
+++ b/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
@@ -2,7 +2,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
-  addTracingExtensions,
   captureException,
   getCurrentScope,
   handleCallbackErrors,
@@ -25,7 +24,6 @@ export function wrapServerComponentWithSentry<F extends (...args: any[]) => any>
   appDirComponent: F,
   context: ServerComponentContext,
 ): F {
-  addTracingExtensions();
   const { componentRoute, componentType } = context;
 
   // Even though users may define server components as async functions, for the client bundles

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, applySdkMetadata } from '@sentry/core';
+import { applySdkMetadata, registerSpanErrorInstrumentation } from '@sentry/core';
 import { GLOBAL_OBJ } from '@sentry/utils';
 import type { VercelEdgeOptions } from '@sentry/vercel-edge';
 import { getDefaultIntegrations, init as vercelEdgeInit } from '@sentry/vercel-edge';
@@ -14,7 +14,7 @@ const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
 
 /** Inits the Sentry NextJS SDK on the Edge Runtime. */
 export function init(options: VercelEdgeOptions = {}): void {
-  addTracingExtensions();
+  registerSpanErrorInstrumentation();
 
   if (isBuild()) {
     return;

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -1,4 +1,4 @@
-import { addEventProcessor, addTracingExtensions, applySdkMetadata, getClient } from '@sentry/core';
+import { addEventProcessor, applySdkMetadata, getClient } from '@sentry/core';
 import { getDefaultIntegrations, init as nodeInit } from '@sentry/node';
 import type { NodeOptions } from '@sentry/node';
 import { GLOBAL_OBJ, logger } from '@sentry/utils';
@@ -64,8 +64,6 @@ export function showReportDialog(): void {
 
 /** Inits the Sentry NextJS SDK on node. */
 export function init(options: NodeOptions): void {
-  addTracingExtensions();
-
   if (isBuild()) {
     return;
   }

--- a/packages/nextjs/test/config/withSentry.test.ts
+++ b/packages/nextjs/test/config/withSentry.test.ts
@@ -1,13 +1,9 @@
 import * as SentryCore from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, addTracingExtensions } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import type { AugmentedNextApiResponse, NextApiHandler } from '../../src/common/types';
 import { wrapApiHandlerWithSentry } from '../../src/server';
-
-// The wrap* functions require the hub to have tracing extensions. This is normally called by the NodeClient
-// constructor but the client isn't used in these tests.
-addTracingExtensions();
 
 const startSpanManualSpy = jest.spyOn(SentryCore, 'startSpanManual');
 

--- a/packages/nextjs/test/config/wrappers.test.ts
+++ b/packages/nextjs/test/config/wrappers.test.ts
@@ -1,15 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import * as SentryCore from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, addTracingExtensions } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 
 import type { Client } from '@sentry/types';
 import { wrapGetInitialPropsWithSentry, wrapGetServerSidePropsWithSentry } from '../../src/common';
 
 const startSpanManualSpy = jest.spyOn(SentryCore, 'startSpanManual');
-
-// The wrap* functions require the hub to have tracing extensions. This is normally called by the NodeClient
-// constructor but the client isn't used in these tests.
-addTracingExtensions();
 
 describe('data-fetching function wrappers should create spans', () => {
   const route = '/tricks/[trickName]';

--- a/packages/opentelemetry/test/propagator.test.ts
+++ b/packages/opentelemetry/test/propagator.test.ts
@@ -8,17 +8,13 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { addTracingExtensions, withScope } from '@sentry/core';
+import { withScope } from '@sentry/core';
 
 import { SENTRY_BAGGAGE_HEADER, SENTRY_SCOPES_CONTEXT_KEY, SENTRY_TRACE_HEADER } from '../src/constants';
 import { SentryPropagator, makeTraceState } from '../src/propagator';
 import { getScopesFromContext } from '../src/utils/contextData';
 import { getSamplingDecision } from '../src/utils/getSamplingDecision';
 import { cleanupOtel, mockSdkInit } from './helpers/mockSdkInit';
-
-beforeAll(() => {
-  addTracingExtensions();
-});
 
 describe('SentryPropagator', () => {
   const propagator = new SentryPropagator();

--- a/packages/svelte/test/performance.test.ts
+++ b/packages/svelte/test/performance.test.ts
@@ -1,5 +1,5 @@
 import { act, render } from '@testing-library/svelte';
-import { addTracingExtensions, getClient, getCurrentScope, getIsolationScope, init, startSpan } from '../src';
+import { getClient, getCurrentScope, getIsolationScope, init, startSpan } from '../src';
 
 import type { TransactionEvent } from '@sentry/types';
 import { vi } from 'vitest';
@@ -18,8 +18,6 @@ describe('Sentry.trackComponent()', () => {
 
     getCurrentScope().clear();
     getIsolationScope().clear();
-
-    addTracingExtensions();
 
     const beforeSendTransaction = vi.fn(event => {
       transactions.push(event);

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -33,10 +33,6 @@ const MOCK_LOAD_ARGS: any = {
   url: new URL('http://localhost:3000/users/123'),
 };
 
-beforeAll(() => {
-  SentrySvelte.addTracingExtensions();
-});
-
 describe('wrapLoadWithSentry', () => {
   beforeEach(() => {
     mockCaptureException.mockClear();

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -1,6 +1,5 @@
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  addTracingExtensions,
   getRootSpan,
   getSpanDescendants,
   spanIsSampled,
@@ -89,10 +88,6 @@ function resolve(
 }
 
 let client: NodeClient;
-
-beforeAll(() => {
-  addTracingExtensions();
-});
 
 beforeEach(() => {
   const options = getDefaultNodeClientOptions({ tracesSampleRate: 1.0 });

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -2,7 +2,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  addTracingExtensions,
 } from '@sentry/core';
 import { NodeClient, getCurrentScope, getIsolationScope, setCurrentClient } from '@sentry/node';
 import * as SentryNode from '@sentry/node';
@@ -75,10 +74,6 @@ function getServerOnlyArgs() {
     },
   };
 }
-
-beforeAll(() => {
-  addTracingExtensions();
-});
 
 afterEach(() => {
   mockCaptureException.mockClear();


### PR DESCRIPTION
Instead, users can use `registerSpanErrorInstrumentation` which is now does much less things than before.

I opted to not fully remove this yet because I guess the chance that somebody may have been using this is somewhat high, and we can easily continue to have it with no bundle size hit for those who don't need it. We also couldn't really deprecate this in v7 so I think it's OK to leave this in for now. 