### PR TITLE
fix(node): Ensure `execArgv` are not sent to worker threads

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-instrument.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-instrument.js
@@ -1,0 +1,8 @@
+const Sentry = require('@sentry/node');
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  includeLocalVariables: true,
+  transport: loggingTransport,
+});

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-no-sentry.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-no-sentry.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-unused-vars */
+process.on('uncaughtException', () => {
+  // do nothing - this will prevent the Error below from closing this process
+});
+
+class Some {
+  two(name) {
+    throw new Error('Enough!');
+  }
+}
+
+function one(name) {
+  const arr = [1, '2', null];
+  const obj = {
+    name,
+    num: 5,
+  };
+  const bool = false;
+  const num = 0;
+  const str = '';
+  const something = undefined;
+  const somethingElse = null;
+
+  const ty = new Some();
+
+  ty.two(name);
+}
+
+setTimeout(() => {
+  one('some name');
+}, 1000);

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -59,6 +59,16 @@ conditionalTest({ min: 18 })('LocalVariables integration', () => {
       .start(done);
   });
 
+  test('Should include local variables when instrumenting via --require', done => {
+    const requirePath = path.resolve(__dirname, 'local-variables-instrument.js');
+
+    createRunner(__dirname, 'local-variables-no-sentry.js')
+      .withFlags(`--require=${requirePath}`)
+      .ignore('session')
+      .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
+      .start(done);
+  });
+
   test('Should include local variables with ESM', done => {
     createRunner(__dirname, 'local-variables-caught.mjs')
       .ignore('session')

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -156,6 +156,8 @@ async function _startWorker(
 
   const worker = new Worker(new URL(`data:application/javascript;base64,${base64WorkerScript}`), {
     workerData: options,
+    // We don't want any Node args to be passed to the worker
+    execArgv: [],
   });
 
   process.on('exit', () => {

--- a/packages/node/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-async.ts
@@ -84,6 +84,8 @@ export const localVariablesAsyncIntegration = defineIntegration(((
   function startWorker(options: LocalVariablesWorkerArgs): void {
     const worker = new Worker(new URL(`data:application/javascript;base64,${base64WorkerScript}`), {
       workerData: options,
+      // We don't want any Node args to be passed to the worker
+      execArgv: [],
     });
 
     process.on('exit', () => {


### PR DESCRIPTION
Closes #11956
