### PR TITLE
ci: Add workflow to automatically add external contributors to CHANGELOG.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,6 @@ jobs:
           title: "ref: Add external contributor to CHANGELOG.md"
           branch: 'external-contributor/patch-${{ github.event.pull_request.user.login }}'
           delete-branch: true
-          path: 'CHANGELOG.md'
 
   job_build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,9 +230,6 @@ jobs:
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'pull_request'
-      && github.event.pull_request.author_association != 'COLLABORATOR'
-      && github.event.pull_request.author_association != 'MEMBER'
-      && github.event.pull_request.author_association != 'OWNER'
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
 
   job_external_contributor:
     name: Mention external contributor in changelog
-    needs: job_get_metadata
+    needs: job_install_deps
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'pull_request'
@@ -234,6 +234,17 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+      - name: Check dependency cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
+          fail-on-cache-miss: true
+
       - name: Add external contributor to CHANGELOG.md
         uses: ./dev-packages/external-contributor-gh-action
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,8 +230,6 @@ jobs:
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'pull_request'
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,6 +234,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -253,6 +255,8 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Add external contributor to CHANGELOG.md"
+          skip_fetch: true
+          skip_checkout: true
 
   job_build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,6 +230,9 @@ jobs:
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'pull_request'
+      && github.event.pull_request.author_association != 'COLLABORATOR'
+      && github.event.pull_request.author_association != 'MEMBER'
+      && github.event.pull_request.author_association != 'OWNER'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,12 +251,14 @@ jobs:
         uses: ./dev-packages/external-contributor-gh-action
         with:
           name: ${{ github.event.pull_request.user.login }}
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Create PR with changes
+        uses: peter-evans/create-pull-request@v6
         with:
-          commit_message: "Add external contributor to CHANGELOG.md"
-          skip_fetch: true
-          skip_checkout: true
+          commit-message: "ref: Add external contributor to CHANGELOG.md"
+          title: "ref: Add external contributor to CHANGELOG.md"
+          branch: 'external-contributor/patch-${{ github.event.pull_request.user.login }}'
+          delete-branch: true
+          path: 'CHANGELOG.md'
 
   job_build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,10 +234,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: ./dev-packages/external-contributor-gh-action
+      - name: Add external contributor to CHANGELOG.md
+        uses: ./dev-packages/external-contributor-gh-action
         with:
           name: ${{ github.event.pull_request.user.login }}
-      - uses: parkerbxyz/suggest-changes@v1
+      - name: Propose changes
+        uses: parkerbxyz/suggest-changes@v1
         with:
           comment: 'Please commit the suggested changes from markdownlint.'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,8 +231,7 @@ jobs:
     if: |
       github.event_name == 'pull_request'
     permissions:
-      contents: read
-      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node
@@ -250,10 +249,10 @@ jobs:
         uses: ./dev-packages/external-contributor-gh-action
         with:
           name: ${{ github.event.pull_request.user.login }}
-      - name: Propose changes
-        uses: parkerbxyz/suggest-changes@v1
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          comment: 'Add external contributor to CHANGELOG.md'
+          commit_message: "Add external contributor to CHANGELOG.md"
 
   job_build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,12 +225,13 @@ jobs:
             ⚠️ This PR is opened against **master**. You probably want to open it against **develop**.
 
   job_external_contributor:
-    name: Mention external contributor in changelog
+    name: External Contributors
     needs: job_install_deps
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'pull_request'
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -252,7 +253,7 @@ jobs:
       - name: Propose changes
         uses: parkerbxyz/suggest-changes@v1
         with:
-          comment: 'Please commit the suggested changes from markdownlint.'
+          comment: 'Add external contributor to CHANGELOG.md'
 
   job_build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,6 +256,7 @@ jobs:
           title: "ref: Add external contributor to CHANGELOG.md"
           branch: 'external-contributor/patch-${{ github.event.pull_request.user.login }}'
           delete-branch: true
+          body: This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution.
 
   job_build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,6 +230,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'pull_request'
