### PR TITLE
feat(core): Ignore additional common but inactionable errors

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -9,8 +9,12 @@ import { defineIntegration } from '../integration';
 const DEFAULT_IGNORE_ERRORS = [
   /^Script error\.?$/,
   /^Javascript error: Script error\.? on line 0$/,
-  /^ResizeObserver loop completed with undelivered notifications.$/,
-  /^Cannot redefine property: googletag$/,
+  /^ResizeObserver loop completed with undelivered notifications.$/, // The browser logs this when a ResizeObserver handler takes a bit longer. Usually this is not an actual issue though. It indicates slowness.
+  /^Cannot redefine property: googletag$/, // This is thrown when google tag manager is used in combination with an ad blocker
+  "undefined is not an object (evaluating 'a.L')", // Random error that happens but not actionable or noticeable to end-users.
+  'can\'t redefine non-configurable property "solana"', // Probably a browser extension or custom browser (Brave) throwing this error
+  "vv().getRestrictions is not a function. (In 'vv().getRestrictions(1,a)', 'vv().getRestrictions' is undefined)", // Error thrown by GTM, seemingly not affecting end-users
+  "Can't find variable: _AutofillCallbackHandler", // Unactionable error in instagram webview https://developers.facebook.com/community/threads/320013549791141/
 ];
 
 /** Options for the InboundFilters integration */


### PR DESCRIPTION
Adds a few errors to our default ignore list that we have identified analyzing incoming events on Sentry:

- `undefined is not an object (evaluating 'a.L')`: 2250 projects, 12598 issues
- `can\'t redefine non-configurable property "solana"`: 647 projects, 1600 issues
- `vv().getRestrictions is not a function. (In 'vv().getRestrictions(1,a)', 'vv().getRestrictions' is undefined)`: 612 projects, 1555 issues
- `Can't find variable: _AutofillCallbackHandler`: 447 projects, 4135 issues

