### PR TITLE
feat(browser): Export `thirdPartyErrorFilterIntegration` from `@sentry/browser`

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -69,6 +69,7 @@ export {
   makeMultiplexedTransport,
   moduleMetadataIntegration,
   zodErrorsIntegration,
+  thirdPartyErrorFilterIntegration,
 } from '@sentry/core';
 export type { Span } from '@sentry/types';
 export { makeBrowserOfflineTransport } from './transports/offline';


### PR DESCRIPTION
We may or may not have forgotten to export this from the browser SDK.