### PR TITLE
fix(replay): Fix guard for exception event

### DIFF
--- a/packages/replay-internal/src/coreHandlers/handleBeforeSendEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleBeforeSendEvent.ts
@@ -21,7 +21,8 @@ export function handleBeforeSendEvent(replay: ReplayContainer): BeforeSendEventC
 }
 
 function handleHydrationError(replay: ReplayContainer, event: ErrorEvent): void {
-  const exceptionValue = event.exception && event.exception.values && event.exception.values[0].value;
+  const exceptionValue =
+    event.exception && event.exception.values && event.exception.values[0] && event.exception.values[0].value;
   if (typeof exceptionValue !== 'string') {
     return;
   }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/11759, hopefully.

One more example for why we should enable noUncheckedIndexedAccess... See https://github.com/getsentry/sentry-javascript/issues/12440