### PR TITLE
feat(core): Remove `getCurrentHub` from `AsyncContextStrategy`

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,4 +1,4 @@
-import { getCurrentScope } from '@sentry/core';
+import { getCurrentScope, withScope } from '@sentry/core';
 import { functionToStringIntegration, inboundFiltersIntegration } from '@sentry/core';
 import {
   captureSession,
@@ -156,6 +156,11 @@ export function init(browserOptions: BrowserOptions = {}): void {
   };
 
   initAndBind(BrowserClient, clientOptions);
+
+  // tmp test
+  getCurrentScope();
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  withScope(() => {});
 
   if (options.autoSessionTracking) {
     startSessionTracking();

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,4 +1,4 @@
-import { getCurrentScope, withScope } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
 import { functionToStringIntegration, inboundFiltersIntegration } from '@sentry/core';
 import {
   captureSession,
@@ -156,11 +156,6 @@ export function init(browserOptions: BrowserOptions = {}): void {
   };
 
   initAndBind(BrowserClient, clientOptions);
-
-  // tmp test
-  getCurrentScope();
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  withScope(() => {});
 
   if (options.autoSessionTracking) {
     startSessionTracking();

--- a/packages/core/src/asyncContext.ts
+++ b/packages/core/src/asyncContext.ts
@@ -1,4 +1,4 @@
-import type { Hub, Integration } from '@sentry/types';
+import type { Integration } from '@sentry/types';
 import type { Scope } from '@sentry/types';
 import { GLOBAL_OBJ } from '@sentry/utils';
 import type { startInactiveSpan, startSpan, startSpanManual, suppressTracing, withActiveSpan } from './tracing/trace';
@@ -10,12 +10,6 @@ import type { getActiveSpan } from './utils/spanUtils';
  * Strategy used to track async context.
  */
 export interface AsyncContextStrategy {
-  /**
-   * Gets the currently active hub.
-   */
-  // eslint-disable-next-line deprecation/deprecation
-  getCurrentHub: () => Hub;
-
   /**
    * Fork the isolation scope inside of the provided callback.
    */

--- a/packages/core/src/getCurrentHubShim.ts
+++ b/packages/core/src/getCurrentHubShim.ts
@@ -71,6 +71,18 @@ export function getCurrentHubShim(): Hub {
 }
 
 /**
+ * Returns the default hub instance.
+ *
+ * If a hub is already registered in the global carrier but this module
+ * contains a more recent version, it replaces the registered version.
+ * Otherwise, the currently registered hub will be returned.
+ *
+ * @deprecated Use the respective replacement method directly instead.
+ */
+// eslint-disable-next-line deprecation/deprecation
+export const getCurrentHub = getCurrentHubShim;
+
+/**
  * Sends the current Session on the scope
  */
 function _sendSessionUpdate(): void {

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -24,7 +24,6 @@ import type { AsyncContextStrategy, Carrier } from './asyncContext';
 import { getMainCarrier, getSentryCarrier } from './asyncContext';
 import { DEFAULT_ENVIRONMENT } from './constants';
 import { DEBUG_BUILD } from './debug-build';
-import { getCurrentHubShim } from './getCurrentHubShim';
 import { Scope } from './scope';
 import { closeSession, makeSession, updateSession } from './session';
 import { SDK_VERSION } from './version';
@@ -496,18 +495,6 @@ export class Hub implements HubInterface {
     return !!this.getStack().pop();
   }
 }
-
-/**
- * Returns the default hub instance.
- *
- * If a hub is already registered in the global carrier but this module
- * contains a more recent version, it replaces the registered version.
- * Otherwise, the currently registered hub will be returned.
- *
- * @deprecated Use the respective replacement method directly instead.
- */
-// eslint-disable-next-line deprecation/deprecation
-export const getCurrentHub = getCurrentHubShim;
 
 /** Get the default current scope. */
 export function getDefaultCurrentScope(): Scope {

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -24,6 +24,7 @@ import type { AsyncContextStrategy, Carrier } from './asyncContext';
 import { getMainCarrier, getSentryCarrier } from './asyncContext';
 import { DEFAULT_ENVIRONMENT } from './constants';
 import { DEBUG_BUILD } from './debug-build';
+import { getCurrentHubShim } from './getCurrentHubShim';
 import { Scope } from './scope';
 import { closeSession, makeSession, updateSession } from './session';
 import { SDK_VERSION } from './version';
@@ -506,13 +507,7 @@ export class Hub implements HubInterface {
  * @deprecated Use the respective replacement method directly instead.
  */
 // eslint-disable-next-line deprecation/deprecation
-export function getCurrentHub(): HubInterface {
-  // Get main carrier (global for every environment)
-  const carrier = getMainCarrier();
-
-  const acs = getAsyncContextStrategy(carrier);
-  return acs.getCurrentHub() || getGlobalHub();
-}
+export const getCurrentHub = getCurrentHubShim;
 
 /** Get the default current scope. */
 export function getDefaultCurrentScope(): Scope {
@@ -586,7 +581,6 @@ function withIsolationScope<T>(callback: (isolationScope: ScopeInterface) => T):
 /* eslint-disable deprecation/deprecation */
 function getHubStackAsyncContextStrategy(): AsyncContextStrategy {
   return {
-    getCurrentHub: getGlobalHub,
     withIsolationScope,
     withScope,
     withSetScope,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,8 +30,6 @@ export {
   addEventProcessor,
 } from './exports';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  getCurrentHub,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
 } from './hub';
@@ -107,4 +105,4 @@ export { addTracingHeadersToFetchRequest, instrumentFetchRequest } from './fetch
 export { trpcMiddleware } from './trpc';
 
 // eslint-disable-next-line deprecation/deprecation
-export { getCurrentHubShim } from './getCurrentHubShim';
+export { getCurrentHubShim, getCurrentHub } from './getCurrentHubShim';

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -1,10 +1,8 @@
-import type { Client, ClientOptions, Hub as HubInterface } from '@sentry/types';
+import type { Client, ClientOptions } from '@sentry/types';
 import { consoleSandbox, logger } from '@sentry/utils';
 import { getCurrentScope } from './currentScopes';
 
 import { DEBUG_BUILD } from './debug-build';
-import type { Hub } from './hub';
-import { getCurrentHub } from './hub';
 
 /** A class object that can instantiate Client objects. */
 export type ClientClass<F extends Client, O extends ClientOptions> = new (options: O) => F;
@@ -44,19 +42,4 @@ export function initAndBind<F extends Client, O extends ClientOptions>(
  */
 export function setCurrentClient(client: Client): void {
   getCurrentScope().setClient(client);
-
-  // is there a hub too?
-  // eslint-disable-next-line deprecation/deprecation
-  const hub = getCurrentHub();
-  if (isHubClass(hub)) {
-    // eslint-disable-next-line deprecation/deprecation
-    const top = hub.getStackTop();
-    top.client = client;
-  }
-}
-
-// eslint-disable-next-line deprecation/deprecation
-function isHubClass(hub: HubInterface): hub is Hub {
-  // eslint-disable-next-line deprecation/deprecation
-  return !!(hub as Hub).getStackTop;
 }

--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -1,12 +1,9 @@
 import { isThenable, normalize } from '@sentry/utils';
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  captureException,
-  setContext,
-  startSpanManual,
-} from '.';
+
 import { getClient } from './currentScopes';
+import { captureException, setContext } from './exports';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from './semanticAttributes';
+import { startSpanManual } from './tracing';
 
 interface SentryTrpcMiddlewareOptions {
   /** Whether to include procedure inputs in reported events. Defaults to `false`. */

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -40,23 +40,6 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     };
   }
 
-  // eslint-disable-next-line deprecation/deprecation
-  function getCurrentHub(): Hub {
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = getCurrentHubShim();
-    return {
-      ...hub,
-      getScope: () => {
-        const scopes = getScopes();
-        return scopes.scope;
-      },
-      getIsolationScope: () => {
-        const scopes = getScopes();
-        return scopes.isolationScope;
-      },
-    };
-  }
-
   function withScope<T>(callback: (scope: Scope) => T): T {
     const ctx = api.context.active();
 
@@ -114,7 +97,6 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
   }
 
   setAsyncContextStrategy({
-    getCurrentHub,
     withScope,
     withSetScope,
     withSetIsolationScope,

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,12 +1,7 @@
 import * as api from '@opentelemetry/api';
-import {
-  getCurrentHubShim,
-  getDefaultCurrentScope,
-  getDefaultIsolationScope,
-  setAsyncContextStrategy,
-} from '@sentry/core';
+import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
 import type { withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
-import type { Hub, Scope } from '@sentry/types';
+import type { Scope } from '@sentry/types';
 
 import {
   SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY,

--- a/packages/vercel-edge/src/async.ts
+++ b/packages/vercel-edge/src/async.ts
@@ -1,10 +1,5 @@
-import {
-  getCurrentHubShim,
-  getDefaultCurrentScope,
-  getDefaultIsolationScope,
-  setAsyncContextStrategy,
-} from '@sentry/core';
-import type { Hub, Scope } from '@sentry/types';
+import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
+import type { Scope } from '@sentry/types';
 import { GLOBAL_OBJ, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
@@ -51,23 +46,6 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     };
   }
 
-  // eslint-disable-next-line deprecation/deprecation
-  function getCurrentHub(): Hub {
-    // eslint-disable-next-line deprecation/deprecation
-    const hub = getCurrentHubShim();
-    return {
-      ...hub,
-      getScope: () => {
-        const scopes = getScopes();
-        return scopes.scope;
-      },
-      getIsolationScope: () => {
-        const scopes = getScopes();
-        return scopes.isolationScope;
-      },
-    };
-  }
-
   function withScope<T>(callback: (scope: Scope) => T): T {
     const scope = getScopes().scope.clone();
     const isolationScope = getScopes().isolationScope;
@@ -99,7 +77,6 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
   }
 
   setAsyncContextStrategy({
-    getCurrentHub,
     withScope,
     withSetScope,
     withIsolationScope,


### PR DESCRIPTION
This PR removes the `getCurrentHub` property from the `AsyncContextStrategy` interface and consequently also the property in the interface implementers.

There's still some stuff left to clean up but it is only internal anymore.

Hopefully the last breaking change in connection to #11482 