### PR TITLE
fix(replay): Avoid infinite loop of logs

### DIFF
--- a/packages/replay-internal/src/util/addEvent.ts
+++ b/packages/replay-internal/src/util/addEvent.ts
@@ -5,7 +5,7 @@ import { logger } from '@sentry/utils';
 import { DEBUG_BUILD } from '../debug-build';
 import { EventBufferSizeExceededError } from '../eventBuffer/error';
 import type { AddEventResult, RecordingEvent, ReplayContainer, ReplayFrameEvent, ReplayPluginOptions } from '../types';
-import { logInfo } from './log';
+import { logInfoNextTick } from './log';
 import { timestampToMs } from './timestamp';
 
 function isCustomEvent(event: RecordingEvent): event is ReplayFrameEvent {
@@ -109,7 +109,7 @@ export function shouldAddEvent(replay: ReplayContainer, event: RecordingEvent): 
 
   // Throw out events that are +60min from the initial timestamp
   if (timestampInMs > replay.getContext().initialTimestamp + replay.getOptions().maxReplayDuration) {
-    logInfo(
+    logInfoNextTick(
       `[Replay] Skipping event with timestamp ${timestampInMs} because it is after maxReplayDuration`,
       replay.getOptions()._experiments.traceInternals,
     );


### PR DESCRIPTION
When using `_experiments.traceInternals`, this could lead to an infinite loop, as we run this check when a breadcrumb is added, and we add this breadcrumb in the check, ...

Fixes https://github.com/getsentry/sentry-javascript/issues/12283
