### PR TITLE
test: Fix test for release branch

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/validIntegration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/validIntegration/test.ts
@@ -1,9 +1,18 @@
 import { expect } from '@playwright/test';
+import { SDK_VERSION } from '@sentry/browser';
 
 import { sentryTest } from '../../../../utils/fixtures';
 
 sentryTest('it allows to lazy load an integration', async ({ getLocalTestUrl, page }) => {
   const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.route(`https://browser.sentry-cdn.com/${SDK_VERSION}/httpclient.min.js`, route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/javascript;',
+      body: "window.Sentry.httpClientIntegration = () => ({ name: 'HttpClient' })",
+    });
+  });
 
   await page.goto(url);
 


### PR DESCRIPTION
Sadly, our release failed. The reason is that the lazy load integration test loads the CDN bundle with the current version, which obv. does not exist yet 😬 so we now properly mock this so this always passes.