### PR TITLE
test(browser-integration-tests): Check `trace` envelope headers in trace lifetime tests

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -1,7 +1,9 @@
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
+import type { EventAndTraceHeader } from '../../../../utils/helpers';
 import {
+  eventAndTraceHeaderRequestParser,
   getFirstSentryEnvelopeRequest,
   getMultipleSentryEnvelopeRequests,
   shouldSkipTracingTest,
@@ -14,12 +16,21 @@ sentryTest('creates a new trace on each navigation', async ({ getLocalTestPath, 
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  await getFirstSentryEnvelopeRequest<Event>(page, url);
-  const navigationEvent1 = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
-  const navigationEvent2 = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#bar`);
+  await getFirstSentryEnvelopeRequest(page, url);
 
-  const navigation1TraceContext = navigationEvent1.contexts?.trace;
-  const navigation2TraceContext = navigationEvent2.contexts?.trace;
+  const [navigation1Event, navigation1TraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    `${url}#foo`,
+    eventAndTraceHeaderRequestParser,
+  );
+  const [navigation2Event, navigation2TraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    `${url}#bar`,
+    eventAndTraceHeaderRequestParser,
+  );
+
+  const navigation1TraceContext = navigation1Event.contexts?.trace;
+  const navigation2TraceContext = navigation2Event.contexts?.trace;
 
   expect(navigation1TraceContext).toMatchObject({
     op: 'navigation',
@@ -28,12 +39,28 @@ sentryTest('creates a new trace on each navigation', async ({ getLocalTestPath, 
   });
   expect(navigation1TraceContext).not.toHaveProperty('parent_span_id');
 
+  expect(navigation1TraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: navigation1TraceContext?.trace_id,
+  });
+
   expect(navigation2TraceContext).toMatchObject({
     op: 'navigation',
     trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
   });
   expect(navigation2TraceContext).not.toHaveProperty('parent_span_id');
+
+  expect(navigation2TraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: navigation2TraceContext?.trace_id,
+  });
 
   expect(navigation1TraceContext?.trace_id).not.toEqual(navigation2TraceContext?.trace_id);
 });
@@ -48,7 +75,11 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
   // ensure pageload transaction is finished
   await getFirstSentryEnvelopeRequest<Event>(page, url);
 
-  const navigationEvent = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+  const [navigationEvent, navigationTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    `${url}#foo`,
+    eventAndTraceHeaderRequestParser,
+  );
   const navigationTraceContext = navigationEvent.contexts?.trace;
 
   expect(navigationTraceContext).toMatchObject({
@@ -58,14 +89,33 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
   });
   expect(navigationTraceContext).not.toHaveProperty('parent_span_id');
 
-  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+  expect(navigationTraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: navigationTraceContext?.trace_id,
+  });
+
+  const errorEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    undefined,
+    eventAndTraceHeaderRequestParser,
+  );
   await page.locator('#errorBtn').click();
-  const errorEvent = await errorEventPromise;
+  const [errorEvent, errorTraceHeader] = await errorEventPromise;
 
   const errorTraceContext = errorEvent.contexts?.trace;
   expect(errorTraceContext).toEqual({
     trace_id: navigationTraceContext?.trace_id,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+  });
+  expect(errorTraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: navigationTraceContext?.trace_id,
   });
 });
 
