### PR TITLE
build(v7): Ensure we do not mark as `latest` on npm

### DIFF
--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -12,7 +12,8 @@
   "main": "build/bundles/sentry-angular.umd.js",
   "module": "build/fesm2015/sentry-angular.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "peerDependencies": {
     "@angular/common": ">= 12.x <= 17.x",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -12,7 +12,8 @@
   "main": "build/bundles/sentry-angular.umd.js",
   "module": "build/fesm2015/sentry-angular.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "peerDependencies": {
     "@angular/common": ">= 10.x <= 15.x",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -43,7 +43,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "peerDependencies": {
     "astro": ">=3.x || >=4.0.0-beta"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry-internal/feedback": "7.114.0",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/core": "7.114.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/types": "7.114.0",

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -9,7 +9,8 @@
   "module": "build/index.mjs",
   "types": "build/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "files": [
     "index.mjs",

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -10,7 +10,8 @@
     "ember-addon"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "directories": {
     "doc": "doc",

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -19,7 +19,8 @@
   ],
   "main": "src/index.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry-internal/eslint-plugin-sdk": "7.114.0",

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -19,7 +19,8 @@
   ],
   "main": "src/index.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "requireindex": "~1.1.0"

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/core": "7.114.0",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -34,7 +34,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/core": "7.114.0",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/core": "7.114.0",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -10,7 +10,8 @@
     "node": ">=8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "files": [
     "cjs",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -21,7 +21,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@rollup/plugin-commonjs": "24.0.0",

--- a/packages/node-experimental/package.json
+++ b/packages/node-experimental/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@opentelemetry/api": "1.7.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry-internal/tracing": "7.114.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/core": "7.114.0",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/core": "7.114.0",

--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -22,7 +22,8 @@
     "node": ">=8.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "files": [
     "lib",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/browser": "7.114.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -31,7 +31,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@remix-run/router": "1.x",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -42,7 +42,8 @@
     "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push --sig"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "repository": {
     "type": "git",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/core": "7.114.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/browser": "7.114.0",

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -31,7 +31,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "peerDependencies": {
     "@sveltejs/kit": "1.x || 2.x"

--- a/packages/tracing-internal/package.json
+++ b/packages/tracing-internal/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/core": "7.114.0",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry-internal/tracing": "7.114.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "files": [
     "tsconfig.json"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/types": "7.114.0"

--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry-internal/tracing": "7.114.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/browser": "7.114.0",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -26,7 +26,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v7"
   },
   "dependencies": {
     "@sentry/browser": "7.114.0",


### PR DESCRIPTION
Instead, we'll tag everything as `v7` now, so 8.x remains `latest`.