### PR TITLE
fix(feedback): Set optionOverrides to be optional in TS definition

### DIFF
--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -55,9 +55,9 @@ export const buildFeedbackIntegration = ({
   getScreenshotIntegration,
 }: BuilderOptions): IntegrationFn<
   Integration & {
-    attachTo(el: Element | string, optionOverrides: OverrideFeedbackConfiguration): Unsubscribe;
-    createForm(optionOverrides: OverrideFeedbackConfiguration): Promise<FeedbackDialog>;
-    createWidget(optionOverrides: OverrideFeedbackConfiguration): ActorComponent;
+    attachTo(el: Element | string, optionOverrides?: OverrideFeedbackConfiguration): Unsubscribe;
+    createForm(optionOverrides?: OverrideFeedbackConfiguration): Promise<FeedbackDialog>;
+    createWidget(optionOverrides?: OverrideFeedbackConfiguration): ActorComponent;
     remove(): void;
   }
 > => {


### PR DESCRIPTION
These params are optional, to the TS typedef should align with that.

**Before:**
<img width="1008" alt="SCR-20240520-ltyb" src="https://github.com/getsentry/sentry-javascript/assets/187460/8d242640-f67a-406d-a963-9b40fea1de54">


**After:**
<img width="1089" alt="SCR-20240520-ltvg" src="https://github.com/getsentry/sentry-javascript/assets/187460/71d98556-9151-4146-8de9-6504e22d4731">

Related to https://github.com/getsentry/sentry-javascript/issues/12015