### PR TITLE
fix(browser): Handle more edge cases with INP

### DIFF
--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -12,6 +12,7 @@ export {
   startTrackingLongTasks,
   startTrackingWebVitals,
   startTrackingINP,
+  registerInpInteractionListener,
 } from './metrics/browserMetrics';
 
 export { addClickKeypressInstrumentationHandler } from './instrument/dom';

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -157,7 +157,7 @@ export function startTrackingInteractions(): void {
   });
 }
 
-export { startTrackingINP } from './inp';
+export { startTrackingINP, registerInpInteractionListener } from './inp';
 
 /** Starts tracking the Cumulative Layout Shift on the current page. */
 function _trackCLS(): () => void {

--- a/packages/browser-utils/src/metrics/inp.ts
+++ b/packages/browser-utils/src/metrics/inp.ts
@@ -12,8 +12,20 @@ import {
 } from '@sentry/core';
 import type { Integration, SpanAttributes } from '@sentry/types';
 import { browserPerformanceTimeOrigin, dropUndefinedKeys, htmlTreeAsString } from '@sentry/utils';
-import { addInpInstrumentationHandler } from './instrument';
+import {
+  addInpInstrumentationHandler,
+  addPerformanceInstrumentationHandler,
+  isPerformanceEventTiming,
+} from './instrument';
 import { getBrowserPerformanceAPI, msToSec } from './utils';
+
+// We only care about name here
+interface PartialRouteInfo {
+  name: string | undefined;
+}
+
+const LAST_INTERACTIONS: number[] = [];
+const INTERACTIONS_ROUTE_MAP = new Map<number, string>();
 
 /**
  * Start tracking INP webvital events.
@@ -74,6 +86,7 @@ function _trackINP(): () => void {
       return;
     }
 
+    const { interactionId } = entry;
     const interactionType = INP_ENTRY_MAP[entry.name];
 
     const options = client.getOptions();
@@ -84,9 +97,15 @@ function _trackINP(): () => void {
     const activeSpan = getActiveSpan();
     const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
 
-    // If there is no active span, we fall back to look at the transactionName on the scope
-    // This is set if the pageload/navigation span is already finished,
-    const routeName = rootSpan ? spanToJSON(rootSpan).description : scope.getScopeData().transactionName;
+    // We first try to lookup the route name from our INTERACTIONS_ROUTE_MAP,
+    // where we cache the route per interactionId
+    const cachedRouteName = interactionId != null ? INTERACTIONS_ROUTE_MAP.get(interactionId) : undefined;
+
+    // Else, we try to use the active span.
+    // Finally, we fall back to look at the transactionName on the scope
+    const routeName =
+      cachedRouteName || (rootSpan ? spanToJSON(rootSpan).description : scope.getScopeData().transactionName);
+
     const user = scope.getUser();
 
     // We need to get the replay, user, and activeTransaction from the current scope
@@ -133,4 +152,40 @@ function _trackINP(): () => void {
 
     span.end(startTime + duration);
   });
+}
+
+/** Register a listener to cache route information for INP interactions. */
+export function registerInpInteractionListener(latestRoute: PartialRouteInfo): void {
+  const handleEntries = ({ entries }: { entries: PerformanceEntry[] }): void => {
+    entries.forEach(entry => {
+      if (!isPerformanceEventTiming(entry) || !latestRoute.name) {
+        return;
+      }
+
+      const interactionId = entry.interactionId;
+      if (interactionId == null) {
+        return;
+      }
+
+      // If the interaction was already recorded before, nothing more to do
+      if (INTERACTIONS_ROUTE_MAP.has(interactionId)) {
+        return;
+      }
+
+      // We keep max. 10 interactions in the list, then remove the oldest one & clean up
+      if (LAST_INTERACTIONS.length > 10) {
+        const last = LAST_INTERACTIONS.shift() as number;
+        INTERACTIONS_ROUTE_MAP.delete(last);
+      }
+
+      // We add the interaction to the list of recorded interactions
+      // and store the route information for this interaction
+      // (we clone the object because it is mutated when it changes)
+      LAST_INTERACTIONS.push(interactionId);
+      INTERACTIONS_ROUTE_MAP.set(interactionId, latestRoute.name);
+    });
+  };
+
+  addPerformanceInstrumentationHandler('event', handleEntries);
+  addPerformanceInstrumentationHandler('first-input', handleEntries);
 }

--- a/packages/browser-utils/src/metrics/instrument.ts
+++ b/packages/browser-utils/src/metrics/instrument.ts
@@ -8,7 +8,13 @@ import { onLCP } from './web-vitals/getLCP';
 import { observe } from './web-vitals/lib/observe';
 import { onTTFB } from './web-vitals/onTTFB';
 
-type InstrumentHandlerTypePerformanceObserver = 'longtask' | 'event' | 'navigation' | 'paint' | 'resource';
+type InstrumentHandlerTypePerformanceObserver =
+  | 'longtask'
+  | 'event'
+  | 'navigation'
+  | 'paint'
+  | 'resource'
+  | 'first-input';
 
 type InstrumentHandlerTypeMetric = 'cls' | 'lcp' | 'fid' | 'ttfb' | 'inp';
 
@@ -318,4 +324,11 @@ function getCleanupCallback(
       typeHandlers.splice(index, 1);
     }
   };
+}
+
+/**
+ * Check if a PerformanceEntry is a PerformanceEventTiming by checking for the `duration` property.
+ */
+export function isPerformanceEventTiming(entry: PerformanceEntry): entry is PerformanceEventTiming {
+  return 'duration' in entry;
 }


### PR DESCRIPTION
This is a PR adjusting https://github.com/getsentry/sentry-javascript/pull/12372 to keep transaction name for INP even if the route has changed in the meanwhile.

Now, we keep a map of the last 10 interactionId <> route names, which we use instead (if possible).