### PR TITLE
fix(nextjs): Fix legacy configuration method detection for emitting warning

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -420,7 +420,7 @@ function warnAboutDeprecatedConfigFiles(projectDir: string, platform: 'server' |
 
       return (
         instrumentationHookContent.includes('@sentry/') ||
-        instrumentationHookContent.match(/sentry\.(server|edge)\.config\.(ts|js)/)
+        instrumentationHookContent.match(/sentry\.(server|edge)\.config(\.(ts|js))?/)
       );
     } catch (e) {
       return false;


### PR DESCRIPTION
Our logic to detect whether the user used the legacy way of initializing the sdk had a flaw because the heuristic to check whether the user has an instrumentation file with sentry config was matching for `sentry.server.config.ts` instead of `sentry.server.config`, which would be the way users import their config files.