### PR TITLE
chore(ci): Remove unused NODE_VERSION 16 env from browser ci tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -436,8 +436,6 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
       - name: Run tests
-        env:
-          NODE_VERSION: 16
         run: yarn test-ci-browser
       - name: Compute test coverage
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
The action sets up node 18 currently anyway, this doesn't seem to have any effect.