### PR TITLE
docs: fix typo in doc for `reactRouterV6BrowserTracingIntegration`

### DIFF
--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -59,7 +59,7 @@ interface ReactRouterOptions {
 }
 
 /**
- * A browser tracing integration that uses React Router v3 to instrument navigations.
+ * A browser tracing integration that uses React Router v6 to instrument navigations.
  * Expects `history` (and optionally `routes` and `matchPath`) to be passed as options.
  */
 export function reactRouterV6BrowserTracingIntegration(

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -60,7 +60,7 @@ interface ReactRouterOptions {
 
 /**
  * A browser tracing integration that uses React Router v6 to instrument navigations.
- * Expects `history` (and optionally `routes` and `matchPath`) to be passed as options.
+ * Expects `useEffect`, `useLocation`, `useNavigationType`, `createRoutesFromChildren` and `matchRoutes` to be passed as options.
  */
 export function reactRouterV6BrowserTracingIntegration(
   options: Parameters<typeof browserTracingIntegration>[0] & ReactRouterOptions,


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Not a big issue but noticed it when the IDE showed the docs for the function