### PR TITLE
chore(changelog): Add external contributor credit message to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+Work in this release was contributed by @soch4n. Thank you for your contribution!
+
 ## 8.8.0
 
 - **feat: Upgrade OTEL dependencies (#12388)**


### PR DESCRIPTION
Discussed internally that we're gonna add external contributor shoutouts to ##Unreleased so that we don't forget them when we create the
changelog for the next release. This PR adds the contributor of #12398.
