### PR TITLE
fix(nextjs): Fix version detection and option insertion logic for `clientTraceMetadata` option

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -89,11 +89,13 @@ function getFinalConfigObject(
   const nextJsVersion = getNextjsVersion();
   if (nextJsVersion) {
     const { major, minor } = parseSemver(nextJsVersion);
-    if (major && minor && (major >= 15 || (major === 14 && minor >= 3))) {
-      incomingUserNextConfigObject.experimental = {
-        clientTraceMetadata: ['baggage', 'sentry-trace'],
-        ...incomingUserNextConfigObject.experimental,
-      };
+    if (major !== undefined && minor !== undefined && (major >= 15 || (major === 14 && minor >= 3))) {
+      incomingUserNextConfigObject.experimental = incomingUserNextConfigObject.experimental || {};
+      incomingUserNextConfigObject.experimental.clientTraceMetadata = [
+        'baggage',
+        'sentry-trace',
+        ...(incomingUserNextConfigObject.experimental?.clientTraceMetadata || []),
+      ];
     }
   } else {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
The detection logic didn't work for Next.js 15.0.0 because the minor was falsy.

Also, we were not merging the `clientTraceMetadata` option and instead just overriding it.