### PR TITLE
feat(node): Use ANR integration by default

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -10,7 +10,7 @@ setTimeout(() => {
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
   autoSessionTracking: true,
 });
 

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 Sentry.setUser({ email: 'person@home.com' });

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 Sentry.setUser({ email: 'person@home.com' });

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -12,7 +12,7 @@ Sentry.init({
   release: '1.0',
   autoSessionTracking: false,
   debug: true,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 Sentry.setUser({ email: 'person@home.com' });

--- a/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 Sentry.setUser({ email: 'person@home.com' });

--- a/dev-packages/node-integration-tests/suites/anr/isolated.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/isolated.mjs
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ anrThreshold: 100 })],
 });
 
 async function longWork() {

--- a/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
@@ -6,7 +6,7 @@ function configureSentry() {
     release: '1.0',
     autoSessionTracking: false,
     debug: true,
-    integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
+    integrations: [Sentry.anrIntegration()],
   });
 }
 

--- a/dev-packages/node-integration-tests/suites/anr/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit.js
@@ -6,7 +6,7 @@ function configureSentry() {
     release: '1.0',
     autoSessionTracking: false,
     debug: true,
-    integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
+    integrations: [Sentry.anrIntegration()],
   });
 }
 

--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -7,7 +7,7 @@ setTimeout(() => {
   process.exit();
 }, 10000);
 
-const anr = Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 });
+const anr = Sentry.anrIntegration({ anrThreshold: 100 });
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/rollup-utils/utils.mjs
+++ b/dev-packages/rollup-utils/utils.mjs
@@ -21,7 +21,7 @@ export function mergePlugins(pluginsA, pluginsB) {
     // here.
     // Additionally, the excludeReplay plugin must run before TS/Sucrase so that we can eliminate the replay code
     // before anything is type-checked (TS-only) and transpiled.
-    const order = ['excludeReplay', 'typescript', 'sucrase', '...', 'terser', 'license'];
+    const order = ['excludeReplay', 'typescript', 'sucrase', '...', 'terser', 'license', 'output-base64-worker-script'];
     const sortKeyA = order.includes(a.name) ? a.name : '...';
     const sortKeyB = order.includes(b.name) ? b.name : '...';
 

--- a/packages/node/src/integrations/anr/common.ts
+++ b/packages/node/src/integrations/anr/common.ts
@@ -16,7 +16,7 @@ export interface AnrIntegrationOptions {
   /**
    * Whether to capture a stack trace when the ANR event is triggered.
    *
-   * Defaults to `false`.
+   * Defaults to `true`.
    *
    * This uses the node debugger which enables the inspector API and opens the required ports.
    */

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -164,7 +164,11 @@ async function _startWorker(
 
   if (options.captureStackTrace) {
     if (!inspector.url()) {
-      inspector.open(0);
+      try {
+        inspector.open(0);
+      } catch (_) {
+        //
+      }
     }
   }
 

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -82,7 +82,9 @@ const _anrIntegration = ((options: Partial<AnrIntegrationOptions> = {}) => {
       }
 
       if (client) {
+        // We only await the Promise later if we want to stop the worker
         worker = _startWorker(client, options);
+        worker.catch(e => log('Error starting ANR worker', e));
       }
     },
     stopWorker: () => {
@@ -162,14 +164,8 @@ async function _startWorker(
     contexts,
   };
 
-  if (options.captureStackTrace) {
-    if (!inspector.url()) {
-      try {
-        inspector.open(0);
-      } catch (_) {
-        //
-      }
-    }
+  if (options.captureStackTrace && !inspector.url()) {
+    inspector.open(0);
   }
 
   const worker = new Worker(new URL(`data:application/javascript;base64,${base64WorkerScript}`), {

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -58,6 +58,10 @@ const _anrIntegration = ((options: Partial<AnrIntegrationOptions> = {}) => {
     throw new Error('ANR detection requires Node 16.17.0 or later');
   }
 
+  if (options.captureStackTrace === undefined) {
+    options.captureStackTrace = true;
+  }
+
   let worker: Promise<() => void> | undefined;
   let client: NodeClient | undefined;
 

--- a/packages/node/src/sdk/init.ts
+++ b/packages/node/src/sdk/init.ts
@@ -21,11 +21,10 @@ import {
   stackParserFromStackParserOptions,
 } from '@sentry/utils';
 import { DEBUG_BUILD } from '../debug-build';
-import { anrIntegration } from '../integrations/anr';
+import { anrIntegrationIfSupported } from '../integrations/anr';
 import { consoleIntegration } from '../integrations/console';
 import { nodeContextIntegration } from '../integrations/context';
 import { contextLinesIntegration } from '../integrations/contextlines';
-
 import { httpIntegration } from '../integrations/http';
 import { localVariablesIntegration } from '../integrations/local-variables';
 import { modulesIntegration } from '../integrations/modules';
@@ -64,7 +63,7 @@ export function getDefaultIntegrations(options: Options): Integration[] {
     localVariablesIntegration(),
     nodeContextIntegration(),
     // Features
-    anrIntegration(),
+    ...anrIntegrationIfSupported,
     ...getCjsOnlyIntegrations(),
     ...(hasTracingEnabled(options) ? getAutoPerformanceIntegrations() : []),
   ];

--- a/packages/node/src/sdk/init.ts
+++ b/packages/node/src/sdk/init.ts
@@ -21,6 +21,7 @@ import {
   stackParserFromStackParserOptions,
 } from '@sentry/utils';
 import { DEBUG_BUILD } from '../debug-build';
+import { anrIntegration } from '../integrations/anr';
 import { consoleIntegration } from '../integrations/console';
 import { nodeContextIntegration } from '../integrations/context';
 import { contextLinesIntegration } from '../integrations/contextlines';
@@ -62,6 +63,8 @@ export function getDefaultIntegrations(options: Options): Integration[] {
     contextLinesIntegration(),
     localVariablesIntegration(),
     nodeContextIntegration(),
+    // Features
+    anrIntegration(),
     ...getCjsOnlyIntegrations(),
     ...(hasTracingEnabled(options) ? getAutoPerformanceIntegrations() : []),
   ];


### PR DESCRIPTION
Adds the `anrIntegration` to the defaults and makes `captureStackTrace: true` the default too.