### PR TITLE
ref(profiling-node): Add warning when using non-LTS node

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -5,6 +5,7 @@ import type { IntegrationFn, Span } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
+import { NODE_MAJOR, NODE_VERSION } from './nodeVersion';
 import { MAX_PROFILE_DURATION_MS, maybeProfileSpan, stopSpanProfile } from './spanProfileUtils';
 import type { Profile, RawThreadCpuProfile } from './types';
 
@@ -25,6 +26,15 @@ function addToProfileQueue(profile: RawThreadCpuProfile): void {
 
 /** Exported only for tests. */
 export const _nodeProfilingIntegration = (() => {
+  if (DEBUG_BUILD && ![16, 18, 20, 22].includes(NODE_MAJOR)) {
+    logger.warn(
+      `[Profiling] You are using a Node.js version that does not have prebuilt binaries (${NODE_VERSION}).`,
+      'The @sentry/profiling-node package only has prebuilt support for the following LTS versions of Node.js: 16, 18, 20, 22.',
+      'To use the @sentry/profiling-node package with this version of Node.js, you will need to compile the native addon from source.',
+      'See: https://github.com/getsentry/sentry-javascript/tree/develop/packages/profiling-node#building-the-package-from-source',
+    );
+  }
+
   return {
     name: 'ProfilingIntegration',
     setup(client: NodeClient) {

--- a/packages/profiling-node/src/nodeVersion.ts
+++ b/packages/profiling-node/src/nodeVersion.ts
@@ -1,0 +1,4 @@
+import { parseSemver } from '@sentry/utils';
+
+export const NODE_VERSION = parseSemver(process.versions.node) as { major: number; minor: number; patch: number };
+export const NODE_MAJOR = NODE_VERSION.major;


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/11777