### PR TITLE
fix(replay): Fix user activity not being updated in `start()`

### DIFF
--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -28,6 +28,7 @@ import { clearSession } from './session/clearSession';
 import { loadOrCreateSession } from './session/loadOrCreateSession';
 import { saveSession } from './session/saveSession';
 import { shouldRefreshSession } from './session/shouldRefreshSession';
+
 import type {
   AddEventResult,
   AddUpdateCallback,
@@ -294,6 +295,12 @@ export class ReplayContainer implements ReplayContainerInterface {
     }
 
     logInfoNextTick('[Replay] Starting replay in session mode', this._options._experiments.traceInternals);
+
+    // Required as user activity is initially set in
+    // constructor, so if `start()` is called after
+    // session idle expiration, a replay will not be
+    // created due to an idle timeout.
+    this._updateUserActivity();
 
     const session = loadOrCreateSession(
       {

--- a/packages/replay-internal/test/integration/start.test.ts
+++ b/packages/replay-internal/test/integration/start.test.ts
@@ -3,32 +3,21 @@ import { vi } from 'vitest';
 import { getClient } from '@sentry/core';
 import type { Transport } from '@sentry/types';
 
-import {
-  DEFAULT_FLUSH_MIN_DELAY,
-  MAX_REPLAY_DURATION,
-  SESSION_IDLE_EXPIRE_DURATION,
-  WINDOW,
-} from '../../src/constants';
+import { DEFAULT_FLUSH_MIN_DELAY, SESSION_IDLE_EXPIRE_DURATION } from '../../src/constants';
+import type { Replay } from '../../src/integration';
 import type { ReplayContainer } from '../../src/replay';
 import { BASE_TIMESTAMP } from '../index';
-import type { RecordMock } from '../mocks/mockRrweb';
 import { resetSdkMock } from '../mocks/resetSdkMock';
-import type { DomHandler } from '../types';
 import { useFakeTimers } from '../utils/use-fake-timers';
-import type { Replay } from '../../src/integration';
 
 useFakeTimers();
-
-const prevLocation = WINDOW.location;
 
 describe('Integration | start', () => {
   let replay: ReplayContainer;
   let integration: Replay;
-  let domHandler: DomHandler;
-  let mockRecord: RecordMock;
 
   beforeEach(async () => {
-    ({ mockRecord, domHandler, replay, integration } = await resetSdkMock({
+    ({ replay, integration } = await resetSdkMock({
       replayOptions: {
         stickySession: false,
       },
@@ -47,11 +36,6 @@ describe('Integration | start', () => {
 
     await vi.runAllTimersAsync();
     vi.setSystemTime(new Date(BASE_TIMESTAMP));
-
-    Object.defineProperty(WINDOW, 'location', {
-      value: prevLocation,
-      writable: true,
-    });
   });
 
   it('sends replay when calling `start()` after [SESSION_IDLE_EXPIRE_DURATION]ms', async () => {

--- a/packages/replay-internal/test/integration/start.test.ts
+++ b/packages/replay-internal/test/integration/start.test.ts
@@ -1,0 +1,68 @@
+import { vi } from 'vitest';
+
+import { getClient } from '@sentry/core';
+import type { Transport } from '@sentry/types';
+
+import {
+  DEFAULT_FLUSH_MIN_DELAY,
+  MAX_REPLAY_DURATION,
+  SESSION_IDLE_EXPIRE_DURATION,
+  WINDOW,
+} from '../../src/constants';
+import type { ReplayContainer } from '../../src/replay';
+import { BASE_TIMESTAMP } from '../index';
+import type { RecordMock } from '../mocks/mockRrweb';
+import { resetSdkMock } from '../mocks/resetSdkMock';
+import type { DomHandler } from '../types';
+import { useFakeTimers } from '../utils/use-fake-timers';
+import type { Replay } from '../../src/integration';
+
+useFakeTimers();
+
+const prevLocation = WINDOW.location;
+
+describe('Integration | start', () => {
+  let replay: ReplayContainer;
+  let integration: Replay;
+  let domHandler: DomHandler;
+  let mockRecord: RecordMock;
+
+  beforeEach(async () => {
+    ({ mockRecord, domHandler, replay, integration } = await resetSdkMock({
+      replayOptions: {
+        stickySession: false,
+      },
+      sentryOptions: {
+        replaysSessionSampleRate: 0.0,
+      },
+    }));
+
+    const mockTransport = getClient()?.getTransport()?.send as vi.MockedFunction<Transport['send']>;
+    mockTransport?.mockClear();
+    await vi.runAllTimersAsync();
+  });
+
+  afterEach(async () => {
+    integration.stop();
+
+    await vi.runAllTimersAsync();
+    vi.setSystemTime(new Date(BASE_TIMESTAMP));
+
+    Object.defineProperty(WINDOW, 'location', {
+      value: prevLocation,
+      writable: true,
+    });
+  });
+
+  it('sends replay when calling `start()` after [SESSION_IDLE_EXPIRE_DURATION]ms', async () => {
+    await vi.advanceTimersByTimeAsync(SESSION_IDLE_EXPIRE_DURATION + 1);
+
+    integration.start();
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_FLUSH_MIN_DELAY);
+
+    expect(replay).toHaveLastSentReplay({
+      recordingPayloadHeader: { segment_id: 0 },
+    });
+  });
+});


### PR DESCRIPTION
Replays will fail to start recording when using `start()` specifically when manually recording and after the user has been idle for a long period of time. We need to reset the user activity state when we call `start()`, otherwise the session will be [incorrectly] considered to be idle and unable to send any replay events.

Closes #11983
