### PR TITLE
feat(core): Add `startNewTrace` API

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/subject.js
@@ -1,0 +1,7 @@
+const fetchBtn = document.getElementById('fetchBtn');
+fetchBtn.addEventListener('click', async () => {
+  Sentry.startNewTrace();
+  Sentry.startSpan({ op: 'ui.interaction.click', name: 'fetch click' }, async () => {
+    await fetch('http://example.com');
+  });
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/subject.js
@@ -1,7 +1,15 @@
-const fetchBtn = document.getElementById('fetchBtn');
-fetchBtn.addEventListener('click', async () => {
-  Sentry.startNewTrace();
-  Sentry.startSpan({ op: 'ui.interaction.click', name: 'fetch click' }, async () => {
+const newTraceBtn = document.getElementById('newTrace');
+newTraceBtn.addEventListener('click', async () => {
+  Sentry.startNewTrace(() => {
+    Sentry.startSpan({ op: 'ui.interaction.click', name: 'new-trace' }, async () => {
+      await fetch('http://example.com');
+    });
+  });
+});
+
+const oldTraceBtn = document.getElementById('oldTrace');
+oldTraceBtn.addEventListener('click', async () => {
+  Sentry.startSpan({ op: 'ui.interaction.click', name: 'old-trace' }, async () => {
     await fetch('http://example.com');
   });
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <button id="oldTrace">Old Trace</button>
+    <button id="newTrace">new Trace</button>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/test.ts
@@ -1,0 +1,80 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../utils/fixtures';
+import type { EventAndTraceHeader } from '../../../../utils/helpers';
+import {
+  eventAndTraceHeaderRequestParser,
+  getFirstSentryEnvelopeRequest,
+  shouldSkipTracingTest,
+} from '../../../../utils/helpers';
+
+sentryTest('should create a new trace if `startNewTrace` is called', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.route('http://example.com/**', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  const [pageloadEvent, pageloadTraceHeaders] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    url,
+    eventAndTraceHeaderRequestParser,
+  );
+
+  const pageloadTraceContext = pageloadEvent.contexts?.trace;
+
+  expect(pageloadEvent.type).toEqual('transaction');
+
+  expect(pageloadTraceContext).toMatchObject({
+    op: 'pageload',
+    trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
+    span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+  });
+  expect(pageloadTraceContext).not.toHaveProperty('parent_span_id');
+
+  expect(pageloadTraceHeaders).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: pageloadTraceContext?.trace_id,
+  });
+
+  const customTransactionPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+    page,
+    undefined,
+    eventAndTraceHeaderRequestParser,
+  );
+
+  await page.locator('#fetchBtn').click();
+
+  const [customTransactionEvent, customTransactionTraceHeaders] = await customTransactionPromise;
+
+  expect(customTransactionEvent.type).toEqual('transaction');
+  expect(customTransactionEvent.transaction).toEqual('fetch click');
+
+  const customTransactionTraceContext = customTransactionEvent.contexts?.trace;
+  expect(customTransactionTraceContext).toMatchObject({
+    op: 'ui.interaction.click',
+    trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
+    span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+  });
+
+  expect(customTransactionTraceHeaders).toEqual({
+    environment: 'production',
+    public_key: 'public',
+    sample_rate: '1',
+    sampled: 'true',
+    trace_id: customTransactionTraceContext?.trace_id,
+    transaction: 'fetch click',
+  });
+
+  expect(customTransactionTraceContext?.trace_id).not.toEqual(pageloadTraceContext?.trace_id);
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/test.ts
@@ -7,104 +7,107 @@ import {
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
 
-sentryTest('should create a new trace if `startNewTrace` is called', async ({ getLocalTestUrl, page }) => {
-  if (shouldSkipTracingTest()) {
-    sentryTest.skip();
-  }
+sentryTest(
+  'creates a new trace if `startNewTrace` is called and leaves old trace valid outside the callback',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
 
-  const url = await getLocalTestUrl({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.route('http://example.com/**', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({}),
+    await page.route('http://example.com/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
     });
-  });
 
-  const [pageloadEvent, pageloadTraceHeaders] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
-    page,
-    url,
-    eventAndTraceHeaderRequestParser,
-  );
+    const [pageloadEvent, pageloadTraceHeaders] = await getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      url,
+      eventAndTraceHeaderRequestParser,
+    );
 
-  const pageloadTraceContext = pageloadEvent.contexts?.trace;
+    const pageloadTraceContext = pageloadEvent.contexts?.trace;
 
-  expect(pageloadEvent.type).toEqual('transaction');
+    expect(pageloadEvent.type).toEqual('transaction');
 
-  expect(pageloadTraceContext).toMatchObject({
-    op: 'pageload',
-    trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
-    span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
-  });
-  expect(pageloadTraceContext).not.toHaveProperty('parent_span_id');
+    expect(pageloadTraceContext).toMatchObject({
+      op: 'pageload',
+      trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
+      span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
+    expect(pageloadTraceContext).not.toHaveProperty('parent_span_id');
 
-  expect(pageloadTraceHeaders).toEqual({
-    environment: 'production',
-    public_key: 'public',
-    sample_rate: '1',
-    sampled: 'true',
-    trace_id: pageloadTraceContext?.trace_id,
-  });
+    expect(pageloadTraceHeaders).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: pageloadTraceContext?.trace_id,
+    });
 
-  const newTraceTransactionPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
-    page,
-    undefined,
-    eventAndTraceHeaderRequestParser,
-  );
+    const newTraceTransactionPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      undefined,
+      eventAndTraceHeaderRequestParser,
+    );
 
-  await page.locator('#newTrace').click();
+    await page.locator('#newTrace').click();
 
-  const [newTraceTransactionEvent, newTraceTransactionTraceHeaders] = await newTraceTransactionPromise;
+    const [newTraceTransactionEvent, newTraceTransactionTraceHeaders] = await newTraceTransactionPromise;
 
-  expect(newTraceTransactionEvent.type).toEqual('transaction');
-  expect(newTraceTransactionEvent.transaction).toEqual('new-trace');
+    expect(newTraceTransactionEvent.type).toEqual('transaction');
+    expect(newTraceTransactionEvent.transaction).toEqual('new-trace');
 
-  const newTraceTransactionTraceContext = newTraceTransactionEvent.contexts?.trace;
-  expect(newTraceTransactionTraceContext).toMatchObject({
-    op: 'ui.interaction.click',
-    trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
-    span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
-  });
+    const newTraceTransactionTraceContext = newTraceTransactionEvent.contexts?.trace;
+    expect(newTraceTransactionTraceContext).toMatchObject({
+      op: 'ui.interaction.click',
+      trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
+      span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
 
-  expect(newTraceTransactionTraceHeaders).toEqual({
-    environment: 'production',
-    public_key: 'public',
-    sample_rate: '1',
-    sampled: 'true',
-    trace_id: newTraceTransactionTraceContext?.trace_id,
-    transaction: 'new-trace',
-  });
+    expect(newTraceTransactionTraceHeaders).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: newTraceTransactionTraceContext?.trace_id,
+      transaction: 'new-trace',
+    });
 
-  const oldTraceTransactionPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
-    page,
-    undefined,
-    eventAndTraceHeaderRequestParser,
-  );
-  await page.locator('#oldTrace').click();
+    const oldTraceTransactionPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
+      page,
+      undefined,
+      eventAndTraceHeaderRequestParser,
+    );
+    await page.locator('#oldTrace').click();
 
-  const [oldTraceTransactionEvent, oldTraceTransactionTraceHeaders] = await oldTraceTransactionPromise;
+    const [oldTraceTransactionEvent, oldTraceTransactionTraceHeaders] = await oldTraceTransactionPromise;
 
-  expect(oldTraceTransactionEvent.type).toEqual('transaction');
-  expect(oldTraceTransactionEvent.transaction).toEqual('old-trace');
+    expect(oldTraceTransactionEvent.type).toEqual('transaction');
+    expect(oldTraceTransactionEvent.transaction).toEqual('old-trace');
 
-  const oldTraceTransactionEventTraceContext = oldTraceTransactionEvent.contexts?.trace;
-  expect(oldTraceTransactionEventTraceContext).toMatchObject({
-    op: 'ui.interaction.click',
-    trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
-    span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
-  });
+    const oldTraceTransactionEventTraceContext = oldTraceTransactionEvent.contexts?.trace;
+    expect(oldTraceTransactionEventTraceContext).toMatchObject({
+      op: 'ui.interaction.click',
+      trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
+      span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
 
-  expect(oldTraceTransactionTraceHeaders).toEqual({
-    environment: 'production',
-    public_key: 'public',
-    sample_rate: '1',
-    sampled: 'true',
-    trace_id: oldTraceTransactionTraceHeaders?.trace_id,
-    // transaction: 'old-trace', <-- this is not in the DSC because the DSC is continued from the pageload transaction
-    // which does not have a `transaction` field because its source is URL.
-  });
+    expect(oldTraceTransactionTraceHeaders).toEqual({
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: oldTraceTransactionTraceHeaders?.trace_id,
+      // transaction: 'old-trace', <-- this is not in the DSC because the DSC is continued from the pageload transaction
+      // which does not have a `transaction` field because its source is URL.
+    });
 
-  expect(oldTraceTransactionEventTraceContext?.trace_id).toEqual(pageloadTraceContext?.trace_id);
-  expect(newTraceTransactionTraceContext?.trace_id).not.toEqual(pageloadTraceContext?.trace_id);
-});
+    expect(oldTraceTransactionEventTraceContext?.trace_id).toEqual(pageloadTraceContext?.trace_id);
+    expect(newTraceTransactionTraceContext?.trace_id).not.toEqual(pageloadTraceContext?.trace_id);
+  },
+);

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -64,6 +64,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   getSpanDescendants,
   continueTrace,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -62,6 +62,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   getRootSpan,
   getSpanDescendants,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -10,6 +10,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   getSpanDescendants,
   setMeasurement,

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -10,6 +10,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   getSpanDescendants,
   setMeasurement,

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -11,6 +11,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   getSpanDescendants,
   setMeasurement,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -59,6 +59,7 @@ export {
   startInactiveSpan,
   startSpanManual,
   withActiveSpan,
+  startNewTrace,
   getSpanDescendants,
   setMeasurement,
   getSpanStatusFromHttpCode,

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -22,6 +22,7 @@ import {
   spanIsSampled,
   spanToJSON,
   startIdleSpan,
+  startNewTrace,
 } from '@sentry/core';
 import type { Client, IntegrationFn, StartSpanOptions, TransactionSource } from '@sentry/types';
 import type { Span } from '@sentry/types';
@@ -412,8 +413,7 @@ export function startBrowserTracingPageLoadSpan(
  * This will only do something if a browser tracing integration has been setup.
  */
 export function startBrowserTracingNavigationSpan(client: Client, spanOptions: StartSpanOptions): Span | undefined {
-  getCurrentScope().setPropagationContext(generatePropagationContext());
-  getIsolationScope().setPropagationContext(generatePropagationContext());
+  startNewTrace();
 
   client.emit('startNavigationSpan', spanOptions);
 
@@ -486,11 +486,4 @@ function registerInteractionListener(
   if (WINDOW.document) {
     addEventListener('click', registerInteractionTransaction, { once: false, capture: true });
   }
-}
-
-function generatePropagationContext(): { traceId: string; spanId: string } {
-  return {
-    traceId: uuid4(),
-    spanId: uuid4().substring(16),
-  };
 }

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -22,7 +22,6 @@ import {
   spanIsSampled,
   spanToJSON,
   startIdleSpan,
-  startNewTrace,
 } from '@sentry/core';
 import type { Client, IntegrationFn, StartSpanOptions, TransactionSource } from '@sentry/types';
 import type { Span } from '@sentry/types';
@@ -32,7 +31,6 @@ import {
   getDomElement,
   logger,
   propagationContextFromHeaders,
-  uuid4,
 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -28,6 +28,7 @@ import type { Client, IntegrationFn, StartSpanOptions, TransactionSource } from 
 import type { Span } from '@sentry/types';
 import {
   browserPerformanceTimeOrigin,
+  generatePropagationContext,
   getDomElement,
   logger,
   propagationContextFromHeaders,
@@ -413,7 +414,8 @@ export function startBrowserTracingPageLoadSpan(
  * This will only do something if a browser tracing integration has been setup.
  */
 export function startBrowserTracingNavigationSpan(client: Client, spanOptions: StartSpanOptions): Span | undefined {
-  startNewTrace();
+  getIsolationScope().setPropagationContext(generatePropagationContext());
+  getCurrentScope().setPropagationContext(generatePropagationContext());
 
   client.emit('startNavigationSpan', spanOptions);
 

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -82,6 +82,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   getRootSpan,
   getSpanDescendants,

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -24,6 +24,7 @@ import type {
 import { dateTimestampInSeconds, isPlainObject, logger, uuid4 } from '@sentry/utils';
 
 import { updateSession } from './session';
+import { generatePropagationContext } from './tracing/propagationContext';
 import { _getSpanForScope, _setSpanForScope } from './utils/spanOnScope';
 
 /**
@@ -600,10 +601,3 @@ export const Scope = ScopeClass;
  * Holds additional event information.
  */
 export type Scope = ScopeInterface;
-
-function generatePropagationContext(): PropagationContext {
-  return {
-    traceId: uuid4(),
-    spanId: uuid4().substring(16),
-  };
-}

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -21,10 +21,9 @@ import type {
   SeverityLevel,
   User,
 } from '@sentry/types';
-import { dateTimestampInSeconds, isPlainObject, logger, uuid4 } from '@sentry/utils';
+import { dateTimestampInSeconds, generatePropagationContext, isPlainObject, logger, uuid4 } from '@sentry/utils';
 
 import { updateSession } from './session';
-import { generatePropagationContext } from './tracing/propagationContext';
 import { _getSpanForScope, _setSpanForScope } from './utils/spanOnScope';
 
 /**

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -17,6 +17,7 @@ export {
   continueTrace,
   withActiveSpan,
   suppressTracing,
+  startNewTrace,
 } from './trace';
 export {
   getDynamicSamplingContextFromClient,

--- a/packages/core/src/tracing/propagationContext.ts
+++ b/packages/core/src/tracing/propagationContext.ts
@@ -1,0 +1,12 @@
+import type { PropagationContext } from '@sentry/types';
+import { uuid4 } from '@sentry/utils';
+
+/**
+ * Generates a new minimal propagation context
+ */
+export function generatePropagationContext(): PropagationContext {
+  return {
+    traceId: uuid4(),
+    spanId: uuid4().substring(16),
+  };
+}

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -1,11 +1,12 @@
 import type { ClientOptions, Scope, SentrySpanArguments, Span, SpanTimeInput, StartSpanOptions } from '@sentry/types';
-import { propagationContextFromHeaders, uuid4 } from '@sentry/utils';
+import { logger, propagationContextFromHeaders, uuid4 } from '@sentry/utils';
 import type { AsyncContextStrategy } from '../asyncContext/types';
 import { getMainCarrier } from '../carrier';
 
 import { getClient, getCurrentScope, getIsolationScope, withScope } from '../currentScopes';
 
 import { getAsyncContextStrategy } from '../asyncContext';
+import { DEBUG_BUILD } from '../debug-build';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../semanticAttributes';
 import { handleCallbackErrors } from '../utils/handleCallbackErrors';
 import { hasTracingEnabled } from '../utils/hasTracingEnabled';
@@ -226,8 +227,9 @@ export function suppressTracing<T>(callback: () => T): T {
  *            or page will automatically create a new trace.
  */
 export function startNewTrace(): void {
-  getCurrentScope().setPropagationContext(generatePropagationContext());
   getIsolationScope().setPropagationContext(generatePropagationContext());
+  getCurrentScope().setPropagationContext(generatePropagationContext());
+  DEBUG_BUILD && logger.info(`Starting a new trace with id ${getCurrentScope().getPropagationContext().traceId}`);
 }
 
 function createChildOrRootSpan({

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -14,6 +14,7 @@ import { _getSpanForScope, _setSpanForScope } from '../utils/spanOnScope';
 import { addChildSpanToSpan, getRootSpan, spanIsSampled, spanTimeInputToSeconds, spanToJSON } from '../utils/spanUtils';
 import { freezeDscOnSpan, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { logSpanStart } from './logSpans';
+import { generatePropagationContext } from './propagationContext';
 import { sampleSpan } from './sampling';
 import { SentryNonRecordingSpan } from './sentryNonRecordingSpan';
 import { SentrySpan } from './sentrySpan';
@@ -413,11 +414,4 @@ function getParentSpan(scope: Scope): SentrySpan | undefined {
   }
 
   return span;
-}
-
-function generatePropagationContext(): { traceId: string; spanId: string } {
-  return {
-    traceId: uuid4(),
-    spanId: uuid4().substring(16),
-  };
 }

--- a/packages/core/test/lib/tracing/proagationContext.test.ts
+++ b/packages/core/test/lib/tracing/proagationContext.test.ts
@@ -1,0 +1,10 @@
+import { generatePropagationContext } from '../../../src/tracing/propagationContext';
+
+describe('generatePropagationContext', () => {
+  it('generates a new minimal propagation context', () => {
+    expect(generatePropagationContext()).toEqual({
+      traceId: expect.stringMatching(/^[0-9a-f]{32}$/),
+      spanId: expect.stringMatching(/^[0-9a-f]{16}$/),
+    });
+  });
+});

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -24,6 +24,7 @@ import {
   withActiveSpan,
 } from '../../../src/tracing';
 import { SentryNonRecordingSpan } from '../../../src/tracing/sentryNonRecordingSpan';
+import { startNewTrace } from '../../../src/tracing/trace';
 import { _setSpanForScope } from '../../../src/utils/spanOnScope';
 import { getActiveSpan, getRootSpan, getSpanDescendants, spanIsSampled } from '../../../src/utils/spanUtils';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
@@ -1588,5 +1589,27 @@ describe('suppressTracing', () => {
       expect(child.isRecording()).toBe(false);
       expect(spanIsSampled(child)).toBe(false);
     });
+  });
+});
+
+describe('startNewTrace', () => {
+  beforeEach(() => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+  });
+
+  it('resets the propagation context on current scope and isolation scope', () => {
+    const oldIsolationScopeItraceId = getIsolationScope().getPropagationContext().traceId;
+    const oldCurrentScopeItraceId = getCurrentScope().getPropagationContext().traceId;
+
+    startNewTrace();
+
+    const newIsolationScopeItraceId = getIsolationScope().getPropagationContext().traceId;
+    const newCurrentScopeItraceId = getCurrentScope().getPropagationContext().traceId;
+
+    expect(newIsolationScopeItraceId).toMatch(/^[a-f0-9]{32}$/);
+    expect(newCurrentScopeItraceId).toMatch(/^[a-f0-9]{32}$/);
+    expect(newIsolationScopeItraceId).not.toBe(oldIsolationScopeItraceId);
+    expect(newCurrentScopeItraceId).not.toBe(oldCurrentScopeItraceId);
   });
 });

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1598,18 +1598,25 @@ describe('startNewTrace', () => {
     getIsolationScope().clear();
   });
 
-  it('resets the propagation context on current scope and isolation scope', () => {
-    const oldIsolationScopeItraceId = getIsolationScope().getPropagationContext().traceId;
+  it('creates a new propagation context on the current scope', () => {
     const oldCurrentScopeItraceId = getCurrentScope().getPropagationContext().traceId;
 
-    startNewTrace();
+    startNewTrace(() => {
+      const newCurrentScopeItraceId = getCurrentScope().getPropagationContext().traceId;
 
-    const newIsolationScopeItraceId = getIsolationScope().getPropagationContext().traceId;
-    const newCurrentScopeItraceId = getCurrentScope().getPropagationContext().traceId;
+      expect(newCurrentScopeItraceId).toMatch(/^[a-f0-9]{32}$/);
+      expect(newCurrentScopeItraceId).not.toEqual(oldCurrentScopeItraceId);
+    });
+  });
 
-    expect(newIsolationScopeItraceId).toMatch(/^[a-f0-9]{32}$/);
-    expect(newCurrentScopeItraceId).toMatch(/^[a-f0-9]{32}$/);
-    expect(newIsolationScopeItraceId).not.toBe(oldIsolationScopeItraceId);
-    expect(newCurrentScopeItraceId).not.toBe(oldCurrentScopeItraceId);
+  it('keeps the propagation context on the isolation scope as-is', () => {
+    const oldIsolationScopeTraceId = getIsolationScope().getPropagationContext().traceId;
+
+    startNewTrace(() => {
+      const newIsolationScopeTraceId = getIsolationScope().getPropagationContext().traceId;
+
+      expect(newIsolationScopeTraceId).toMatch(/^[a-f0-9]{32}$/);
+      expect(newIsolationScopeTraceId).toEqual(oldIsolationScopeTraceId);
+    });
   });
 });

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -58,6 +58,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   metricsDefault as metrics,
   inboundFiltersIntegration,
   linkedErrorsIntegration,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -62,6 +62,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   getRootSpan,
   getSpanDescendants,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -111,6 +111,7 @@ export {
   startSpan,
   startSpanManual,
   startInactiveSpan,
+  startNewTrace,
   getActiveSpan,
   withActiveSpan,
   getRootSpan,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -67,6 +67,7 @@ export {
   startSpan,
   startSpanManual,
   startInactiveSpan,
+  startNewTrace,
   withActiveSpan,
   getSpanDescendants,
   continueTrace,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -60,6 +60,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   continueTrace,
   cron,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -35,3 +35,4 @@ export * from './eventbuilder';
 export * from './anr';
 export * from './lru';
 export * from './buildPolyfills';
+export * from './propagationContext';

--- a/packages/utils/src/propagationContext.ts
+++ b/packages/utils/src/propagationContext.ts
@@ -1,8 +1,8 @@
 import type { PropagationContext } from '@sentry/types';
-import { uuid4 } from '@sentry/utils';
+import { uuid4 } from './misc';
 
 /**
- * Generates a new minimal propagation context
+ * Returns a new minimal propagation context
  */
 export function generatePropagationContext(): PropagationContext {
   return {

--- a/packages/utils/test/proagationContext.test.ts
+++ b/packages/utils/test/proagationContext.test.ts
@@ -1,4 +1,4 @@
-import { generatePropagationContext } from '../../../src/tracing/propagationContext';
+import { generatePropagationContext } from '../src/propagationContext';
 
 describe('generatePropagationContext', () => {
   it('generates a new minimal propagation context', () => {

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -58,6 +58,7 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
+  startNewTrace,
   withActiveSpan,
   getSpanDescendants,
   continueTrace,


### PR DESCRIPTION
This PR adds a new `Sentry.startNewTrace` function that allows users to start a trace in isolation of a potentially still active trace. When this function is called, a new trace will be started on a forked scope which remains valid throughout the callback lifetime.

Simple usage example:

```js
myButton.addEventListener('click', async () => {
  Sentry.startNewTrace(() => {
    Sentry.startSpan({ op: 'ui.interaction.click', name: 'fetch click' }, async () => {
      await fetch('http://example.com');
    });
  });
});
```

Extraced the `generatePropagationContext` utility to utils because it's used in multiple packages