### PR TITLE
feat(node): Log process and thread info on initialisation

### DIFF
--- a/packages/node/src/sdk/client.ts
+++ b/packages/node/src/sdk/client.ts
@@ -23,7 +23,9 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
 
     applySdkMetadata(clientOptions, 'node');
 
-    logger.log(`Initializing Sentry, pid: ${process.pid}, thread: ${isMainThread ? 'main' : `worker-${threadId}`}.`);
+    logger.log(
+      `Initializing Sentry: process: ${process.pid}, thread: ${isMainThread ? 'main' : `worker-${threadId}`}.`,
+    );
 
     super(clientOptions);
   }

--- a/packages/node/src/sdk/client.ts
+++ b/packages/node/src/sdk/client.ts
@@ -1,9 +1,11 @@
+import { isMainThread, threadId } from 'node:worker_threads';
 import * as os from 'os';
 import type { Tracer } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import type { ServerRuntimeClientOptions } from '@sentry/core';
 import { SDK_VERSION, ServerRuntimeClient, applySdkMetadata } from '@sentry/core';
+import { logger } from '@sentry/utils';
 import type { NodeClientOptions } from '../types';
 
 /** A client for using Sentry with Node & OpenTelemetry. */
@@ -20,6 +22,8 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
     };
 
     applySdkMetadata(clientOptions, 'node');
+
+    logger.log(`Initializing Sentry, pid: ${process.pid}, thread: ${isMainThread ? 'main' : `worker-${threadId}`}.`);
 
     super(clientOptions);
   }

--- a/packages/node/src/sdk/client.ts
+++ b/packages/node/src/sdk/client.ts
@@ -1,4 +1,3 @@
-import { isMainThread, threadId } from 'node:worker_threads';
 import * as os from 'os';
 import type { Tracer } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
@@ -6,6 +5,7 @@ import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import type { ServerRuntimeClientOptions } from '@sentry/core';
 import { SDK_VERSION, ServerRuntimeClient, applySdkMetadata } from '@sentry/core';
 import { logger } from '@sentry/utils';
+import { isMainThread, threadId } from 'worker_threads';
 import type { NodeClientOptions } from '../types';
 
 /** A client for using Sentry with Node & OpenTelemetry. */


### PR DESCRIPTION
Starting Sentry via `--require` and `--import` can cause the SDK to be initialised in every worker thread and forked process which can be confusing to users. With `debug: true` you can see the SDK being initialised multiple times but it's not immediately obvious why this is happening.

This PR adds logging to the `NodeClient` constructor that logs `Initializing Sentry` along with with the `process.pid` and `threadId` to make it a little more clear what's happening:

<img width="527" alt="image" src="https://github.com/getsentry/sentry-javascript/assets/1150298/cda6d153-6c4d-43f1-9be8-9c7f03e93805">



