### PR TITLE
fix(feedback): Check  for empty user

### DIFF
--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -5,11 +5,25 @@ import type {
   FeedbackFormData,
   FeedbackModalIntegration,
   IntegrationFn,
+  User,
 } from '@sentry/types';
 import { h, render } from 'preact';
 import { DOCUMENT } from '../constants';
 import { Dialog } from './components/Dialog';
 import { createDialogStyles } from './components/Dialog.css';
+
+function getUser(): User | undefined {
+  const currentUser = getCurrentScope().getUser();
+  const isolationUser = getIsolationScope().getUser();
+  const globalUser = getGlobalScope().getUser();
+  if (currentUser && Object.keys(currentUser).length) {
+    return currentUser;
+  }
+  if (isolationUser && Object.keys(isolationUser).length) {
+    return isolationUser;
+  }
+  return globalUser;
+}
 
 export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
   return {
@@ -19,7 +33,7 @@ export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
     createDialog: ({ options, screenshotIntegration, sendFeedback, shadow }: CreateDialogProps) => {
       const shadowRoot = shadow as unknown as ShadowRoot;
       const userKey = options.useSentryUser;
-      const user = getCurrentScope().getUser() || getIsolationScope().getUser() || getGlobalScope().getUser();
+      const user = getUser();
 
       const el = DOCUMENT.createElement('div');
       const style = createDialogStyles();


### PR DESCRIPTION
When getting the user from the scope, the user can also be an empty object, which doesn't work with null coalescing. This checks to see if the user exists and that it's not empty in all scopes

Fixes https://github.com/getsentry/sentry/issues/70347