### PR TITLE
doc(migration): Add entry for runWithAsyncContext

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -706,10 +706,11 @@ You can import from `@sentry/browser` (or from a respective SDK package like `@s
 
 ### Server-side SDKs (Node, Deno, Bun, etc.)
 
-Removed top-level exports: `enableAnrDetection`, `Anr`, `deepReadDirSync`
+Removed top-level exports: `enableAnrDetection`, `Anr`, `deepReadDirSync`, `runWithAsyncContext`
 
 - [Removal of `enableAnrDetection` and `Anr` class](./MIGRATION.md#removal-of-enableanrdetection-and-anr-class)
 - [Removal of `deepReadDirSync` method](./MIGRATION.md#removal-of-deepreaddirsync-method)
+- [Removal of `runWithAsyncContext` method](./MIGRATION.md#removal-of-runwithasynccontext-method)
 
 #### Removal of `enableAnrDetection` and `Anr` class
 
@@ -719,6 +720,22 @@ The `enableAnrDetection` and `Anr` class have been removed. See the
 #### Removal of `deepReadDirSync` method
 
 The `deepReadDirSync` method has been removed. There is no replacement API.
+
+#### Removal of `runWithAsyncContext` method
+
+The `runWithAsyncContext` method has been removed in favour of `Sentry.withIsolationScope`.
+
+```js
+// before (v7)
+Sentry.runWithAsyncContext(() => {
+  // Your code here...
+});
+
+// after (v8)
+Sentry.withIsolationScope(() => {
+  // Your code here...
+});
+```
 
 ### Next.js SDK
 


### PR DESCRIPTION
Adds https://github.com/getsentry/sentry-javascript/pull/10780 to the migration guide.