@@ -79,13 +129,19 @@ sentryTest('error during navigation has new navigation traceId', async ({ getLoc
   // ensure navigation transaction is finished
   await getFirstSentryEnvelopeRequest<Event>(page, url);
 
-  const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
+  const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<EventAndTraceHeader>(
+    page,
+    2,
+    undefined,
+    eventAndTraceHeaderRequestParser,
+  );
+
   await page.goto(`${url}#foo`);
   await page.locator('#errorBtn').click();
-  const events = await envelopeRequestsPromise;
+  const envelopes = await envelopeRequestsPromise;
 
-  const navigationEvent = events.find(event => event.type === 'transaction');
-  const errorEvent = events.find(event => !event.type);
+  const [navigationEvent, navigationTraceHeader] = envelopes.find(envelope => envelope[0].type === 'transaction')!;
+  const [errorEvent, errorTraceHeader] = envelopes.find(envelope => !envelope[0].type)!;
 
   const navigationTraceContext = navigationEvent?.contexts?.trace;
   expect(navigationTraceContext).toMatchObject({
@@ -95,11 +151,27 @@ sentryTest('error during navigation has new navigation traceId', async ({ getLoc
   });
   expect(navigationTraceContext).not.toHaveProperty('parent_span_id');
 
+  expect(navigationTraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: navigationTraceContext?.trace_id,
+  });
+
   const errorTraceContext = errorEvent?.contexts?.trace;
   expect(errorTraceContext).toMatchObject({
     op: 'navigation',
-    trace_id: errorTraceContext?.trace_id,
+    trace_id: navigationTraceContext?.trace_id,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+  });
+
+  expect(errorTraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: navigationTraceContext?.trace_id,
   });
 });
 
@@ -115,7 +187,11 @@ sentryTest(
     // ensure navigation transaction is finished
     await getFirstSentryEnvelopeRequest<Event>(page, url);
 
-    const navigationEvent = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+    const [navigationEvent, navigationTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      `${url}#foo`,
+      eventAndTraceHeaderRequestParser,
+    );
 
     const navigationTraceContext = navigationEvent.contexts?.trace;
     expect(navigationTraceContext).toMatchObject({
@@ -124,6 +200,14 @@ sentryTest(
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
     });
     expect(navigationTraceContext).not.toHaveProperty('parent_span_id');
+
+    expect(navigationTraceHeader).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: navigationTraceContext?.trace_id,
+    });
 
     const requestPromise = page.waitForRequest('http://example.com/*');
     await page.locator('#fetchBtn').click();
@@ -151,11 +235,18 @@ sentryTest(
     // ensure navigation transaction is finished
     await getFirstSentryEnvelopeRequest<Event>(page, url);
 
-    const navigationEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+    const navigationEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      undefined,
+      eventAndTraceHeaderRequestParser,
+    );
     const requestPromise = page.waitForRequest('http://example.com/*');
     await page.goto(`${url}#foo`);
     await page.locator('#fetchBtn').click();
-    const [navigationEvent, request] = await Promise.all([navigationEventPromise, requestPromise]);
+    const [[navigationEvent, navigationTraceHeader], request] = await Promise.all([
+      navigationEventPromise,
+      requestPromise,
+    ]);
 
     const navigationTraceContext = navigationEvent.contexts?.trace;
     expect(navigationTraceContext).toMatchObject({
@@ -164,6 +255,14 @@ sentryTest(
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
     });
     expect(navigationTraceContext).not.toHaveProperty('parent_span_id');
+
+    expect(navigationTraceHeader).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: navigationTraceContext?.trace_id,
+    });
 
     const headers = request.headers();
 
@@ -186,9 +285,13 @@ sentryTest(
     const url = await getLocalTestPath({ testDir: __dirname });
 
     // ensure navigation transaction is finished
-    await getFirstSentryEnvelopeRequest<Event>(page, url);
+    await getFirstSentryEnvelopeRequest(page, url);
 
-    const navigationEvent = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+    const [navigationEvent, navigationTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      `${url}#foo`,
+      eventAndTraceHeaderRequestParser,
+    );
 
     const navigationTraceContext = navigationEvent.contexts?.trace;
     expect(navigationTraceContext).toMatchObject({
@@ -197,6 +300,14 @@ sentryTest(
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
     });
     expect(navigationTraceContext).not.toHaveProperty('parent_span_id');
+
+    expect(navigationTraceHeader).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: navigationTraceContext?.trace_id,
+    });
 
     const xhrPromise = page.waitForRequest('http://example.com/*');
     await page.locator('#xhrBtn').click();
@@ -222,13 +333,20 @@ sentryTest(
     const url = await getLocalTestPath({ testDir: __dirname });
 
     // ensure navigation transaction is finished
-    await getFirstSentryEnvelopeRequest<Event>(page, url);
+    await getFirstSentryEnvelopeRequest(page, url);
 
-    const navigationEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+    const navigationEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      undefined,
+      eventAndTraceHeaderRequestParser,
+    );
     const requestPromise = page.waitForRequest('http://example.com/*');
     await page.goto(`${url}#foo`);
     await page.locator('#xhrBtn').click();
-    const [navigationEvent, request] = await Promise.all([navigationEventPromise, requestPromise]);
+    const [[navigationEvent, navigationTraceHeader], request] = await Promise.all([
+      navigationEventPromise,
+      requestPromise,
+    ]);
 
     const navigationTraceContext = navigationEvent.contexts?.trace;
     expect(navigationTraceContext).toMatchObject({
@@ -237,6 +355,15 @@ sentryTest(
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
     });
     expect(navigationTraceContext).not.toHaveProperty('parent_span_id');
+
+    expect(navigationTraceHeader).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: navigationTraceContext?.trace_id,
+    });
+
     const headers = request.headers();
 
     // sampling decision is propagated from active span sampling decision

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
@@ -1,6 +1,4 @@
-import { release } from 'os';
 import { expect } from '@playwright/test';
