### PR TITLE
fix(v7): Ensure  next & sveltekit correctly handle `browserTracingIntegration`

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -10,8 +10,7 @@ import type { EventProcessor, Integration } from '@sentry/types';
 
 import { devErrorSymbolicationEventProcessor } from '../common/devErrorSymbolicationEventProcessor';
 import { getVercelEnv } from '../common/getVercelEnv';
-import { browserTracingIntegration } from './browserTracingIntegration';
-import { BrowserTracing } from './browserTracingIntegration';
+import { BrowserTracing, browserTracingIntegration } from './browserTracingIntegration';
 import { rewriteFramesIntegration } from './rewriteFramesIntegration';
 import { applyTunnelRouteOption } from './tunnelRoute';
 
@@ -107,7 +106,7 @@ function maybeUpdateBrowserTracingIntegration(integrations: Integration[]): Inte
   if (isNewBrowserTracingIntegration(browserTracing)) {
     const { options } = browserTracing;
     // eslint-disable-next-line deprecation/deprecation
-    integrations[integrations.indexOf(browserTracing)] = new BrowserTracing(options);
+    integrations[integrations.indexOf(browserTracing)] = browserTracingIntegration(options);
   }
 
   // If BrowserTracing was added, but it is not our forked version,

--- a/packages/sveltekit/src/client/sdk.ts
+++ b/packages/sveltekit/src/client/sdk.ts
@@ -1,5 +1,5 @@
 import { applySdkMetadata, hasTracingEnabled } from '@sentry/core';
-import { BrowserOptions, browserTracingIntegration } from '@sentry/svelte';
+import type { BrowserOptions, browserTracingIntegration } from '@sentry/svelte';
 import { getDefaultIntegrations as getDefaultSvelteIntegrations } from '@sentry/svelte';
 import { WINDOW, getCurrentScope, init as initSvelteSdk } from '@sentry/svelte';
 import type { Integration } from '@sentry/types';

--- a/packages/sveltekit/src/client/sdk.ts
+++ b/packages/sveltekit/src/client/sdk.ts
@@ -1,5 +1,5 @@
 import { applySdkMetadata, hasTracingEnabled } from '@sentry/core';
-import type { BrowserOptions, browserTracingIntegration } from '@sentry/svelte';
+import { BrowserOptions, browserTracingIntegration } from '@sentry/svelte';
 import { getDefaultIntegrations as getDefaultSvelteIntegrations } from '@sentry/svelte';
 import { WINDOW, getCurrentScope, init as initSvelteSdk } from '@sentry/svelte';
 import type { Integration } from '@sentry/types';
@@ -82,7 +82,7 @@ function maybeUpdateBrowserTracingIntegration(integrations: Integration[]): Inte
   if (isNewBrowserTracingIntegration(browserTracing)) {
     const { options } = browserTracing;
     // eslint-disable-next-line deprecation/deprecation
-    integrations[integrations.indexOf(browserTracing)] = new BrowserTracing(options);
+    integrations[integrations.indexOf(browserTracing)] = svelteKitBrowserTracingIntegration(options);
   }
 
   // If BrowserTracing was added, but it is not our forked version,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/11627