### PR TITLE
test(aws-lambda): Add basic lambda layer e2e test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -993,6 +993,7 @@ jobs:
           [
             'angular-17',
             'angular-18',
+            'aws-lambda-layer',
             'cloudflare-astro',
             'node-express',
             'create-react-app',

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/.npmrc
@@ -1,0 +1,2 @@
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
   },
   "devDependencies": {
-    "@sentry-internal/event-proxy-server": "link:../../../event-proxy-server",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
     "@playwright/test": "^1.41.1",
     "wait-port": "1.0.4"
   },

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "node-express-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "copy:layer": "cp -r ./../../../../packages/aws-serverless/build/aws/dist-serverless/nodejs/node_modules/ ./node_modules",
+    "start": "node src/run.js",
+    "test": "playwright test",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "test:build": "pnpm install && pnpm copy:layer",
+    "test:assert": "pnpm test"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@sentry-internal/event-proxy-server": "link:../../../event-proxy-server",
+    "@playwright/test": "^1.41.1",
+    "wait-port": "1.0.4"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/playwright.config.ts
@@ -1,0 +1,79 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+// Fix urls not resolving to localhost on Node v17+
+// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
+import { setDefaultResultOrder } from 'dns';
+setDefaultResultOrder('ipv4first');
+
+const eventProxyPort = 3031;
+const lambdaPort = 3030;
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 150_000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: 0,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'list',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: `http://localhost:${lambdaPort}`,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+    // For now we only test Chrome!
+    // {
+    //   name: 'firefox',
+    //   use: {
+    //     ...devices['Desktop Firefox'],
+    //   },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: {
+    //     ...devices['Desktop Safari'],
+    //   },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: [
+    {
+      command: `node start-event-proxy.mjs && pnpm wait-port ${eventProxyPort}`,
+      port: eventProxyPort,
+      stdout: 'pipe',
+    },
+  ],
+};
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/src/lambda-function.js
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/src/lambda-function.js
@@ -1,0 +1,19 @@
+const Sentry = require('@sentry/aws-serverless');
+
+const http = require('http');
+
+function handle() {
+  Sentry.startSpanManual({ name: 'aws-lambda-layer-test-txn', op: 'test' }, span => {
+    http.get('http://example.com', res => {
+      res.on('data', d => {
+        process.stdout.write(d);
+      });
+
+      res.on('end', () => {
+        span.end();
+      });
+    });
+  });
+}
+
+module.exports = { handle };

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/src/run-lambda.js
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/src/run-lambda.js
@@ -1,0 +1,2 @@
+const { handle } = require('./lambda-function');
+handle();

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/src/run.js
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/src/run.js
@@ -1,0 +1,16 @@
+const child_process = require('child_process');
+
+child_process.execSync('node ./src/run-lambda.js', {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    LAMBDA_TASK_ROOT: '.',
+    _HANDLER: 'handle',
+
+    NODE_OPTIONS: '--require @sentry/aws-serverless/dist/awslambda-auto',
+    SENTRY_DSN: 'http://public@localhost:3031/1337',
+    SENTRY_TRACES_SAMPLE_RATE: '1.0',
+    SENTRY_DEBUG: 'true',
+  },
+  cwd: process.cwd(),
+});

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/start-event-proxy.mjs
@@ -1,6 +1,4 @@
-import { startEventProxyServer } from '@sentry-internal/event-proxy-server';
-
-console.log('start proxy server');
+import { startEventProxyServer } from '@sentry-internal/test-utils';
 
 startEventProxyServer({
   port: 3031,

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/start-event-proxy.mjs
@@ -1,0 +1,9 @@
+import { startEventProxyServer } from '@sentry-internal/event-proxy-server';
+
+console.log('start proxy server');
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'aws-serverless-lambda-layer',
+  forwardToSentry: false,
+});

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/tests/basic.test.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/tests/basic.test.ts
@@ -1,0 +1,36 @@
+import * as child_process from 'child_process';
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/event-proxy-server';
+
+test('Lambda layer SDK bundle sends events', async ({ request }) => {
+  const transactionEventPromise = waitForTransaction('aws-serverless-lambda-layer', transactionEvent => {
+    return transactionEvent?.transaction === 'aws-lambda-layer-test-txn';
+  });
+
+  await new Promise<void>(resolve =>
+    setTimeout(() => {
+      resolve();
+    }, 1000),
+  );
+
+  child_process.execSync('pnpm start', {
+    stdio: 'ignore',
+  });
+
+  const transactionEvent = await transactionEventPromise;
+
+  // shows the SDK sent a transaction
+  expect(transactionEvent.transaction).toEqual('aws-lambda-layer-test-txn');
+
+  // shows that the Otel Http instrumentation is working
+  expect(transactionEvent.spans).toHaveLength(1);
+  expect(transactionEvent.spans![0]).toMatchObject({
+    data: expect.objectContaining({
+      'sentry.op': 'http.client',
+      'sentry.origin': 'auto.http.otel.http',
+      url: 'http://example.com/',
+    }),
+    description: 'GET http://example.com/',
+    op: 'http.client',
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer/tests/basic.test.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer/tests/basic.test.ts
@@ -1,6 +1,6 @@
 import * as child_process from 'child_process';
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/event-proxy-server';
+import { waitForTransaction } from '@sentry-internal/test-utils';
 
 test('Lambda layer SDK bundle sends events', async ({ request }) => {
   const transactionEventPromise = waitForTransaction('aws-serverless-lambda-layer', transactionEvent => {

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -76,9 +76,10 @@
   },
   "scripts": {
     "build": "run-p build:transpile build:types build:bundle",
-    "build:bundle": "yarn ts-node scripts/buildLambdaLayer.ts",
+    "build:bundle": "yarn build:layer",
+    "build:layer": "yarn ts-node scripts/buildLambdaLayer.ts",
     "build:dev": "run-p build:transpile build:types",
-    "build:transpile": "rollup -c rollup.npm.config.mjs",
+    "build:transpile": "rollup -c rollup.npm.config.mjs && yarn build:layer",
     "build:types": "run-s build:types:core build:types:downlevel",
     "build:types:core": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "yarn downlevel-dts build/npm/types build/npm/types-ts3.8 --to ts3.8",


### PR DESCRIPTION
This PR adds an e2e (or rather integration) test for our AWS lambda layer bundle. The motivation for this test is that we broke the layer during the initial v8 releases (multiple times for different reasons) without us noticing this in tests. Simply because we never tested the bundled SDK code that we create and publish for the lambda layer. 

The new e2e test tries to simulate a lambda environment by:

- copying over the lambda layer content into the test app as if a layer was added to a lambda function
- running a lambda function as a process which gets passed all environment variables that we [instruct users ](https://docs.sentry.io/platforms/javascript/guides/aws-lambda/container-image/#function-configuration)to set for a code-change-less Sentry lambda layer setup. This includes the `-r` argument to auto-init the SDK.
- Checking that an event was sent to Sentry
- Checking that Otel Insteumentation works

This is not the most sophisticated setup and definitely not fully E2E as we don't auto deploy anything to AWS. However, it's a good start and a relatively simple way to ensure at least basic functionality. This test would have caught all the layer-specific bugs we missed in the initial v8 releases.

Note: I had to make some adjustments to the proxy server to basically not always forward events to Sentry if you specify the respective flag when starting the proxy server. This is because we can't pass a tunnel option to the layer without calling `Sentry.init` explicitly in the code (which defeats the purpose of this test). 