-import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import type { EventAndTraceHeader } from '../../../../utils/helpers';
 import {

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
@@ -1,7 +1,10 @@
+import { release } from 'os';
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
+import type { EventAndTraceHeader } from '../../../../utils/helpers';
 import {
+  eventAndTraceHeaderRequestParser,
   getFirstSentryEnvelopeRequest,
   getMultipleSentryEnvelopeRequests,
   shouldSkipTracingTest,
@@ -21,8 +24,16 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
-    const navigationEvent = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+    const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      url,
+      eventAndTraceHeaderRequestParser,
+    );
+    const [navigationEvent, navigationTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      `${url}#foo`,
+      eventAndTraceHeaderRequestParser,
+    );
 
     const pageloadTraceContext = pageloadEvent.contexts?.trace;
     const navigationTraceContext = navigationEvent.contexts?.trace;
@@ -33,6 +44,17 @@ sentryTest(
       parent_span_id: META_TAG_PARENT_SPAN_ID,
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
     });
+
+    expect(pageloadTraceHeader).toEqual({
+      environment: 'prod',
+      release: '1.0.0',
+      sample_rate: '0.2',
+      sampled: 'true',
+      transaction: 'my-transaction',
+      public_key: 'public',
+      trace_id: META_TAG_TRACE_ID,
+    });
+
     expect(navigationTraceContext).toMatchObject({
       op: 'navigation',
       trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
@@ -40,6 +62,14 @@ sentryTest(
     });
     // navigation span is head of trace, so there's no parent span:
     expect(navigationTraceContext?.trace_id).not.toHaveProperty('parent_span_id');
+
+    expect(navigationTraceHeader).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: navigationTraceContext?.trace_id,
+    });
 
     expect(pageloadTraceContext?.trace_id).not.toEqual(navigationTraceContext?.trace_id);
   },
