### PR TITLE
feat(react): Add React 19 to peer deps

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,7 +49,7 @@
     "hoist-non-react-statics": "^3.3.2"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || 17.x || 18.x"
+    "react": "^16.14.0 || 17.x || 18.x || 19.x"
   },
   "devDependencies": {
     "@testing-library/react": "^13.0.0",


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/12200

From my personal testing everything works with with React 19, so we can bump the peer dep.

For the new error APIs, there is https://github.com/getsentry/sentry-javascript/pull/12147, but that PR is draft while we get feedback from the React team.