### PR TITLE
fix(node): Do not manually finish / update root Hapi spans.

### DIFF
--- a/packages/node/src/integrations/tracing/hapi/index.ts
+++ b/packages/node/src/integrations/tracing/hapi/index.ts
@@ -3,14 +3,11 @@ import {
   SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SPAN_STATUS_ERROR,
   captureException,
   defineIntegration,
-  getActiveSpan,
   getClient,
   getDefaultIsolationScope,
   getIsolationScope,
-  getRootSpan,
   spanToJSON,
 } from '@sentry/core';
 import type { IntegrationFn, Span } from '@sentry/types';
@@ -79,18 +76,10 @@ export const hapiErrorPlugin = {
           logger.warn('Isolation scope is still the default isolation scope - skipping setting transactionName');
       }
 
-      const activeSpan = getActiveSpan();
-      const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
-
       if (request.response && isBoomObject(request.response)) {
         sendErrorToSentry(request.response);
       } else if (isErrorEvent(event)) {
         sendErrorToSentry(event.error);
-      }
-
-      if (rootSpan) {
-        rootSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-        rootSpan.end();
       }
     });
   },


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-javascript/issues/12260

We're currently attempting to manually update the Hapi route transaction status, followed by `.end()` call. 

Looking at `@opentelemetry/instrumentation-hapi`s code, it looks like that is [already covered by the underlying instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/27d6503089163a3d1ed85687cd8e0bc43f525fdd/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts#L395-L402).

This PR removes that, also extends tests to make sure the error events and the transactions are linked properly.