### PR TITLE
test(node): Add test for express without tracing

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/without-tracing/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/server.ts
@@ -18,7 +18,7 @@ app.get('/test/isolationScope/:id', (req, res) => {
   const id = req.params.id;
   Sentry.setTag('isolation-scope', 'tag');
   Sentry.setTag(`isolation-scope-${id}`, id);
-  Sentry.setTag(`isolation-scope-transactionName`, `${Sentry.getIsolationScope().getScopeData().transactionName}`);
+  Sentry.setTag('isolation-scope-transactionName', `${Sentry.getIsolationScope().getScopeData().transactionName}`);
 
   Sentry.captureException(new Error('This is an exception'));
 

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/server.ts
@@ -1,0 +1,30 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+});
+
+import { startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
+import express from 'express';
+
+const app = express();
+
+Sentry.setTag('global', 'tag');
+
+app.get('/test/isolationScope/:id', (req, res) => {
+  const id = req.params.id;
+  Sentry.setTag('isolation-scope', 'tag');
+  Sentry.setTag(`isolation-scope-${id}`, id);
+  Sentry.setTag(`isolation-scope-transactionName`, `${Sentry.getIsolationScope().getScopeData().transactionName}`);
+
+  Sentry.captureException(new Error('This is an exception'));
+
+  res.send({});
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
@@ -4,7 +4,7 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('correctly applies isolation scope even without tracing', async () => {
+test('correctly applies isolation scope even without tracing', done => {
   const runner = createRunner(__dirname, 'server.ts')
     .ignore('session', 'sessions')
     .expect({
@@ -43,8 +43,7 @@ test('correctly applies isolation scope even without tracing', async () => {
         },
       },
     })
-    .start();
+    .start(done);
 
-  await runner.makeRequest('get', '/test/isolationScope/1');
-  await runner.makeRequest('get', '/test/isolationScope/2');
+  runner.makeRequest('get', '/test/isolationScope/1').then(() => runner.makeRequest('get', '/test/isolationScope/2'));
 });

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
@@ -1,0 +1,50 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+test('correctly applies isolation scope even without tracing', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
+    .ignore('session', 'sessions')
+    .expect({
+      event: {
+        tags: {
+          global: 'tag',
+          'isolation-scope': 'tag',
+          'isolation-scope-1': '1',
+          // We can't properly test non-existance of fields here, so we cast this to a string to test it here
+          'isolation-scope-transactionName': 'undefined',
+        },
+        // Request is correctly set
+        request: {
+          url: expect.stringContaining('/test/isolationScope/1'),
+          headers: {
+            'user-agent': expect.stringContaining(''),
+          },
+        },
+      },
+    })
+    .expect({
+      event: {
+        tags: {
+          global: 'tag',
+          'isolation-scope': 'tag',
+          'isolation-scope-2': '2',
+          // We can't properly test non-existance of fields here, so we cast this to a string to test it here
+          'isolation-scope-transactionName': 'undefined',
+        },
+        // Request is correctly set
+        request: {
+          url: expect.stringContaining('/test/isolationScope/2'),
+          headers: {
+            'user-agent': expect.stringContaining(''),
+          },
+        },
+      },
+    })
+    .start();
+
+  await runner.makeRequest('get', '/test/isolationScope/1');
+  await runner.makeRequest('get', '/test/isolationScope/2');
+});


### PR DESCRIPTION
Just to ensure we do not regress here.
Request isolation should work even without tracing (which means, even without the express integration added - that is only added when tracing is enabled, today!). 

Really, the only thing missing should be `transactionName`. 