### PR TITLE
fix(nextjs): Don't capture suspense errors in server components

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-15/app/suspense-error/client-page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/app/suspense-error/client-page.tsx
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/nextjs';
+import { use } from 'react';
+
+export function ClientComponentTakingAPromise({ promise }: { promise: Promise<string> }) {
+  let value;
+  try {
+    value = use(promise);
+  } catch (e) {
+    Sentry.captureException(e); // This error should not be reported
+    throw e;
+  }
+  return <p>Promise value: {value}</p>;
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/app/suspense-error/loading.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/app/suspense-error/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading...</p>;
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/app/suspense-error/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/app/suspense-error/page.tsx
@@ -1,0 +1,8 @@
+import { ClientComponentTakingAPromise } from './client-page';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  const promise = fetch('http://example.com/').then(() => 'foobar');
+  return <ClientComponentTakingAPromise promise={promise} />;
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/tests/suspense-error.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/tests/suspense-error.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { waitForError, waitForTransaction } from '@sentry-internal/event-proxy-server';
+
+test('should not capture serverside suspense errors', async ({ page }) => {
+  const pageServerComponentTransactionPromise = waitForTransaction('nextjs-15', async transactionEvent => {
+    return transactionEvent?.transaction === 'Page Server Component (/suspense-error)';
+  });
+
+  let errorEventReceived = false;
+  waitForError('nextjs-15', async transactionEvent => {
+    return transactionEvent?.transaction === 'Page Server Component (/suspense-error)';
+  }).then(() => {
+    errorEventReceived = true;
+  });
+
+  await page.goto(`/suspense-error`);
+
+  await page.waitForTimeout(5000);
+
+  const pageServerComponentTransaction = await pageServerComponentTransactionPromise;
+  expect(pageServerComponentTransaction).toBeDefined();
+
+  expect(errorEventReceived).toBe(false);
+});


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
