### PR TITLE
fix(browser): Only start `http.client` spans if there is an active parent span

### DIFF
--- a/packages/browser-utils/src/instrument/xhr.ts
+++ b/packages/browser-utils/src/instrument/xhr.ts
@@ -1,5 +1,6 @@
 import type { HandlerDataXhr, SentryWrappedXMLHttpRequest, WrappedFunction } from '@sentry/types';
 
+import { getActiveSpan } from '@sentry/core';
 import { addHandler, fill, isString, maybeInstrument, triggerHandlers } from '@sentry/utils';
 import { WINDOW } from '../metrics/types';
 

--- a/packages/browser-utils/src/instrument/xhr.ts
+++ b/packages/browser-utils/src/instrument/xhr.ts
@@ -1,6 +1,5 @@
 import type { HandlerDataXhr, SentryWrappedXMLHttpRequest, WrappedFunction } from '@sentry/types';
 
-import { getActiveSpan } from '@sentry/core';
 import { addHandler, fill, isString, maybeInstrument, triggerHandlers } from '@sentry/utils';
 import { WINDOW } from '../metrics/types';
 


### PR DESCRIPTION
We introduced sending standalone `http.client` spans in https://github.com/getsentry/sentry-javascript/pull/11783. Subsequently, we had to revert this change due to internal timeline problems (😢). However, in the revert PR (#11879) we missed that originally, we checked for an active parent span and only then created an `http.client` span. The result were `http.client` _transactions_ which we also don't want. This PR fixes that by re-introducing the `hasParent` check as it was pre-#11783.