### PR TITLE
fix(feedback): Be consistent about whether screenshot should and can render

### DIFF
--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -187,10 +187,17 @@ export const buildFeedbackIntegration = ({
             )
           : undefined,
       ]);
-      if (!modalIntegration || (screenshotRequired && !screenshotIntegration)) {
+      if (!modalIntegration) {
         // TODO: Let the end-user retry async loading
-        // Include more verbose logs so developers can understand the options (like preloading).
-        throw new Error('Missing feedback helper integration!');
+        DEBUG_BUILD &&
+          logger.error(
+            '[Feedback] Missing feedback modal integration. Try using `feedbackSyncIntegration` in your `Sentry.init`.',
+          );
+        throw new Error('[Feedback] Missing feedback modal integration!');
+      }
+      if (screenshotRequired && !screenshotIntegration) {
+        DEBUG_BUILD &&
+          logger.error('[Feedback] Missing feedback screenshot integration. Proceeding without screenshots.');
       }
 
       return modalIntegration.createDialog({

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -176,9 +176,10 @@ export const buildFeedbackIntegration = ({
     };
 
     const _loadAndRenderDialog = async (options: FeedbackInternalOptions): Promise<FeedbackDialog> => {
+      const screenshotRequired = options.showScreenshot && isScreenshotSupported();
       const [modalIntegration, screenshotIntegration] = await Promise.all([
         _findIntegration<FeedbackModalIntegration>('FeedbackModal', getModalIntegration, 'feedbackModalIntegration'),
-        showScreenshot && isScreenshotSupported()
+        screenshotRequired
           ? _findIntegration<FeedbackScreenshotIntegration>(
               'FeedbackScreenshot',
               getScreenshotIntegration,
@@ -186,7 +187,7 @@ export const buildFeedbackIntegration = ({
             )
           : undefined,
       ]);
-      if (!modalIntegration || (showScreenshot && !screenshotIntegration)) {
+      if (!modalIntegration || (screenshotRequired && !screenshotIntegration)) {
         // TODO: Let the end-user retry async loading
         // Include more verbose logs so developers can understand the options (like preloading).
         throw new Error('Missing feedback helper integration!');
@@ -194,7 +195,7 @@ export const buildFeedbackIntegration = ({
 
       return modalIntegration.createDialog({
         options,
-        screenshotIntegration: showScreenshot ? screenshotIntegration : undefined,
+        screenshotIntegration: screenshotRequired ? screenshotIntegration : undefined,
         sendFeedback,
         shadow: _createShadow(options),
       });


### PR DESCRIPTION
This fixes the conditions for loading and rendering the screenshot integration.... also improves the conditions for not rendering it if we're on a mobile device.

- We should check the local`options.showScreenshot` instead of the closed-over `showScreenshot` because the options might have changed for this instance of the widget
- We should combine `options.showScreenshot` (the desire) with `isScreenshotSupported()` (the possibility) to set the right expectation