### PR TITLE
fix(feedback): Fix feedback type

### DIFF
--- a/packages/browser/src/feedback.ts
+++ b/packages/browser/src/feedback.ts
@@ -5,7 +5,7 @@ import {
 } from '@sentry-internal/feedback';
 import { lazyLoadIntegration } from './utils/lazyLoadIntegration';
 
-// The full feedback widget, with everything pre-loaded
+/** Add a widget to capture user feedback to your application. */
 export const feedbackIntegration = buildFeedbackIntegration({
   lazyLoadIntegration,
   getModalIntegration: () => feedbackModalIntegration,

--- a/packages/browser/src/feedbackAsync.ts
+++ b/packages/browser/src/feedbackAsync.ts
@@ -1,7 +1,10 @@
 import { buildFeedbackIntegration } from '@sentry-internal/feedback';
 import { lazyLoadIntegration } from './utils/lazyLoadIntegration';
 
-// This is for users who want to have a lazy-loaded feedback widget
+/**
+ * An integration to add user feedback to your application,
+ * while loading most of the code lazily only when it's needed.
+ */
 export const feedbackAsyncIntegration = buildFeedbackIntegration({
   lazyLoadIntegration,
 });

--- a/packages/feedback/src/core/getFeedback.test.ts
+++ b/packages/feedback/src/core/getFeedback.test.ts
@@ -43,5 +43,6 @@ describe('getFeedback', () => {
     // has correct type
     expect(typeof actual?.attachTo).toBe('function');
     expect(typeof actual?.createWidget).toBe('function');
+    expect(typeof actual?.remove).toBe('function');
   });
 });

--- a/packages/feedback/src/core/getFeedback.test.ts
+++ b/packages/feedback/src/core/getFeedback.test.ts
@@ -39,5 +39,9 @@ describe('getFeedback', () => {
     const actual = getFeedback();
     expect(actual).toBeDefined();
     expect(actual === configuredIntegration).toBe(true);
+
+    // has correct type
+    expect(typeof actual?.attachTo).toBe('function');
+    expect(typeof actual?.createWidget).toBe('function');
   });
 });

--- a/packages/feedback/src/core/getFeedback.ts
+++ b/packages/feedback/src/core/getFeedback.ts
@@ -8,5 +8,5 @@ type FeedbackIntegration = ReturnType<typeof buildFeedbackIntegration>;
  */
 export function getFeedback(): ReturnType<FeedbackIntegration> | undefined {
   const client = getClient();
-  return client && client.getIntegrationByName('Feedback');
+  return client && client.getIntegrationByName<ReturnType<FeedbackIntegration>>('Feedback');
 }

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -46,13 +46,17 @@ interface BuilderOptions {
   getScreenshotIntegration?: null | (() => IntegrationFn);
 }
 
-// We want to avoid repeating the whole type definition here...
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const buildFeedbackIntegration = ({
   lazyLoadIntegration,
   getModalIntegration,
   getScreenshotIntegration,
-}: BuilderOptions) => {
+}: BuilderOptions): IntegrationFn<
+  Integration & {
+    attachTo(el: Element | string, optionOverrides: OverrideFeedbackConfiguration): Unsubscribe;
+    createWidget(optionOverrides: OverrideFeedbackConfiguration): Promise<FeedbackDialog>;
+    remove(): void;
+  }
+> => {
   const feedbackIntegration = (({
     // FeedbackGeneralConfiguration
     id = 'sentry-feedback',

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -45,11 +45,14 @@ interface BuilderOptions {
   getModalIntegration?: null | (() => IntegrationFn);
   getScreenshotIntegration?: null | (() => IntegrationFn);
 }
+
+// We want to avoid repeating the whole type definition here...
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const buildFeedbackIntegration = ({
   lazyLoadIntegration,
   getModalIntegration,
   getScreenshotIntegration,
-}: BuilderOptions): IntegrationFn => {
+}: BuilderOptions) => {
   const feedbackIntegration = (({
     // FeedbackGeneralConfiguration
     id = 'sentry-feedback',

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -57,4 +57,4 @@ export interface Integration {
  * An integration in function form.
  * This is expected to return an integration.
  */
-export type IntegrationFn = (...rest: any[]) => Integration;
+export type IntegrationFn<IntegrationType = Integration> = (...rest: any[]) => IntegrationType;


### PR DESCRIPTION
Noticed this while bumping sentry itself - the types are wrong today, because we return it as `IntegrationFn` which is just a generic integration with no custom methods.