### PR TITLE
test: Fix flakey `inspector` test

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/deny-inspector.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/deny-inspector.mjs
@@ -4,14 +4,17 @@ const hookScript = Buffer.from(`
 
   `);
 
-register(new URL(`data:application/javascript,
+register(
+  new URL(`data:application/javascript,
 export async function resolve(specifier, context, nextResolve) {
   if (specifier === 'node:inspector' || specifier === 'inspector') {
     throw new Error('Should not use node:inspector module');
   }
 
   return nextResolve(specifier);
-}`), import.meta.url);
+}`),
+  import.meta.url,
+);
 
 const Sentry = await import('@sentry/node');
 

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/deny-inspector.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/deny-inspector.mjs
@@ -1,13 +1,18 @@
-import * as Sentry from '@sentry/node';
-import Hook from 'import-in-the-middle';
+import { register } from 'node:module';
 
-Hook((_, name) => {
-  if (name === 'inspector') {
-    throw new Error('No inspector!');
+const hookScript = Buffer.from(`
+
+  `);
+
+register(new URL(`data:application/javascript,
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === 'node:inspector' || specifier === 'inspector') {
+    throw new Error('Should not use node:inspector module');
   }
-  if (name === 'node:inspector') {
-    throw new Error('No inspector!');
-  }
-});
+
+  return nextResolve(specifier);
+}`), import.meta.url);
+
+const Sentry = await import('@sentry/node');
 
 Sentry.init({});

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -76,12 +76,10 @@ conditionalTest({ min: 18 })('LocalVariables integration', () => {
       .start(done);
   });
 
-  test('Should not import inspector when not in use', done => {
-    createRunner(__dirname, 'deny-inspector.mjs')
-      .withFlags('--import=@sentry/node/import')
-      .ensureNoErrorOutput()
-      .ignore('session')
-      .start(done);
+  conditionalTest({ min: 19 })('Node v19+', () => {
+    test('Should not import inspector when not in use', done => {
+      createRunner(__dirname, 'deny-inspector.mjs').ensureNoErrorOutput().ignore('session').start(done);
+    });
   });
 
   test('Includes local variables for caught exceptions when enabled', done => {


### PR DESCRIPTION
Uses an alternative test method.

Should reduce failures like [this](https://github.com/getsentry/sentry-javascript/actions/runs/9281632639/job/25538103763).