### PR TITLE
fix(nextjs): Do not hide `sourceMappingURL` comment on client when `nextConfig.productionBrowserSourceMaps: true` is set

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -48,6 +48,7 @@ export type NextConfigObject = {
     instrumentationHook?: boolean;
     clientTraceMetadata?: string[];
   };
+  productionBrowserSourceMaps?: boolean;
 };
 
 export type SentryBuildOptions = {

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -329,7 +329,8 @@ export function constructWebpackConfigFunction(
           // the browser won't look for them and throw errors into the console when it can't find them. Because this is a
           // front-end-only problem, and because `sentry-cli` handles sourcemaps more reliably with the comment than
           // without, the option to use `hidden-source-map` only applies to the client-side build.
-          newConfig.devtool = !isServer ? 'hidden-source-map' : 'source-map';
+          newConfig.devtool =
+            isServer || userNextConfig.productionBrowserSourceMaps ? 'source-map' : 'hidden-source-map';
         }
 
         newConfig.plugins = newConfig.plugins || [];


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/issues/12219 correctly points out that we are stomping the webpack `devtool` option for when people actually want to have the `sourceMappingURL` show up via `productionBrowserSourceMaps`.

With this PR, if people set `productionBrowserSourceMaps` in Next.js, we will not hide their `sourceMappingURL` comment.

Fixes https://github.com/getsentry/sentry-javascript/issues/12219