### PR TITLE
fix(browser): Fix INP span creation & transaction tagging

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -15,14 +15,14 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration'),
     gzip: true,
-    limit: '34 KB',
+    limit: '35 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration'),
     gzip: true,
-    limit: '71 KB',
+    limit: '72 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - with treeshaking flags',
@@ -48,14 +48,14 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'replayCanvasIntegration'),
     gzip: true,
-    limit: '75 KB',
+    limit: '76 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'feedbackIntegration'),
     gzip: true,
-    limit: '87 KB',
+    limit: '89 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback, metrics)',
@@ -69,21 +69,21 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'metrics'),
     gzip: true,
-    limit: '40 KB',
+    limit: '30 KB',
   },
   {
     name: '@sentry/browser (incl. Feedback)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'feedbackIntegration'),
     gzip: true,
-    limit: '40 KB',
+    limit: '41 KB',
   },
   {
     name: '@sentry/browser (incl. sendFeedback)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'sendFeedback'),
     gzip: true,
-    limit: '28 KB',
+    limit: '29 KB',
   },
   {
     name: '@sentry/browser (incl. FeedbackAsync)',
@@ -107,7 +107,7 @@ module.exports = [
     import: createImport('init', 'ErrorBoundary', 'reactRouterV6BrowserTracingIntegration'),
     ignore: ['react/jsx-runtime'],
     gzip: true,
-    limit: '37 KB',
+    limit: '38 KB',
   },
   // Vue SDK (ESM)
   {
@@ -143,7 +143,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing)',
     path: createCDNPath('bundle.tracing.min.js'),
     gzip: true,
-    limit: '36 KB',
+    limit: '37 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay)',
@@ -193,7 +193,7 @@ module.exports = [
     import: createImport('init'),
     ignore: ['next/router', 'next/constants'],
     gzip: true,
-    limit: '37 KB',
+    limit: '38 KB',
   },
   // SvelteKit SDK (ESM)
   {

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/init.js
@@ -6,7 +6,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 4000,
+      idleTimeout: 1000,
       enableLongTask: false,
       enableInp: true,
       instrumentPageLoad: false,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/subject.js
@@ -1,0 +1,18 @@
+const blockUI = (delay = 70) => e => {
+  const startTime = Date.now();
+
+  function getElasped() {
+    const time = Date.now();
+    return time - startTime;
+  }
+
+  while (getElasped() < delay) {
+    //
+  }
+
+  e.target.classList.add('clicked');
+};
+
+document.querySelector('[data-test-id=not-so-slow-button]').addEventListener('click', blockUI(300));
+document.querySelector('[data-test-id=slow-button]').addEventListener('click', blockUI(450));
+document.querySelector('[data-test-id=normal-button]').addEventListener('click', blockUI());

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <div>Rendered Before Long Task</div>
+    <button data-test-id="slow-button" data-sentry-element="SlowButton">Slow</button>
+    <button data-test-id="not-so-slow-button" data-sentry-element="NotSoSlowButton">Not so slow</button>
+    <button data-test-id="normal-button" data-sentry-element="NormalButton">Click Me</button>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/test.ts
@@ -1,0 +1,98 @@
+import { expect } from '@playwright/test';
+import type { Event as SentryEvent, SpanEnvelope } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import {
+  getFirstSentryEnvelopeRequest,
+  getMultipleSentryEnvelopeRequests,
+  properFullEnvelopeRequestParser,
+  shouldSkipTracingTest,
+} from '../../../../utils/helpers';
+
+sentryTest('should capture an INP click event span after pageload', async ({ browserName, getLocalTestPath, page }) => {
+  const supportedBrowsers = ['chromium'];
+
+  if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
+    sentryTest.skip();
+  }
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await page.goto(url);
+  await getFirstSentryEnvelopeRequest<SentryEvent>(page); // wait for page load
+
+  const spanEnvelopePromise = getMultipleSentryEnvelopeRequests<SpanEnvelope>(
+    page,
+    1,
+    { envelopeType: 'span' },
+    properFullEnvelopeRequestParser,
+  );
+
+  await page.locator('[data-test-id=normal-button]').click();
+  await page.locator('.clicked[data-test-id=normal-button]').isVisible();
+
+  await page.waitForTimeout(500);
+
+  // Page hide to trigger INP
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event('pagehide'));
+  });
+
+  // Get the INP span envelope
+  const spanEnvelope = (await spanEnvelopePromise)[0];
+
+  const spanEnvelopeHeaders = spanEnvelope[0];
+  const spanEnvelopeItem = spanEnvelope[1][0][1];
+
+  const traceId = spanEnvelopeHeaders.trace!.trace_id;
+  expect(traceId).toMatch(/[a-f0-9]{32}/);
+
+  expect(spanEnvelopeHeaders).toEqual({
+    sent_at: expect.any(String),
+    trace: {
+      environment: 'production',
+      public_key: 'public',
+      sample_rate: '1',
+      sampled: 'true',
+      trace_id: traceId,
+    },
+  });
+
+  const inpValue = spanEnvelopeItem.measurements?.inp.value;
+  expect(inpValue).toBeGreaterThan(0);
+
+  expect(spanEnvelopeItem).toEqual({
+    data: {
+      'sentry.exclusive_time': inpValue,
+      'sentry.op': 'ui.interaction.click',
+      'sentry.origin': 'auto.http.browser.inp',
+      'sentry.sample_rate': 1,
+      'sentry.source': 'custom',
+      transaction: 'test-url',
+    },
+    measurements: {
+      inp: {
+        unit: 'millisecond',
+        value: inpValue,
+      },
+    },
+    description: 'body > NormalButton',
+    exclusive_time: inpValue,
+    op: 'ui.interaction.click',
+    origin: 'auto.http.browser.inp',
+    is_segment: true,
+    segment_id: spanEnvelopeItem.span_id,
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: traceId,
+  });
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/init.js
@@ -6,7 +6,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 4000,
+      idleTimeout: 1000,
       enableLongTask: false,
       enableInp: true,
       instrumentPageLoad: false,
