### PR TITLE
fix(nextjs): Fix memory leak

### DIFF
--- a/packages/nextjs/src/common/utils/responseEnd.ts
+++ b/packages/nextjs/src/common/utils/responseEnd.ts
@@ -50,8 +50,6 @@ export function finishSpan(span: Span, res: ServerResponse): void {
 export async function flushSafelyWithTimeout(): Promise<void> {
   try {
     DEBUG_BUILD && logger.log('Flushing events...');
-    // We give things that are currently stuck in event processors a tiny bit more time to finish before flushing. 50ms was chosen very unscientifically.
-    await new Promise(resolve => setTimeout(resolve, 50));
     await flush(2000);
     DEBUG_BUILD && logger.log('Done flushing events');
   } catch (e) {


### PR DESCRIPTION
I honestly don't know why this fixes the memory leak.

I tried using

```ts
await new Promise(resolve => setTimeout(() => { resolve() }), 50))
```

and

```ts
await new Promise(resolve => { setTimeout(() => { resolve() }) }, 50))
```

but they both also leak.

Since this was just a nice to have, the best path moving forward is just to remove the artificial delay.

Probably fixes https://github.com/getsentry/sentry-javascript/issues/12317