### PR TITLE
feat(node): Ensure manual OTEL setup works

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -18,6 +18,8 @@ const NODE_EXPORTS_IGNORE = [
   'setNodeAsyncContextStrategy',
   'getDefaultIntegrationsWithoutPerformance',
   'initWithoutDefaultIntegrations',
+  'SentryContextManager',
+  'validateOpenTelemetrySetup',
 ];
 
 const nodeExports = Object.keys(SentryNode).filter(e => !NODE_EXPORTS_IGNORE.includes(e));

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -26,11 +26,13 @@ export { koaIntegration, setupKoaErrorHandler } from './integrations/tracing/koa
 export { connectIntegration, setupConnectErrorHandler } from './integrations/tracing/connect';
 export { spotlightIntegration } from './integrations/spotlight';
 
+export { SentryContextManager } from './otel/contextManager';
 export {
   init,
   getDefaultIntegrations,
   getDefaultIntegrationsWithoutPerformance,
   initWithoutDefaultIntegrations,
+  validateOpenTelemetrySetup,
 } from './sdk/init';
 export { initOpenTelemetry } from './sdk/initOtel';
 export { getAutoPerformanceIntegrations } from './integrations/tracing';

--- a/packages/node/src/sdk/init.ts
+++ b/packages/node/src/sdk/init.ts
@@ -11,7 +11,11 @@ import {
   requestDataIntegration,
   startSession,
 } from '@sentry/core';
-import { openTelemetrySetupCheck, setOpenTelemetryContextAsyncContextStrategy } from '@sentry/opentelemetry';
+import {
+  openTelemetrySetupCheck,
+  setOpenTelemetryContextAsyncContextStrategy,
+  setupEventContextTrace,
+} from '@sentry/opentelemetry';
 import type { Client, Integration, Options } from '@sentry/types';
 import {
   GLOBAL_OBJ,
@@ -196,12 +200,16 @@ function _init(
   // There is no way to use this SDK without OpenTelemetry!
   if (!options.skipOpenTelemetrySetup) {
     initOpenTelemetry(client);
+    validateOpenTelemetrySetup();
   }
 
-  validateOpenTelemetrySetup();
+  setupEventContextTrace(client);
 }
 
-function validateOpenTelemetrySetup(): void {
+/**
+ * Validate that your OpenTelemetry setup is correct.
+ */
+export function validateOpenTelemetrySetup(): void {
   if (!DEBUG_BUILD) {
     return;
   }

--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -7,7 +7,7 @@ import {
   SEMRESATTRS_SERVICE_VERSION,
 } from '@opentelemetry/semantic-conventions';
 import { SDK_VERSION } from '@sentry/core';
-import { SentryPropagator, SentrySampler, SentrySpanProcessor, setupEventContextTrace } from '@sentry/opentelemetry';
+import { SentryPropagator, SentrySampler, SentrySpanProcessor } from '@sentry/opentelemetry';
 import { logger } from '@sentry/utils';
 
 import { SentryContextManager } from '../otel/contextManager';
@@ -27,8 +27,6 @@ export function initOpenTelemetry(client: NodeClient): void {
 
     diag.setLogger(otelLogger, DiagLogLevel.DEBUG);
   }
-
-  setupEventContextTrace(client);
 
   const provider = setupOtel(client);
   client.traceProvider = provider;


### PR DESCRIPTION
Based on the great feedback in https://github.com/getsentry/sentry-javascript/discussions/12191, this does some small adjustments to ensure that you actually can use the Node SDK properly with a custom OTEL setup:

## 1. Ensure we do not run `validateOpenTelemetrySetup()` when `skipOpenTelemetrySetup` is configured. 

Today, this is impossible to fix because you need a client to create the sampler, and you need the sampler to satisfy the validation, but the validation runs in `init()`. So either you call init() before doing your manual setup, which means you get the warning, or you do the manual setup first, but then you can't actually add the sampler, and still get the warning.

This change means that users that configure `skipOpenTelemetrySetup` can manually call `Sentry.validateOpenTelemetrySetup()` if they want to get the validation, else there will be no validation automtically.

## 2. Export `SentryContextManager` from `@sentry/node`

This is easier to use than to use the primitive `wrapContextManagerClass` from `@sentry/opentelemetry`.

## 3. Ensure we always run `setupEventContextTrace`, not tied to `skipOpenTelemetrySetup`

There is no reason to tie this together, this now just always runs in `init()` - it's just an event processor!