### PR TITLE
ref(api): Remove `lastEventId` deprecation warnings (#11951)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -256,7 +256,7 @@ If you are using the `Hub` right now, see the following table on how to migrate 
 | captureException()     | `Sentry.captureException()`                                                          |
 | captureMessage()       | `Sentry.captureMessage()`                                                            |
 | captureEvent()         | `Sentry.captureEvent()`                                                              |
-| lastEventId()          | REMOVED - Use event processors or beforeSend instead                                 |
+| lastEventId()          | `Sentry.lastEventId()`                                                               |
 | addBreadcrumb()        | `Sentry.addBreadcrumb()`                                                             |
 | setUser()              | `Sentry.setUser()`                                                                   |
 | setTags()              | `Sentry.setTags()`                                                                   |
@@ -381,36 +381,6 @@ app.get('/your-route', req => {
 });
 ```
 
-## Deprecate `Sentry.lastEventId()` and `hub.lastEventId()`
-
-`Sentry.lastEventId()` sometimes causes race conditions, so we are deprecating it in favour of the `beforeSend`
-callback.
-
-```js
-// Before
-
-Sentry.init({
-  beforeSend(event, hint) {
-    const lastCapturedEventId = Sentry.lastEventId();
-
-    // Do something with `lastCapturedEventId` here
-
-    return event;
-  },
-});
-
-// After
-Sentry.init({
-  beforeSend(event, hint) {
-    const lastCapturedEventId = event.event_id;
-
-    // Do something with `lastCapturedEventId` here
-
-    return event;
-  },
-});
-```
-
 ## Deprecated fields on `Span` and `Transaction`
 
 In v8, the Span class is heavily reworked. The following properties & methods are thus deprecated:
@@ -477,25 +447,6 @@ Instead, import this directly from `@sentry/utils`.
 
 Generally, in most cases you should probably use `continueTrace` instead, which abstracts this away from you and handles
 scope propagation for you.
-
-## Deprecate `lastEventId()`
-
-Instead, if you need the ID of a recently captured event, we recommend using `beforeSend` instead:
-
-```ts
-import * as Sentry from '@sentry/browser';
-
-Sentry.init({
-  dsn: '__DSN__',
-  beforeSend(event, hint) {
-    const lastCapturedEventId = event.event_id;
-
-    // Do something with `lastCapturedEventId` here
-
-    return event;
-  },
-});
-```
 
 ## Deprecate `timestampWithMs` export - #7878
 
@@ -621,7 +572,7 @@ This is no longer used.
 
 ## Deprecate @sentry/hub (since 7.15.0) - #5823
 
-This release deprecates `@sentry/hub` and all of it's exports. All of the `@sentry/hub` exports have moved to
+This release deprecates `@sentry/hub` and all of its exports. All of the `@sentry/hub` exports have moved to
 `@sentry/core`. `@sentry/hub` will be removed in the next major release.
 
 # Upgrading Sentry Replay (beta, 7.24.0)

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -61,7 +61,6 @@ export {
   defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   flush,
   close,

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -26,10 +26,6 @@ export declare const defaultStackParser: StackParser;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
-
-/**
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
- */
 export declare function lastEventId(): string | undefined;
 
 export default sentryAstro;

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -44,7 +44,6 @@ export {
   getCurrentScope,
   // eslint-disable-next-line deprecation/deprecation
   Hub,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   // eslint-disable-next-line deprecation/deprecation
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -198,8 +198,6 @@ export const showReportDialog: ShowReportDialogFunction = (
     };
   }
 
-  // TODO(v8): Remove this entire if statement. `eventId` will be a required option.
-  // eslint-disable-next-line deprecation/deprecation
   if (!options.eventId) {
     // eslint-disable-next-line deprecation/deprecation
     options.eventId = hub.lastEventId();

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -51,7 +51,6 @@ export {
   getIsolationScope,
   // eslint-disable-next-line deprecation/deprecation
   Hub,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   // eslint-disable-next-line deprecation/deprecation
   makeMain,

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -387,7 +387,6 @@ export async function close(timeout?: number): Promise<boolean> {
  * This is the getter for lastEventId.
  *
  * @returns The last event id of a captured event.
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
  */
 export function lastEventId(): string | undefined {
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,6 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   configureScope,
   flush,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   // eslint-disable-next-line deprecation/deprecation
   startTransaction,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -50,7 +50,6 @@ export {
   getIsolationScope,
   // eslint-disable-next-line deprecation/deprecation
   Hub,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   // eslint-disable-next-line deprecation/deprecation
   makeMain,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -36,7 +36,6 @@ export {
   captureMessage,
   addGlobalEventProcessor,
   addEventProcessor,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   setContext,
   setExtra,

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -99,10 +99,8 @@ export function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T
 
 /**
  * Get the ID of the last sent error event.
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
  */
 export function lastEventId(): string | undefined {
-  // eslint-disable-next-line deprecation/deprecation
   return getCurrentScope().lastEventId();
 }
 

--- a/packages/node-experimental/src/sdk/types.ts
+++ b/packages/node-experimental/src/sdk/types.ts
@@ -32,9 +32,6 @@ export interface Scope extends BaseScope {
   isolationScope: typeof this | undefined;
   // @ts-expect-error typeof this is what we want here
   clone(scope?: Scope): typeof this;
-  /**
-   * @deprecated This function will be removed in the next major version of the Sentry SDK.
-   */
   lastEventId(): string | undefined;
   getScopeData(): ScopeData;
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -50,7 +50,6 @@ export {
   getIsolationScope,
   // eslint-disable-next-line deprecation/deprecation
   Hub,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   // eslint-disable-next-line deprecation/deprecation
   makeMain,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -65,7 +65,6 @@ export {
   defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   flush,
   close,

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -30,9 +30,4 @@ declare const runtime: 'client' | 'server';
 
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
 export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;
-
-/**
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
- */
-// eslint-disable-next-line deprecation/deprecation
 export const lastEventId = runtime === 'client' ? clientSdk.lastEventId : serverSdk.lastEventId;

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -66,7 +66,6 @@ export {
   flush,
   getSentryRelease,
   init,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   DEFAULT_USER_INCLUDES,
   addRequestDataToEvent,

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -49,8 +49,4 @@ export declare const defaultStackParser: StackParser;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
-
-/**
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
- */
 export declare function lastEventId(): string | undefined;

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -59,7 +59,6 @@ export {
   defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   flush,
   close,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -50,7 +50,6 @@ export {
   getIsolationScope,
   // eslint-disable-next-line deprecation/deprecation
   Hub,
-  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   // eslint-disable-next-line deprecation/deprecation
   makeMain,


### PR DESCRIPTION
The `lastEventId` api will be brought back in v8 in the near future.