### PR TITLE
docs: Add migration docs to point out that default import does not work

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1323,6 +1323,14 @@ export class HeaderComponent {
 }
 ```
 
+## 6. Build Changes
+
+We now provide a proper ESM output of the SDK. There have also been some other build changes under the hood. One side
+effect of this is that importing Sentry as a default import does not work anymore. Note that this was never supported
+(even on v7) and this was never intended to work (and also not documented anywhere). However, it seems that for some
+configuration combinations, it was still possible to do `import Sentry from '@sentry/browser'`. This is not possible
+anymore in v8. Please use `import * as Sentry from '@sentry/browser'` instead.
+
 # Upgrading Sentry Feedback (beta, 7.x to 8.0)
 
 For details on upgrading Feedback from the beta 7.x to the release 8.x version, please view the


### PR DESCRIPTION
It was brought up https://github.com/getsentry/sentry-javascript/issues/12013 that importing Sentry as a default import is not working anymore in v8. While this was never officially supported (and also not "removed" on purpose, it just seemed to have worked incidentally before), I do not really consider this a "breaking change", but, as pointed out in the issue, it is still helpful to point this out in the migration docs, for users who incidentally did this before.

We should also add this to migration docs on docs.sentry.io.