### PR TITLE
feat(browser): If we have debugIds, use filenames to populate `in_app` on stack frames

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -96,5 +96,6 @@ export { globalHandlersIntegration } from './integrations/globalhandlers';
 export { httpContextIntegration } from './integrations/httpcontext';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
 export { browserApiErrorsIntegration } from './integrations/browserapierrors';
+export { inAppIntegration } from './integrations/in-app';
 
 export { lazyLoadIntegration } from './utils/lazyLoadIntegration';

--- a/packages/browser/src/integrations/in-app.ts
+++ b/packages/browser/src/integrations/in-app.ts
@@ -1,0 +1,30 @@
+import { defineIntegration, getFilenameDebugIdMap } from '@sentry/core';
+
+/**
+ * Sets the `in_app` property on stack frames according to whether the file has a debugId.
+ */
+export const inAppIntegration = defineIntegration(() => {
+  return {
+    name: 'InApp',
+    processEvent: (event, _, client) => {
+      const stackParser = client.getOptions().stackParser;
+      const debugIds = new Set(Object.keys(getFilenameDebugIdMap(stackParser)));
+
+      if (debugIds.size === 0) {
+        return event;
+      }
+
+      if (event.exception) {
+        for (const exception of event.exception.values || []) {
+          if (exception.stacktrace) {
+            for (const frame of exception.stacktrace.frames || []) {
+              frame.in_app = !!(frame.filename && debugIds.has(frame.filename));
+            }
+          }
+        }
+      }
+
+      return event;
+    },
+  };
+});

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -1,18 +1,8 @@
 /* eslint-disable max-lines */
 
