### PR TITLE
build: Bump node to 18.20.3

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -149,7 +149,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Replay)',
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: true,
-    limit: '70 KB',
+    limit: '72 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback)',
@@ -170,7 +170,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.min.js'),
     gzip: false,
     brotli: false,
-    limit: '105 KB',
+    limit: '110 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay) - uncompressed',

--- a/dev-packages/e2e-tests/package.json
+++ b/dev-packages/e2e-tests/package.json
@@ -27,8 +27,7 @@
     "yaml": "2.2.2"
   },
   "volta": {
-    "node": "18.20.2",
-    "yarn": "1.22.22",
+    "extends": "../../package.json",
     "pnpm": "8.15.8"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/package.json
@@ -18,7 +18,6 @@
     "@playwright/test": "^1.27.1"
   },
   "volta": {
-    "extends": "../../package.json",
-    "node": "18.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-loader/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-loader/package.json
@@ -18,7 +18,6 @@
     "@playwright/test": "^1.27.1"
   },
   "volta": {
-    "extends": "../../package.json",
-    "node": "18.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-preload/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-preload/package.json
@@ -18,7 +18,6 @@
     "@playwright/test": "^1.27.1"
   },
   "volta": {
-    "extends": "../../package.json",
-    "node": "18.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/package.json
@@ -18,7 +18,6 @@
     "@playwright/test": "^1.27.1"
   },
   "volta": {
-    "extends": "../../package.json",
-    "node": "18.19.1"
+    "extends": "../../package.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "yalc:publish": "lerna run yalc:publish"
   },
   "volta": {
-    "node": "18.18.0",
+    "node": "18.20.3",
     "yarn": "1.22.19"
   },
   "workspaces": [


### PR DESCRIPTION
I noticed that locally the node-integration-tests that check versions fail, because in the SDK we use 18.18.0, we only check for "If node.major >= 18", and then get an incorrect test because actually in code we check the minor too.

Instead of adjust this, IMHO it's better to update this. This also never failed on CI because there we do use latest 18 for the matrix tests...