### PR TITLE
fix(node): Ensure DSC on envelope header uses root span

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/scenario.ts
@@ -11,5 +11,7 @@ Sentry.init({
 });
 
 Sentry.startSpan({ name: 'test span' }, () => {
-  Sentry.captureException(new Error('foo'));
+  Sentry.startSpan({ name: 'test inner span' }, () => {
+    Sentry.captureException(new Error('foo'));
+  });
 });

--- a/packages/opentelemetry/src/setupEventContextTrace.ts
+++ b/packages/opentelemetry/src/setupEventContextTrace.ts
@@ -28,12 +28,13 @@ export function setupEventContextTrace(client: Client): void {
       ...event.contexts,
     };
 
+    const rootSpan = getRootSpan(span);
+
     event.sdkProcessingMetadata = {
-      dynamicSamplingContext: getDynamicSamplingContextFromSpan(span),
+      dynamicSamplingContext: getDynamicSamplingContextFromSpan(rootSpan),
       ...event.sdkProcessingMetadata,
     };
 
-    const rootSpan = getRootSpan(span);
     const transactionName = spanHasName(rootSpan) ? rootSpan.name : undefined;
     if (transactionName && !event.transaction) {
       event.transaction = transactionName;


### PR DESCRIPTION
Fixes an oversight from https://github.com/getsentry/sentry-javascript/pull/11628, which was found in the example app.