### PR TITLE
fix(nextjs): correct types conditional export ordering

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -15,6 +15,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./build/types/index.types.d.ts",
       "edge": {
         "import": "./build/esm/edge/index.js",
         "require": "./build/cjs/edge/index.js",
@@ -40,8 +41,7 @@
         "require": "./build/cjs/index.client.js"
       },
       "node": "./build/cjs/index.server.js",
-      "import": "./build/esm/index.server.js",
-      "types": "./build/types/index.types.d.ts"
+      "import": "./build/esm/index.server.js"
     },
     "./import": {
       "import": {


### PR DESCRIPTION
## Description
As stated [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing) in the typescript docs, `types` exports should always come first, so that they are resolved correctly. This also applies to the nested `types` within and `exports` condition.

This corrects an issue where `eslint-import-resolver-typescript` was not correctly resolving the full types for Sentry.
