### PR TITLE
feat(remix): Update scope `transactionName` for Remix server features

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -451,6 +451,7 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
       const url = new URL(request.url);
       const [name, source] = getTransactionName(routes, url);
 
+      isolationScope.setTransactionName(name);
       isolationScope.setSDKProcessingMetadata({
         request: {
           ...normalizedRequest,

--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -1,6 +1,6 @@
 import { getClient, hasTracingEnabled, setHttpStatus, withIsolationScope } from '@sentry/core';
 import { flush } from '@sentry/node';
-import type { Span } from '@sentry/types';
+import type { Span, TransactionSource } from '@sentry/types';
 import { extractRequestData, fill, isString, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
@@ -53,33 +53,35 @@ function wrapExpressRequestHandler(
           return resolvedBuild.then(resolved => {
             routes = createRoutes(resolved.routes);
 
-            startRequestHandlerTransactionWithRoutes.call(this, origRequestHandler, routes, req, res, next, url);
+            const [name, source] = getTransactionName(routes, url);
+            isolationScope.setTransactionName(name);
+
+            startRequestHandlerTransaction.call(this, origRequestHandler, req, res, next, name, source);
           });
         } else {
           routes = createRoutes(resolvedBuild.routes);
-
-          return startRequestHandlerTransactionWithRoutes.call(this, origRequestHandler, routes, req, res, next, url);
         }
       } else {
         routes = createRoutes(build.routes);
       }
 
-      return startRequestHandlerTransactionWithRoutes.call(this, origRequestHandler, routes, req, res, next, url);
+      const [name, source] = getTransactionName(routes, url);
+      isolationScope.setTransactionName(name);
+
+      return startRequestHandlerTransaction.call(this, origRequestHandler, req, res, next, name, source);
     });
   };
 }
 
-function startRequestHandlerTransactionWithRoutes(
+function startRequestHandlerTransaction(
   this: unknown,
   origRequestHandler: ExpressRequestHandler,
-  routes: ServerRoute[],
   req: ExpressRequest,
   res: ExpressResponse,
   next: ExpressNextFunction,
-  url: URL,
+  name: string,
+  source: TransactionSource,
 ): unknown {
-  const [name, source] = getTransactionName(routes, url);
-
   return startRequestHandlerSpan(
     {
       name,

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -70,6 +70,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/action-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -117,6 +118,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/action-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -180,6 +182,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/action-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -228,6 +231,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/action-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -276,6 +280,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/action-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -324,6 +329,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/action-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -372,6 +378,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/action-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -420,6 +427,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/server-side-unexpected-errors(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -468,6 +476,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/server-side-unexpected-errors(\/|\.)\$id/),
       exception: {
         values: [
           {

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -28,6 +28,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     });
 
     assertSentryEvent(event, {
+      transaction: expect.stringMatching(/routes\/loader-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -70,6 +71,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     });
 
     assertSentryEvent(event, {
+      transaction: expect.stringMatching(/routes\/loader-throw-response(\/|\.)\$id/),
       exception: {
         values: [
           {
@@ -159,6 +161,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     });
 
     assertSentryEvent(event[2], {
+      transaction: expect.stringMatching(/routes\/loader-json-response(\/|\.)\$id/),
       exception: {
         values: [
           {

--- a/packages/remix/test/integration/test/server/ssr.test.ts
+++ b/packages/remix/test/integration/test/server/ssr.test.ts
@@ -22,6 +22,7 @@ describe('Server Side Rendering', () => {
     });
 
     assertSentryEvent(event[2], {
+      transaction: 'routes/ssr-error',
       exception: {
         values: [
           {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/10846

Sets a transaction name on the isolation scope for remix serverside features.