### PR TITLE
[v7] Bun Global Unhandled Handlers

### DIFF
--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -13,6 +13,8 @@ import {
   modulesIntegration,
   nativeNodeFetchintegration,
   nodeContextIntegration,
+  onUncaughtExceptionIntegration,
+  onUnhandledRejectionIntegration,
 } from '@sentry/node';
 import type { Integration, Options } from '@sentry/types';
 
@@ -32,9 +34,9 @@ export const defaultIntegrations = [
   consoleIntegration(),
   httpIntegration(),
   nativeNodeFetchintegration(),
-  // Global Handlers # TODO (waiting for https://github.com/oven-sh/bun/issues/5091)
-  // new NodeIntegrations.OnUncaughtException(),
-  // new NodeIntegrations.OnUnhandledRejection(),
+  // Global Handlers
+  onUncaughtExceptionIntegration(),
+  onUnhandledRejectionIntegration(),
   // Event Info
   contextLinesIntegration(),
   // new NodeIntegrations.LocalVariables(), # does't work with Bun


### PR DESCRIPTION
Add support for global onUnhandled Error/Promise for Bun.

```javascript
import * as Sentry from "@sentry/bun";

Sentry.init({
    dsn: "DSN",
});

console.log("Hello via Bun!");

throw new Error('Unhandled Bun Sentry Error!');
```

<img width="1063" alt="image" src="https://github.com/getsentry/sentry-javascript/assets/363802/fd90969f-82a4-4300-a67e-1ebb5cf540fa">

ref: https://github.com/oven-sh/bun/issues/5091