### PR TITLE
fix(replay): Fix type for `replayCanvasIntegration`

### DIFF
--- a/packages/replay-canvas/src/canvas.ts
+++ b/packages/replay-canvas/src/canvas.ts
@@ -1,7 +1,11 @@
 import type { CanvasManagerInterface, CanvasManagerOptions } from '@sentry-internal/replay';
 import { CanvasManager } from '@sentry-internal/rrweb';
 import { defineIntegration } from '@sentry/core';
-import type { IntegrationFn } from '@sentry/types';
+import type { Integration, IntegrationFn } from '@sentry/types';
+
+interface ReplayCanvasIntegration extends Integration {
+  snapshot: (canvasElement?: HTMLCanvasElement) => Promise<void>;
+}
 
 interface ReplayCanvasOptions {
   enableManualSnapshot?: boolean;
@@ -107,9 +111,11 @@ export const _replayCanvasIntegration = ((options: Partial<ReplayCanvasOptions> 
       canvasManager.snapshot(canvasElement);
     },
   };
-}) satisfies IntegrationFn;
+}) satisfies IntegrationFn<ReplayCanvasIntegration>;
 
 /**
  * Add this in addition to `replayIntegration()` to enable canvas recording.
  */
-export const replayCanvasIntegration = defineIntegration(_replayCanvasIntegration);
+export const replayCanvasIntegration = defineIntegration(
+  _replayCanvasIntegration,
+) as IntegrationFn<ReplayCanvasIntegration>;

--- a/packages/replay-canvas/test/canvas.test.ts
+++ b/packages/replay-canvas/test/canvas.test.ts
@@ -1,5 +1,5 @@
 import { CanvasManager } from '@sentry-internal/rrweb';
-import { _replayCanvasIntegration } from '../src/canvas';
+import { _replayCanvasIntegration, replayCanvasIntegration } from '../src/canvas';
 
 jest.mock('@sentry-internal/rrweb');
 
@@ -85,4 +85,16 @@ it('enforces a max canvas size', () => {
       maxCanvasSize: [1280, 1280],
     }),
   );
+});
+
+it('has correct types', () => {
+  const rc = replayCanvasIntegration();
+
+  expect(typeof rc.snapshot).toBe('function');
+  const res = rc.snapshot();
+  expect(res).toBeInstanceOf(Promise);
+
+  // Function signature is correctly typed
+  const res2 = rc.snapshot(document.createElement('canvas'));
+  expect(res2).toBeInstanceOf(Promise);
 });


### PR DESCRIPTION
`snapshot` is a public API.

I think the other methods we do not need to expose (?).

With this, usage will be:

```ts
const canvas = getClient()?.getIntegrationByName<ReturnType<typeof replayCanvasIntegration>>('ReplayCanvas');
await canvas.snapshot();
```

Closes https://github.com/getsentry/sentry-javascript/issues/11971
