### PR TITLE
docs: Clarify Node.js specific imports in Next.js register hook migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -833,6 +833,24 @@ The following is an example of how to initialize the serverside SDK in a Next.js
    }
    ```
 
+   If you need to import a Node.js specific integration (like for example `@sentry/profiling-node`), you will have to
+   import the package using a dynamic import to prevent Next.js from bundling Node.js APIs into bundles for other
+   runtime environments (like the Browser or the Edge runtime). You can do so as follows:
+
+   ```ts
+   import * as Sentry from '@sentry/nextjs';
+
+   export async function register() {
+     if (process.env.NEXT_RUNTIME === 'nodejs') {
+       const { nodeProfilingIntegration } = await import('@sentry/profiling-node');
+       Sentry.init({
+         dsn: 'YOUR_DSN',
+         integrations: [nodeProfilingIntegration()],
+       });
+     }
+   }
+   ```
+
    Note that you can initialize the SDK differently depending on which server runtime is being used.
 
 If you are using a


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/issues/11823 rightfully mentioned that the way we recommend people to init the SDK may crash if there are nodejs specific packages being imported in `instrumentation.ts`.

We could solve this by either changing the way we recommend users to add configuration like so:

```ts
import * as Sentry from '@sentry/nextjs';

export async function register() {
  if (process.env.NEXT_RUNTIME === 'nodejs') {
    await import('./sentry.server.config.ts');
  }

  if (process.env.NEXT_RUNTIME === 'edge') {
    await import('./sentry.edge.config.ts');
  }
}
```

But for now I'd rather keep the base-case simple and add additional explanation for the more complicated case. Maybe we need to switch this up in the future.