### PR TITLE
ref(browser): Refactor `isNativeFetch` -> `isNativeFunction`

### DIFF
--- a/packages/browser-utils/src/getNativeImplementation.ts
+++ b/packages/browser-utils/src/getNativeImplementation.ts
@@ -1,4 +1,4 @@
-import { logger } from '@sentry/utils';
+import { isNativeFunction, logger } from '@sentry/utils';
 import { DEBUG_BUILD } from './debug-build';
 import { WINDOW } from './types';
 
@@ -14,14 +14,6 @@ interface CacheableImplementations {
 }
 
 const cachedImplementations: Partial<CacheableImplementations> = {};
-
-/**
- * isNative checks if the given function is a native implementation
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function isNative(func: Function): boolean {
-  return func && /^function\s+\w+\(\)\s+\{\s+\[native code\]\s+\}$/.test(func.toString());
-}
 
 /**
  * Get the native implementation of a browser function.
@@ -43,7 +35,7 @@ export function getNativeImplementation<T extends keyof CacheableImplementations
   let impl = WINDOW[name] as CacheableImplementations[T];
 
   // Fast path to avoid DOM I/O
-  if (isNative(impl)) {
+  if (isNativeFunction(impl)) {
     return (cachedImplementations[name] = impl.bind(WINDOW) as CacheableImplementations[T]);
   }
 

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -76,12 +76,13 @@ export function supportsFetch(): boolean {
     return false;
   }
 }
+
 /**
- * isNativeFetch checks if the given function is a native implementation of fetch()
+ * isNative checks if the given function is a native implementation
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function isNativeFetch(func: Function): boolean {
-  return func && /^function fetch\(\)\s+\{\s+\[native code\]\s+\}$/.test(func.toString());
+export function isNativeFunction(func: Function): boolean {
+  return func && /^function\s+\w+\(\)\s+\{\s+\[native code\]\s+\}$/.test(func.toString());
 }
 
 /**
@@ -101,7 +102,7 @@ export function supportsNativeFetch(): boolean {
 
   // Fast path to avoid DOM I/O
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  if (isNativeFetch(WINDOW.fetch)) {
+  if (isNativeFunction(WINDOW.fetch)) {
     return true;
   }
 
@@ -117,7 +118,7 @@ export function supportsNativeFetch(): boolean {
       doc.head.appendChild(sandbox);
       if (sandbox.contentWindow && sandbox.contentWindow.fetch) {
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        result = isNativeFetch(sandbox.contentWindow.fetch);
+        result = isNativeFunction(sandbox.contentWindow.fetch);
       }
       doc.head.removeChild(sandbox);
     } catch (err) {


### PR DESCRIPTION
This makes the `isNativeFetch` check a bit more generic/naive. It no longer checks that the function name matches `fetch` explicitly, but I think thats ok.


Follow-up to https://github.com/getsentry/sentry-javascript/pull/11924