### PR TITLE
fix(nextjs): Don't put `undefined` values in props

### DIFF
--- a/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
@@ -56,10 +56,20 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
         }
 
         if (requestSpan) {
-          appGetInitialProps.pageProps._sentryTraceData = spanToTraceHeader(requestSpan);
+          const sentryTrace = spanToTraceHeader(requestSpan);
+
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (sentryTrace) {
+            appGetInitialProps.pageProps._sentryTraceData = sentryTrace;
+          }
+
           const dynamicSamplingContext = getDynamicSamplingContextFromSpan(requestSpan);
-          appGetInitialProps.pageProps._sentryBaggage =
-            dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
+          const baggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
+
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (baggage) {
+            appGetInitialProps.pageProps._sentryBaggage = baggage;
+          }
         }
 
         return appGetInitialProps;

--- a/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
@@ -49,10 +49,20 @@ export function wrapErrorGetInitialPropsWithSentry(
         const requestSpan = getSpanFromRequest(req) ?? (activeSpan ? getRootSpan(activeSpan) : undefined);
 
         if (requestSpan) {
-          errorGetInitialProps._sentryTraceData = spanToTraceHeader(requestSpan);
+          const sentryTrace = spanToTraceHeader(requestSpan);
+
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (sentryTrace) {
+            errorGetInitialProps._sentryTraceData = sentryTrace;
+          }
 
           const dynamicSamplingContext = getDynamicSamplingContextFromSpan(requestSpan);
-          errorGetInitialProps._sentryBaggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
+          const baggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
+
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (baggage) {
+            errorGetInitialProps._sentryBaggage = baggage;
+          }
         }
 
         return errorGetInitialProps;

--- a/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
@@ -45,10 +45,20 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
         const requestSpan = getSpanFromRequest(req) ?? (activeSpan ? getRootSpan(activeSpan) : undefined);
 
         if (requestSpan) {
-          initialProps._sentryTraceData = spanToTraceHeader(requestSpan);
+          const sentryTrace = spanToTraceHeader(requestSpan);
+
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (sentryTrace) {
+            initialProps._sentryTraceData = sentryTrace;
+          }
 
           const dynamicSamplingContext = getDynamicSamplingContextFromSpan(requestSpan);
-          initialProps._sentryBaggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
+          const baggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
+
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (baggage) {
+            initialProps._sentryBaggage = baggage;
+          }
         }
 
         return initialProps;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/12102

Next.js seems to employ a custom serializer that doesn't like `undefined` values. This PR will guard the undefined values.