### PR TITLE
feat(nextjs): Mute webpack warnings about critical dependencies inside `@opentelemetry/instrumentation`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
@@ -8,24 +8,9 @@ const buildStdout = fs.readFileSync('.tmp_build_stdout', 'utf-8');
 const buildStderr = fs.readFileSync('.tmp_build_stderr', 'utf-8');
 
 // Assert that there was no funky build time warning when we are on a stable (pinned) version
-// if (nextjsVersion !== 'latest' && nextjsVersion !== 'canary') {
-//   assert.doesNotMatch(buildStderr, /Import trace for requested module/); // This is Next.js/Webpack speech for "something is off"
-// }
-// Note(lforst): I disabled this for the time being to figure out OTEL + Next.js - Next.js is currently complaining about a critical import in the @opentelemetry/instrumentation package. E.g:
-// --- Start logs ---
-// ./node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
-// ./node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
-// Critical dependency: the request of a dependency is an expression
-// Import trace for requested module:
-// ./node_modules/@opentelemetry/instrumentation/build/esm/platform/node/instrumentation.js
-// ./node_modules/@opentelemetry/instrumentation/build/esm/platform/node/index.js
-// ./node_modules/@opentelemetry/instrumentation/build/esm/platform/index.js
-// ./node_modules/@opentelemetry/instrumentation/build/esm/index.js
-// ./node_modules/@sentry/node/cjs/index.js
-// ./node_modules/@sentry/nextjs/cjs/server/index.js
-// ./node_modules/@sentry/nextjs/cjs/index.server.js
-// ./app/page.tsx
-// --- End logs ---
+if (nextjsVersion !== 'latest' && nextjsVersion !== 'canary') {
+  assert.doesNotMatch(buildStderr, /Import trace for requested module/); // This is Next.js/Webpack speech for "something is off"
+}
 
 // Assert that all static components stay static and all dynamic components stay dynamic
 assert.match(buildStdout, /○ \/client-component/);

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -418,6 +418,7 @@ export type WebpackConfigObject = {
   output: { filename: string; path: string };
   target: string;
   context: string;
+  ignoreWarnings?: { module?: RegExp }[]; // Note: The interface for `ignoreWarnings` is larger but we only need this. See https://webpack.js.org/configuration/other-options/#ignorewarnings
   resolve?: {
     modules?: string[];
     alias?: { [key: string]: string | boolean };

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -73,6 +73,10 @@ export function constructWebpackConfigFunction(
     // Add a loader which will inject code that sets global values
     addValueInjectionLoader(newConfig, userNextConfig, userSentryOptions, buildContext);
 
+    if (isServer) {
+      addOtelWarningIgnoreRule(newConfig);
+    }
+
     let pagesDirPath: string | undefined;
     const maybePagesDirPath = path.join(projectDir, 'pages');
     const maybeSrcPagesDirPath = path.join(projectDir, 'src', 'pages');
@@ -725,4 +729,13 @@ function getRequestAsyncStorageModuleLocation(
   }
 
   return undefined;
+}
+
+function addOtelWarningIgnoreRule(newConfig: WebpackConfigObjectWithModuleRules): void {
+  const ignoreRule = { module: /@opentelemetry\/instrumentation/ };
+  if (newConfig.ignoreWarnings === undefined) {
+    newConfig.ignoreWarnings = [ignoreRule];
+  } else if (Array.isArray(newConfig.ignoreWarnings)) {
+    newConfig.ignoreWarnings.push(ignoreRule);
+  }
 }


### PR DESCRIPTION
Currently, Next.js (Webpack) prints an annoying warning about an import statement that cannot be statically analyzed inside `@opentelemetry/instrumentation`. This is annoying (but harmless) and spams the logs **a lot** so we should probably ignore the warning.

More info on the issue in OTEL: https://github.com/open-telemetry/opentelemetry-js/issues/4173

Hopefully this will be fixed in https://github.com/open-telemetry/opentelemetry-js/pull/4660 soon.