-import { DEFAULT_ENVIRONMENT, getClient, spanToJSON } from '@sentry/core';
-import type {
-  DebugImage,
-  Envelope,
-  Event,
-  EventEnvelope,
-  Profile,
-  Span,
-  StackFrame,
-  StackParser,
-  ThreadCpuProfile,
-} from '@sentry/types';
-import { GLOBAL_OBJ, browserPerformanceTimeOrigin, forEachEnvelopeItem, logger, uuid4 } from '@sentry/utils';
+import { DEFAULT_ENVIRONMENT, getClient, getFilenameDebugIdMap, spanToJSON } from '@sentry/core';
+import type { DebugImage, Envelope, Event, EventEnvelope, Profile, Span, ThreadCpuProfile } from '@sentry/types';
+import { browserPerformanceTimeOrigin, forEachEnvelopeItem, logger, uuid4 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../helpers';
@@ -345,17 +335,10 @@ export function findProfiledTransactionsFromEnvelope(envelope: Envelope): Event[
   return events;
 }
 
-const debugIdStackParserCache = new WeakMap<StackParser, Map<string, StackFrame[]>>();
 /**
  * Applies debug meta data to an event from a list of paths to resources (sourcemaps)
  */
 export function applyDebugMetadata(resource_paths: ReadonlyArray<string>): DebugImage[] {
-  const debugIdMap = GLOBAL_OBJ._sentryDebugIds;
-
-  if (!debugIdMap) {
-    return [];
-  }
-
   const client = getClient();
   const options = client && client.getOptions();
   const stackParser = options && options.stackParser;
@@ -364,38 +347,8 @@ export function applyDebugMetadata(resource_paths: ReadonlyArray<string>): Debug
     return [];
   }
 
-  let debugIdStackFramesCache: Map<string, StackFrame[]>;
-  const cachedDebugIdStackFrameCache = debugIdStackParserCache.get(stackParser);
-  if (cachedDebugIdStackFrameCache) {
-    debugIdStackFramesCache = cachedDebugIdStackFrameCache;
-  } else {
-    debugIdStackFramesCache = new Map<string, StackFrame[]>();
-    debugIdStackParserCache.set(stackParser, debugIdStackFramesCache);
-  }
-
   // Build a map of filename -> debug_id
-  const filenameDebugIdMap = Object.keys(debugIdMap).reduce<Record<string, string>>((acc, debugIdStackTrace) => {
-    let parsedStack: StackFrame[];
-
-    const cachedParsedStack = debugIdStackFramesCache.get(debugIdStackTrace);
-    if (cachedParsedStack) {
-      parsedStack = cachedParsedStack;
-    } else {
-      parsedStack = stackParser(debugIdStackTrace);
-      debugIdStackFramesCache.set(debugIdStackTrace, parsedStack);
-    }
-
-    for (let i = parsedStack.length - 1; i >= 0; i--) {
-      const stackFrame = parsedStack[i];
-      const file = stackFrame && stackFrame.filename;
-
-      if (stackFrame && file) {
-        acc[file] = debugIdMap[debugIdStackTrace] as string;
-        break;
-      }
-    }
-    return acc;
-  }, {});
+  const filenameDebugIdMap = getFilenameDebugIdMap(stackParser);
 
   const images: DebugImage[] = [];
   for (const path of resource_paths) {

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -16,6 +16,7 @@ import { dedupeIntegration } from '@sentry/core';
 import type { BrowserClientOptions, BrowserOptions } from './client';
 import { BrowserClient } from './client';
 import { DEBUG_BUILD } from './debug-build';
+import { inAppIntegration } from './exports';
 import { WINDOW } from './helpers';
 import { breadcrumbsIntegration } from './integrations/breadcrumbs';
 import { browserApiErrorsIntegration } from './integrations/browserapierrors';
@@ -40,6 +41,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
     linkedErrorsIntegration(),
     dedupeIntegration(),
     httpContextIntegration(),
+    inAppIntegration(),
   ];
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,7 +59,7 @@ export {
   defineIntegration,
 } from './integration';
 export { applyScopeDataToEvent, mergeScopeData } from './utils/applyScopeDataToEvent';
-export { prepareEvent } from './utils/prepareEvent';
+export { getFilenameDebugIdMap, prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';
 export { createSpanEnvelope } from './span';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -160,13 +160,13 @@ function applyClientOptions(event: Event, options: ClientOptions): void {
 const debugIdStackParserCache = new WeakMap<StackParser, Map<string, StackFrame[]>>();
 
 /**
- * Puts debug IDs into the stack frames of an error event.
+ * Given a stackParser, retrieve every filename and debugId pair
  */
-export function applyDebugIds(event: Event, stackParser: StackParser): void {
+export function getFilenameDebugIdMap(stackParser: StackParser): Record<string, string> {
   const debugIdMap = GLOBAL_OBJ._sentryDebugIds;
 
   if (!debugIdMap) {
-    return;
+    return {};
   }
 
   let debugIdStackFramesCache: Map<string, StackFrame[]>;
@@ -179,7 +179,7 @@ export function applyDebugIds(event: Event, stackParser: StackParser): void {
   }
 
   // Build a map of filename -> debug_id
-  const filenameDebugIdMap = Object.keys(debugIdMap).reduce<Record<string, string>>((acc, debugIdStackTrace) => {
+  return Object.keys(debugIdMap).reduce<Record<string, string>>((acc, debugIdStackTrace) => {
     let parsedStack: StackFrame[];
     const cachedParsedStack = debugIdStackFramesCache.get(debugIdStackTrace);
     if (cachedParsedStack) {
@@ -198,6 +198,14 @@ export function applyDebugIds(event: Event, stackParser: StackParser): void {
     }
     return acc;
   }, {});
+}
+
+/**
+ * Puts debug IDs into the stack frames of an error event.
+ */
+export function applyDebugIds(event: Event, stackParser: StackParser): void {
+  // Build a map of filename -> debug_id
+  const filenameDebugIdMap = getFilenameDebugIdMap(stackParser);
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -4,7 +4,7 @@ import { env, versions } from 'process';
 import { isMainThread, threadId } from 'worker_threads';
 
 import { getFilenameDebugIdMap } from '@sentry/core';
-import { GLOBAL_OBJ, forEachEnvelopeItem, logger } from '@sentry/utils';
+import { forEachEnvelopeItem, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
 import type { Profile, RawThreadCpuProfile, ThreadCpuProfile } from './types';

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -3,6 +3,7 @@ import type { Client, Context, Envelope, Event, StackFrame, StackParser } from '
 import { env, versions } from 'process';
 import { isMainThread, threadId } from 'worker_threads';
 
+import { getFilenameDebugIdMap } from '@sentry/core';
 import { GLOBAL_OBJ, forEachEnvelopeItem, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
@@ -270,49 +271,14 @@ const debugIdStackParserCache = new WeakMap<StackParser, Map<string, StackFrame[
  * @returns {DebugImage[]}
  */
 export function applyDebugMetadata(client: Client, resource_paths: ReadonlyArray<string>): DebugImage[] {
-  const debugIdMap = GLOBAL_OBJ._sentryDebugIds;
-  if (!debugIdMap) {
-    return [];
-  }
-
   const options = client.getOptions();
 
   if (!options || !options.stackParser) {
     return [];
   }
 
-  let debugIdStackFramesCache: Map<string, StackFrame[]>;
-  const cachedDebugIdStackFrameCache = debugIdStackParserCache.get(options.stackParser);
-  if (cachedDebugIdStackFrameCache) {
-    debugIdStackFramesCache = cachedDebugIdStackFrameCache;
-  } else {
-    debugIdStackFramesCache = new Map<string, StackFrame[]>();
-    debugIdStackParserCache.set(options.stackParser, debugIdStackFramesCache);
-  }
-
   // Build a map of filename -> debug_id.
-  const filenameDebugIdMap = Object.keys(debugIdMap).reduce<Record<string, string>>((acc, debugIdStackTrace) => {
-    let parsedStack: StackFrame[];
-
-    const cachedParsedStack = debugIdStackFramesCache.get(debugIdStackTrace);
-    if (cachedParsedStack) {
-      parsedStack = cachedParsedStack;
-    } else {
-      parsedStack = options.stackParser(debugIdStackTrace);
-      debugIdStackFramesCache.set(debugIdStackTrace, parsedStack);
-    }
-
-    for (let i = parsedStack.length - 1; i >= 0; i--) {
-      const stackFrame = parsedStack[i];
-      const file = stackFrame && stackFrame.filename;
-
-      if (stackFrame && file) {
-        acc[file] = debugIdMap[debugIdStackTrace] as string;
-        break;
-      }
-    }
-    return acc;
-  }, {});
+  const filenameDebugIdMap = getFilenameDebugIdMap(options.stackParser);
 
   const images: DebugImage[] = [];
 


### PR DESCRIPTION
Currently in the browser, all stack frames are marked with `in_app: true` which makes it difficult to determine if the error originated from user code or elsewhere.

If we have debugIds we can assume that these filenames are the users app code and everything else is not.  