### PR TITLE
build: Add `tsconfig.json` to test directories to fix VSCode

### DIFF
--- a/packages/astro/test/tsconfig.json
+++ b/packages/astro/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/aws-serverless/test/tsconfig.json
+++ b/packages/aws-serverless/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/browser-utils/test/tsconfig.json
+++ b/packages/browser-utils/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/browser/test/tsconfig.json
+++ b/packages/browser/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/bun/test/tsconfig.json
+++ b/packages/bun/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/deno/test/tsconfig.json
+++ b/packages/deno/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/gatsby/test/tsconfig.json
+++ b/packages/gatsby/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/google-cloud-serverless/test/tsconfig.json
+++ b/packages/google-cloud-serverless/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/node/test/tsconfig.json
+++ b/packages/node/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/opentelemetry/test/tsconfig.json
+++ b/packages/opentelemetry/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/profiling-node/test/tsconfig.json
+++ b/packages/profiling-node/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/react/test/tsconfig.json
+++ b/packages/react/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/remix/test/tsconfig.json
+++ b/packages/remix/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/replay-canvas/test/tsconfig.json
+++ b/packages/replay-canvas/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/replay-internal/test/tsconfig.json
+++ b/packages/replay-internal/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/replay-worker/test/tsconfig.json
+++ b/packages/replay-worker/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/solid/test/tsconfig.json
+++ b/packages/solid/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/svelte/test/tsconfig.json
+++ b/packages/svelte/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/sveltekit/test/tsconfig.json
+++ b/packages/sveltekit/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/utils/test/tsconfig.json
+++ b/packages/utils/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/vercel-edge/test/tsconfig.json
+++ b/packages/vercel-edge/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/vue/test/tsconfig.json
+++ b/packages/vue/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}


### PR DESCRIPTION
VSCode does not pick up the `tsconfig.test.json` files, and thus does not apply the config properly to the test files. By adding a tsconfig.json into the test/ directory, this is picked up correctly by VSCode as well.