### PR TITLE
fix(node): Fix nest.js error handler

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-nestjs-app/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-app/src/main.ts
@@ -1,4 +1,4 @@
-import { NestFactory } from '@nestjs/core';
+import { BaseExceptionFilter, HttpAdapterHost, NestFactory } from '@nestjs/core';
 import * as Sentry from '@sentry/node';
 import { AppModule1, AppModule2 } from './app.module';
 
@@ -15,7 +15,9 @@ async function bootstrap() {
   });
 
   const app1 = await NestFactory.create(AppModule1);
-  Sentry.setupNestErrorHandler(app1);
+
+  const { httpAdapter } = app1.get(HttpAdapterHost);
+  Sentry.setupNestErrorHandler(app1, new BaseExceptionFilter(httpAdapter));
 
   await app1.listen(app1Port);
 

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-app/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-app/tests/errors.test.ts
@@ -47,9 +47,12 @@ test('Sends exception to Sentry', async ({ baseURL }) => {
   });
 
   try {
-    axios.get(`${baseURL}/test-exception/123`);
-  } catch {
-    // this results in an error, but we don't care - we want to check the error event
+    await axios.get(`${baseURL}/test-exception/123`);
+    // Should never be reached!
+    expect(false).toBe(true);
+  } catch (error) {
+    expect(error).toBeInstanceOf(AxiosError);
+    expect(error.response?.status).toBe(500);
   }
 
   const errorEvent = await errorEventPromise;

--- a/dev-packages/node-integration-tests/suites/tracing/nestjs-errors-no-express/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/nestjs-errors-no-express/scenario.ts
@@ -15,7 +15,7 @@ Sentry.init({
 });
 
 import { Controller, Get, Injectable, Module, Param } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { BaseExceptionFilter, HttpAdapterHost, NestFactory } from '@nestjs/core';
 
 const port = 3480;
 
@@ -49,7 +49,8 @@ class AppModule {}
 
 async function init(): Promise<void> {
   const app = await NestFactory.create(AppModule);
-  Sentry.setupNestErrorHandler(app);
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  Sentry.setupNestErrorHandler(app, new BaseExceptionFilter(httpAdapter));
   await app.listen(port);
   sendPortToRunner(port);
 }

--- a/dev-packages/node-integration-tests/suites/tracing/nestjs-errors/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/nestjs-errors/scenario.ts
@@ -13,7 +13,7 @@ Sentry.init({
 });
 
 import { Controller, Get, Injectable, Module, Param } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { BaseExceptionFilter, HttpAdapterHost, NestFactory } from '@nestjs/core';
 
 const port = 3460;
 
@@ -47,7 +47,8 @@ class AppModule {}
 
 async function init(): Promise<void> {
   const app = await NestFactory.create(AppModule);
-  Sentry.setupNestErrorHandler(app);
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  Sentry.setupNestErrorHandler(app, new BaseExceptionFilter(httpAdapter));
   await app.listen(port);
   sendPortToRunner(port);
 }

--- a/dev-packages/node-integration-tests/suites/tracing/nestjs-no-express/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/nestjs-no-express/scenario.ts
@@ -15,7 +15,7 @@ Sentry.init({
 });
 
 import { Controller, Get, Injectable, Module, Param } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { BaseExceptionFilter, HttpAdapterHost, NestFactory } from '@nestjs/core';
 
 const port = 3470;
 
@@ -49,7 +49,8 @@ class AppModule {}
 
 async function init(): Promise<void> {
   const app = await NestFactory.create(AppModule);
-  Sentry.setupNestErrorHandler(app);
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  Sentry.setupNestErrorHandler(app, new BaseExceptionFilter(httpAdapter));
   await app.listen(port);
   sendPortToRunner(port);
 }


### PR DESCRIPTION
This was brought up here https://github.com/getsentry/sentry-javascript/discussions/5578#discussioncomment-9284317,

our error handler implementation was too naive, and our tests not ideal - the tests only checked that stuff is sent to sentry (which it was!) but not that the page otherwise worked.

Now, I updated the test to ensure this works as expected.

With this PR, the signature for `Sentry.setupNestErrorHandler()` changes ( breaking change, but sadly required at this point). You have to pass in an exception filter, which we'll extend to _also_ send exceptions to Sentry:


```js
import { BaseExceptionFilter, HttpAdapterHost } from '@nestjs/core';

const { httpAdapter } = app1.get(HttpAdapterHost);
Sentry.setupNestErrorHandler(app1, new BaseExceptionFilter(httpAdapter));
```

This is a bit more involved, but also allows you to use a custom filter if needed (we can extend _any_ exception filter).