### PR TITLE
fix(remix): Rethrow `loader`, `action` and `documentRequest` errors

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -228,6 +228,8 @@ function makeWrappedDocumentRequestFunction(remixVersion?: number) {
                 // eslint-disable-next-line @typescript-eslint/no-floating-promises
                 captureRemixServerException(err, 'documentRequest', request);
               }
+
+              throw err;
             },
           );
         },
@@ -270,6 +272,8 @@ function makeWrappedDataFunction(
               // eslint-disable-next-line @typescript-eslint/no-floating-promises
               captureRemixServerException(err, name, args.request);
             }
+
+            throw err;
           },
         );
       },


### PR DESCRIPTION
Closes: https://github.com/getsentry/sentry-javascript/issues/11615