### PR TITLE
fix(performance): Fix INP spans not retrieving correct origin transaction name

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/init.js
@@ -13,3 +13,12 @@ Sentry.init({
   ],
   tracesSampleRate: 1,
 });
+
+const client = Sentry.getClient();
+
+if (client) {
+  // Force page load transaction name to a testable value
+  Sentry.startBrowserTracingPageLoadSpan(client, {
+    name: 'test-route',
+  });
+}

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/test.ts
@@ -63,6 +63,7 @@ sentryTest('should capture an INP click event span.', async ({ browserName, getL
       sample_rate: '1',
       sampled: 'true',
       trace_id: traceId,
+      transaction: 'test-route',
     },
   });
 
@@ -76,6 +77,7 @@ sentryTest('should capture an INP click event span.', async ({ browserName, getL
       'sentry.origin': 'manual',
       'sentry.sample_rate': 1,
       'sentry.source': 'custom',
+      transaction: 'test-route',
     },
     measurements: {
       inp: {

--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -4,6 +4,7 @@ export {
   addFidInstrumentationHandler,
   addTtfbInstrumentationHandler,
   addLcpInstrumentationHandler,
+  isPerformanceEventTiming,
 } from './metrics/instrument';
 
 export {

--- a/packages/browser-utils/src/metrics/instrument.ts
+++ b/packages/browser-utils/src/metrics/instrument.ts
@@ -8,7 +8,13 @@ import { onLCP } from './web-vitals/getLCP';
 import { observe } from './web-vitals/lib/observe';
 import { onTTFB } from './web-vitals/onTTFB';
 
-type InstrumentHandlerTypePerformanceObserver = 'longtask' | 'event' | 'navigation' | 'paint' | 'resource';
+type InstrumentHandlerTypePerformanceObserver =
+  | 'longtask'
+  | 'event'
+  | 'navigation'
+  | 'paint'
+  | 'resource'
+  | 'first-input';
 
 type InstrumentHandlerTypeMetric = 'cls' | 'lcp' | 'fid' | 'ttfb' | 'inp';
 
@@ -153,7 +159,7 @@ export function addInpInstrumentationHandler(
 }
 
 export function addPerformanceInstrumentationHandler(
-  type: 'event',
+  type: 'event' | 'first-input',
   callback: (data: { entries: ((PerformanceEntry & { target?: unknown | null }) | PerformanceEventTiming)[] }) => void,
 ): CleanupHandlerCallback;
 export function addPerformanceInstrumentationHandler(
@@ -318,4 +324,11 @@ function getCleanupCallback(
       typeHandlers.splice(index, 1);
     }
   };
+}
+
+/**
+ * Check if a PerformanceEntry is a PerformanceEventTiming by checking for the `duration` property.
+ */
+export function isPerformanceEventTiming(entry: PerformanceEntry): entry is PerformanceEventTiming {
+  return 'duration' in entry;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -169,3 +169,4 @@ export type {
 } from './metrics';
 export type { ParameterizedString } from './parameterize';
 export type { ViewHierarchyData, ViewHierarchyWindow } from './view-hierarchy';
+export type { InteractionContext } from './interactionContext';

--- a/packages/types/src/interactionContext.ts
+++ b/packages/types/src/interactionContext.ts
@@ -1,0 +1,12 @@
+import type { Span } from './span';
+import type { User } from './user';
+
+export type InteractionContext = {
+  routeName: string;
+  duration: number;
+  parentContext: any;
+  user?: User;
+  activeSpan?: Span;
+  replayId?: string;
+  startTime: number;
+};


### PR DESCRIPTION
Adds a `registerInpInteractionListener` handler to browser tracing that caches an interactions to transaction name mapping (`interactionIdToRouteNameMapping`). This mapping allows us to fetch the correct origin transaction name that an INP occurred on, instead of looking for an active pageload/navigation span (which is inaccurate, and might not even exist at the time of INP).

This also reduces the chances that `transaction` will be undefined for INP spans, which mitigates this issue: https://github.com/getsentry/sentry/issues/71435 