### PR TITLE
feat(profiling) add global profile context while profiler is running

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -12,6 +12,7 @@ import type { RawChunkCpuProfile, RawThreadCpuProfile } from './types';
 import { ProfileFormat } from './types';
 import { getGlobalScope } from '../../core/src/currentScopes';
 import { PROFILER_THREAD_NAME } from './utils';
+import { setContext } from '../../core/src/exports';
 
 import {
   addProfilesToEnvelope,
@@ -313,16 +314,10 @@ class ContinuousProfiler {
    * during a profiling session.
    */
   private _setupSpanChunkInstrumentation(): void {
-    // Set context once when the profiler session starts and have the spans inherit from it
-    const globalScope = getGlobalScope();
-    globalScope.setExtra('trace', {
-      data: {
-        ['thread.id']: PROFILER_THREAD_ID_STRING,
-        ['thread.name']: PROFILER_THREAD_NAME,
-      }
-    });
-    globalScope.setExtra('profiler', {
+    getGlobalScope().setContext('profile', {
       profiler_id: this._profilerId,
+      ['thread.id']: PROFILER_THREAD_ID_STRING,
+      ['thread.name']: PROFILER_THREAD_NAME,
     });
   }
 
@@ -331,8 +326,6 @@ class ContinuousProfiler {
    */
   private _teardownSpanChunkInstrumentation(): void {
     const globalScope = getGlobalScope();
-    globalScope.setExtra('trace', undefined);
-    globalScope.setExtra('profiler', undefined);
   }
 
   /**

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -8,8 +8,10 @@ import { CpuProfilerBindings } from './cpu_profiler';
 import { DEBUG_BUILD } from './debug-build';
 import { NODE_MAJOR, NODE_VERSION } from './nodeVersion';
 import { MAX_PROFILE_DURATION_MS, maybeProfileSpan, stopSpanProfile } from './spanProfileUtils';
-import type { RawThreadCpuProfile } from './types';
+import type { RawChunkCpuProfile, RawThreadCpuProfile } from './types';
 import { ProfileFormat } from './types';
+import { getGlobalScope } from '../../core/src/currentScopes';
+import { PROFILER_THREAD_NAME } from './utils';
 
 import {
   addProfilesToEnvelope,
@@ -17,6 +19,7 @@ import {
   createProfilingEvent,
   findProfiledTransactionsFromEnvelope,
   makeProfileChunkEnvelope,
+  PROFILER_THREAD_ID_STRING,
 } from './utils';
 
 const CHUNK_INTERVAL_MS = 5000;
@@ -211,7 +214,9 @@ class ContinuousProfiler {
         logger.log(`[Profiling] Failed to collect profile for: ${this._chunkData?.id}, the chunk_id is missing.`);
       return;
     }
-    const profile = CpuProfilerBindings.stopProfiling(this._chunkData.id, ProfileFormat.CHUNK);
+
+    const profile = this._stopChunkProfiling(this._chunkData);
+
     if (!profile || !this._chunkData.startTimestampMS) {
       DEBUG_BUILD && logger.log(`[Profiling] _chunkiledStartTraceID to collect profile for: ${this._chunkData.id}`);
       return;
@@ -275,10 +280,20 @@ class ContinuousProfiler {
   }
 
   /**
+   * Stops the profile and clears chunk instrumentation from global scope
+   * @returns void
+   */
+  private _stopChunkProfiling(chunk: ChunkData): RawChunkCpuProfile | null {
+    this._teardownSpanChunkInstrumentation();
+    return CpuProfilerBindings.stopProfiling(chunk.id, ProfileFormat.CHUNK);
+  }
+
+  /**
    * Starts the profiler and registers the flush timer for a given chunk.
    * @param chunk
    */
   private _startChunkProfiling(chunk: ChunkData): void {
+    this._setupSpanChunkInstrumentation();
     CpuProfilerBindings.startProfiling(chunk.id!);
     DEBUG_BUILD && logger.log(`[Profiling] starting profiling chunk: ${chunk.id}`);
 
@@ -291,6 +306,33 @@ class ContinuousProfiler {
 
     // Unref timeout so it doesn't keep the process alive.
     chunk.timer.unref();
+  }
+
+  /**
+   * Attaches profiling information to spans that were started
+   * during a profiling session.
+   */
+  private _setupSpanChunkInstrumentation(): void {
+    // Set context once when the profiler session starts and have the spans inherit from it
+    const globalScope = getGlobalScope();
+    globalScope.setExtra('trace', {
+      data: {
+        ['thread.id']: PROFILER_THREAD_ID_STRING,
+        ['thread.name']: PROFILER_THREAD_NAME,
+      }
+    });
+    globalScope.setExtra('profiler', {
+      profiler_id: this._profilerId,
+    });
+  }
+
+  /**
+   * Clear profiling information from global context when a profile is not running.
+   */
+  private _teardownSpanChunkInstrumentation(): void {
+    const globalScope = getGlobalScope();
+    globalScope.setExtra('trace', undefined);
+    globalScope.setExtra('profiler', undefined);
   }
 
   /**

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -326,6 +326,7 @@ class ContinuousProfiler {
    */
   private _teardownSpanChunkInstrumentation(): void {
     const globalScope = getGlobalScope();
+    globalScope.setContext('profile', {});
   }
 
   /**

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -4,22 +4,22 @@ import type { Integration, IntegrationFn, Profile, ProfileChunk, Span } from '@s
 
 import { LRUMap, logger, timestampInSeconds, uuid4 } from '@sentry/utils';
 
+import { getGlobalScope } from '../../core/src/currentScopes';
 import { CpuProfilerBindings } from './cpu_profiler';
 import { DEBUG_BUILD } from './debug-build';
 import { NODE_MAJOR, NODE_VERSION } from './nodeVersion';
 import { MAX_PROFILE_DURATION_MS, maybeProfileSpan, stopSpanProfile } from './spanProfileUtils';
 import type { RawChunkCpuProfile, RawThreadCpuProfile } from './types';
 import { ProfileFormat } from './types';
-import { getGlobalScope } from '../../core/src/currentScopes';
 import { PROFILER_THREAD_NAME } from './utils';
 
 import {
+  PROFILER_THREAD_ID_STRING,
   addProfilesToEnvelope,
   createProfilingChunkEvent,
   createProfilingEvent,
   findProfiledTransactionsFromEnvelope,
   makeProfileChunkEnvelope,
-  PROFILER_THREAD_ID_STRING,
 } from './utils';
 
 const CHUNK_INTERVAL_MS = 5000;

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -12,7 +12,6 @@ import type { RawChunkCpuProfile, RawThreadCpuProfile } from './types';
 import { ProfileFormat } from './types';
 import { getGlobalScope } from '../../core/src/currentScopes';
 import { PROFILER_THREAD_NAME } from './utils';
-import { setContext } from '../../core/src/exports';
 
 import {
   addProfilesToEnvelope,
@@ -295,7 +294,7 @@ class ContinuousProfiler {
    */
   private _startChunkProfiling(chunk: ChunkData): void {
     this._setupSpanChunkInstrumentation();
-    CpuProfilerBindings.startProfiling(chunk.id!);
+    CpuProfilerBindings.startProfiling(chunk.id);
     DEBUG_BUILD && logger.log(`[Profiling] starting profiling chunk: ${chunk.id}`);
 
     chunk.timer = global.setTimeout(() => {

--- a/packages/profiling-node/src/spanProfileUtils.ts
+++ b/packages/profiling-node/src/spanProfileUtils.ts
@@ -115,7 +115,6 @@ export function stopSpanProfile(span: Span, profile_id: string | undefined): Raw
   }
 
   const profile = CpuProfilerBindings.stopProfiling(profile_id, 0);
-
   DEBUG_BUILD && logger.log(`[Profiling] stopped profiling of transaction: ${spanToJSON(span).description}`);
 
   // In case of an overlapping span, stopProfiling may return null and silently ignore the overlapping profile.

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -28,8 +28,8 @@ import type { RawChunkCpuProfile, RawThreadCpuProfile } from './types';
 
 // We require the file because if we import it, it will be included in the bundle.
 // I guess tsc does not check file contents when it's imported.
-const THREAD_ID_STRING = String(threadId);
-const THREAD_NAME = isMainThread ? 'main' : 'worker';
+export const PROFILER_THREAD_ID_STRING = String(threadId);
+export const PROFILER_THREAD_NAME = isMainThread ? 'main' : 'worker';
 const FORMAT_VERSION = '1';
 const CONTINUOUS_FORMAT_VERSION = '2';
 
@@ -75,8 +75,8 @@ export function enrichWithThreadInformation(
     frames: profile.frames,
     stacks: profile.stacks,
     thread_metadata: {
-      [THREAD_ID_STRING]: {
-        name: THREAD_NAME,
+      [PROFILER_THREAD_ID_STRING]: {
+        name: PROFILER_THREAD_NAME,
       },
     },
   } as ThreadCpuProfile | ContinuousThreadCpuProfile;
@@ -172,7 +172,7 @@ function createProfilePayload(
       name: transaction,
       id: event_id,
       trace_id: trace_id || '',
-      active_thread_id: THREAD_ID_STRING,
+      active_thread_id: PROFILER_THREAD_ID_STRING,
     },
   };
 

--- a/packages/profiling-node/test/spanProfileUtils.test.ts
+++ b/packages/profiling-node/test/spanProfileUtils.test.ts
@@ -587,11 +587,7 @@ describe('continuous profiling', () => {
 
     expect(transportSpy.mock.calls?.[0]?.[0]?.[1]?.[0]?.[1]).not.toMatchObject({
       contexts: {
-        profiler: {
-          profiler_id: expect.any(String),
-          ['thread.id']: expect.any(String),
-          ['thread.name']: expect.any(String),
-        },
+        profile: {},
       },
     });
 

--- a/packages/profiling-node/test/spanProfileUtils.test.ts
+++ b/packages/profiling-node/test/spanProfileUtils.test.ts
@@ -606,7 +606,7 @@ describe('continuous profiling', () => {
           data: expect.objectContaining({
             ['thread.id']: expect.any(String),
             ['thread.name']: expect.any(String),
-          })
+          }),
         },
         profile: {
           profiler_id: expect.any(String),

--- a/packages/profiling-node/test/spanProfileUtils.test.ts
+++ b/packages/profiling-node/test/spanProfileUtils.test.ts
@@ -322,7 +322,6 @@ describe('automated span instrumentation', () => {
     transaction.end();
     expect(stopProfilingSpy).toHaveBeenCalledTimes(1);
   });
-
   it('enriches profile with debug_id', async () => {
     GLOBAL_OBJ._sentryDebugIds = {
       'Error\n    at filename.js (filename.js:36:15)': 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa',
@@ -603,10 +602,14 @@ describe('continuous profiling', () => {
 
     expect(transportSpy.mock.calls?.[1]?.[0]?.[1]?.[0]?.[1]).toMatchObject({
       contexts: {
+        trace: {
+          data: expect.objectContaining({
+            ['thread.id']: expect.any(String),
+            ['thread.name']: expect.any(String),
+          })
+        },
         profile: {
           profiler_id: expect.any(String),
-          ['thread.id']: expect.any(String),
-          ['thread.name']: expect.any(String),
         },
       },
     });

--- a/packages/profiling-node/test/spanProfileUtils.test.ts
+++ b/packages/profiling-node/test/spanProfileUtils.test.ts
@@ -7,8 +7,6 @@ import { GLOBAL_OBJ, createEnvelope, logger } from '@sentry/utils';
 import { CpuProfilerBindings } from '../src/cpu_profiler';
 import { type ProfilingIntegration, _nodeProfilingIntegration } from '../src/integration';
 
-jest.setTimeout(10000);
-
 function makeClientWithHooks(): [Sentry.NodeClient, Transport] {
   const integration = _nodeProfilingIntegration();
   const client = new Sentry.NodeClient({

--- a/packages/profiling-node/test/spanProfileUtils.worker.test.ts
+++ b/packages/profiling-node/test/spanProfileUtils.worker.test.ts
@@ -1,0 +1,75 @@
+// Mock the modules before the import, so that the value is initialized before the module is loaded
+jest.mock('worker_threads', () => {
+  return {
+    isMainThread: false,
+    threadId: 9999,
+  }
+})
+jest.setTimeout(10000);
+
+import * as Sentry from '@sentry/node';
+import type { Transport } from '@sentry/types';
+import { type ProfilingIntegration, _nodeProfilingIntegration } from '../src/integration';
+
+function makeContinuousProfilingClient(): [Sentry.NodeClient, Transport] {
+  const integration = _nodeProfilingIntegration();
+  const client = new Sentry.NodeClient({
+    stackParser: Sentry.defaultStackParser,
+    tracesSampleRate: 1,
+    profilesSampleRate: undefined,
+    debug: true,
+    environment: 'test-environment',
+    dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
+    integrations: [integration],
+    transport: _opts =>
+      Sentry.makeNodeTransport({
+        url: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
+        recordDroppedEvent: () => {
+          return undefined;
+        },
+      }),
+  });
+
+  return [client, client.getTransport() as Transport];
+}
+
+it('worker threads context', () => {
+  const [client, transport] = makeContinuousProfilingClient();
+  Sentry.setCurrentClient(client);
+  client.init();
+
+  const transportSpy = jest.spyOn(transport, 'send').mockReturnValue(Promise.resolve({}));
+
+  const nonProfiledTransaction = Sentry.startInactiveSpan({ forceTransaction: true, name: 'profile_hub' });
+  nonProfiledTransaction.end();
+
+  expect(transportSpy.mock.calls?.[0]?.[0]?.[1]?.[0]?.[1]).not.toMatchObject({
+    contexts: {
+      profile: {},
+    },
+  });
+
+  const integration = client.getIntegrationByName<ProfilingIntegration>('ProfilingIntegration');
+  if (!integration) {
+    throw new Error('Profiling integration not found');
+  }
+
+  integration._profiler.start();
+  const profiledTransaction = Sentry.startInactiveSpan({ forceTransaction: true, name: 'profile_hub' });
+  profiledTransaction.end();
+  integration._profiler.stop();
+
+  expect(transportSpy.mock.calls?.[1]?.[0]?.[1]?.[0]?.[1]).toMatchObject({
+    contexts: {
+      trace: {
+        data: expect.objectContaining({
+          ['thread.id']: '9999',
+          ['thread.name']: 'worker',
+        }),
+      },
+      profile: {
+        profiler_id: expect.any(String),
+      },
+    },
+  });
+});

--- a/packages/profiling-node/test/spanProfileUtils.worker.test.ts
+++ b/packages/profiling-node/test/spanProfileUtils.worker.test.ts
@@ -3,8 +3,8 @@ jest.mock('worker_threads', () => {
   return {
     isMainThread: false,
     threadId: 9999,
-  }
-})
+  };
+});
 jest.setTimeout(10000);
 
 import * as Sentry from '@sentry/node';


### PR DESCRIPTION
Attach profile context to events while a profiler is active and assign thread id and name to the trace context.

This will be required by the profiling API so that we can figure out the links between spans and profiles. In the future (span streaming), tid and thread name will be assigned to each span