@@ -20,8 +20,8 @@ const client = Sentry.getClient();
 
 // Force page load transaction name to a testable value
 Sentry.startBrowserTracingPageLoadSpan(client, {
-  name: 'test-url',
+  name: 'test-route',
   attributes: {
-    [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+    [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
   },
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/subject.js
@@ -1,0 +1,18 @@
+const blockUI = (delay = 70) => e => {
+  const startTime = Date.now();
+
+  function getElasped() {
+    const time = Date.now();
+    return time - startTime;
+  }
+
+  while (getElasped() < delay) {
+    //
+  }
+
+  e.target.classList.add('clicked');
+};
+
+document.querySelector('[data-test-id=not-so-slow-button]').addEventListener('click', blockUI(300));
+document.querySelector('[data-test-id=slow-button]').addEventListener('click', blockUI(450));
+document.querySelector('[data-test-id=normal-button]').addEventListener('click', blockUI());

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <div>Rendered Before Long Task</div>
+    <button data-test-id="slow-button" data-sentry-element="SlowButton">Slow</button>
+    <button data-test-id="not-so-slow-button" data-sentry-element="NotSoSlowButton">Not so slow</button>
+    <button data-test-id="normal-button" data-sentry-element="NormalButton">Click Me</button>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import type { Event as SentryEvent, SpanEnvelope, SpanJSON } from '@sentry/types';
+import type { Event as SentryEvent, SpanEnvelope } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
 import {
@@ -10,7 +10,7 @@ import {
 } from '../../../../utils/helpers';
 
 sentryTest(
-  'should capture an INP click event span during pageload',
+  'should capture an INP click event span after pageload for a parametrized transaction',
   async ({ browserName, getLocalTestPath, page }) => {
     const supportedBrowsers = ['chromium'];
 
@@ -29,6 +29,7 @@ sentryTest(
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);
+    await getFirstSentryEnvelopeRequest<SentryEvent>(page); // wait for page load
 
     const spanEnvelopePromise = getMultipleSentryEnvelopeRequests<SpanEnvelope>(
       page,
@@ -64,7 +65,7 @@ sentryTest(
         sample_rate: '1',
         sampled: 'true',
         trace_id: traceId,
-        // no transaction, because span source is URL
+        transaction: 'test-route',
       },
     });
 
@@ -76,7 +77,9 @@ sentryTest(
         'sentry.exclusive_time': inpValue,
         'sentry.op': 'ui.interaction.click',
         'sentry.origin': 'auto.http.browser.inp',
-        transaction: 'test-url',
+        'sentry.sample_rate': 1,
+        'sentry.source': 'custom',
+        transaction: 'test-route',
       },
       measurements: {
         inp: {
@@ -88,65 +91,12 @@ sentryTest(
       exclusive_time: inpValue,
       op: 'ui.interaction.click',
       origin: 'auto.http.browser.inp',
-      segment_id: expect.not.stringMatching(spanEnvelopeItem.span_id!),
-      // Parent is the pageload span
-      parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+      is_segment: true,
+      segment_id: spanEnvelopeItem.span_id,
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       timestamp: expect.any(Number),
       trace_id: traceId,
     });
-  },
-);
-
-sentryTest(
-  'should choose the slowest interaction click event when INP is triggered.',
-  async ({ browserName, getLocalTestPath, page }) => {
-    const supportedBrowsers = ['chromium'];
-
-    if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
-      sentryTest.skip();
-    }
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
-    const url = await getLocalTestPath({ testDir: __dirname });
-
-    await page.goto(url);
-    await getFirstSentryEnvelopeRequest<SentryEvent>(page);
-
-    await page.locator('[data-test-id=normal-button]').click();
-    await page.locator('.clicked[data-test-id=normal-button]').isVisible();
-
-    await page.waitForTimeout(500);
-
-    await page.locator('[data-test-id=slow-button]').click();
-    await page.locator('.clicked[data-test-id=slow-button]').isVisible();
-
-    await page.waitForTimeout(500);
-
-    const spanPromise = getMultipleSentryEnvelopeRequests<SpanJSON>(page, 1, {
-      envelopeType: 'span',
-    });
-
-    // Page hide to trigger INP
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event('pagehide'));
-    });
-
-    // Get the INP span envelope
-    const span = (await spanPromise)[0];
-
-    expect(span.op).toBe('ui.interaction.click');
-    expect(span.description).toBe('body > SlowButton');
-    expect(span.exclusive_time).toBeGreaterThan(400);
-    expect(span.measurements?.inp.value).toBeGreaterThan(400);
-    expect(span.measurements?.inp.unit).toBe('millisecond');
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/init.js
@@ -20,8 +20,8 @@ const client = Sentry.getClient();
 
 // Force page load transaction name to a testable value
 Sentry.startBrowserTracingPageLoadSpan(client, {
-  name: 'test-url',
+  name: 'test-route',
   attributes: {
-    [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+    [Sentry.SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
   },
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/subject.js
@@ -1,0 +1,18 @@
+const blockUI = (delay = 70) => e => {
+  const startTime = Date.now();
+
+  function getElasped() {
+    const time = Date.now();
+    return time - startTime;
+  }
+
+  while (getElasped() < delay) {
+    //
+  }
+
+  e.target.classList.add('clicked');
+};
+
+document.querySelector('[data-test-id=not-so-slow-button]').addEventListener('click', blockUI(300));
+document.querySelector('[data-test-id=slow-button]').addEventListener('click', blockUI(450));
+document.querySelector('[data-test-id=normal-button]').addEventListener('click', blockUI());

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <div>Rendered Before Long Task</div>
+    <button data-test-id="slow-button" data-sentry-element="SlowButton">Slow</button>
+    <button data-test-id="not-so-slow-button" data-sentry-element="NotSoSlowButton">Not so slow</button>
+    <button data-test-id="normal-button" data-sentry-element="NormalButton">Click Me</button>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/test.ts
@@ -1,16 +1,15 @@
 import { expect } from '@playwright/test';
-import type { Event as SentryEvent, SpanEnvelope, SpanJSON } from '@sentry/types';
+import type { SpanEnvelope } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
 import {
-  getFirstSentryEnvelopeRequest,
   getMultipleSentryEnvelopeRequests,
   properFullEnvelopeRequestParser,
   shouldSkipTracingTest,
 } from '../../../../utils/helpers';
 
 sentryTest(
-  'should capture an INP click event span during pageload',
+  'should capture an INP click event span during pageload for a parametrized transaction',
   async ({ browserName, getLocalTestPath, page }) => {
     const supportedBrowsers = ['chromium'];
 
@@ -64,7 +63,7 @@ sentryTest(
         sample_rate: '1',
         sampled: 'true',
         trace_id: traceId,
-        // no transaction, because span source is URL
+        transaction: 'test-route',
       },
     });
 
@@ -76,7 +75,7 @@ sentryTest(
         'sentry.exclusive_time': inpValue,
         'sentry.op': 'ui.interaction.click',
         'sentry.origin': 'auto.http.browser.inp',
-        transaction: 'test-url',
+        transaction: 'test-route',
       },
       measurements: {
         inp: {
@@ -89,64 +88,12 @@ sentryTest(
       op: 'ui.interaction.click',
       origin: 'auto.http.browser.inp',
       segment_id: expect.not.stringMatching(spanEnvelopeItem.span_id!),
-      // Parent is the pageload span
+      // parent is the pageload span
       parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       timestamp: expect.any(Number),
       trace_id: traceId,
     });
-  },
-);
-
-sentryTest(
-  'should choose the slowest interaction click event when INP is triggered.',
-  async ({ browserName, getLocalTestPath, page }) => {
-    const supportedBrowsers = ['chromium'];
-
-    if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
-      sentryTest.skip();
-    }
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
-    const url = await getLocalTestPath({ testDir: __dirname });
-
-    await page.goto(url);
-    await getFirstSentryEnvelopeRequest<SentryEvent>(page);
-
-    await page.locator('[data-test-id=normal-button]').click();
-    await page.locator('.clicked[data-test-id=normal-button]').isVisible();
-
-    await page.waitForTimeout(500);
-
-    await page.locator('[data-test-id=slow-button]').click();
-    await page.locator('.clicked[data-test-id=slow-button]').isVisible();
-
-    await page.waitForTimeout(500);
-
-    const spanPromise = getMultipleSentryEnvelopeRequests<SpanJSON>(page, 1, {
-      envelopeType: 'span',
-    });
-
-    // Page hide to trigger INP
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event('pagehide'));
-    });
-
-    // Get the INP span envelope
-    const span = (await spanPromise)[0];
-
-    expect(span.op).toBe('ui.interaction.click');
-    expect(span.description).toBe('body > SlowButton');
-    expect(span.exclusive_time).toBeGreaterThan(400);
-    expect(span.measurements?.inp.value).toBeGreaterThan(400);
-    expect(span.measurements?.inp.unit).toBe('millisecond');
   },
 );

--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -12,6 +12,7 @@ export {
   startTrackingLongTasks,
   startTrackingWebVitals,
   startTrackingINP,
+  registerInpInteractionListener,
 } from './metrics/browserMetrics';
 
 export { addClickKeypressInstrumentationHandler } from './instrument/dom';

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -157,7 +157,7 @@ export function startTrackingInteractions(): void {
   });
 }
 
