### PR TITLE
ref(sveltekit): Emit warning to delete source maps if Sentry plugin enabled source maps generation

### DIFF
--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -239,10 +239,6 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
       };
     }
 
-    if (!sentryVitePluginsOptions.sourcemaps?.filesToDeleteAfterUpload) {
-      console.warn('');
-    }
-
     const sentryVitePlugins = await makeCustomSentryVitePlugins(sentryVitePluginsOptions);
 
     sentryPlugins.push(...sentryVitePlugins);

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -239,6 +239,10 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
       };
     }
 
+    if (!sentryVitePluginsOptions.sourcemaps?.filesToDeleteAfterUpload) {
+      console.warn('');
+    }
+
     const sentryVitePlugins = await makeCustomSentryVitePlugins(sentryVitePluginsOptions);
 
     sentryPlugins.push(...sentryVitePlugins);

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -103,8 +103,18 @@ export async function makeCustomSentryVitePlugins(options?: CustomSentryVitePlug
 
     // Modify the config to generate source maps
     config: config => {
-      // eslint-disable-next-line no-console
-      debug && console.log('[Source Maps Plugin] Enabeling source map generation');
+      const sourceMapsPreviouslyEnabled = !config.build?.sourcemap;
+      if (debug && sourceMapsPreviouslyEnabled) {
+        // eslint-disable-next-line no-console
+        console.log('[Source Maps Plugin] Enabeling source map generation');
+        if (!mergedOptions.sourcemaps?.filesToDeleteAfterUpload) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[Source Maps Plugin] We recommend setting the \`sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload\` option to clean up source maps after uploading.
+[Source Maps Plugin] Otherwise, source maps might be deployed to production, depending on your configuration`,
+          );
+        }
+      }
       return {
         ...config,
         build: {


### PR DESCRIPTION
Adresses https://github.com/getsentry/sentry-javascript/issues/8260#issuecomment-2113620033. Now we can at least recommend to use `filesToDeleteAfterUpload` since we bumped to vite plugin 2.x with 8.0.0

realistically, this also

closes https://github.com/getsentry/sentry-javascript/issues/8260