### PR TITLE
feat(fastify): Warn if fastify is not instrumented

### DIFF
--- a/packages/node/src/integrations/tracing/fastify.ts
+++ b/packages/node/src/integrations/tracing/fastify.ts
@@ -1,7 +1,9 @@
+import { isWrapped } from '@opentelemetry/core';
 import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify';
 import { captureException, defineIntegration, getIsolationScope } from '@sentry/core';
 import { addOpenTelemetryInstrumentation } from '@sentry/opentelemetry';
 import type { IntegrationFn } from '@sentry/types';
+import { consoleSandbox } from '@sentry/utils';
 
 import { addOriginToSpan } from '../../utils/addOriginToSpan';
 
@@ -81,4 +83,13 @@ export function setupFastifyErrorHandler(fastify: Fastify): void {
   );
 
   fastify.register(plugin);
+
+  if (!isWrapped(fastify.addHook)) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[Sentry] Fastify is not instrumented. This is likely because you required/imported fastify before calling `Sentry.init()`.',
+      );
+    });
+  }
 }


### PR DESCRIPTION
When using `setupFastifyErrorHandler(app)` we can check if the app was correctly instrumented.

Not sure how to best test this - I tested this manually in a test app and could verify that the log was printed when requiring fastify before calling init!