### PR TITLE
ci(e2e): Use react beta for Next.js canary tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/package.json
@@ -8,7 +8,7 @@
     "test:prod": "TEST_ENV=production playwright test",
     "test:dev": "TEST_ENV=development playwright test",
     "test:build": "pnpm install && npx playwright install && pnpm build",
-    "test:build-canary": "pnpm install && pnpm add next@canary && npx playwright install && pnpm build",
+    "test:build-canary": "pnpm install && pnpm add next@canary && pnpm add react@beta && pnpm add react-dom@beta && npx playwright install && pnpm build",
     "test:build-latest": "pnpm install && pnpm add next@latest && npx playwright install && pnpm build",
     "test:assert": "pnpm test:prod && pnpm test:dev"
   },

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
@@ -9,7 +9,7 @@
     "test:dev": "TEST_ENV=development playwright test",
     "test:build": "pnpm install && npx playwright install && pnpm build",
     "test:test-build": "pnpm ts-node --script-mode assert-build.ts",
-    "test:build-canary": "pnpm install && pnpm add next@canary && npx playwright install && pnpm build",
+    "test:build-canary": "pnpm install && pnpm add next@canary && pnpm add react@beta && pnpm add react-dom@beta && npx playwright install && pnpm build",
     "test:build-latest": "pnpm install && pnpm add next@latest && npx playwright install && pnpm build",
     "test:build-13": "pnpm install && pnpm add next@13.4.19 && npx playwright install && pnpm build",
     "test:assert": "pnpm test:test-build && pnpm test:prod && pnpm test:dev"


### PR DESCRIPTION
Next.js 15 will require react 19