### PR TITLE
ref(replay): Add INP web vital breadcrumb test

### DIFF
--- a/dev-packages/browser-integration-tests/suites/replay/customEvents/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/customEvents/test.ts
@@ -7,6 +7,7 @@ import {
   expectedFCPPerformanceSpan,
   expectedFIDPerformanceSpan,
   expectedFPPerformanceSpan,
+  expectedINPPerformanceSpan,
   expectedLCPPerformanceSpan,
   expectedMemoryPerformanceSpan,
   expectedNavigationPerformanceSpan,
@@ -51,6 +52,13 @@ sentryTest(
 
     await page.locator('#img-button').click();
 
+    // Page hide to trigger INP
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    await page.waitForTimeout(500);
+
     const replayEvent1 = getReplayEvent(await reqPromise1);
     const { performanceSpans: performanceSpans1 } = getCustomRecordingEvents(await reqPromise1);
 
@@ -66,6 +74,7 @@ sentryTest(
         expectedLCPPerformanceSpan,
         expectedCLSPerformanceSpan,
         expectedFIDPerformanceSpan,
+        expectedINPPerformanceSpan,
         expectedFPPerformanceSpan,
         expectedFCPPerformanceSpan,
         expectedMemoryPerformanceSpan, // two memory spans - once per flush


### PR DESCRIPTION
Testing for INP breadcrumbs was flakey previously, so it wasn't included in original PR.

Fixes https://github.com/getsentry/sentry-javascript/issues/12470
