### PR TITLE
test: Remove `getLocalTestPath`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/ContextLines/inline/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/ContextLines/inline/test.ts
@@ -5,7 +5,7 @@ import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../uti
 
 sentryTest(
   'should add source context lines around stack frames from errors in Html inline JS',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     if (browserName === 'webkit') {
       // The error we're throwing in this test is thrown as "Script error." in Webkit.
       // We filter "Script error." out by default in `InboundFilters`.
@@ -15,7 +15,7 @@ sentryTest(
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventReqPromise = waitForErrorRequestOnUrl(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/integrations/ContextLines/noAddedLines/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/ContextLines/noAddedLines/test.ts
@@ -3,8 +3,8 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../utils/helpers';
 
-sentryTest('should not add source context lines to errors from script files', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should not add source context lines to errors from script files', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventReqPromise = waitForErrorRequestOnUrl(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/integrations/ContextLines/scriptTag/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/ContextLines/scriptTag/test.ts
@@ -5,7 +5,7 @@ import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../uti
 
 sentryTest(
   'should add source context lines around stack frames from errors in Html script tags',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     if (browserName === 'webkit') {
       // The error we're throwing in this test is thrown as "Script error." in Webkit.
       // We filter "Script error." out by default in `InboundFilters`.
@@ -15,7 +15,7 @@ sentryTest(
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventReqPromise = waitForErrorRequestOnUrl(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/integrations/globalHandlers/fetchStackTrace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/globalHandlers/fetchStackTrace/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('should create errors with stack traces for failing fetch calls', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should create errors with stack traces for failing fetch calls', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 3, { url, timeout: 10000 });
   const errorEvent = envelopes.find(event => !event.type)!;

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest(
   'should assign request and response context from a failed 500 XHR request',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.route('**/foo', route => {
       return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
@@ -8,8 +8,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 // https://github.com/microsoft/playwright/issues/10376
 sentryTest(
   'should assign request and response context from a failed 500 fetch request',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.route('**/foo', route => {
       return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withAbortController/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withAbortController/test.ts
@@ -3,12 +3,12 @@ import type { Event as SentryEvent } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../../utils/helpers';
 
-sentryTest('should handle aborted fetch calls', async ({ getLocalTestPath, page }) => {
+sentryTest('should handle aborted fetch calls', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.route('**/foo', async () => {
     // never fulfil this route because we abort the request as part of the test

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('works with a Request passed in', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('works with a Request passed in', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.route('**/foo', route => {
     return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
 sentryTest(
   'works with a Request (with body) & options passed in - handling used body',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.route('**/foo', route => {
       return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('works with a Request (without body) & options passed in', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('works with a Request (without body) & options passed in', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.route('**/foo', route => {
     return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('works with httpClientIntegration', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('works with httpClientIntegration', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.route('**/foo', route => {
     return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest(
   'should assign request and response context from a failed 500 XHR request',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.route('**/foo', route => {
       return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/test.ts
@@ -4,13 +4,13 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should provide module_metadata on stack frames in beforeSend', async ({ getLocalTestPath, page }) => {
+sentryTest('should provide module_metadata on stack frames in beforeSend', async ({ getLocalTestUrl, page }) => {
   // moduleMetadataIntegration is not included in any CDN bundles
   if (process.env.PW_BUNDLE?.startsWith('bundle')) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const errorEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
   expect(errorEvent.extra?.['module_metadata_entries']).toEqual([{ foo: 'bar' }]);

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/test.ts
@@ -6,13 +6,13 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest(
   'should provide module_metadata on stack frames in beforeSend even though an event processor (rewriteFramesIntegration) modified the filename',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     // moduleMetadataIntegration is not included in any CDN bundles
     if (process.env.PW_BUNDLE?.startsWith('bundle')) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const errorEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
     expect(errorEvent?.extra?.['module_metadata_entries']).toEqual([{ foo: 'baz' }]);

--- a/dev-packages/browser-integration-tests/suites/metrics/metricsShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/metrics/metricsShim/test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { shouldSkipMetricsTest } from '../../../utils/helpers';
 
-sentryTest('exports shim metrics integration for non-tracing bundles', async ({ getLocalTestPath, page }) => {
+sentryTest('exports shim metrics integration for non-tracing bundles', async ({ getLocalTestUrl, page }) => {
   // Skip in tracing tests
   if (!shouldSkipMetricsTest()) {
     sentryTest.skip();
@@ -22,7 +22,7 @@ sentryTest('exports shim metrics integration for non-tracing bundles', async ({ 
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/empty_obj/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/empty_obj/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest(
   'should add an empty breadcrumb initialized with a timestamp, when an empty object is given',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should add multiple breadcrumbs', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should add multiple breadcrumbs', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should add a simple breadcrumb', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should add a simple breadcrumb', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/undefined_arg/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/undefined_arg/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest(
   'should add an empty breadcrumb initialized with a timestamp, when no argument is given',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/classInstance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/classInstance/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture an POJO', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture an POJO', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/emptyObj/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/emptyObj/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture an empty object', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture an empty object', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/subject.js
@@ -1,5 +1,1 @@
-window.addEventListener('error', function (event) {
-  Sentry.captureException(event);
-});
-
-window.thisDoesNotExist();
+Sentry.captureException(new ErrorEvent('something', { message: 'test error' }));

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/test.ts
@@ -4,15 +4,15 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture an ErrorEvent', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture an ErrorEvent', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.exception?.values).toHaveLength(1);
   expect(eventData.exception?.values?.[0]).toMatchObject({
     type: 'ErrorEvent',
-    value: 'Event `ErrorEvent` captured as exception with message `Script error.`',
+    value: 'Event `ErrorEvent` captured as exception with message `test error`',
     mechanism: {
       type: 'generic',
       handled: true,

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/event/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/event/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture an Event', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture an Event', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/eventBreadcrumbs/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/eventBreadcrumbs/test.ts
@@ -6,8 +6,8 @@ import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
 sentryTest(
   'should capture recorded transactions as breadcrumbs for the following event sent',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const events = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/linkedErrors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/linkedErrors/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture a linked error with messages', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a linked error with messages', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/multipleErrorsDifferentStacktrace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/multipleErrorsDifferentStacktrace/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('should not reject back-to-back errors with different stack traces', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should not reject back-to-back errors with different stack traces', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getMultipleSentryEnvelopeRequests<Event>(page, 3, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/multipleErrorsSameStacktrace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/multipleErrorsSameStacktrace/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('should reject duplicate, back-to-back errors from captureException', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should reject duplicate, back-to-back errors from captureException', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getMultipleSentryEnvelopeRequests<Event>(page, 7, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/plainObject/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/plainObject/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture an class instance', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture an class instance', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/simpleError/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/simpleError/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture a simple error with message', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a simple error with message', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/transactionBreadcrumbs/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/transactionBreadcrumbs/test.ts
@@ -6,8 +6,8 @@ import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
 sentryTest(
   'should capture recorded transactions as breadcrumbs for the following event sent',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const events = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/undefinedArg/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/undefinedArg/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture an undefined error when no arguments are provided', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture an undefined error when no arguments are provided', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/multipleMessageAttachStacktrace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/multipleMessageAttachStacktrace/test.ts
@@ -6,8 +6,8 @@ import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
 sentryTest(
   'should reject duplicate, back-to-back messages from captureMessage when it has stacktrace',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getMultipleSentryEnvelopeRequests<Event>(page, 5, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/parameterized_message/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/parameterized_message/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture a parameterized representation of the message', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a parameterized representation of the message', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture a simple message string', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a simple message string', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/with_level/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/with_level/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('should capture with different severity levels', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture with different severity levels', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const events = await getMultipleSentryEnvelopeRequests<Event>(page, 6, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/simple_feedback/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/simple_feedback/test.ts
@@ -4,8 +4,8 @@ import type { UserFeedback } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture simple user feedback', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture simple user feedback', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<UserFeedback>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureException/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureException/test.ts
@@ -4,8 +4,8 @@ import type { Event, UserFeedback } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('capture user feedback when captureException is called', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('capture user feedback when captureException is called', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const data = (await getMultipleSentryEnvelopeRequests(page, 2, { url })) as (Event | UserFeedback)[];
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureMessage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureMessage/test.ts
@@ -4,8 +4,8 @@ import type { Event, UserFeedback } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('capture user feedback when captureMessage is called', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('capture user feedback when captureMessage is called', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const data = (await getMultipleSentryEnvelopeRequests(page, 2, { url })) as (Event | UserFeedback)[];
 

--- a/dev-packages/browser-integration-tests/suites/public-api/denyUrls/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/denyUrls/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
-sentryTest('should allow to ignore specific urls', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should allow to ignore specific urls', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/ignoreErrors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/ignoreErrors/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../utils/helpers';
 
-sentryTest('should allow to ignore specific errors', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should allow to ignore specific errors', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const events = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/init/built-pkg/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/init/built-pkg/test.ts
@@ -6,8 +6,8 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 
 // Regression test against https://github.com/getsentry/sentry-javascript/pull/1896
-sentryTest('should not contain tslib_1__default', async ({ getLocalTestPath }) => {
-  await getLocalTestPath({ testDir: __dirname });
+sentryTest('should not contain tslib_1__default', async ({ getLocalTestUrl }) => {
+  await getLocalTestUrl({ testDir: __dirname });
 
   const initBundle = fs.readFileSync(path.join(__dirname, 'dist', 'init.bundle.js'), 'utf-8');
   expect(initBundle.length).toBeGreaterThan(0);

--- a/dev-packages/browser-integration-tests/suites/public-api/init/console/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/init/console/test.ts
@@ -5,8 +5,8 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 
 // Regression test against https://github.com/getsentry/sentry-javascript/issues/4558
-sentryTest('should not change console output', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should not change console output', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   // https://playwright.dev/docs/api/class-page#page-event-console
   page.on('console', (msg: ConsoleMessage) => {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/instrumentation-behaviour/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/instrumentation-behaviour/test.ts
@@ -4,8 +4,8 @@ import { sentryTest } from '../../../../../utils/fixtures';
 
 sentryTest(
   'Event listener instrumentation should attach the same event listener only once',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     let functionListenerCalls = 0;

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/named-function/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/named-function/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should capture built-in handlers fn name in mechanism data', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture built-in handlers fn name in mechanism data', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/original-callback/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/original-callback/test.ts
@@ -4,8 +4,8 @@ import { sentryTest } from '../../../../../utils/fixtures';
 
 sentryTest(
   'should remove the original callback if it was registered before Sentry initialized (w. original method)',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/remove/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/remove/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should transparently remove event listeners from wrapped functions', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should transparently remove event listeners from wrapped functions', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/this-preservation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/this-preservation/test.ts
@@ -2,8 +2,8 @@ import { expect } from '@playwright/test';
 
 import { sentryTest } from '../../../../../utils/fixtures';
 
-sentryTest('Event listener instrumentation preserves "this" context', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('Event listener instrumentation preserves "this" context', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   let assertions = 0;

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/thrown-error/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/thrown-error/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
 sentryTest(
   'Event listener instrumentation should capture an error thrown in an event handler',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/wrapping/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/wrapping/test.ts
@@ -4,8 +4,8 @@ import { sentryTest } from '../../../../../utils/fixtures';
 
 sentryTest(
   'Event listener instrumentation should not wrap event listeners multiple times',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     const functionListenerStackHeights: number[] = [];

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/non-string-arg/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/non-string-arg/test.ts
@@ -6,13 +6,13 @@ import { getFirstSentryEnvelopeRequest, runScriptInSandbox } from '../../../../.
 
 sentryTest(
   'should catch onerror calls with non-string first argument gracefully',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     if (browserName === 'webkit') {
       // This test fails on Webkit as erros thrown from `runScriptInSandbox` are Script Errors and skipped by Sentry
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/rethrown/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/rethrown/test.ts
@@ -6,13 +6,13 @@ import { getMultipleSentryEnvelopeRequests, runScriptInSandbox } from '../../../
 
 sentryTest(
   'should NOT catch an exception already caught [but rethrown] via Sentry.captureException',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     if (browserName === 'webkit') {
       // This test fails on Webkit as erros thrown from `runScriptInSandbox` are Script Errors and skipped by Sentry
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/syntax-errors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/syntax-errors/test.ts
@@ -4,13 +4,13 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, runScriptInSandbox } from '../../../../../utils/helpers';
 
-sentryTest('should catch syntax errors', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('should catch syntax errors', async ({ getLocalTestUrl, page, browserName }) => {
   if (browserName === 'webkit') {
     // This test fails on Webkit as erros thrown from `runScriptInSandbox` are Script Errors and skipped by Sentry
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-errors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-errors/test.ts
@@ -4,13 +4,13 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, runScriptInSandbox } from '../../../../../utils/helpers';
 
-sentryTest('should catch thrown errors', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('should catch thrown errors', async ({ getLocalTestUrl, page, browserName }) => {
   if (browserName === 'webkit') {
     // This test fails on Webkit as erros thrown from `runScriptInSandbox` are Script Errors and skipped by Sentry
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-objects/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-objects/test.ts
@@ -4,13 +4,13 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, runScriptInSandbox } from '../../../../../utils/helpers';
 
-sentryTest('should catch thrown objects', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('should catch thrown objects', async ({ getLocalTestUrl, page, browserName }) => {
   if (browserName === 'webkit') {
     // This test fails on Webkit as erros thrown from `runScriptInSandbox` are Script Errors and skipped by Sentry
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-strings/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-strings/test.ts
@@ -4,13 +4,13 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, runScriptInSandbox } from '../../../../../utils/helpers';
 
-sentryTest('should catch thrown strings', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page, browserName }) => {
   if (browserName === 'webkit') {
     // This test fails on Webkit as erros thrown from `runScriptInSandbox` are Script Errors and skipped by Sentry
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/custom-event/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/custom-event/test.ts
@@ -11,8 +11,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 // https://github.com/getsentry/sentry-javascript/issues/2380
 sentryTest(
   'should capture PromiseRejectionEvent cast to CustomEvent with type unhandledrejection',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/event/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/event/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
 // there's no evidence that this actually happens, but it could, and our code correctly
 // handles it, so might as well prevent future regression on that score
-sentryTest('should capture a random Event with type unhandledrejection', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a random Event with type unhandledrejection', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-errors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-errors/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should catch thrown errors', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should catch thrown errors', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-null/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-null/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should catch thrown strings', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-number/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-number/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should catch thrown strings', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-object-complex/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-object-complex/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should capture unhandledrejection with a complex object', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture unhandledrejection with a complex object', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-objects/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-objects/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should capture unhandledrejection with an object', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture unhandledrejection with an object', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-string-large/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-string-large/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should capture unhandledrejection with a large string', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture unhandledrejection with a large string', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-strings/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-strings/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should catch thrown strings', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-undefined/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-undefined/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should catch thrown strings', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/requestAnimationFrame/callback/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/requestAnimationFrame/callback/test.ts
@@ -4,8 +4,8 @@ import { sentryTest } from '../../../../../utils/fixtures';
 
 sentryTest(
   'wrapped callback should preserve correct context - window (not-bound)',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 
@@ -24,8 +24,8 @@ sentryTest(
 
 sentryTest(
   'wrapped callback should preserve correct context - `bind` bound method',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/requestAnimationFrame/thrown-errors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/requestAnimationFrame/thrown-errors/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('should capture exceptions inside callback', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture exceptions inside callback', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/setInterval/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/setInterval/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('Instrumentation should capture errors in setInterval', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('Instrumentation should capture errors in setInterval', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/setTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/setTimeout/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('Instrumentation should capture errors in setTimeout', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('Instrumentation should capture errors in setTimeout', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/setTimeoutFrozen/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/setTimeoutFrozen/test.ts
@@ -6,11 +6,11 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest(
   'Instrumentation does not fail when using frozen callback for setTimeout',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     const bundleKey = process.env.PW_BUNDLE || '';
     const hasDebug = !bundleKey.includes('_min');
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const logMessages: string[] = [];
 

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/onreadystatechange/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/onreadystatechange/subject.js
@@ -1,6 +1,6 @@
 window.calls = {};
 const xhr = new XMLHttpRequest();
-xhr.open('GET', 'test');
+xhr.open('GET', 'http://example.com');
 xhr.onreadystatechange = function wat() {
   window.calls[xhr.readyState] = window.calls[xhr.readyState] ? window.calls[xhr.readyState] + 1 : 1;
 };

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/thrown-error/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/thrown-error/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
 sentryTest(
   'should capture exceptions from XMLHttpRequest event handlers (e.g. onreadystatechange)',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setContext/multiple_contexts/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setContext/multiple_contexts/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should record multiple contexts', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should record multiple contexts', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setContext/non_serializable_context/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setContext/non_serializable_context/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should normalize non-serializable context', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should normalize non-serializable context', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setContext/simple_context/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setContext/simple_context/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should set a simple context', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should set a simple context', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setExtra/multiple_extras/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setExtra/multiple_extras/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should record multiple extras of different types', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should record multiple extras of different types', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setExtra/non_serializable_extra/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setExtra/non_serializable_extra/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should normalize non-serializable extra', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should normalize non-serializable extra', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setExtra/simple_extra/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setExtra/simple_extra/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should record a simple extra object', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should record a simple extra object', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setExtras/consecutive_calls/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setExtras/consecutive_calls/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should set extras from multiple consecutive calls', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should set extras from multiple consecutive calls', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setExtras/multiple_extras/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setExtras/multiple_extras/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should record an extras object', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should record an extras object', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setTag/with_non_primitives/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setTag/with_non_primitives/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should not accept non-primitive tags', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should not accept non-primitive tags', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setTag/with_primitives/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setTag/with_primitives/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should set primitive tags', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should set primitive tags', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setTags/with_non_primitives/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setTags/with_non_primitives/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should not accept non-primitive tags', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should not accept non-primitive tags', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setTags/with_primitives/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setTags/with_primitives/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should set primitive tags', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should set primitive tags', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setUser/unset_user/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setUser/unset_user/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('should unset user', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should unset user', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getMultipleSentryEnvelopeRequests<Event>(page, 3, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/setUser/update_user/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/setUser/update_user/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('should update user', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should update user', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/showReportDialog/inject-script/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/showReportDialog/inject-script/test.ts
@@ -2,8 +2,8 @@ import { expect } from '@playwright/test';
 
 import { sentryTest } from '../../../../utils/fixtures';
 
-sentryTest('should inject dialog script into <head> with correct attributes', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should inject dialog script into <head> with correct attributes', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const dialogScriptSelector = 'head > script[src^="https://dsn.ingest.sentry.io/api/embed/error-page"]';
 

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/basic/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/basic/test.ts
@@ -7,12 +7,12 @@ import {
   waitForTransactionRequestOnUrl,
 } from '../../../../utils/helpers';
 
-sentryTest('should send a transaction in an envelope', async ({ getLocalTestPath, page }) => {
+sentryTest('should send a transaction in an envelope', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const req = await waitForTransactionRequestOnUrl(page, url);
   const transaction = envelopeRequestParser(req);
 
@@ -20,12 +20,12 @@ sentryTest('should send a transaction in an envelope', async ({ getLocalTestPath
   expect(transaction.spans).toBeDefined();
 });
 
-sentryTest('should report finished spans as children of the root transaction', async ({ getLocalTestPath, page }) => {
+sentryTest('should report finished spans as children of the root transaction', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const req = await waitForTransactionRequestOnUrl(page, url);
   const transaction = envelopeRequestParser(req);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/circular_data/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/circular_data/test.ts
@@ -4,12 +4,12 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should be able to handle circular data', async ({ getLocalTestPath, page }) => {
+sentryTest('should be able to handle circular data', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.type).toBe('transaction');

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-async-reject/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-async-reject/test.ts
@@ -6,12 +6,12 @@ import { getMultipleSentryEnvelopeRequests, shouldSkipTracingTest } from '../../
 
 sentryTest(
   'should capture a promise rejection within an async startSpan callback',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     const envelopePromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-async-throw-not-awaited/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-async-throw-not-awaited/test.ts
@@ -6,13 +6,13 @@ import { getMultipleSentryEnvelopeRequests, shouldSkipTracingTest } from '../../
 
 sentryTest(
   "should capture a thrown error within an async startSpan callback that's not awaited properly",
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
     const envelopePromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     const clickPromise = page.getByText('Button 1').click();

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-async-throw/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-async-throw/test.ts
@@ -4,13 +4,13 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should capture a thrown error within an async startSpan callback', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture a thrown error within an async startSpan callback', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
   const envelopePromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const clickPromise = page.getByText('Button 1').click();

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-sync/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-sync/test.ts
@@ -10,7 +10,7 @@ import {
 
 sentryTest(
   'should capture an error within a sync startSpan callback',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     if (browserName === 'webkit') {
       // This test fails on Webkit as erros thrown from `runScriptInSandbox` are Script Errors and skipped by Sentry
       sentryTest.skip();
@@ -20,7 +20,7 @@ sentryTest(
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/setMeasurement/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/setMeasurement/test.ts
@@ -4,12 +4,12 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should attach measurement to transaction', async ({ getLocalTestPath, page }) => {
+sentryTest('should attach measurement to transaction', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const event = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(event.measurements?.['metric.foo'].value).toBe(42);

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-mixed-transaction/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-mixed-transaction/test.ts
@@ -10,12 +10,12 @@ import {
 
 sentryTest(
   'sends a transaction and a span envelope if a standalone span is created as a child of an ongoing span tree',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     const envelopes = await getMultipleSentryEnvelopeRequests<Envelope>(
       page,
       2,

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone/test.ts
@@ -8,12 +8,12 @@ import {
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
 
-sentryTest('sends a segment span envelope', async ({ getLocalTestPath, page }) => {
+sentryTest('sends a segment span envelope', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const spanEnvelope = await getFirstSentryEnvelopeRequest<SpanEnvelope>(page, url, properFullEnvelopeRequestParser);
 
   const headers = spanEnvelope[0];

--- a/dev-packages/browser-integration-tests/suites/public-api/withScope/nested_scopes/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/withScope/nested_scopes/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
-sentryTest('should allow nested scoping', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should allow nested scoping', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getMultipleSentryEnvelopeRequests<Event>(page, 5, { url });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/withScope/throwError/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/withScope/throwError/test.ts
@@ -15,8 +15,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
  */
 sentryTest(
   'withScope scope is NOT applied to thrown error caught by global handler',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/bufferModeManual/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferModeManual/test.ts
@@ -15,7 +15,7 @@ import {
 
 sentryTest(
   '[buffer-mode] manually start buffer mode and capture buffer',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // This was sometimes flaky on webkit, so skipping for now
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -45,7 +45,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await page.locator('#go-background').click();
@@ -161,7 +161,7 @@ sentryTest(
 
 sentryTest(
   '[buffer-mode] manually start buffer mode and capture buffer, but do not continue as session',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // This was sometimes flaky on webkit, so skipping for now
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -190,7 +190,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await page.locator('#go-background').click();
@@ -291,7 +291,7 @@ sentryTest(
 // error happens.
 sentryTest(
   '[buffer-mode] can sample on each error event',
-  async ({ getLocalTestPath, page, browserName, enableConsole }) => {
+  async ({ getLocalTestUrl, page, browserName, enableConsole }) => {
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
     }
@@ -321,7 +321,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     // Start buffering and assert that it is enabled

--- a/dev-packages/browser-integration-tests/suites/replay/bufferModeReload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferModeReload/test.ts
@@ -8,7 +8,7 @@ import {
   waitForReplayRunning,
 } from '../../../utils/replayHelpers';
 
-sentryTest('continues buffer session in session mode after error & reload', async ({ getLocalTestPath, page }) => {
+sentryTest('continues buffer session in session mode after error & reload', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -23,7 +23,7 @@ sentryTest('continues buffer session in session mode after error & reload', asyn
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/captureComponentName/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureComponentName/test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('captures component name attribute when available', async ({ forceFlushReplay, getLocalTestPath, page }) => {
+sentryTest('captures component name attribute when available', async ({ forceFlushReplay, getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -18,7 +18,7 @@ sentryTest('captures component name attribute when available', async ({ forceFlu
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   await reqPromise0;
@@ -88,7 +88,7 @@ sentryTest('captures component name attribute when available', async ({ forceFlu
   ]);
 });
 
-sentryTest('sets element name to component name attribute', async ({ forceFlushReplay, getLocalTestPath, page }) => {
+sentryTest('sets element name to component name attribute', async ({ forceFlushReplay, getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -103,7 +103,7 @@ sentryTest('sets element name to component name attribute', async ({ forceFlushR
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   await reqPromise0;

--- a/dev-packages/browser-integration-tests/suites/replay/captureConsoleLog/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureConsoleLog/test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('should capture console messages in replay', async ({ getLocalTestPath, page, forceFlushReplay }) => {
+sentryTest('should capture console messages in replay', async ({ getLocalTestUrl, page, forceFlushReplay }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -18,7 +18,7 @@ sentryTest('should capture console messages in replay', async ({ getLocalTestPat
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await Promise.all([page.goto(url), reqPromise0]);
 
@@ -54,7 +54,7 @@ sentryTest('should capture console messages in replay', async ({ getLocalTestPat
   );
 });
 
-sentryTest('should capture very large console logs', async ({ getLocalTestPath, page, forceFlushReplay }) => {
+sentryTest('should capture very large console logs', async ({ getLocalTestUrl, page, forceFlushReplay }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -69,7 +69,7 @@ sentryTest('should capture very large console logs', async ({ getLocalTestPath, 
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await Promise.all([page.goto(url), reqPromise0]);
 

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { SDK_VERSION } from '@sentry/browser';
 
-import { sentryTest } from '../../../utils/fixtures';
+import { TEST_HOST, sentryTest } from '../../../utils/fixtures';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -20,7 +20,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const replayEvent0 = getReplayEvent(await reqPromise0);
@@ -34,7 +34,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
     timestamp: expect.any(Number),
     error_ids: [],
     trace_ids: [],
-    urls: [expect.stringContaining('/dist/index.html')],
+    urls: [`${TEST_HOST}/index.html`],
     replay_id: expect.stringMatching(/\w{32}/),
     replay_start_timestamp: expect.any(Number),
     segment_id: 0,
@@ -57,7 +57,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringContaining('/dist/index.html'),
+      url: `${TEST_HOST}/index.html`,
       headers: {
         'User-Agent': expect.stringContaining(''),
       },
@@ -94,7 +94,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringContaining('/dist/index.html'),
+      url: `${TEST_HOST}/index.html`,
       headers: {
         'User-Agent': expect.stringContaining(''),
       },

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { SDK_VERSION } from '@sentry/browser';
 
-import { sentryTest } from '../../../utils/fixtures';
+import { TEST_HOST, sentryTest } from '../../../utils/fixtures';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('should capture replays (@sentry-internal/replay export)', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture replays (@sentry-internal/replay export)', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -20,7 +20,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const replayEvent0 = getReplayEvent(await reqPromise0);
@@ -34,7 +34,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
     timestamp: expect.any(Number),
     error_ids: [],
     trace_ids: [],
-    urls: [expect.stringContaining('/dist/index.html')],
+    urls: [`${TEST_HOST}/index.html`],
     replay_id: expect.stringMatching(/\w{32}/),
     replay_start_timestamp: expect.any(Number),
     segment_id: 0,
@@ -57,7 +57,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringContaining('/dist/index.html'),
+      url: `${TEST_HOST}/index.html`,
       headers: {
         'User-Agent': expect.stringContaining(''),
       },
@@ -94,7 +94,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringContaining('/dist/index.html'),
+      url: `${TEST_HOST}/index.html`,
       headers: {
         'User-Agent': expect.stringContaining(''),
       },

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayOffline/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayOffline/test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('should capture replays offline', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture replays offline', async ({ getLocalTestUrl, page }) => {
   // makeBrowserOfflineTransport is not included in any CDN bundles
   if (shouldSkipReplayTest() || (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle'))) {
     sentryTest.skip();
@@ -20,7 +20,7 @@ sentryTest('should capture replays offline', async ({ getLocalTestPath, page }) 
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   // This would be the obvious way to test offline support but it doesn't appear to work!
   // await context.setOffline(true);

--- a/dev-packages/browser-integration-tests/suites/replay/compressionDisabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionDisabled/test.ts
@@ -12,7 +12,7 @@ import {
 
 sentryTest(
   'replay recording should allow to disable compression',
-  async ({ getLocalTestPath, page, forceFlushReplay }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay }) => {
     if (shouldSkipReplayTest()) {
       sentryTest.skip();
     }
@@ -27,7 +27,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/compressionEnabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionEnabled/test.ts
@@ -10,7 +10,7 @@ import {
   waitForReplayRequest,
 } from '../../../utils/replayHelpers';
 
-sentryTest('replay recording should be compressed by default', async ({ getLocalTestPath, page, forceFlushReplay }) => {
+sentryTest('replay recording should be compressed by default', async ({ getLocalTestUrl, page, forceFlushReplay }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -25,7 +25,7 @@ sentryTest('replay recording should be compressed by default', async ({ getLocal
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/customEvents/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/customEvents/test.ts
@@ -23,7 +23,7 @@ import {
 
 sentryTest(
   'replay recording should contain default performance spans',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // We only test this against the NPM package and replay bundles
     // and only on chromium as most performance entries are only available in chromium
     if (shouldSkipReplayTest() || browserName !== 'chromium') {
@@ -41,7 +41,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     const replayEvent0 = getReplayEvent(await reqPromise0);
@@ -84,7 +84,7 @@ sentryTest(
 
 sentryTest(
   'replay recording should contain a click breadcrumb when a button is clicked',
-  async ({ forceFlushReplay, getLocalTestPath, page, browserName }) => {
+  async ({ forceFlushReplay, getLocalTestUrl, page, browserName }) => {
     // TODO(replay): This is flakey on webkit where clicks are flakey
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -103,7 +103,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await reqPromise0;
@@ -189,7 +189,7 @@ sentryTest(
 
 sentryTest(
   'replay recording should contain an "options" breadcrumb for Replay SDK configuration',
-  async ({ forceFlushReplay, getLocalTestPath, page, browserName }) => {
+  async ({ forceFlushReplay, getLocalTestUrl, page, browserName }) => {
     // TODO(replay): This is flakey on webkit where clicks are flakey
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -206,7 +206,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -13,13 +13,13 @@ type TestWindow = Window & {
 
 sentryTest(
   'should add replay_id to dsc of transactions when in session mode',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // This is flaky on webkit, so skipping there...
     if (shouldSkipReplayTest() || shouldSkipTracingTest() || browserName === 'webkit') {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     const transactionReq = waitForTransactionRequest(page);
@@ -63,13 +63,13 @@ sentryTest(
 
 sentryTest(
   'should not add replay_id to dsc of transactions when in buffer mode',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // This is flaky on webkit, so skipping there...
     if (shouldSkipReplayTest() || shouldSkipTracingTest() || browserName === 'webkit') {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     const transactionReq = waitForTransactionRequest(page);
@@ -109,7 +109,7 @@ sentryTest(
 
 sentryTest(
   'should add replay_id to dsc of transactions when switching from buffer to session mode',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // This is flaky on webkit, so skipping there...
     if (shouldSkipReplayTest() || shouldSkipTracingTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -123,7 +123,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     const transactionReq = waitForTransactionRequest(page);
@@ -170,7 +170,7 @@ sentryTest(
 
 sentryTest(
   'should not add replay_id to dsc of transactions if replay is not enabled',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // This is flaky on webkit, so skipping there...
     if (shouldSkipReplayTest() || shouldSkipTracingTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -184,7 +184,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     const transactionReq = waitForTransactionRequest(page);

--- a/dev-packages/browser-integration-tests/suites/replay/errorResponse/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errorResponse/test.ts
@@ -8,7 +8,7 @@ import {
   waitForReplayRequest,
 } from '../../../utils/replayHelpers';
 
-sentryTest('should stop recording after receiving an error response', async ({ getLocalTestPath, page }) => {
+sentryTest('should stop recording after receiving an error response', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -22,7 +22,7 @@ sentryTest('should stop recording after receiving an error response', async ({ g
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await Promise.all([page.goto(url), waitForReplayRequest(page)]);
 
   await page.locator('button').click();

--- a/dev-packages/browser-integration-tests/suites/replay/errors/beforeErrorSampling/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/beforeErrorSampling/test.ts
@@ -5,7 +5,7 @@ import { getReplaySnapshot, shouldSkipReplayTest, waitForReplayRunning } from '.
 
 sentryTest(
   '[error-mode] should not flush if error event is ignored in beforeErrorSampling',
-  async ({ getLocalTestPath, page, browserName, forceFlushReplay }) => {
+  async ({ getLocalTestUrl, page, browserName, forceFlushReplay }) => {
     // Skipping this in webkit because it is flakey there
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -19,7 +19,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await waitForReplayRunning(page);

--- a/dev-packages/browser-integration-tests/suites/replay/errors/droppedError/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/droppedError/test.ts
@@ -6,7 +6,7 @@ import { getReplaySnapshot, isReplayEvent, shouldSkipReplayTest } from '../../..
 
 sentryTest(
   '[error-mode] should not start recording if an error occurred when the error was dropped',
-  async ({ getLocalTestPath, page, forceFlushReplay }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay }) => {
     if (shouldSkipReplayTest()) {
       sentryTest.skip();
     }
@@ -28,7 +28,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
@@ -17,7 +17,7 @@ import {
 
 sentryTest(
   '[error-mode] should start recording and switch to session mode once an error is thrown',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // This was sometimes flaky on webkit, so skipping for now
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -48,7 +48,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await Promise.all([
       page.goto(url),
@@ -93,7 +93,7 @@ sentryTest(
     expect(content0.fullSnapshots).toHaveLength(1);
     // We don't know how many incremental snapshots we'll have (also browser-dependent),
     // but we know that we have at least 5
-    expect(content0.incrementalSnapshots.length).toBeGreaterThan(5);
+    expect(content0.incrementalSnapshots.length).toBeGreaterThan(4);
     // We want to make sure that the event that triggered the error was recorded.
     expect(content0.breadcrumbs).toEqual(
       expect.arrayContaining([

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorNotSent/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorNotSent/test.ts
@@ -5,7 +5,7 @@ import { getReplaySnapshot, shouldSkipReplayTest } from '../../../../utils/repla
 
 sentryTest(
   '[error-mode] should handle errors that result in API error response',
-  async ({ getLocalTestPath, page, forceFlushReplay }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay }) => {
     if (shouldSkipReplayTest()) {
       sentryTest.skip();
     }
@@ -21,7 +21,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
@@ -12,7 +12,7 @@ import {
 
 sentryTest(
   '[session-mode] replay event should contain an error id of an error that occurred during session recording',
-  async ({ getLocalTestPath, page, browserName, forceFlushReplay }) => {
+  async ({ getLocalTestUrl, page, browserName, forceFlushReplay }) => {
     // Skipping this in webkit because it is flakey there
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -37,7 +37,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     const req0 = await reqPromise0;
@@ -85,7 +85,7 @@ sentryTest(
 
 sentryTest(
   '[session-mode] replay event should not contain an error id of a dropped error while recording',
-  async ({ getLocalTestPath, page, forceFlushReplay, browserName }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay, browserName }) => {
     // Skipping this in webkit because it is flakey there
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -102,7 +102,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await reqPromise0;

--- a/dev-packages/browser-integration-tests/suites/replay/eventBufferError/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/eventBufferError/test.ts
@@ -14,7 +14,7 @@ import {
 
 sentryTest(
   'should stop recording when running into eventBuffer error',
-  async ({ getLocalTestPath, page, forceFlushReplay }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay }) => {
     if (shouldSkipReplayTest()) {
       sentryTest.skip();
     }
@@ -25,7 +25,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     await waitForReplayRequest(page);

--- a/dev-packages/browser-integration-tests/suites/replay/exceptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/exceptions/test.ts
@@ -3,12 +3,12 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { shouldSkipReplayTest } from '../../../utils/replayHelpers';
 
-sentryTest('exceptions within rrweb and re-thrown and annotated', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('exceptions within rrweb and re-thrown and annotated', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures text request body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -34,7 +34,7 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -88,7 +88,7 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
   ]);
 });
 
-sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures JSON request body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -114,7 +114,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -168,7 +168,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
   ]);
 });
 
-sentryTest('captures non-text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures non-text request body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -194,7 +194,7 @@ sentryTest('captures non-text request body', async ({ getLocalTestPath, page, br
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -332,7 +332,7 @@ sentryTest('captures text request body when matching relative URL', async ({ get
   ]);
 });
 
-sentryTest('does not capture request body when URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest('does not capture request body when URL does not match', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -356,7 +356,7 @@ sentryTest('does not capture request body when URL does not match', async ({ get
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('handles empty/missing request headers', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -32,7 +32,7 @@ sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, p
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
@@ -81,7 +81,7 @@ sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, p
   ]);
 });
 
-sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers as POJO', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -107,7 +107,7 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, 
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
@@ -170,7 +170,7 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, 
   ]);
 });
 
-sentryTest('captures request headers on Request', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers on Request', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -194,7 +194,7 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
@@ -256,7 +256,7 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
   ]);
 });
 
-sentryTest('captures request headers as Headers instance', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers as Headers instance', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -280,7 +280,7 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 
@@ -343,7 +343,7 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
   ]);
 });
 
-sentryTest('does not captures request headers if URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest('does not captures request headers if URL does not match', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -367,7 +367,7 @@ sentryTest('does not captures request headers if URL does not match', async ({ g
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures request body size when body is sent', async ({ getLocalTestPath, page }) => {
+sentryTest('captures request body size when body is sent', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -32,7 +32,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
@@ -95,7 +95,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
   ]);
 });
 
-sentryTest('captures request size from non-text request body', async ({ getLocalTestPath, page }) => {
+sentryTest('captures request size from non-text request body', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -119,7 +119,7 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures text response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures text response body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -35,7 +35,7 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -90,7 +90,7 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
   ]);
 });
 
-sentryTest('captures JSON response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures JSON response body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -117,7 +117,7 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -172,7 +172,7 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
   ]);
 });
 
-sentryTest('captures non-text response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures non-text response body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -199,7 +199,7 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -256,7 +256,7 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
 
 // This test is flaky
 // See: https://github.com/getsentry/sentry-javascript/issues/11136
-sentryTest.skip('does not capture response body when URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest.skip('does not capture response body when URL does not match', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -281,7 +281,7 @@ sentryTest.skip('does not capture response body when URL does not match', async 
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('handles empty headers', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -34,7 +34,7 @@ sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
@@ -79,7 +79,7 @@ sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName
   ]);
 });
 
-sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response headers', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -110,7 +110,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
@@ -161,7 +161,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
   ]);
 });
 
-sentryTest('does not capture response headers if URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest('does not capture response headers if URL does not match', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -192,7 +192,7 @@ sentryTest('does not capture response headers if URL does not match', async ({ g
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures response size from Content-Length header if available', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response size from Content-Length header if available', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -40,7 +40,7 @@ sentryTest('captures response size from Content-Length header if available', asy
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
@@ -100,7 +100,7 @@ sentryTest('captures response size from Content-Length header if available', asy
   ]);
 });
 
-sentryTest('captures response size without Content-Length header', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response size without Content-Length header', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -132,7 +132,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
@@ -192,7 +192,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
   ]);
 });
 
-sentryTest('captures response size from non-text response body', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response size from non-text response body', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -221,7 +221,7 @@ sentryTest('captures response size from non-text response body', async ({ getLoc
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures correct timestamps', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -34,7 +34,7 @@ sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures text request body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -33,7 +33,7 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
@@ -90,7 +90,7 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
   ]);
 });
 
-sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures JSON request body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -115,7 +115,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
@@ -172,7 +172,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
   ]);
 });
 
-sentryTest('captures non-text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures non-text request body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -197,7 +197,7 @@ sentryTest('captures non-text request body', async ({ getLocalTestPath, page, br
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -340,7 +340,7 @@ sentryTest('captures text request body when matching relative URL', async ({ get
   ]);
 });
 
-sentryTest('does not capture request body when URL does not match', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('does not capture request body when URL does not match', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -365,7 +365,7 @@ sentryTest('does not capture request body when URL does not match', async ({ get
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures request headers', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -33,7 +33,7 @@ sentryTest('captures request headers', async ({ getLocalTestPath, page, browserN
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
@@ -95,98 +95,95 @@ sentryTest('captures request headers', async ({ getLocalTestPath, page, browserN
   ]);
 });
 
-sentryTest(
-  'does not capture request headers if URL does not match',
-  async ({ getLocalTestPath, page, browserName }) => {
-    // These are a bit flaky on non-chromium browsers
-    if (shouldSkipReplayTest() || browserName !== 'chromium') {
-      sentryTest.skip();
-    }
+sentryTest('does not capture request headers if URL does not match', async ({ getLocalTestUrl, page, browserName }) => {
+  // These are a bit flaky on non-chromium browsers
+  if (shouldSkipReplayTest() || browserName !== 'chromium') {
+    sentryTest.skip();
+  }
 
-    await page.route('**/bar', route => {
-      return route.fulfill({
-        status: 200,
-      });
+  await page.route('**/bar', route => {
+    return route.fulfill({
+      status: 200,
     });
+  });
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
     });
+  });
 
-    const requestPromise = waitForErrorRequest(page);
-    const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
-      return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
+  const requestPromise = waitForErrorRequest(page);
+  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
+    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  void page.evaluate(() => {
+    /* eslint-disable */
+    const xhr = new XMLHttpRequest();
+
+    xhr.open('POST', 'http://localhost:7654/bar');
+    xhr.setRequestHeader('Accept', 'application/json');
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.setRequestHeader('Cache', 'no-cache');
+    xhr.setRequestHeader('X-Test-Header', 'test-value');
+    xhr.send();
+
+    xhr.addEventListener('readystatechange', function () {
+      if (xhr.readyState === 4) {
+        // @ts-expect-error Sentry is a global
+        setTimeout(() => Sentry.captureException('test error', 0));
+      }
     });
+    /* eslint-enable */
+  });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
-    await page.goto(url);
+  const [request] = await Promise.all([requestPromise]);
 
-    void page.evaluate(() => {
-      /* eslint-disable */
-      const xhr = new XMLHttpRequest();
+  const eventData = envelopeRequestParser(request);
 
-      xhr.open('POST', 'http://localhost:7654/bar');
-      xhr.setRequestHeader('Accept', 'application/json');
-      xhr.setRequestHeader('Content-Type', 'application/json');
-      xhr.setRequestHeader('Cache', 'no-cache');
-      xhr.setRequestHeader('X-Test-Header', 'test-value');
-      xhr.send();
+  expect(eventData.exception?.values).toHaveLength(1);
 
-      xhr.addEventListener('readystatechange', function () {
-        if (xhr.readyState === 4) {
-          // @ts-expect-error Sentry is a global
-          setTimeout(() => Sentry.captureException('test error', 0));
-        }
-      });
-      /* eslint-enable */
-    });
+  expect(eventData?.breadcrumbs?.length).toBe(1);
+  expect(eventData!.breadcrumbs![0]).toEqual({
+    timestamp: expect.any(Number),
+    category: 'xhr',
+    type: 'http',
+    data: {
+      method: 'POST',
+      status_code: 200,
+      url: 'http://localhost:7654/bar',
+    },
+  });
 
-    const [request] = await Promise.all([requestPromise]);
-
-    const eventData = envelopeRequestParser(request);
-
-    expect(eventData.exception?.values).toHaveLength(1);
-
-    expect(eventData?.breadcrumbs?.length).toBe(1);
-    expect(eventData!.breadcrumbs![0]).toEqual({
-      timestamp: expect.any(Number),
-      category: 'xhr',
-      type: 'http',
+  const { replayRecordingSnapshots } = await replayRequestPromise;
+  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.xhr')).toEqual([
+    {
       data: {
         method: 'POST',
-        status_code: 200,
-        url: 'http://localhost:7654/bar',
-      },
-    });
-
-    const { replayRecordingSnapshots } = await replayRequestPromise;
-    expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.xhr')).toEqual([
-      {
-        data: {
-          method: 'POST',
-          statusCode: 200,
-          request: {
-            headers: {},
-            _meta: {
-              warnings: ['URL_SKIPPED'],
-            },
-          },
-          response: {
-            headers: {},
-            _meta: {
-              warnings: ['URL_SKIPPED'],
-            },
+        statusCode: 200,
+        request: {
+          headers: {},
+          _meta: {
+            warnings: ['URL_SKIPPED'],
           },
         },
-        description: 'http://localhost:7654/bar',
-        endTimestamp: expect.any(Number),
-        op: 'resource.xhr',
-        startTimestamp: expect.any(Number),
+        response: {
+          headers: {},
+          _meta: {
+            warnings: ['URL_SKIPPED'],
+          },
+        },
       },
-    ]);
-  },
-);
+      description: 'http://localhost:7654/bar',
+      endTimestamp: expect.any(Number),
+      op: 'resource.xhr',
+      startTimestamp: expect.any(Number),
+    },
+  ]);
+});

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestSize/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures request body size when body is sent', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request body size when body is sent', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -33,7 +33,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
@@ -100,7 +100,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
   ]);
 });
 
-sentryTest('captures request size from non-text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request size from non-text request body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -125,7 +125,7 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures response headers', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures response headers', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -40,7 +40,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page, browser
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -100,7 +100,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page, browser
 
 sentryTest(
   'does not capture response headers if URL does not match',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // These are a bit flaky on non-chromium browsers
     if (shouldSkipReplayTest() || browserName !== 'chromium') {
       sentryTest.skip();
@@ -132,7 +132,7 @@ sentryTest(
       return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     await page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseSize/test.ts
@@ -10,7 +10,7 @@ import {
 
 sentryTest(
   'captures response size from Content-Length header if available',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // These are a bit flaky on non-chromium browsers
     if (shouldSkipReplayTest() || browserName !== 'chromium') {
       sentryTest.skip();
@@ -38,7 +38,7 @@ sentryTest(
       return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     await page.evaluate(() => {
@@ -104,7 +104,7 @@ sentryTest(
   },
 );
 
-sentryTest('captures response size without Content-Length header', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures response size without Content-Length header', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -135,7 +135,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
@@ -200,7 +200,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
   ]);
 });
 
-sentryTest('captures response size for non-string bodies', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures response size for non-string bodies', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -229,7 +229,7 @@ sentryTest('captures response size for non-string bodies', async ({ getLocalTest
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/test.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures correct timestamps', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -34,7 +34,7 @@ sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/fileInput/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/fileInput/test.ts
@@ -18,7 +18,7 @@ function isInputMutation(
 
 sentryTest(
   'should not capture file input mutations',
-  async ({ forceFlushReplay, getLocalTestPath, page, browserName }) => {
+  async ({ forceFlushReplay, getLocalTestUrl, page, browserName }) => {
     // This seems to be flaky on webkit, so skipping there
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -34,7 +34,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/flushing/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/flushing/test.ts
@@ -12,7 +12,7 @@ import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../.
  * assert on the flush timestamps. Therefore we only assert that events were eventually
  * sent (i.e. flushed).
  */
-sentryTest('replay events are flushed after max flush delay was reached', async ({ getLocalTestPath, page }) => {
+sentryTest('replay events are flushed after max flush delay was reached', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -29,7 +29,7 @@ sentryTest('replay events are flushed after max flush delay was reached', async 
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const replayEvent0 = getReplayEvent(await reqPromise0);

--- a/dev-packages/browser-integration-tests/suites/replay/keyboardEvents/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/keyboardEvents/test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('captures keyboard events', async ({ forceFlushReplay, getLocalTestPath, page }) => {
+sentryTest('captures keyboard events', async ({ forceFlushReplay, getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -18,7 +18,7 @@ sentryTest('captures keyboard events', async ({ forceFlushReplay, getLocalTestPa
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   await reqPromise0;

--- a/dev-packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
@@ -5,7 +5,7 @@ import { getReplayRecordingContent, shouldSkipReplayTest, waitForReplayRequest }
 
 sentryTest(
   'handles large mutations with default options',
-  async ({ getLocalTestPath, page, forceFlushReplay, browserName }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay, browserName }) => {
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
     }
@@ -18,7 +18,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     // We have to click in order to ensure the LCP is generated, leading to consistent results
     async function gotoPageAndClick() {

--- a/dev-packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/test.ts
@@ -10,7 +10,7 @@ import {
 
 sentryTest(
   'handles large mutations by stopping replay when `mutationLimit` configured',
-  async ({ getLocalTestPath, page, forceFlushReplay, browserName }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay, browserName }) => {
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
     }
@@ -23,7 +23,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     // We have to click in order to ensure the LCP is generated, leading to consistent results
     async function gotoPageAndClick() {

--- a/dev-packages/browser-integration-tests/suites/replay/maxReplayDuration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/maxReplayDuration/test.ts
@@ -6,7 +6,7 @@ import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../.
 
 const MAX_REPLAY_DURATION = 2000;
 
-sentryTest('keeps track of max duration across reloads', async ({ getLocalTestPath, page }) => {
+sentryTest('keeps track of max duration across reloads', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -22,7 +22,7 @@ sentryTest('keeps track of max duration across reloads', async ({ getLocalTestPa
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/minReplayDuration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/minReplayDuration/test.ts
@@ -6,7 +6,7 @@ import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../.
 
 const MIN_DURATION = 2000;
 
-sentryTest('doest not send replay before min. duration', async ({ getLocalTestPath, page }) => {
+sentryTest('doest not send replay before min. duration', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -25,7 +25,7 @@ sentryTest('doest not send replay before min. duration', async ({ getLocalTestPa
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -80,7 +80,7 @@ sentryTest(
     const collectedPerformanceSpans = [...recording0.performanceSpans, ...recording1.performanceSpans];
     const collectedBreadcrumbs = [...recording0.breadcrumbs, ...recording1.breadcrumbs];
 
-    expect(collectedPerformanceSpans.length).toEqual(8);
+    expect(collectedPerformanceSpans.length).toBeGreaterThanOrEqual(6);
     expect(collectedPerformanceSpans).toEqual(
       expect.arrayContaining([
         expectedNavigationPerformanceSpan,
@@ -120,7 +120,7 @@ sentryTest(
     const collectedPerformanceSpansAfterReload = [...recording2.performanceSpans, ...recording3.performanceSpans];
     const collectedBreadcrumbsAdterReload = [...recording2.breadcrumbs, ...recording3.breadcrumbs];
 
-    expect(collectedPerformanceSpansAfterReload.length).toEqual(8);
+    expect(collectedPerformanceSpansAfterReload.length).toBeGreaterThanOrEqual(6);
     expect(collectedPerformanceSpansAfterReload).toEqual(
       expect.arrayContaining([
         expectedReloadPerformanceSpan,
@@ -312,7 +312,7 @@ sentryTest(
     ];
     const collectedBreadcrumbsAfterIndexNavigation = [...recording8.breadcrumbs, ...recording9.breadcrumbs];
 
-    expect(collectedPerformanceSpansAfterIndexNavigation.length).toEqual(8);
+    expect(collectedPerformanceSpansAfterIndexNavigation.length).toBeGreaterThanOrEqual(6);
     expect(collectedPerformanceSpansAfterIndexNavigation).toEqual(
       expect.arrayContaining([
         expectedNavigationPerformanceSpan,

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -30,7 +30,7 @@ well as the correct DOM snapshots and updates are recorded and sent.
 */
 sentryTest(
   'record page navigations and performance entries across multiple pages',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // We only test this against the NPM package and replay bundles
     // and only on chromium as most performance entries are only available in chromium
     if (shouldSkipReplayTest() || browserName !== 'chromium') {
@@ -56,7 +56,7 @@ sentryTest(
     const reqPromise8 = waitForReplayRequest(page, 8);
     const reqPromise9 = waitForReplayRequest(page, 9);
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const [req0] = await Promise.all([reqPromise0, page.goto(url)]);
     const replayEvent0 = getReplayEvent(req0);

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -155,6 +155,7 @@ sentryTest(
           headers: {
             // @ts-expect-error this is fine
             'User-Agent': expect.stringContaining(''),
+            Referer: 'http://sentry-test.io/index.html',
           },
         },
       }),

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full-chromium
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full-chromium
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full-chromium
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full-chromium
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full-chromium
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full-chromium
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/privacyBlock/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyBlock/test.ts
@@ -8,7 +8,7 @@ import {
   waitForReplayRequest,
 } from '../../../utils/replayHelpers';
 
-sentryTest('should allow to manually block elements', async ({ getLocalTestPath, page }) => {
+sentryTest('should allow to manually block elements', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -23,7 +23,7 @@ sentryTest('should allow to manually block elements', async ({ getLocalTestPath,
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const snapshots = getFullRecordingSnapshots(await reqPromise0);

--- a/dev-packages/browser-integration-tests/suites/replay/privacyDefault/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyDefault/test.ts
@@ -8,7 +8,7 @@ import {
   waitForReplayRequest,
 } from '../../../utils/replayHelpers';
 
-sentryTest('should have the correct default privacy settings', async ({ getLocalTestPath, page }) => {
+sentryTest('should have the correct default privacy settings', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -23,7 +23,7 @@ sentryTest('should have the correct default privacy settings', async ({ getLocal
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/privacyInput/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyInput/test.ts
@@ -19,7 +19,7 @@ function isInputMutation(
 
 sentryTest(
   'should mask input initial value and its changes',
-  async ({ browserName, forceFlushReplay, getLocalTestPath, page }) => {
+  async ({ browserName, forceFlushReplay, getLocalTestUrl, page }) => {
     // TODO(replay): This is flakey on webkit (~1%) where we do not always get the latest mutation.
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -62,7 +62,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 
@@ -92,7 +92,7 @@ sentryTest(
 
 sentryTest(
   'should mask textarea initial value and its changes',
-  async ({ browserName, forceFlushReplay, getLocalTestPath, page }) => {
+  async ({ browserName, forceFlushReplay, getLocalTestUrl, page }) => {
     // TODO(replay): This is flakey on webkit (~1%) where we do not always get the latest mutation.
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -147,7 +147,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     const fullSnapshot = getFullRecordingSnapshots(await reqPromise0);

--- a/dev-packages/browser-integration-tests/suites/replay/privacyInputMaskAll/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyInputMaskAll/test.ts
@@ -19,7 +19,7 @@ function isInputMutation(
 
 sentryTest(
   'should mask input initial value and its changes from `maskAllInputs` and allow unmasked selector',
-  async ({ browserName, forceFlushReplay, getLocalTestPath, page }) => {
+  async ({ browserName, forceFlushReplay, getLocalTestUrl, page }) => {
     // TODO(replay): This is flakey on webkit (~1%) where we do not always get the latest mutation.
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -54,7 +54,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 
@@ -83,7 +83,7 @@ sentryTest(
 
 sentryTest(
   'should mask textarea initial value and its changes from `maskAllInputs` and allow unmasked selector',
-  async ({ browserName, forceFlushReplay, getLocalTestPath, page }) => {
+  async ({ browserName, forceFlushReplay, getLocalTestUrl, page }) => {
     // TODO(replay): This is flakey on webkit (~1%) where we do not always get the latest mutation.
     if (shouldSkipReplayTest() || browserName === 'webkit') {
       sentryTest.skip();
@@ -118,7 +118,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/replayIntegrationShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/replayIntegrationShim/test.ts
@@ -4,7 +4,7 @@ import { sentryTest } from '../../../utils/fixtures';
 
 sentryTest(
   'exports a shim replayIntegration integration for non-replay bundles',
-  async ({ getLocalTestPath, page, forceFlushReplay }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay }) => {
     const bundle = process.env.PW_BUNDLE;
 
     if (!bundle || !bundle.startsWith('bundle_') || bundle.includes('replay')) {
@@ -24,7 +24,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/replayShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/replayShim/test.ts
@@ -4,7 +4,7 @@ import { sentryTest } from '../../../utils/fixtures';
 
 sentryTest(
   'exports a shim Replay integration for non-replay bundles',
-  async ({ getLocalTestPath, page, forceFlushReplay }) => {
+  async ({ getLocalTestUrl, page, forceFlushReplay }) => {
     const bundle = process.env.PW_BUNDLE;
 
     if (!bundle || !bundle.startsWith('bundle_') || bundle.includes('replay')) {
@@ -24,7 +24,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/requests/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/requests/test.ts
@@ -4,7 +4,7 @@ import { sentryTest } from '../../../utils/fixtures';
 import { expectedFetchPerformanceSpan, expectedXHRPerformanceSpan } from '../../../utils/replayEventTemplates';
 import { getReplayRecordingContent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('replay recording should contain fetch request span', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('replay recording should contain fetch request span', async ({ getLocalTestUrl, page, browserName }) => {
   // Possibly related: https://github.com/microsoft/playwright/issues/11390
   if (shouldSkipReplayTest() || browserName === 'webkit') {
     sentryTest.skip();
@@ -29,7 +29,7 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const [req0] = await Promise.all([reqPromise0, page.goto(url), page.locator('#go-background').click()]);
 
@@ -43,7 +43,7 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
   expect(performanceSpans).toContainEqual(expectedFetchPerformanceSpan);
 });
 
-sentryTest('replay recording should contain XHR request span', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('replay recording should contain XHR request span', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest() || browserName === 'webkit') {
     sentryTest.skip();
   }
@@ -67,7 +67,7 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const [req0] = await Promise.all([reqPromise0, page.goto(url), page.locator('#go-background').click()]);
 

--- a/dev-packages/browser-integration-tests/suites/replay/sampling/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/sampling/test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { getReplaySnapshot, shouldSkipReplayTest } from '../../../utils/replayHelpers';
 
-sentryTest('should not send replays if both sample rates are 0', async ({ getLocalTestPath, page }) => {
+sentryTest('should not send replays if both sample rates are 0', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -19,7 +19,7 @@ sentryTest('should not send replays if both sample rates are 0', async ({ getLoc
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.locator('button').click();

--- a/dev-packages/browser-integration-tests/suites/replay/sessionExpiry/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionExpiry/test.ts
@@ -14,7 +14,7 @@ import {
 // Session should expire after 2s - keep in sync with init.js
 const SESSION_TIMEOUT = 2000;
 
-sentryTest('handles an expired session', async ({ browserName, forceFlushReplay, getLocalTestPath, page }) => {
+sentryTest('handles an expired session', async ({ browserName, forceFlushReplay, getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest() || browserName === 'webkit') {
     sentryTest.skip();
   }
@@ -30,7 +30,7 @@ sentryTest('handles an expired session', async ({ browserName, forceFlushReplay,
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const req0 = await reqPromise0;

--- a/dev-packages/browser-integration-tests/suites/replay/sessionInactive/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionInactive/test.ts
@@ -14,7 +14,7 @@ import {
 // Session should be paused after 2s - keep in sync with init.js
 const SESSION_PAUSED = 2000;
 
-sentryTest('handles an inactive session', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('handles an inactive session', async ({ getLocalTestUrl, page, browserName }) => {
   // webkit is a bit flakey here, the ids are sometimes off by <number of total
   // nodes>, so seems like there is a race condition with checkout?
   if (shouldSkipReplayTest() || browserName === 'webkit') {
@@ -31,7 +31,7 @@ sentryTest('handles an inactive session', async ({ getLocalTestPath, page, brows
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const req0 = await reqPromise0;

--- a/dev-packages/browser-integration-tests/suites/replay/sessionMaxAge/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionMaxAge/test.ts
@@ -18,7 +18,7 @@ const MAX_REPLAY_DURATION = 4000;
   The main difference between this and sessionExpiry test, is that here we wait for the overall time (4s)
   in multiple steps (2s, 2s) instead of waiting for the whole time at once (4s).
 */
-sentryTest('handles session that exceeds max age', async ({ forceFlushReplay, getLocalTestPath, page }) => {
+sentryTest('handles session that exceeds max age', async ({ forceFlushReplay, getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -34,7 +34,7 @@ sentryTest('handles session that exceeds max age', async ({ forceFlushReplay, ge
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/unicode/compressed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/unicode/compressed/test.ts
@@ -8,7 +8,7 @@ import {
   waitForReplayRequest,
 } from '../../../../utils/replayHelpers';
 
-sentryTest('replay should handle unicode characters', async ({ getLocalTestPath, page }) => {
+sentryTest('replay should handle unicode characters', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -23,7 +23,7 @@ sentryTest('replay should handle unicode characters', async ({ getLocalTestPath,
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const snapshots = getFullRecordingSnapshots(await reqPromise0);

--- a/dev-packages/browser-integration-tests/suites/replay/unicode/uncompressed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/unicode/uncompressed/test.ts
@@ -8,7 +8,7 @@ import {
   waitForReplayRequest,
 } from '../../../../utils/replayHelpers';
 
-sentryTest('replay should handle unicode characters', async ({ getLocalTestPath, page }) => {
+sentryTest('replay should handle unicode characters', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -23,7 +23,7 @@ sentryTest('replay should handle unicode characters', async ({ getLocalTestPath,
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const snapshots = getFullRecordingSnapshots(await reqPromise0);

--- a/dev-packages/browser-integration-tests/suites/sessions/initial-scope/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/initial-scope/test.ts
@@ -5,8 +5,8 @@ import type { SessionContext } from '@sentry/types';
 import { sentryTest } from '../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
-sentryTest('should start a new session on pageload.', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should start a new session on pageload.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const session = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
 
   expect(session).toBeDefined();
@@ -16,13 +16,8 @@ sentryTest('should start a new session on pageload.', async ({ getLocalTestPath,
   expect(session.did).toBe('1337');
 });
 
-sentryTest('should start a new session with navigation.', async ({ getLocalTestPath, page, browserName }) => {
-  // Navigations get CORS error on Firefox and WebKit as we're using `file://` protocol.
-  if (browserName !== 'chromium') {
-    sentryTest.skip();
-  }
-
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should start a new session with navigation.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.route('**/foo', (route: Route) => route.fulfill({ path: `${__dirname}/dist/index.html` }));
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {

--- a/dev-packages/browser-integration-tests/suites/sessions/start-session/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/start-session/test.ts
@@ -5,8 +5,8 @@ import type { SessionContext } from '@sentry/types';
 import { sentryTest } from '../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
-sentryTest('should start a new session on pageload.', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should start a new session on pageload.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const session = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
 
   expect(session).toBeDefined();
@@ -15,13 +15,8 @@ sentryTest('should start a new session on pageload.', async ({ getLocalTestPath,
   expect(session.status).toBe('ok');
 });
 
-sentryTest('should start a new session with navigation.', async ({ getLocalTestPath, page, browserName }) => {
-  // Navigations get CORS error on Firefox and WebKit as we're using `file://` protocol.
-  if (browserName !== 'chromium') {
-    sentryTest.skip();
-  }
-
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should start a new session with navigation.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.route('**/foo', (route: Route) => route.fulfill({ path: `${__dirname}/dist/index.html` }));
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {

--- a/dev-packages/browser-integration-tests/suites/sessions/update-session/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/update-session/test.ts
@@ -4,8 +4,8 @@ import type { SessionContext } from '@sentry/types';
 import { sentryTest } from '../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
-sentryTest('should update session when an error is thrown.', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should update session when an error is thrown.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const pageloadSession = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
   const updatedSession = (
     await Promise.all([page.locator('#throw-error').click(), getFirstSentryEnvelopeRequest<SessionContext>(page)])
@@ -21,8 +21,8 @@ sentryTest('should update session when an error is thrown.', async ({ getLocalTe
   expect(pageloadSession.sid).toBe(updatedSession.sid);
 });
 
-sentryTest('should update session when an exception is captured.', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should update session when an exception is captured.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const pageloadSession = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
   const updatedSession = (

--- a/dev-packages/browser-integration-tests/suites/sessions/v7-hub-start-session/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/v7-hub-start-session/test.ts
@@ -5,8 +5,8 @@ import type { SessionContext } from '@sentry/types';
 import { sentryTest } from '../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
-sentryTest('should start a new session on pageload.', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should start a new session on pageload.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const session = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
 
   expect(session).toBeDefined();
@@ -15,13 +15,8 @@ sentryTest('should start a new session on pageload.', async ({ getLocalTestPath,
   expect(session.status).toBe('ok');
 });
 
-sentryTest('should start a new session with navigation.', async ({ getLocalTestPath, page, browserName }) => {
-  // Navigations get CORS error on Firefox and WebKit as we're using `file://` protocol.
-  if (browserName !== 'chromium') {
-    sentryTest.skip();
-  }
-
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should start a new session with navigation.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.route('**/foo', (route: Route) => route.fulfill({ path: `${__dirname}/dist/index.html` }));
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {

--- a/dev-packages/browser-integration-tests/suites/stacktraces/protocol_containing_fn_identifiers/test.ts
+++ b/dev-packages/browser-integration-tests/suites/stacktraces/protocol_containing_fn_identifiers/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
 sentryTest(
   'should parse function identifiers that contain protocol names correctly @firefox',
-  async ({ getLocalTestPath, page, runInChromium, runInFirefox, runInWebkit }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page, runInChromium, runInFirefox, runInWebkit }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const frames = eventData.exception?.values?.[0].stacktrace?.frames;
@@ -52,14 +52,14 @@ sentryTest(
 
 sentryTest(
   'should not add any part of the function identifier to beginning of filename',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     expect(eventData.exception?.values?.[0].stacktrace?.frames).toMatchObject(
       // specifically, we're trying to avoid values like `Blob@file://path/to/file` in frames with function names like `makeBlob`
-      Array(7).fill({ filename: expect.stringMatching(/^file:\/?/) }),
+      Array(7).fill({ filename: expect.stringMatching(/^http:\/?/) }),
     );
   },
 );

--- a/dev-packages/browser-integration-tests/suites/stacktraces/protocol_fn_identifiers/test.ts
+++ b/dev-packages/browser-integration-tests/suites/stacktraces/protocol_fn_identifiers/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
 sentryTest(
   'should parse function identifiers that are protocol names correctly @firefox',
-  async ({ getLocalTestPath, page, runInChromium, runInFirefox, runInWebkit }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page, runInChromium, runInFirefox, runInWebkit }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const frames = eventData.exception?.values?.[0].stacktrace?.frames;
@@ -56,8 +56,8 @@ sentryTest(
 
 sentryTest(
   'should not add any part of the function identifier to beginning of filename',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
@@ -65,7 +65,7 @@ sentryTest(
     expect(eventData.exception?.values).toBeDefined();
     expect(eventData.exception?.values?.[0].stacktrace).toBeDefined();
     expect(eventData.exception?.values?.[0].stacktrace?.frames).toMatchObject(
-      Array(7).fill({ filename: expect.stringMatching(/^file:\/?/) }),
+      Array(7).fill({ filename: expect.stringMatching(/^http:\/?/) }),
     );
   },
 );

--- a/dev-packages/browser-integration-tests/suites/stacktraces/regular_fn_identifiers/test.ts
+++ b/dev-packages/browser-integration-tests/suites/stacktraces/regular_fn_identifiers/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
 sentryTest(
   'should parse function identifiers correctly @firefox',
-  async ({ getLocalTestPath, page, runInChromium, runInFirefox, runInWebkit }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page, runInChromium, runInFirefox, runInWebkit }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const frames = eventData.exception?.values?.[0].stacktrace?.frames;
@@ -56,14 +56,14 @@ sentryTest(
 
 sentryTest(
   'should not add any part of the function identifier to beginning of filename',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     expect(eventData.exception?.values?.[0].stacktrace?.frames).toMatchObject(
       // specifically, we're trying to avoid values like `Blob@file://path/to/file` in frames with function names like `makeBlob`
-      Array(8).fill({ filename: expect.stringMatching(/^file:\/?/) }),
+      Array(8).fill({ filename: expect.stringMatching(/^http:\/?/) }),
     );
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
@@ -11,12 +11,12 @@ type WindowWithSpan = Window & {
 
 sentryTest(
   'async spans with different durations lead to unexpected behavior in browser (no "asynchronous context tracking")',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     const envelope = await getFirstSentryEnvelopeRequest<Event>(page);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/test.ts
@@ -4,12 +4,12 @@ import type { SpanJSON } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should finish a custom transaction when the page goes background', async ({ getLocalTestPath, page }) => {
+sentryTest('should finish a custom transaction when the page goes background', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.locator('#start-span').click();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-pageload/test.ts
@@ -4,11 +4,11 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should finish pageload transaction when the page goes background', async ({ getLocalTestPath, page }) => {
+sentryTest('should finish pageload transaction when the page goes background', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   await page.locator('#go-background').click();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/error/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/error/test.ts
@@ -9,7 +9,7 @@ import {
 
 sentryTest(
   'should put the pageload transaction name onto an error event caught during pageload',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     if (browserName === 'webkit') {
       // This test fails on Webkit as erros thrown from `runScriptInSandbox` are Script Errors and skipped by Sentry
       sentryTest.skip();
@@ -19,7 +19,7 @@ sentryTest(
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/test.ts
@@ -4,7 +4,7 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should create fetch spans with http timing @firefox', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should create fetch spans with http timing @firefox', async ({ browserName, getLocalTestUrl, page }) => {
   const supportedBrowsers = ['chromium', 'firefox'];
 
   if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
@@ -21,7 +21,7 @@ sentryTest('should create fetch spans with http timing @firefox', async ({ brows
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { url, timeout: 10000 });
   const tracingEvent = envelopes[envelopes.length - 1]; // last envelope contains tracing data on all browsers

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions/test.ts
@@ -8,13 +8,13 @@ import {
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
 
-sentryTest('should capture interaction transaction. @firefox', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should capture interaction transaction. @firefox', async ({ browserName, getLocalTestUrl, page }) => {
   const supportedBrowsers = ['chromium', 'firefox'];
 
   if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
     sentryTest.skip();
   }
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   await getFirstSentryEnvelopeRequest<SentryEvent>(page);
@@ -47,14 +47,14 @@ sentryTest('should capture interaction transaction. @firefox', async ({ browserN
 
 sentryTest(
   'should create only one transaction per interaction @firefox',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     const supportedBrowsers = ['chromium', 'firefox'];
 
     if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
     await getFirstSentryEnvelopeRequest<SentryEvent>(page);
 
@@ -70,14 +70,14 @@ sentryTest(
 
 sentryTest(
   'should use the component name for a clicked element when it is available',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     const supportedBrowsers = ['chromium', 'firefox'];
 
     if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await getFirstSentryEnvelopeRequest<SentryEvent>(page);
@@ -100,14 +100,14 @@ sentryTest(
 
 sentryTest(
   'should use the element name for a clicked element when no component name',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     const supportedBrowsers = ['chromium', 'firefox'];
 
     if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await getFirstSentryEnvelopeRequest<SentryEvent>(page);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled/test.ts
@@ -7,7 +7,7 @@ import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../.
 
 sentryTest(
   'should not capture long animation frame when flag is disabled.',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
     if (shouldSkipTracingTest() || browserName !== 'chromium') {
       sentryTest.skip();
@@ -17,7 +17,7 @@ sentryTest(
       route.fulfill({ path: `${__dirname}/assets/script.js` }),
     );
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui'));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/test.ts
@@ -8,7 +8,7 @@ import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../.
 
 sentryTest(
   'should capture long animation frame for top-level script.',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
     if (shouldSkipTracingTest() || browserName !== 'chromium') {
       sentryTest.skip();
@@ -18,7 +18,7 @@ sentryTest(
       route.fulfill({ path: `${__dirname}/assets/script.js` }),
     );
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const promise = getFirstSentryEnvelopeRequest<Event>(page);
 
@@ -59,7 +59,7 @@ sentryTest(
 
 sentryTest(
   'should capture long animation frame for event listener.',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
     if (shouldSkipTracingTest() || browserName !== 'chromium') {
       sentryTest.skip();
@@ -69,7 +69,7 @@ sentryTest(
       route.fulfill({ path: `${__dirname}/assets/script.js` }),
     );
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const promise = getFirstSentryEnvelopeRequest<Event>(page);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-non-chromium/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-non-chromium/test.ts
@@ -7,7 +7,7 @@ import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../.
 
 sentryTest(
   'should not capture long animation frame or long task when browser is non-chromium',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     // Only test non-chromium browsers
     if (shouldSkipTracingTest() || browserName === 'chromium') {
       sentryTest.skip();
@@ -17,7 +17,7 @@ sentryTest(
       route.fulfill({ path: `${__dirname}/assets/script.js` }),
     );
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui'));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/test.ts
@@ -8,7 +8,7 @@ import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../.
 
 sentryTest(
   'should capture long animation frame for top-level script.',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
     if (shouldSkipTracingTest() || browserName !== 'chromium') {
       sentryTest.skip();
@@ -20,7 +20,7 @@ sentryTest(
       route.fulfill({ path: `${__dirname}/assets/script.js` }),
     );
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const promise = getFirstSentryEnvelopeRequest<Event>(page);
 
@@ -61,7 +61,7 @@ sentryTest(
 
 sentryTest(
   'should capture long animation frame for event listener.',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
     if (shouldSkipTracingTest() || browserName !== 'chromium') {
       sentryTest.skip();
@@ -71,7 +71,7 @@ sentryTest(
       route.fulfill({ path: `${__dirname}/assets/script.js` }),
     );
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const promise = getFirstSentryEnvelopeRequest<Event>(page);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled/test.ts
@@ -5,7 +5,7 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should not capture long task when flag is disabled.', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should not capture long task when flag is disabled.', async ({ browserName, getLocalTestUrl, page }) => {
   // Long tasks only work on chrome
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -13,7 +13,7 @@ sentryTest('should not capture long task when flag is disabled.', async ({ brows
 
   await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui'));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/test.ts
@@ -5,7 +5,7 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should capture long task.', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should capture long task.', async ({ browserName, getLocalTestUrl, page }) => {
   // Long tasks only work on chrome
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -13,7 +13,7 @@ sentryTest('should capture long task.', async ({ browserName, getLocalTestPath, 
 
   await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui'));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/test.ts
@@ -5,7 +5,7 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should capture long task.', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should capture long task.', async ({ browserName, getLocalTestUrl, page }) => {
   // Long tasks only work on chrome
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -13,7 +13,7 @@ sentryTest('should capture long task.', async ({ browserName, getLocalTestPath, 
 
   await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui'));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/meta/test.ts
@@ -8,35 +8,32 @@ import {
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
 
-sentryTest(
-  'should create a pageload transaction based on `sentry-trace` <meta>',
-  async ({ getLocalTestPath, page }) => {
-    if (shouldSkipTracingTest()) {
-      sentryTest.skip();
-    }
+sentryTest('should create a pageload transaction based on `sentry-trace` <meta>', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
-    const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
-    expect(eventData.contexts?.trace).toMatchObject({
-      op: 'pageload',
-      parent_span_id: '1121201211212012',
-      trace_id: '12312012123120121231201212312012',
-    });
+  expect(eventData.contexts?.trace).toMatchObject({
+    op: 'pageload',
+    parent_span_id: '1121201211212012',
+    trace_id: '12312012123120121231201212312012',
+  });
 
-    expect(eventData.spans?.length).toBeGreaterThan(0);
-  },
-);
+  expect(eventData.spans?.length).toBeGreaterThan(0);
+});
 
 sentryTest(
   'should pick up `baggage` <meta> tag, propagate the content in transaction and not add own data',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
 
@@ -52,12 +49,12 @@ sentryTest(
 
 sentryTest(
   "should create a navigation that's not influenced by `sentry-trace` <meta>",
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const pageloadRequest = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const navigationRequest = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation/test.ts
@@ -4,12 +4,12 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should create a navigation transaction on page navigation', async ({ getLocalTestPath, page }) => {
+sentryTest('should create a navigation transaction on page navigation', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const pageloadRequest = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const navigationRequest = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload/test.ts
@@ -4,12 +4,12 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should create a pageload transaction', async ({ getLocalTestPath, page }) => {
+sentryTest('should create a pageload transaction', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const timeOrigin = await page.evaluate<number>('window._testBaseTimestamp');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadDelayed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadDelayed/test.ts
@@ -4,12 +4,12 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should create a pageload transaction when initialized delayed', async ({ getLocalTestPath, page }) => {
+sentryTest('should create a pageload transaction when initialized delayed', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const timeOrigin = await page.evaluate<number>('window._testBaseTimestamp');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/test.ts
@@ -5,12 +5,12 @@ import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 
 sentryTest(
   'should attach `sentry-trace` and `baggage` header to request matching tracePropagationTargets',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const requests = (
       await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsNoMatch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsNoMatch/test.ts
@@ -5,12 +5,12 @@ import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 
 sentryTest(
   'should not attach `sentry-trace` and `baggage` header to cross-origin requests when no tracePropagationTargets are defined',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const requests = (
       await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationShim/init.js
@@ -7,6 +7,3 @@ Sentry.init({
   sampleRate: 1,
   integrations: [Sentry.browserTracingIntegration()],
 });
-
-// This should not fail
-Sentry.addTracingExtensions();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationShim/test.ts
@@ -5,7 +5,7 @@ import { shouldSkipTracingTest } from '../../../utils/helpers';
 
 sentryTest(
   'exports a shim browserTracingIntegration() integration for non-tracing bundles',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     // Skip in tracing tests
     if (!shouldSkipTracingTest()) {
       sentryTest.skip();
@@ -24,7 +24,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/envelope-header-transaction-name/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/envelope-header-transaction-name/test.ts
@@ -10,12 +10,12 @@ import {
 
 sentryTest(
   'should only include transaction name if source is better than an unparameterized URL',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/envelope-header/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/envelope-header/test.ts
@@ -10,12 +10,12 @@ import {
 
 sentryTest(
   'should send dynamic sampling context data in trace envelope header of a transaction envelope',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt/test.ts
@@ -23,8 +23,8 @@ async function createSessionWithLatency(page: Page, latency: number) {
   return session;
 }
 
-sentryTest('should capture a `connection.rtt` metric.', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a `connection.rtt` metric.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.measurements).toBeDefined();
@@ -33,10 +33,10 @@ sentryTest('should capture a `connection.rtt` metric.', async ({ getLocalTestPat
 
 sentryTest(
   'should capture a `connection.rtt` metric with emulated value 200ms on Chromium.',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     const session = await createSessionWithLatency(page, 200);
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     await session.detach();
@@ -48,10 +48,10 @@ sentryTest(
 
 sentryTest(
   'should capture a `connection.rtt` metric with emulated value 100ms on Chromium.',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     const session = await createSessionWithLatency(page, 100);
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     await session.detach();
@@ -63,10 +63,10 @@ sentryTest(
 
 sentryTest(
   'should capture a `connection.rtt` metric with emulated value 50ms on Chromium.',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     const session = await createSessionWithLatency(page, 50);
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     await session.detach();

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/handlers-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/handlers-lcp/test.ts
@@ -9,17 +9,17 @@ const bundle = process.env.PW_BUNDLE || '';
 
 sentryTest(
   'should capture metrics for LCP instrumentation handlers',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     // This uses a utility that is not exported in CDN bundles
     if (shouldSkipTracingTest() || browserName !== 'chromium' || bundle.startsWith('bundle')) {
       sentryTest.skip();
     }
 
-    await page.route('**/path/to/image.png', (route: Route) =>
+    await page.route('https://example.com/path/to/image.png', (route: Route) =>
       route.fulfill({ path: `${__dirname}/assets/sentry-logo-600x179.png` }),
     );
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     const [eventData] = await Promise.all([
       getFirstSentryEnvelopeRequest<Event>(page),
       page.goto(url),

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-browser-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-browser-spans/test.ts
@@ -4,12 +4,12 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should add browser-related spans to pageload transaction', async ({ getLocalTestPath, page }) => {
+sentryTest('should add browser-related spans to pageload transaction', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const browserSpans = eventData.spans?.filter(({ op }) => op === 'browser');

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans/test.ts
@@ -5,12 +5,12 @@ import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
 // Validation test for https://github.com/getsentry/sentry-javascript/issues/12281
-sentryTest('should add browser-related spans to pageload transaction', async ({ getLocalTestPath, page }) => {
+sentryTest('should add browser-related spans to pageload transaction', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const browserSpans = eventData.spans?.filter(({ op }) => op === 'browser');

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
@@ -5,7 +5,7 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should add resource spans to pageload transaction', async ({ getLocalTestUrl, page, browser }) => {
+sentryTest('should add resource spans to pageload transaction', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls/test.ts
@@ -12,8 +12,8 @@ sentryTest.beforeEach(async ({ browserName, page }) => {
   await page.setViewportSize({ width: 800, height: 1200 });
 });
 
-sentryTest('should capture a "GOOD" CLS vital with its source(s).', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a "GOOD" CLS vital with its source(s).', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#0.05`);
 
   expect(eventData.measurements).toBeDefined();
@@ -26,8 +26,8 @@ sentryTest('should capture a "GOOD" CLS vital with its source(s).', async ({ get
   expect(eventData.contexts?.trace?.data?.['cls.source.1']).toBe('body > div#content > p#partial');
 });
 
-sentryTest('should capture a "MEH" CLS vital with its source(s).', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a "MEH" CLS vital with its source(s).', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#0.21`);
 
   expect(eventData.measurements).toBeDefined();
@@ -40,8 +40,8 @@ sentryTest('should capture a "MEH" CLS vital with its source(s).', async ({ getL
   expect(eventData.contexts?.trace?.data?.['cls.source.1']).toBe('body > div#content > p');
 });
 
-sentryTest('should capture a "POOR" CLS vital with its source(s).', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture a "POOR" CLS vital with its source(s).', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#0.35`);
 
   expect(eventData.measurements).toBeDefined();

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
@@ -4,13 +4,13 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should capture a FID vital.', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should capture a FID vital.', async ({ browserName, getLocalTestUrl, page }) => {
   // FID measurement is not generated on webkit
   if (shouldSkipTracingTest() || browserName === 'webkit') {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   // To trigger FID

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-fp-fcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-fp-fcp/test.ts
@@ -4,13 +4,13 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should capture FP vital.', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should capture FP vital.', async ({ browserName, getLocalTestUrl, page }) => {
   // FP is not generated on webkit or firefox
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.measurements).toBeDefined();
@@ -23,12 +23,12 @@ sentryTest('should capture FP vital.', async ({ browserName, getLocalTestPath, p
   expect(fpSpan?.parent_span_id).toBe(eventData.contexts?.trace?.span_id);
 });
 
-sentryTest('should capture FCP vital.', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture FCP vital.', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.measurements).toBeDefined();

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/test.ts
@@ -9,7 +9,7 @@ import {
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
 
-sentryTest('should capture an INP click event span after pageload', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should capture an INP click event span after pageload', async ({ browserName, getLocalTestUrl, page }) => {
   const supportedBrowsers = ['chromium'];
 
   if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
@@ -24,7 +24,7 @@ sentryTest('should capture an INP click event span after pageload', async ({ bro
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   await getFirstSentryEnvelopeRequest<SentryEvent>(page); // wait for page load

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/test.ts
@@ -11,7 +11,7 @@ import {
 
 sentryTest(
   'should capture an INP click event span after pageload for a parametrized transaction',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     const supportedBrowsers = ['chromium'];
 
     if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
@@ -26,7 +26,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await getFirstSentryEnvelopeRequest<SentryEvent>(page); // wait for page load

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/test.ts
@@ -10,7 +10,7 @@ import {
 
 sentryTest(
   'should capture an INP click event span during pageload for a parametrized transaction',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     const supportedBrowsers = ['chromium'];
 
     if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
@@ -25,7 +25,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/test.ts
@@ -9,100 +9,97 @@ import {
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
 
-sentryTest(
-  'should capture an INP click event span during pageload',
-  async ({ browserName, getLocalTestPath, page }) => {
-    const supportedBrowsers = ['chromium'];
+sentryTest('should capture an INP click event span during pageload', async ({ browserName, getLocalTestUrl, page }) => {
+  const supportedBrowsers = ['chromium'];
 
-    if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
-      sentryTest.skip();
-    }
+  if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
+    sentryTest.skip();
+  }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
     });
+  });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.goto(url);
+  await page.goto(url);
 
-    const spanEnvelopePromise = getMultipleSentryEnvelopeRequests<SpanEnvelope>(
-      page,
-      1,
-      { envelopeType: 'span' },
-      properFullEnvelopeRequestParser,
-    );
+  const spanEnvelopePromise = getMultipleSentryEnvelopeRequests<SpanEnvelope>(
+    page,
+    1,
+    { envelopeType: 'span' },
+    properFullEnvelopeRequestParser,
+  );
 
-    await page.locator('[data-test-id=normal-button]').click();
-    await page.locator('.clicked[data-test-id=normal-button]').isVisible();
+  await page.locator('[data-test-id=normal-button]').click();
+  await page.locator('.clicked[data-test-id=normal-button]').isVisible();
 
-    await page.waitForTimeout(500);
+  await page.waitForTimeout(500);
 
-    // Page hide to trigger INP
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event('pagehide'));
-    });
+  // Page hide to trigger INP
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event('pagehide'));
+  });
 
-    // Get the INP span envelope
-    const spanEnvelope = (await spanEnvelopePromise)[0];
+  // Get the INP span envelope
+  const spanEnvelope = (await spanEnvelopePromise)[0];
 
-    const spanEnvelopeHeaders = spanEnvelope[0];
-    const spanEnvelopeItem = spanEnvelope[1][0][1];
+  const spanEnvelopeHeaders = spanEnvelope[0];
+  const spanEnvelopeItem = spanEnvelope[1][0][1];
 
-    const traceId = spanEnvelopeHeaders.trace!.trace_id;
-    expect(traceId).toMatch(/[a-f0-9]{32}/);
+  const traceId = spanEnvelopeHeaders.trace!.trace_id;
+  expect(traceId).toMatch(/[a-f0-9]{32}/);
 
-    expect(spanEnvelopeHeaders).toEqual({
-      sent_at: expect.any(String),
-      trace: {
-        environment: 'production',
-        public_key: 'public',
-        sample_rate: '1',
-        sampled: 'true',
-        trace_id: traceId,
-        // no transaction, because span source is URL
-      },
-    });
-
-    const inpValue = spanEnvelopeItem.measurements?.inp.value;
-    expect(inpValue).toBeGreaterThan(0);
-
-    expect(spanEnvelopeItem).toEqual({
-      data: {
-        'sentry.exclusive_time': inpValue,
-        'sentry.op': 'ui.interaction.click',
-        'sentry.origin': 'auto.http.browser.inp',
-        transaction: 'test-url',
-        'user_agent.original': expect.stringContaining('Chrome'),
-      },
-      measurements: {
-        inp: {
-          unit: 'millisecond',
-          value: inpValue,
-        },
-      },
-      description: 'body > NormalButton',
-      exclusive_time: inpValue,
-      op: 'ui.interaction.click',
-      origin: 'auto.http.browser.inp',
-      segment_id: expect.not.stringMatching(spanEnvelopeItem.span_id!),
-      // Parent is the pageload span
-      parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-      span_id: expect.stringMatching(/[a-f0-9]{16}/),
-      start_timestamp: expect.any(Number),
-      timestamp: expect.any(Number),
+  expect(spanEnvelopeHeaders).toEqual({
+    sent_at: expect.any(String),
+    trace: {
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
       trace_id: traceId,
-    });
-  },
-);
+      // no transaction, because span source is URL
+    },
+  });
+
+  const inpValue = spanEnvelopeItem.measurements?.inp.value;
+  expect(inpValue).toBeGreaterThan(0);
+
+  expect(spanEnvelopeItem).toEqual({
+    data: {
+      'sentry.exclusive_time': inpValue,
+      'sentry.op': 'ui.interaction.click',
+      'sentry.origin': 'auto.http.browser.inp',
+      transaction: 'test-url',
+      'user_agent.original': expect.stringContaining('Chrome'),
+    },
+    measurements: {
+      inp: {
+        unit: 'millisecond',
+        value: inpValue,
+      },
+    },
+    description: 'body > NormalButton',
+    exclusive_time: inpValue,
+    op: 'ui.interaction.click',
+    origin: 'auto.http.browser.inp',
+    segment_id: expect.not.stringMatching(spanEnvelopeItem.span_id!),
+    // Parent is the pageload span
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: traceId,
+  });
+});
 
 sentryTest(
   'should choose the slowest interaction click event when INP is triggered.',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     const supportedBrowsers = ['chromium'];
 
     if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
@@ -117,7 +114,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
     await getFirstSentryEnvelopeRequest<SentryEvent>(page);

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -5,7 +5,7 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should capture a LCP vital with element details.', async ({ browserName, getLocalTestPath, page }) => {
+sentryTest('should capture a LCP vital with element details.', async ({ browserName, getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
@@ -15,7 +15,7 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
     return route.fulfill({ path: `${__dirname}/assets/sentry-logo-600x179.png` });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   const [eventData] = await Promise.all([
     getFirstSentryEnvelopeRequest<Event>(page),
     page.goto(url),

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/test.ts
@@ -5,12 +5,12 @@ import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
 sentryTest(
   'should not attach `sentry-trace` header to fetch requests without tracing',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const requests = (
       await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/test.ts
@@ -3,12 +3,12 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should attach `sentry-trace` header to unsampled fetch requests', async ({ getLocalTestPath, page }) => {
+sentryTest('should attach `sentry-trace` header to unsampled fetch requests', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const requests = (
     await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/test.ts
@@ -5,12 +5,12 @@ import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
 sentryTest(
   'should attach `sentry-trace` header to tracing without performance (TWP) fetch requests',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const requests = (
       await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/test.ts
@@ -5,7 +5,7 @@ import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
 sentryTest(
   'instrumentation should pass on headers from fetch options instead of init request, if set',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
@@ -25,6 +25,6 @@ sentryTest(
       });
     });
 
-    await getLocalTestPath({ testDir: __dirname });
+    await getLocalTestUrl({ testDir: __dirname });
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch/test.ts
@@ -4,12 +4,20 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should create spans for fetch requests', async ({ getLocalTestPath, page }) => {
+sentryTest('should create spans for fetch requests', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.route('http://example.com/**', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'hello world',
+    });
+  });
 
   // Because we fetch from http://example.com, fetch will throw a CORS error in firefox and webkit.
   // Chromium does not throw for cors errors.
@@ -43,12 +51,20 @@ sentryTest('should create spans for fetch requests', async ({ getLocalTestPath, 
   );
 });
 
-sentryTest('should attach `sentry-trace` header to fetch requests', async ({ getLocalTestPath, page }) => {
+sentryTest('should attach `sentry-trace` header to fetch requests', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  await page.route('http://example.com/**', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'hello world',
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const requests = (
     await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/test.ts
@@ -5,12 +5,12 @@ import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
 sentryTest(
   'should not attach `sentry-trace` header to fetch requests without tracing',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const requests = (
       await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/test.ts
@@ -3,12 +3,12 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should attach `sentry-trace` header to unsampled xhr requests', async ({ getLocalTestPath, page }) => {
+sentryTest('should attach `sentry-trace` header to unsampled xhr requests', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const requests = (
     await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/test.ts
@@ -5,12 +5,12 @@ import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
 sentryTest(
   'should attach `sentry-trace` header to tracing without performance (TWP) xhr requests',
-  async ({ getLocalTestPath, page }) => {
+  async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const requests = (
       await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr/test.ts
@@ -4,12 +4,12 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should create spans for XHR requests', async ({ getLocalTestPath, page }) => {
+sentryTest('should create spans for XHR requests', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const requestSpans = eventData.spans?.filter(({ op }) => op === 'http.client');
@@ -35,12 +35,12 @@ sentryTest('should create spans for XHR requests', async ({ getLocalTestPath, pa
   );
 });
 
-sentryTest('should attach `sentry-trace` header to XHR requests', async ({ getLocalTestPath, page }) => {
+sentryTest('should attach `sentry-trace` header to XHR requests', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const requests = (
     await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/transport/offline/queued/test.ts
+++ b/dev-packages/browser-integration-tests/suites/transport/offline/queued/test.ts
@@ -8,13 +8,13 @@ function delay(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-sentryTest('should queue and retry events when they fail to send', async ({ getLocalTestPath, page }) => {
+sentryTest('should queue and retry events when they fail to send', async ({ getLocalTestUrl, page }) => {
   // makeBrowserOfflineTransport is not included in any CDN bundles
   if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle')) {
     sentryTest.skip();
   }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   // This would be the obvious way to test offline support but it doesn't appear to work!
   // await context.setOffline(true);

--- a/dev-packages/browser-integration-tests/suites/wasm/test.ts
+++ b/dev-packages/browser-integration-tests/suites/wasm/test.ts
@@ -7,12 +7,12 @@ import { shouldSkipWASMTests } from '../../utils/wasmHelpers';
 
 sentryTest(
   'captured exception should include modified frames and debug_meta attribute',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     if (shouldSkipWASMTests(browserName)) {
       sentryTest.skip();
     }
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.route('**/simple.wasm', route => {
       const wasmModule = fs.readFileSync(path.resolve(__dirname, 'simple.wasm'));

--- a/dev-packages/browser-integration-tests/utils/fixtures.ts
+++ b/dev-packages/browser-integration-tests/utils/fixtures.ts
@@ -27,7 +27,6 @@ const getAsset = (assetDir: string, asset: string): string => {
 export type TestFixtures = {
   _autoSnapshotSuffix: void;
   testDir: string;
-  getLocalTestPath: (options: { testDir: string }) => Promise<string>;
   getLocalTestUrl: (options: { testDir: string; skipRouteHandler?: boolean }) => Promise<string>;
   forceFlushReplay: () => Promise<string>;
   enableConsole: () => void;
@@ -87,15 +86,6 @@ const sentryTest = base.extend<TestFixtures>({
     });
   },
 
-  getLocalTestPath: ({}, use) => {
-    return use(async ({ testDir }) => {
-      const pagePath = `file:///${path.resolve(testDir, './dist/index.html')}`;
-
-      await build(testDir);
-
-      return pagePath;
-    });
-  },
   runInChromium: ({ runInSingleBrowser }, use) => {
     return use((fn, args) => runInSingleBrowser('chromium', fn, args));
   },


### PR DESCRIPTION
Just use `getLocalTestUrl` everywhere, which is actually closer to reality.