### PR TITLE
meta: Fix changelog script

### DIFF
--- a/scripts/get-commit-list.ts
+++ b/scripts/get-commit-list.ts
@@ -3,11 +3,19 @@ import { execSync } from 'child_process';
 function run(): void {
   const commits = execSync('git log --format="- %s"').toString().split('\n');
 
-  const lastReleasePos = commits.findIndex(commit => commit.includes("Merge branch 'release"));
+  const lastReleasePos = commits.findIndex(commit => /- meta(.*)changelog/i.test(commit));
 
   const newCommits = commits.splice(0, lastReleasePos).filter(commit => {
-    // Filter out master/develop merges
-    if (/Merge pull request #(\d+) from getsentry\/(master|develop)/.test(commit)) {
+    // Filter out merge commits
+    if (/Merge pull request/.test(commit)) {
+      return false;
+    }
+    // Filter release branch merged
+    if (/Merge branch/.test(commit)) {
+      return false;
+    }
+    // Filter release commit itself
+    if (/release:/.test(commit)) {
       return false;
     }
 


### PR DESCRIPTION
Actually we should check for the changelog commit, which we look for by checking `-meta` and `changelog` in the commit message. (Not perfect, but good enough hopefully...)

I noticed it was not correctly picking up all commits while a release was in progress before.