### PR TITLE
feat(sveltekit): Add request data to server-side events

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/test/errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/test/errors.server.test.ts
@@ -20,6 +20,16 @@ test.describe('server-side errors', () => {
     );
 
     expect(errorEvent.tags).toMatchObject({ runtime: 'node' });
+
+    expect(errorEvent.request).toEqual({
+      cookies: {},
+      headers: expect.objectContaining({
+        accept: expect.any(String),
+        'user-agent': expect.any(String),
+      }),
+      method: 'GET',
+      url: 'http://localhost:3030/universal-load-error',
+    });
   });
 
   test('captures server load error', async ({ page }) => {
@@ -40,6 +50,16 @@ test.describe('server-side errors', () => {
     );
 
     expect(errorEvent.tags).toMatchObject({ runtime: 'node' });
+
+    expect(errorEvent.request).toEqual({
+      cookies: {},
+      headers: expect.objectContaining({
+        accept: expect.any(String),
+        'user-agent': expect.any(String),
+      }),
+      method: 'GET',
+      url: 'http://localhost:3030/server-load-error',
+    });
   });
 
   test('captures server route (GET) error', async ({ page }) => {
@@ -61,5 +81,14 @@ test.describe('server-side errors', () => {
     );
 
     expect(errorEvent.transaction).toEqual('GET /server-route-error');
+
+    expect(errorEvent.request).toEqual({
+      cookies: {},
+      headers: expect.objectContaining({
+        accept: expect.any(String),
+      }),
+      method: 'GET',
+      url: 'http://localhost:3030/server-route-error',
+    });
   });
 });

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/test/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/test/performance.server.test.ts
@@ -32,4 +32,14 @@ test('server pageload request span has nested request span for sub request', asy
       expect.objectContaining({ op: 'http.server', description: 'GET /api/users' }),
     ]),
   );
+
+  expect(serverTxnEvent.request).toEqual({
+    cookies: {},
+    headers: expect.objectContaining({
+      accept: expect.any(String),
+      'user-agent': expect.any(String),
+    }),
+    method: 'GET',
+    url: 'http://localhost:3030/server-load-fetch',
+  });
 });

--- a/dev-packages/e2e-tests/test-applications/sveltekit/test/errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit/test/errors.server.test.ts
@@ -21,6 +21,16 @@ test.describe('server-side errors', () => {
     );
 
     expect(errorEvent.tags).toMatchObject({ runtime: 'node' });
+
+    expect(errorEvent.request).toEqual({
+      cookies: {},
+      headers: expect.objectContaining({
+        accept: expect.any(String),
+        'user-agent': expect.any(String),
+      }),
+      method: 'GET',
+      url: 'http://localhost:3030/universal-load-error',
+    });
   });
 
   test('captures server load error', async ({ page }) => {
@@ -42,6 +52,16 @@ test.describe('server-side errors', () => {
     );
 
     expect(errorEvent.tags).toMatchObject({ runtime: 'node' });
+
+    expect(errorEvent.request).toEqual({
+      cookies: {},
+      headers: expect.objectContaining({
+        accept: expect.any(String),
+        'user-agent': expect.any(String),
+      }),
+      method: 'GET',
+      url: 'http://localhost:3030/server-load-error',
+    });
   });
 
   test('captures server route (GET) error', async ({ page }) => {
@@ -64,5 +84,14 @@ test.describe('server-side errors', () => {
     );
 
     expect(errorEvent.transaction).toEqual('GET /server-route-error');
+
+    expect(errorEvent.request).toEqual({
+      cookies: {},
+      headers: expect.objectContaining({
+        accept: expect.any(String),
+      }),
+      method: 'GET',
+      url: 'http://localhost:3030/server-route-error',
+    });
   });
 });

--- a/dev-packages/e2e-tests/test-applications/sveltekit/test/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit/test/performance.server.test.ts
@@ -32,4 +32,14 @@ test('server pageload request span has nested request span for sub request', asy
       expect.objectContaining({ op: 'http.server', description: 'GET /api/users' }),
     ]),
   );
+
+  expect(serverTxnEvent.request).toEqual({
+    cookies: {},
+    headers: expect.objectContaining({
+      accept: expect.any(String),
+      'user-agent': expect.any(String),
+    }),
+    method: 'GET',
+    url: 'http://localhost:3030/server-load-fetch',
+  });
 });

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -12,7 +12,7 @@ import {
 } from '@sentry/core';
 import { startSpan } from '@sentry/core';
 import { captureException, continueTrace } from '@sentry/node';
-import type { Scope, Span } from '@sentry/types';
+import type { Span } from '@sentry/types';
 import {
   dynamicSamplingContextToSentryBaggageHeader,
   logger,
@@ -177,7 +177,7 @@ export function sentryHandle(handlerOptions?: SentryHandleOptions): Handle {
     return withIsolationScope(isolationScope => {
       // We only call continueTrace in the initial top level request to avoid
       // creating a new root span for the sub request.
-      setRequestOnScope(input.event.request.clone(), isolationScope);
+      isolationScope.setSDKProcessingMetadata({ request: winterCGRequestToRequestData(input.event.request.clone()) });
       return continueTrace(getTracePropagationData(input.event), () => instrumentHandle(input, options));
     });
   };
@@ -213,7 +213,7 @@ async function instrumentHandle(
         name: routeName,
       },
       async (span?: Span) => {
-        setRequestOnScope(event.request.clone(), getCurrentScope());
+        getCurrentScope().setSDKProcessingMetadata({ request: winterCGRequestToRequestData(event.request.clone()) });
         const res = await resolve(event, {
           transformPageChunk: addSentryCodeToPage(options),
         });
@@ -230,10 +230,4 @@ async function instrumentHandle(
   } finally {
     await flushIfServerless();
   }
-}
-
-function setRequestOnScope(request: Request, scope: Scope): void {
-  scope.setSDKProcessingMetadata({
-    request: winterCGRequestToRequestData(request),
-  });
 }

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -44,6 +44,8 @@ function mockEvent(override: Record<string, unknown> = {}): Parameters<Handle>[0
     ...override,
   };
 
+  event.request.clone = () => event.request;
+
   return event;
 }
 


### PR DESCRIPTION
This PR adds request data to server-side Sentry events by extracting the request object in our `sentryHandle` request handler. This is in line with our other SDKs and was simply missing from the SvelteKit SDK so far.

closes #12253 
ref: https://stackoverflow.com/questions/78534091/sentry-logging-missing-http-server-side-metadata-for-sveltekit/78537808