### PR TITLE
fix(aws-serverless): Avoid minifying `Module._resolveFilename` in Lambda layer bundle

### DIFF
--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -130,7 +130,6 @@ export function makeTerserPlugin() {
           '_sentryIsolationScope',
           // require-in-the-middle calls `Module._resolveFilename`. We cannot mangle this (AWS lambda layer bundle).
           '_resolveFilename',
-          '__proto__',
         ],
       },
     },
@@ -139,7 +138,6 @@ export function makeTerserPlugin() {
     },
   });
 }
-‘
 
 // We don't pass these plugins any options which need to be calculated or changed by us, so no need to wrap them in
 // another factory function, as they are themselves already factory functions.

--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -128,6 +128,9 @@ export function makeTerserPlugin() {
           '_sentrySpan',
           '_sentryScope',
           '_sentryIsolationScope',
+          // require-in-the-middle calls `Module._resolveFilename`. We cannot mangle this (AWS lambda layer bundle).
+          '_resolveFilename',
+          '__proto__',
         ],
       },
     },
@@ -136,6 +139,7 @@ export function makeTerserPlugin() {
     },
   });
 }
+‘
 
 // We don't pass these plugins any options which need to be calculated or changed by us, so no need to wrap them in
 // another factory function, as they are themselves already factory functions.


### PR DESCRIPTION
This PR fixes one of the two issues that currently cause our lambda layer to break. When we build the lambda layer bundle we apply minification via our terser plugin which mangles `_`-prefixed private variables - like `Module._resolveFilename`. 

To be clear, this PR unfortunately does not fix the lambda layer as we're still blocked on [this issue](https://github.com/getsentry/sentry-javascript/issues/12009#issuecomment-2126211967). Not sure what we can do SDK-side to fix this.

ref: https://github.com/getsentry/sentry-javascript/issues/12089