### PR TITLE
feat(browser): Add `interactionsSampleRate` to `browserTracingIntegration` options

### DIFF
--- a/packages/browser-utils/src/metrics/inp.ts
+++ b/packages/browser-utils/src/metrics/inp.ts
@@ -17,10 +17,10 @@ import { getBrowserPerformanceAPI, msToSec } from './utils';
 /**
  * Start tracking INP webvital events.
  */
-export function startTrackingINP(): () => void {
+export function startTrackingINP(interactionsSampleRate: number): () => void {
   const performance = getBrowserPerformanceAPI();
   if (performance && browserPerformanceTimeOrigin) {
-    const inpCallback = _trackINP();
+    const inpCallback = _trackINP(interactionsSampleRate);
 
     return (): void => {
       inpCallback();
@@ -60,8 +60,16 @@ const INP_ENTRY_MAP: Record<string, 'click' | 'hover' | 'drag' | 'press'> = {
 };
 
 /** Starts tracking the Interaction to Next Paint on the current page. */
-function _trackINP(): () => void {
+function _trackINP(interactionsSampleRate: number): () => void {
   return addInpInstrumentationHandler(({ metric }) => {
+    // As specified in the `interactionsSampleRate` option, the sampling decision shall be based on
+    // `tracesSampleRate` x `interactionsSampleRate`
+    // This is the same as sampling here first on `interactionsSampleRate` and later again on `tracesSampleRate`
+    // (which is done in `startInactiveSpan`). Doing it this way is easier and more bundle-size efficient.
+    if (Math.random() > interactionsSampleRate) {
+      return;
+    }
+
     const client = getClient();
     if (!client || metric.value == undefined) {
       return;

--- a/packages/browser/test/unit/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/unit/tracing/browserTracingIntegration.test.ts
@@ -36,6 +36,8 @@ import {
 } from '../../../src/tracing/browserTracingIntegration';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
 
+import * as browserUtils from '@sentry-internal/browser-utils';
+
 // We're setting up JSDom here because the Next.js routing instrumentations requires a few things to be present on pageload:
 // 1. Access to window.document API for `window.document.getElementById`
 // 2. Access to window.location API for `window.location.pathname`
@@ -996,6 +998,28 @@ describe('browserTracingIntegration', () => {
       expect(spans).toHaveLength(2);
       expect(spans[1]).toBe(idleSpan);
     });
+  });
+
+  describe('INP - interactionsSampleRate', () => {
+    const startTrackingInpSpy = jest.spyOn(browserUtils, 'startTrackingINP');
+
+    it('sets interactionsSampleRate to 1 by default', () => {
+      browserTracingIntegration();
+      expect(startTrackingInpSpy).toHaveBeenCalledWith(1);
+    });
+
+    it.each([0, 0.5, 1])('passes on user-defined interactionsSampleRate', interactionsSampleRate => {
+      browserTracingIntegration({ interactionsSampleRate });
+      expect(startTrackingInpSpy).toHaveBeenCalledWith(interactionsSampleRate);
+    });
+
+    it.each([-1, 1.1, NaN, Infinity])(
+      'falls back to 100% when receiving an invalid interactionsSampleRate',
+      interactionsSampleRate => {
+        browserTracingIntegration({ interactionsSampleRate });
+        expect(startTrackingInpSpy).toHaveBeenCalledWith(1);
+      },
+    );
   });
 
   // TODO(lforst): I cannot manage to get this test to pass.


### PR DESCRIPTION
This PR forward-ports the `interactionsSampleRate` option for `browserTracingIntegration` introduced in 7.110.0 to v8. Looks like we missed this when forward-porting the INP implementation as reported in #12006, probably because these two things happened in parallel.

Generally, this PR orients itself on https://github.com/getsentry/sentry-javascript/pull/11382 but I made a couple of changes (that are not API-breaking):

- In v7 we used to sample the span completely manually. In v8 we no longer do this after migrating to using `startInactiveSpan` with `standalone: true`. This function internally samples the span based on `tracesSampleRate` and the usual sampling controlling SDK options. In an effort to keep things simple, I opted to simply sample twice - once on `interactionsSampleRate` and afterwards on `tracesSampleRate`. Unless my basic math skills left me, this should lead to the same outcome as sampling once on `interactionsSampleRate * tracesSampleRate`. 
- In case users set invalid sample rates, we'll fall back to the default value which for v8 is 100%/`1`. In v7, we discarded all INP spans in case of an invalid rate but given we switched defaults for recording and sending INP spans I think we're fine with defaulting to 100%. 

Gonna tag @edwardgou-sentry please also take a look 🙏 

closes #12006