### PR TITLE
fix(aws-serverless): Remove invalid esm/import entry point in `package.json`

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -21,10 +21,6 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": {
-        "types": "./build/npm/types/index.d.ts",
-        "default": "./build/npm/esm/index.js"
-      },
       "require": {
         "types": "./build/npm/types/index.d.ts",
         "default": "./build/npm/cjs/index.js"


### PR DESCRIPTION
Looks like we intentionally removed the `esm` artifacts in our `@sentry/aws-serverless` package but still referenced them via the `import` entry point in the `package.json`. This PR removes the `import` entry for now until we have proper ESM support in the serverless package.

Full disclaimer: I'm not sure if this is the right way to go but the alternative (see comment below) feels wrong, too.

closes https://github.com/getsentry/sentry-javascript/issues/11965