### PR TITLE
fix(remix): Export no-op as `captureRemixServerException` from client SDK

### DIFF
--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -1,10 +1,30 @@
 import { applySdkMetadata, setTag } from '@sentry/core';
 import { init as reactInit } from '@sentry/react';
+import { logger } from '@sentry/utils';
+import { DEBUG_BUILD } from './utils/debug-build';
 import type { RemixOptions } from './utils/remixOptions';
 export { captureRemixErrorBoundaryError } from './client/errors';
 export { withSentry } from './client/performance';
 
 export { browserTracingIntegration } from './client/browserTracingIntegration';
+
+// This is a no-op function that does nothing. It's here to make sure that the
+// function signature is the same as in the server SDK.
+// See issue: https://github.com/getsentry/sentry-javascript/issues/9594
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export async function captureRemixServerException(
+  err: unknown,
+  name: string,
+  request: Request,
+  isRemixV2: boolean,
+): Promise<void> {
+  DEBUG_BUILD &&
+    logger.warn(
+      '`captureRemixServerException` is a server-only function and should not be called in the browser. ' +
+        'This function is a no-op in the browser environment.',
+    );
+}
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
 export * from '@sentry/react';
 

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -18,6 +18,13 @@ export declare const contextLinesIntegration: typeof clientSdk.contextLinesInteg
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
+export declare function captureRemixServerException(
+  err: unknown,
+  name: string,
+  request: Request,
+  isRemixV2: boolean,
+): Promise<void>;
+
 // This variable is not a runtime variable but just a type to tell typescript that the methods below can either come
 // from the client SDK or from the server SDK. TypeScript is smart enough to understand that these resolve to the same
 // methods from `@sentry/core`.


### PR DESCRIPTION
Resolves #9594 