### PR TITLE
feat(core): Add `trace` envelope header to span envelope

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-mixed-transaction/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-mixed-transaction/test.ts
@@ -38,9 +38,16 @@ sentryTest(
     expect(traceId).toMatch(/[a-f0-9]{32}/);
     expect(parentSpanId).toMatch(/[a-f0-9]{16}/);
 
-    // TODO: the span envelope also needs to contain the `trace` header (follow-up PR)
     expect(spanEnvelopeHeader).toEqual({
       sent_at: expect.any(String),
+      trace: {
+        environment: 'production',
+        public_key: 'public',
+        sample_rate: '1',
+        sampled: 'true',
+        trace_id: traceId,
+        transaction: 'outer',
+      },
     });
 
     expect(transactionEnvelopeHeader).toEqual({

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone/test.ts
@@ -22,8 +22,18 @@ sentryTest('sends a segment span envelope', async ({ getLocalTestPath, page }) =
   const itemHeader = item[0];
   const spanJson = item[1];
 
+  const traceId = spanJson.trace_id;
+
   expect(headers).toEqual({
     sent_at: expect.any(String),
+    trace: {
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: traceId,
+      transaction: 'standalone_segment_span',
+    },
   });
 
   expect(itemHeader).toEqual({

--- a/packages/core/test/lib/envelope.test.ts
+++ b/packages/core/test/lib/envelope.test.ts
@@ -1,6 +1,15 @@
-import type { DsnComponents, DynamicSamplingContext, Event } from '@sentry/types';
+import type { Client, DsnComponents, DynamicSamplingContext, Event } from '@sentry/types';
 
-import { createEventEnvelope } from '../../src/envelope';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SentrySpan,
+  getCurrentScope,
+  getIsolationScope,
+  setAsyncContextStrategy,
+  setCurrentClient,
+} from '../../src';
+import { createEventEnvelope, createSpanEnvelope } from '../../src/envelope';
+import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
 const testDsn: DsnComponents = { protocol: 'https', projectId: 'abc', host: 'testry.io', publicKey: 'pubKey123' };
 
@@ -72,6 +81,80 @@ describe('createEventEnvelope', () => {
       expect(envelopeHeaders).toBeDefined();
       expect(envelopeHeaders.trace).toBeDefined();
       expect(envelopeHeaders.trace).toEqual(trace);
+    });
+  });
+});
+
+describe('createSpanEnvelope', () => {
+  let client: Client | undefined;
+  beforeEach(() => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    setAsyncContextStrategy(undefined);
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 1, dsn: 'https://username@domain/123' });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+  });
+
+  it('creates a span envelope', () => {
+    const span = new SentrySpan({
+      name: 'test',
+      isStandalone: true,
+      startTimestamp: 1,
+      endTimestamp: 2,
+      sampled: true,
+      attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom' },
+    });
+
+    const spanEnvelope = createSpanEnvelope([span]);
+
+    const spanItem = spanEnvelope[1][0][1];
+    expect(spanItem).toEqual({
+      data: {
+        'sentry.origin': 'manual',
+        'sentry.source': 'custom',
+      },
+      description: 'test',
+      is_segment: true,
+      origin: 'manual',
+      span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+      segment_id: spanItem.segment_id,
+      start_timestamp: 1,
+      timestamp: 2,
+      trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
+    });
+  });
+
+  it('adds `trace` and `sent_at` envelope headers', () => {
+    const spanEnvelope = createSpanEnvelope([
+      new SentrySpan({ name: 'test', attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom' } }),
+    ]);
+
+    const spanEnvelopeHeaders = spanEnvelope[0];
+    expect(spanEnvelopeHeaders).toEqual({
+      sent_at: expect.any(String),
+      trace: {
+        environment: 'production',
+        public_key: 'username',
+        sampled: 'false',
+        trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
+        transaction: 'test',
+      },
+    });
+  });
+
+  it("doesn't add a `trace` envelope header if there's no public key", () => {
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 1, dsn: 'https://domain/123' });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    const spanEnvelope = createSpanEnvelope([new SentrySpan()]);
+
+    const spanEnvelopeHeaders = spanEnvelope[0];
+    expect(spanEnvelopeHeaders).toEqual({
+      sent_at: expect.any(String),
     });
   });
 });


### PR DESCRIPTION
based on #11696 

This PR adds a `trace` envelope header to our standalone span envelope creation function.

ref #11562 
