### PR TITLE
fix(browser): Use consistent timestamps

### DIFF
--- a/packages/browser-utils/src/instrument/xhr.ts
+++ b/packages/browser-utils/src/instrument/xhr.ts
@@ -1,6 +1,6 @@
 import type { HandlerDataXhr, SentryWrappedXMLHttpRequest, WrappedFunction } from '@sentry/types';
 
-import { addHandler, fill, isString, maybeInstrument, triggerHandlers } from '@sentry/utils';
+import { addHandler, fill, isString, maybeInstrument, timestampInSeconds, triggerHandlers } from '@sentry/utils';
 import { WINDOW } from '../metrics/types';
 
 export const SENTRY_XHR_DATA_KEY = '__sentry_xhr_v3__';
@@ -31,7 +31,7 @@ export function instrumentXHR(): void {
 
   fill(xhrproto, 'open', function (originalOpen: () => void): () => void {
     return function (this: XMLHttpRequest & SentryWrappedXMLHttpRequest, ...args: unknown[]): void {
-      const startTimestamp = Date.now();
+      const startTimestamp = timestampInSeconds() * 1000;
 
       // open() should always be called with two or more arguments
       // But to be on the safe side, we actually validate this and bail out if we don't have a method & url
@@ -71,7 +71,7 @@ export function instrumentXHR(): void {
           }
 
           const handlerData: HandlerDataXhr = {
-            endTimestamp: Date.now(),
+            endTimestamp: timestampInSeconds() * 1000,
             startTimestamp,
             xhr: this,
           };
@@ -124,7 +124,7 @@ export function instrumentXHR(): void {
       }
 
       const handlerData: HandlerDataXhr = {
-        startTimestamp: Date.now(),
+        startTimestamp: timestampInSeconds() * 1000,
         xhr: this,
       };
       triggerHandlers('xhr', handlerData);

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -12,7 +12,14 @@ import type {
   StackParser,
   ThreadCpuProfile,
 } from '@sentry/types';
-import { GLOBAL_OBJ, browserPerformanceTimeOrigin, forEachEnvelopeItem, logger, uuid4 } from '@sentry/utils';
+import {
+  GLOBAL_OBJ,
+  browserPerformanceTimeOrigin,
+  forEachEnvelopeItem,
+  logger,
+  timestampInSeconds,
+  uuid4,
+} from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../helpers';
@@ -152,8 +159,8 @@ export function createProfilePayload(
     ? start_timestamp
     : typeof event.start_timestamp === 'number'
       ? event.start_timestamp * 1000
-      : Date.now();
-  const transactionEndMs = typeof event.timestamp === 'number' ? event.timestamp * 1000 : Date.now();
+      : timestampInSeconds() * 1000;
+  const transactionEndMs = typeof event.timestamp === 'number' ? event.timestamp * 1000 : timestampInSeconds() * 1000;
 
   const profile: Profile = {
     event_id: profile_id,

--- a/packages/core/src/integrations/sessiontiming.ts
+++ b/packages/core/src/integrations/sessiontiming.ts
@@ -1,15 +1,16 @@
 import type { IntegrationFn } from '@sentry/types';
+import { timestampInSeconds } from '@sentry/utils';
 import { defineIntegration } from '../integration';
 
 const INTEGRATION_NAME = 'SessionTiming';
 
 const _sessionTimingIntegration = (() => {
-  const startTime = Date.now();
+  const startTime = timestampInSeconds() * 1000;
 
   return {
     name: INTEGRATION_NAME,
     processEvent(event) {
-      const now = Date.now();
+      const now = timestampInSeconds() * 1000;
 
       return {
         ...event,

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -3,6 +3,7 @@ import type { HandlerDataFetch } from '@sentry/types';
 
 import { fill } from '../object';
 import { supportsNativeFetch } from '../supports';
+import { timestampInSeconds } from '../time';
 import { GLOBAL_OBJ } from '../worldwide';
 import { addHandler, maybeInstrument, triggerHandlers } from './handlers';
 
@@ -37,7 +38,7 @@ function instrumentFetch(): void {
           method,
           url,
         },
-        startTimestamp: Date.now(),
+        startTimestamp: timestampInSeconds() * 1000,
       };
 
       triggerHandlers('fetch', {
@@ -49,7 +50,7 @@ function instrumentFetch(): void {
         (response: Response) => {
           const finishedHandlerData: HandlerDataFetch = {
             ...handlerData,
-            endTimestamp: Date.now(),
+            endTimestamp: timestampInSeconds() * 1000,
             response,
           };
 
@@ -59,7 +60,7 @@ function instrumentFetch(): void {
         (error: Error) => {
           const erroredHandlerData: HandlerDataFetch = {
             ...handlerData,
-            endTimestamp: Date.now(),
+            endTimestamp: timestampInSeconds() * 1000,
             error,
           };
 


### PR DESCRIPTION
In some places we used `Date.now()`, instead of `timestampInSeconds()` which used performance.now().

There are still other places where we use `Date.now()`, esp. in replay and node, but I focused on regular browser stuff for now (because this is most likely to be affected by this).