### PR TITLE
feat(nextjs): Add `transactionName` to isolation scope for Next.js server side features

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/tests/generation-functions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/tests/generation-functions.test.ts
@@ -40,6 +40,8 @@ test('Should send a transaction and an error event for a faulty generateMetadata
   const errorEvent = await errorEventPromise;
   const transactionEvent = await transactionPromise;
 
+  expect(errorEvent.transaction).toBe('Page.generateMetadata (/generation-functions)');
+
   // Assert that isolation scope works properly
   expect(errorEvent.tags?.['my-isolated-tag']).toBe(true);
   expect(errorEvent.tags?.['my-global-scope-isolated-tag']).not.toBeDefined();
@@ -82,6 +84,10 @@ test('Should send a transaction and an error event for a faulty generateViewport
 
   expect(await transactionPromise).toBeDefined();
   expect(await errorEventPromise).toBeDefined();
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.transaction).toBe('Page.generateViewport (/generation-functions)');
 });
 
 test('Should send a transaction event with correct status for a generateMetadata() function invokation with redirect()', async ({

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/edge-route.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/edge-route.test.ts
@@ -60,4 +60,6 @@ test('Should record exceptions for faulty edge routes', async ({ request }) => {
   // Assert that isolation scope works properly
   expect(errorEvent.tags?.['my-isolated-tag']).toBe(true);
   expect(errorEvent.tags?.['my-global-scope-isolated-tag']).not.toBeDefined();
+
+  expect(errorEvent.transaction).toBe('GET /api/error-edge-endpoint');
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/edge.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/edge.test.ts
@@ -15,6 +15,8 @@ test('Should record exceptions for faulty edge server components', async ({ page
   // Assert that isolation scope works properly
   expect(errorEvent.tags?.['my-isolated-tag']).toBe(true);
   expect(errorEvent.tags?.['my-global-scope-isolated-tag']).not.toBeDefined();
+
+  expect(errorEvent.transaction).toBe(`Page Server Component (/edge-server-components/error)`);
 });
 
 test('Should record transaction for edge server components', async ({ page }) => {

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/middleware.test.ts
@@ -52,6 +52,7 @@ test('Records exceptions happening in middleware', async ({ request }) => {
   // Assert that isolation scope works properly
   expect(errorEvent.tags?.['my-isolated-tag']).toBe(true);
   expect(errorEvent.tags?.['my-global-scope-isolated-tag']).not.toBeDefined();
+  expect(errorEvent.transaction).toBe('middleware');
 });
 
 test('Should trace outgoing fetch requests inside middleware and create breadcrumbs for it', async ({ request }) => {

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/route-handlers.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/route-handlers.test.ts
@@ -59,8 +59,8 @@ test('Should record exceptions and transactions for faulty route handlers', asyn
   expect(routehandlerTransaction.contexts?.trace?.origin).toBe('auto.function.nextjs');
 
   expect(routehandlerError.exception?.values?.[0].value).toBe('route-handler-error');
-  // TODO: Uncomment once we update the scope transaction name on the server side
-  // expect(routehandlerError.transaction).toBe('PUT /route-handlers/[param]/error');
+
+  expect(routehandlerError.transaction).toBe('PUT /route-handlers/[param]/error');
 });
 
 test.describe('Edge runtime', () => {
@@ -106,6 +106,8 @@ test.describe('Edge runtime', () => {
 
     expect(routehandlerError.exception?.values?.[0].value).toBe('route-handler-edge-error');
     expect(routehandlerError.contexts?.runtime?.name).toBe('vercel-edge');
+
+    expect(routehandlerError.transaction).toBe('DELETE /route-handlers/[param]/edge');
   });
 });
 

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
@@ -98,6 +98,8 @@ test('Should capture an error and transaction with correct status for a faulty s
 
   expect(transactionEvent.contexts?.trace?.status).toBe('internal_error');
 
+  expect(errorEvent.transaction).toBe(`Page Server Component (/server-component/faulty)`);
+
   expect(errorEvent.tags?.['my-isolated-tag']).toBe(true);
   expect(errorEvent.tags?.['my-global-scope-isolated-tag']).not.toBeDefined();
   expect(transactionEvent.tags?.['my-isolated-tag']).toBe(true);

--- a/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
@@ -38,6 +38,8 @@ export function withEdgeWrapping<H extends EdgeRouteHandler>(
           });
         }
 
+        isolationScope.setTransactionName(options.spanDescription);
+
         return continueTrace(
           {
             sentryTrace,

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -93,6 +93,7 @@ export function withTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
     return escapeNextjsTracing(() => {
       const isolationScope = commonObjectToIsolationScope(req);
       return withIsolationScope(isolationScope, () => {
+        isolationScope.setTransactionName(`${options.dataFetchingMethodName} (${options.dataFetcherRouteName})`);
         isolationScope.setSDKProcessingMetadata({
           request: req,
         });

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -75,6 +75,7 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
           );
       }
 
+      isolationScope.setTransactionName(`serverAction/${serverActionName}`);
       isolationScope.setSDKProcessingMetadata({
         request: {
           headers: fullHeadersObject,

--- a/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
@@ -81,6 +81,7 @@ export function wrapApiHandlerWithSentry(apiHandler: NextApiHandler, parameteriz
 
               const reqMethod = `${(req.method || 'GET').toUpperCase()} `;
 
+              isolationScope.setTransactionName(`${reqMethod}${reqPath}`);
               isolationScope.setSDKProcessingMetadata({ request: req });
 
               return startSpanManual(

--- a/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
@@ -64,7 +64,6 @@ export function wrapApiHandlerWithSentry(apiHandler: NextApiHandler, parameteriz
             () => {
               const reqMethod = `${(req.method || 'GET').toUpperCase()} `;
 
-              isolationScope.setTransactionName(`${reqMethod}${reqPath}`);
               isolationScope.setSDKProcessingMetadata({ request: req });
               isolationScope.setTransactionName(`${reqMethod}${parameterizedRoute}`);
 

--- a/packages/nextjs/src/common/wrapGenerationFunctionWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGenerationFunctionWithSentry.ts
@@ -59,6 +59,7 @@ export function wrapGenerationFunctionWithSentry<F extends (...args: any[]) => a
         const propagationContext = commonObjectToPropagationContext(headers, incomingPropagationContext);
 
         return withIsolationScope(isolationScope, () => {
+          isolationScope.setTransactionName(`${componentType}.${generationFunctionIdentifier} (${componentRoute})`);
           isolationScope.setSDKProcessingMetadata({
             request: {
               headers: headers ? winterCGHeadersToDict(headers) : undefined,

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -52,6 +52,7 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
         const propagationContext = commonObjectToPropagationContext(headers, incomingPropagationContext);
 
         return withIsolationScope(isolationScope, async () => {
+          isolationScope.setTransactionName(`${method} ${parameterizedRoute}`);
           getCurrentScope().setPropagationContext(propagationContext);
           try {
             return startSpan(

--- a/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
+++ b/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
@@ -55,6 +55,7 @@ export function wrapServerComponentWithSentry<F extends (...args: any[]) => any>
         const propagationContext = commonObjectToPropagationContext(context.headers, incomingPropagationContext);
 
         return withIsolationScope(isolationScope, () => {
+          isolationScope.setTransactionName(`${componentType} Server Component (${componentRoute})`);
           getCurrentScope().setPropagationContext(propagationContext);
           return startSpanManual(
             {

--- a/packages/nextjs/test/integration/test/server/errorServerSideProps.test.ts
+++ b/packages/nextjs/test/integration/test/server/errorServerSideProps.test.ts
@@ -11,6 +11,7 @@ describe('Error Server-side Props', () => {
     });
 
     expect(envelope[2]).toMatchObject({
+      transaction: `getServerSideProps (/withErrorServerSideProps)`,
       exception: {
         values: [
           {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/10846

Adds relevant transaction names to isolation scopes in Next.js.