### PR TITLE
feat(browser/v7): Publish browserprofling CDN bundle

### DIFF
--- a/packages/browser/rollup.bundle.config.mjs
+++ b/packages/browser/rollup.bundle.config.mjs
@@ -25,7 +25,19 @@ targets.forEach(jsVersion => {
     outputFileBase: () => `bundles/bundle.tracing${jsVersion === 'es5' ? '.es5' : ''}`,
   });
 
-  builds.push(...makeBundleConfigVariants(baseBundleConfig), ...makeBundleConfigVariants(tracingBaseBundleConfig));
+  const browserProfilingAddonBaseBundleConfig = makeBaseBundleConfig({
+    bundleType: 'addon',
+    entrypoints: ['src/profiling/integration.ts'],
+    jsVersion,
+    licenseTitle: '@sentry/browser',
+    outputFileBase: () => `bundles/browserprofiling${jsVersion === 'es5' ? '.es5' : ''}`,
+  });
+
+  builds.push(
+    ...makeBundleConfigVariants(baseBundleConfig),
+    ...makeBundleConfigVariants(tracingBaseBundleConfig),
+    ...makeBundleConfigVariants(browserProfilingAddonBaseBundleConfig),
+  );
 });
 
 if (targets.includes('es6')) {


### PR DESCRIPTION
Backporting https://github.com/getsentry/sentry-javascript/pull/12158 to v7

ref https://github.com/getsentry/sentry-javascript/issues/12156

This is also necessary (or at least helpful) if we want to make this selectable in the loader script.