### PR TITLE
feat(core): Allow to pass custom scope to `captureFeedback()`

### DIFF
--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -8,10 +8,9 @@ import { getClient, getCurrentScope } from './currentScopes';
 export function captureFeedback(
   feedbackParams: SendFeedbackParams,
   hint: EventHint & { includeReplay?: boolean } = {},
+  scope = getCurrentScope(),
 ): string {
   const { message, name, email, url, source, associatedEventId } = feedbackParams;
-
-  const client = getClient();
 
   const feedbackEvent: FeedbackEvent = {
     contexts: {
@@ -28,11 +27,13 @@ export function captureFeedback(
     level: 'info',
   };
 
+  const client = (scope && scope.getClient()) || getClient();
+
   if (client) {
     client.emit('beforeSendFeedback', feedbackEvent, hint);
   }
 
-  const eventId = getCurrentScope().captureEvent(feedbackEvent, hint);
+  const eventId = scope.captureEvent(feedbackEvent, hint);
 
   return eventId;
 }

--- a/packages/core/test/lib/feedback.test.ts
+++ b/packages/core/test/lib/feedback.test.ts
@@ -1,5 +1,13 @@
 import type { Span } from '@sentry/types';
-import { addBreadcrumb, getCurrentScope, setCurrentClient, startSpan, withIsolationScope, withScope } from '../../src';
+import {
+  Scope,
+  addBreadcrumb,
+  getCurrentScope,
+  setCurrentClient,
+  startSpan,
+  withIsolationScope,
+  withScope,
+} from '../../src';
 import { captureFeedback } from '../../src/feedback';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
@@ -447,5 +455,46 @@ describe('captureFeedback', () => {
         ],
       ],
     ]);
+  });
+
+  test('it allows to pass a custom client', async () => {
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://dsn@ingest.f00.f00/1',
+        enableSend: true,
+      }),
+    );
+    setCurrentClient(client);
+    client.init();
+
+    const client2 = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://dsn@ingest.f00.f00/1',
+        enableSend: true,
+        defaultIntegrations: false,
+      }),
+    );
+    client2.init();
+    const scope = new Scope();
+    scope.setClient(client2);
+
+    const mockTransport = jest.spyOn(client.getTransport()!, 'send');
+    const mockTransport2 = jest.spyOn(client2.getTransport()!, 'send');
+
+    const eventId = captureFeedback(
+      {
+        message: 'test',
+      },
+      {},
+      scope,
+    );
+
+    await client.flush();
+    await client2.flush();
+
+    expect(typeof eventId).toBe('string');
+
+    expect(mockTransport).not.toHaveBeenCalled();
+    expect(mockTransport2).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This allows to pass a custom scope to `Sentry.captureFeedback()`, like this:

```js
Sentry.captureFeedback({message : 'test' }, {}, scope);
```

This should fix the use case from https://github.com/getsentry/sentry-javascript/issues/11072#issuecomment-2129259591