### PR TITLE
feat(koa): Warn if koa is not instrumented

### DIFF
--- a/packages/node/src/integrations/tracing/koa.ts
+++ b/packages/node/src/integrations/tracing/koa.ts
@@ -1,3 +1,4 @@
+import { isWrapped } from '@opentelemetry/core';
 import { KoaInstrumentation } from '@opentelemetry/instrumentation-koa';
 import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import {
@@ -9,7 +10,7 @@ import {
 } from '@sentry/core';
 import { addOpenTelemetryInstrumentation } from '@sentry/opentelemetry';
 import type { IntegrationFn } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { consoleSandbox, logger } from '@sentry/utils';
 import { DEBUG_BUILD } from '../../debug-build';
 
 const _koaIntegration = (() => {
@@ -48,4 +49,13 @@ export const setupKoaErrorHandler = (app: { use: (arg0: (ctx: any, next: any) =>
       captureException(error);
     }
   });
+
+  if (!isWrapped(app.use)) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[Sentry] Koa is not instrumented. This is likely because you required/imported koa before calling `Sentry.init()`.',
+      );
+    });
+  }
 };


### PR DESCRIPTION
This prints a warning if we detect that the koa app passed to setupKoaErrorHandler is not instrumented.
This happens if you import koa before calling Sentry.init.