### PR TITLE
ref(browser): Ensure idle span ending is consistent

### DIFF
--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -85,6 +85,7 @@ jobs:
         env:
           CHANGED_TEST_PATHS: ${{ steps.changed.outputs.browser_integration_files }}
           TEST_RUN_COUNT: 'AUTO'
+          PW_BUNDLE: bundle_tracing_replay_feedback
 
       - name: Artifacts upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -85,7 +85,6 @@ jobs:
         env:
           CHANGED_TEST_PATHS: ${{ steps.changed.outputs.browser_integration_files }}
           TEST_RUN_COUNT: 'AUTO'
-          PW_BUNDLE: bundle_tracing_replay_feedback
 
       - name: Artifacts upload
         uses: actions/upload-artifact@v4

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
@@ -12,6 +12,7 @@ Sentry.init({
   ],
   defaultIntegrations: false,
   tracesSampleRate: 1,
+  debug: true
 });
 
 const activeSpan = Sentry.getActiveSpan();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
@@ -12,6 +12,7 @@ Sentry.init({
   ],
   defaultIntegrations: false,
   tracesSampleRate: 1,
+  debug: true,
 });
 
 const activeSpan = Sentry.getActiveSpan();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
@@ -12,14 +12,13 @@ Sentry.init({
   ],
   defaultIntegrations: false,
   tracesSampleRate: 1,
-  debug: true
+  debug: true,
 });
 
 const activeSpan = Sentry.getActiveSpan();
-if (activeSpan) {
-  Sentry.startInactiveSpan({ name: 'pageload-child-span' });
-} else {
-  setTimeout(() => {
-    Sentry.startInactiveSpan({ name: 'pageload-child-span' });
-  }, 200);
-}
+Sentry.startInactiveSpan({
+  name: 'pageload-child-span',
+  onlyIfParent: true,
+  // Set this to ensure we do not discard this span due to timeout
+  startTime: activeSpan && Sentry.spanToJSON(activeSpan).start_timestamp,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
@@ -12,7 +12,6 @@ Sentry.init({
   ],
   defaultIntegrations: false,
   tracesSampleRate: 1,
-  debug: true,
 });
 
 const activeSpan = Sentry.getActiveSpan();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/test.ts
@@ -21,6 +21,7 @@ sentryTest('should send a pageload span terminated via child span timeout', asyn
   const eventData = envelopeRequestParser(req);
 
   expect(eventData.contexts?.trace?.op).toBe('pageload');
+  expect(eventData.contexts?.trace?.data?.['sentry.idle_span_discarded_spans']).toBeUndefined();
   expect(eventData.spans?.length).toBeGreaterThanOrEqual(1);
   const testSpan = eventData.spans?.find(span => span.description === 'pageload-child-span');
   expect(testSpan).toBeDefined();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/test.ts
@@ -15,8 +15,6 @@ sentryTest('should send a pageload span terminated via child span timeout', asyn
     sentryTest.skip();
   }
 
-  page.on('console', msg => console.log(msg.text()));
-
   const url = await getLocalTestUrl({ testDir: __dirname });
   const req = await waitForTransactionRequestOnUrl(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/test.ts
@@ -15,6 +15,8 @@ sentryTest('should send a pageload span terminated via child span timeout', asyn
     sentryTest.skip();
   }
 
+  page.on('console', msg => console.log(msg.text()));
+
   const url = await getLocalTestUrl({ testDir: __dirname });
   const req = await waitForTransactionRequestOnUrl(page, url);
 

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -268,17 +268,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       }
 
       const childSpanJSON = spanToJSON(childSpan);
-      const { timestamp: childEndTimestamp, start_timestamp: childStartTimestamp } = childSpanJSON;
-
-      if (!childStartTimestamp || !childEndTimestamp) {
-        DEBUG_BUILD &&
-          logger.log(
-            '[Tracing] Discarding span since it has no start or end timestamp',
-            JSON.stringify(childSpan, undefined, 2),
-          );
-
-        return;
-      }
+      const { timestamp: childEndTimestamp = 0, start_timestamp: childStartTimestamp = 0 } = childSpanJSON;
 
       const spanStartedBeforeIdleSpanEnd = childStartTimestamp <= endTimestamp;
 
@@ -289,11 +279,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       if (DEBUG_BUILD) {
         const stringifiedSpan = JSON.stringify(childSpan, undefined, 2);
         if (!spanStartedBeforeIdleSpanEnd) {
-          logger.log(
-            '[Tracing] Discarding span since it happened after idle span was finished',
-            stringifiedSpan,
-            endTimestamp,
-          );
+          logger.log('[Tracing] Discarding span since it happened after idle span was finished', stringifiedSpan);
         } else if (!spanEndedBeforeFinalTimeout) {
           logger.log('[Tracing] Discarding span since it finished after idle span final timeout', stringifiedSpan);
         }

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -130,7 +130,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       // If we have no spans, we just end, nothing else to do here
       if (!spans.length) {
         onIdleSpanEnded(spanEndTimestamp);
-        return Reflect.apply(target, thisArg, args);
+        return Reflect.apply(target, thisArg, [spanEndTimestamp]);
       }
 
       const childEndTimestamps = spans

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -121,7 +121,9 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
         beforeSpanEnd(span);
       }
 
-      const timestamp = args[0] || timestampInSeconds();
+      // Just ensuring that this keeps working, even if we ever have more arguments here
+      const [definedEndTimestamp, ...rest] = args;
+      const timestamp = definedEndTimestamp || timestampInSeconds();
       const spanEndTimestamp = spanTimeInputToSeconds(timestamp);
 
       // Ensure we end with the last span timestamp, if possible
@@ -130,7 +132,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       // If we have no spans, we just end, nothing else to do here
       if (!spans.length) {
         onIdleSpanEnded(spanEndTimestamp);
-        return Reflect.apply(target, thisArg, [spanEndTimestamp]);
+        return Reflect.apply(target, thisArg, [spanEndTimestamp, ...rest]);
       }
 
       const childEndTimestamps = spans
@@ -152,7 +154,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       );
 
       onIdleSpanEnded(endTimestamp);
-      return Reflect.apply(target, thisArg, [endTimestamp]);
+      return Reflect.apply(target, thisArg, [endTimestamp, ...rest]);
     },
   });
 

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -268,7 +268,17 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       }
 
       const childSpanJSON = spanToJSON(childSpan);
