### PR TITLE
test: Disable ember-release and embroider-optimized ember canary tests

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -159,7 +159,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [ember-release, embroider-optimized, ember-4.0]
+        # scenario: [ember-release, embroider-optimized, ember-4.0]
+        scenario: [ember-4.0]
     steps:
       - name: 'Check out current commit'
         uses: actions/checkout@v4


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/12176

Given the test apps are having issues, disable these tests for now.