### PR TITLE
feat(browser): Improve idle span handling

### DIFF
--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -129,15 +129,17 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
     const latestSpanEndTimestamp = childEndTimestamps.length ? Math.max(...childEndTimestamps) : undefined;
 
     const spanEndTimestamp = spanTimeInputToSeconds(timestamp);
+    // In reality this should always exist here, but type-wise it may be undefined...
     const spanStartTimestamp = spanToJSON(span).start_timestamp;
 
     // The final endTimestamp should:
     // * Never be before the span start timestamp
     // * Be the latestSpanEndTimestamp, if there is one, and it is smaller than the passed span end timestamp
     // * Otherwise be the passed end timestamp
-    const endTimestamp = Math.max(
-      spanStartTimestamp || -Infinity,
-      Math.min(spanEndTimestamp, latestSpanEndTimestamp || Infinity),
+    // Final timestamp can never be after finalTimeout
+    const endTimestamp = Math.min(
+      spanStartTimestamp ? spanStartTimestamp + finalTimeout / 1000 : Infinity,
+      Math.max(spanStartTimestamp || -Infinity, Math.min(spanEndTimestamp, latestSpanEndTimestamp || Infinity)),
     );
 
     span.end(endTimestamp);
@@ -248,6 +250,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
 
     const childSpans = getSpanDescendants(span).filter(child => child !== span);
 
+    let discardedSpans = 0;
     childSpans.forEach(childSpan => {
       // We cancel all pending spans with status "cancelled" to indicate the idle span was finished early
       if (childSpan.isRecording()) {
@@ -277,8 +280,13 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
 
       if (!spanEndedBeforeFinalTimeout || !spanStartedBeforeIdleSpanEnd) {
         removeChildSpanFromSpan(span, childSpan);
+        discardedSpans++;
       }
     });
+
+    if (discardedSpans > 0) {
+      span.setAttribute('sentry.idle_span_discarded_spans', discardedSpans);
+    }
   }
 
   client.on('spanStart', startedSpan => {

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -240,7 +240,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
     }
 
     const attributes: SpanAttributes = spanJSON.data || {};
-    if (spanJSON.op === 'ui.action.click' && !attributes[SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]) {
+    if (!attributes[SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]) {
       span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON, _finishReason);
     }
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/12051

This PR does two things:

1. Ensures we add helpful attributes to idle spans more consistently. We now add the `sentry.idle_span_finish_reason` attribute always for idle spans, not only when op == `ui.action.click`. This should also make it easier to debug stuff etc, and I see no reason to not always set this. Additionally, we also keep the number of spans we discarded (if any) for easier debugging too (as `sentry.idle_span_discarded_spans`).
2. We ensure that idle spans cannot exceed the configured `finalTimeout`. Previously, due to the order of things, it was possible that we ended a span very late, if it had a child span with a very late end timestamp (as we took the last child span timestamp). Possibly this could lead to overly long transactions.

I think 2, combined with the fact that later we _do_ filter out child spans that ended after idle span, lead to the incorrect-length spans.