### PR TITLE
feat(opentelemetry): Support new http method attribute

### DIFF
--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -35,7 +35,10 @@ export function parseSpanDescription(span: AbstractSpan): SpanDescription {
   const name = spanHasName(span) ? span.name : '<unknown>';
 
   // if http.method exists, this is an http request span
-  const httpMethod = attributes[SEMATTRS_HTTP_METHOD];
+  //
+  // TODO: Referencing `http.request.method` is a temporary workaround until the semantic
+  // conventions export an attribute key for it.
+  const httpMethod = attributes['http.request.method'] || attributes[SEMATTRS_HTTP_METHOD];
   if (httpMethod) {
     return descriptionForHttpMethod({ attributes, name, kind: getSpanKind(span) }, httpMethod);
   }

--- a/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
+++ b/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
@@ -41,9 +41,22 @@ describe('parseSpanDescription', () => {
       },
     ],
     [
-      'works with http method',
+      'works with deprecated http method',
       {
         [SEMATTRS_HTTP_METHOD]: 'GET',
+      },
+      'test name',
+      SpanKind.CLIENT,
+      {
+        description: 'test name',
+        op: 'http.client',
+        source: 'custom',
+      },
+    ],
+    [
+      'works with http method',
+      {
+        'http.request.method': 'GET',
       },
       'test name',
       SpanKind.CLIENT,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/11755

OpenTelemetry restructured their http semantic conventions and declared them stable: https://opentelemetry.io/blog/2023/http-conventions-declared-stable/

This has unfortunately not been reflected in OpenTelemetry JS yet, blocked on them making everything backwards compat: https://github.com/open-telemetry/opentelemetry-js/issues/4572

For now we can directly reference `http.request.method`, the replacement to `http.method`. When the OTEL SDK is finally updated to use proper conventions, we can avoid hard coding the string.