### PR TITLE
fix(core): Pass in cron monitor config correctly

### DIFF
--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -179,6 +179,8 @@ export class ServerRuntimeClient<
         checkin_margin: monitorConfig.checkinMargin,
         max_runtime: monitorConfig.maxRuntime,
         timezone: monitorConfig.timezone,
+        failure_issue_threshold: monitorConfig.failureIssueThreshold,
+        recovery_threshold: monitorConfig.recoveryThreshold,
       };
     }
 

--- a/packages/core/test/lib/serverruntimeclient.test.ts
+++ b/packages/core/test/lib/serverruntimeclient.test.ts
@@ -89,6 +89,8 @@ describe('ServerRuntimeClient', () => {
           checkinMargin: 2,
           maxRuntime: 12333,
           timezone: 'Canada/Eastern',
+          failureIssueThreshold: 2,
+          recoveryThreshold: 3,
         },
       );
 
@@ -112,6 +114,8 @@ describe('ServerRuntimeClient', () => {
                 checkin_margin: 2,
                 max_runtime: 12333,
                 timezone: 'Canada/Eastern',
+                failure_issue_threshold: 2,
+                recovery_threshold: 3,
               },
             },
           ],

--- a/packages/types/src/checkin.ts
+++ b/packages/types/src/checkin.ts
@@ -37,6 +37,10 @@ export interface SerializedCheckIn {
     // A tz database string representing the timezone which the monitor's execution schedule is in.
     // See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone?: string;
+    // How many consecutive failed check-ins it takes to create an issue.
+    failure_issue_threshold?: number;
+    // How many consecutive OK check-ins it takes to resolve an issue.
+    recovery_threshold?: number;
   };
   contexts?: {
     trace?: TraceContext;
@@ -84,7 +88,7 @@ export interface MonitorConfig {
   // See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   timezone?: SerializedMonitorConfig['timezone'];
   // How many consecutive failed check-ins it takes to create an issue.
-  failure_issue_threshold?: number;
+  failureIssueThreshold?: SerializedMonitorConfig['failure_issue_threshold'];
   // How many consecutive OK check-ins it takes to resolve an issue.
-  recovery_threshold?: number;
+  recoveryThreshold?: SerializedMonitorConfig['recovery_threshold'];
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/12217

Make sure `failure_issue_threshold` and `recovery_threshold` get passed in correctly.