-export { startTrackingINP } from './inp';
+export { startTrackingINP, registerInpInteractionListener } from './inp';
 
 /** Starts tracking the Cumulative Layout Shift on the current page. */
 function _trackCLS(): () => void {

--- a/packages/browser-utils/src/metrics/inp.ts
+++ b/packages/browser-utils/src/metrics/inp.ts
@@ -2,6 +2,7 @@ import {
   SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME,
   SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_UNIT,
   SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_VALUE,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   getActiveSpan,
   getClient,
   getCurrentScope,
@@ -83,7 +84,9 @@ function _trackINP(): () => void {
     const activeSpan = getActiveSpan();
     const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
 
-    const routeName = rootSpan ? spanToJSON(rootSpan).description : undefined;
+    // If there is no active span, we fall back to look at the transactionName on the scope
+    // This is set if the pageload/navigation span is already finished,
+    const routeName = rootSpan ? spanToJSON(rootSpan).description : scope.getScopeData().transactionName;
     const user = scope.getUser();
 
     // We need to get the replay, user, and activeTransaction from the current scope
@@ -107,6 +110,7 @@ function _trackINP(): () => void {
       environment: options.environment,
       transaction: routeName,
       [SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME]: metric.value,
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser.inp',
       user: userDisplay || undefined,
       profile_id: profileId || undefined,
       replay_id: replayId || undefined,

--- a/packages/browser-utils/src/metrics/inp.ts
+++ b/packages/browser-utils/src/metrics/inp.ts
@@ -12,8 +12,20 @@ import {
 } from '@sentry/core';
 import type { Integration, SpanAttributes } from '@sentry/types';
 import { browserPerformanceTimeOrigin, dropUndefinedKeys, htmlTreeAsString } from '@sentry/utils';
-import { addInpInstrumentationHandler } from './instrument';
+import {
+  addInpInstrumentationHandler,
+  addPerformanceInstrumentationHandler,
+  isPerformanceEventTiming,
+} from './instrument';
 import { getBrowserPerformanceAPI, msToSec } from './utils';
+
+// We only care about name here
+interface PartialRouteInfo {
+  name: string | undefined;
+}
+
+const LAST_INTERACTIONS: number[] = [];
+const INTERACTIONS_ROUTE_MAP = new Map<number, string>();
 
 /**
  * Start tracking INP webvital events.
@@ -74,6 +86,7 @@ function _trackINP(): () => void {
       return;
     }
 
+    const { interactionId } = entry;
     const interactionType = INP_ENTRY_MAP[entry.name];
 
     const options = client.getOptions();
@@ -84,9 +97,15 @@ function _trackINP(): () => void {
     const activeSpan = getActiveSpan();
     const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
 
-    // If there is no active span, we fall back to look at the transactionName on the scope
-    // This is set if the pageload/navigation span is already finished,
-    const routeName = rootSpan ? spanToJSON(rootSpan).description : scope.getScopeData().transactionName;
+    // We first try to lookup the route name from our INTERACTIONS_ROUTE_MAP,
+    // where we cache the route per interactionId
+    const cachedRouteName = interactionId != null ? INTERACTIONS_ROUTE_MAP.get(interactionId) : undefined;
+
+    // Else, we try to use the active span.
+    // Finally, we fall back to look at the transactionName on the scope
+    const routeName =
+      cachedRouteName || (rootSpan ? spanToJSON(rootSpan).description : scope.getScopeData().transactionName);
+
     const user = scope.getUser();
 
     // We need to get the replay, user, and activeTransaction from the current scope
@@ -133,4 +152,40 @@ function _trackINP(): () => void {
 
     span.end(startTime + duration);
   });
+}
+
+/** Register a listener to cache route information for INP interactions. */
+export function registerInpInteractionListener(latestRoute: PartialRouteInfo): void {
+  const handleEntries = ({ entries }: { entries: PerformanceEntry[] }): void => {
+    entries.forEach(entry => {
+      if (!isPerformanceEventTiming(entry) || !latestRoute.name) {
+        return;
+      }
+
+      const interactionId = entry.interactionId;
+      if (interactionId == null) {
+        return;
+      }
+
+      // If the interaction was already recorded before, nothing more to do
+      if (INTERACTIONS_ROUTE_MAP.has(interactionId)) {
+        return;
+      }
+
+      // We keep max. 10 interactions in the list, then remove the oldest one & clean up
+      if (LAST_INTERACTIONS.length > 10) {
+        const last = LAST_INTERACTIONS.shift() as number;
+        INTERACTIONS_ROUTE_MAP.delete(last);
+      }
+
+      // We add the interaction to the list of recorded interactions
+      // and store the route information for this interaction
+      // (we clone the object because it is mutated when it changes)
+      LAST_INTERACTIONS.push(interactionId);
+      INTERACTIONS_ROUTE_MAP.set(interactionId, latestRoute.name);
+    });
+  };
+
+  addPerformanceInstrumentationHandler('event', handleEntries);
+  addPerformanceInstrumentationHandler('first-input', handleEntries);
 }

--- a/packages/browser-utils/src/metrics/instrument.ts
+++ b/packages/browser-utils/src/metrics/instrument.ts
@@ -8,7 +8,13 @@ import { onLCP } from './web-vitals/getLCP';
 import { observe } from './web-vitals/lib/observe';
 import { onTTFB } from './web-vitals/onTTFB';
 
-type InstrumentHandlerTypePerformanceObserver = 'longtask' | 'event' | 'navigation' | 'paint' | 'resource';
+type InstrumentHandlerTypePerformanceObserver =
+  | 'longtask'
+  | 'event'
+  | 'navigation'
+  | 'paint'
+  | 'resource'
+  | 'first-input';
 
 type InstrumentHandlerTypeMetric = 'cls' | 'lcp' | 'fid' | 'ttfb' | 'inp';
 
@@ -323,4 +329,11 @@ function getCleanupCallback(
       typeHandlers.splice(index, 1);
     }
   };
+}
+
+/**
+ * Check if a PerformanceEntry is a PerformanceEventTiming by checking for the `duration` property.
+ */
+export function isPerformanceEventTiming(entry: PerformanceEntry): entry is PerformanceEventTiming {
+  return 'duration' in entry;
 }


### PR DESCRIPTION
Instead of https://github.com/getsentry/sentry-javascript/pull/12358, this is a simpler change which ensures we pick the transaction from the scope instead.

I also added tests for the various different scenarios, to ensure we see how they behave:

1. INP is emitted _during_ pageload (span is active)
2. INP is emitted _after_ pageload

a. Pageload is parametrized (route)
b. Pageload is unparametrized (URL)

When the pageload is unparametrized (default browser SDK), the transaction is not added to the DSC envelope header (which is correct and also what we do in other places). it is _always_ added to the span attributes now, though. If no span is active, it will use transactionName from the last active pageload/navigation span.

There may be edge cases where this is not 100% correct (e.g. if the INP span is only emitted once the pageload is done but another navigation already started) but IMHO these are more edge cases and this change is probably fine for now..?

(While at it, I also added an origin to the INP spans)