### PR TITLE
test: Improve E2E node tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/create-next-app/tests/behaviour-server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/tests/behaviour-server.test.ts
@@ -7,7 +7,8 @@ const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
 const EVENT_POLLING_TIMEOUT = 90_000;
 
 test('Sends a server-side exception to Sentry', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/api/error`);
+  const response = await fetch(`${baseURL}/api/error`);
+  const data = await response.json();
   const { exceptionId } = data;
 
   const url = `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionId}/`;
@@ -39,7 +40,8 @@ test('Sends a server-side exception to Sentry', async ({ baseURL }) => {
 });
 
 test('Sends server-side transactions to Sentry', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/api/success`);
+  const response = await fetch(`${baseURL}/api/success`);
+  const data = await response.json();
   const { transactionIds } = data;
 
   console.log(`Polling for transaction eventIds: ${JSON.stringify(transactionIds)}`);

--- a/dev-packages/e2e-tests/test-applications/node-connect/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-connect/tests/errors.test.ts
@@ -1,54 +1,12 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
-
-test('Sends exception to Sentry', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/test-error`);
-  const { exceptionId } = data;
-
-  const url = `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionId}/`;
-
-  console.log(`Polling for error eventId: ${exceptionId}`);
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      { timeout: EVENT_POLLING_TIMEOUT },
-    )
-    .toBe(200);
-});
 
 test('Sends correct error event', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-connect', event => {
     return !event.type && event.exception?.values?.[0]?.value === 'This is an exception';
   });
 
-  try {
-    await axios.get(`${baseURL}/test-exception`);
-  } catch {
-    // this results in an error, but we don't care - we want to check the error event
-  }
+  await fetch(`${baseURL}/test-exception`);
 
   const errorEvent = await errorEventPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-connect/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-connect/tests/transactions.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
@@ -15,7 +14,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     );
   });
 
-  await axios.get(`${baseURL}/test-transaction`);
+  await fetch(`${baseURL}/test-transaction`);
 
   const transactionEvent = await pageloadTransactionEventPromise;
   const transactionEventId = transactionEvent.event_id;
@@ -35,7 +34,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': '/test-transaction',
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -97,32 +96,4 @@ test('Sends an API route transaction', async ({ baseURL }) => {
       },
     }),
   );
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      {
-        timeout: EVENT_POLLING_TIMEOUT,
-      },
-    )
-    .toBe(200);
 });

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/errors.test.ts
@@ -1,54 +1,12 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError, AxiosResponse } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
-
-test('Sends exception to Sentry', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/test-error`);
-  const { exceptionId } = data;
-
-  const url = `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionId}/`;
-
-  console.log(`Polling for error eventId: ${exceptionId}`);
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      { timeout: EVENT_POLLING_TIMEOUT },
-    )
-    .toBe(200);
-});
 
 test('Sends correct error event', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-express', event => {
     return !event.type && event.exception?.values?.[0]?.value === 'This is an exception with id 123';
   });
 
-  try {
-    await axios.get(`${baseURL}/test-exception/123`);
-  } catch {
-    // this results in an error, but we don't care - we want to check the error event
-  }
+  await fetch(`${baseURL}/test-exception/123`);
 
   const errorEvent = await errorEventPromise;
 
