### PR TITLE
feat(opentelemetry): Remove setupGlobalHub

### DIFF
--- a/packages/opentelemetry/src/custom/hub.ts
+++ b/packages/opentelemetry/src/custom/hub.ts
@@ -1,8 +1,0 @@
-/**
- * Ensure the global hub is setup.
- *
- * @deprecated This will be removed in the next major version.
- */
-export function setupGlobalHub(): void {
-  // noop
-}

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -26,8 +26,6 @@ export { startSpan, startSpanManual, startInactiveSpan, withActiveSpan, continue
 export { suppressTracing } from './utils/suppressTracing';
 
 // eslint-disable-next-line deprecation/deprecation
-export { setupGlobalHub } from './custom/hub';
-// eslint-disable-next-line deprecation/deprecation
 export { getCurrentHubShim } from '@sentry/core';
 export { setupEventContextTrace } from './setupEventContextTrace';
 


### PR DESCRIPTION
Now that https://github.com/getsentry/sentry-javascript/pull/11630 was merged in, we can remove `setupGlobalHub`.