### PR TITLE
fix(browser): Don't assume window.document is available

### DIFF
--- a/packages/browser-utils/src/metrics/types.ts
+++ b/packages/browser-utils/src/metrics/types.ts
@@ -1,3 +1,6 @@
 import { GLOBAL_OBJ } from '@sentry/utils';
 
-export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
+export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ &
+  // document is not available in all browser environments (webworkers). We make it optional so you have to explicitly check for it
+  Omit<Window, 'document'> &
+  Partial<Pick<Window, 'document'>>;

--- a/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
@@ -87,7 +87,7 @@ export const onLCP = (onReport: LCPReportCallback, opts: ReportOpts = {}) => {
           // Wrap in a setTimeout so the callback is run in a separate task
           // to avoid extending the keyboard/click handler to reduce INP impact
           // https://github.com/GoogleChrome/web-vitals/issues/383
-          WINDOW.document.addEventListener(type, () => setTimeout(stopListening, 0), true);
+          addEventListener(type, () => setTimeout(stopListening, 0), true);
         }
       });
 

--- a/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { WINDOW } from '../types';
 import { bindReporter } from './lib/bindReporter';
 import { getActivationStart } from './lib/getActivationStart';
 import { getVisibilityWatcher } from './lib/getVisibilityWatcher';
