### PR TITLE
fix: Ensure we always send exclusive_time for standalone spans

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -127,10 +127,6 @@ export function createAttachmentEnvelope(
  * Create envelope from Span item.
  */
 export function createSpanEnvelope(spans: SentrySpan[]): SpanEnvelope {
-  function dscHasRequiredProps(dsc: Partial<DynamicSamplingContext>): dsc is DynamicSamplingContext {
-    return !!dsc.trace_id && !!dsc.public_key;
-  }
-
   // For the moment we'll obtain the DSC from the first span in the array
   // This might need to be changed if we permit sending multiple spans from
   // different segments in one envelope
@@ -142,4 +138,8 @@ export function createSpanEnvelope(spans: SentrySpan[]): SpanEnvelope {
   };
   const items = spans.map(span => createSpanEnvelopeItem(spanToJSON(span)));
   return createEnvelope<SpanEnvelope>(headers, items);
+}
+
+function dscHasRequiredProps(dsc: Partial<DynamicSamplingContext>): dsc is DynamicSamplingContext {
+  return !!dsc.trace_id && !!dsc.public_key;
 }

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -20,7 +20,11 @@ import { getMainCarrier } from '../carrier';
 import { getCurrentScope } from '../currentScopes';
 import { getMetricSummaryJsonForSpan, updateMetricSummaryOnSpan } from '../metrics/metric-summary';
 import type { MetricType } from '../metrics/types';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../semanticAttributes';
+import {
+  SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+} from '../semanticAttributes';
 import type { SentrySpan } from '../tracing/sentrySpan';
 import { SPAN_STATUS_OK, SPAN_STATUS_UNSET } from '../tracing/spanstatus';
 import { _getSpanForScope } from './spanOnScope';
@@ -127,6 +131,7 @@ export function spanToJSON(span: Span): Partial<SpanJSON> {
         op: attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP],
         origin: attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined,
         _metrics_summary: getMetricSummaryJsonForSpan(span),
+        exclusive_time: attributes[SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME] as number | undefined,
       });
     }
 

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -187,6 +187,11 @@ export function createSpanEnvelopeItem(spanJson: Partial<SpanJSON>): SpanItem {
     type: 'span',
   };
 
+  // ensure we have exclusive_time
+  if (typeof spanJson.exclusive_time === 'undefined' && spanJson.timestamp && spanJson.start_timestamp) {
+    spanJson.exclusive_time = spanJson.timestamp - spanJson.start_timestamp;
+  }
+
   return [spanHeaders, spanJson];
 }
 


### PR DESCRIPTION
Currently the backend expects this to exist, so we fill it to the duration if we don't have other data points.