### PR TITLE
fix(core): Avoid looking up client for `hasTracingEnabled()` if possible

### DIFF
--- a/packages/core/src/utils/hasTracingEnabled.ts
+++ b/packages/core/src/utils/hasTracingEnabled.ts
@@ -16,7 +16,11 @@ export function hasTracingEnabled(
     return false;
   }
 
-  const client = getClient();
-  const options = maybeOptions || (client && client.getOptions());
+  const options = maybeOptions || getClientOptions();
   return !!options && (options.enableTracing || 'tracesSampleRate' in options || 'tracesSampler' in options);
+}
+
+function getClientOptions(): Options | undefined {
+  const client = getClient();
+  return client && client.getOptions();
 }


### PR DESCRIPTION
This is a bit weird in that we access the current scope & client etc., even if options are passed. Since we also use this method in `init()` before we have setup stuff, it seems safer to avoid calling this at all if possible.

This is related to https://github.com/getsentry/sentry-javascript/issues/12054, but not really the cause of it.