### PR TITLE
fix(aws-serverless): Only auto-patch handler in CJS when loading `awslambda-auto`

### DIFF
--- a/packages/aws-serverless/src/awslambda-auto.ts
+++ b/packages/aws-serverless/src/awslambda-auto.ts
@@ -1,3 +1,5 @@
+// Important: This file cannot import anything other than the index file below.
+// This is the entry point to the lambda layer, which only contains the entire SDK bundled into the index file
 import * as Sentry from './index';
 
 const lambdaTaskRoot = process.env.LAMBDA_TASK_ROOT;
@@ -21,7 +23,9 @@ if (lambdaTaskRoot) {
     ),
   });
 
-  Sentry.tryPatchHandler(lambdaTaskRoot, handlerString);
+  if (typeof require !== 'undefined') {
+    Sentry.tryPatchHandler(lambdaTaskRoot, handlerString);
+  }
 } else {
   throw Error('LAMBDA_TASK_ROOT environment variable is not set');
 }


### PR DESCRIPTION
The `awslambda-auto.js` file can be used to automatically init the AWS Serverless SDK by only setting [environment variables](https://docs.sentry.io/platforms/javascript/guides/aws-lambda/container-image/#function-configuration). This file is currently only exposed for CJS output. In a future PR, I'd like to also expose it in ESM so that users don't have to create their own `instrumentation.ts` file for lambda functions. 

To make this file compatible with ESM though, we can only conditionally try to auto patch the lambda function handler as our auto patching method relies on `require`ing users' lambda function handlers. So this PR guards the `tryPatcHandler` call by checking for the availability of `require` (which is undefined in ESM).