### PR TITLE
fix(node): Change import of `@prisma/instrumentation` to use default import

### DIFF
--- a/packages/node/src/integrations/tracing/prisma.ts
+++ b/packages/node/src/integrations/tracing/prisma.ts
@@ -1,6 +1,5 @@
-// The "@prisma/instrumentation" package is CJS, meaning we cannot use named exports, or the "import * as" syntax, otherwise we will break people on ESM, importing `prismaIntegration`.
-import prismaInstrumentation from '@prisma/instrumentation';
-
+// When importing CJS modules into an ESM module, we cannot import the named exports directly.
+import * as prismaInstrumentation from '@prisma/instrumentation';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration, spanToJSON } from '@sentry/core';
 import { addOpenTelemetryInstrumentation } from '@sentry/opentelemetry';
 import type { IntegrationFn } from '@sentry/types';
@@ -9,9 +8,14 @@ const _prismaIntegration = (() => {
   return {
     name: 'Prisma',
     setupOnce() {
+      const EsmInteropPrismaInstrumentation: typeof prismaInstrumentation.PrismaInstrumentation =
+        // @ts-expect-error We need to do the following for interop reasons
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        prismaInstrumentation.default?.PrismaInstrumentation || prismaInstrumentation.PrismaInstrumentation;
+
       addOpenTelemetryInstrumentation(
         // does not have a hook to adjust spans & add origin
-        new prismaInstrumentation.PrismaInstrumentation({}),
+        new EsmInteropPrismaInstrumentation({}),
       );
     },
 

--- a/packages/node/src/integrations/tracing/prisma.ts
+++ b/packages/node/src/integrations/tracing/prisma.ts
@@ -1,5 +1,6 @@
-// When importing CJS modules into an ESM module, we cannot import the named exports directly.
-import * as prismaInstrumentation from '@prisma/instrumentation';
+// The "@prisma/instrumentation" package is CJS, meaning we cannot use named exports, or the "import * as" syntax, otherwise we will break people on ESM, importing `prismaIntegration`.
+import prismaInstrumentation from '@prisma/instrumentation';
+
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration, spanToJSON } from '@sentry/core';
 import { addOpenTelemetryInstrumentation } from '@sentry/opentelemetry';
 import type { IntegrationFn } from '@sentry/types';


### PR DESCRIPTION
Potentially fixes https://github.com/getsentry/sentry-javascript/issues/11216

In esm due to interop, the PrismaInstrumentation can be found under `default`.