### PR TITLE
fix(react): Set dependency-injected functions as early as possible

### DIFF
--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -84,6 +84,14 @@ export function reactRouterV6BrowserTracingIntegration(
 
   return {
     ...integration,
+    setup() {
+      _useEffect = useEffect;
+      _useLocation = useLocation;
+      _useNavigationType = useNavigationType;
+      _matchRoutes = matchRoutes;
+      _createRoutesFromChildren = createRoutesFromChildren;
+      _stripBasename = stripBasename || false;
+    },
     afterAllSetup(client) {
       integration.afterAllSetup(client);
 
@@ -98,13 +106,6 @@ export function reactRouterV6BrowserTracingIntegration(
           },
         });
       }
-
-      _useEffect = useEffect;
-      _useLocation = useLocation;
-      _useNavigationType = useNavigationType;
-      _matchRoutes = matchRoutes;
-      _createRoutesFromChildren = createRoutesFromChildren;
-      _stripBasename = stripBasename || false;
 
       if (instrumentNavigation) {
         CLIENTS_WITH_INSTRUMENT_NAVIGATION.push(client);


### PR DESCRIPTION
Hoping that this may address https://github.com/getsentry/sentry-javascript/issues/12018

We should set these dependency-injections as early as possible.