### PR TITLE
fix(core): Add dsn to span envelope header

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -110,9 +110,13 @@ export function createSpanEnvelope(spans: SentrySpan[], client?: Client): SpanEn
   // different segments in one envelope
   const dsc = getDynamicSamplingContextFromSpan(spans[0]);
 
+  const dsn = client && client.getDsn();
+  const tunnel = client && client.getOptions().tunnel;
+
   const headers: SpanEnvelope[0] = {
     sent_at: new Date().toISOString(),
     ...(dscHasRequiredProps(dsc) && { trace: dsc }),
+    ...(!!tunnel && dsn && { dsn: dsnToString(dsn) }),
   };
 
   const beforeSendSpan = client && client.getOptions().beforeSendSpan;

--- a/packages/core/test/lib/envelope.test.ts
+++ b/packages/core/test/lib/envelope.test.ts
@@ -144,6 +144,32 @@ describe('createSpanEnvelope', () => {
     });
   });
 
+  it('adds `dsn` envelope header if tunnel is enabled', () => {
+    const options = getDefaultTestClientOptions({ dsn: 'https://username@domain/123', tunnel: 'http://tunnel' });
+    const client = new TestClient(options);
+
+    const spanEnvelope = createSpanEnvelope(
+      [new SentrySpan({ name: 'test', attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom' } })],
+      client,
+    );
+
+    const spanEnvelopeHeaders = spanEnvelope[0];
+    expect(spanEnvelopeHeaders.dsn).toEqual('https://username@domain/123');
+  });
+
+  it('does not add `dsn` envelope header if tunnel is not enabled', () => {
+    const options = getDefaultTestClientOptions({ dsn: 'https://username@domain/123' });
+    const client = new TestClient(options);
+
+    const spanEnvelope = createSpanEnvelope(
+      [new SentrySpan({ name: 'test', attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom' } })],
+      client,
+    );
+
+    const spanEnvelopeHeaders = spanEnvelope[0];
+    expect(spanEnvelopeHeaders.dsn).toBeUndefined();
+  });
+
   it("doesn't add a `trace` envelope header if there's no public key", () => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 1, dsn: 'https://domain/123' });
     client = new TestClient(options);


### PR DESCRIPTION
This was forgotten/got lost while we migrated this from v7 to v8. Now, adding the dsn again when the tunnel is enabled.

Fixes https://github.com/getsentry/sentry-javascript/issues/12094