@@ -71,55 +29,14 @@ test('Sends correct error event', async ({ baseURL }) => {
 });
 
 test('Should record caught exceptions with local variable', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/test-local-variables-caught`);
-  const { exceptionId } = data;
-
-  const url = `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionId}/json/`;
-
-  console.log(`Polling for error eventId: ${exceptionId}`);
-
-  let response: AxiosResponse;
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      { timeout: EVENT_POLLING_TIMEOUT },
-    )
-    .toBe(200);
-
-  const frames = response!.data.exception.values[0].stacktrace.frames;
-
-  expect(frames[frames.length - 1].vars?.randomVariableToRecord).toBeDefined();
-});
-
-test('Should record uncaught exceptions with local variable', async ({ baseURL }) => {
-  const errorEventPromise = waitForError('node-express', errorEvent => {
-    return !!errorEvent?.exception?.values?.[0]?.value?.includes('Uncaught Local Variable Error');
+  const errorEventPromise = waitForError('node-express', event => {
+    return event.transaction === 'GET /test-local-variables-caught';
   });
 
-  await axios.get(`${baseURL}/test-local-variables-uncaught`).catch(() => {
-    // noop
-  });
+  await fetch(`${baseURL}/test-local-variables-caught`);
 
-  const routehandlerError = await errorEventPromise;
+  const errorEvent = await errorEventPromise;
 
-  const frames = routehandlerError!.exception!.values![0]!.stacktrace!.frames!;
-
-  expect(frames[frames.length - 1].vars?.randomVariableToRecord).toBeDefined();
+  const frames = errorEvent.exception?.values?.[0].stacktrace?.frames;
+  expect(frames?.[frames.length - 1].vars?.randomVariableToRecord).toBeDefined();
 });

--- a/dev-packages/e2e-tests/test-applications/node-fastify/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/tests/errors.test.ts
@@ -1,54 +1,12 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
-
-test('Sends exception to Sentry', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/test-error`);
-  const { exceptionId } = data;
-
-  const url = `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionId}/`;
-
-  console.log(`Polling for error eventId: ${exceptionId}`);
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      { timeout: EVENT_POLLING_TIMEOUT },
-    )
-    .toBe(200);
-});
 
 test('Sends correct error event', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-fastify', event => {
     return !event.type && event.exception?.values?.[0]?.value === 'This is an exception with id 123';
   });
 
-  try {
-    await axios.get(`${baseURL}/test-exception/123`);
-  } catch {
-    // this results in an error, but we don't care - we want to check the error event
-  }
+  await fetch(`${baseURL}/test-exception/123`);
 
   const errorEvent = await errorEventPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-fastify/tests/propagation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/tests/propagation.test.ts
@@ -2,7 +2,6 @@ import crypto from 'crypto';
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
 import { SpanJSON } from '@sentry/types';
-import axios from 'axios';
 
 test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
   const id = crypto.randomUUID();
@@ -21,7 +20,8 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http/${id}`);
+  const response = await fetch(`${baseURL}/test-outgoing-http/${id}`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
   const outboundTransaction = await outboundTransactionPromise;
@@ -66,7 +66,7 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': `/test-outgoing-http/${id}`,
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -135,7 +135,8 @@ test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch/${id}`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch/${id}`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
   const outboundTransaction = await outboundTransactionPromise;
@@ -180,7 +181,7 @@ test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': `/test-outgoing-fetch/${id}`,
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -240,7 +241,8 @@ test('Propagates trace for outgoing external http requests', async ({ baseURL })
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http-external-allowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-http-external-allowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -276,7 +278,8 @@ test('Does not propagate outgoing http requests not covered by tracePropagationT
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http-external-disallowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-http-external-disallowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -299,7 +302,8 @@ test('Propagates trace for outgoing external fetch requests', async ({ baseURL }
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch-external-allowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch-external-allowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -335,7 +339,8 @@ test('Does not propagate outgoing fetch requests not covered by tracePropagation
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch-external-disallowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch-external-disallowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-fastify/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/tests/transactions.test.ts
@@ -1,11 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
 
 test('Sends an API route transaction', async ({ baseURL }) => {
   const pageloadTransactionEventPromise = waitForTransaction('node-fastify', transactionEvent => {
@@ -15,7 +9,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     );
   });
 
-  await axios.get(`${baseURL}/test-transaction`);
+  await fetch(`${baseURL}/test-transaction`);
 
   const transactionEvent = await pageloadTransactionEventPromise;
   const transactionEventId = transactionEvent.event_id;
@@ -35,7 +29,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': '/test-transaction',
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -134,32 +128,4 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     trace_id: expect.any(String),
     origin: 'manual',
   });
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      {
-        timeout: EVENT_POLLING_TIMEOUT,
-      },
-    )
-    .toBe(200);
 });

--- a/dev-packages/e2e-tests/test-applications/node-hapi/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-hapi/tests/errors.test.ts
@@ -1,83 +1,32 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
-
-test('Sends captured exception to Sentry', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/test-error`);
-  const { exceptionId } = data;
-
-  const url = `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionId}/`;
-
-  console.log(`Polling for error eventId: ${exceptionId}`);
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      { timeout: EVENT_POLLING_TIMEOUT },
-    )
-    .toBe(200);
-});
 
 test('Sends thrown error to Sentry', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-hapi', errorEvent => {
     return errorEvent?.exception?.values?.[0]?.value === 'This is an error';
   });
 