@@ -52,7 +82,12 @@ sentryTest('error after <meta> tag pageload has pageload traceId', async ({ getL
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const pageloadEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
+  const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    url,
+    eventAndTraceHeaderRequestParser,
+  );
+
   expect(pageloadEvent.contexts?.trace).toMatchObject({
     op: 'pageload',
     trace_id: META_TAG_TRACE_ID,
@@ -60,14 +95,38 @@ sentryTest('error after <meta> tag pageload has pageload traceId', async ({ getL
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
   });
 
-  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+  expect(pageloadTraceHeader).toEqual({
+    environment: 'prod',
+    release: '1.0.0',
+    sample_rate: '0.2',
+    sampled: 'true',
+    transaction: 'my-transaction',
+    public_key: 'public',
+    trace_id: META_TAG_TRACE_ID,
+  });
+
+  const errorEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    undefined,
+    eventAndTraceHeaderRequestParser,
+  );
   await page.locator('#errorBtn').click();
-  const errorEvent = await errorEventPromise;
+  const [errorEvent, errorTraceHeader] = await errorEventPromise;
 
   expect(errorEvent.contexts?.trace).toMatchObject({
     trace_id: META_TAG_TRACE_ID,
     parent_span_id: META_TAG_PARENT_SPAN_ID,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+  });
+
+  expect(errorTraceHeader).toEqual({
+    environment: 'prod',
+    release: '1.0.0',
+    sample_rate: '0.2',
+    sampled: 'true',
+    transaction: 'my-transaction',
+    public_key: 'public',
+    trace_id: META_TAG_TRACE_ID,
   });
 });
 
@@ -78,13 +137,20 @@ sentryTest('error during <meta> tag pageload has pageload traceId', async ({ get
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
+  const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<EventAndTraceHeader>(
+    page,
+    2,
+    undefined,
+    eventAndTraceHeaderRequestParser,
+  );
   await page.goto(url);
   await page.locator('#errorBtn').click();
-  const events = await envelopeRequestsPromise;
+  const envelopes = await envelopeRequestsPromise;
 
-  const pageloadEvent = events.find(event => event.type === 'transaction');
-  const errorEvent = events.find(event => !event.type);
+  const [pageloadEvent, pageloadTraceHeader] = envelopes.find(
+    eventAndHeader => eventAndHeader[0].type === 'transaction',
+  )!;
+  const [errorEvent, errorTraceHeader] = envelopes.find(eventAndHeader => !eventAndHeader[0].type)!;
 
   expect(pageloadEvent?.contexts?.trace).toMatchObject({
     op: 'pageload',
@@ -93,10 +159,30 @@ sentryTest('error during <meta> tag pageload has pageload traceId', async ({ get
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
   });
 
+  expect(pageloadTraceHeader).toEqual({
+    environment: 'prod',
+    release: '1.0.0',
+    sample_rate: '0.2',
+    sampled: 'true',
+    transaction: 'my-transaction',
+    public_key: 'public',
+    trace_id: META_TAG_TRACE_ID,
+  });
+
   expect(errorEvent?.contexts?.trace).toMatchObject({
     trace_id: META_TAG_TRACE_ID,
     parent_span_id: META_TAG_PARENT_SPAN_ID,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+  });
+
+  expect(errorTraceHeader).toEqual({
+    environment: 'prod',
+    release: '1.0.0',
+    sample_rate: '0.2',
+    sampled: 'true',
+    transaction: 'my-transaction',
+    public_key: 'public',
+    trace_id: META_TAG_TRACE_ID,
   });
 });
 
@@ -109,12 +195,26 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
+    const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      url,
+      eventAndTraceHeaderRequestParser,
+    );
     expect(pageloadEvent?.contexts?.trace).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,
       parent_span_id: META_TAG_PARENT_SPAN_ID,
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
+
+    expect(pageloadTraceHeader).toEqual({
+      environment: 'prod',
+      release: '1.0.0',
+      sample_rate: '0.2',
+      sampled: 'true',
+      transaction: 'my-transaction',
+      public_key: 'public',
+      trace_id: META_TAG_TRACE_ID,
     });
 
     const requestPromise = page.waitForRequest('http://example.com/*');
@@ -137,17 +237,31 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+    const pageloadEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      undefined,
+      eventAndTraceHeaderRequestParser,
+    );
     const requestPromise = page.waitForRequest('http://example.com/*');
     await page.goto(url);
     await page.locator('#fetchBtn').click();
-    const [pageloadEvent, request] = await Promise.all([pageloadEventPromise, requestPromise]);
+    const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);
 
     expect(pageloadEvent?.contexts?.trace).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,
       parent_span_id: META_TAG_PARENT_SPAN_ID,
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
+
+    expect(pageloadTraceHeader).toEqual({
+      environment: 'prod',
+      release: '1.0.0',
+      sample_rate: '0.2',
+      sampled: 'true',
+      transaction: 'my-transaction',
+      public_key: 'public',
+      trace_id: META_TAG_TRACE_ID,
     });
 
     const headers = request.headers();
@@ -167,12 +281,25 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
+    const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      url,
+      eventAndTraceHeaderRequestParser,
+    );
     expect(pageloadEvent?.contexts?.trace).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,
       parent_span_id: META_TAG_PARENT_SPAN_ID,
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
+    expect(pageloadTraceHeader).toEqual({
+      environment: 'prod',
+      release: '1.0.0',
+      sample_rate: '0.2',
+      sampled: 'true',
+      transaction: 'my-transaction',
+      public_key: 'public',
+      trace_id: META_TAG_TRACE_ID,
     });
 
     const requestPromise = page.waitForRequest('http://example.com/*');
@@ -195,17 +322,31 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+    const pageloadEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      undefined,
+      eventAndTraceHeaderRequestParser,
+    );
     const requestPromise = page.waitForRequest('http://example.com/*');
     await page.goto(url);
     await page.locator('#xhrBtn').click();
-    const [pageloadEvent, request] = await Promise.all([pageloadEventPromise, requestPromise]);
+    const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);
 
     expect(pageloadEvent?.contexts?.trace).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,
       parent_span_id: META_TAG_PARENT_SPAN_ID,
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
+
+    expect(pageloadTraceHeader).toEqual({
+      environment: 'prod',
+      release: '1.0.0',
+      sample_rate: '0.2',
+      sampled: 'true',
+      transaction: 'my-transaction',
+      public_key: 'public',
+      trace_id: META_TAG_TRACE_ID,
     });
 
     const headers = request.headers();

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import type { EventAndTraceHeader } from '../../../../utils/helpers';
 import {

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
@@ -1,7 +1,9 @@
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
+import type { EventAndTraceHeader } from '../../../../utils/helpers';
 import {
+  eventAndTraceHeaderRequestParser,
   getFirstSentryEnvelopeRequest,
   getMultipleSentryEnvelopeRequests,
   shouldSkipTracingTest,
@@ -16,8 +18,16 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
-    const navigationEvent = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+    const [pageloadEvent, pageloadTraceHeaders] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      url,
+      eventAndTraceHeaderRequestParser,
+    );
+    const [navigationEvent, navigationTraceHeaders] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      `${url}#foo`,
+      eventAndTraceHeaderRequestParser,
+    );
 
     const pageloadTraceContext = pageloadEvent.contexts?.trace;
     const navigationTraceContext = navigationEvent.contexts?.trace;
