### PR TITLE
feat(google-cloud): Expose ESM build

### DIFF
--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -22,6 +22,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "import": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
+      },
       "require": {
         "types": "./build/types/index.d.ts",
         "default": "./build/cjs/index.js"

--- a/packages/google-cloud-serverless/src/sdk.ts
+++ b/packages/google-cloud-serverless/src/sdk.ts
@@ -5,13 +5,22 @@ import type { Integration, Options, SdkMetadata } from '@sentry/types';
 import { googleCloudGrpcIntegration } from './integrations/google-cloud-grpc';
 import { googleCloudHttpIntegration } from './integrations/google-cloud-http';
 
+function isCjs(): boolean {
+  return typeof require !== 'undefined';
+}
+
+function getCjsOnlyIntegrations(): Integration[] {
+  return isCjs()
+    ? [
+        googleCloudHttpIntegration({ optional: true }), // We mark this integration optional since '@google-cloud/common' module could be missing.
+        googleCloudGrpcIntegration({ optional: true }), // We mark this integration optional since 'google-gax' module could be missing.
+      ]
+    : [];
+}
+
 /** Get the default integrations for the GCP SDK. */
 export function getDefaultIntegrations(_options: Options): Integration[] {
-  return [
-    ...getDefaultIntegrationsWithoutPerformance(),
-    googleCloudHttpIntegration({ optional: true }), // We mark this integration optional since '@google-cloud/common' module could be missing.
-    googleCloudGrpcIntegration({ optional: true }), // We mark this integration optional since 'google-gax' module could be missing.
-  ];
+  return [...getDefaultIntegrationsWithoutPerformance(), ...getCjsOnlyIntegrations()];
 }
 
 /**


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/11776

This exposes the ESM build for `@sentry/google-cloud-serverless`, with the caveat that the performance related instrumentation does not work atm. These need to be ported to use OpenTelemetry instrumentation.