### PR TITLE
feat(feedback): Use type=email for the email input textbox

### DIFF
--- a/packages/feedback/src/modal/components/Form.tsx
+++ b/packages/feedback/src/modal/components/Form.tsx
@@ -184,7 +184,7 @@ export function Form({
                 name="email"
                 placeholder={emailPlaceholder}
                 required={isEmailRequired}
-                type="text"
+                type="email"
               ></input>
             </label>
           ) : (


### PR DESCRIPTION
The `type="email"` textbox enables some basic browser settings like validating that the input looks like an email address, and will change the keyboard to make it easier for phone users to type their info into the box. 