### PR TITLE
fix(core): Call `getCurrentHubShim` when accessing `__SENTRY__.hub`

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration'),
     gzip: true,
-    limit: '70 KB',
+    limit: '71 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - with treeshaking flags',

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/init.js
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/init.js
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/subject.js
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/subject.js
@@ -1,3 +1,4 @@
+console.log(window.__SENTRY__);
 /**
  * Simulate an old pre v8 SDK obtaining the hub from the global sentry carrier
  * and checking for the hub version.

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/subject.js
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/subject.js
@@ -1,0 +1,8 @@
+/**
+ * Simulate an old pre v8 SDK obtaining the hub from the global sentry carrier
+ * and checking for the hub version.
+ */
+const res = window && window.__SENTRY__ && window.__SENTRY__.hub && window.__SENTRY__.hub.isOlderThan(7);
+
+// Write back result into the document
+document.getElementById('olderThan').innerText = res;

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/template.html
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <p id="olderThan"></p>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/test.ts
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/test.ts
@@ -1,0 +1,13 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../utils/fixtures';
+
+sentryTest(
+  "doesn't crash if older SDKs access `hub.isOlderThan` on the global object",
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
+    await page.goto(url);
+
+    await expect(page.locator('#olderThan')).toHaveText('false');
+  },
+);

--- a/packages/core/src/asyncContext/stackStrategy.ts
+++ b/packages/core/src/asyncContext/stackStrategy.ts
@@ -105,6 +105,16 @@ export class AsyncContextStack {
   }
 
   /**
+   * Only here for compatibility with <v8 versions
+   * @deprecated DO NOT use this function
+   * @hidden
+   * @internal
+   */
+  public isOlderThan(_version: number): boolean {
+    return false;
+  }
+
+  /**
    * Push a scope to the stack.
    */
   private _pushScope(): ScopeInterface {

--- a/packages/core/src/getCurrentHubShim.ts
+++ b/packages/core/src/getCurrentHubShim.ts
@@ -1,4 +1,4 @@
-import type { Client, EventHint, Hub, Integration, IntegrationClass, SeverityLevel } from '@sentry/types';
+import type { Client, EventHint, Hub, Integration, IntegrationClass, Scope, SeverityLevel } from '@sentry/types';
 import { addBreadcrumb } from './breadcrumbs';
 import { getClient, getCurrentScope, getIsolationScope, withScope } from './currentScopes';
 import {
@@ -22,7 +22,10 @@ import {
  * usage
  */
 // eslint-disable-next-line deprecation/deprecation
-export function getCurrentHubShim(): Hub {
+export function getCurrentHubShim(): Hub & {
+  getStackTop: () => { client: Client | undefined; scope: Scope };
+  isOlderThan: () => boolean;
+} {
   return {
     bindClient(client: Client): void {
       const scope = getCurrentScope();
@@ -63,6 +66,13 @@ export function getCurrentHubShim(): Hub {
 
       // only send the update
       _sendSessionUpdate();
+    },
+    getStackTop: () => ({
+      client: getClient(),
+      scope: getCurrentScope(),
+    }),
+    isOlderThan() {
+      return false;
     },
   };
 }

--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -45,6 +45,7 @@ export interface InternalGlobal {
   _sentryDebugIds?: Record<string, string>;
   __SENTRY__: {
     hub: any;
+    stack: any;
     logger: any;
     extensions?: {
       /** Extension methods for the hub, which are bound to the current Hub instance */


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/12151
fixes https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/533

This PR makes a change to set our `AsyncStackStrategy` onto `__SENTRY__.stack` instead of `__SENTRY__.hub`. Instead, we now set the `getCurrentHubShim` onto `.hub`. The shim now also has the old `isOlderThan` and `getStackTop`.