@@ -29,12 +39,28 @@ sentryTest(
     });
     expect(pageloadTraceContext).not.toHaveProperty('parent_span_id');
 
+    expect(pageloadTraceHeaders).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: pageloadTraceContext?.trace_id,
+    });
+
     expect(navigationTraceContext).toMatchObject({
       op: 'navigation',
       trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
       span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
     });
     expect(navigationTraceContext).not.toHaveProperty('parent_span_id');
+
+    expect(navigationTraceHeaders).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: navigationTraceContext?.trace_id,
+    });
 
     expect(pageloadTraceContext?.span_id).not.toEqual(navigationTraceContext?.span_id);
   },
@@ -47,7 +73,11 @@ sentryTest('error after pageload has pageload traceId', async ({ getLocalTestPat
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const pageloadEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
+  const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    url,
+    eventAndTraceHeaderRequestParser,
+  );
   const pageloadTraceContext = pageloadEvent.contexts?.trace;
 
   expect(pageloadTraceContext).toMatchObject({
@@ -57,15 +87,35 @@ sentryTest('error after pageload has pageload traceId', async ({ getLocalTestPat
   });
   expect(pageloadTraceContext).not.toHaveProperty('parent_span_id');
 
-  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+  expect(pageloadTraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: pageloadTraceContext?.trace_id,
+  });
+
+  const errorEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    undefined,
+    eventAndTraceHeaderRequestParser,
+  );
   await page.locator('#errorBtn').click();
-  const errorEvent = await errorEventPromise;
+  const [errorEvent, errorTraceHeader] = await errorEventPromise;
 
   const errorTraceContext = errorEvent.contexts?.trace;
 
   expect(errorTraceContext).toEqual({
     trace_id: pageloadTraceContext?.trace_id,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+  });
+
+  expect(errorTraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: pageloadTraceContext?.trace_id,
   });
 });
 
