### PR TITLE
ref(otel): Remove mentions of hub from comments

### DIFF
--- a/packages/opentelemetry/src/contextManager.ts
+++ b/packages/opentelemetry/src/contextManager.ts
@@ -11,7 +11,7 @@ import { getScopesFromContext, setContextOnScope, setScopesOnContext } from './u
 import { setIsSetup } from './utils/setupCheck';
 
 /**
- * Wrap an OpenTelemetry ContextManager in a way that ensures the context is kept in sync with the Sentry Hub.
+ * Wrap an OpenTelemetry ContextManager in a way that ensures the context is kept in sync with the Sentry Scope.
  *
  * Usage:
  * import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
@@ -23,7 +23,7 @@ export function wrapContextManagerClass<ContextManagerInstance extends ContextMa
 ): typeof ContextManagerClass {
   /**
    * This is a custom ContextManager for OpenTelemetry, which extends the default AsyncLocalStorageContextManager.
-   * It ensures that we create a new hub per context, so that the OTEL Context & the Sentry Hub are always in sync.
+   * It ensures that we create new scopes per context, so that the OTEL Context & the Sentry Scope are always in sync.
    *
    * Note that we currently only support AsyncHooks with this,
    * but since this should work for Node 14+ anyhow that should be good enough.
@@ -37,7 +37,7 @@ export function wrapContextManagerClass<ContextManagerInstance extends ContextMa
     }
     /**
      * Overwrite with() of the original AsyncLocalStorageContextManager
-     * to ensure we also create a new hub per context.
+     * to ensure we also create new scopes per context.
      */
     public with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
       context: Context,


### PR DESCRIPTION
Just noticed we still mention the hub in the `ContextManager`, removing that.