-  try {
-    await axios.get(`${baseURL}/test-failure`);
-  } catch (e) {}
+  await fetch(`${baseURL}/test-failure`);
 
   const errorEvent = await errorEventPromise;
   const errorEventId = errorEvent.event_id;
 
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${errorEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('This is an error');
 
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      {
-        timeout: EVENT_POLLING_TIMEOUT,
-      },
-    )
-    .toBe(200);
+  expect(errorEvent.request).toEqual({
+    method: 'GET',
+    cookies: {},
+    headers: expect.any(Object),
+    url: 'http://localhost:3030/test-failure',
+  });
+
+  expect(errorEvent.transaction).toEqual('GET /test-failure');
+
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: expect.any(String),
+    span_id: expect.any(String),
+  });
 });
 
 test('sends error with parameterized transaction name', async ({ baseURL }) => {
@@ -85,9 +34,7 @@ test('sends error with parameterized transaction name', async ({ baseURL }) => {
     return errorEvent?.exception?.values?.[0]?.value === 'This is an error with id 123';
   });
 
-  try {
-    await axios.get(`${baseURL}/test-error/123`);
-  } catch {}
+  await fetch(`${baseURL}/test-error/123`);
 
   const errorEvent = await errorEventPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-hapi/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-hapi/tests/transactions.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
-import axios from 'axios';
 
 test('Sends successful transaction', async ({ baseURL }) => {
   const pageloadTransactionEventPromise = waitForTransaction('node-hapi', transactionEvent => {
@@ -9,10 +8,9 @@ test('Sends successful transaction', async ({ baseURL }) => {
     );
   });
 
-  await axios.get(`${baseURL}/test-success`);
+  await fetch(`${baseURL}/test-success`);
 
   const transactionEvent = await pageloadTransactionEventPromise;
-  const transactionEventId = transactionEvent.event_id;
 
   expect(transactionEvent.contexts?.trace).toEqual({
     data: {
@@ -29,7 +27,7 @@ test('Sends successful transaction', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': '/test-success',
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -90,10 +88,9 @@ test('Sends parameterized transactions to Sentry', async ({ baseURL }) => {
     );
   });
 
-  await axios.get(`${baseURL}/test-param/123`);
+  await fetch(`${baseURL}/test-param/123`);
 
   const transactionEvent = await pageloadTransactionEventPromise;
-  const transactionEventId = transactionEvent.event_id;
 
   expect(transactionEvent?.contexts?.trace?.op).toBe('http.server');
   expect(transactionEvent?.contexts?.trace?.data?.['http.route']).toBe('/test-param/{param}');
@@ -114,7 +111,7 @@ test('Isolates requests', async ({ baseURL }) => {
     );
   });
 
-  await Promise.all([axios.get(`${baseURL}/test-param/888`), axios.get(`${baseURL}/test-param/999`)]);
+  await Promise.all([fetch(`${baseURL}/test-param/888`), fetch(`${baseURL}/test-param/999`)]);
 
   const transaction1 = await transaction1Promise;
   const transaction2 = await transaction2Promise;

--- a/dev-packages/e2e-tests/test-applications/node-koa/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-koa/tests/errors.test.ts
@@ -1,54 +1,12 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
-
-test('Sends exception to Sentry', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/test-error`);
-  const { exceptionId } = data;
-
-  const url = `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionId}/`;
-
-  console.log(`Polling for error eventId: ${exceptionId}`);
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      { timeout: EVENT_POLLING_TIMEOUT },
-    )
-    .toBe(200);
-});
 
 test('Sends correct error event', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-koa', event => {
     return !event.type && event.exception?.values?.[0]?.value === 'This is an exception with id 123';
   });
 
-  try {
-    await axios.get(`${baseURL}/test-exception/123`);
-  } catch {
-    // this results in an error, but we don't care - we want to check the error event
-  }
+  await fetch(`${baseURL}/test-exception/123`);
 
   const errorEvent = await errorEventPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-koa/tests/propagation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-koa/tests/propagation.test.ts
@@ -2,7 +2,6 @@ import crypto from 'crypto';
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
 import { SpanJSON } from '@sentry/types';
-import axios from 'axios';
 
 test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
   const id = crypto.randomUUID();
@@ -21,7 +20,8 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http/${id}`);
+  const response = await fetch(`${baseURL}/test-outgoing-http/${id}`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
   const outboundTransaction = await outboundTransactionPromise;
@@ -66,7 +66,7 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': `/test-outgoing-http/${id}`,
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -135,7 +135,8 @@ test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch/${id}`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch/${id}`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
   const outboundTransaction = await outboundTransactionPromise;
@@ -180,7 +181,7 @@ test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': `/test-outgoing-fetch/${id}`,
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -240,7 +241,8 @@ test('Propagates trace for outgoing external http requests', async ({ baseURL })
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http-external-allowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-http-external-allowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -276,7 +278,8 @@ test('Does not propagate outgoing http requests not covered by tracePropagationT
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http-external-disallowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-http-external-disallowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -299,7 +302,8 @@ test('Propagates trace for outgoing external fetch requests', async ({ baseURL }
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch-external-allowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch-external-allowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -335,7 +339,8 @@ test('Does not propagate outgoing fetch requests not covered by tracePropagation
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch-external-disallowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch-external-disallowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-koa/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-koa/tests/transactions.test.ts
@@ -1,11 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
 
 test('Sends an API route transaction', async ({ baseURL }) => {
   const pageloadTransactionEventPromise = waitForTransaction('node-koa', transactionEvent => {
@@ -15,10 +9,9 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     );
   });
 
-  await axios.get(`${baseURL}/test-transaction`);
+  await fetch(`${baseURL}/test-transaction`);
 
   const transactionEvent = await pageloadTransactionEventPromise;
-  const transactionEventId = transactionEvent.event_id;
 
   expect(transactionEvent.contexts?.trace).toEqual({
     data: {
@@ -35,7 +28,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': '/test-transaction',
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -129,32 +122,4 @@ test('Sends an API route transaction', async ({ baseURL }) => {
       },
     }),
   );
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      {
-        timeout: EVENT_POLLING_TIMEOUT,
-      },
-    )
-    .toBe(200);
 });

--- a/dev-packages/e2e-tests/test-applications/node-nestjs/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs/tests/errors.test.ts
@@ -1,59 +1,13 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
-
-test('Sends captured error to Sentry', async ({ baseURL }) => {
-  const { data } = await axios.get(`${baseURL}/test-error`);
-  const { exceptionId } = data;
-
-  const url = `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionId}/`;
-
-  console.log(`Polling for error eventId: ${exceptionId}`);
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(url, {
-            headers: { Authorization: `Bearer ${authToken}` },
-          });
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      { timeout: EVENT_POLLING_TIMEOUT },
-    )
-    .toBe(200);
-});
 
 test('Sends exception to Sentry', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-nestjs', event => {
     return !event.type && event.exception?.values?.[0]?.value === 'This is an exception with id 123';
   });
 
-  try {
-    await axios.get(`${baseURL}/test-exception/123`);
-    // Should never be reached!
-    expect(false).toBe(true);
-  } catch (error) {
-    expect(error).toBeInstanceOf(AxiosError);
-    expect(error.response?.status).toBe(500);
-  }
+  const response = await fetch(`${baseURL}/test-exception/123`);
+  expect(response.status).toBe(500);
 
   const errorEvent = await errorEventPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-nestjs/tests/propagation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs/tests/propagation.test.ts
@@ -2,7 +2,6 @@ import crypto from 'crypto';
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
 import { SpanJSON } from '@sentry/types';
-import axios from 'axios';
 
 test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
   const id = crypto.randomUUID();
@@ -21,7 +20,8 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http/${id}`);
+  const response = await fetch(`${baseURL}/test-outgoing-http/${id}`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
   const outboundTransaction = await outboundTransactionPromise;
@@ -66,7 +66,7 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': `/test-outgoing-http/${id}`,
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -135,7 +135,8 @@ test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch/${id}`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch/${id}`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
   const outboundTransaction = await outboundTransactionPromise;
@@ -180,7 +181,7 @@ test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': `/test-outgoing-fetch/${id}`,
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -240,7 +241,8 @@ test('Propagates trace for outgoing external http requests', async ({ baseURL })
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http-external-allowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-http-external-allowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -276,7 +278,8 @@ test('Does not propagate outgoing http requests not covered by tracePropagationT
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-http-external-disallowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-http-external-disallowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -299,7 +302,8 @@ test('Propagates trace for outgoing external fetch requests', async ({ baseURL }
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch-external-allowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch-external-allowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 
@@ -335,7 +339,8 @@ test('Does not propagate outgoing fetch requests not covered by tracePropagation
     );
   });
 
-  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch-external-disallowed`);
+  const response = await fetch(`${baseURL}/test-outgoing-fetch-external-disallowed`);
+  const data = await response.json();
 
   const inboundTransaction = await inboundTransactionPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-nestjs/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs/tests/transactions.test.ts
@@ -1,11 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
-
-const authToken = process.env.E2E_TEST_AUTH_TOKEN;
-const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
-const EVENT_POLLING_TIMEOUT = 90_000;
 
 test('Sends an API route transaction', async ({ baseURL }) => {
   const pageloadTransactionEventPromise = waitForTransaction('node-nestjs', transactionEvent => {
@@ -15,10 +9,9 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     );
   });
 
-  await axios.get(`${baseURL}/test-transaction`);
+  await fetch(`${baseURL}/test-transaction`);
 
   const transactionEvent = await pageloadTransactionEventPromise;
-  const transactionEventId = transactionEvent.event_id;
 
   expect(transactionEvent.contexts?.trace).toEqual({
     data: {
@@ -35,7 +28,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
       'http.method': 'GET',
       'http.scheme': 'http',
       'http.target': '/test-transaction',
-      'http.user_agent': 'axios/1.6.7',
+      'http.user_agent': 'node',
       'http.flavor': '1.1',
       'net.transport': 'ip_tcp',
       'net.host.ip': expect.any(String),
@@ -131,32 +124,4 @@ test('Sends an API route transaction', async ({ baseURL }) => {
       },
     }),
   );
-
-  await expect
-    .poll(
-      async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
-      },
-      {
-        timeout: EVENT_POLLING_TIMEOUT,
-      },
-    )
-    .toBe(200);
 });


### PR DESCRIPTION
This does two main things:

1. Updates node E2E tests to use `fetch` instead of axios
2. Update node E2E tests to avoid sending to Sentry.

Instead, we check everywhere via the proxy that the data sent is OK.


Part of https://github.com/getsentry/sentry-javascript/issues/11910