### PR TITLE
ref(core): Steamline `parseSampleRate` utility function

### DIFF
--- a/packages/core/src/utils/parseSampleRate.ts
+++ b/packages/core/src/utils/parseSampleRate.ts
@@ -14,19 +14,13 @@ export function parseSampleRate(sampleRate: unknown): number | undefined {
   }
 
   const rate = typeof sampleRate === 'string' ? parseFloat(sampleRate) : sampleRate;
-  if (typeof rate !== 'number' || isNaN(rate)) {
+  if (typeof rate !== 'number' || isNaN(rate) || rate < 0 || rate > 1) {
     DEBUG_BUILD &&
       logger.warn(
         `[Tracing] Given sample rate is invalid. Sample rate must be a boolean or a number between 0 and 1. Got ${JSON.stringify(
           sampleRate,
         )} of type ${JSON.stringify(typeof sampleRate)}.`,
       );
-    return undefined;
-  }
-
-  if (rate < 0 || rate > 1) {
-    DEBUG_BUILD &&
-      logger.warn(`[Tracing] Given sample rate is invalid. Sample rate must be between 0 and 1. Got ${rate}.`);
     return undefined;
   }
 


### PR DESCRIPTION
Just noticed that there's not really a reason to have the two separate warnings. Let's save some bytes. 
(we have tests covering this change)