### PR TITLE
build(aws-lambda/v7): Turn off lambda layer publishing

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -144,20 +144,22 @@ targets:
     id: '@sentry/node-experimental'
     includeNames: /^sentry-node-experimental-\d.*\.tgz$/
 
+  # NOTE: Lambda layer releasing was turned off for v7, because AWS lambda versioning is linear, meaning the version number is always increased by 1 for each release. Since this would make it impossible for us to communicate to people which layer version corresponds to which SDK version, we will simply not publish lambda layers for v7 any longer. The latest released lambda layer for v7 was 235.
+
   # AWS Lambda Layer target
-  - name: aws-lambda-layer
-    includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha)\.\d+)?\.zip$/
-    layerName: SentryNodeServerlessSDK
-    compatibleRuntimes:
-      - name: node
-        versions:
-          - nodejs10.x
-          - nodejs12.x
-          - nodejs14.x
-          - nodejs16.x
-          - nodejs18.x
-          - nodejs20.x
-    license: MIT
+  # - name: aws-lambda-layer
+  #   includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha)\.\d+)?\.zip$/
+  #   layerName: SentryNodeServerlessSDK
+  #   compatibleRuntimes:
+  #     - name: node
+  #       versions:
+  #         - nodejs10.x
+  #         - nodejs12.x
+  #         - nodejs14.x
+  #         - nodejs16.x
+  #         - nodejs18.x
+  #         - nodejs20.x
+  #   license: MIT
 
   # CDN Bundle Target
   - name: gcs

--- a/.craft.yml
+++ b/.craft.yml
@@ -144,7 +144,9 @@ targets:
     id: '@sentry/node-experimental'
     includeNames: /^sentry-node-experimental-\d.*\.tgz$/
 
-  # NOTE: Lambda layer releasing was turned off for v7, because AWS lambda versioning is linear, meaning the version number is always increased by 1 for each release. Since this would make it impossible for us to communicate to people which layer version corresponds to which SDK version, we will simply not publish lambda layers for v7 any longer. The latest released lambda layer for v7 was 235.
+  # NOTE: Lambda layer releasing was turned off for v7, because AWS lambda versioning is linear, meaning the version number is always increased by 1 for each release.
+  # Since this would make it impossible for us to communicate to people which layer version corresponds to which SDK version,
+  # we will simply not publish lambda layers for v7 any longer. The latest released lambda layer for v7 was 235.
 
   # AWS Lambda Layer target
   # - name: aws-lambda-layer


### PR DESCRIPTION
We want to stop publishing lambda layers for v7, since lambda layer versioning is linear (a number is incremented), and communitcating which layer version corresponds to which SDK version would be impossible.

Also this lets us use very simple logic in Sentry to determine whether we should include `@sentry/serverless` or `@sentry/aws-lambda` within the layer.