### PR TITLE
fix(core): Capture only failed console.assert calls

### DIFF
--- a/packages/core/src/integrations/captureconsole.ts
+++ b/packages/core/src/integrations/captureconsole.ts
@@ -64,7 +64,7 @@ function consoleHandler(args: unknown[], level: string): void {
     });
 
     if (level === 'assert') {
-      if (args[0] === false) {
+      if (!args[0]) {
         const message = `Assertion failed: ${safeJoin(args.slice(1), ' ') || 'console.assert'}`;
         scope.setExtra('arguments', args.slice(1));
         captureMessage(message, captureContext);

--- a/packages/core/src/integrations/captureconsole.ts
+++ b/packages/core/src/integrations/captureconsole.ts
@@ -63,10 +63,12 @@ function consoleHandler(args: unknown[], level: string): void {
       return event;
     });
 
-    if (level === 'assert' && args[0] === false) {
-      const message = `Assertion failed: ${safeJoin(args.slice(1), ' ') || 'console.assert'}`;
-      scope.setExtra('arguments', args.slice(1));
-      captureMessage(message, captureContext);
+    if (level === 'assert') {
+      if (args[0] === false) {
+        const message = `Assertion failed: ${safeJoin(args.slice(1), ' ') || 'console.assert'}`;
+        scope.setExtra('arguments', args.slice(1));
+        captureMessage(message, captureContext);
+      }
       return;
     }
 

--- a/packages/core/test/lib/integrations/captureconsole.test.ts
+++ b/packages/core/test/lib/integrations/captureconsole.test.ts
@@ -175,6 +175,8 @@ describe('CaptureConsole setup', () => {
     captureConsole.setup?.(mockClient);
 
     GLOBAL_OBJ.console.assert(1 + 1 === 2);
+
+    expect(captureMessage).toHaveBeenCalledTimes(0);
   });
 
   it('should capture exception when console logs an error object with level set to "error"', () => {


### PR DESCRIPTION
I'm seeing a lot of breadcrumbs for `console.assert`s even though they are passing. This issue was previously fixed in #2239 but I guess there was a regression at some point. There was already an existing test case for this, but it was missing an assertion.