### PR TITLE
fix(serverless): Check if cloud event callback is a function (#9044)

### DIFF
--- a/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
@@ -56,7 +56,9 @@ function _wrapCloudEventFunction(
               DEBUG_BUILD && logger.error(e);
             })
             .then(() => {
-              callback(...args);
+              if (typeof callback === 'function') {
+                callback(...args);
+              }
             });
         });
 

--- a/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
@@ -84,6 +84,59 @@ describe('wrapCloudEventFunction', () => {
       expect(mockFlush).toBeCalledWith(2000);
     });
 
+    describe('wrapEventFunction() as Promise', () => {
+      test('successful execution', async () => {
+        const func: CloudEventFunction = (_context) =>
+          new Promise(resolve => {
+            setTimeout(() => {
+              resolve(42);
+            }, 10);
+          });
+        const wrappedHandler = wrapCloudEventFunction(func);
+        await expect(handleCloudEvent(wrappedHandler)).resolves.toBe(42);
+
+        const fakeTransactionContext = {
+          name: 'event.type',
+          op: 'function.gcp.cloud_event',
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
+          },
+        };
+
+        expect(mockStartSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
+        expect(mockSpan.end).toBeCalled();
+        expect(mockFlush).toBeCalledWith(2000);
+      });
+
+      test('capture error', async () => {
+        const error = new Error('wat');
+        const handler: CloudEventFunction = (_context) =>
+          new Promise((_, reject) => {
+            setTimeout(() => {
+              reject(error);
+            }, 10);
+          });
+
+        const wrappedHandler = wrapCloudEventFunction(handler);
+        await expect(handleCloudEvent(wrappedHandler)).rejects.toThrowError(error);
+
+        const fakeTransactionContext = {
+          name: 'event.type',
+          op: 'function.gcp.cloud_event',
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
+          },
+        };
+
+        expect(mockStartSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
+        expect(mockCaptureException).toBeCalledWith(error, expect.any(Function));
+        expect(mockSpan.end).toBeCalled();
+        expect(mockFlush).toBeCalled();
+      });
+    });
+
     test('capture error', async () => {
       const error = new Error('wat');
       const handler: CloudEventFunction = _context => {

--- a/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
@@ -86,7 +86,7 @@ describe('wrapCloudEventFunction', () => {
 
     describe('wrapEventFunction() as Promise', () => {
       test('successful execution', async () => {
-        const func: CloudEventFunction = (_context) =>
+        const func: CloudEventFunction = _context =>
           new Promise(resolve => {
             setTimeout(() => {
               resolve(42);
@@ -111,7 +111,7 @@ describe('wrapCloudEventFunction', () => {
 
       test('capture error', async () => {
         const error = new Error('wat');
-        const handler: CloudEventFunction = (_context) =>
+        const handler: CloudEventFunction = _context =>
           new Promise((_, reject) => {
             setTimeout(() => {
               reject(error);


### PR DESCRIPTION
Closes #9044

Adds relevant tests for testing handlers that return promises.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
