### PR TITLE
fix(nextjs|sveltekit/v7): Ensure we can pass `browserTracingIntegration`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/sentry.client.config.ts
@@ -6,4 +6,7 @@ Sentry.init({
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1.0,
   sendDefaultPii: true,
+
+  // Ensure it also works with passing the integration
+  integrations: [Sentry.browserTracingIntegration()],
 });

--- a/packages/nextjs/src/client/browserTracingIntegration.ts
+++ b/packages/nextjs/src/client/browserTracingIntegration.ts
@@ -5,7 +5,7 @@ import {
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from '@sentry/react';
-import type { Integration, StartSpanOptions } from '@sentry/types';
+import type { StartSpanOptions } from '@sentry/types';
 import { nextRouterInstrumentation } from '../index.client';
 
 /**
@@ -42,7 +42,7 @@ export class BrowserTracing extends OriginalBrowserTracing {
  */
 export function browserTracingIntegration(
   options?: Parameters<typeof originalBrowserTracingIntegration>[0],
-): Integration {
+): ReturnType<typeof originalBrowserTracingIntegration> {
   const browserTracingIntegrationInstance = originalBrowserTracingIntegration({
     // eslint-disable-next-line deprecation/deprecation
     tracingOrigins:
@@ -61,8 +61,16 @@ export function browserTracingIntegration(
     instrumentPageLoad: false,
   });
 
+  const fullOptions = {
+    ...browserTracingIntegrationInstance.options,
+    instrumentPageLoad: true,
+    instrumentNavigation: true,
+    ...options,
+  };
+
   return {
     ...browserTracingIntegrationInstance,
+    options: fullOptions,
     afterAllSetup(client) {
       const startPageloadCallback = (startSpanOptions: StartSpanOptions): void => {
         startBrowserTracingPageLoadSpan(client, startSpanOptions);
@@ -80,7 +88,7 @@ export function browserTracingIntegration(
       nextRouterInstrumentation(
         () => undefined,
         false,
-        options?.instrumentNavigation,
+        fullOptions.instrumentNavigation,
         startPageloadCallback,
         startNavigationCallback,
       );
@@ -90,7 +98,7 @@ export function browserTracingIntegration(
       // eslint-disable-next-line deprecation/deprecation
       nextRouterInstrumentation(
         () => undefined,
-        options?.instrumentPageLoad,
+        fullOptions.instrumentPageLoad,
         false,
         startPageloadCallback,
         startNavigationCallback,

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -9,7 +9,7 @@ import {
   startBrowserTracingPageLoadSpan,
   startInactiveSpan,
 } from '@sentry/svelte';
-import type { Client, Integration, Span } from '@sentry/types';
+import type { Client, Span } from '@sentry/types';
 import { svelteKitRoutingInstrumentation } from './router';
 
 /**
@@ -36,7 +36,7 @@ export class BrowserTracing extends OriginalBrowserTracing {
  */
 export function browserTracingIntegration(
   options: Parameters<typeof originalBrowserTracingIntegration>[0] = {},
-): Integration {
+): ReturnType<typeof originalBrowserTracingIntegration> {
   const integration = {
     ...originalBrowserTracingIntegration({
       ...options,
@@ -45,16 +45,24 @@ export function browserTracingIntegration(
     }),
   };
 
+  const fullOptions = {
+    ...integration.options,
+    instrumentPageLoad: true,
+    instrumentNavigation: true,
+    ...options,
+  };
+
   return {
     ...integration,
+    options: fullOptions,
     afterAllSetup: client => {
       integration.afterAllSetup(client);
 
-      if (options.instrumentPageLoad !== false) {
+      if (fullOptions.instrumentPageLoad) {
         _instrumentPageload(client);
       }
 
-      if (options.instrumentNavigation !== false) {
+      if (fullOptions.instrumentNavigation) {
         _instrumentNavigations(client);
       }
     },


### PR DESCRIPTION
Turns out the logic to get the options was not correct, because we used the `options` that the integration exposes, but this has `instrumentPageload: false` & `instrumentNavigation: false` because we did not "fix" the `options` we expose on the integration. This was not caught by the tests, because it only happens if passing the `browserTracingIntegration` from `@sentry/nextjs` or `@sentry/sveltekit`, not when passing the "original" one (which we had tests for). 

Really fixes https://github.com/getsentry/sentry-javascript/issues/11627