-      const { timestamp: childEndTimestamp = 0, start_timestamp: childStartTimestamp = 0 } = childSpanJSON;
+      const { timestamp: childEndTimestamp, start_timestamp: childStartTimestamp } = childSpanJSON;
+
+      if (!childStartTimestamp || !childEndTimestamp) {
+        DEBUG_BUILD &&
+          logger.log(
+            '[Tracing] Discarding span since it has no start or end timestamp',
+            JSON.stringify(childSpan, undefined, 2),
+          );
+
+        return;
+      }
 
       const spanStartedBeforeIdleSpanEnd = childStartTimestamp <= endTimestamp;
 
@@ -279,7 +289,11 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       if (DEBUG_BUILD) {
         const stringifiedSpan = JSON.stringify(childSpan, undefined, 2);
         if (!spanStartedBeforeIdleSpanEnd) {
-          logger.log('[Tracing] Discarding span since it happened after idle span was finished', stringifiedSpan);
+          logger.log(
+            '[Tracing] Discarding span since it happened after idle span was finished',
+            stringifiedSpan,
+            endTimestamp,
+          );
         } else if (!spanEndedBeforeFinalTimeout) {
           logger.log('[Tracing] Discarding span since it finished after idle span final timeout', stringifiedSpan);
         }


### PR DESCRIPTION
Saw this flake here: https://github.com/getsentry/sentry-javascript/actions/runs/9316244122/job/25644256391

It seems this was sometimes minimally flakey because we used a slightly different end time in the two places - no, we ensure to use the same, which should make this more consistent.