### PR TITLE
ref(browser): Create standalone INP spans via `startInactiveSpan`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/test.ts
@@ -8,7 +8,6 @@ import {
   properFullEnvelopeRequestParser,
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
-import { getFullRecordingSnapshots } from '../../../../utils/replayHelpers';
 
 sentryTest('should capture an INP click event span.', async ({ browserName, getLocalTestPath, page }) => {
   const supportedBrowsers = ['chromium'];

--- a/packages/browser-utils/src/metrics/inp.ts
+++ b/packages/browser-utils/src/metrics/inp.ts
@@ -2,20 +2,15 @@ import {
   SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME,
   SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_UNIT,
   SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_VALUE,
-  SentrySpan,
-  createSpanEnvelope,
   getActiveSpan,
   getClient,
   getCurrentScope,
   getRootSpan,
-  sampleSpan,
-  spanIsSampled,
   spanToJSON,
   startInactiveSpan,
 } from '@sentry/core';
 import type { Integration, SpanAttributes } from '@sentry/types';
-import { browserPerformanceTimeOrigin, dropUndefinedKeys, htmlTreeAsString, logger } from '@sentry/utils';
-import { DEBUG_BUILD } from '../debug-build';
+import { browserPerformanceTimeOrigin, dropUndefinedKeys, htmlTreeAsString } from '@sentry/utils';
 import { addInpInstrumentationHandler } from './instrument';
 import { getBrowserPerformanceAPI, msToSec } from './utils';
 

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -106,7 +106,7 @@ type CheckInEnvelopeHeaders = { trace?: DynamicSamplingContext };
 type ClientReportEnvelopeHeaders = BaseEnvelopeHeaders;
 type ReplayEnvelopeHeaders = BaseEnvelopeHeaders;
 type StatsdEnvelopeHeaders = BaseEnvelopeHeaders;
-type SpanEnvelopeHeaders = BaseEnvelopeHeaders;
+type SpanEnvelopeHeaders = BaseEnvelopeHeaders & { trace?: DynamicSamplingContext };
 
 export type EventEnvelope = BaseEnvelope<
   EventEnvelopeHeaders,


### PR DESCRIPTION
builds on top of #11696 #11699 

This PR refactors how we create INP spans. Previously we'd directly initialize a `SentrySpan` instance with the necessary properties and manually sample the span. Ironically, we heavily discourage directly initializing a `Span` class. 

With this refactor PR, we leverage the `standalone: true` flag introduced in #11696. This way, we can also use the built-in sampling functionality and ensure that we only have one logic for creating standalone span envelopes. Also bundle size should decrease slightly 🤞 

Adjusted the integration tests to more thoroughly test the INP span envelopes