### PR TITLE
fix(v7/publish): Add `v7` tag to `@sentry/replay`

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -5,6 +5,10 @@
   "main": "build/npm/cjs/index.js",
   "module": "build/npm/esm/index.js",
   "types": "build/npm/types/index.d.ts",
+  "publishConfig": {
+    "access": "public",
+    "tag": "v7"
+  },
   "typesVersions": {
     "<4.9": {
       "build/npm/types/index.d.ts": [


### PR DESCRIPTION
Noticed that this package was missing the `v7` npm tag entry, causing some tests in migr8 to fail. 