### PR TITLE
fix(nextjs): Use global scope for generic event filters

### DIFF
--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -1,4 +1,4 @@
-import { addEventProcessor, applySdkMetadata, getClient } from '@sentry/core';
+import { applySdkMetadata, getClient, getGlobalScope } from '@sentry/core';
 import { getDefaultIntegrations, init as nodeInit } from '@sentry/node';
 import type { NodeOptions } from '@sentry/node';
 import { GLOBAL_OBJ, logger } from '@sentry/utils';
@@ -143,7 +143,7 @@ export function init(options: NodeOptions): void {
     }
   });
 
-  addEventProcessor(
+  getGlobalScope().addEventProcessor(
     Object.assign(
       (event => {
         if (event.type === 'transaction') {
@@ -182,7 +182,7 @@ export function init(options: NodeOptions): void {
   );
 
   if (process.env.NODE_ENV === 'development') {
-    addEventProcessor(devErrorSymbolicationEventProcessor);
+    getGlobalScope().addEventProcessor(devErrorSymbolicationEventProcessor);
   }
 
   DEBUG_BUILD && logger.log('SDK successfully initialized');


### PR DESCRIPTION
While doing https://github.com/getsentry/sentry-javascript/pull/12194 I noticed that there were some inconsistencies with how the generic event processors were running in nextjs and I think it might be because we are attaching to an isolation scope instead of a global scope.