+      && (github.action == 'opened' || github.action == 'reopened')
       && github.event.pull_request.author_association != 'COLLABORATOR'
       && github.event.pull_request.author_association != 'MEMBER'
       && github.event.pull_request.author_association != 'OWNER'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,6 +224,26 @@ jobs:
           message: |
             ⚠️ This PR is opened against **master**. You probably want to open it against **develop**.
 
+  job_external_contributor:
+    name: Mention external contributor in changelog
+    needs: job_get_metadata
+    runs-on: ubuntu-20.04
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.author_association != 'COLLABORATOR'
+      && github.event.pull_request.author_association != 'MEMBER'
+      && github.event.pull_request.author_association != 'OWNER'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./dev-packages/external-contributor-gh-action
+        with:
+          name: ${{ github.event.pull_request.user.login }}
+      - uses: parkerbxyz/suggest-changes@v1
+        with:
+          comment: 'Please commit the suggested changes from markdownlint.'
+
   job_build:
     name: Build
     needs: [job_get_metadata, job_install_deps]

--- a/dev-packages/external-contributor-gh-action/.eslintrc.cjs
+++ b/dev-packages/external-contributor-gh-action/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: ['../../.eslintrc.js'],
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+  },
+
+  overrides: [
+    {
+      files: ['*.mjs'],
+      extends: ['@sentry-internal/sdk/src/base'],
+    },
+  ],
+};

--- a/dev-packages/external-contributor-gh-action/action.yml
+++ b/dev-packages/external-contributor-gh-action/action.yml
@@ -1,0 +1,9 @@
+name: 'external-contributor-gh-action'
+description: 'Add external contributors to CHANGELOG.md'
+inputs:
+  name:
+    required: true
+    description: 'The name of the external contributor'
+runs:
+  using: 'node20'
+  main: 'index.mjs'

