### PR TITLE
test(e2e): Add ESM http instrumentation test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express-esm-preload/src/app.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-preload/src/app.mjs
@@ -1,3 +1,4 @@
+import * as http from 'http';
 import * as Sentry from '@sentry/node';
 import express from 'express';
 
@@ -25,6 +26,22 @@ app.get('/test-error', function (req, res) {
   }, 100);
 });
 
+app.get('/http-req', function (req, res) {
+  http
+    .request('http://example.com', httpRes => {
+      let data = '';
+      httpRes.on('data', d => {
+        // we don't care about data
+        data += d;
+      });
+      httpRes.on('end', () => {
+        // span.end();
+        res.status(200).send(data).end();
+      });
+    })
+    .end();
+});
+
 Sentry.setupExpressErrorHandler(app);
 
 app.use(function onError(err, req, res, next) {
@@ -42,6 +59,7 @@ async function run() {
     dsn: process.env.E2E_TEST_DSN,
     tunnel: `http://localhost:3031/`, // proxy server
     tracesSampleRate: 1,
+    debug: true,
   });
 
   app.listen(port, () => {

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-preload/src/app.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-preload/src/app.mjs
@@ -31,11 +31,9 @@ app.get('/http-req', function (req, res) {
     .request('http://example.com', httpRes => {
       let data = '';
       httpRes.on('data', d => {
-        // we don't care about data
         data += d;
       });
       httpRes.on('end', () => {
-        // span.end();
         res.status(200).send(data).end();
       });
     })
@@ -59,7 +57,6 @@ async function run() {
     dsn: process.env.E2E_TEST_DSN,
     tunnel: `http://localhost:3031/`, // proxy server
     tracesSampleRate: 1,
-    debug: true,
   });
 
   app.listen(port, () => {

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-preload/tests/server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-preload/tests/server.test.ts
@@ -121,3 +121,46 @@ test('Should record a transaction for route with parameters', async ({ request }
     trace_id: expect.any(String),
   });
 });
+
+test('Should record spans from http instrumentation', async ({ request }) => {
+  const transactionEventPromise = waitForTransaction('node-express-esm-preload', transactionEvent => {
+    return transactionEvent.contexts?.trace?.data?.['http.target'] === '/http-req';
+  });
+
+  await request.get('/http-req');
+
+  const transactionEvent = await transactionEventPromise;
+
+  const httpClientSpan = transactionEvent.spans?.find(span => span.op === 'http.client');
+
+  expect(httpClientSpan).toEqual({
+    span_id: expect.any(String),
+    trace_id: expect.any(String),
+    data: {
+      'http.flavor': '1.1',
+      'http.host': 'example.com:80',
+      'http.method': 'GET',
+      'http.response.status_code': 200,
+      'http.response_content_length_uncompressed': expect.any(Number),
+      'http.status_code': 200,
+      'http.status_text': 'OK',
+      'http.target': '/',
+      'http.url': 'http://example.com/',
+      'net.peer.ip': expect.any(String),
+      'net.peer.name': 'example.com',
+      'net.peer.port': 80,
+      'net.transport': 'ip_tcp',
+      'otel.kind': 'CLIENT',
+      'sentry.op': 'http.client',
+      'sentry.origin': 'auto.http.otel.http',
+      url: 'http://example.com/',
+    },
+    description: 'GET http://example.com/',
+    parent_span_id: expect.any(String),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    status: 'ok',
+    op: 'http.client',
+    origin: 'auto.http.otel.http',
+  });
+});


### PR DESCRIPTION
Just a quick by-product of working on the ESM lambda layer: This PR adds a test to our ESM Express e2e test app to test that http instrumentation is working correctly by ensuring a `http.client` span is captured.