### PR TITLE
fix(aws-serverless): Include ESM artifacts in package

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -11,6 +11,7 @@
   },
   "files": [
     "cjs",
+    "esm",
     "types",
     "types-ts3.8",
     "import-hook.mjs",


### PR DESCRIPTION
This PR fixes the `files` property in our AWS Serverless SDK `package.json` to include ESM artifacts now that we support ESM in AWS Serverless. 

(supersedes #11968)

closes #11965 