### PR TITLE
fix(core): Export Scope interface as `Scope`

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -34,7 +34,7 @@ const DEFAULT_MAX_BREADCRUMBS = 100;
 /**
  * Holds additional event information.
  */
-export class Scope implements ScopeInterface {
+class ScopeClass implements ScopeInterface {
   /** Flag if notifying is happening. */
   protected _notifyingListeners: boolean;
 
@@ -116,8 +116,8 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public clone(): Scope {
-    const newScope = new Scope();
+  public clone(): ScopeClass {
+    const newScope = new ScopeClass();
     newScope._breadcrumbs = [...this._breadcrumbs];
     newScope._tags = { ...this._tags };
     newScope._extra = { ...this._extra };
@@ -586,6 +586,20 @@ export class Scope implements ScopeInterface {
     }
   }
 }
+
+// NOTE: By exporting this here as const & type, instead of doing `export class`,
+// We can get the correct class when importing from `@sentry/core`, but the original type (from `@sentry/types`)
+// This is helpful for interop, e.g. when doing `import type { Scope } from '@sentry/node';` (which re-exports this)
+
+/**
+ * Holds additional event information.
+ */
+export const Scope = ScopeClass;
+
+/**
+ * Holds additional event information.
+ */
+export type Scope = ScopeInterface;
 
 function generatePropagationContext(): PropagationContext {
   return {

--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -985,4 +985,15 @@ describe('withIsolationScope()', () => {
       done();
     });
   });
+
+  it('Scope type is equal to Scope from @sentry/types', () => {
+    // We pass the Scope _class_ here to the callback,
+    // Which actually is typed as using the Scope from @sentry/types
+    // This should not TS-error, as we export the type from core as well
+    const scope = withScope((scope: Scope) => {
+      return scope;
+    });
+
+    expect(scope).toBeDefined();
+  });
 });


### PR DESCRIPTION
To make interop with e.g. importing `Scope` from `@sentry/node` easier.

Closes https://github.com/getsentry/sentry-javascript/issues/12053