### PR TITLE
feat(react): Add React version to events

### DIFF
--- a/packages/react/src/sdk.ts
+++ b/packages/react/src/sdk.ts
@@ -1,6 +1,8 @@
 import type { BrowserOptions } from '@sentry/browser';
-import { init as browserInit } from '@sentry/browser';
+import { init as browserInit, setContext } from '@sentry/browser';
 import { applySdkMetadata } from '@sentry/core';
+
+import { version } from 'react';
 
 /**
  * Inits the React SDK
@@ -11,6 +13,6 @@ export function init(options: BrowserOptions): void {
   };
 
   applySdkMetadata(opts, 'react');
-
+  setContext('react', { version });
   browserInit(opts);
 }

--- a/packages/react/test/sdk.test.ts
+++ b/packages/react/test/sdk.test.ts
@@ -1,0 +1,16 @@
+import * as SentryBrowser from '@sentry/browser';
+import { version } from 'react';
+import { init } from '../src/sdk';
+
+describe('init', () => {
+  it('sets the React version (if available) in the global scope', () => {
+    const setContextSpy = jest.spyOn(SentryBrowser, 'setContext');
+
+    init({});
+
+    // In our case, the Angular version is 10 because that's the version we use for compilation
+    // (and hence the dependency version of Angular core we installed (see package.json))
+    expect(setContextSpy).toHaveBeenCalledTimes(1);
+    expect(setContextSpy).toHaveBeenCalledWith('react', { version });
+  });
+});


### PR DESCRIPTION
Given React 19 has changes with error handling, we may want to treat it differently in the product. (see https://www.notion.so/sentry/React-JS-19-23a7a2c5f88d4ef59a4b9647c84333a3?d=98df57f2272d482fa12a3c0618b43fc4#9bb5d5f0a9604508bb290fd7405fcce0 as an example).

To make this easier, we now attach the react version as context on all outgoing events.