### PR TITLE
test(ci): Reduce flaky test detector assumed average test runtime

### DIFF
--- a/dev-packages/browser-integration-tests/scripts/detectFlakyTests.ts
+++ b/dev-packages/browser-integration-tests/scripts/detectFlakyTests.ts
@@ -9,9 +9,9 @@ import * as glob from 'glob';
 const NUM_BROWSERS = 3;
 
 /**
- * Assume that each test runs for 3s.
+ * Assume that each test runs for 2s.
  */
-const ASSUMED_TEST_DURATION_SECONDS = 3;
+const ASSUMED_TEST_DURATION_SECONDS = 2;
 
 /**
  * We keep the runtime of the detector if possible under 30min.


### PR DESCRIPTION
I checked in the last couple of PRs where added integration tests how long our flaky test detector usually runs. Seems like we average somewhere around 18 minutes. Which is generally fine but our target is 30mins runtime. The reason for the "short" runs is that we assume an average runtime of 3s per test. Which apparently is a bit too long (this actually surprised me). Let's try reduce it to 2s and see if we get closer. We can always revert if we overshoot the time budget in the future. 

More runs => less ❄️ 🤞 