### PR TITLE
feat(core): Ensure trace context only includes relevant data

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -9,12 +9,12 @@ import {
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
 
-sentryTest('creates a new trace on each navigation', async ({ getLocalTestPath, page }) => {
+sentryTest('creates a new trace on each navigation', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await getFirstSentryEnvelopeRequest(page, url);
 
@@ -31,6 +31,9 @@ sentryTest('creates a new trace on each navigation', async ({ getLocalTestPath, 
 
   const navigation1TraceContext = navigation1Event.contexts?.trace;
   const navigation2TraceContext = navigation2Event.contexts?.trace;
+
+  expect(navigation1Event.type).toEqual('transaction');
+  expect(navigation2Event.type).toEqual('transaction');
 
   expect(navigation1TraceContext).toMatchObject({
     op: 'navigation',
@@ -65,12 +68,12 @@ sentryTest('creates a new trace on each navigation', async ({ getLocalTestPath, 
   expect(navigation1TraceContext?.trace_id).not.toEqual(navigation2TraceContext?.trace_id);
 });
 
-sentryTest('error after navigation has navigation traceId', async ({ getLocalTestPath, page }) => {
+sentryTest('error after navigation has navigation traceId', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   // ensure pageload transaction is finished
   await getFirstSentryEnvelopeRequest<Event>(page, url);
@@ -81,6 +84,8 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
     eventAndTraceHeaderRequestParser,
   );
   const navigationTraceContext = navigationEvent.contexts?.trace;
+
+  expect(navigationEvent.type).toEqual('transaction');
 
   expect(navigationTraceContext).toMatchObject({
     op: 'navigation',
@@ -105,6 +110,8 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
   await page.locator('#errorBtn').click();
   const [errorEvent, errorTraceHeader] = await errorEventPromise;
 
+  expect(errorEvent.type).toEqual(undefined);
+
   const errorTraceContext = errorEvent.contexts?.trace;
   expect(errorTraceContext).toEqual({
     trace_id: navigationTraceContext?.trace_id,
@@ -119,12 +126,12 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
   });
 });
 
-sentryTest('error during navigation has new navigation traceId', async ({ getLocalTestPath, page }) => {
+sentryTest('error during navigation has new navigation traceId', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   // ensure navigation transaction is finished
   await getFirstSentryEnvelopeRequest<Event>(page, url);
@@ -142,6 +149,9 @@ sentryTest('error during navigation has new navigation traceId', async ({ getLoc
 
   const [navigationEvent, navigationTraceHeader] = envelopes.find(envelope => envelope[0].type === 'transaction')!;
   const [errorEvent, errorTraceHeader] = envelopes.find(envelope => !envelope[0].type)!;
+
+  expect(navigationEvent.type).toEqual('transaction');
+  expect(errorEvent.type).toEqual(undefined);
 
   const navigationTraceContext = navigationEvent?.contexts?.trace;
   expect(navigationTraceContext).toMatchObject({
@@ -176,12 +186,20 @@ sentryTest('error during navigation has new navigation traceId', async ({ getLoc
 
 sentryTest(
   'outgoing fetch request after navigation has navigation traceId in headers',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
 
     // ensure navigation transaction is finished
     await getFirstSentryEnvelopeRequest<Event>(page, url);
@@ -193,6 +211,8 @@ sentryTest(
     );
 
     const navigationTraceContext = navigationEvent.contexts?.trace;
+
+    expect(navigationEvent.type).toEqual('transaction');
     expect(navigationTraceContext).toMatchObject({
       op: 'navigation',
       trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
@@ -224,12 +244,20 @@ sentryTest(
 
 sentryTest(
   'outgoing fetch request during navigation has navigation traceId in headers',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
 
     // ensure navigation transaction is finished
     await getFirstSentryEnvelopeRequest<Event>(page, url);
@@ -248,6 +276,8 @@ sentryTest(
     ]);
 
     const navigationTraceContext = navigationEvent.contexts?.trace;
+
+    expect(navigationEvent.type).toEqual('transaction');
     expect(navigationTraceContext).toMatchObject({
       op: 'navigation',
       trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
@@ -276,12 +306,20 @@ sentryTest(
 
 sentryTest(
   'outgoing XHR request after navigation has navigation traceId in headers',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
 
     // ensure navigation transaction is finished
     await getFirstSentryEnvelopeRequest(page, url);
@@ -293,6 +331,8 @@ sentryTest(
     );
 
     const navigationTraceContext = navigationEvent.contexts?.trace;
+
+    expect(navigationEvent.type).toEqual('transaction');
     expect(navigationTraceContext).toMatchObject({
       op: 'navigation',
       trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
@@ -324,12 +364,20 @@ sentryTest(
 
 sentryTest(
   'outgoing XHR request during navigation has navigation traceId in headers',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
 
     // ensure navigation transaction is finished
     await getFirstSentryEnvelopeRequest(page, url);
@@ -348,6 +396,8 @@ sentryTest(
     ]);
 
     const navigationTraceContext = navigationEvent.contexts?.trace;
+
+    expect(navigationEvent.type).toEqual('transaction');
     expect(navigationTraceContext).toMatchObject({
       op: 'navigation',
       trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -161,14 +161,6 @@ sentryTest('error during navigation has new navigation traceId', async ({ getLoc
 
   const errorTraceContext = errorEvent?.contexts?.trace;
   expect(errorTraceContext).toEqual({
-    data: {
-      'sentry.op': 'navigation',
-      'sentry.origin': 'auto.navigation.browser',
-      'sentry.sample_rate': 1,
-      'sentry.source': 'url',
-    },
-    op: 'navigation',
-    origin: 'auto.navigation.browser',
     trace_id: navigationTraceContext?.trace_id,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
   });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
@@ -168,14 +168,6 @@ sentryTest('error during <meta> tag pageload has pageload traceId', async ({ get
   });
 
   expect(errorEvent?.contexts?.trace).toEqual({
-    data: {
-      'sentry.op': 'pageload',
-      'sentry.origin': 'auto.pageload.browser',
-      'sentry.sample_rate': 1,
-      'sentry.source': 'url',
-    },
-    op: 'pageload',
-    origin: 'auto.pageload.browser',
     trace_id: META_TAG_TRACE_ID,
     parent_span_id: META_TAG_PARENT_SPAN_ID,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
@@ -15,12 +15,12 @@ const META_TAG_BAGGAGE =
 
 sentryTest(
   'create a new trace for a navigation after the <meta> tag pageload trace',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
       page,
@@ -36,6 +36,7 @@ sentryTest(
     const pageloadTraceContext = pageloadEvent.contexts?.trace;
     const navigationTraceContext = navigationEvent.contexts?.trace;
 
+    expect(pageloadEvent.type).toEqual('transaction');
     expect(pageloadTraceContext).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,
@@ -53,6 +54,7 @@ sentryTest(
       trace_id: META_TAG_TRACE_ID,
     });
 
+    expect(navigationEvent.type).toEqual('transaction');
     expect(navigationTraceContext).toMatchObject({
       op: 'navigation',
       trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
@@ -73,12 +75,12 @@ sentryTest(
   },
 );
 
-sentryTest('error after <meta> tag pageload has pageload traceId', async ({ getLocalTestPath, page }) => {
+sentryTest('error after <meta> tag pageload has pageload traceId', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
     page,
@@ -111,6 +113,7 @@ sentryTest('error after <meta> tag pageload has pageload traceId', async ({ getL
   await page.locator('#errorBtn').click();
   const [errorEvent, errorTraceHeader] = await errorEventPromise;
 
+  expect(errorEvent.type).toEqual(undefined);
   expect(errorEvent.contexts?.trace).toEqual({
     trace_id: META_TAG_TRACE_ID,
     parent_span_id: META_TAG_PARENT_SPAN_ID,
@@ -128,12 +131,12 @@ sentryTest('error after <meta> tag pageload has pageload traceId', async ({ getL
   });
 });
 
-sentryTest('error during <meta> tag pageload has pageload traceId', async ({ getLocalTestPath, page }) => {
+sentryTest('error during <meta> tag pageload has pageload traceId', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const envelopeRequestsPromise = getMultipleSentryEnvelopeRequests<EventAndTraceHeader>(
     page,
@@ -150,6 +153,7 @@ sentryTest('error during <meta> tag pageload has pageload traceId', async ({ get
   )!;
   const [errorEvent, errorTraceHeader] = envelopes.find(eventAndHeader => !eventAndHeader[0].type)!;
 
+  expect(pageloadEvent.type).toEqual('transaction');
   expect(pageloadEvent?.contexts?.trace).toMatchObject({
     op: 'pageload',
     trace_id: META_TAG_TRACE_ID,
@@ -167,6 +171,7 @@ sentryTest('error during <meta> tag pageload has pageload traceId', async ({ get
     trace_id: META_TAG_TRACE_ID,
   });
 
+  expect(errorEvent.type).toEqual(undefined);
   expect(errorEvent?.contexts?.trace).toEqual({
     trace_id: META_TAG_TRACE_ID,
     parent_span_id: META_TAG_PARENT_SPAN_ID,
@@ -186,18 +191,27 @@ sentryTest('error during <meta> tag pageload has pageload traceId', async ({ get
 
 sentryTest(
   'outgoing fetch request after <meta> tag pageload has pageload traceId in headers',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
 
     const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
       page,
       url,
       eventAndTraceHeaderRequestParser,
     );
+    expect(pageloadEvent.type).toEqual('transaction');
     expect(pageloadEvent?.contexts?.trace).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,
@@ -228,12 +242,20 @@ sentryTest(
 
 sentryTest(
   'outgoing fetch request during <meta> tag pageload has pageload traceId in headers',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
 
     const pageloadEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
       page,
@@ -245,6 +267,7 @@ sentryTest(
     await page.locator('#fetchBtn').click();
     const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);
 
+    expect(pageloadEvent.type).toEqual('transaction');
     expect(pageloadEvent?.contexts?.trace).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,
@@ -272,18 +295,27 @@ sentryTest(
 
 sentryTest(
   'outgoing XHR request after <meta> tag pageload has pageload traceId in headers',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const [pageloadEvent, pageloadTraceHeader] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
       page,
       url,
       eventAndTraceHeaderRequestParser,
     );
+    expect(pageloadEvent.type).toEqual('transaction');
     expect(pageloadEvent?.contexts?.trace).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,
@@ -313,12 +345,20 @@ sentryTest(
 
 sentryTest(
   'outgoing XHR request during <meta> tag pageload has pageload traceId in headers',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const pageloadEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
       page,
@@ -330,6 +370,7 @@ sentryTest(
     await page.locator('#xhrBtn').click();
     const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);
 
+    expect(pageloadEvent.type).toEqual('transaction');
     expect(pageloadEvent?.contexts?.trace).toMatchObject({
       op: 'pageload',
       trace_id: META_TAG_TRACE_ID,

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
@@ -158,14 +158,6 @@ sentryTest('error during pageload has pageload traceId', async ({ getLocalTestPa
 
   const errorTraceContext = errorEvent?.contexts?.trace;
   expect(errorTraceContext).toEqual({
-    data: {
-      'sentry.op': 'pageload',
-      'sentry.origin': 'auto.pageload.browser',
-      'sentry.sample_rate': 1,
-      'sentry.source': 'url',
-    },
-    op: 'pageload',
-    origin: 'auto.pageload.browser',
     trace_id: pageloadTraceContext?.trace_id,
     span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
   });

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -257,7 +257,7 @@ export class ServerRuntimeClient<
     if (span) {
       const rootSpan = getRootSpan(span);
       const samplingContext = getDynamicSamplingContextFromSpan(rootSpan);
-      return [samplingContext, spanToTraceContext(rootSpan)];
+      return [samplingContext, spanToTraceContext(rootSpan, false)];
     }
 
     const { traceId, spanId, parentSpanId, dsc } = scope.getPropagationContext();

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -257,7 +257,7 @@ export class ServerRuntimeClient<
     if (span) {
       const rootSpan = getRootSpan(span);
       const samplingContext = getDynamicSamplingContextFromSpan(rootSpan);
-      return [samplingContext, spanToTraceContext(rootSpan, false)];
+      return [samplingContext, spanToTraceContext(rootSpan)];
     }
 
     const { traceId, spanId, parentSpanId, dsc } = scope.getPropagationContext();

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -275,7 +275,7 @@ export class SentrySpan implements Span {
 
     const transaction: TransactionEvent = {
       contexts: {
-        trace: spanToTraceContext(this),
+        trace: spanToTraceContext(this, true),
       },
       spans,
       start_timestamp: this._startTime,

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -32,7 +32,7 @@ import {
   getStatusMessage,
   spanTimeInputToSeconds,
   spanToJSON,
-  spanToTraceContext,
+  spanToTransactionTraceContext,
 } from '../utils/spanUtils';
 import { getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { logSpanEnd } from './logSpans';
@@ -275,7 +275,7 @@ export class SentrySpan implements Span {
 
     const transaction: TransactionEvent = {
       contexts: {
-        trace: spanToTraceContext(this, true),
+        trace: spanToTransactionTraceContext(this),
       },
       spans,
       start_timestamp: this._startTime,

--- a/packages/core/src/utils/applyScopeDataToEvent.ts
+++ b/packages/core/src/utils/applyScopeDataToEvent.ts
@@ -162,7 +162,7 @@ function applySdkMetadataToEvent(event: Event, sdkProcessingMetadata: ScopeData[
 
 function applySpanToEvent(event: Event, span: Span): void {
   event.contexts = {
-    trace: spanToTraceContext(span, false),
+    trace: spanToTraceContext(span),
     ...event.contexts,
   };
 

--- a/packages/core/src/utils/applyScopeDataToEvent.ts
+++ b/packages/core/src/utils/applyScopeDataToEvent.ts
@@ -161,7 +161,10 @@ function applySdkMetadataToEvent(event: Event, sdkProcessingMetadata: ScopeData[
 }
 
 function applySpanToEvent(event: Event, span: Span): void {
-  event.contexts = { trace: spanToTraceContext(span), ...event.contexts };
+  event.contexts = {
+    trace: spanToTraceContext(span, false),
+    ...event.contexts,
+  };
 
   event.sdkProcessingMetadata = {
     dynamicSamplingContext: getDynamicSamplingContextFromSpan(span),

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -34,15 +34,29 @@ export const TRACE_FLAG_SAMPLED = 0x1;
  * By default, this will only include trace_id, span_id & parent_span_id.
  * If `includeAllData` is true, it will also include data, op, status & origin.
  */
-export function spanToTraceContext(span: Span, includeAllData = false): TraceContext {
+export function spanToTransactionTraceContext(span: Span): TraceContext {
   const { spanId: span_id, traceId: trace_id } = span.spanContext();
   const { data, op, parent_span_id, status, origin } = spanToJSON(span);
 
-  const reqFields = { parent_span_id, span_id, trace_id };
-  // These are only included if `includeAllData` is true
-  const optFields = { data, op, status, origin };
+  return dropUndefinedKeys({
+    parent_span_id,
+    span_id,
+    trace_id,
+    data,
+    op,
+    status,
+    origin,
+  });
+}
 
-  return dropUndefinedKeys(includeAllData ? { ...reqFields, ...optFields } : reqFields);
+/**
+ * Convert a span to a trace context, which can be sent as the `trace` context in a non-transaction event.
+ */
+export function spanToTraceContext(span: Span): TraceContext {
+  const { spanId: span_id, traceId: trace_id } = span.spanContext();
+  const { parent_span_id } = spanToJSON(span);
+
+  return dropUndefinedKeys({ parent_span_id, span_id, trace_id });
 }
 
 /**

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -31,20 +31,18 @@ export const TRACE_FLAG_SAMPLED = 0x1;
 
 /**
  * Convert a span to a trace context, which can be sent as the `trace` context in an event.
+ * By default, this will only include trace_id, span_id & parent_span_id.
+ * If `includeAllData` is true, it will also include data, op, status & origin.
  */
-export function spanToTraceContext(span: Span): TraceContext {
+export function spanToTraceContext(span: Span, includeAllData = false): TraceContext {
   const { spanId: span_id, traceId: trace_id } = span.spanContext();
   const { data, op, parent_span_id, status, origin } = spanToJSON(span);
 
-  return dropUndefinedKeys({
-    data,
-    op,
-    parent_span_id,
-    span_id,
-    status,
-    trace_id,
-    origin,
-  });
+  const reqFields = { parent_span_id, span_id, trace_id };
+  // These are only included if `includeAllData` is true
+  const optFields = { data, op, status, origin };
+
+  return dropUndefinedKeys(includeAllData ? { ...reqFields, ...optFields } : reqFields);
 }
 
 /**

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -1,7 +1,7 @@
 import { timestampInSeconds } from '@sentry/utils';
 import { SentrySpan } from '../../../src/tracing/sentrySpan';
 import { SPAN_STATUS_ERROR } from '../../../src/tracing/spanstatus';
-import { TRACE_FLAG_NONE, TRACE_FLAG_SAMPLED, spanToJSON, spanToTraceContext } from '../../../src/utils/spanUtils';
+import { TRACE_FLAG_NONE, TRACE_FLAG_SAMPLED, spanToJSON } from '../../../src/utils/spanUtils';
 
 describe('SentrySpan', () => {
   describe('name', () => {
@@ -33,7 +33,7 @@ describe('SentrySpan', () => {
     test('setStatus', () => {
       const span = new SentrySpan({});
       span.setStatus({ code: SPAN_STATUS_ERROR, message: 'permission_denied' });
-      expect(spanToTraceContext(span).status).toBe('permission_denied');
+      expect(spanToJSON(span).status).toBe('permission_denied');
     });
   });
 


### PR DESCRIPTION
Today, we have different behavior for the `trace` context in core/browser & node:

In Node, we made the change so that `contexts.trace` only contains `span_id`, `trace_id` and `parent_span_id` for non-transaction events. 

In contrast, in core/browser we are always adding the full span trace context, if there is an active span (including e.g. data, status, etc.) 

This PR aligns this to use the node behavior everywhere.

Transaction events are unchanged by this PR.