### PR TITLE
fix(feedback): Fix timeout on feedback submission

### DIFF
--- a/packages/feedback/src/modal/components/DialogContainer.tsx
+++ b/packages/feedback/src/modal/components/DialogContainer.tsx
@@ -33,7 +33,12 @@ export function DialogComponent({ open, onFormSubmitted, successMessageText, ...
   const onSubmitSuccess = useCallback(
     (data: FeedbackFormData) => {
       props.onSubmitSuccess(data);
-      setTimeoutId(() => setTimeout(onFormSubmitted, SUCCESS_MESSAGE_TIMEOUT));
+      setTimeoutId(() =>
+        setTimeout(() => {
+          onFormSubmitted();
+          setTimeoutId(null);
+        }, SUCCESS_MESSAGE_TIMEOUT),
+      );
     },
     [onFormSubmitted],
   );

--- a/packages/feedback/src/modal/components/DialogContainer.tsx
+++ b/packages/feedback/src/modal/components/DialogContainer.tsx
@@ -33,7 +33,7 @@ export function DialogComponent({ open, onFormSubmitted, successMessageText, ...
   const onSubmitSuccess = useCallback(
     (data: FeedbackFormData) => {
       props.onSubmitSuccess(data);
-      setTimeoutId(() =>
+      setTimeoutId(
         setTimeout(() => {
           onFormSubmitted();
           setTimeoutId(null);


### PR DESCRIPTION
The timeout id wasn't getting reset to null after submission which was causing additional clicks on the feedback button to pop up the success message instead. Now, a click on the success message brings back the feedback button, which brings up the dialog when clicked.

Fixes [#418](https://github.com/getsentry/team-replay/issues/418)
