### PR TITLE
feat(core): Increase default transport buffer size from 30 to 64

### DIFF
--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -26,7 +26,7 @@ import {
 
 import { DEBUG_BUILD } from '../debug-build';
 
-export const DEFAULT_TRANSPORT_BUFFER_SIZE = 30;
+export const DEFAULT_TRANSPORT_BUFFER_SIZE = 64;
 
 /**
  * Creates an instance of a Sentry `Transport`


### PR DESCRIPTION
Nowadays, the SDK simply sends more data and we are seeing overflows in our E2E tests which do not produce an unreasonable amount of events.

Dropped events can lead to broken traces and confusing data inside Sentry, which is why I think bumping this is reasonable.

We make this under the assumption that an event in the transport holds at max something like 5MB of memory, which would bump the memory consumption from 150MB to 320MB.