### PR TITLE
test(browser-integration-tests): Check for full equality in error event trace context

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -160,8 +160,15 @@ sentryTest('error during navigation has new navigation traceId', async ({ getLoc
   });
 
   const errorTraceContext = errorEvent?.contexts?.trace;
-  expect(errorTraceContext).toMatchObject({
+  expect(errorTraceContext).toEqual({
+    data: {
+      'sentry.op': 'navigation',
+      'sentry.origin': 'auto.navigation.browser',
+      'sentry.sample_rate': 1,
+      'sentry.source': 'url',
+    },
     op: 'navigation',
+    origin: 'auto.navigation.browser',
     trace_id: navigationTraceContext?.trace_id,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
   });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
@@ -111,7 +111,7 @@ sentryTest('error after <meta> tag pageload has pageload traceId', async ({ getL
   await page.locator('#errorBtn').click();
   const [errorEvent, errorTraceHeader] = await errorEventPromise;
 
-  expect(errorEvent.contexts?.trace).toMatchObject({
+  expect(errorEvent.contexts?.trace).toEqual({
     trace_id: META_TAG_TRACE_ID,
     parent_span_id: META_TAG_PARENT_SPAN_ID,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
@@ -167,7 +167,15 @@ sentryTest('error during <meta> tag pageload has pageload traceId', async ({ get
     trace_id: META_TAG_TRACE_ID,
   });
 
-  expect(errorEvent?.contexts?.trace).toMatchObject({
+  expect(errorEvent?.contexts?.trace).toEqual({
+    data: {
+      'sentry.op': 'pageload',
+      'sentry.origin': 'auto.pageload.browser',
+      'sentry.sample_rate': 1,
+      'sentry.source': 'url',
+    },
+    op: 'pageload',
+    origin: 'auto.pageload.browser',
     trace_id: META_TAG_TRACE_ID,
     parent_span_id: META_TAG_PARENT_SPAN_ID,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
@@ -157,8 +157,15 @@ sentryTest('error during pageload has pageload traceId', async ({ getLocalTestPa
   });
 
   const errorTraceContext = errorEvent?.contexts?.trace;
-  expect(errorTraceContext).toMatchObject({
+  expect(errorTraceContext).toEqual({
+    data: {
+      'sentry.op': 'pageload',
+      'sentry.origin': 'auto.pageload.browser',
+      'sentry.sample_rate': 1,
+      'sentry.source': 'url',
+    },
     op: 'pageload',
+    origin: 'auto.pageload.browser',
     trace_id: pageloadTraceContext?.trace_id,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
   });


### PR DESCRIPTION
More clearly shows the current difference in `event.contexts.trace` for error events, depending on if they were sent during an active span or afterwards.