### PR TITLE
fix(ember): Do not create rendering spans without transaction

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -163,6 +163,7 @@ export function _instrumentEmberRouter(
       },
       op: 'ui.ember.transition',
       name: `route:${fromRoute} -> route:${toRoute}`,
+      onlyIfParent: true,
     });
   });
 
@@ -224,6 +225,7 @@ function _instrumentEmberRunloop(config: EmberSentryConfig): void {
             name: 'runloop',
             op: `ui.ember.runloop.${queue}`,
             startTime: currentQueueStart,
+            onlyIfParent: true,
           })?.end(now);
         }
         currentQueueStart = undefined;
@@ -299,6 +301,7 @@ function processComponentRenderAfter(
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.ember',
       },
+      onlyIfParent: true,
     })?.end(now);
   }
 }
@@ -384,6 +387,7 @@ function _instrumentInitialLoad(config: EmberSentryConfig): void {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.ember',
     },
     startTime,
+    onlyIfParent: true,
   })?.end(endTime);
   performance.clearMarks(startName);
   performance.clearMarks(endName);


### PR DESCRIPTION
This was brought up in discord - we forgot to add `onlyIfParent` to the ui spans we emit for ember, so it's possible to capture a bunch of them as transactions, accidentally.