### PR TITLE
test(node): Add test for console.log & isolation scope

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/span-isolationScope/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/span-isolationScope/server.ts
@@ -1,0 +1,29 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});
+
+import { startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
+import express from 'express';
+
+const app = express();
+
+Sentry.setTag('global', 'tag');
+
+app.get('/test/isolationScope', (_req, res) => {
+  // eslint-disable-next-line no-console
+  console.log('This is a test log.');
+  Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+  Sentry.setTag('isolation-scope', 'tag');
+
+  res.send({});
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/span-isolationScope/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/span-isolationScope/test.ts
@@ -1,0 +1,39 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+test('correctly applies isolation scope to span', done => {
+  createRunner(__dirname, 'server.ts')
+    .ignore('session', 'sessions')
+    .expect({
+      transaction: {
+        transaction: 'GET /test/isolationScope',
+        breadcrumbs: [
+          {
+            category: 'console',
+            level: 'log',
+            message: expect.stringMatching(/\{"port":(\d+)\}/),
+            timestamp: expect.any(Number),
+          },
+          {
+            category: 'console',
+            level: 'log',
+            message: 'This is a test log.',
+            timestamp: expect.any(Number),
+          },
+          {
+            message: 'manual breadcrumb',
+            timestamp: expect.any(Number),
+          },
+        ],
+        tags: {
+          global: 'tag',
+          'isolation-scope': 'tag',
+        },
+      },
+    })
+    .start(done)
+    .makeRequest('get', '/test/isolationScope');
+});


### PR DESCRIPTION
Adds a test to ensure isolation scope is correctly applied to express spans, and also that console.log is correctly instrumented.

We have related tests in E2E tests and in other places, but it doesn't hurt to have this explicitly here I guess...