### PR TITLE
fix(browser): Fix types export path for CJS

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -26,7 +26,7 @@
         "default": "./build/npm/esm/index.js"
       },
       "require": {
-        "types": "./build/npm.types/index.d.ts",
+        "types": "./build/npm/types/index.d.ts",
         "default": "./build/npm/cjs/index.js"
       }
     }


### PR DESCRIPTION
Oops... 

Fixes https://github.com/getsentry/sentry-javascript/issues/12295