@@ -76,13 +126,20 @@ sentryTest('error during pageload has pageload traceId', async ({ getLocalTestPa
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
+  const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<EventAndTraceHeader>(
+    page,
+    2,
+    undefined,
+    eventAndTraceHeaderRequestParser,
+  );
   await page.goto(url);
   await page.locator('#errorBtn').click();
-  const events = await envelopeRequestsPromise;
+  const envelopes = await envelopeRequestsPromise;
 
-  const pageloadEvent = events.find(event => event.type === 'transaction');
-  const errorEvent = events.find(event => !event.type);
+  const [pageloadEvent, pageloadTraceHeader] = envelopes.find(
+    eventAndHeader => eventAndHeader[0].type === 'transaction',
+  )!;
+  const [errorEvent, errorTraceHeader] = envelopes.find(eventAndHeader => !eventAndHeader[0].type)!;
 
   const pageloadTraceContext = pageloadEvent?.contexts?.trace;
   expect(pageloadTraceContext).toMatchObject({
@@ -92,11 +149,27 @@ sentryTest('error during pageload has pageload traceId', async ({ getLocalTestPa
   });
   expect(pageloadTraceContext).not.toHaveProperty('parent_span_id');
 
+  expect(pageloadTraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: pageloadTraceContext?.trace_id,
+  });
+
   const errorTraceContext = errorEvent?.contexts?.trace;
   expect(errorTraceContext).toMatchObject({
     op: 'pageload',
     trace_id: pageloadTraceContext?.trace_id,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+  });
+
+  expect(errorTraceHeader).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: pageloadTraceContext?.trace_id,
   });
 });
 
@@ -109,8 +182,13 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
+    const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      url,
+      eventAndTraceHeaderRequestParser,
+    );
     const pageloadTraceContext = pageloadEvent.contexts?.trace;
+    const pageloadTraceId = pageloadTraceContext?.trace_id;
 
     expect(pageloadTraceContext).toMatchObject({
       op: 'pageload',
@@ -119,13 +197,20 @@ sentryTest(
     });
     expect(pageloadTraceContext).not.toHaveProperty('parent_span_id');
 
+    expect(pageloadTraceHeader).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: pageloadTraceId,
+    });
+
     const requestPromise = page.waitForRequest('http://example.com/*');
     await page.locator('#fetchBtn').click();
     const request = await requestPromise;
     const headers = request.headers();
 
     // sampling decision and DSC are continued from the pageload span even after it ended
-    const pageloadTraceId = pageloadTraceContext?.trace_id;
     expect(headers['sentry-trace']).toMatch(new RegExp(`^${pageloadTraceId}-[0-9a-f]{16}-1$`));
     expect(headers['baggage']).toEqual(
       `sentry-environment=production,sentry-public_key=public,sentry-trace_id=${pageloadTraceId},sentry-sample_rate=1,sentry-sampled=true`,
@@ -142,13 +227,19 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+    const pageloadEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      undefined,
+      eventAndTraceHeaderRequestParser,
+    );
     const requestPromise = page.waitForRequest('http://example.com/*');
     await page.goto(url);
     await page.locator('#fetchBtn').click();
