### PR TITLE
test(browser-integration-tests): Ensure error after navigation has navigation traceId

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -24,3 +24,28 @@ sentryTest('should create a new trace on each navigation', async ({ getLocalTest
   expect(navigation2TraceId).toMatch(/^[0-9a-f]{32}$/);
   expect(navigation1TraceId).not.toEqual(navigation2TraceId);
 });
+
+sentryTest('error after navigation has navigation traceId', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  // ensure navigation transaction is finished
+  await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  const navigationEvent1 = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+  expect(navigationEvent1.contexts?.trace?.op).toBe('navigation');
+
+  const navigationTraceId = navigationEvent1.contexts?.trace?.trace_id;
+  expect(navigationTraceId).toMatch(/^[0-9a-f]{32}$/);
+
+  const [, errorEvent] = await Promise.all([
+    page.locator('#errorBtn').click(),
+    getFirstSentryEnvelopeRequest<Event>(page),
+  ]);
+
+  const errorTraceId = errorEvent.contexts?.trace?.trace_id;
+  expect(errorTraceId).toBe(navigationTraceId);
+});


### PR DESCRIPTION
builds on top of #11600 

Adds a test to ensure that errors thrown after a navigation transaction finished are still associated with he trace started from the navigation.