### PR TITLE
ci: Put CODEOWNERS in the correct folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
-
+packages/replay                                   @getsentry/replay-sdk-web
+packages/replay-worker                            @getsentry/replay-sdk-web
+packages/replay-canvas                            @getsentry/replay-sdk-web
+packages/feedback                                 @getsentry/replay-sdk-web
+dev-packages/browser-integration-tests/suites/replay  @getsentry/replay-sdk-web

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,0 @@
-packages/replay                                   @getsentry/replay-sdk-web
-packages/replay-worker                            @getsentry/replay-sdk-web
-packages/replay-canvas                            @getsentry/replay-sdk-web
-packages/feedback                                 @getsentry/replay-sdk-web
-dev-packages/browser-integration-tests/suites/replay  @getsentry/replay-sdk-web


### PR DESCRIPTION
Per the docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location

> file called CODEOWNERS in the .github/, root, or docs/ directory of the repository, in the branch where you'd like to add the code owners.

But also, in our case:
> If CODEOWNERS files exist in more than one of those locations, GitHub will search for them in that order and use the first one it finds.

So we just need the one file.