### PR TITLE
fix(aws-serverless): Add `awslambda-auto` to `package.json` exports

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -40,6 +40,16 @@
       "import": {
         "default": "./build/loader-hook.mjs"
       }
+    },
+    "./awslambda-auto": {
+      "import": {
+        "default": "./build/npm/cjs/awslambda-auto.js"
+      }
+    },
+    "./dist/awslambda-auto": {
+      "require": {
+        "default": "./build/npm/cjs/awslambda-auto.js"
+      }
     }
   },
   "typesVersions": {

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -42,7 +42,7 @@
       }
     },
     "./awslambda-auto": {
-      "import": {
+      "require": {
         "default": "./build/npm/cjs/awslambda-auto.js"
       }
     },


### PR DESCRIPTION
In v7, the exports were not explicitly defined. In v8, the `awslambda-auto` export has to be added to the list of exports (done in this PR). Also added a variant without the `dist`, so it can be added to the `NODE_OPTIONS ` as `-r @sentry/aws-serverless/awslambda-auto`

fixes https://github.com/getsentry/sentry-javascript/issues/12012
