### PR TITLE
feat(scope): Bring back `lastEventId` on isolation scope (#11951)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -375,7 +375,7 @@ To make sure these integrations work properly you'll have to change how you
 ### General
 
 Removed top-level exports: `tracingOrigins`, `MetricsAggregator`, `metricsAggregatorIntegration`, `Severity`,
-`Sentry.configureScope`, `Span`, `spanStatusfromHttpCode`, `makeMain`, `lastEventId`, `pushScope`, `popScope`,
+`Sentry.configureScope`, `Span`, `spanStatusfromHttpCode`, `makeMain`, `pushScope`, `popScope`,
 `addGlobalEventProcessor`, `timestampWithMs`, `addExtensionMethods`, `addGlobalEventProcessor`, `getActiveTransaction`
 
 Removed `@sentry/utils` exports: `timestampWithMs`, `addOrUpdateIntegration`, `tracingContextFromHeaders`, `walk`
@@ -389,7 +389,6 @@ Removed `@sentry/utils` exports: `timestampWithMs`, `addOrUpdateIntegration`, `t
 - [Removal of `Span` class export from SDK packages](./MIGRATION.md#removal-of-span-class-export-from-sdk-packages)
 - [Removal of `spanStatusfromHttpCode` in favour of `getSpanStatusFromHttpCode`](./MIGRATION.md#removal-of-spanstatusfromhttpcode-in-favour-of-getspanstatusfromhttpcode)
 - [Removal of `addGlobalEventProcessor` in favour of `addEventProcessor`](./MIGRATION.md#removal-of-addglobaleventprocessor-in-favour-of-addeventprocessor)
-- [Removal of `lastEventId()` method](./MIGRATION.md#deprecate-lasteventid)
 - [Remove `void` from transport return types](./MIGRATION.md#remove-void-from-transport-return-types)
 - [Remove `addGlobalEventProcessor` in favor of `addEventProcessor`](./MIGRATION.md#remove-addglobaleventprocessor-in-favor-of-addeventprocessor)
 
@@ -567,10 +566,6 @@ Sentry.getGlobalScope().addEventProcessor(event => {
   return event;
 });
 ```
-
-#### Removal of `lastEventId()` method
-
-The `lastEventId` function has been removed. See [below](./MIGRATION.md#deprecate-lasteventid) for more details.
 
 #### Removal of `void` from transport return types
 
@@ -1569,7 +1564,7 @@ If you are using the `Hub` right now, see the following table on how to migrate 
 | captureException()     | `Sentry.captureException()`                                                          |
 | captureMessage()       | `Sentry.captureMessage()`                                                            |
 | captureEvent()         | `Sentry.captureEvent()`                                                              |
-| lastEventId()          | REMOVED - Use event processors or beforeSend instead                                 |
+| lastEventId()          | `Sentry.lastEventId()`                                                               |
 | addBreadcrumb()        | `Sentry.addBreadcrumb()`                                                             |
 | setUser()              | `Sentry.setUser()`                                                                   |
 | setTags()              | `Sentry.setTags()`                                                                   |
@@ -1690,35 +1685,6 @@ app.get('/your-route', req => {
 });
 ```
 
-## Deprecate `Sentry.lastEventId()` and `hub.lastEventId()`
-
-`Sentry.lastEventId()` sometimes causes race conditions, so we are deprecating it in favour of the `beforeSend`
-callback.
-
-```js
-// Before
-Sentry.init({
-  beforeSend(event, hint) {
-    const lastCapturedEventId = Sentry.lastEventId();
-
-    // Do something with `lastCapturedEventId` here
-
-    return event;
-  },
-});
-
-// After
-Sentry.init({
-  beforeSend(event, hint) {
-    const lastCapturedEventId = event.event_id;
-
-    // Do something with `lastCapturedEventId` here
-
-    return event;
-  },
-});
-```
-
 ## Deprecated fields on `Span` and `Transaction`
 
 In v8, the Span class is heavily reworked. The following properties & methods are thus deprecated:
@@ -1785,25 +1751,6 @@ Instead, import this directly from `@sentry/utils`.
 
 Generally, in most cases you should probably use `continueTrace` instead, which abstracts this away from you and handles
 scope propagation for you.
-
-## Deprecate `lastEventId()`
-
-Instead, if you need the ID of a recently captured event, we recommend using `beforeSend` instead:
-
-```ts
-import * as Sentry from '@sentry/browser';
-
-Sentry.init({
-  dsn: '__DSN__',
-  beforeSend(event, hint) {
-    const lastCapturedEventId = event.event_id;
-
-    // Do something with `lastCapturedEventId` here
-
-    return event;
-  },
-});
-```
 
 ## Deprecate `timestampWithMs` export - #7878
 

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -40,6 +40,7 @@ export {
   makeNodeTransport,
   getDefaultIntegrations,
   defaultStackParser,
+  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -35,6 +35,7 @@ export {
   makeNodeTransport,
   NodeClient,
   defaultStackParser,
+  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -28,6 +28,7 @@ export {
   captureMessage,
   close,
   createTransport,
+  lastEventId,
   flush,
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -55,6 +55,7 @@ export {
   makeNodeTransport,
   NodeClient,
   defaultStackParser,
+  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -650,6 +650,11 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
     this.emit('preprocessEvent', event, hint);
 
+    const eventId = event.event_id || hint.event_id;
+    if (eventId) {
+      isolationScope.setLastEventId(eventId);
+    }
+
     return prepareEvent(options, event, hint, currentScope, this, isolationScope).then(evt => {
       if (evt === null) {
         return evt;

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -650,9 +650,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
     this.emit('preprocessEvent', event, hint);
 
-    const eventId = event.event_id || hint.event_id;
-    if (eventId) {
-      isolationScope.setLastEventId(eventId);
+    if (!event.type) {
+      isolationScope.setLastEventId(event.event_id || hint.event_id);
     }
 
     return prepareEvent(options, event, hint, currentScope, this, isolationScope).then(evt => {

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -123,10 +123,10 @@ export function setUser(user: User | null): void {
 /**
  * The last error event id of the isolation scope.
  *
- * Warning: This function really returns the last recorded error event id on the current 
- * isolation scope.  If you call this function after handling a certain error and another error 
- * is captured in between, the last one is returned instead of the one you might expect. 
- * Also, ids of events that were never sent to Sentry (for example because 
+ * Warning: This function really returns the last recorded error event id on the current
+ * isolation scope. If you call this function after handling a certain error and another error
+ * is captured in between, the last one is returned instead of the one you might expect.
+ * Also, ids of events that were never sent to Sentry (for example because
  * they were dropped in `beforeSend`) could be returned.
  *
  * @returns The last event id of the isolation scope.

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -121,7 +121,14 @@ export function setUser(user: User | null): void {
 }
 
 /**
- * The last event id of the isolation scope.
+ * The last error event id of the isolation scope.
+ *
+ * Warning: This function really returns the last recorded error event id on the current 
+ * isolation scope.  If you call this function after handling a certain error and another error 
+ * is captured in between, the last one is returned instead of the one you might expect. 
+ * Also, ids of events that were never sent to Sentry (for example because 
+ * they were dropped in `beforeSend`) could be returned.
+ *
  * @returns The last event id of the isolation scope.
  */
 export function lastEventId(): string | undefined {

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -121,6 +121,14 @@ export function setUser(user: User | null): void {
 }
 
 /**
+ * The last event id of the isolation scope.
+ * @returns The last event id of the isolation scope.
+ */
+export function lastEventId(): string | undefined {
+  return getIsolationScope().lastEventId();
+}
+
+/**
  * Create a cron monitor check in and send it to Sentry.
  *
  * @param checkIn An object that describes a check in.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {
   captureException,
   captureEvent,
   captureMessage,
+  lastEventId,
   close,
   flush,
   setContext,

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -94,6 +94,9 @@ export class Scope implements ScopeInterface {
   /** The client on this scope */
   protected _client?: Client;
 
+  /** Contains the last event id of a captured event.  */
+  protected _lastEventId?: string;
+
   // NOTE: Any field which gets added here should get added not only to the constructor but also to the `clone` method.
 
   public constructor() {
@@ -130,6 +133,7 @@ export class Scope implements ScopeInterface {
     newScope._sdkProcessingMetadata = { ...this._sdkProcessingMetadata };
     newScope._propagationContext = { ...this._propagationContext };
     newScope._client = this._client;
+    newScope._lastEventId = this._lastEventId;
 
     _setSpanForScope(newScope, _getSpanForScope(this));
 
@@ -146,8 +150,22 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
+  public setLastEventId(lastEventId: string | undefined): void {
+    this._lastEventId = lastEventId;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public getClient<C extends Client>(): C | undefined {
     return this._client as C | undefined;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public lastEventId(): string | undefined {
+    return this._lastEventId;
   }
 
   /**

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,7 +1,15 @@
 import type { Client, Envelope, ErrorEvent, Event, TransactionEvent } from '@sentry/types';
 import { SentryError, SyncPromise, dsnToString, logger } from '@sentry/utils';
 
-import { Scope, addBreadcrumb, getCurrentScope, getIsolationScope, makeSession, setCurrentClient } from '../../src';
+import {
+  Scope,
+  addBreadcrumb,
+  getCurrentScope,
+  getIsolationScope,
+  lastEventId,
+  makeSession,
+  setCurrentClient,
+} from '../../src';
 import * as integrationModule from '../../src/integration';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 import { AdHocIntegration, TestIntegration } from '../mocks/integration';
@@ -226,7 +234,6 @@ describe('BaseClient', () => {
       const client = new TestClient(options);
 
       client.captureException(new Error('test exception'));
-
       expect(TestClient.instance!.event).toEqual(
         expect.objectContaining({
           environment: 'production',
@@ -242,6 +249,14 @@ describe('BaseClient', () => {
           timestamp: 2020,
         }),
       );
+    });
+
+    test('sets the correct lastEventId', () => {
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
+      const client = new TestClient(options);
+
+      const eventId = client.captureException(new Error('test exception'));
+      expect(eventId).toEqual(lastEventId());
     });
 
     test('allows for providing explicit scope', () => {
@@ -343,6 +358,14 @@ describe('BaseClient', () => {
       );
     });
 
+    test('sets the correct lastEventId', () => {
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
+      const client = new TestClient(options);
+
+      const eventId = client.captureMessage('test message');
+      expect(eventId).toEqual(lastEventId());
+    });
+
     test('should call `eventFromException` if input to `captureMessage` is not a primitive', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
@@ -442,6 +465,14 @@ describe('BaseClient', () => {
           timestamp: 2020,
         }),
       );
+    });
+
+    test('sets the correct lastEventId', () => {
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
+      const client = new TestClient(options);
+
+      const eventId = client.captureEvent({ message: 'message' }, undefined);
+      expect(eventId).toEqual(lastEventId());
     });
 
     test('does not overwrite existing timestamp', () => {

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -30,6 +30,7 @@ export {
   close,
   createTransport,
   continueTrace,
+  lastEventId,
   flush,
   getClient,
   isInitialized,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -35,6 +35,7 @@ export {
   makeNodeTransport,
   NodeClient,
   defaultStackParser,
+  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -56,6 +56,7 @@ export {
   addBreadcrumb,
   isInitialized,
   getGlobalScope,
+  lastEventId,
   close,
   createTransport,
   flush,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -43,6 +43,7 @@ export {
   makeNodeTransport,
   getDefaultIntegrations,
   defaultStackParser,
+  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -30,5 +30,6 @@ export declare const continueTrace: typeof clientSdk.continueTrace;
 
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
 export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;
+export const lastEventId = runtime === 'client' ? clientSdk.lastEventId : serverSdk.lastEventId;
 
 export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -48,6 +48,7 @@ export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
+export declare function lastEventId(): string | undefined;
 
 export declare const continueTrace: typeof clientSdk.continueTrace;
 

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -36,6 +36,7 @@ export {
   makeNodeTransport,
   getDefaultIntegrations,
   defaultStackParser,
+  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -60,6 +60,18 @@ export interface Scope {
   getClient<C extends Client>(): C | undefined;
 
   /**
+   * Sets the last event id on the scope.
+   * @param lastEventId The last event id of a captured event.
+   */
+  setLastEventId(lastEventId: string | undefined): void;
+
+  /**
+   * This is the getter for lastEventId.
+   * @returns The last event id of a captured event.
+   */
+  lastEventId(): string | undefined;
+
+  /**
    * Add internal on change listener. Used for sub SDKs that need to store the scope.
    * @hidden
    */

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -30,6 +30,7 @@ export {
   captureFeedback,
   close,
   createTransport,
+  lastEventId,
   flush,
   getClient,
   isInitialized,


### PR DESCRIPTION
As discussed, we'll keep it simple and set the event id regardless of the event getting dropped.

A follow-up PR will update `ReportDialogOptions` to make `eventId` optional again as well as use the isolation scope directly in React ErrorBoundaries.