### PR TITLE
fix(feedback): Wait for document to be ready before doing autoinject

### DIFF
--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -276,7 +276,12 @@ export const buildFeedbackIntegration = ({
           return;
         }
 
-        _createActor().appendToDom();
+        const actor = _createActor();
+        if (DOCUMENT.readyState === 'loading') {
+          DOCUMENT.addEventListener('DOMContentLoaded', actor.appendToDom);
+        } else {
+          actor.appendToDom();
+        }
       },
 
       /**


### PR DESCRIPTION
The error that folks are getting is something like this: `[Error] TypeError: null is not an object (evaluating 'qo.body.appendChild')`

The problem seems to be that we're trying to inject the button into the html before the `<body>` is ready. Using async `<script defer>`  or `<script async>` would probably help, but none of our snippets have that, and it would also defer error observers and everything else.

What we can do for users it have the feedback integration wait before inserting the button + styles!

Fixes https://github.com/getsentry/sentry-javascript/issues/12112