### PR TITLE
fix(nextjs): Fix version detection and option insertion logic for `clientTraceMetadata` option

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -89,11 +89,13 @@ function getFinalConfigObject(
   const nextJsVersion = getNextjsVersion();
   if (nextJsVersion) {
     const { major, minor } = parseSemver(nextJsVersion);
-    if (typeof major === 'number' && typeof minor === 'number' && (major >= 15 || (major === 14 && minor >= 3))) {
-      incomingUserNextConfigObject.experimental = {
-        clientTraceMetadata: ['baggage', 'sentry-trace'],
-        ...incomingUserNextConfigObject.experimental,
-      };
+    if (major !== undefined && minor !== undefined && (major >= 15 || (major === 14 && minor >= 3))) {
+      incomingUserNextConfigObject.experimental = incomingUserNextConfigObject.experimental || {};
+      incomingUserNextConfigObject.experimental.clientTraceMetadata = [
+        'baggage',
+        'sentry-trace',
+        ...(incomingUserNextConfigObject.experimental?.clientTraceMetadata || []),
+      ];
     }
   } else {
     // eslint-disable-next-line no-console

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -89,7 +89,7 @@ function getFinalConfigObject(
   const nextJsVersion = getNextjsVersion();
   if (nextJsVersion) {
     const { major, minor } = parseSemver(nextJsVersion);
-    if (major && minor && (major >= 15 || (major === 14 && minor >= 3))) {
+    if (typeof major === 'number' && typeof minor === 'number' && (major >= 15 || (major === 14 && minor >= 3))) {
       incomingUserNextConfigObject.experimental = {
         clientTraceMetadata: ['baggage', 'sentry-trace'],
         ...incomingUserNextConfigObject.experimental,


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

---

When using Next.js v15.0.0-rc.0 or v15.0.0-canary.6, `withSentryConfig` does not add `clientTraceMetadata` to `experimental`. This is because both rc and canary releases have a minor version of `0` and are always treated as `false`.