-    const [pageloadEvent, request] = await Promise.all([pageloadEventPromise, requestPromise]);
+    const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);
 
     const pageloadTraceContext = pageloadEvent.contexts?.trace;
+    const pageloadTraceId = pageloadTraceContext?.trace_id;
+
     expect(pageloadTraceContext).toMatchObject({
       op: 'pageload',
       trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
@@ -156,10 +247,17 @@ sentryTest(
     });
     expect(pageloadTraceContext).not.toHaveProperty('parent_span_id');
 
+    expect(pageloadTraceHeader).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: pageloadTraceId,
+    });
+
     const headers = request.headers();
 
     // sampling decision is propagated from active span sampling decision
-    const pageloadTraceId = pageloadTraceContext?.trace_id;
     expect(headers['sentry-trace']).toMatch(new RegExp(`^${pageloadTraceId}-[0-9a-f]{16}-1$`));
     expect(headers['baggage']).toEqual(
       `sentry-environment=production,sentry-public_key=public,sentry-trace_id=${pageloadTraceId},sentry-sample_rate=1,sentry-sampled=true`,

--- a/dev-packages/browser-integration-tests/utils/helpers.ts
+++ b/dev-packages/browser-integration-tests/utils/helpers.ts
@@ -1,5 +1,12 @@
 import type { Page, Request } from '@playwright/test';
-import type { EnvelopeItem, EnvelopeItemType, Event, EventEnvelopeHeaders } from '@sentry/types';
+import type {
+  Envelope,
+  EnvelopeItem,
+  EnvelopeItemType,
+  Event,
+  EventEnvelope,
+  EventEnvelopeHeaders,
+} from '@sentry/types';
 import { parseEnvelope } from '@sentry/utils';
 
 export const envelopeUrlRegex = /\.sentry\.io\/api\/\d+\/envelope\//;
@@ -38,6 +45,30 @@ export const properEnvelopeParser = (request: Request | null): EnvelopeItem[] =>
 
   return items;
 };
+
+export type EventAndTraceHeader = [Event, EventEnvelopeHeaders['trace']];
+
+/**
+ * Returns the first event item and `trace` envelope header from an envelope.
+ * This is particularly helpful if you want to test dynamic sampling and trace propagation-related cases.
+ */
+export const eventAndTraceHeaderRequestParser = (request: Request | null): EventAndTraceHeader => {
+  const envelope = properFullEnvelopeParser<EventEnvelope>(request);
+  return getEventAndTraceHeader(envelope);
+};
+
+const properFullEnvelopeParser = <T extends Envelope>(request: Request | null): T => {
+  // https://develop.sentry.dev/sdk/envelopes/
+  const envelope = request?.postData() || '';
+
+  return parseEnvelope(envelope) as T;
+};
+
+function getEventAndTraceHeader(envelope: EventEnvelope): EventAndTraceHeader {
+  const event = envelope[1][0][1] as Event;
+  const trace = envelope[0].trace;
+  return [event, trace];
+}
 
 export const properEnvelopeRequestParser = <T = Event>(request: Request | null, envelopeIndex = 1): T => {
   return properEnvelopeParser(request)[0][envelopeIndex] as T;


### PR DESCRIPTION
This PR adds checks for the contents of the `trace` envelope headers in our new `trace-lifetime` test suite. The purpose of these checks is to ensure that we not only propagate and send correct trace data in request headers and Sentry events (trace context) but also in the `trace` envelope header. 

Side note: This makes the tests notably longer but IMO its worth to have deep checks here because we can ensure that we always send the right data everywhere. Also, I had to write a "new" request parser to get both, events and the envelope headers. 

ref #11599 