### PR TITLE
feat(replay): Bump `rrweb` to 2.25.0

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -177,7 +177,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: false,
     brotli: false,
-    limit: '221 KB',
+    limit: '230 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback) - uncompressed',

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/manualSnapshot/template.html
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/manualSnapshot/template.html
@@ -13,7 +13,6 @@
   function draw() {
   const canvas = document.getElementById("canvas");
     if (canvas.getContext) {
-      console.log('has canvas')
       const ctx = canvas.getContext("2d");
 
       ctx.fillRect(25, 25, 100, 100);

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/records/template.html
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/records/template.html
@@ -13,7 +13,6 @@
   function draw() {
   const canvas = document.getElementById("canvas");
     if (canvas.getContext) {
-      console.log('has canvas')
       const ctx = canvas.getContext("2d");
 
       ctx.fillRect(25, 25, 100, 100);

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@sentry-internal/rrweb": "2.15.0"
+    "@sentry-internal/rrweb": "2.25.0"
   },
   "dependencies": {
     "@sentry-internal/replay": "8.17.0",

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -69,8 +69,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "8.17.0",
-    "@sentry-internal/rrweb": "2.15.0",
-    "@sentry-internal/rrweb-snapshot": "2.15.0",
+    "@sentry-internal/rrweb": "2.25.0",
+    "@sentry-internal/rrweb-snapshot": "2.25.0",
     "fflate": "^0.8.1",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/packages/replay-internal/src/types/rrweb.ts
+++ b/packages/replay-internal/src/types/rrweb.ts
@@ -31,7 +31,7 @@ export type ReplayEventWithTime = {
 
 /**
  * This is a partial copy of rrweb's recording options which only contains the properties
- * we specifically us in the SDK. Users can specify additional properties, hence we add the
+ * we specifically use in the SDK. Users can specify additional properties, hence we add the
  * Record<string, unknown> union type.
  */
 export type RrwebRecordOptions = {
@@ -52,6 +52,9 @@ export interface CanvasManagerInterface {
   lock(): void;
   unlock(): void;
   snapshot(): void;
+  addWindow(win: typeof globalThis & Window): void;
+  addShadowRoot(): void;
+  resetShadowRoots(): void;
 }
 
 export interface CanvasManagerOptions {

--- a/packages/replay-internal/src/types/rrweb.ts
+++ b/packages/replay-internal/src/types/rrweb.ts
@@ -53,7 +53,7 @@ export interface CanvasManagerInterface {
   unlock(): void;
   snapshot(): void;
   addWindow(win: typeof globalThis & Window): void;
-  addShadowRoot(): void;
+  addShadowRoot(shadowRoot: ShadowRoot): void;
   resetShadowRoots(): void;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7895,22 +7895,22 @@
   dependencies:
     "@sentry-internal/rrweb-snapshot" "2.11.0"
 
-"@sentry-internal/rrdom@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.15.0.tgz#1ac070a7a00664b2c5351c8ba13979369024128a"
-  integrity sha512-LDy2LbmEytIuV9vKTr2dK4iMCTTFTpNW/eJ6IoapB0syYBc4yuUsbH39s/gamxcR5Y7KjkySSh0XkMnCHyV5gg==
+"@sentry-internal/rrdom@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.25.0.tgz#4be842f7f4efae383bbd5a9dcbbecc212d378d70"
+  integrity sha512-YTxGHnCdv6D2JVJ6YFezMsGOHLy7CM8x8qMaY3Yh3QTubFOjdGpcGJGITF/9Lkx+rFVCTdjL32cQu9NUgEJO8g==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.15.0"
+    "@sentry-internal/rrweb-snapshot" "2.25.0"
 
 "@sentry-internal/rrweb-snapshot@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.11.0.tgz#1af79130604afea989d325465b209ac015b27c9a"
   integrity sha512-1nP22QlplMNooSNvTh+L30NSZ+E3UcfaJyxXSMLxUjQHTGPyM1VkndxZMmxlKhyR5X+rLbxi/+RvuAcpM43VoA==
 
-"@sentry-internal/rrweb-snapshot@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.15.0.tgz#04c79d3dc723ed80e4f10685d5ebc6c1b90fcf1b"
-  integrity sha512-g/gqzKab6lQ/YvioIXVWQTaQXrUctepqIgXP7vYvpnU+ZmxmsOVd10gQuryDCSLYt2wQiwkffYyeaP2BVqxbwQ==
+"@sentry-internal/rrweb-snapshot@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.25.0.tgz#f20bd20436edac24ed1075b47fc4773894739d97"
+  integrity sha512-7j90eSGFRS1YWcuo0bXPtV9oDdCQxutilyYbim/I09GA7kx4/d8OG8ryxQl6WWXW+E50x6dEpDsZXWMPkSleEg==
 
 "@sentry-internal/rrweb-types@2.11.0":
   version "2.11.0"
@@ -7919,12 +7919,13 @@
   dependencies:
     "@sentry-internal/rrweb-snapshot" "2.11.0"
 
-"@sentry-internal/rrweb-types@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.15.0.tgz#caeabffc227405110946447f30893aa037493b23"
-  integrity sha512-D3i9+G4h6gLlG/B1lkP3jc3pM84hP2d2WFGrapTBI0bJou822ERD3Wj9KBVPEkwsRM+qDZRqRMrq0PicdAqJAA==
+"@sentry-internal/rrweb-types@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.25.0.tgz#61662befc57ed7054a491eb35ad3deda7d66157c"
+  integrity sha512-sM2YdevhIRxQ/Kr89cfbNBO7/EFhycTmQT0NKg4owdKkIvuuqz1AhbRpMMdpJ4NJnos+h06VPObeXm6rcrffsw==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.15.0"
+    "@sentry-internal/rrweb-snapshot" "2.25.0"
+    "@types/css-font-loading-module" "0.0.7"
 
 "@sentry-internal/rrweb@2.11.0":
   version "2.11.0"
@@ -7940,14 +7941,14 @@
     fflate "^0.4.4"
     mitt "^3.0.0"
 
-"@sentry-internal/rrweb@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.15.0.tgz#a38dff464624c7ab421579b5ec626007e10c9da8"
-  integrity sha512-WO2QJJMJYVcuc8aq6j4YEzNo512FZ2Ro7/04Ip1MYhPI4BpHhn3KI7lRoHvprZeVNYWXyBtiPy7JFehuVCppdw==
+"@sentry-internal/rrweb@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.25.0.tgz#0148f1904f1e9549f2c2cae209fe3d3fe891d3ec"
+  integrity sha512-0tgBI0CFpyO3Z3dw4IjS/D6AnQypro4dquRrcZZzqnMH65Vxw3yytGDtmvE/FzHzGC0vmKFTM+sTkzFY0bo+Bg==
   dependencies:
-    "@sentry-internal/rrdom" "2.15.0"
-    "@sentry-internal/rrweb-snapshot" "2.15.0"
-    "@sentry-internal/rrweb-types" "2.15.0"
+    "@sentry-internal/rrdom" "2.25.0"
+    "@sentry-internal/rrweb-snapshot" "2.25.0"
+    "@sentry-internal/rrweb-types" "2.25.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
* Uses clean `Array.from` implementation
* Revert css parsing (player)
* Implements multitouch gestures (player)
* Many upstream fixes
