### PR TITLE
doc(v7): Add package discontinuity notes to remaining discontinued packages

### DIFF
--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -10,6 +10,12 @@
 [![npm dm](https://img.shields.io/npm/dm/@sentry/hub.svg)](https://www.npmjs.com/package/@sentry/hub)
 [![npm dt](https://img.shields.io/npm/dt/@sentry/hub.svg)](https://www.npmjs.com/package/@sentry/hub)
 
+## Package Discontinued
+
+This package was discontinued with version 8.0.0 of the Sentry JavaScript SDKs. Instead, relevant exports from this
+package are exported from `@sentry/core`. For more information have a look at the
+[Migration Guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#sentryhub).
+
 ## Links
 
 - [Official SDK Docs](https://docs.sentry.io/quickstart/)

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -15,6 +15,15 @@
 - [Official SDK Docs](https://docs.sentry.io/quickstart/)
 - [TypeDoc](http://getsentry.github.io/sentry-javascript/)
 
+## Package Discontinued
+
+This package was discontinued with version 8.0.0 of the Sentry JavaScript SDKs. All integrations from this package are
+now directly exported from the SDK packages like `@sentry/react` or `@sentry/node`. For more information have a look at
+the migration guide for
+[client-](https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/#removal-of-sentryintegrations-package) and
+[server-side](https://docs.sentry.io/platforms/javascript/guides/node/migration/v7-to-v8/#removal-of-sentryintegrations-package)
+SDKs.
+
 ## General
 
 Pluggable integrations that can be used to enhance JS SDKs.

--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -10,21 +10,29 @@
 [![npm dm](https://img.shields.io/npm/dm/@sentry/replay.svg)](https://www.npmjs.com/package/@sentry/replay)
 [![npm dt](https://img.shields.io/npm/dt/@sentry/replay.svg)](https://www.npmjs.com/package/@sentry/replay)
 
+## Package Discontinued
+
+The standalone `@sentry/replay` package is no longer published with version 8.0.0 of the Sentry JavaScript SDKs.
+Instead, the replay integration is now directly exported in all client-side SDK packages (e.g `@sentry/react` or
+`@sentry/nextjs`). Head over to our v8
+[Migration Guide](https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/#removal-of-sentryreplay-package) for
+more information.
+
 ## Pre-requisites
 
 `@sentry/replay` requires Node 12+, and browsers newer than IE11.
 
 ## Installation
 
-Replay can be imported from `@sentry/browser`, or a respective SDK package like `@sentry/react` or `@sentry/vue`.
-You don't need to install anything in order to use Session Replay. The minimum version that includes Replay is 7.27.0.
+Replay can be imported from `@sentry/browser`, or a respective SDK package like `@sentry/react` or `@sentry/vue`. You
+don't need to install anything in order to use Session Replay. The minimum version that includes Replay is 7.27.0.
 
 For details on using Replay when using Sentry via the CDN bundles, see [CDN bundle](#loading-replay-as-a-cdn-bundle).
 
 ## Setup
 
-To set up the integration, add the following to your Sentry initialization. Several options are supported and passable via the integration constructor.
-See the [configuration section](#configuration) below for more details.
+To set up the integration, add the following to your Sentry initialization. Several options are supported and passable
+via the integration constructor. See the [configuration section](#configuration) below for more details.
 
 ```javascript
 import * as Sentry from '@sentry/browser';
@@ -45,9 +53,9 @@ Sentry.init({
     new Sentry.Replay({
       // Additional SDK configuration goes in here, for example:
       maskAllText: true,
-      blockAllMedia: true
+      blockAllMedia: true,
       // See below for all available options
-    })
+    }),
   ],
   // ...
 });
@@ -55,9 +63,8 @@ Sentry.init({
 
 ### Lazy loading Replay
 
-Replay will start automatically when you add the integration.
-If you do not want to start Replay immediately (e.g. if you want to lazy-load it),
-you can also use `addIntegration` to load it later:
+Replay will start automatically when you add the integration. If you do not want to start Replay immediately (e.g. if
+you want to lazy-load it), you can also use `addIntegration` to load it later:
 
 ```js
 import * as Sentry from "@sentry/react";
@@ -78,17 +85,20 @@ client?.addIntegration(new Replay());
 
 ### Identifying Users
 
-If you have only followed the above instructions to setup session replays, you will only see IP addresses in Sentry's UI. In order to associate a user identity to a session replay, use [`setUser`](https://docs.sentry.io/platforms/javascript/enriching-events/identify-user/).
+If you have only followed the above instructions to setup session replays, you will only see IP addresses in Sentry's
+UI. In order to associate a user identity to a session replay, use
+[`setUser`](https://docs.sentry.io/platforms/javascript/enriching-events/identify-user/).
 
 ```javascript
-import * as Sentry from "@sentry/browser";
+import * as Sentry from '@sentry/browser';
 
-Sentry.setUser({ email: "jane.doe@example.com" });
+Sentry.setUser({ email: 'jane.doe@example.com' });
 ```
 
 ### Stopping & starting Replays manually
 
-Replay recording only starts when it is included in the `integrations` array when calling `Sentry.init` or calling `addIntegration` from the a Sentry client instance. To stop recording you can call `stop()`.
+Replay recording only starts when it is included in the `integrations` array when calling `Sentry.init` or calling
+`addIntegration` from the a Sentry client instance. To stop recording you can call `stop()`.
 
 ```js
 import * as Sentry from "@sentry/react";
@@ -109,20 +119,19 @@ client?.addIntegration(replay);
 replay.stop();
 ```
 
-When both `replaysSessionSampleRate` and `replaysOnErrorSampleRate` are `0`, recording will _not_ start.
-In this case, you can manually start recording:
+When both `replaysSessionSampleRate` and `replaysOnErrorSampleRate` are `0`, recording will _not_ start. In this case,
+you can manually start recording:
 
 ```js
 replay.start(); // Will start a session in "session" mode, regardless of sample rates
 replay.startBuffering(); // Will start a session in "buffer" mode, regardless of sample rates
 ```
 
-
-
 ## Loading Replay as a CDN Bundle
 
-As an alternative to the NPM package, you can use Replay as a CDN bundle.
-Please refer to the [Session Replay installation guide](https://docs.sentry.io/platforms/javascript/session-replay/#install) for CDN bundle instructions.
+As an alternative to the NPM package, you can use Replay as a CDN bundle. Please refer to the
+[Session Replay installation guide](https://docs.sentry.io/platforms/javascript/session-replay/#install) for CDN bundle
+instructions.
 
 <details>
 <summary>Deprecated Replay integration bundle</summary>
@@ -131,44 +140,47 @@ complete CDN bundles that already contain the replay integration. No need to kee
 The `replay.(min.)js` bundle will be removed in v8 of the JS SDKs.
 
 ```html
-<script
-  src="https://browser.sentry-cdn.com/7.41.0/bundle.min.js"
-  crossorigin="anonymous"
-></script>
-<script
-  src="https://browser.sentry-cdn.com/7.41.0/replay.min.js"
-  crossorigin="anonymous"
-></script>
+<script src="https://browser.sentry-cdn.com/7.41.0/bundle.min.js" crossorigin="anonymous"></script>
+<script src="https://browser.sentry-cdn.com/7.41.0/replay.min.js" crossorigin="anonymous"></script>
 ```
+
 </details>
 
 ## Sessions
 
-A session starts when the Session Replay SDK is first loaded and initialized. The session will continue until 5 minutes passes without any user interactions[^1] with the application *OR* until a maximum of 30 minutes have elapsed. Closing the browser tab will end the session immediately according to the rules for [SessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).
+A session starts when the Session Replay SDK is first loaded and initialized. The session will continue until 5 minutes
+passes without any user interactions[^1] with the application _OR_ until a maximum of 30 minutes have elapsed. Closing
+the browser tab will end the session immediately according to the rules for
+[SessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).
 
 [^1]: An 'interaction' refers to either a mouse click or a browser navigation event.
 
 ### Accessing the Replay Session ID
 
-You can get the ID of the currently running session via `replay.getReplayId()`.
-This will return `undefined` if no session is ongoing.
+You can get the ID of the currently running session via `replay.getReplayId()`. This will return `undefined` if no
+session is ongoing.
 
 ### Replay Captures Only on Errors
 
-Alternatively, rather than recording an entire session, you can capture a replay only when an error occurs. In this case, the integration will buffer up to one minute worth of events prior to the error being thrown. It will continue to record the session following the rules above regarding session life and activity. Read the [sampling](#Sampling) section for configuration options.
+Alternatively, rather than recording an entire session, you can capture a replay only when an error occurs. In this
+case, the integration will buffer up to one minute worth of events prior to the error being thrown. It will continue to
+record the session following the rules above regarding session life and activity. Read the [sampling](#Sampling) section
+for configuration options.
 
 ## Sampling
 
-Sampling allows you to control how much of your website's traffic will result in a Session Replay. There are two sample rates you can adjust to get the replays more relevant to your interests:
+Sampling allows you to control how much of your website's traffic will result in a Session Replay. There are two sample
+rates you can adjust to get the replays more relevant to your interests:
 
-- `replaysSessionSampleRate` - The sample rate for replays that begin recording immediately and last the entirety of the user's session.
-- `replaysOnErrorSampleRate` - The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends.
+- `replaysSessionSampleRate` - The sample rate for replays that begin recording immediately and last the entirety of the
+  user's session.
+- `replaysOnErrorSampleRate` - The sample rate for replays that are recorded when an error happens. This type of replay
+  will record up to a minute of events prior to the error and continue recording until the session ends.
 
-When Replay is initialized, we check the `replaysSessionSampleRate`.
-If it is sampled, then we start recording & sending Replay data immediately.
-Else, if `replaysOnErrorSampleRate > 0`, we'll start recording in buffering mode.
-In this mode, whenever an error occurs we'll check `replaysOnErrorSampleRate`.
-If it is sampled, when we'll upload the Replay to Sentry and continue recording normally.
+When Replay is initialized, we check the `replaysSessionSampleRate`. If it is sampled, then we start recording & sending
+Replay data immediately. Else, if `replaysOnErrorSampleRate > 0`, we'll start recording in buffering mode. In this mode,
+whenever an error occurs we'll check `replaysOnErrorSampleRate`. If it is sampled, when we'll upload the Replay to
+Sentry and continue recording normally.
 
 ## Configuration
 
@@ -176,76 +188,87 @@ If it is sampled, when we'll upload the Replay to Sentry and continue recording 
 
 The following options can be configured on the root level of your browser-based Sentry SDK, in `init({})`:
 
-
-| key                 | type    | default | description                                                                                                                                                                                                                     |
-| ------------------- | ------- | ------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------   |
-| replaysSessionSampleRate   | number  | `0`   | The sample rate for replays that begin recording immediately and last the entirety of the user's session. 1.0 will collect all replays, 0 will collect no replays.                                           |
-| replaysOnErrorSampleRate     | number  | `0`   |The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. 1.0 capturing all sessions with an error, and 0 capturing none.
+| key                      | type   | default | description                                                                                                                                                                                                                                                     |
+| ------------------------ | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| replaysSessionSampleRate | number | `0`     | The sample rate for replays that begin recording immediately and last the entirety of the user's session. 1.0 will collect all replays, 0 will collect no replays.                                                                                              |
+| replaysOnErrorSampleRate | number | `0`     | The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. 1.0 capturing all sessions with an error, and 0 capturing none. |
 
 ### General Integration Configuration
 
 The following options can be configured as options to the integration, in `new Replay({})`:
 
-| key                 | type    | default | description                                                                                                                                                                                                                     |
-| ------------------- | ------- | ------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------   |
-| stickySession       | boolean | `true`  | Keep track of the user across page loads. Note a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well.                                               |
-
+| key           | type    | default | description                                                                                                                                                                       |
+| ------------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| stickySession | boolean | `true`  | Keep track of the user across page loads. Note a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well. |
 
 ### Privacy Configuration
 
 The following options can be configured as options to the integration, in `new Replay({})`:
 
-| key              | type                     | default                                 | description                                                                                                                                  |
-| ---------------- | ------------------------ | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| maskAllText      | boolean                  | `true`                                  | Mask _all_ text content. Will pass text content through `maskFn` before sending to server.                                                   |
-| maskAllInputs    | boolean                  | `true`                                  | Mask values of `<input>` elements. Passes input values through `maskInputFn` before sending to server.                                       |
-| blockAllMedia    | boolean                  | `true`                                  | Block _all_ media elements (`img, svg, video, object, picture, embed, map, audio`)                                                           |
-| maskFn           | (text: string) => string | `(text) => '*'.repeat(text.length)`     | Function to customize how text content is masked before sending to server. By default, masks text with `*`.                                  |
-| block            | Array<string>            | `.sentry-block, [data-sentry-block]`    | Redact any elements that match the DOM selectors. See [privacy](#blocking) section for an example.                                           |
-| unblock          | Array<string>            | `.sentry-unblock, [data-sentry-unblock]`| Do not redact any elements that match the DOM selectors. Useful when using `blockAllMedia`. See [privacy](#blocking) section for an example. |
-| mask             | Array<string>            | `.sentry-mask, [data-sentry-mask]`      | Mask all elements that match the given DOM selectors. See [privacy](#masking) section for an example.                                        |
-| unmask           | Array<string>            | `.sentry-unmask, [data-sentry-unmask]`  | Unmask all elements that match the given DOM selectors. Useful when using `maskAllText`. See [privacy](#masking) section for an example.     |
-| ignore           | Array<string>            | `.sentry-ignore, [data-sentry-ignore]`  | Ignores all events on the matching input fields. See [privacy](#ignoring) section for an example.                                            |
+| key           | type                     | default                                  | description                                                                                                                                  |
+| ------------- | ------------------------ | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| maskAllText   | boolean                  | `true`                                   | Mask _all_ text content. Will pass text content through `maskFn` before sending to server.                                                   |
+| maskAllInputs | boolean                  | `true`                                   | Mask values of `<input>` elements. Passes input values through `maskInputFn` before sending to server.                                       |
+| blockAllMedia | boolean                  | `true`                                   | Block _all_ media elements (`img, svg, video, object, picture, embed, map, audio`)                                                           |
+| maskFn        | (text: string) => string | `(text) => '*'.repeat(text.length)`      | Function to customize how text content is masked before sending to server. By default, masks text with `*`.                                  |
+| block         | Array<string>            | `.sentry-block, [data-sentry-block]`     | Redact any elements that match the DOM selectors. See [privacy](#blocking) section for an example.                                           |
+| unblock       | Array<string>            | `.sentry-unblock, [data-sentry-unblock]` | Do not redact any elements that match the DOM selectors. Useful when using `blockAllMedia`. See [privacy](#blocking) section for an example. |
+| mask          | Array<string>            | `.sentry-mask, [data-sentry-mask]`       | Mask all elements that match the given DOM selectors. See [privacy](#masking) section for an example.                                        |
+| unmask        | Array<string>            | `.sentry-unmask, [data-sentry-unmask]`   | Unmask all elements that match the given DOM selectors. Useful when using `maskAllText`. See [privacy](#masking) section for an example.     |
+| ignore        | Array<string>            | `.sentry-ignore, [data-sentry-ignore]`   | Ignores all events on the matching input fields. See [privacy](#ignoring) section for an example.                                            |
 
 #### Deprecated options
-In order to streamline our privacy options, the following have been deprecated in favor for the respective options above.
 
-| deprecated key   | replaced by | description |
-| ---------------- | ----------- | ----------- |
-| maskInputOptions | mask        | Use CSS selectors in `mask` in order to mask all inputs of a certain type. For example, `input[type="address"]` |
-| blockSelector    | block       | The selector(s) can be moved directly in the `block` array. |
-| blockClass       | block       | Convert the class name to a CSS selector and add to `block` array. For example, `first-name` becomes `.first-name`. Regexes can be moved as-is. |
-| maskClass        | mask        | Convert the class name to a CSS selector and add to `mask` array. For example, `first-name` becomes `.first-name`. Regexes can be moved as-is. |
-| maskSelector     | mask        | The selector(s) can be moved directly in the `mask` array. |
+In order to streamline our privacy options, the following have been deprecated in favor for the respective options
+above.
+
+| deprecated key   | replaced by | description                                                                                                                                      |
+| ---------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| maskInputOptions | mask        | Use CSS selectors in `mask` in order to mask all inputs of a certain type. For example, `input[type="address"]`                                  |
+| blockSelector    | block       | The selector(s) can be moved directly in the `block` array.                                                                                      |
+| blockClass       | block       | Convert the class name to a CSS selector and add to `block` array. For example, `first-name` becomes `.first-name`. Regexes can be moved as-is.  |
+| maskClass        | mask        | Convert the class name to a CSS selector and add to `mask` array. For example, `first-name` becomes `.first-name`. Regexes can be moved as-is.   |
+| maskSelector     | mask        | The selector(s) can be moved directly in the `mask` array.                                                                                       |
 | ignoreClass      | ignore      | Convert the class name to a CSS selector and add to `ignore` array. For example, `first-name` becomes `.first-name`. Regexes can be moved as-is. |
 
 ## Privacy
-There are several ways to deal with PII. By default, the integration will mask all text content with `*` and block all media elements (`img, svg, video, object, picture, embed, map, audio`). This can be disabled by setting `maskAllText` to `false`. It is also possible to add the following CSS classes to specific DOM elements to prevent recording its contents: `sentry-block`, `sentry-ignore`, and `sentry-mask`. The following sections will show examples of how content is handled by the differing methods.
+
+There are several ways to deal with PII. By default, the integration will mask all text content with `*` and block all
+media elements (`img, svg, video, object, picture, embed, map, audio`). This can be disabled by setting `maskAllText` to
+`false`. It is also possible to add the following CSS classes to specific DOM elements to prevent recording its
+contents: `sentry-block`, `sentry-ignore`, and `sentry-mask`. The following sections will show examples of how content
+is handled by the differing methods.
 
 ### Masking
-Masking replaces the text content with something else. The default masking behavior is to replace each character with a `*`. In this example the relevant html code is: `<table class="sentry-mask">...</table>`.
+
+Masking replaces the text content with something else. The default masking behavior is to replace each character with a
+`*`. In this example the relevant html code is: `<table class="sentry-mask">...</table>`.
 ![Masking example](https://user-images.githubusercontent.com/79684/193118192-dee1d3d8-5813-47e8-b532-f9ee1c8714b3.png)
 
 ### Blocking
-Blocking replaces the element with a placeholder that has the same dimensions. The recording will show an empty space where the content was. In this example the relevant html code is: `<table data-sentry-block>...</table>`.
+
+Blocking replaces the element with a placeholder that has the same dimensions. The recording will show an empty space
+where the content was. In this example the relevant html code is: `<table data-sentry-block>...</table>`.
 ![Blocking example](https://user-images.githubusercontent.com/79684/193118084-51a589fc-2160-476a-a8dc-b681eddb136c.png)
 
 ### Ignoring
-Ignoring only applies to form inputs. Events will be ignored on the input element so that the replay does not show what occurs inside of the input. In the below example, notice how the results in the table below the input changes, but no text is visible in the input.
+
+Ignoring only applies to form inputs. Events will be ignored on the input element so that the replay does not show what
+occurs inside of the input. In the below example, notice how the results in the table below the input changes, but no
+text is visible in the input.
 
 https://user-images.githubusercontent.com/79684/192815134-a6451c3f-d3cb-455f-a699-7c3fe04d0a2e.mov
 
 ## Error Linking
 
-Currently, errors that happen on the page while a replay is running are linked to the Replay,
-making it as easy as possible to jump between related issues/replays.
-However, please note that it is _possible_ that the error count reported on the Replay Detail page
-does not match the actual errors that have been captured.
-The reason for that is that errors _can_ be lost, e.g. a network request fails, or similar.
-This should not happen to often, but be aware that it is theoretically possible.
+Currently, errors that happen on the page while a replay is running are linked to the Replay, making it as easy as
+possible to jump between related issues/replays. However, please note that it is _possible_ that the error count
+reported on the Replay Detail page does not match the actual errors that have been captured. The reason for that is that
+errors _can_ be lost, e.g. a network request fails, or similar. This should not happen to often, but be aware that it is
+theoretically possible.
 
 ## Manually sending replay data
 
-You can use `replay.flush()` to immediately send all currently captured replay data.
-When Replay is currently in buffering mode, this will send up to the last 60 seconds of replay data,
-and also continue sending afterwards, similar to when an error happens & is recorded.
+You can use `replay.flush()` to immediately send all currently captured replay data. When Replay is currently in
+buffering mode, this will send up to the last 60 seconds of replay data, and also continue sending afterwards, similar
+to when an error happens & is recorded.

--- a/packages/serverless/README.md
+++ b/packages/serverless/README.md
@@ -11,6 +11,13 @@
 - [Official SDK Docs](https://docs.sentry.io/)
 - [TypeDoc](http://getsentry.github.io/sentry-javascript/)
 
+## Package Discontinued
+
+The `@sentry/serverless` package was discontinued in version 8.0.0 of the Sentry JavaScript SDKs in favour of dedicated
+SDK packages for AWS Lambda and Google Cloud. For more information, head over to the respective v8 migration guides for
+[Google Cloud](https://docs.sentry.io/platforms/javascript/guides/gcp-functions/migration/v7-to-v8/) and
+[AWS Lambda](https://docs.sentry.io/platforms/javascript/guides/aws-lambda/migration/v7-to-v8/).
+
 ## General
 
 This package is a wrapper around `@sentry/node`, with added functionality related to various Serverless solutions. All
@@ -41,7 +48,8 @@ exports.handler = Sentry.AWSLambda.wrapHandler((event, context, callback) => {
 });
 ```
 
-If you also want to trace performance of all the incoming requests and also outgoing AWS service requests, just set the `tracesSampleRate` option.
+If you also want to trace performance of all the incoming requests and also outgoing AWS service requests, just set the
+`tracesSampleRate` option.
 
 ```javascript
 import * as Sentry from '@sentry/serverless';
@@ -61,7 +69,9 @@ Another and much simpler way to integrate Sentry to your AWS Lambda function is 
 3. Go to Environment variables and add:
    - `NODE_OPTIONS`: `-r @sentry/serverless/build/npm/cjs/awslambda-auto`.
    - `SENTRY_DSN`: `your dsn`.
-   - `SENTRY_TRACES_SAMPLE_RATE`: a number between 0 and 1 representing the chance a transaction is sent to Sentry. For more information, see [docs](https://docs.sentry.io/platforms/node/guides/aws-lambda/configuration/options/#tracesSampleRate).
+   - `SENTRY_TRACES_SAMPLE_RATE`: a number between 0 and 1 representing the chance a transaction is sent to Sentry. For
+     more information, see
+     [docs](https://docs.sentry.io/platforms/node/guides/aws-lambda/configuration/options/#tracesSampleRate).
 
 ### Google Cloud Functions
 

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -4,13 +4,21 @@
   </a>
 </p>
 
-> ⚠️ **Deprecation Notice:** From SDK versions >= `7.47.0` onwards, the `@sentry/tracing` package is officially deprecated. This package will be removed in a future major release. More details can be found in the [migration docs](https://github.com/getsentry/sentry-javascript/blob/7.47.0/MIGRATION.md/#remove-requirement-for-sentrytracing-package-since-7460).
+> ⚠️ **Deprecation Notice:** From SDK versions >= `7.47.0` onwards, the `@sentry/tracing` package is officially
+> deprecated. This package will be removed in a future major release. More details can be found in the
+> [migration docs](https://github.com/getsentry/sentry-javascript/blob/7.47.0/MIGRATION.md/#remove-requirement-for-sentrytracing-package-since-7460).
 
 # Sentry Tracing Extensions
 
 [![npm version](https://img.shields.io/npm/v/@sentry/tracing.svg)](https://www.npmjs.com/package/@sentry/tracing)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/tracing.svg)](https://www.npmjs.com/package/@sentry/tracing)
 [![npm dt](https://img.shields.io/npm/dt/@sentry/tracing.svg)](https://www.npmjs.com/package/@sentry/tracing)
+
+## Package Discontinued
+
+This package was discontinued with version 8.0.0 of the Sentry JavaScript SDKs. Instead, exports from this package are
+exported directly from the main SDK packages like `@sentry/react` or `@sentry/node`. For more information have a look at
+the [Migration Guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#sentrytracing).
 
 ## Links
 
@@ -19,24 +27,23 @@
 
 ## General
 
-This package contains extensions to the `@sentry/hub` to enable Sentry AM related functionality. It also provides integrations for Browser and Node that provide a good experience out of the box.
+This package contains extensions to the `@sentry/hub` to enable Sentry AM related functionality. It also provides
+integrations for Browser and Node that provide a good experience out of the box.
 
 ## Migrating from @sentry/apm to @sentry/tracing
 
-The tracing integration for JavaScript SDKs has moved from
-[`@sentry/apm`](https://www.npmjs.com/package/@sentry/apm) to
-[`@sentry/tracing`](https://www.npmjs.com/package/@sentry/tracing). While the
-two packages are similar, some imports and APIs have changed slightly.
+The tracing integration for JavaScript SDKs has moved from [`@sentry/apm`](https://www.npmjs.com/package/@sentry/apm) to
+[`@sentry/tracing`](https://www.npmjs.com/package/@sentry/tracing). While the two packages are similar, some imports and
+APIs have changed slightly.
 
-The old package `@sentry/apm` is deprecated in favor of `@sentry/tracing`.
-Future support for `@sentry/apm` is limited to bug fixes only.
+The old package `@sentry/apm` is deprecated in favor of `@sentry/tracing`. Future support for `@sentry/apm` is limited
+to bug fixes only.
 
 ## Migrating from @sentry/apm to @sentry/tracing
 
 ### Browser (CDN bundle)
 
-If you were using the Browser CDN bundle, switch from the old
-`bundle.apm.min.js` to the new tracing bundle:
+If you were using the Browser CDN bundle, switch from the old `bundle.apm.min.js` to the new tracing bundle:
 
 ```html
 <script
@@ -57,8 +64,8 @@ And then update `Sentry.init`:
 
 ### Browser (npm package)
 
-If you were using automatic instrumentation, update the import statement and
-update `Sentry.init` to use the new `BrowserTracing` integration:
+If you were using automatic instrumentation, update the import statement and update `Sentry.init` to use the new
+`BrowserTracing` integration:
 
 ```diff
  import * as Sentry from "@sentry/browser";
@@ -73,20 +80,17 @@ update `Sentry.init` to use the new `BrowserTracing` integration:
  });
 ```
 
-If you were using the `beforeNavigate` option from the `Tracing` integration,
-the API in `BrowserTracing` has changed slightly. Instead of passing in a
-location and returning a string representing transaction name, `beforeNavigate`
-now accepts a transaction context and is expected to return a transaction
-context. You can now add extra tags or change the `op` based on different
-parameters. If you want to access the location like before, you can get it from
+If you were using the `beforeNavigate` option from the `Tracing` integration, the API in `BrowserTracing` has changed
+slightly. Instead of passing in a location and returning a string representing transaction name, `beforeNavigate` now
+accepts a transaction context and is expected to return a transaction context. You can now add extra tags or change the
+`op` based on different parameters. If you want to access the location like before, you can get it from
 `window.location`.
 
-For example, if you had a function like so that computed a custom transaction
-name:
+For example, if you had a function like so that computed a custom transaction name:
 
 ```javascript
-import * as Sentry from "@sentry/browser";
-import { Integrations } from "@sentry/apm";
+import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/apm';
 
 Sentry.init({
   integrations: [
@@ -102,8 +106,8 @@ Sentry.init({
 You would now leverage the context to do the same thing:
 
 ```javascript
-import * as Sentry from "@sentry/browser";
-import { Integrations } from "@sentry/tracing";
+import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
 
 Sentry.init({
   integrations: [
@@ -147,8 +151,8 @@ For the full diff:
 
 ### Node
 
-If you were using the Express integration for automatic instrumentation, the
-only necessary change is to update the import statement:
+If you were using the Express integration for automatic instrumentation, the only necessary change is to update the
+import statement:
 
 ```diff
  import * as Sentry from "@sentry/node";


### PR DESCRIPTION
This PR adds discontinuity notes to the Readme files of

- @sentry/tracing
- @sentry/hub
- @sentry/serverless
- @sentry/integrations
- @sentry/replay

with links to the respective sections in the migration guide.

Figured, since I started with #12344 I might as well add similar notes to the other packages 😅 