### PR TITLE
fix(node): Ensure fetch/http breadcrumbs are created correctly

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/scenario.ts
@@ -1,0 +1,33 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  integrations: [],
+  transport: loggingTransport,
+  // Ensure this gets a correct hint
+  beforeBreadcrumb(breadcrumb, hint) {
+    breadcrumb.data = breadcrumb.data || {};
+    const req = hint?.request as { path?: string };
+    breadcrumb.data.ADDED_PATH = req?.path;
+    return breadcrumb;
+  },
+});
+
+async function run(): Promise<void> {
+  Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+
+  // Since fetch is lazy loaded, we need to wait a bit until it's fully instrumented
+  await new Promise(resolve => setTimeout(resolve, 100));
+  await fetch(`${process.env.SERVER_URL}/api/v0`).then(res => res.text());
+  await fetch(`${process.env.SERVER_URL}/api/v1`).then(res => res.text());
+  await fetch(`${process.env.SERVER_URL}/api/v2`).then(res => res.text());
+  await fetch(`${process.env.SERVER_URL}/api/v3`).then(res => res.text());
+
+  Sentry.captureException(new Error('foo'));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/test.ts
@@ -1,0 +1,79 @@
+import { conditionalTest } from '../../../../utils';
+import { createRunner } from '../../../../utils/runner';
+import { createTestServer } from '../../../../utils/server';
+
+conditionalTest({ min: 18 })('outgoing fetch', () => {
+  test('outgoing fetch requests create breadcrumbs', done => {
+    createTestServer(done)
+      .start()
+      .then(SERVER_URL => {
+        createRunner(__dirname, 'scenario.ts')
+          .withEnv({ SERVER_URL })
+          .ensureNoErrorOutput()
+          .ignore('session', 'sessions')
+          .expect({
+            event: {
+              breadcrumbs: [
+                {
+                  message: 'manual breadcrumb',
+                  timestamp: expect.any(Number),
+                },
+                {
+                  category: 'http',
+                  data: {
+                    'http.method': 'GET',
+                    url: `${SERVER_URL}/api/v0`,
+                    status_code: 404,
+                    ADDED_PATH: '/api/v0',
+                  },
+                  timestamp: expect.any(Number),
+                  type: 'http',
+                },
+                {
+                  category: 'http',
+                  data: {
+                    'http.method': 'GET',
+                    url: `${SERVER_URL}/api/v1`,
+                    status_code: 404,
+                    ADDED_PATH: '/api/v1',
+                  },
+                  timestamp: expect.any(Number),
+                  type: 'http',
+                },
+                {
+                  category: 'http',
+                  data: {
+                    'http.method': 'GET',
+                    url: `${SERVER_URL}/api/v2`,
+                    status_code: 404,
+                    ADDED_PATH: '/api/v2',
+                  },
+                  timestamp: expect.any(Number),
+                  type: 'http',
+                },
+                {
+                  category: 'http',
+                  data: {
+                    'http.method': 'GET',
+                    url: `${SERVER_URL}/api/v3`,
+                    status_code: 404,
+                    ADDED_PATH: '/api/v3',
+                  },
+                  timestamp: expect.any(Number),
+                  type: 'http',
+                },
+              ],
+              exception: {
+                values: [
+                  {
+                    type: 'Error',
+                    value: 'foo',
+                  },
+                ],
+              },
+            },
+          })
+          .start(done);
+      });
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/scenario.ts
@@ -1,0 +1,48 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  integrations: [],
+  transport: loggingTransport,
+  // Ensure this gets a correct hint
+  beforeBreadcrumb(breadcrumb, hint) {
+    breadcrumb.data = breadcrumb.data || {};
+    const req = hint?.request as { path?: string };
+    breadcrumb.data.ADDED_PATH = req?.path;
+    return breadcrumb;
+  },
+});
+
+import * as http from 'http';
+
+async function run(): Promise<void> {
+  Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v0`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v1`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v2`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v3`);
+
+  Sentry.captureException(new Error('foo'));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+run();
+
+function makeHttpRequest(url: string): Promise<void> {
+  return new Promise<void>(resolve => {
+    http
+      .request(url, httpRes => {
+        httpRes.on('data', () => {
+          // we don't care about data
+        });
+        httpRes.on('end', () => {
+          resolve();
+        });
+      })
+      .end();
+  });
+}

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/test.ts
@@ -1,0 +1,76 @@
+import { createRunner } from '../../../../utils/runner';
+import { createTestServer } from '../../../../utils/server';
+
+test('outgoing http requests create breadcrumbs', done => {
+  createTestServer(done)
+    .start()
+    .then(SERVER_URL => {
+      createRunner(__dirname, 'scenario.ts')
+        .withEnv({ SERVER_URL })
+        .ensureNoErrorOutput()
+        .ignore('session', 'sessions')
+        .expect({
+          event: {
+            breadcrumbs: [
+              {
+                message: 'manual breadcrumb',
+                timestamp: expect.any(Number),
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v0`,
+                  status_code: 404,
+                  ADDED_PATH: '/api/v0',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v1`,
+                  status_code: 404,
+                  ADDED_PATH: '/api/v1',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v2`,
+                  status_code: 404,
+                  ADDED_PATH: '/api/v2',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v3`,
+                  status_code: 404,
+                  ADDED_PATH: '/api/v3',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+            ],
+            exception: {
+              values: [
+                {
+                  type: 'Error',
+                  value: 'foo',
+                },
+              ],
+            },
+          },
+        })
+        .start(done);
+    });
+});

--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -44,11 +44,11 @@ const _nativeNodeFetchIntegration = ((options: NodeFetchOptions = {}) => {
           const url = request.origin;
           return _ignoreOutgoingRequests && url && _ignoreOutgoingRequests(url);
         },
-        onRequest: ({ span }: { span: Span }) => {
+        onRequest: ({ span, request }: { span: Span; request: unknown }) => {
           _updateSpan(span);
 
           if (_breadcrumbs) {
-            _addRequestBreadcrumb(span);
+            _addRequestBreadcrumb(span, request);
           }
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -80,17 +80,23 @@ function _updateSpan(span: Span): void {
 }
 
 /** Add a breadcrumb for outgoing requests. */
-function _addRequestBreadcrumb(span: Span): void {
+function _addRequestBreadcrumb(span: Span, request: unknown): void {
   if (getSpanKind(span) !== SpanKind.CLIENT) {
     return;
   }
 
   const data = getRequestSpanData(span);
-  addBreadcrumb({
-    category: 'http',
-    data: {
-      ...data,
+  addBreadcrumb(
+    {
+      category: 'http',
+      data: {
+        ...data,
+      },
+      type: 'http',
     },
-    type: 'http',
-  });
+    {
+      event: 'response',
+      request,
+    },
+  );
 }


### PR DESCRIPTION
This PR ensures that (node) fetch and http requests generate breadcrumbs correctly, even if tracing is disabled.

It also adds tests for this, and ensures we pass the request/response to the hint correctly.

Fixes https://github.com/getsentry/sentry-javascript/issues/12132