### PR TITLE
feat(opentelemetry): Remove `otel.attributes` in context

### DIFF
--- a/packages/node/test/integration/transactions.test.ts
+++ b/packages/node/test/integration/transactions.test.ts
@@ -75,12 +75,6 @@ describe('Integration | Transactions', () => {
     ]);
 
     expect(transaction.contexts?.otel).toEqual({
-      attributes: {
-        'test.outer': 'test value',
-        'sentry.op': 'test op',
-        'sentry.origin': 'auto.test',
-        'sentry.source': 'task',
-      },
       resource: {
         'service.name': 'node',
         'service.namespace': 'sentry',
@@ -245,14 +239,6 @@ describe('Integration | Transactions', () => {
           { message: 'test breadcrumb 3', timestamp: 123456 },
         ],
         contexts: expect.objectContaining({
-          otel: expect.objectContaining({
-            attributes: {
-              'test.outer': 'test value',
-              'sentry.op': 'test op',
-              'sentry.origin': 'auto.test',
-              'sentry.source': 'task',
-            },
-          }),
           trace: {
             data: {
               'otel.kind': 'INTERNAL',
@@ -294,12 +280,6 @@ describe('Integration | Transactions', () => {
           { message: 'test breadcrumb 3b', timestamp: 123456 },
         ],
         contexts: expect.objectContaining({
-          otel: expect.objectContaining({
-            attributes: {
-              'test.outer': 'test value b',
-              'sentry.op': 'test op b',
-            },
-          }),
           trace: {
             data: {
               'otel.kind': 'INTERNAL',
@@ -408,11 +388,6 @@ describe('Integration | Transactions', () => {
           { message: 'test breadcrumb 3', timestamp: 123456 },
         ],
         contexts: expect.objectContaining({
-          otel: expect.objectContaining({
-            attributes: {
-              'test.outer': 'test value',
-            },
-          }),
           trace: {
             data: {
               'otel.kind': 'INTERNAL',
@@ -449,11 +424,6 @@ describe('Integration | Transactions', () => {
           { message: 'test breadcrumb 3b', timestamp: 123456 },
         ],
         contexts: expect.objectContaining({
-          otel: expect.objectContaining({
-            attributes: {
-              'test.outer': 'test value b',
-            },
-          }),
           trace: {
             data: {
               'otel.kind': 'INTERNAL',
@@ -527,13 +497,6 @@ describe('Integration | Transactions', () => {
     expect(beforeSendTransaction).toHaveBeenLastCalledWith(
       expect.objectContaining({
         contexts: expect.objectContaining({
-          otel: expect.objectContaining({
-            attributes: {
-              'sentry.op': 'test op',
-              'sentry.origin': 'auto.test',
-              'sentry.source': 'task',
-            },
-          }),
           trace: {
             data: {
               'otel.kind': 'INTERNAL',

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -212,8 +212,6 @@ function createTransactionForOtelSpan(span: ReadableSpan): TransactionEvent {
     contexts: {
       trace: traceContext,
       otel: {
-        // TODO: remove the attributes here?
-        attributes: removeSentryAttributes(span.attributes),
         resource: span.resource.attributes,
       },
     },

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -89,12 +89,6 @@ describe('Integration | Transactions', () => {
     ]);
 
     expect(transaction.contexts?.otel).toEqual({
-      attributes: {
-        'test.outer': 'test value',
-        'sentry.op': 'test op',
-        'sentry.origin': 'auto.test',
-        'sentry.source': 'task',
-      },
       resource: {
         'service.name': 'opentelemetry-test',
         'service.namespace': 'sentry',
@@ -259,14 +253,6 @@ describe('Integration | Transactions', () => {
           { message: 'test breadcrumb 3', timestamp: 123456 },
         ],
         contexts: expect.objectContaining({
-          otel: expect.objectContaining({
-            attributes: {
-              'test.outer': 'test value',
-              'sentry.op': 'test op',
-              'sentry.origin': 'auto.test',
-              'sentry.source': 'task',
-            },
-          }),
           trace: {
             data: {
               'otel.kind': 'INTERNAL',
@@ -308,12 +294,6 @@ describe('Integration | Transactions', () => {
           { message: 'test breadcrumb 3b', timestamp: 123456 },
         ],
         contexts: expect.objectContaining({
-          otel: expect.objectContaining({
-            attributes: {
-              'test.outer': 'test value b',
-              'sentry.op': 'test op b',
-            },
-          }),
           trace: {
             data: {
               'otel.kind': 'INTERNAL',
@@ -391,13 +371,6 @@ describe('Integration | Transactions', () => {
     expect(beforeSendTransaction).toHaveBeenLastCalledWith(
       expect.objectContaining({
         contexts: expect.objectContaining({
-          otel: expect.objectContaining({
-            attributes: {
-              'sentry.op': 'test op',
-              'sentry.origin': 'auto.test',
-              'sentry.source': 'task',
-            },
-          }),
           trace: {
             data: {
               'otel.kind': 'INTERNAL',


### PR DESCRIPTION
This is duplicated from the trace data, no need to send this anymore.