### PR TITLE
feat(core): Set default scope for BaseClient methods

### DIFF
--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -31,33 +31,39 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   /**
    * Captures an exception event and sends it to Sentry.
    *
+   * Unlike `captureException` exported from every SDK, this method requires that you pass it the current scope.
+   *
    * @param exception An exception-like object.
    * @param hint May contain additional information about the original exception.
-   * @param scope An optional scope containing event metadata.
+   * @param currentScope An optional scope containing event metadata.
    * @returns The event id
    */
-  captureException(exception: any, hint?: EventHint, scope?: Scope): string | undefined;
+  captureException(exception: any, hint?: EventHint, currentScope?: Scope): string | undefined;
 
   /**
    * Captures a message event and sends it to Sentry.
    *
+   * Unlike `captureMessage` exported from every SDK, this method requires that you pass it the current scope.
+   *
    * @param message The message to send to Sentry.
    * @param level Define the level of the message.
    * @param hint May contain additional information about the original exception.
-   * @param scope An optional scope containing event metadata.
+   * @param currentScope An optional scope containing event metadata.
    * @returns The event id
    */
-  captureMessage(message: string, level?: SeverityLevel, hint?: EventHint, scope?: Scope): string | undefined;
+  captureMessage(message: string, level?: SeverityLevel, hint?: EventHint, currentScope?: Scope): string | undefined;
 
   /**
    * Captures a manually created event and sends it to Sentry.
    *
+   * Unlike `captureEvent` exported from every SDK, this method requires that you pass it the current scope.
+   *
    * @param event The event to send to Sentry.
    * @param hint May contain additional information about the original exception.
-   * @param scope An optional scope containing event metadata.
+   * @param currentScope An optional scope containing event metadata.
    * @returns The event id
    */
-  captureEvent(event: Event, hint?: EventHint, scope?: Scope): string | undefined;
+  captureEvent(event: Event, hint?: EventHint, currentScope?: Scope): string | undefined;
 
   /**
    * Captures a session


### PR DESCRIPTION
`client.captureException/captureMessage/captureEvent` do not include current scope in events by default. This is in contrast to `captureException/captureMessage/captureEvent` exported from every SDK which include the current scope by default.

This PR changes the parameter names (`scope` > `currentScope`) and adds jsdocs to make this more clear. It also changes the parameters to use the scope interface instead of the scope class.