@@ -82,10 +83,12 @@ export const onLCP = (onReport: LCPReportCallback, opts: ReportOpts = {}) => {
       // stops LCP observation, it's unreliable since it can be programmatically
       // generated. See: https://github.com/GoogleChrome/web-vitals/issues/75
       ['keydown', 'click'].forEach(type => {
-        // Wrap in a setTimeout so the callback is run in a separate task
-        // to avoid extending the keyboard/click handler to reduce INP impact
-        // https://github.com/GoogleChrome/web-vitals/issues/383
-        addEventListener(type, () => setTimeout(stopListening, 0), true);
+        if (WINDOW.document) {
+          // Wrap in a setTimeout so the callback is run in a separate task
+          // to avoid extending the keyboard/click handler to reduce INP impact
+          // https://github.com/GoogleChrome/web-vitals/issues/383
+          WINDOW.document.addEventListener(type, () => setTimeout(stopListening, 0), true);
+        }
       });
 
       onHidden(stopListening);

--- a/packages/browser-utils/src/metrics/web-vitals/lib/getVisibilityWatcher.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/lib/getVisibilityWatcher.ts
@@ -19,44 +19,46 @@ import { WINDOW } from '../../types';
 let firstHiddenTime = -1;
 
 const initHiddenTime = () => {
-  // If the document is hidden when this code runs, assume it was always
-  // hidden and the page was loaded in the background, with the one exception
-  // that visibility state is always 'hidden' during prerendering, so we have
-  // to ignore that case until prerendering finishes (see: `prerenderingchange`
-  // event logic below).
-  return WINDOW.document.visibilityState === 'hidden' && !WINDOW.document.prerendering ? 0 : Infinity;
+  if (WINDOW.document) {
+    // If the document is hidden when this code runs, assume it was always
+    // hidden and the page was loaded in the background, with the one exception
+    // that visibility state is always 'hidden' during prerendering, so we have
+    // to ignore that case until prerendering finishes (see: `prerenderingchange`
+    // event logic below).
+    firstHiddenTime = WINDOW.document.visibilityState === 'hidden' && !WINDOW.document.prerendering ? 0 : Infinity;
+  }
 };
 
 const onVisibilityUpdate = (event: Event) => {
-  // If the document is 'hidden' and no previous hidden timestamp has been
-  // set, update it based on the current event data.
-  if (WINDOW.document.visibilityState === 'hidden' && firstHiddenTime > -1) {
-    // If the event is a 'visibilitychange' event, it means the page was
-    // visible prior to this change, so the event timestamp is the first
-    // hidden time.
-    // However, if the event is not a 'visibilitychange' event, then it must
-    // be a 'prerenderingchange' event, and the fact that the document is
-    // still 'hidden' from the above check means the tab was activated
-    // in a background state and so has always been hidden.
-    firstHiddenTime = event.type === 'visibilitychange' ? event.timeStamp : 0;
+  if (WINDOW.document) {
+    // If the document is 'hidden' and no previous hidden timestamp has been
+    // set, update it based on the current event data.
+    if (WINDOW.document.visibilityState === 'hidden' && firstHiddenTime > -1) {
+      // If the event is a 'visibilitychange' event, it means the page was
+      // visible prior to this change, so the event timestamp is the first
+      // hidden time.
+      // However, if the event is not a 'visibilitychange' event, then it must
+      // be a 'prerenderingchange' event, and the fact that the document is
+      // still 'hidden' from the above check means the tab was activated
+      // in a background state and so has always been hidden.
+      firstHiddenTime = event.type === 'visibilitychange' ? event.timeStamp : 0;
 
-    // Remove all listeners now that a `firstHiddenTime` value has been set.
-    removeChangeListeners();
+      // Remove all listeners now that a `firstHiddenTime` value has been set.
+      WINDOW.document.removeEventListener('visibilitychange', onVisibilityUpdate, true);
+      WINDOW.document.removeEventListener('prerenderingchange', onVisibilityUpdate, true);
+    }
   }
 };
 
 const addChangeListeners = () => {
-  addEventListener('visibilitychange', onVisibilityUpdate, true);
-  // IMPORTANT: when a page is prerendering, its `visibilityState` is
-  // 'hidden', so in order to account for cases where this module checks for
-  // visibility during prerendering, an additional check after prerendering
-  // completes is also required.
-  addEventListener('prerenderingchange', onVisibilityUpdate, true);
-};
-
-const removeChangeListeners = () => {
-  removeEventListener('visibilitychange', onVisibilityUpdate, true);
-  removeEventListener('prerenderingchange', onVisibilityUpdate, true);
+  if (WINDOW.document) {
+    WINDOW.document.addEventListener('visibilitychange', onVisibilityUpdate, true);
+    // IMPORTANT: when a page is prerendering, its `visibilityState` is
+    // 'hidden', so in order to account for cases where this module checks for
+    // visibility during prerendering, an additional check after prerendering
+    // completes is also required.
+    WINDOW.document.addEventListener('prerenderingchange', onVisibilityUpdate, true);
+  }
 };
 
 export const getVisibilityWatcher = () => {
@@ -65,7 +67,7 @@ export const getVisibilityWatcher = () => {
     // since navigation start. This isn't a perfect heuristic, but it's the
     // best we can do until an API is available to support querying past
     // visibilityState.
-    firstHiddenTime = initHiddenTime();
+    initHiddenTime();
     addChangeListeners();
   }
   return {

--- a/packages/browser-utils/src/metrics/web-vitals/lib/initMetric.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/lib/initMetric.ts
@@ -25,9 +25,9 @@ export const initMetric = <MetricName extends MetricType['name']>(name: MetricNa
   let navigationType: MetricType['navigationType'] = 'navigate';
 
   if (navEntry) {
-    if (WINDOW.document.prerendering || getActivationStart() > 0) {
+    if ((WINDOW.document && WINDOW.document.prerendering) || getActivationStart() > 0) {
       navigationType = 'prerender';
-    } else if (WINDOW.document.wasDiscarded) {
+    } else if (WINDOW.document && WINDOW.document.wasDiscarded) {
       navigationType = 'restore';
     } else if (navEntry.type) {
       navigationType = navEntry.type.replace(/_/g, '-') as MetricType['navigationType'];

--- a/packages/browser-utils/src/metrics/web-vitals/lib/onHidden.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/lib/onHidden.ts
@@ -22,12 +22,15 @@ export interface OnHiddenCallback {
 
 export const onHidden = (cb: OnHiddenCallback) => {
   const onHiddenOrPageHide = (event: Event) => {
-    if (event.type === 'pagehide' || WINDOW.document.visibilityState === 'hidden') {
+    if (event.type === 'pagehide' || (WINDOW.document && WINDOW.document.visibilityState === 'hidden')) {
       cb(event);
     }
   };
-  addEventListener('visibilitychange', onHiddenOrPageHide, true);
-  // Some browsers have buggy implementations of visibilitychange,
-  // so we use pagehide in addition, just to be safe.
-  addEventListener('pagehide', onHiddenOrPageHide, true);
+
+  if (WINDOW.document) {
+    WINDOW.document.addEventListener('visibilitychange', onHiddenOrPageHide, true);
+    // Some browsers have buggy implementations of visibilitychange,
+    // so we use pagehide in addition, just to be safe.
+    WINDOW.document.addEventListener('pagehide', onHiddenOrPageHide, true);
+  }
 };

--- a/packages/browser-utils/src/metrics/web-vitals/lib/onHidden.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/lib/onHidden.ts
@@ -28,9 +28,9 @@ export const onHidden = (cb: OnHiddenCallback) => {
   };
 
   if (WINDOW.document) {
-    WINDOW.document.addEventListener('visibilitychange', onHiddenOrPageHide, true);
+    addEventListener('visibilitychange', onHiddenOrPageHide, true);
     // Some browsers have buggy implementations of visibilitychange,
     // so we use pagehide in addition, just to be safe.
-    WINDOW.document.addEventListener('pagehide', onHiddenOrPageHide, true);
+    addEventListener('pagehide', onHiddenOrPageHide, true);
   }
 };

--- a/packages/browser-utils/src/metrics/web-vitals/lib/whenActivated.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/lib/whenActivated.ts
@@ -17,8 +17,8 @@
 import { WINDOW } from '../../types';
 
 export const whenActivated = (callback: () => void) => {
-  if (WINDOW.document.prerendering) {
-    addEventListener('prerenderingchange', () => callback(), true);
+  if (WINDOW.document && WINDOW.document.prerendering) {
+    WINDOW.document.addEventListener('prerenderingchange', () => callback(), true);
   } else {
     callback();
   }

--- a/packages/browser-utils/src/metrics/web-vitals/lib/whenActivated.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/lib/whenActivated.ts
@@ -18,7 +18,7 @@ import { WINDOW } from '../../types';
 
 export const whenActivated = (callback: () => void) => {
   if (WINDOW.document && WINDOW.document.prerendering) {
-    WINDOW.document.addEventListener('prerenderingchange', () => callback(), true);
+    addEventListener('prerenderingchange', () => callback(), true);
   } else {
     callback();
   }

--- a/packages/browser-utils/src/metrics/web-vitals/onTTFB.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/onTTFB.ts
@@ -30,9 +30,9 @@ export const TTFBThresholds: MetricRatingThresholds = [800, 1800];
  * @param callback
  */
 const whenReady = (callback: () => void) => {
-  if (WINDOW.document.prerendering) {
+  if (WINDOW.document && WINDOW.document.prerendering) {
     whenActivated(() => whenReady(callback));
-  } else if (WINDOW.document.readyState !== 'complete') {
+  } else if (WINDOW.document && WINDOW.document.readyState !== 'complete') {
     addEventListener('load', () => whenReady(callback), true);
   } else {
     // Queue a task so the callback runs after `loadEventEnd`.

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -450,6 +450,8 @@ function registerInteractionListener(
   };
 
   ['click'].forEach(type => {
-    addEventListener(type, registerInteractionTransaction, { once: false, capture: true });
+    if (WINDOW.document) {
+      WINDOW.document.addEventListener(type, registerInteractionTransaction, { once: false, capture: true });
+    }
   });
 }

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -451,7 +451,7 @@ function registerInteractionListener(
 
   ['click'].forEach(type => {
     if (WINDOW.document) {
-      WINDOW.document.addEventListener(type, registerInteractionTransaction, { once: false, capture: true });
+      addEventListener(type, registerInteractionTransaction, { once: false, capture: true });
     }
   });
 }


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/5289#issuecomment-2056479108

We cannot assume window.document is available because we support web workers.