### PR TITLE
ci: Streamline naming of CI workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky.yml
+++ b/.github/ISSUE_TEMPLATE/flaky.yml
@@ -18,7 +18,7 @@ body:
     id: job-name
     attributes:
       label: Name of Job
-      placeholder: Build & Test / Nextjs (Node 14) Tests
+      placeholder: "CI: Build & Test / Nextjs (Node 14) Tests"
       description: name of job as reported in the status report
     validations:
       required: true

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,4 +1,4 @@
-name: Gitflow - Auto prepare release
+name: "Gitflow: Auto prepare release"
 on:
   pull_request:
     types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: 'Build & Test'
+name: 'CI: Build & Test'
 on:
   push:
     branches:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,4 +1,4 @@
-name: 'Canary Tests'
+name: 'CI: Canary Tests'
 on:
   schedule:
     # Run every day at midnight

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,4 +1,4 @@
-name: Clear all GHA caches
+name: "Action: Clear all GHA caches"
 on:
   workflow_dispatch:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: 'CodeQL'
+name: 'CI: CodeQL'
 
 on:
   push:

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -1,4 +1,4 @@
-name: Enforce License Compliance
+name: "CI: Enforce License Compliance"
 
 on:
   push:

--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -1,4 +1,4 @@
-name: 'Detect flaky tests'
+name: 'CI: Detect flaky tests'
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/gitflow-sync-develop.yml
+++ b/.github/workflows/gitflow-sync-develop.yml
@@ -1,4 +1,4 @@
-name: Gitflow - Sync master into develop
+name: "Gitflow: Sync master into develop"
 on:
   push:
     branches:

--- a/.github/workflows/issue-package-label.yml
+++ b/.github/workflows/issue-package-label.yml
@@ -1,4 +1,4 @@
-name: 'Tag issue with package label'
+name: 'Automation: Tag issue with package label'
 
 on:
   issues:

--- a/.github/workflows/release-size-info.yml
+++ b/.github/workflows/release-size-info.yml
@@ -1,4 +1,4 @@
-name: Add size info to release
+name: "Automation: Add size info to release"
 on:
   release:
     types:
@@ -27,4 +27,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.get_version.outputs.version }}
-          workflow_name: 'Build & Test'
+          workflow_name: 'CI: Build & Test'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Prepare Release
+name: "Action: Prepare Release"
 on:
   workflow_dispatch:
     inputs:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ _Bad software is everywhere, and we're tired of it. Sentry is on a mission to he
 faster, so we can get back to enjoying technology. If you want to join us
 [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_
 
-![Build & Test](https://github.com/getsentry/sentry-javascript/workflows/Build%20&%20Test/badge.svg)
-[![codecov](https://codecov.io/gh/getsentry/sentry-javascript/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/sentry-javascript)
+![Build & Test](https://github.com/getsentry/sentry-javascript/workflows/CI:%20Build%20&%20Test/badge.svg)
+[![codecov](https://codecov.io/gh/getsentry/sentry-javascript/branch/develop/graph/badge.svg)](https://codecov.io/gh/getsentry/sentry-javascript)
 [![npm version](https://img.shields.io/npm/v/@sentry/core.svg)](https://www.npmjs.com/package/@sentry/core)
 [![Discord](https://img.shields.io/discord/621778831602221064)](https://discord.gg/Ww9hbqr)
 


### PR DESCRIPTION
The list in https://github.com/getsentry/sentry-javascript/actions is a bit hard to parse, maybe streamlining this makes this easier...