### PR TITLE
feat(serverless): Do not include performance integrations by default

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -16,6 +16,7 @@ const NODE_EXPORTS_IGNORE = [
   '__esModule',
   // Only required from the Node package
   'setNodeAsyncContextStrategy',
+  'getDefaultIntegrationsWithoutPerformance',
 ];
 
 const nodeExports = Object.keys(SentryNode).filter(e => !NODE_EXPORTS_IGNORE.includes(e));

--- a/packages/aws-serverless/src/awslambda-auto.ts
+++ b/packages/aws-serverless/src/awslambda-auto.ts
@@ -1,3 +1,4 @@
+import { getDefaultIntegrations as getNodeDefaultIntegrations } from '@sentry/node';
 import { init, tryPatchHandler } from './sdk';
 
 const lambdaTaskRoot = process.env.LAMBDA_TASK_ROOT;
@@ -7,7 +8,19 @@ if (lambdaTaskRoot) {
     throw Error(`LAMBDA_TASK_ROOT is non-empty(${lambdaTaskRoot}) but _HANDLER is not set`);
   }
 
-  init();
+  init({
+    // We want to load the performance integrations here, if the tracesSampleRate is set for the layer in env vars
+    // Sentry node's `getDefaultIntegrations` will load them if tracing is enabled,
+    // which is the case if `tracesSampleRate` is set.
+    // We can safely add all the node default integrations
+    integrations: getNodeDefaultIntegrations(
+      process.env.SENTRY_TRACES_SAMPLE_RATE
+        ? {
+            tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE),
+          }
+        : {},
+    ),
+  });
 
   tryPatchHandler(lambdaTaskRoot, handlerString);
 } else {

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -63,8 +63,8 @@ export interface WrapperOptions {
 /**
  * Get the default integrations for the AWSLambda SDK.
  */
- // NOTE: in awslambda-auto.ts, we also call the original `getDefaultIntegrations` from `@sentry/node` to load performance integrations.
- // If at some point we need to filter a node integration out for good, we need to make sure to also filter it out there.
+// NOTE: in awslambda-auto.ts, we also call the original `getDefaultIntegrations` from `@sentry/node` to load performance integrations.
+// If at some point we need to filter a node integration out for good, we need to make sure to also filter it out there.
 export function getDefaultIntegrations(_options: Options): Integration[] {
   return [...getDefaultIntegrationsWithoutPerformance(), awsIntegration(), awsLambdaIntegration()];
 }

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -10,7 +10,7 @@ import {
   continueTrace,
   flush,
   getCurrentScope,
-  getDefaultIntegrations as getNodeDefaultIntegrations,
+  getDefaultIntegrationsWithoutPerformance,
   init as initNode,
   startSpanManual,
   withScope,
@@ -61,8 +61,8 @@ export interface WrapperOptions {
 }
 
 /** Get the default integrations for the AWSLambda SDK. */
-export function getDefaultIntegrations(options: Options): Integration[] {
-  return [...getNodeDefaultIntegrations(options), awsIntegration(), awsLambdaIntegration()];
+export function getDefaultIntegrations(_options: Options): Integration[] {
+  return [...getDefaultIntegrationsWithoutPerformance(), awsIntegration(), awsLambdaIntegration()];
 }
 
 /**

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -62,9 +62,9 @@ export interface WrapperOptions {
 
 /**
  * Get the default integrations for the AWSLambda SDK.
- * NOTE: in awslambda-auto.ts, we also call the original `getDefaultIntegrations` from `@sentry/node` to load performance integrations.
- * If at some point we need to filter a node integration out for good, we need to make sure to also filter it out there.
  */
+ // NOTE: in awslambda-auto.ts, we also call the original `getDefaultIntegrations` from `@sentry/node` to load performance integrations.
+ // If at some point we need to filter a node integration out for good, we need to make sure to also filter it out there.
 export function getDefaultIntegrations(_options: Options): Integration[] {
   return [...getDefaultIntegrationsWithoutPerformance(), awsIntegration(), awsLambdaIntegration()];
 }

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -60,7 +60,11 @@ export interface WrapperOptions {
   startTrace: boolean;
 }
 
-/** Get the default integrations for the AWSLambda SDK. */
+/**
+ * Get the default integrations for the AWSLambda SDK.
+ * NOTE: in awslambda-auto.ts, we also call the original `getDefaultIntegrations` from `@sentry/node` to load performance integrations.
+ * If at some point we need to filter a node integration out for good, we need to make sure to also filter it out there.
+ */
 export function getDefaultIntegrations(_options: Options): Integration[] {
   return [...getDefaultIntegrationsWithoutPerformance(), awsIntegration(), awsLambdaIntegration()];
 }

--- a/packages/google-cloud-serverless/src/sdk.ts
+++ b/packages/google-cloud-serverless/src/sdk.ts
@@ -1,14 +1,14 @@
 import type { NodeOptions } from '@sentry/node';
-import { SDK_VERSION, getDefaultIntegrations as getDefaultNodeIntegrations, init as initNode } from '@sentry/node';
+import { SDK_VERSION, getDefaultIntegrationsWithoutPerformance, init as initNode } from '@sentry/node';
 import type { Integration, Options, SdkMetadata } from '@sentry/types';
 
 import { googleCloudGrpcIntegration } from './integrations/google-cloud-grpc';
 import { googleCloudHttpIntegration } from './integrations/google-cloud-http';
 
 /** Get the default integrations for the GCP SDK. */
-export function getDefaultIntegrations(options: Options): Integration[] {
+export function getDefaultIntegrations(_options: Options): Integration[] {
   return [
-    ...getDefaultNodeIntegrations(options),
+    ...getDefaultIntegrationsWithoutPerformance(),
     googleCloudHttpIntegration({ optional: true }), // We mark this integration optional since '@google-cloud/common' module could be missing.
     googleCloudGrpcIntegration({ optional: true }), // We mark this integration optional since 'google-gax' module could be missing.
   ];

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -26,7 +26,11 @@ export { koaIntegration, setupKoaErrorHandler } from './integrations/tracing/koa
 export { connectIntegration, setupConnectErrorHandler } from './integrations/tracing/connect';
 export { spotlightIntegration } from './integrations/spotlight';
 
-export { init, getDefaultIntegrations } from './sdk/init';
+export {
+  init,
+  getDefaultIntegrations,
+  getDefaultIntegrationsWithoutPerformance,
+} from './sdk/init';
 export { initOpenTelemetry } from './sdk/initOtel';
 export { getAutoPerformanceIntegrations } from './integrations/tracing';
 export { getSentryRelease, defaultStackParser } from './sdk/api';

--- a/packages/node/src/sdk/init.ts
+++ b/packages/node/src/sdk/init.ts
@@ -49,8 +49,10 @@ function getCjsOnlyIntegrations(): Integration[] {
   return isCjs() ? [modulesIntegration()] : [];
 }
 
-/** Get the default integrations for the Node Experimental SDK. */
-export function getDefaultIntegrations(options: Options): Integration[] {
+/**
+ * Get default integrations, excluding performance.
+ */
+export function getDefaultIntegrationsWithoutPerformance(): Integration[] {
   return [
     // Common
     inboundFiltersIntegration(),
@@ -69,6 +71,13 @@ export function getDefaultIntegrations(options: Options): Integration[] {
     localVariablesIntegration(),
     nodeContextIntegration(),
     ...getCjsOnlyIntegrations(),
+  ];
+}
+
+/** Get the default integrations for the Node SDK. */
+export function getDefaultIntegrations(options: Options): Integration[] {
+  return [
+    ...getDefaultIntegrationsWithoutPerformance(),
     ...(hasTracingEnabled(options) ? getAutoPerformanceIntegrations() : []),
   ];
 }

--- a/packages/node/src/sdk/init.ts
+++ b/packages/node/src/sdk/init.ts
@@ -192,10 +192,6 @@ function validateOpenTelemetrySetup(): void {
 }
 
 function getClientOptions(options: NodeOptions): NodeClientOptions {
-  if (options.defaultIntegrations === undefined) {
-    options.defaultIntegrations = getDefaultIntegrations(options);
-  }
-
   const release = getRelease(options.release);
 
   const autoSessionTracking =
@@ -218,6 +214,13 @@ function getClientOptions(options: NodeOptions): NodeClientOptions {
     autoSessionTracking,
     tracesSampleRate,
   });
+
+  if (options.defaultIntegrations === undefined) {
+    options.defaultIntegrations = getDefaultIntegrations({
+      ...options,
+      ...overwriteOptions,
+    });
+  }
 
   const clientOptions: NodeClientOptions = {
     ...baseOptions,


### PR DESCRIPTION
In order to keep bundle size compact, performance integrations (except for http & fetch) have to be manually added for serverless packages.

This means that users will have to do e.g. this if they want to have mysql instrumented:

```js
import * as Sentry from '@sentry/aws-serverless';

Sentry.init({
  integrations: [Sentry.mysqlIntegration()]
});
```

Closes https://github.com/getsentry/sentry-javascript/issues/11991
