### PR TITLE
fix(aws-serverless): Fix build of lambda layer

### DIFF
--- a/packages/aws-serverless/rollup.aws.config.mjs
+++ b/packages/aws-serverless/rollup.aws.config.mjs
@@ -15,6 +15,7 @@ export default [
           sourcemap: false,
         },
       },
+      preserveModules: false,
     }),
     // We only need one copy of the SDK, and we pick the minified one because there's a cap on how big a lambda function
     // plus its dependencies can be, and we might as well take up as little of that space as is necessary. We'll rename

--- a/packages/aws-serverless/src/awslambda-auto.ts
+++ b/packages/aws-serverless/src/awslambda-auto.ts
@@ -1,5 +1,4 @@
-import { getDefaultIntegrations as getNodeDefaultIntegrations } from '@sentry/node';
-import { init, tryPatchHandler } from './sdk';
+import * as Sentry from './index';
 
 const lambdaTaskRoot = process.env.LAMBDA_TASK_ROOT;
 if (lambdaTaskRoot) {
@@ -8,12 +7,12 @@ if (lambdaTaskRoot) {
     throw Error(`LAMBDA_TASK_ROOT is non-empty(${lambdaTaskRoot}) but _HANDLER is not set`);
   }
 
-  init({
+  Sentry.init({
     // We want to load the performance integrations here, if the tracesSampleRate is set for the layer in env vars
     // Sentry node's `getDefaultIntegrations` will load them if tracing is enabled,
     // which is the case if `tracesSampleRate` is set.
     // We can safely add all the node default integrations
-    integrations: getNodeDefaultIntegrations(
+    integrations: Sentry.getDefaultIntegrations(
       process.env.SENTRY_TRACES_SAMPLE_RATE
         ? {
             tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE),
@@ -22,7 +21,7 @@ if (lambdaTaskRoot) {
     ),
   });
 
-  tryPatchHandler(lambdaTaskRoot, handlerString);
+  Sentry.tryPatchHandler(lambdaTaskRoot, handlerString);
 } else {
   throw Error('LAMBDA_TASK_ROOT environment variable is not set');
 }


### PR DESCRIPTION
We previously adjusted our lambda layer auto initialization in https://github.com/getsentry/sentry-javascript/pull/12017. This unfortunately changed the build output of the `awslambda-auto` bootstrapping script which required a package that isn't included in the layer (`@sentry/node`). This PR fixes the `awslambda-auto` file; local testing showed no more imports from `@sentry/node`.

fixes https://github.com/getsentry/sentry-javascript/issues/12074