### PR TITLE
ref: Add geo location types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- ref: Add `geo` location types to `user` (#11847)
+
 ## 8.0.0-beta.4
 
 ### Important Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-- ref: Add `geo` location types to `user` (#11847)
-
 ## 8.0.0-beta.4
 
 ### Important Changes

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -7,4 +7,11 @@ export interface User {
   ip_address?: string;
   email?: string;
   username?: string;
+  geo?: GeoLocation;
+}
+
+export interface GeoLocation {
+  country_code?: string;
+  region?: string;
+  city?: string;
 }


### PR DESCRIPTION
Adds types for `geo` in the user object
https://develop.sentry.dev/sdk/event-payloads/user/