--- a/dev-packages/external-contributor-gh-action/index.mjs
+++ b/dev-packages/external-contributor-gh-action/index.mjs
@@ -12,13 +12,15 @@ const contributorMessageRegex = /Work in this release was contributed by (.+)\. 
 async function run() {
   const { getInput } = core;
 
-  const name = getInput('name');
+  const name = getInput('name') || '@test-user';
 
   if (!name) {
     return;
   }
 
-  const cwd = process.cwd();
+  const ghUserName = name.startsWith('@') ? name : `@${name}`;
+
+  const cwd = path.join(process.cwd(), '../..');
   const changelogFilePath = path.resolve(cwd, 'CHANGELOG.md');
 
   const changelogStr = await fs.readFile(changelogFilePath, 'utf8');
@@ -34,8 +36,8 @@ async function run() {
   // If the contributor message already exists, add the new contributor to the list
   if (existing) {
     const users = existing[1].split(/(?:,? and )|(?:, )/);
-    if (!users.includes(name)) {
-      users.push(name);
+    if (!users.includes(ghUserName)) {
+      users.push(ghUserName);
     }
 
     const formatter = new Intl.ListFormat('en', {
@@ -50,15 +52,21 @@ async function run() {
     );
 
     fs.writeFile(changelogFilePath, newChangelog);
+
+    // eslint-disable-next-line no-console
+    console.log('Added contributor to list of existing contributors.');
     return;
   }
 
   // If the contributor message does not exist, add it
   const newChangelog = changelogStr.replace(
     UNRELEASED_HEADING,
-    `${UNRELEASED_HEADING}\nWork in this release was contributed by ${name}. Thank you for your contribution!\n`,
+    `${UNRELEASED_HEADING}\nWork in this release was contributed by ${ghUserName}. Thank you for your contribution!\n`,
   );
   fs.writeFile(changelogFilePath, newChangelog);
+
+    // eslint-disable-next-line no-console
+    console.log('Added contributor message.');
 }
 
 run();

--- a/dev-packages/external-contributor-gh-action/index.mjs
+++ b/dev-packages/external-contributor-gh-action/index.mjs
@@ -1,0 +1,64 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import * as core from '@actions/core';
+
+const UNRELEASED_HEADING = `## Unreleased
+
+- "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+`;
+
+const contributorMessageRegex = /Work in this release was contributed by (.+)\. Thank you for your contribution!/;
+
+async function run() {
+  const { getInput } = core;
+
+  const name = getInput('name');
+
+  if (!name) {
+    return;
+  }
+
+  const cwd = process.cwd();
+  const changelogFilePath = path.resolve(cwd, 'CHANGELOG.md');
+
+  const changelogStr = await fs.readFile(changelogFilePath, 'utf8');
+
+  // Find the unreleased section
+  const start = changelogStr.indexOf(UNRELEASED_HEADING) + UNRELEASED_HEADING.length;
+  const end = changelogStr.slice(start).indexOf('## ');
+
+  const inBetween = changelogStr.slice(start, start + end);
+
+  const existing = contributorMessageRegex.exec(inBetween);
+
+  // If the contributor message already exists, add the new contributor to the list
+  if (existing) {
+    const users = existing[1].split(/(?:,? and )|(?:, )/);
+    if (!users.includes(name)) {
+      users.push(name);
+    }
+
+    const formatter = new Intl.ListFormat('en', {
+      style: 'long',
+      type: 'conjunction',
+    });
+
+    const newContributors = formatter.format(users);
+    const newChangelog = changelogStr.replace(
+      contributorMessageRegex,
+      `Work in this release was contributed by ${newContributors}. Thank you for your contribution!`,
+    );
+
+    fs.writeFile(changelogFilePath, newChangelog);
+    return;
+  }
+
+  // If the contributor message does not exist, add it
+  const newChangelog = changelogStr.replace(
+    UNRELEASED_HEADING,
+    `${UNRELEASED_HEADING}\nWork in this release was contributed by ${name}. Thank you for your contribution!\n`,
+  );
+  fs.writeFile(changelogFilePath, newChangelog);
+}
+
+run();

--- a/dev-packages/external-contributor-gh-action/index.mjs
+++ b/dev-packages/external-contributor-gh-action/index.mjs
@@ -12,7 +12,7 @@ const contributorMessageRegex = /Work in this release was contributed by (.+)\. 
 async function run() {
   const { getInput } = core;
 
-  const name = getInput('name') || '@test-user';
+  const name = getInput('name');
 
   if (!name) {
     return;
@@ -20,7 +20,7 @@ async function run() {
 
   const ghUserName = name.startsWith('@') ? name : `@${name}`;
 
-  const cwd = path.join(process.cwd(), '../..');
+  const cwd = process.cwd();
   const changelogFilePath = path.resolve(cwd, 'CHANGELOG.md');
 
   const changelogStr = await fs.readFile(changelogFilePath, 'utf8');
@@ -65,8 +65,8 @@ async function run() {
   );
   fs.writeFile(changelogFilePath, newChangelog);
 
-    // eslint-disable-next-line no-console
-    console.log('Added contributor message.');
+  // eslint-disable-next-line no-console
+  console.log('Added contributor message.');
 }
 
 run();

--- a/dev-packages/external-contributor-gh-action/package.json
+++ b/dev-packages/external-contributor-gh-action/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sentry-internal/external-contributor-gh-action",
+  "description": "An internal Github Action to add external contributors to the CHANGELOG.md file.",
+  "version": "8.8.0",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "private": true,
+  "main": "index.mjs",
+  "type": "module",
+  "scripts": {
+    "lint": "eslint . --format stylish",
+    "fix": "eslint . --format stylish --fix"
+  },
+  "dependencies": {
+    "@actions/core": "1.10.1"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "dev-packages/overhead-metrics",
     "dev-packages/test-utils",
     "dev-packages/size-limit-gh-action",
+    "dev-packages/external-contributor-gh-action",
     "dev-packages/rollup-utils"
   ],
   "devDependencies": {


### PR DESCRIPTION
This adds a new GHA job that, if a PR is created by an external contributor, it will open a PR against that branch that adds the contributor to the changelog, so we do not forget about this.

It will open a PR like this:

https://github.com/getsentry/sentry-javascript/pull/12435

which we have to manually merge/review, so nothing "bad" can happen.