### PR TITLE
ci(canary-tests): Fix Next.js canary test issues

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -54,7 +54,7 @@ jobs:
     name: E2E ${{ matrix.label }} Test
     needs: [job_e2e_prepare]
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       E2E_TEST_AUTH_TOKEN: ${{ secrets.E2E_TEST_AUTH_TOKEN }}
       E2E_TEST_DSN: ${{ secrets.E2E_TEST_DSN }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Run E2E test
         working-directory: dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: yarn test:assert
 
       - name: Create Issue

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
@@ -9,7 +9,7 @@
     "test:dev": "TEST_ENV=development playwright test",
     "test:build": "pnpm install && npx playwright install && pnpm build",
     "test:build-canary": "pnpm install && pnpm add next@rc && pnpm add react@beta && pnpm add react-dom@beta && npx playwright install && pnpm build",
-    "test:build-latest": "pnpm install && pnpm add next@latest && npx playwright install && pnpm build",
+    "test:build-latest": "pnpm install && pnpm add next@rc && pnpm add react@beta && pnpm add react-dom@beta && npx playwright install && pnpm build",
     "test:assert": "pnpm test:prod && pnpm test:dev"
   },
   "dependencies": {

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
@@ -8,7 +8,7 @@
     "test:prod": "TEST_ENV=production playwright test",
     "test:dev": "TEST_ENV=development playwright test",
     "test:build": "pnpm install && npx playwright install && pnpm build",
-    "test:build-canary": "pnpm install && pnpm add next@canary && pnpm add react@beta && pnpm add react-dom@beta && npx playwright install && pnpm build",
+    "test:build-canary": "pnpm install && pnpm add next@rc && pnpm add react@beta && pnpm add react-dom@beta && npx playwright install && pnpm build",
     "test:build-latest": "pnpm install && pnpm add next@latest && npx playwright install && pnpm build",
     "test:assert": "pnpm test:prod && pnpm test:dev"
   },

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
@@ -8,7 +8,7 @@ const buildStdout = fs.readFileSync('.tmp_build_stdout', 'utf-8');
 const buildStderr = fs.readFileSync('.tmp_build_stderr', 'utf-8');
 
 // Assert that there was no funky build time warning when we are on a stable (pinned) version
-if (nextjsVersion !== 'latest' && nextjsVersion !== 'canary') {
+if (nextjsVersion !== 'latest' && !nextjsVersion.includes('-canary') && !nextjsVersion.includes('-rc')) {
   assert.doesNotMatch(buildStderr, /Import trace for requested module/); // This is Next.js/Webpack speech for "something is off"
 }
 


### PR DESCRIPTION
- Increase timout for canary tests
- Use Next.js `rc` build, otherwise build crashes
- Don't assert build output for canary and rc builds