### PR TITLE
fix(feedback): Improve CSS theme variable names and layout

### DIFF
--- a/packages/feedback/src/constants/theme.ts
+++ b/packages/feedback/src/constants/theme.ts
@@ -53,7 +53,7 @@ export const DEFAULT_THEME = {
     successForeground: '#2da98c',
     errorForeground: '#f55459',
     background: '#29232f',
-    border: '1.5px solid rgba(235, 230, 239, 0.15)',
+    border: '1.5px solid rgba(235, 230, 239, 0.5)',
     boxShadow: '0px 4px 24px 0px rgba(43, 34, 51, 0.12)',
 
     buttonBackgroundHover: '#352f3b',

--- a/packages/feedback/src/constants/theme.ts
+++ b/packages/feedback/src/constants/theme.ts
@@ -10,9 +10,6 @@ export const LIGHT_THEME = {
   border: '1.5px solid rgba(41, 35, 47, 0.13)',
   boxShadow: '0px 4px 24px 0px rgba(43, 34, 51, 0.12)',
 
-  backgroundHover: '#f6f6f7',
-  borderRadius: '25px',
-
   inputForeground: INHERIT,
   inputBackground: INHERIT,
   inputBackgroundHover: INHERIT,

--- a/packages/feedback/src/constants/theme.ts
+++ b/packages/feedback/src/constants/theme.ts
@@ -1,44 +1,47 @@
-const LIGHT_BACKGROUND = '#ffffff';
 const INHERIT = 'inherit';
-const SUBMIT_COLOR = 'rgba(108, 95, 199, 1)';
+const PURPLE = 'rgba(88, 74, 192, 1)';
+const PURPLE_HOVER = 'rgba(108, 95, 199, 1)';
 
 export const LIGHT_THEME = {
-  fontFamily: "system-ui, 'Helvetica Neue', Arial, sans-serif",
-  fontSize: '14px',
-
   foreground: '#2b2233',
-  background: LIGHT_BACKGROUND,
-  success: '#268d75',
-  error: '#df3338',
-
-  zIndex: 100000,
+  successForeground: '#268d75',
+  errorForeground: '#df3338',
+  background: '#ffffff',
   border: '1.5px solid rgba(41, 35, 47, 0.13)',
   boxShadow: '0px 4px 24px 0px rgba(43, 34, 51, 0.12)',
 
   backgroundHover: '#f6f6f7',
   borderRadius: '25px',
 
-  formBorderRadius: '20px',
-  formContentBorderRadius: '6px',
+  inputForeground: INHERIT,
+  inputBackground: INHERIT,
+  inputBackgroundHover: INHERIT,
+  inputBackgroundFocus: INHERIT,
+  inputBorder: 'var(--border)',
+  inputBorderRadius: '6px',
+  inputOutlineFocus: PURPLE_HOVER,
 
-  submitForeground: LIGHT_BACKGROUND,
-  submitBackground: 'rgba(88, 74, 192, 1)',
-  submitForegroundHover: LIGHT_BACKGROUND,
-  submitBackgroundHover: SUBMIT_COLOR,
-  submitBorder: SUBMIT_COLOR,
+  buttonForeground: INHERIT,
+  buttonForegroundHover: INHERIT,
+  buttonBackground: 'var(--background)',
+  buttonBackgroundHover: '#f6f6f7',
+  buttonBorder: 'var(--border)',
+  buttonOutlineFocus: 'var(--input-outline-focus)',
+
+  submitForeground: '#ffffff',
+  submitForegroundHover: '#ffffff',
+  submitBackground: PURPLE,
+  submitBackgroundHover: PURPLE_HOVER,
+  submitBorder: PURPLE_HOVER,
+  submitBorderRadius: 'var(--button-border-radius)',
   submitOutlineFocus: '#29232f',
 
-  cancelForeground: 'var(--foreground)',
-  cancelBackground: 'transparent',
-  cancelForegroundHover: 'var(--foreground)',
-  cancelBackgroundHover: 'var(--background-hover)',
-  cancelBorder: 'var(--border)',
-  cancelOutlineFocus: 'var(--input-outline-focus)',
+  triggerBackground: 'var(--background)',
+  triggerBackgroundHover: 'var(--button-background-hover)',
+  triggerBorderRadius: '1.7em/50%',
 
-  inputBackground: INHERIT,
-  inputForeground: INHERIT,
-  inputBorder: 'var(--border)',
-  inputOutlineFocus: SUBMIT_COLOR,
+  dialogBackground: 'var(--background)',
+  dialogBorderRadius: '20px',
 };
 
 export const DEFAULT_THEME = {
@@ -46,12 +49,13 @@ export const DEFAULT_THEME = {
   dark: {
     ...LIGHT_THEME,
 
-    background: '#29232f',
-    backgroundHover: '#352f3b',
     foreground: '#ebe6ef',
+    successForeground: '#2da98c',
+    errorForeground: '#f55459',
+    background: '#29232f',
     border: '1.5px solid rgba(235, 230, 239, 0.15)',
+    boxShadow: '0px 4px 24px 0px rgba(43, 34, 51, 0.12)',
 
-    success: '#2da98c',
-    error: '#f55459',
+    buttonBackgroundHover: '#352f3b',
   },
 };

--- a/packages/feedback/src/core/components/Actor.css.ts
+++ b/packages/feedback/src/core/components/Actor.css.ts
@@ -28,6 +28,7 @@ export function createActorStyles(): HTMLStyleElement {
   border: var(--border);
   box-shadow: var(--box-shadow);
   color: var(--foreground);
+  fill: var(--foreground);
   cursor: pointer;
   opacity: 1;
   transition: transform 0.2s ease-in-out;

--- a/packages/feedback/src/core/components/Actor.css.ts
+++ b/packages/feedback/src/core/components/Actor.css.ts
@@ -9,7 +9,7 @@ export function createActorStyles(): HTMLStyleElement {
 .widget__actor {
   position: fixed;
   z-index: var(--z-index);
-  margin: 0;
+  margin: var(--page-margin);
   inset: var(--actor-inset);
 
   display: flex;
@@ -20,11 +20,11 @@ export function createActorStyles(): HTMLStyleElement {
   font-family: inherit;
   font-size: var(--font-size);
   font-weight: 600;
-  line-height: 16px;
+  line-height: 1.14em;
   text-decoration: none;
 
-  background-color: var(--background);
-  border-radius: var(--border-radius);
+  background-color: var(--trigger-background);
+  border-radius: var(--trigger-border-radius);
   border: var(--border);
   box-shadow: var(--box-shadow);
   color: var(--foreground);
@@ -41,12 +41,12 @@ export function createActorStyles(): HTMLStyleElement {
 }
 
 .widget__actor:hover {
-  background-color: var(--background-hover);
+  background-color: var(--trigger-background-hover);
 }
 
 .widget__actor svg {
-  width: 16px;
-  height: 16px;
+  width: 1.14em;
+  height: 1.14em;
 }
 
 @media (max-width: 600px) {

--- a/packages/feedback/src/core/createMainStyles.ts
+++ b/packages/feedback/src/core/createMainStyles.ts
@@ -3,14 +3,23 @@ import { DOCUMENT } from '../constants';
 
 function getThemedCssVariables(theme: FeedbackInternalOptions['themeLight']): string {
   return `
-  --background: ${theme.background};
-  --background-hover: ${theme.backgroundHover};
   --foreground: ${theme.foreground};
-  --error: ${theme.error};
-  --success: ${theme.success};
+  --success-foreground: ${theme.successForeground};
+  --error-foreground: ${theme.errorForeground};
+  --background: ${theme.background};
   --border: ${theme.border};
-  --border-radius: ${theme.borderRadius};
   --box-shadow: ${theme.boxShadow};
+
+  --button-foreground: ${theme.buttonForeground};
+  --button-foreground-hover: ${theme.buttonForegroundHover};
+  --button-background: ${theme.buttonBackground};
+  --button-background-hover: ${theme.buttonBackgroundHover};
+  --button-border: ${theme.buttonBorder};
+  --button-outline-focus: ${theme.buttonOutlineFocus};
+
+  --trigger-background: ${theme.triggerBackground};
+  --trigger-background-hover: ${theme.triggerBackgroundHover};
+  --trigger-border-radius: ${theme.triggerBorderRadius};
   `;
 }
 
@@ -21,25 +30,16 @@ export function createMainStyles({ colorScheme, themeDark, themeLight }: Feedbac
   const style = DOCUMENT.createElement('style');
   style.textContent = `
 :host {
-  --z-index: ${themeLight.zIndex};
-  --font-family: ${themeLight.fontFamily};
-  --font-size: ${themeLight.fontSize};
+  --font-family: system-ui, 'Helvetica Neue', Arial, sans-serif;
+  --font-size: 14px;
+  --z-index: 100000;
+
+  --page-margin: 16px;
+  --inset: auto 0 0 auto;
+  --actor-inset: var(--inset);
 
   font-family: var(--font-family);
   font-size: var(--font-size);
-
-  --page-margin: 16px;
-  --actor-inset: auto var(--page-margin) var(--page-margin) auto;
-
-  .brand-link path {
-    fill: ${colorScheme === 'dark' ? '#fff' : '#362d59'};
-  }
-  @media (prefers-color-scheme: dark)
-  {
-    path: {
-      fill: '#fff';
-    }
-  }
 
   ${getThemedCssVariables(colorScheme === 'dark' ? themeDark : themeLight)}
 }

--- a/packages/feedback/src/modal/components/Dialog.css.ts
+++ b/packages/feedback/src/modal/components/Dialog.css.ts
@@ -6,6 +6,7 @@ const DIALOG = `
   position: fixed;
   z-index: var(--z-index);
   margin: 0;
+  inset: 0;
 
   display: flex;
   align-items: center;
@@ -23,6 +24,26 @@ const DIALOG = `
   transition: opacity 0.2s ease-in-out;
 }
 
+.dialog__position {
+  position: fixed;
+  z-index: var(--z-index);
+  inset: var(--dialog-inset);
+  padding: var(--page-margin);
+  display: flex;
+  max-height: calc(100vh - (2 * var(--page-margin)));
+}
+@media (max-width: 600px) {
+  .dialog__position {
+    inset: var(--page-margin);
+    padding: 0;
+  }
+}
+
+.dialog__position:has(.editor) {
+  inset: var(--page-margin);
+  padding: 0;
+}
+
 .dialog:not([open]) {
   opacity: 0;
   pointer-events: none;
@@ -33,33 +54,23 @@ const DIALOG = `
 }
 
 .dialog__content {
-  position: fixed;
-  inset: var(--dialog-inset);
-
   display: flex;
   flex-direction: column;
   gap: 16px;
   padding: var(--dialog-padding);
   max-width: 100%;
-  max-height: calc(100% - (2 * var(--page-margin)) - (2 * var(--dialog-padding)));
+  width: 100%;
+  max-height: 100%;
   overflow: auto;
 
-  background-color: var(--background);
-  border-radius: var(--form-border-radius);
+  background-color: var(--dialog-background);
+  border-radius: var(--dialog-border-radius);
   border: var(--border);
   box-shadow: var(--box-shadow);
   color: var(--foreground);
+  fill: var(--foreground);
   transform: translate(0, 0) scale(1);
   transition: transform 0.2s ease-in-out;
-}
-
-.dialog__content:has(.editor) {
-  inset: var(--page-margin);
-}
-@media (max-width: 600px) {
-  .dialog__content {
-    inset: var(--page-margin);
-  }
 }
 `;
 
@@ -74,6 +85,9 @@ const DIALOG_HEADER = `
 
 .brand-link {
   display: inline-flex;
+}
+.brand-link:focus-visible {
+  outline: 1px auto var(--input-outline-focus);
 }
 `;
 
@@ -109,7 +123,8 @@ const FORM = `
 }
 
 .form__error-container {
-  color: var(--error);
+  color: var(--error-foreground);
+  fill: var(--error-foreground);
 }
 
 .form__label {
@@ -135,8 +150,9 @@ const FORM = `
   background-color: var(--input-background);
   box-sizing: border-box;
   border: var(--input-border);
-  border-radius: var(--form-content-border-radius);
+  border-radius: var(--input-border-radius);
   color: var(--input-foreground);
+  fill: var(--input-foreground);
   font-size: var(--font-size);
   font-weight: 500;
   padding: 6px 12px;
@@ -157,7 +173,8 @@ const FORM = `
 }
 
 .error {
-  color: var(--error);
+  color: var(--error-foreground);
+  fill: var(--error-foreground);
 }
 `;
 
@@ -183,47 +200,55 @@ const BUTTON = `
 }
 
 .btn--primary {
-  background-color: var(--submit-background);
-  border-color: var(--submit-border);
   color: var(--submit-foreground);
+  fill: var(--submit-foreground);
+  background-color: var(--submit-background);
+  border: var(--submit-border);
+  border-radius: var(--input-border-radius);
+  font-weight: 500;
 }
 .btn--primary:hover {
-  background-color: var(--submit-background-hover);
   color: var(--submit-foreground-hover);
+  fill: var(--submit-foreground-hover);
+  background-color: var(--submit-background-hover);
 }
 .btn--primary:focus-visible {
   outline: 1px auto var(--submit-outline-focus);
 }
 
 .btn--default {
-  background-color: var(--cancel-background);
-  color: var(--cancel-foreground);
+  color: var(--button-foreground);
+  fill: var(--button-foreground);
+  background-color: var(--button-background);
+  border: var(--button-border);
+  border-radius: var(--input-border-radius);
   font-weight: 500;
 }
 .btn--default:hover {
-  background-color: var(--cancel-background-hover);
-  color: var(--cancel-foreground-hover);
+  color: var(--button-foreground-hover);
+  fill: var(--button-foreground-hover);
+  background-color: var(--button-background-hover);
 }
 .btn--default:focus-visible {
-  outline: 1px auto var(--cancel-outline-focus);
+  outline: 1px auto var(--button-outline-focus);
 }
 `;
 
 const SUCCESS = `
-.success-message {
+.success__position {
   position: fixed;
-  left: var(--left);
-  right: var(--right);
-  bottom: var(--bottom);
-  top: var(--top);
+  inset: var(--dialog-inset);
+  padding: var(--page-margin);
   z-index: var(--z-index);
-
-  background-color: var(--background);
+}
+.success__content {
+  background-color: var(--trigger-background);
   border: var(--border);
-  border-radius: var(--border-radius);
+  border-radius: var(--trigger-border-radius);
   box-shadow: var(--box-shadow);
   font-weight: 600;
-  color: var(--success);
+  color: var(--success-foreground);
+  fill: var(--success-foreground);
   padding: 12px 24px;
   line-height: 25px;
   display: grid;
@@ -233,34 +258,30 @@ const SUCCESS = `
   cursor: default;
 }
 
-.success-icon {
+.success__icon {
   display: flex;
 }
 `;
 
 function getThemedCssVariables(theme: FeedbackInternalOptions['themeLight']): string {
   return `
-  --submit-background: ${theme.submitBackground};
-  --submit-background-hover: ${theme.submitBackgroundHover};
-  --submit-border: ${theme.submitBorder};
-  --submit-outline-focus: ${theme.submitOutlineFocus};
-  --submit-foreground: ${theme.submitForeground};
-  --submit-foreground-hover: ${theme.submitForegroundHover};
-
-  --cancel-background: ${theme.cancelBackground};
-  --cancel-background-hover: ${theme.cancelBackgroundHover};
-  --cancel-border: ${theme.cancelBorder};
-  --cancel-outline-focus: ${theme.cancelOutlineFocus};
-  --cancel-foreground: ${theme.cancelForeground};
-  --cancel-foreground-hover: ${theme.cancelForegroundHover};
-
+  --input-border-radius: ${theme.inputBorderRadius};
   --input-background: ${theme.inputBackground};
+  --input-background-hover: ${theme.inputBackgroundHover};
+  --input-background-focus: ${theme.inputBackgroundFocus};
   --input-foreground: ${theme.inputForeground};
   --input-border: ${theme.inputBorder};
   --input-outline-focus: ${theme.inputOutlineFocus};
 
-  --form-border-radius: ${theme.formBorderRadius};
-  --form-content-border-radius: ${theme.formContentBorderRadius};
+  --submit-foreground: ${theme.submitForeground};
+  --submit-foreground-hover: ${theme.submitForegroundHover};
+  --submit-background: ${theme.submitBackground};
+  --submit-background-hover: ${theme.submitBackgroundHover};
+  --submit-border: ${theme.submitBorder};
+  --submit-outline-focus: ${theme.submitOutlineFocus};
+
+  --dialog-background: ${theme.dialogBackground};
+  --dialog-border-radius: ${theme.dialogBorderRadius};
   `;
 }
 
@@ -272,7 +293,7 @@ export function createDialogStyles({ colorScheme, themeDark, themeLight }: Feedb
 
   style.textContent = `
 :host {
-  --dialog-inset: auto var(--page-margin) var(--page-margin) auto;
+  --dialog-inset: var(--inset);
   --dialog-padding: 24px;
 
   ${getThemedCssVariables(colorScheme === 'dark' ? themeDark : themeLight)}
@@ -287,7 +308,6 @@ ${
   }
 }`
     : ''
-}
 }
 
 ${DIALOG}

--- a/packages/feedback/src/modal/components/Dialog.css.ts
+++ b/packages/feedback/src/modal/components/Dialog.css.ts
@@ -15,6 +15,8 @@ const DIALOG = `
   height: 100vh;
   width: 100vw;
 
+  color: var(--foreground);
+  fill: var(--foreground);
   line-height: 1.75em;
 
   background-color: rgba(0, 0, 0, 0.05);
@@ -67,8 +69,6 @@ const DIALOG = `
   border-radius: var(--dialog-border-radius);
   border: var(--border);
   box-shadow: var(--box-shadow);
-  color: var(--foreground);
-  fill: var(--foreground);
   transform: translate(0, 0) scale(1);
   transition: transform 0.2s ease-in-out;
 }

--- a/packages/feedback/src/modal/components/Dialog.tsx
+++ b/packages/feedback/src/modal/components/Dialog.tsx
@@ -46,21 +46,25 @@ export function Dialog({ open, onFormSubmitted, ...props }: Props): VNode {
   return (
     <Fragment>
       {timeoutId ? (
-        <div class="success-message" onClick={handleOnSuccessClick}>
-          {options.successMessageText}
-          <span class="success-icon" dangerouslySetInnerHTML={successIconHtml} />
+        <div class="success__position" onClick={handleOnSuccessClick}>
+          <div class="success__content">
+            {options.successMessageText}
+            <span class="success__icon" dangerouslySetInnerHTML={successIconHtml} />
+          </div>
         </div>
       ) : (
-        <dialog class="dialog" onClick={props.onFormClose} open={open}>
-          <div
-            class="dialog__content"
-            onClick={e => {
-              // Stop event propagation so clicks on content modal do not propagate to dialog (which will close dialog)
-              e.stopPropagation();
-            }}
-          >
-            <DialogHeader {...props} />
-            <Form {...props} onSubmitSuccess={onSubmitSuccess} />
+        <dialog class="dialog" onClick={options.onFormClose} open={open}>
+          <div class="dialog__position">
+            <div
+              class="dialog__content"
+              onClick={e => {
+                // Stop event propagation so clicks on content modal do not propagate to dialog (which will close dialog)
+                e.stopPropagation();
+              }}
+            >
+              <DialogHeader options={options} />
+              <Form {...props} onSubmitSuccess={onSubmitSuccess} />
+            </div>
           </div>
         </dialog>
       )}

--- a/packages/feedback/src/modal/components/SentryLogo.ts
+++ b/packages/feedback/src/modal/components/SentryLogo.ts
@@ -13,7 +13,7 @@ export function SentryLogo(): SVGElement {
     width: '32',
     height: '30',
     viewBox: '0 0 72 66',
-    fill: 'none',
+    fill: 'inherit',
   });
 
   const path = setAttributesNS(createElementNS('path'), {

--- a/packages/feedback/src/modal/components/SuccessIcon.ts
+++ b/packages/feedback/src/modal/components/SuccessIcon.ts
@@ -15,7 +15,7 @@ export function SuccessIcon(): SVGElement {
     width: `${WIDTH}`,
     height: `${HEIGHT}`,
     viewBox: `0 0 ${WIDTH} ${HEIGHT}`,
-    fill: 'var(--success)',
+    fill: 'inherit',
   });
 
   const g = setAttributesNS(createElementNS('g'), {

--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -1,5 +1,11 @@
 import { getCurrentScope, getGlobalScope, getIsolationScope } from '@sentry/core';
-import type { CreateDialogProps, FeedbackFormData, FeedbackModalIntegration, IntegrationFn } from '@sentry/types';
+import type {
+  CreateDialogProps,
+  FeedbackDialog,
+  FeedbackFormData,
+  FeedbackModalIntegration,
+  IntegrationFn,
+} from '@sentry/types';
 import { h, render } from 'preact';
 import { DOCUMENT } from '../constants';
 import { Dialog } from './components/Dialog';
@@ -19,7 +25,7 @@ export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
       const style = createDialogStyles(options);
 
       let originalOverflow = '';
-      const dialog = {
+      const dialog: FeedbackDialog = {
         get el() {
           return el;
         },

--- a/packages/types/src/feedback/theme.ts
+++ b/packages/types/src/feedback/theme.ts
@@ -1,40 +1,23 @@
 interface BaseStyles {
   /**
-   * Font family for widget
-   */
-  fontFamily: string;
-
-  /**
-   * Font size for widget
-   */
-  fontSize: string;
-
-  /**
    * Foreground color (i.e. text color)
    */
   foreground: string;
 
   /**
-   * Background color for actor and dialog
-   */
-  background: string;
-
-  /**
    * Success color
    */
-  success: string;
+  successForeground: string;
 
   /**
    * Error color
    */
-  error: string;
-}
+  errorForeground: string;
 
-interface ActorAndModal {
   /**
-   * z-index of the floating Actor or Modal
+   * Background color for actor and dialog
    */
-  zIndex: number;
+  background: string;
 
   /**
    * Border styling for actor and dialog
@@ -47,104 +30,26 @@ interface ActorAndModal {
   boxShadow: string;
 }
 
-interface ActorButton {
-  /**
-   * Background color on hover
-   */
-  backgroundHover: string;
-
-  /**
-   * Border radius styling for actor
-   */
-  borderRadius: string;
-}
-
-interface Modal {
-  /**
-   * Border radius for dialog
-   */
-  formBorderRadius: string;
-
-  /**
-   * Border radius for form inputs
-   */
-  formContentBorderRadius: string;
-}
-
-interface SubmitButton {
-  /**
-   * Foreground color for the submit button
-   */
-  submitForeground: string;
-
-  /**
-   * Background color for the submit button
-   */
-  submitBackground: string;
-
-  /**
-   * Foreground color for the submit button, in the hover state
-   */
-  submitForegroundHover: string;
-
-  /**
-   * Background color when hovering over the submit button
-   */
-  submitBackgroundHover: string;
-
-  /**
-   * Border style for the submit button
-   */
-  submitBorder: string;
-
-  /**
-   * Border style for the submit button, in the focued state
-   */
-  submitOutlineFocus: string;
-}
-
-interface CancelButton {
-  /**
-   * Foreground color for the cancel button
-   */
-  cancelForeground: string;
-
-  /**
-   * Background color for the cancel button
-   */
-  cancelBackground: string;
-
-  /**
-   * Foreground color for the cancel button, in the hover state
-   */
-  cancelForegroundHover: string;
-
-  /**
-   * Background color when hovering over the cancel button
-   */
-  cancelBackgroundHover: string;
-
-  /**
-   * Border style for the cancel button
-   */
-  cancelBorder: string;
-
-  /**
-   * Border style for the cancel button, in the focued state
-   */
-  cancelOutlineFocus: string;
-}
-
 interface Input {
+  /**
+   * Foreground color for form inputs
+   */
+  inputForeground: string;
+
   /**
    * Background color for form inputs
    */
   inputBackground: string;
 
   /**
-   * Foreground color for form inputs
+   * Background color for form inputs, in the hover state
    */
-  inputForeground: string;
+  inputBackgroundHover: string;
+
+  /**
+   * Background color for form inputs, in the focus state
+   */
+  inputBackgroundFocus: string;
 
   /**
    * Border styles for form inputs
@@ -152,16 +57,107 @@ interface Input {
   inputBorder: string;
 
   /**
+   * Border radius for form inputs
+   */
+  inputBorderRadius: string;
+
+  /**
    * Border styles for form inputs when focused
    */
   inputOutlineFocus: string;
 }
 
-export interface FeedbackTheme
-  extends BaseStyles,
-    ActorAndModal,
-    ActorButton,
-    Modal,
-    SubmitButton,
-    CancelButton,
-    Input {}
+interface Button {
+  /**
+   * Foreground color for buttons
+   */
+  buttonForeground: string;
+
+  /**
+   * Foreground color for buttons, in the hover state
+   */
+  buttonForegroundHover: string;
+
+  /**
+   * Background color for buttons
+   */
+  buttonBackground: string;
+
+  /**
+   * Background color when hovering over buttons
+   */
+  buttonBackgroundHover: string;
+
+  /**
+   * Border style for buttons
+   */
+  buttonBorder: string;
+
+  /**
+   * Border style for buttons, in the focued state
+   */
+  buttonOutlineFocus: string;
+}
+
+interface SubmitButton {
+  /**
+   * Foreground color for submit buttons
+   */
+  submitForeground: string;
+
+  /**
+   * Foreground color for submit buttons, in the hover state
+   */
+  submitForegroundHover: string;
+
+  /**
+   * Background color for submit buttons
+   */
+  submitBackground: string;
+
+  /**
+   * Background color when hovering over submit buttons
+   */
+  submitBackgroundHover: string;
+
+  /**
+   * Border style for submit buttons
+   */
+  submitBorder: string;
+
+  /**
+   * Border style for submit buttons, in the focued state
+   */
+  submitOutlineFocus: string;
+}
+
+interface Trigger {
+  /**
+   * Background color of the actor button
+   */
+  triggerBackground: string;
+
+  /**
+   * Background color on hover
+   */
+  triggerBackgroundHover: string;
+
+  /**
+   * Border radius styling for actor
+   */
+  triggerBorderRadius: string;
+}
+
+interface Dialog {
+  /**
+   * Background color of the open dialog
+   */
+  dialogBackground: string;
+
+  /**
+   * Border radius for dialog
+   */
+  dialogBorderRadius: string;
+}
+
+export interface FeedbackTheme extends BaseStyles, Input, Button, SubmitButton, Trigger, Dialog {}


### PR DESCRIPTION
This updates the CSS theme, variable names and also how the css works.
The widget is better able to handle cases like:
- short desktop window (scrolls form)
- phone in portrait (full width if the screen is 600px or less)
- phone in landscape (scrolls form)
- when screenshots are in use, stick to screen edges

I also made it, I think, easier to position the button (aka trigger, aka actor) around the screen. You can override in css `--page-margin: 16px` to dictate the distance from the edge, and override `--inset: auto 0 0 auto;` to position the button in the different corners of the screen. For example, you can put the trigger button on the edge of the screen with something like: 
```css
#sentry-feedback {
  --actor-inset: auto 0 calc(50% - var(--header-height)) auto;
}
```

Docs are updated in https://github.com/getsentry/sentry-docs/pull/9961 to reflect the changed config/variable names too.

Some samples of different situations:
| Desc | Img |
| --- | --- |
| Normal | ![normal](https://github.com/getsentry/sentry-javascript/assets/187460/9223cf1f-9b4b-4bdc-b35a-65ccded71540)
| Short Window | ![short window](https://github.com/getsentry/sentry-javascript/assets/187460/5749a07a-ccb6-4c3c-909e-712cf5172f11)
| Screenshot editor | ![screenshot](https://github.com/getsentry/sentry-javascript/assets/187460/3a3bbbd0-c982-4d23-b0cf-d6f96ad2a7d1)
| Mobile landscape | ![mobile landscape](https://github.com/getsentry/sentry-javascript/assets/187460/aee7ca1f-c6a1-4555-9b07-0ff75aad93e2)
| Mobile portrait | ![mobile portrait](https://github.com/getsentry/sentry-javascript/assets/187460/c7c08261-8343-4498-9084-5432c6f1c60e)
| Override Color | ![colors override](https://github.com/getsentry/sentry-javascript/assets/187460/99d2ae92-58a0-49f0-982c-95b3e312a694)
