### PR TITLE
feat(aws-serverless): Fix tree-shaking for aws-serverless package

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -211,8 +211,8 @@ module.exports = [
     gzip: true,
     limit: '180 KB',
   },
-   // AWS SDK (ESM)
-   {
+  // AWS SDK (ESM)
+  {
     name: '@sentry/aws-serverless',
     path: 'packages/aws-serverless/build/npm/esm/index.js',
     import: createImport('init'),

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -211,6 +211,33 @@ module.exports = [
     gzip: true,
     limit: '180 KB',
   },
+   // AWS SDK (ESM)
+   {
+    name: '@sentry/aws-serverless',
+    path: 'packages/aws-serverless/build/npm/esm/index.js',
+    import: createImport('init'),
+    ignore: [
+      'node:http',
+      'node:https',
+      'node:diagnostics_channel',
+      'async_hooks',
+      'child_process',
+      'perf_hooks',
+      'fs',
+      'os',
+      'path',
+      'inspector',
+      'worker_threads',
+      'http',
+      'stream',
+      'zlib',
+      'net',
+      'tls',
+      'module',
+    ],
+    gzip: true,
+    limit: '140 KB',
+  },
 ];
 
 function createImport(...args) {

--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -17,6 +17,7 @@ const NODE_EXPORTS_IGNORE = [
   // Only required from the Node package
   'setNodeAsyncContextStrategy',
   'getDefaultIntegrationsWithoutPerformance',
+  'initWithoutDefaultIntegrations',
 ];
 
 const nodeExports = Object.keys(SentryNode).filter(e => !NODE_EXPORTS_IGNORE.includes(e));

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -11,7 +11,7 @@ import {
   flush,
   getCurrentScope,
   getDefaultIntegrationsWithoutPerformance,
-  init as initNode,
+  initWithoutPerformance,
   startSpanManual,
   withScope,
 } from '@sentry/node';
@@ -93,7 +93,7 @@ export function init(options: NodeOptions = {}): void {
     version: SDK_VERSION,
   };
 
-  initNode(opts);
+  initWithoutPerformance(opts);
 }
 
 /** */

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -11,7 +11,7 @@ import {
   flush,
   getCurrentScope,
   getDefaultIntegrationsWithoutPerformance,
-  initWithoutPerformance,
+  initWithoutDefaultIntegrations,
   startSpanManual,
   withScope,
 } from '@sentry/node';
@@ -93,7 +93,7 @@ export function init(options: NodeOptions = {}): void {
     version: SDK_VERSION,
   };
 
-  initWithoutPerformance(opts);
+  initWithoutDefaultIntegrations(opts);
 }
 
 /** */

--- a/packages/aws-serverless/test/sdk.test.ts
+++ b/packages/aws-serverless/test/sdk.test.ts
@@ -24,7 +24,7 @@ jest.mock('@sentry/node', () => {
   const original = jest.requireActual('@sentry/node');
   return {
     ...original,
-    init: (options: unknown) => {
+    initWithoutDefaultIntegrations: (options: unknown) => {
       mockInit(options);
     },
     startInactiveSpan: (...args: unknown[]) => {

--- a/packages/node/rollup.npm.config.mjs
+++ b/packages/node/rollup.npm.config.mjs
@@ -23,11 +23,7 @@ export default [
         output: {
           // set exports to 'named' or 'auto' so that rollup doesn't warn
           exports: 'named',
-          // set preserveModules to false because we want to bundle everything into one file.
-          preserveModules:
-            process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-              ? false
-              : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+          preserveModules: true,
         },
         plugins: [
           replace({

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -30,6 +30,7 @@ export {
   init,
   getDefaultIntegrations,
   getDefaultIntegrationsWithoutPerformance,
+  initWithoutPerformance,
 } from './sdk/init';
 export { initOpenTelemetry } from './sdk/initOtel';
 export { getAutoPerformanceIntegrations } from './integrations/tracing';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -30,7 +30,7 @@ export {
   init,
   getDefaultIntegrations,
   getDefaultIntegrationsWithoutPerformance,
-  initWithoutPerformance,
+  initWithoutDefaultIntegrations,
 } from './sdk/init';
 export { initOpenTelemetry } from './sdk/initOtel';
 export { getAutoPerformanceIntegrations } from './integrations/tracing';

--- a/packages/node/src/sdk/init.ts
+++ b/packages/node/src/sdk/init.ts
@@ -88,7 +88,28 @@ declare const __IMPORT_META_URL_REPLACEMENT__: string;
  * Initialize Sentry for Node.
  */
 export function init(options: NodeOptions | undefined = {}): void {
+  return _init(options, getDefaultIntegrations);
+}
+
+/**
+ * Initialize Sentry for Node, without performance instrumentation.
+ */
+export function initWithoutPerformance(options: NodeOptions | undefined = {}): void {
+  return _init(options, getDefaultIntegrationsWithoutPerformance);
+}
+
+/**
+ * Initialize Sentry for Node, without performance instrumentation.
+ */
+function _init(
+  options: NodeOptions | undefined = {},
+  getDefaultIntegrationsImpl: (options: Options) => Integration[],
+): void {
   const clientOptions = getClientOptions(options);
+
+  if (options.defaultIntegrations === undefined) {
+    options.defaultIntegrations = getDefaultIntegrationsImpl(options);
+  }
 
   if (clientOptions.debug === true) {
     if (DEBUG_BUILD) {
@@ -214,13 +235,6 @@ function getClientOptions(options: NodeOptions): NodeClientOptions {
     autoSessionTracking,
     tracesSampleRate,
   });
-
-  if (options.defaultIntegrations === undefined) {
-    options.defaultIntegrations = getDefaultIntegrations({
-      ...options,
-      ...overwriteOptions,
-    });
-  }
 
   const clientOptions: NodeClientOptions = {
     ...baseOptions,


### PR DESCRIPTION
The prior fix was incomplete, because we were still using `getDefaultIntegrations()` inside of node's `init`, so the deps where pulled in anyhow.

Furthermore, it seems that `preserveModules: false` for `@sentry/node` also prevented this from working as expected.

So this PR does two things:

1. Set `preserveModules: true` so that tree-shaking can work as expected (😿 )
2. Expose a new `initWithoutDefaultIntegrations` method from `@sentry/node` which AWS uses, which avoids including any integrations by default. You have to pass your own `defaultIntegrations` to it.

This is not the prettiest solution, but I couldn't think of anything much better 😬 I also added a size-limit entry to keep track of this.