### PR TITLE
fix: Fix types export order

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -31,17 +31,17 @@
   "types": "build/types/index.types.d.ts",
   "exports": {
     ".": {
+      "types": "./build/types/index.types.d.ts",
       "node": "./build/esm/index.server.js",
       "browser": "./build/esm/index.client.js",
       "import": "./build/esm/index.client.js",
-      "require": "./build/cjs/index.server.js",
-      "types": "./build/types/index.types.d.ts"
+      "require": "./build/cjs/index.server.js"
     },
     "./middleware": {
+      "types": "./build/types/integration/middleware/index.types.d.ts",
       "node": "./build/esm/integration/middleware/index.js",
       "import": "./build/esm/integration/middleware/index.js",
-      "require": "./build/cjs/integration/middleware/index.js",
-      "types": "./build/types/integration/middleware/index.types.d.ts"
+      "require": "./build/cjs/integration/middleware/index.js"
     },
     "./import": {
       "import": {

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -28,12 +28,12 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./build/types/index.types.d.ts",
       "browser": {
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"
       },
-      "node": "./build/cjs/index.server.js",
-      "types": "./build/types/index.types.d.ts"
+      "node": "./build/cjs/index.server.js"
     },
     "./import": {
       "import": {

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -22,12 +22,12 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./build/types/index.types.d.ts",
       "browser": {
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"
       },
-      "node": "./build/cjs/index.server.js",
-      "types": "./build/types/index.types.d.ts"
+      "node": "./build/cjs/index.server.js"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
Ensure the `types` export is always first, as documented here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing

Follow up to https://github.com/getsentry/sentry-javascript/pull/12355