### PR TITLE
test(browser-integration-tests): Test that errors during pageload/navigation have correct trace id

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -65,11 +65,9 @@ sentryTest('error during navigation has new navigation traceId', async ({ getLoc
   await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
-  const [, , events] = await Promise.all([
-    page.goto(`${url}#foo`),
-    page.locator('#errorBtn').click(),
-    envelopeRequestsPromise,
-  ]);
+  await page.goto(`${url}#foo`);
+  await page.locator('#errorBtn').click();
+  const events = await envelopeRequestsPromise;
 
   const navigationEvent = events.find(event => event.type === 'transaction');
   const errorEvent = events.find(event => !event.type);

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -1,9 +1,13 @@
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
+import {
+  getFirstSentryEnvelopeRequest,
+  getMultipleSentryEnvelopeRequests,
+  shouldSkipTracingTest,
+} from '../../../../utils/helpers';
 
-sentryTest('should create a new trace on each navigation', async ({ getLocalTestPath, page }) => {
+sentryTest('creates a new trace on each navigation', async ({ getLocalTestPath, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
@@ -32,13 +36,13 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  // ensure navigation transaction is finished
+  // ensure pageload transaction is finished
   await getFirstSentryEnvelopeRequest<Event>(page, url);
 
-  const navigationEvent1 = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
-  expect(navigationEvent1.contexts?.trace?.op).toBe('navigation');
+  const navigationEvent = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+  expect(navigationEvent.contexts?.trace?.op).toBe('navigation');
 
-  const navigationTraceId = navigationEvent1.contexts?.trace?.trace_id;
+  const navigationTraceId = navigationEvent.contexts?.trace?.trace_id;
   expect(navigationTraceId).toMatch(/^[0-9a-f]{32}$/);
 
   const [, errorEvent] = await Promise.all([
@@ -47,5 +51,34 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
   ]);
 
   const errorTraceId = errorEvent.contexts?.trace?.trace_id;
+  expect(errorTraceId).toBe(navigationTraceId);
+});
+
+sentryTest('error during navigation has new navigation traceId', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  // ensure navigation transaction is finished
+  await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
+  const [, , events] = await Promise.all([
+    page.goto(`${url}#foo`),
+    page.locator('#errorBtn').click(),
+    envelopeRequestsPromise,
+  ]);
+
+  const navigationEvent = events.find(event => event.type === 'transaction');
+  const errorEvent = events.find(event => !event.type);
+
+  expect(navigationEvent?.contexts?.trace?.op).toBe('navigation');
+
+  const navigationTraceId = navigationEvent?.contexts?.trace?.trace_id;
+  expect(navigationTraceId).toMatch(/^[0-9a-f]{32}$/);
+
+  const errorTraceId = errorEvent?.contexts?.trace?.trace_id;
   expect(errorTraceId).toBe(navigationTraceId);
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
@@ -61,7 +61,9 @@ sentryTest('error during pageload has pageload traceId', async ({ getLocalTestPa
   const url = await getLocalTestPath({ testDir: __dirname });
 
   const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
-  const [, , events] = await Promise.all([page.goto(url), page.locator('#errorBtn').click(), envelopeRequestsPromise]);
+  await page.goto(url);
+  await page.locator('#errorBtn').click();
+  const events = await envelopeRequestPromise;
 
   const pageloadEvent = events.find(event => event.type === 'transaction');
   const errorEvent = events.find(event => !event.type);

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
@@ -63,7 +63,7 @@ sentryTest('error during pageload has pageload traceId', async ({ getLocalTestPa
   const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
   await page.goto(url);
   await page.locator('#errorBtn').click();
-  const events = await envelopeRequestPromise;
+  const events = await envelopeRequestsPromise;
 
   const pageloadEvent = events.find(event => event.type === 'transaction');
   const errorEvent = events.find(event => !event.type);


### PR DESCRIPTION
Adds two tests to ensure errors thrown during pageload or navigations have the correct traceId.

(Admittedly, this scenario is pretty obvious and we probably test this in some capacity already but it makes a lot of sense to cover this behaviour in this test suite, too). 

ref https://github.com/getsentry/sentry-javascript/issues/11599