### PR TITLE
fix(node): Ensure DSC is correctly set in envelope headers

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/scenario.ts
@@ -1,0 +1,15 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  tracesSampleRate: 0,
+  integrations: [],
+  transport: loggingTransport,
+});
+
+Sentry.startSpan({ name: 'test span' }, () => {
+  Sentry.captureException(new Error('foo'));
+});

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/test.ts
@@ -1,0 +1,18 @@
+import { createRunner } from '../../../../utils/runner';
+
+test('envelope header for error event during active unsampled span is correct', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .ignore('session', 'sessions', 'transaction')
+    .expectHeader({
+      event: {
+        trace: {
+          trace_id: expect.any(String),
+          public_key: 'public',
+          environment: 'production',
+          release: '1.0',
+          sampled: 'false',
+        },
+      },
+    })
+    .start(done);
+});

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/scenario.ts
@@ -1,0 +1,15 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  tracesSampleRate: 1,
+  integrations: [],
+  transport: loggingTransport,
+});
+
+Sentry.startSpan({ name: 'test span' }, () => {
+  Sentry.captureException(new Error('foo'));
+});

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/test.ts
@@ -1,0 +1,20 @@
+import { createRunner } from '../../../../utils/runner';
+
+test('envelope header for error event during active span is correct', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .ignore('session', 'sessions', 'transaction')
+    .expectHeader({
+      event: {
+        trace: {
+          trace_id: expect.any(String),
+          public_key: 'public',
+          environment: 'production',
+          release: '1.0',
+          sample_rate: '1',
+          sampled: 'true',
+          transaction: 'test span',
+        },
+      },
+    })
+    .start(done);
+});

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/scenario.ts
@@ -1,0 +1,13 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  tracesSampleRate: 0,
+  integrations: [],
+  transport: loggingTransport,
+});
+
+Sentry.captureException(new Error('foo'));

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/test.ts
@@ -1,0 +1,17 @@
+import { createRunner } from '../../../../utils/runner';
+
+test('envelope header for error events is correct', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .ignore('session', 'sessions')
+    .expectHeader({
+      event: {
+        trace: {
+          trace_id: expect.any(String),
+          environment: 'production',
+          public_key: 'public',
+          release: '1.0',
+        },
+      },
+    })
+    .start(done);
+});

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/scenario.ts
@@ -1,0 +1,26 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  tracesSampleRate: 1,
+  integrations: [],
+  transport: loggingTransport,
+});
+
+Sentry.startSpan(
+  {
+    name: 'GET /route',
+    attributes: {
+      'http.method': 'GET',
+      'http.route': '/route',
+      [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+      [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+    },
+  },
+  () => {
+    // noop
+  },
+);

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/test.ts
@@ -1,0 +1,20 @@
+import { createRunner } from '../../../../utils/runner';
+
+test('envelope header for transaction event of route correct', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .ignore('session', 'sessions')
+    .expectHeader({
+      transaction: {
+        trace: {
+          trace_id: expect.any(String),
+          public_key: 'public',
+          transaction: 'GET /route',
+          environment: 'production',
+          release: '1.0',
+          sample_rate: '1',
+          sampled: 'true',
+        },
+      },
+    })
+    .start(done);
+});

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/scenario.ts
@@ -1,0 +1,26 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  tracesSampleRate: 1,
+  integrations: [],
+  transport: loggingTransport,
+});
+
+Sentry.startSpan(
+  {
+    name: 'GET /route/1',
+    attributes: {
+      'http.method': 'GET',
+      'http.route': '/route',
+      [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+      [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+    },
+  },
+  () => {
+    // noop
+  },
+);

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/test.ts
@@ -1,0 +1,19 @@
+import { createRunner } from '../../../../utils/runner';
+
+test('envelope header for transaction event with source=url correct', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .ignore('session', 'sessions')
+    .expectHeader({
+      transaction: {
+        trace: {
+          trace_id: expect.any(String),
+          public_key: 'public',
+          environment: 'production',
+          release: '1.0',
+          sample_rate: '1',
+          sampled: 'true',
+        },
+      },
+    })
+    .start(done);
+});

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/scenario.ts
@@ -1,0 +1,15 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  tracesSampleRate: 1,
+  integrations: [],
+  transport: loggingTransport,
+});
+
+Sentry.startSpan({ name: 'test span' }, () => {
+  // noop
+});

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/test.ts
@@ -1,0 +1,20 @@
+import { createRunner } from '../../../../utils/runner';
+
+test('envelope header for transaction event is correct', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .ignore('session', 'sessions')
+    .expectHeader({
+      transaction: {
+        trace: {
+          trace_id: expect.any(String),
+          public_key: 'public',
+          environment: 'production',
+          release: '1.0',
+          sample_rate: '1',
+          sampled: 'true',
+          transaction: 'test span',
+        },
+      },
+    })
+    .start(done);
+});

--- a/packages/opentelemetry/src/setupEventContextTrace.ts
+++ b/packages/opentelemetry/src/setupEventContextTrace.ts
@@ -1,30 +1,23 @@
 import { getRootSpan } from '@sentry/core';
 import type { Client } from '@sentry/types';
-import { dropUndefinedKeys } from '@sentry/utils';
+import { getDynamicSamplingContextFromSpan } from './utils/dynamicSamplingContext';
 
 import { getActiveSpan } from './utils/getActiveSpan';
-import { spanHasName, spanHasParentId } from './utils/spanTypes';
+import { spanHasName } from './utils/spanTypes';
 
 /** Ensure the `trace` context is set on all events. */
 export function setupEventContextTrace(client: Client): void {
-  client.addEventProcessor(event => {
+  client.on('preprocessEvent', event => {
     const span = getActiveSpan();
     // For transaction events, this is handled separately
     // Because the active span may not be the span that is actually the transaction event
     if (!span || event.type === 'transaction') {
-      return event;
+      return;
     }
 
-    const spanContext = span.spanContext();
-
-    // If event has already set `trace` context, use that one.
-    event.contexts = {
-      trace: dropUndefinedKeys({
-        trace_id: spanContext.traceId,
-        span_id: spanContext.spanId,
-        parent_span_id: spanHasParentId(span) ? span.parentSpanId : undefined,
-      }),
-      ...event.contexts,
+    event.sdkProcessingMetadata = {
+      dynamicSamplingContext: getDynamicSamplingContextFromSpan(span),
+      ...event.sdkProcessingMetadata,
     };
 
     const rootSpan = getRootSpan(span);
@@ -32,7 +25,5 @@ export function setupEventContextTrace(client: Client): void {
     if (transactionName && !event.transaction) {
       event.transaction = transactionName;
     }
-
-    return event;
   });
 }


### PR DESCRIPTION
This was not correctly set before when we had an active span - the `error-active-span` & `error-active-span-unsampled` scenarios failed before and had no `trace` set on the envelope headers.

The fix was to actually fix our `setupEventContextTrace` utility for OTEL, where we now just set the dsc on the event sdkProcessingMetadata, which is picked up when event processing. I also moved this to `preprocessEvent` to ensure this runs before other stuff.

This should fix https://github.com/getsentry/sentry-javascript-examples/pull/7/files#r1561220216 which @s1gr1d found in her example app. 🚀 