### PR TITLE
fix(browser): Continuously record CLS web vital

### DIFF
--- a/packages/browser-utils/src/metrics/instrument.ts
+++ b/packages/browser-utils/src/metrics/instrument.ts
@@ -209,6 +209,8 @@ function instrumentCls(): StopListening {
       });
       _previousCls = metric;
     },
+    // We want the callback to be called whenever the CLS value updates.
+    // By default, the callback is only called when the tab goes to the background.
     { reportAllChanges: true },
   );
 }

--- a/packages/browser-utils/src/metrics/instrument.ts
+++ b/packages/browser-utils/src/metrics/instrument.ts
@@ -202,12 +202,15 @@ function triggerHandlers(type: InstrumentHandlerType, data: unknown): void {
 }
 
 function instrumentCls(): StopListening {
-  return onCLS(metric => {
-    triggerHandlers('cls', {
-      metric,
-    });
-    _previousCls = metric;
-  });
+  return onCLS(
+    metric => {
+      triggerHandlers('cls', {
+        metric,
+      });
+      _previousCls = metric;
+    },
+    { reportAllChanges: true },
+  );
 }
 
 function instrumentFid(): void {


### PR DESCRIPTION
Through debugging I found that we were only recording the CLS web vital when we were hiding the tab (so either when switching tabs or when unloading the page).

This is problematic because it result in us not sending CLS values for pageloads at all (or at least with really low probability). We fix this by setting `reportAllChanges: true` which will continuously update the CLS metric before we send it.