### PR TITLE
ci: Skip cloudflare-astro E2E tests for dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -989,6 +989,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        is_dependabot:
+          - ${{ github.actor == 'dependabot[bot]' }}
         test-application:
           [
             'angular-17',
@@ -1042,6 +1044,10 @@ jobs:
           - test-application: 'nextjs-app-dir'
             build-command: 'test:build-13'
             label: 'nextjs-app-dir (next@13)'
+        exclude:
+          - is_dependabot: true
+            test-application: 'cloudflare-astro'
+
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4


### PR DESCRIPTION
They fail because a secret is missing, we can skip them for dependabot.

See: https://github.com/orgs/community/discussions/26253