### PR TITLE
fix(aws): Ensure lambda layer uses default export from `ImportInTheMiddle`

### DIFF
--- a/dev-packages/rollup-utils/bundleHelpers.mjs
+++ b/dev-packages/rollup-utils/bundleHelpers.mjs
@@ -88,11 +88,27 @@ export function makeBaseBundleConfig(options) {
   };
 
   // used by `@sentry/aws-serverless`, when creating the lambda layer
-  const nodeBundleConfig = {
+  const awsLambdaBundleConfig = {
     output: {
       format: 'cjs',
     },
-    plugins: [jsonPlugin, commonJSPlugin],
+    plugins: [
+      jsonPlugin,
+      commonJSPlugin,
+      // Temporary fix for the lambda layer SDK bundle.
+      // This is necessary to apply to our lambda layer bundle because calling `new ImportInTheMiddle()` will throw an
+      // that `ImportInTheMiddle` is not a constructor. Instead we modify the code to call `new ImportInTheMiddle.default()`
+      // TODO: Remove this plugin once the weird import-in-the-middle exports are fixed, released and we use the respective
+      // version in our SDKs. See: https://github.com/getsentry/sentry-javascript/issues/12009#issuecomment-2126211967
+      {
+        name: 'aws-serverless-lambda-layer-fix',
+        transform: code => {
+          if (code.includes('ImportInTheMiddle')) {
+            return code.replaceAll(/new\s+(ImportInTheMiddle.*)\(/gm, 'new $1.default(');
+          }
+        },
+      },
+    ],
     // Don't bundle any of Node's core modules
     external: builtinModules,
   };
@@ -124,7 +140,7 @@ export function makeBaseBundleConfig(options) {
   const bundleTypeConfigMap = {
     standalone: standAloneBundleConfig,
     addon: addOnBundleConfig,
-    node: nodeBundleConfig,
+    'aws-lambda': awsLambdaBundleConfig,
     'node-worker': workerBundleConfig,
   };
 

--- a/packages/aws-serverless/rollup.aws.config.mjs
+++ b/packages/aws-serverless/rollup.aws.config.mjs
@@ -5,7 +5,7 @@ export default [
   ...makeBundleConfigVariants(
     makeBaseBundleConfig({
       // this automatically sets it to be CJS
-      bundleType: 'node',
+      bundleType: 'aws-lambda',
       entrypoints: ['src/index.ts'],
       licenseTitle: '@sentry/aws-serverless',
       outputFileBase: () => 'index',
@@ -15,7 +15,6 @@ export default [
           sourcemap: false,
         },
       },
-      preserveModules: false,
     }),
     // We only need one copy of the SDK, and we pick the minified one because there's a cap on how big a lambda function
     // plus its dependencies can be, and we might as well take up as little of that space as is necessary. We'll rename


### PR DESCRIPTION
So this is a fun one: 

Our lambda layer relies on one bundled Sentry SDK, which caused problems raised in #12089  and https://github.com/getsentry/sentry-javascript/issues/12009#issuecomment-2126211967. Specifically, by bundling `import-in-the-middle` code into one file, it seems like the library's way of declaring its exports conflict, causing the "ImportInTheMiddle is not a constructor" error to be thrown. While this should ideally be fixed soon in `import-in-the-middle`, for now this PR adds a small Rollup plugin to transform `new ImportInTheMiddle(...)` calls to `new ImportInTheMiddle.default(...)` to our AWS Lambda Layer bundle config.

Once the fixes land upstream and we updated our dependencies accordingly, we should remove this plugin again.

I tested this locally with a [reproduction](https://github.com/Lms24/gh-sentry-javascript-12089-repro) that failed with the exact same error message as reported in #12089. We should add an e2e test that tests the layer (as well as the AWS Serverless SDK). I'm gonna take a look at this today and open a follow up PR.

For now, this (in combination with #12232) hopefully 

fixes #12089 

