### PR TITLE
test(e2e): Remove axios from E2E tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/angular-17/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env['TEST_ENV'] || 'production';
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/angular-18/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-18/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env['TEST_ENV'] || 'production';
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/create-next-app/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/create-next-app/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/tests/behaviour-client.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
@@ -20,24 +19,12 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
 
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -71,28 +58,19 @@ test('Sends a pageload transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'pageload') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'pageload') {
                 hadPageLoadTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -136,28 +114,19 @@ test('Sends a navigation transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'navigation') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'navigation') {
                 hadPageNavigationTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/create-next-app/tests/behaviour-server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/tests/behaviour-server.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
@@ -18,21 +17,8 @@ test('Sends a server-side exception to Sentry', async ({ baseURL }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(url, { headers: { Authorization: `Bearer ${authToken}` } });
+        return response.status;
       },
       { timeout: EVENT_POLLING_TIMEOUT },
     )
@@ -53,21 +39,8 @@ test('Sends server-side transactions to Sentry', async ({ baseURL }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
-            }
+            const response = await fetch(url, { headers: { Authorization: `Bearer ${authToken}` } });
+            return response.status;
           },
           { timeout: EVENT_POLLING_TIMEOUT },
         )

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/tests/behaviour-client.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 
 const EVENT_POLLING_TIMEOUT = 90_000;
 
@@ -21,24 +20,11 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -72,28 +58,19 @@ test('Sends a pageload transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'pageload') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'pageload') {
                 hadPageLoadTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -137,28 +114,19 @@ test('Sends a navigation transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'navigation') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'navigation') {
                 hadPageNavigationTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/tests/behaviour-client.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 
 const EVENT_POLLING_TIMEOUT = 90_000;
 
@@ -21,24 +20,11 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -72,28 +58,19 @@ test('Sends a pageload transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'pageload') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'pageload') {
                 hadPageLoadTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -137,28 +114,19 @@ test('Sends a navigation transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'navigation') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'navigation') {
                 hadPageNavigationTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -182,23 +150,11 @@ test('Sends a client-side ErrorBoundary exception to Sentry', async ({ page }) =
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/behaviour-client.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 
 const EVENT_POLLING_TIMEOUT = 90_000;
 
@@ -21,24 +20,11 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -72,28 +58,19 @@ test('Sends a pageload transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'pageload') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'pageload') {
                 hadPageLoadTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -137,28 +114,19 @@ test('Sends a navigation transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'navigation') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'navigation') {
                 hadPageNavigationTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -182,23 +150,11 @@ test('Sends a client-side ErrorBoundary exception to Sentry', async ({ page }) =
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 
 const EVENT_POLLING_TIMEOUT = 90_000;
 
@@ -21,24 +20,11 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -72,28 +58,19 @@ test('Sends a pageload transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'pageload') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'pageload') {
                 hadPageLoadTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -137,28 +114,19 @@ test('Sends a navigation transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'navigation') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'navigation') {
                 hadPageNavigationTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -182,23 +150,11 @@ test('Sends a client-side ErrorBoundary exception to Sentry', async ({ page }) =
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/playwright.config.ts
@@ -2,11 +2,6 @@ import os from 'os';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/playwright.config.ts
@@ -2,11 +2,6 @@ import os from 'os';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/playwright.config.ts
@@ -2,11 +2,6 @@ import os from 'os';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/exceptions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/exceptions.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
@@ -24,24 +23,11 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { waitForError, waitForTransaction } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
@@ -28,24 +27,11 @@ test('Sends a transaction for a server component', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/event-proxy-server';
-import axios, { AxiosError } from 'axios';
 
 const packageJson = require('../package.json');
 
@@ -22,24 +21,11 @@ test('Sends a pageload transaction', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/playwright.config.mjs
@@ -1,7 +1,5 @@
 import { devices } from '@playwright/test';
 
-
-
 const eventProxyPort = 3031;
 const expressPort = 3030;
 

--- a/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/playwright.config.mjs
@@ -1,9 +1,6 @@
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
+
 
 const eventProxyPort = 3031;
 const expressPort = 3030;

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-loader/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-loader/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const eventProxyPort = 3031;
 const expressPort = 3030;
 

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-preload/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-preload/playwright.config.mjs
@@ -1,7 +1,5 @@
 import { devices } from '@playwright/test';
 
-
-
 const eventProxyPort = 3031;
 const expressPort = 3030;
 

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-preload/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-preload/playwright.config.mjs
@@ -1,9 +1,6 @@
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
+
 
 const eventProxyPort = 3031;
 const expressPort = 3030;

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const eventProxyPort = 3031;
 const expressPort = 3030;
 

--- a/dev-packages/e2e-tests/test-applications/node-express/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const eventProxyPort = 3031;
 const expressPort = 3030;
 

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@playwright/test": "1.26.1",
-    "axios": "1.6.0",
     "serve": "14.0.1"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@playwright/test": "^1.43.1",
     "@sentry-internal/event-proxy-server": "link:../../../event-proxy-server",
-    "axios": "1.6.0",
     "serve": "14.0.1"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/tests/behaviour-test.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/tests/behaviour-test.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 import { ReplayRecordingData } from './fixtures/ReplayRecordingData';
 
 const EVENT_POLLING_TIMEOUT = 90_000;
@@ -22,23 +21,11 @@ test('Sends an exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -72,28 +59,19 @@ test('Sends a pageload transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'pageload') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'pageload') {
                 hadPageLoadTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -137,28 +115,19 @@ test('Sends a navigation transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'navigation') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'navigation') {
                 hadPageNavigationTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -195,24 +164,11 @@ test('Sends a Replay recording to Sentry', async ({ browser }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -224,24 +180,17 @@ test('Sends a Replay recording to Sentry', async ({ browser }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/recording-segments/?cursor=100%3A0%3A1`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/recording-segments/?cursor=100%3A0%3A1`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
 
-          return response.status === 200 ? response.data[0] : response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
+        if (response.ok) {
+          const data = await response.json();
+          return data[0];
         }
+
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@playwright/test": "1.26.1",
-    "axios": "1.6.0",
     "serve": "14.0.1"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/tests/behaviour-test.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/tests/behaviour-test.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 import { ReplayRecordingData } from './fixtures/ReplayRecordingData';
 
 const EVENT_POLLING_TIMEOUT = 90_000;
@@ -22,23 +21,11 @@ test('Sends an exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -72,28 +59,19 @@ test('Sends a pageload transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'pageload') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'pageload') {
                 hadPageLoadTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -137,28 +115,19 @@ test('Sends a navigation transaction to Sentry', async ({ page }) => {
       await expect
         .poll(
           async () => {
-            try {
-              const response = await axios.get(
-                `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
-                { headers: { Authorization: `Bearer ${authToken}` } },
-              );
+            const response = await fetch(
+              `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${transactionEventId}/`,
+              { headers: { Authorization: `Bearer ${authToken}` } },
+            );
 
-              if (response.data.contexts.trace.op === 'navigation') {
+            if (response.ok) {
+              const data = await response.json();
+              if (data.contexts.trace.op === 'navigation') {
                 hadPageNavigationTransaction = true;
               }
-
-              return response.status;
-            } catch (e) {
-              if (e instanceof AxiosError && e.response) {
-                if (e.response.status !== 404) {
-                  throw e;
-                } else {
-                  return e.response.status;
-                }
-              } else {
-                throw e;
-              }
             }
+
+            return response.status;
           },
           {
             timeout: EVENT_POLLING_TIMEOUT,
@@ -195,24 +164,11 @@ test('Sends a Replay recording to Sentry', async ({ browser }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,
@@ -224,24 +180,17 @@ test('Sends a Replay recording to Sentry', async ({ browser }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/recording-segments/?cursor=100%3A0%3A1`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/recording-segments/?cursor=100%3A0%3A1`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
 
-          return response.status === 200 ? response.data[0] : response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
+        if (response.ok) {
+          const data = await response.json();
+          return data[0];
         }
+
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/svelte-5/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/svelte-5/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/vue-3/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/playwright.config.ts
@@ -1,11 +1,6 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
-// Fix urls not resolving to localhost on Node v17+
-// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
-import { setDefaultResultOrder } from 'dns';
-setDefaultResultOrder('ipv4first');
-
 const testEnv = process.env['TEST_ENV'] || 'production';
 
 if (!testEnv) {

--- a/dev-packages/e2e-tests/test-applications/webpack-4/tests/behaviour-test.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/webpack-4/tests/behaviour-test.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 
 const EVENT_POLLING_TIMEOUT = 90_000;
 
@@ -18,23 +17,11 @@ test('Sends an exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,

--- a/dev-packages/e2e-tests/test-applications/webpack-5/tests/behaviour-test.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/webpack-5/tests/behaviour-test.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import axios, { AxiosError } from 'axios';
 
 const EVENT_POLLING_TIMEOUT = 90_000;
 
@@ -18,23 +17,11 @@ test('Sends an exception to Sentry', async ({ page }) => {
   await expect
     .poll(
       async () => {
-        try {
-          const response = await axios.get(
-            `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
-            { headers: { Authorization: `Bearer ${authToken}` } },
-          );
-          return response.status;
-        } catch (e) {
-          if (e instanceof AxiosError && e.response) {
-            if (e.response.status !== 404) {
-              throw e;
-            } else {
-              return e.response.status;
-            }
-          } else {
-            throw e;
-          }
-        }
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${exceptionEventId}/`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
+        return response.status;
       },
       {
         timeout: EVENT_POLLING_TIMEOUT,


### PR DESCRIPTION
No need for it anymore, and actually it is much simpler using fetch because that does not throw when encountering a 404 error!