### PR TITLE
feat: Override `import-in-the-middle` code to only instrument specified modules

### DIFF
--- a/packages/node/src/nodeVersion.ts
+++ b/packages/node/src/nodeVersion.ts
@@ -2,3 +2,4 @@ import { parseSemver } from '@sentry/utils';
 
 export const NODE_VERSION = parseSemver(process.versions.node) as { major: number; minor: number; patch: number };
 export const NODE_MAJOR = NODE_VERSION.major;
+export const NODE_MINOR = NODE_VERSION.minor;

--- a/packages/node/src/sdk/register-hooks.ts
+++ b/packages/node/src/sdk/register-hooks.ts
@@ -1,0 +1,73 @@
+import * as mod from 'node:module';
+import { GLOBAL_OBJ, consoleSandbox, logger } from '@sentry/utils';
+import { NODE_MAJOR, NODE_MINOR } from '../nodeVersion';
+
+declare const __IMPORT_META_URL_REPLACEMENT__: string;
+
+/**
+ * Registers hooks for ESM modules.
+ *
+ * The first hook overrides the source code of 'import-in-the-middle/hook.mjs' so it only instruments pre-specified modules.
+ */
+export function registerEsmModuleHooks(modulesToInstrument: string[]): void {
+  // Register hook was added in v20.6.0 and v18.19.0
+  if (NODE_MAJOR >= 22 || (NODE_MAJOR === 20 && NODE_MINOR >= 6) || (NODE_MAJOR === 18 && NODE_MINOR >= 19)) {
+    // We need to work around using import.meta.url directly because jest complains about it.
+    const importMetaUrl =
+      typeof __IMPORT_META_URL_REPLACEMENT__ !== 'undefined' ? __IMPORT_META_URL_REPLACEMENT__ : undefined;
+
+    if (!importMetaUrl || GLOBAL_OBJ._sentryEsmLoaderHookRegistered) {
+      return;
+    }
+
+    try {
+      const iitmOverrideCode = `
+    import { createHook } from "./hook.js";
+
+    const { load, resolve: resolveIITM, getFormat, getSource } = createHook(import.meta);
+
+    const modulesToInstrument = ${JSON.stringify(modulesToInstrument)};
+
+    export async function resolve(specifier, context, nextResolve) {
+        if (modulesToInstrument.includes(specifier)) {
+            return resolveIITM(specifier, context, nextResolve);
+        }
+
+        return nextResolve(specifier, context);
+    }
+
+    export { load, getFormat, getSource };`;
+
+      // This loader overrides the source code of 'import-in-the-middle/hook.mjs' with
+      // the above code. This code ensures that only the specified modules are proxied.
+      // @ts-expect-error register is available in these versions
+      mod.register(
+        new URL(
+          `data:application/javascript,
+        export async function load(url, context, nextLoad) {
+            if (url.endsWith('import-in-the-middle/hook.mjs')) {
+                const result = await nextLoad(url, context);
+                return {...result, source: '${iitmOverrideCode}' };
+            }
+            return nextLoad(url, context);
+        }`,
+        ),
+        importMetaUrl,
+      );
+
+      // @ts-expect-error register is available in these versions
+      mod.register('@opentelemetry/instrumentation/hook.mjs', importMetaUrl);
+
+      GLOBAL_OBJ._sentryEsmLoaderHookRegistered = true;
+    } catch (error) {
+      logger.warn('Failed to register ESM hook', error);
+    }
+  } else {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[Sentry] You are using Node.js in ESM mode ("import syntax"). The Sentry Node.js SDK is not compatible with ESM in Node.js versions before 18.19.0 or before 20.6.0. Please either build your application with CommonJS ("require() syntax"), or use version 7.x of the Sentry Node.js SDK.',
+      );
+    });
+  }
+}


### PR DESCRIPTION
This is a temporary workaround for `import-in-the-middle` incompatibilities with many libraries (#12059, #12154).

By default, `import-in-the-middle` analyses and proxies every import but it currently can't handle some cases. 

This PR modifies the code in `import-in-the-middle/hook.mjs` via another loader hook. This modified code only resolves via `import-in-the-middle` if the module matches a supplied list. By default, this list contains all the built-in auto-instrumentations for `@sentry/node` and users can add to this list via `options._experiments.modulesToInstrument`:

```ts
Sentry.init({
  dsn: '__DSN__',
  _experiments: {
    modulesToInstrument: ['some-other-module'],
  }
});
```