### PR TITLE
test(replay): Remove outdated test constraint

### DIFF
--- a/dev-packages/browser-integration-tests/suites/replay/captureConsoleLog/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureConsoleLog/test.ts
@@ -4,9 +4,7 @@ import { sentryTest } from '../../../utils/fixtures';
 import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
 sentryTest('should capture console messages in replay', async ({ getLocalTestPath, page, forceFlushReplay }) => {
-  // console integration is not used in bundles/loader
-  const bundle = process.env.PW_BUNDLE || '';
-  if (shouldSkipReplayTest() || bundle.startsWith('bundle_') || bundle.startsWith('loader_')) {
+  if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
@@ -57,9 +55,7 @@ sentryTest('should capture console messages in replay', async ({ getLocalTestPat
 });
 
 sentryTest('should capture very large console logs', async ({ getLocalTestPath, page, forceFlushReplay }) => {
-  // console integration is not used in bundles/loader
-  const bundle = process.env.PW_BUNDLE || '';
-  if (shouldSkipReplayTest() || bundle.startsWith('bundle_') || bundle.startsWith('loader_')) {
+  if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 


### PR DESCRIPTION
Noticed this while looking into https://github.com/getsentry/sentry-javascript/issues/12244, console should be instrumented just fine in the CDN bundle.