### PR TITLE
test(ref): Avoid some unnecessary conditions in tests

### DIFF
--- a/packages/browser/test/unit/eventbuilder.test.ts
+++ b/packages/browser/test/unit/eventbuilder.test.ts
@@ -44,7 +44,7 @@ describe('eventFromUnknownInput', () => {
 
     const event = eventFromUnknownInput(defaultStackParser, deepObject);
 
-    expect(event?.extra?.__serialized__).toEqual({
+    expect(event.extra?.__serialized__).toEqual({
       a: {
         b: {
           c: {

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -357,10 +357,10 @@ describe('SentryBrowser initialization', () => {
 
       const sdkData = getClient()?.getOptions()._metadata?.sdk || {};
 
-      expect(sdkData?.name).toBe('sentry.javascript.browser');
-      expect(sdkData?.packages?.[0]?.name).toBe('npm:@sentry/browser');
-      expect(sdkData?.packages?.[0]?.version).toBe(SDK_VERSION);
-      expect(sdkData?.version).toBe(SDK_VERSION);
+      expect(sdkData.name).toBe('sentry.javascript.browser');
+      expect(sdkData.packages?.[0]?.name).toBe('npm:@sentry/browser');
+      expect(sdkData.packages?.[0]?.version).toBe(SDK_VERSION);
+      expect(sdkData.version).toBe(SDK_VERSION);
     });
 
     it('uses SDK source from window for package name', () => {

--- a/packages/browser/test/unit/profiling/integration.test.ts
+++ b/packages/browser/test/unit/profiling/integration.test.ts
@@ -56,8 +56,8 @@ describe('BrowserProfilingIntegration', () => {
 
     expect(send).toHaveBeenCalledTimes(1);
 
-    const profile = send.mock.calls?.[0]?.[0]?.[1]?.[1]?.[1];
-    const transaction = send.mock.calls?.[0]?.[0]?.[1]?.[0]?.[1];
+    const profile = send.mock.calls[0]?.[0]?.[1]?.[1]?.[1];
+    const transaction = send.mock.calls[0]?.[0]?.[1]?.[0]?.[1];
     const profile_timestamp_ms = new Date(profile.timestamp).getTime();
     const transaction_timestamp_ms = new Date(transaction.start_timestamp * 1e3).getTime();
 

--- a/packages/browser/test/unit/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/unit/tracing/browserTracingIntegration.test.ts
@@ -672,8 +672,8 @@ describe('browserTracingIntegration', () => {
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
       });
 
-      expect(newIsolationScopePropCtx?.traceId).not.toEqual(oldIsolationScopePropCtx?.traceId);
-      expect(newCurrentScopePropCtx?.traceId).not.toEqual(oldCurrentScopePropCtx?.traceId);
+      expect(newIsolationScopePropCtx.traceId).not.toEqual(oldIsolationScopePropCtx.traceId);
+      expect(newCurrentScopePropCtx.traceId).not.toEqual(oldCurrentScopePropCtx.traceId);
     });
 
     it("saves the span's positive sampling decision and its DSC on the propagationContext when the span finishes", () => {
@@ -701,8 +701,8 @@ describe('browserTracingIntegration', () => {
 
       const propCtxAfterEnd = getCurrentScope().getPropagationContext();
       expect(propCtxAfterEnd).toStrictEqual({
-        spanId: propCtxBeforeEnd?.spanId,
-        traceId: propCtxBeforeEnd?.traceId,
+        spanId: propCtxBeforeEnd.spanId,
+        traceId: propCtxBeforeEnd.traceId,
         sampled: true,
         dsc: {
           environment: 'production',
@@ -710,7 +710,7 @@ describe('browserTracingIntegration', () => {
           sample_rate: '1',
           sampled: 'true',
           transaction: 'mySpan',
-          trace_id: propCtxBeforeEnd?.traceId,
+          trace_id: propCtxBeforeEnd.traceId,
         },
       });
     });
@@ -740,8 +740,8 @@ describe('browserTracingIntegration', () => {
 
       const propCtxAfterEnd = getCurrentScope().getPropagationContext();
       expect(propCtxAfterEnd).toStrictEqual({
-        spanId: propCtxBeforeEnd?.spanId,
-        traceId: propCtxBeforeEnd?.traceId,
+        spanId: propCtxBeforeEnd.spanId,
+        traceId: propCtxBeforeEnd.traceId,
         sampled: false,
         dsc: {
           environment: 'production',
@@ -749,7 +749,7 @@ describe('browserTracingIntegration', () => {
           sample_rate: '0',
           sampled: 'false',
           transaction: 'mySpan',
-          trace_id: propCtxBeforeEnd?.traceId,
+          trace_id: propCtxBeforeEnd.traceId,
         },
       });
     });
@@ -950,7 +950,7 @@ describe('browserTracingIntegration', () => {
       client.emit('idleSpanEnableAutoFinish', idleSpan!);
 
       const span = startInactiveSpan({ name: 'inner1' });
-      span?.end(); // activities = 0
+      span.end(); // activities = 0
 
       // inner1 is now ended, all good
       expect(spans).toHaveLength(1);
@@ -985,7 +985,7 @@ describe('browserTracingIntegration', () => {
       client.emit('idleSpanEnableAutoFinish', idleSpan!);
 
       const span = startInactiveSpan({ name: 'inner1' });
-      span?.end(); // activities = 0
+      span.end(); // activities = 0
 
       // inner1 is now ended, all good
       expect(spans).toHaveLength(1);

--- a/packages/core/test/lib/integrations/functiontostring.test.ts
+++ b/packages/core/test/lib/integrations/functiontostring.test.ts
@@ -29,7 +29,7 @@ describe('FunctionToString', () => {
     expect(foo.bar.toString()).not.toBe(originalFunction);
 
     const fts = functionToStringIntegration();
-    getClient()?.addIntegration?.(fts);
+    getClient()?.addIntegration(fts);
 
     expect(foo.bar.toString()).toBe(originalFunction);
   });

--- a/packages/core/test/lib/tracing/idleSpan.test.ts
+++ b/packages/core/test/lib/tracing/idleSpan.test.ts
@@ -72,13 +72,13 @@ describe('startIdleSpan', () => {
     startSpanManual({ name: 'inner1' }, span => {
       const childSpan = startInactiveSpan({ name: 'inner2' });
 
-      span?.end();
+      span.end();
       jest.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout + 1);
 
       // Idle span is still recording
       expect(idleSpan.isRecording()).toBe(true);
 
-      childSpan?.end();
+      childSpan.end();
       jest.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout + 1);
 
       // Now it is finished!
@@ -348,7 +348,7 @@ describe('startIdleSpan', () => {
     const idleSpan = startIdleSpan({ name: 'idle span' });
     expect(idleSpan).toBeDefined();
 
-    idleSpan?.end();
+    idleSpan.end();
 
     expect(recordDroppedEventSpy).toHaveBeenCalledWith('sample_rate', 'transaction');
   });
@@ -649,13 +649,13 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       const span1 = startInactiveSpan({ name: 'span1', startTime: 1001 });
-      span1?.end(1005);
+      span1.end(1005);
 
       const span2 = startInactiveSpan({ name: 'span2', startTime: 1002 });
-      span2?.end(1100);
+      span2.end(1100);
 
       const span3 = startInactiveSpan({ name: 'span1', startTime: 1050 });
-      span3?.end(1060);
+      span3.end(1060);
 
       expect(getActiveSpan()).toBe(idleSpan);
 
@@ -669,13 +669,13 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       const span1 = startInactiveSpan({ name: 'span1', startTime: 1001 });
-      span1?.end(1005);
+      span1.end(1005);
 
       const span2 = startInactiveSpan({ name: 'span2', startTime: 1002 });
-      span2?.end(1100);
+      span2.end(1100);
 
       const span3 = startInactiveSpan({ name: 'span1', startTime: 1050 });
-      span3?.end(1060);
+      span3.end(1060);
 
       expect(getActiveSpan()).toBe(idleSpan);
 
@@ -689,13 +689,13 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       const span1 = startInactiveSpan({ name: 'span1', startTime: 999_999_999 });
-      span1?.end(1005);
+      span1.end(1005);
 
       const span2 = startInactiveSpan({ name: 'span2', startTime: 1002 });
-      span2?.end(1100);
+      span2.end(1100);
 
       const span3 = startInactiveSpan({ name: 'span1', startTime: 1050 });
-      span3?.end(1060);
+      span3.end(1060);
 
       expect(getActiveSpan()).toBe(idleSpan);
 

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -995,7 +995,7 @@ describe('startInactiveSpan', () => {
     startSpan({ name: 'outer transaction' }, () => {
       startSpan({ name: 'inner span' }, () => {
         const innerTransaction = startInactiveSpan({ name: 'inner transaction', forceTransaction: true });
-        innerTransaction?.end();
+        innerTransaction.end();
       });
     });
 
@@ -1516,10 +1516,10 @@ describe('span hooks', () => {
 
         startSpanManual({ name: 'span5' }, span => {
           startInactiveSpan({ name: 'span4' });
-          span?.end();
+          span.end();
         });
 
-        span?.end();
+        span.end();
       });
     });
 

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -63,7 +63,7 @@ export class TestClient extends BaseClient<TestClientOptions> {
     };
 
     const frames = this._options.stackParser(exception.stack || '', 1);
-    if (frames.length && event?.exception?.values?.[0]) {
+    if (frames.length && event.exception?.values?.[0]) {
       event.exception.values[0] = { ...event.exception.values[0], stacktrace: { frames } };
     }
 

--- a/packages/core/test/mocks/integration.ts
+++ b/packages/core/test/mocks/integration.ts
@@ -9,7 +9,7 @@ export class TestIntegration implements Integration {
 
   public setupOnce(): void {
     const eventProcessor: EventProcessor = (event: Event) => {
-      if (!getClient()?.getIntegrationByName?.('TestIntegration')) {
+      if (!getClient()?.getIntegrationByName('TestIntegration')) {
         return event;
       }
 

--- a/packages/node/test/integration/scope.test.ts
+++ b/packages/node/test/integration/scope.test.ts
@@ -42,7 +42,7 @@ describe('Integration | Scope', () => {
           scope2.setTag('tag3', 'val3');
 
           Sentry.startSpan({ name: 'outer' }, span => {
-            expect(getCapturedScopesOnSpan(span)?.scope).toBe(enableTracing ? scope2 : undefined);
+            expect(getCapturedScopesOnSpan(span).scope).toBe(enableTracing ? scope2 : undefined);
 
             spanId = span.spanContext().spanId;
             traceId = span.spanContext().traceId;

--- a/packages/opentelemetry/test/integration/scope.test.ts
+++ b/packages/opentelemetry/test/integration/scope.test.ts
@@ -49,7 +49,7 @@ describe('Integration | Scope', () => {
           scope2.setTag('tag3', 'val3');
 
           startSpan({ name: 'outer' }, span => {
-            expect(getCapturedScopesOnSpan(span)?.scope).toBe(enableTracing ? scope2 : undefined);
+            expect(getCapturedScopesOnSpan(span).scope).toBe(enableTracing ? scope2 : undefined);
 
             spanId = span.spanContext().spanId;
             traceId = span.spanContext().traceId;

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -566,7 +566,7 @@ describe('trace', () => {
       startSpan({ name: 'outer transaction' }, () => {
         startSpan({ name: 'inner span' }, () => {
           const innerTransaction = startInactiveSpan({ name: 'inner transaction', forceTransaction: true });
-          innerTransaction?.end();
+          innerTransaction.end();
         });
       });
 

--- a/packages/react/test/reactrouterv3.test.tsx
+++ b/packages/react/test/reactrouterv3.test.tsx
@@ -123,7 +123,7 @@ describe('browserTracingReactRouterV3', () => {
     client.init();
     render(<Router history={history}>{routes}</Router>);
 
-    expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/');
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
   });
 
   it('starts a navigation transaction', () => {
@@ -213,13 +213,13 @@ describe('browserTracingReactRouterV3', () => {
     client.init();
     const { container } = render(<Router history={history}>{routes}</Router>);
 
-    expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/');
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
 
     act(() => {
       history.push('/users/123');
     });
     expect(container.innerHTML).toContain('123');
 
-    expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/users/:userid');
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('/users/:userid');
   });
 });

--- a/packages/react/test/reactrouterv4.test.tsx
+++ b/packages/react/test/reactrouterv4.test.tsx
@@ -95,7 +95,7 @@ describe('browserTracingReactRouterV4', () => {
 
     client.init();
 
-    expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/');
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
   });
 
   it('starts a navigation transaction', () => {

--- a/packages/react/test/reactrouterv5.test.tsx
+++ b/packages/react/test/reactrouterv5.test.tsx
@@ -95,7 +95,7 @@ describe('browserTracingReactRouterV5', () => {
 
     client.init();
 
-    expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/');
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
   });
 
   it('starts a navigation transaction', () => {

--- a/packages/react/test/reactrouterv6.4.test.tsx
+++ b/packages/react/test/reactrouterv6.4.test.tsx
@@ -152,7 +152,7 @@ describe('reactRouterV6BrowserTracingIntegration (v6.4)', () => {
       // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
-      expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/');
+      expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
     });
 
     it('starts a navigation transaction', () => {
@@ -658,7 +658,7 @@ describe('reactRouterV6BrowserTracingIntegration (v6.4)', () => {
       // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
-      expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/about');
+      expect(getCurrentScope().getScopeData().transactionName).toEqual('/about');
     });
   });
 });

--- a/packages/react/test/reactrouterv6.test.tsx
+++ b/packages/react/test/reactrouterv6.test.tsx
@@ -137,7 +137,7 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
         </MemoryRouter>,
       );
 
-      expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/');
+      expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
     });
 
     it('skips pageload transaction with `instrumentPageLoad: false`', () => {
@@ -417,7 +417,7 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
         </MemoryRouter>,
       );
 
-      expect(getCurrentScope().getScopeData()?.transactionName).toBe('/about/:page');
+      expect(getCurrentScope().getScopeData().transactionName).toBe('/about/:page');
     });
   });
 
@@ -493,7 +493,7 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
         </MemoryRouter>,
       );
 
-      expect(getCurrentScope().getScopeData()?.transactionName).toEqual('/');
+      expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
     });
 
     it('skips pageload transaction with `instrumentPageLoad: false`', () => {
@@ -997,7 +997,7 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
         </MemoryRouter>,
       );
 
-      expect(getCurrentScope().getScopeData()?.transactionName).toBe('/about');
+      expect(getCurrentScope().getScopeData().transactionName).toBe('/about');
     });
   });
 });

--- a/packages/replay-internal/test/integration/session.test.ts
+++ b/packages/replay-internal/test/integration/session.test.ts
@@ -120,7 +120,7 @@ describe('Integration | session', () => {
     const initialSession = { ...replay.session } as Session;
 
     expect(mockRecord).toHaveBeenCalledTimes(1);
-    expect(initialSession?.id).toBeDefined();
+    expect(initialSession.id).toBeDefined();
     expect(replay.getContext()).toEqual(
       expect.objectContaining({
         initialUrl: 'http://localhost:3000/',
@@ -230,7 +230,7 @@ describe('Integration | session', () => {
   it('pauses and resumes a session if user has been idle for more than SESSION_IDLE_PASUE_DURATION and comes back to click their mouse', async () => {
     const initialSession = { ...replay.session } as Session;
 
-    expect(initialSession?.id).toBeDefined();
+    expect(initialSession.id).toBeDefined();
     expect(replay.getContext()).toEqual(
       expect.objectContaining({
         initialUrl: 'http://localhost:3000/',
@@ -327,7 +327,7 @@ describe('Integration | session', () => {
 
     const initialSession = { ...replay.session } as Session;
 
-    expect(initialSession?.id).toBeDefined();
+    expect(initialSession.id).toBeDefined();
     expect(replay.getContext()).toMatchObject({
       initialUrl: 'http://localhost:3000/',
       initialTimestamp: BASE_TIMESTAMP,

--- a/packages/replay-internal/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
@@ -37,10 +37,10 @@ function getMockResponse(contentLength?: string, body?: string, headers?: Record
   const response = {
     headers: {
       has: (prop: string) => {
-        return !!internalHeaders[prop?.toLowerCase() ?? ''];
+        return !!internalHeaders[prop.toLowerCase() ?? ''];
       },
       get: (prop: string) => {
-        return internalHeaders[prop?.toLowerCase() ?? ''];
+        return internalHeaders[prop.toLowerCase() ?? ''];
       },
     },
     clone: () => response,

--- a/packages/utils/test/aggregate-errors.test.ts
+++ b/packages/utils/test/aggregate-errors.test.ts
@@ -132,7 +132,7 @@ describe('applyAggregateErrorsToEvent()', () => {
     expect(event.exception?.values).toHaveLength(5 + 1);
 
     // Last exception in list should be the root exception
-    expect(event.exception?.values?.[event.exception?.values.length - 1]).toStrictEqual({
+    expect(event.exception?.values?.[event.exception.values.length - 1]).toStrictEqual({
       type: 'Error',
       value: 'Root Error',
       mechanism: {


### PR DESCRIPTION
This updates some tests to avoid unnecessary conditions.

Extracted this out while looking at enabling eslint no-uncessary-condition, as this can be done without much reviewing.