### PR TITLE
ref(nextjs): Remove unnecessary logic to filter symbolification/sentry spans

### DIFF
--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -151,29 +151,6 @@ export function init(options: NodeOptions): void {
     ),
   );
 
-  // TODO(v8): Remove this because we have `suppressTracing`
-  addEventProcessor(
-    Object.assign(
-      (event => {
-        if (event.type === 'transaction') {
-          event.spans = event.spans?.filter(span => {
-            // Filter out spans for Sentry event sends
-            const httpTargetAttribute: unknown = span.data?.['http.target'];
-            if (typeof httpTargetAttribute === 'string') {
-              // TODO: Find a more robust matching logic - We likely want to use the OTEL SDK's `suppressTracing` in our transport, if we end up using it, we can delete this filtering logic here.
-              return !httpTargetAttribute.includes('sentry_client') && !httpTargetAttribute.includes('sentry_key');
-            }
-
-            return true;
-          });
-        }
-
-        return event;
-      }) satisfies EventProcessor,
-      { id: 'NextFilterSentrySpans' },
-    ),
-  );
-
   if (process.env.NODE_ENV === 'development') {
     addEventProcessor(devErrorSymbolicationEventProcessor);
   }


### PR DESCRIPTION
Since we are filtering removing Next.js spans by default and we have suppressTracing, we do not need to be manually filtering out spans anymore.