### PR TITLE
fix(browser): Minimum time for initial flush breaks replays for non-SPA #9301

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -14,6 +14,7 @@ import type {
 } from '@sentry/types';
 import { createClientReportEnvelope, dsnToString, getSDKSource, logger } from '@sentry/utils';
 
+import { getReplay } from '@sentry-internal/replay';
 import { DEBUG_BUILD } from './debug-build';
 import { eventFromException, eventFromMessage } from './eventbuilder';
 import { WINDOW } from './helpers';
@@ -69,6 +70,11 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
         }
       });
     }
+
+    window.addEventListener('beforeunload', () => {
+      getReplay()?.flush();
+    });
+
   }
 
   /**


### PR DESCRIPTION
fix(browser): Minimum time for initial flush breaks replays for non-SPA #9301

This implementation is completely dependent on browser functionality. At least this will save some replay events which were getting lost.

