### PR TITLE
feat(node): Do not create GraphQL resolver spans by default

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
@@ -16,19 +16,6 @@ describe('GraphQL/Apollo Tests', () => {
           status: 'ok',
           origin: 'auto.graphql.otel.graphql',
         }),
-        expect.objectContaining({
-          data: {
-            'graphql.field.name': 'hello',
-            'graphql.field.path': 'hello',
-            'graphql.field.type': 'String',
-            'graphql.source': 'hello',
-            'otel.kind': 'INTERNAL',
-            'sentry.origin': 'manual',
-          },
-          description: 'graphql.resolve hello',
-          status: 'ok',
-          origin: 'manual',
-        }),
       ]),
     };
 

--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -5,13 +5,34 @@ import type { IntegrationFn } from '@sentry/types';
 
 import { addOriginToSpan } from '../../utils/addOriginToSpan';
 
-const _graphqlIntegration = (() => {
+interface GraphqlOptions {
+  /** Do not create spans for resolvers. */
+  ignoreResolveSpans?: boolean;
+
+  /**
+   * Don't create spans for the execution of the default resolver on object properties.
+   *
+   * When a resolver function is not defined on the schema for a field, graphql will
+   * use the default resolver which just looks for a property with that name on the object.
+   * If the property is not a function, it's not very interesting to trace.
+   * This option can reduce noise and number of spans created.
+   */
+  ignoreTrivalResolveSpans?: boolean;
+}
+
+const _graphqlIntegration = ((_options: GraphqlOptions = {}) => {
+  const options = {
+    ignoreResolveSpans: true,
+    ignoreTrivialResolveSpans: true,
+    ..._options,
+  };
+
   return {
     name: 'Graphql',
     setupOnce() {
       addOpenTelemetryInstrumentation(
         new GraphQLInstrumentation({
-          ignoreTrivialResolveSpans: true,
+          ...options,
           responseHook(span) {
             addOriginToSpan(span, 'auto.graphql.otel.graphql');
           },


### PR DESCRIPTION
Users can pass `ignoreResolveSpans` and `ignoreTrivalResolveSpans` to the integration now, which is passed to the instrumentation. They default to `true`. This should reduce noise and perf overhead.

Closes https://github.com/getsentry/sentry-javascript/issues/12092