### PR TITLE
feat(replay): Upgrade rrweb packages to 2.16.0

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,14 +22,14 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration'),
     gzip: true,
-    limit: '70 KB',
+    limit: '75 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - with treeshaking flags',
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration'),
     gzip: true,
-    limit: '65 KB',
+    limit: '70 KB',
     modifyWebpackConfig: function (config) {
       const webpack = require('webpack');
       config.plugins.push(
@@ -48,14 +48,14 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'replayCanvasIntegration'),
     gzip: true,
-    limit: '75 KB',
+    limit: '80 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'feedbackIntegration'),
     gzip: true,
-    limit: '87 KB',
+    limit: '92 KB',
   },
   {
     name: '@sentry/browser (incl. Feedback)',
@@ -133,13 +133,13 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Replay)',
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: true,
-    limit: '70 KB',
+    limit: '75 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback)',
     path: createCDNPath('bundle.tracing.replay.feedback.min.js'),
     gzip: true,
-    limit: '86 KB',
+    limit: '91 KB',
   },
   // browser CDN bundles (non-gzipped)
   {
@@ -161,14 +161,14 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: false,
     brotli: false,
-    limit: '220 KB',
+    limit: '225 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback) - uncompressed',
     path: createCDNPath('bundle.tracing.replay.feedback.min.js'),
     gzip: false,
     brotli: false,
-    limit: '264 KB',
+    limit: '270 KB',
   },
   // Next.js SDK (ESM)
   {

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -69,7 +69,7 @@
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@sentry-internal/rrweb": "2.15.0"
+    "@sentry-internal/rrweb": "2.16.0"
   },
   "dependencies": {
     "@sentry-internal/replay": "8.3.0",

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -72,8 +72,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "8.3.0",
-    "@sentry-internal/rrweb": "2.15.0",
-    "@sentry-internal/rrweb-snapshot": "2.15.0",
+    "@sentry-internal/rrweb": "2.16.0",
+    "@sentry-internal/rrweb-snapshot": "2.16.0",
     "fflate": "^0.8.1",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6913,22 +6913,22 @@
   dependencies:
     "@sentry-internal/rrweb-snapshot" "2.11.0"
 
-"@sentry-internal/rrdom@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.15.0.tgz#1ac070a7a00664b2c5351c8ba13979369024128a"
-  integrity sha512-LDy2LbmEytIuV9vKTr2dK4iMCTTFTpNW/eJ6IoapB0syYBc4yuUsbH39s/gamxcR5Y7KjkySSh0XkMnCHyV5gg==
+"@sentry-internal/rrdom@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.16.0.tgz#37e6bf93e11e97be3aecbc60e9b2d4123f00853c"
+  integrity sha512-Yrj1pmC4u+C0k5WSrcVYAv0d4djfHRq+4ChlzKrqOw7ne3MF+1FmaFNb3sYngcNNc5IIjB9EjC3m5XXN+ZZqSw==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.15.0"
+    "@sentry-internal/rrweb-snapshot" "2.16.0"
 
 "@sentry-internal/rrweb-snapshot@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.11.0.tgz#1af79130604afea989d325465b209ac015b27c9a"
   integrity sha512-1nP22QlplMNooSNvTh+L30NSZ+E3UcfaJyxXSMLxUjQHTGPyM1VkndxZMmxlKhyR5X+rLbxi/+RvuAcpM43VoA==
 
-"@sentry-internal/rrweb-snapshot@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.15.0.tgz#04c79d3dc723ed80e4f10685d5ebc6c1b90fcf1b"
-  integrity sha512-g/gqzKab6lQ/YvioIXVWQTaQXrUctepqIgXP7vYvpnU+ZmxmsOVd10gQuryDCSLYt2wQiwkffYyeaP2BVqxbwQ==
+"@sentry-internal/rrweb-snapshot@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.16.0.tgz#12795bc9a02f61531837d1f76e9f0891b22b72b0"
+  integrity sha512-+IjnzGo9HpIsn4mqgZFp5ZprmCXsevvDboVaGiDAwr4V6OBg7lnDJKe7/8sRgc+k6cC+g+xTJN9SkVmM6kI63Q==
 
 "@sentry-internal/rrweb-types@2.11.0":
   version "2.11.0"
@@ -6937,12 +6937,12 @@
   dependencies:
     "@sentry-internal/rrweb-snapshot" "2.11.0"
 
-"@sentry-internal/rrweb-types@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.15.0.tgz#caeabffc227405110946447f30893aa037493b23"
-  integrity sha512-D3i9+G4h6gLlG/B1lkP3jc3pM84hP2d2WFGrapTBI0bJou822ERD3Wj9KBVPEkwsRM+qDZRqRMrq0PicdAqJAA==
+"@sentry-internal/rrweb-types@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.16.0.tgz#38cfb019afbbce79047302691f16dbb9ceb8e4b7"
+  integrity sha512-fXt/g1Yff7VA8eLlVdrcQzH4M5XZZuHcADbntLRAY4CoJSZUiHnmHcWHg1rgTjeikle0xEZdJdx/8ScX+nxUpA==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.15.0"
+    "@sentry-internal/rrweb-snapshot" "2.16.0"
 
 "@sentry-internal/rrweb@2.11.0":
   version "2.11.0"
@@ -6958,14 +6958,14 @@
     fflate "^0.4.4"
     mitt "^3.0.0"
 
-"@sentry-internal/rrweb@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.15.0.tgz#a38dff464624c7ab421579b5ec626007e10c9da8"
-  integrity sha512-WO2QJJMJYVcuc8aq6j4YEzNo512FZ2Ro7/04Ip1MYhPI4BpHhn3KI7lRoHvprZeVNYWXyBtiPy7JFehuVCppdw==
+"@sentry-internal/rrweb@2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.16.0.tgz#44e8540fa6eca3a349aaac335dbbd3f8b0375ca1"
+  integrity sha512-KXYifPRjwL7Od8cX2xbFIgiGKKmuAXkmeHg2TTubCfcpeMdXeQYdAAl9Cfrx0t9Fs3NzGrckVUX7gk5bogYoRg==
   dependencies:
-    "@sentry-internal/rrdom" "2.15.0"
-    "@sentry-internal/rrweb-snapshot" "2.15.0"
-    "@sentry-internal/rrweb-types" "2.15.0"
+    "@sentry-internal/rrdom" "2.16.0"
+    "@sentry-internal/rrweb-snapshot" "2.16.0"
+    "@sentry-internal/rrweb-types" "2.16.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
Pulls in rest of upstream rrweb patches up to https://github.com/rrweb-io/rrweb/commit/ae6908dcdcd7c732c1ce79eea19de5240bec1151

See https://github.com/getsentry/rrweb/pull/189