### PR TITLE
feat(node) add max lineno and colno limits

### DIFF
--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -224,7 +224,7 @@ async function addSourceContext(event: Event, contextLines: number): Promise<Eve
         const filesToLinesOutput = filesToLines[filename];
         if (!filesToLinesOutput) filesToLines[filename] = [];
         // @ts-expect-error this is defined above
-        filesToLinesOutput.push(frame.lineno);
+        filesToLines[filename].push(frame.lineno);
       }
     }
   }

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -45,7 +45,7 @@ function rangeExistsInContentCache(file: string, range: ReadlineRange): boolean 
   if (!contents) return false;
 
   for (let i = range[0]; i <= range[1]; i++) {
-    if (!contents[i]) {
+    if (contents[i] === undefined) {
       return false;
     }
   }

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -2,7 +2,7 @@ import { createReadStream } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { defineIntegration } from '@sentry/core';
 import type { Event, IntegrationFn, StackFrame } from '@sentry/types';
-import { logger, LRUMap, snipLine } from '@sentry/utils';
+import { LRUMap, logger, snipLine } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -95,7 +95,7 @@ function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: 
     // It is important *not* to have any async code between createInterface and the 'line' event listener
     // as it will cause the 'line' event to
     // be emitted before the listener is attached.
-    const stream = createReadStream(path)
+    const stream = createReadStream(path);
     const lineReaded = createInterface({
       input: stream,
     });
@@ -225,9 +225,11 @@ function addSourceContextToFrames(
     // Only add context if we have a filename and it hasn't already been added
     if (frame.filename && frame.context_line === undefined && typeof frame.lineno === 'number') {
       const contents = cache.get(frame.filename);
-      if (contents) {
-        addContextToFrame(frame.lineno, frame, contextLines, contents);
+      if (contents === undefined) {
+        continue;
       }
+
+      addContextToFrame(frame.lineno, frame, contextLines, contents);
     }
   }
 }

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -6,6 +6,7 @@ import { LRUMap, logger, snipLine } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 
+const FILE_CONTENTS_FS_READ_FAILED = new LRUMap<string, 1>(20);
 const LRU_FILE_CONTENTS_CACHE = new LRUMap<string, Record<number, string>>(10);
 const DEFAULT_LINES_OF_CONTEXT = 7;
 const INTEGRATION_NAME = 'ContextLines';
@@ -109,6 +110,8 @@ function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: 
     // We use this inside Promise.all, so we need to resolve the promise even if there is an error
     // to prevent Promise.all from short circuiting the rest.
     function onStreamError(e: Error): void {
+      // Mark file path as failed to read and prevent multiple read attempts.
+      FILE_CONTENTS_FS_READ_FAILED.set(path, 1);
       DEBUG_BUILD && logger.error(`Failed to read file: ${path}. Error: ${e}`);
       lineReaded.close();
       lineReaded.removeAllListeners();
@@ -180,11 +183,15 @@ async function addSourceContext(event: Event, contextLines: number): Promise<Eve
 
   const readlinePromises: Promise<void>[] = [];
   for (const file of files) {
+    // If we failed to read this before, dont try again.
+    if (FILE_CONTENTS_FS_READ_FAILED.get(file)) {
+      continue;
+    }
+
+    // Check if the contents are already in the cache and if we can avoid reading the file again.
     // Sort ranges so that they are sorted by line increasing order and match how the file is read.
     filesToLines[file].sort((a, b) => a - b);
     const ranges = makeLineReaderRanges(filesToLines[file], contextLines);
-
-    // If the contents are already in the cache, then we dont need to read the file.
     if (ranges.every(r => rangeExistsInContentCache(file, r))) {
       continue;
     }

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -303,7 +303,8 @@ export function addContextToFrame(
     DEBUG_BUILD && logger.error(`Could not find line ${lineno} in file ${frame.filename}`);
     return;
   }
-  frame.context_line = snipLine(contents[lineno], frame.colno || 0);
+
+  frame.context_line = contents[lineno];
 
   const end = makeRangeEnd(lineno, contextLines);
   frame.post_context = [];
@@ -313,7 +314,7 @@ export function addContextToFrame(
     if (contents[i] === undefined) {
       break;
     }
-    frame.post_context.push(snipLine(contents[i], 0));
+    frame.post_context.push(contents[i]);
   }
 }
 

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -42,7 +42,7 @@ function shouldSkipContextLinesForFile(path: string): boolean {
  */
 function rangeExistsInContentCache(file: string, range: ReadlineRange): boolean {
   const contents = LRU_FILE_CONTENTS_CACHE.get(file);
-  if (!contents) return false;
+  if (contents === undefined) return false;
 
   for (let i = range[0]; i <= range[1]; i++) {
     if (contents[i] === undefined) {
@@ -182,7 +182,7 @@ async function addSourceContext(event: Event, contextLines: number): Promise<Eve
     }
 
     let cache = LRU_FILE_CONTENTS_CACHE.get(file);
-    if (!cache) {
+    if (cache === undefined) {
       cache = {};
       LRU_FILE_CONTENTS_CACHE.set(file, cache);
     }

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -33,7 +33,7 @@ export function resetFileContentCache(): void {
  * - node: prefixed modules are part of the runtime and cannot be resolved to a file
  * - data: skip json, wasm and inline js https://nodejs.org/api/esm.html#data-imports
  */
-const SKIP_CONTEXTLINES_REGEXP = /^(node|data):|\.min\.(mjs|cjs|js$)/;
+const SKIP_CONTEXTLINES_REGEXP = /(^(node|data):)|(\.min\.(mjs|cjs|js$))/;
 function shouldSkipContextLinesForFile(path: string): boolean {
   return SKIP_CONTEXTLINES_REGEXP.test(path);
 }

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -134,7 +134,7 @@ function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: 
     let lineNumber = 0;
     let currentRangeIndex = 0;
     const range = ranges[currentRangeIndex];
-    if (typeof range !== 'number') {
+    if (range === undefined) {
       // We should never reach this point, but if we do, we should resolve the promise to prevent it from hanging.
       resolve();
       return;
@@ -175,7 +175,7 @@ function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: 
         }
         currentRangeIndex++;
         const range = ranges[currentRangeIndex];
-        if (typeof range !== 'number') {
+        if (range === undefined) {
           // This should never happen as it means we have a bug in the context.
           lineReaded.close();
           lineReaded.removeAllListeners();

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -146,6 +146,7 @@ function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: 
   });
 }
 
+// eslint-disable-next-line complexity
 async function addSourceContext(event: Event, contextLines: number): Promise<Event> {
   // keep a lookup map of which files we've already enqueued to read,
   // so we don't enqueue the same file multiple times which would cause multiple i/o reads
@@ -188,9 +189,9 @@ async function addSourceContext(event: Event, contextLines: number): Promise<Eve
       continue;
     }
 
-    // Check if the contents are already in the cache and if we can avoid reading the file again.
     // Sort ranges so that they are sorted by line increasing order and match how the file is read.
     filesToLines[file].sort((a, b) => a - b);
+    // Check if the contents are already in the cache and if we can avoid reading the file again.
     const ranges = makeLineReaderRanges(filesToLines[file], contextLines);
     if (ranges.every(r => rangeExistsInContentCache(file, r))) {
       continue;

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -11,7 +11,7 @@ const LRU_FILE_CONTENTS_FS_READ_FAILED = new LRUMap<string, 1>(20);
 const DEFAULT_LINES_OF_CONTEXT = 7;
 const INTEGRATION_NAME = 'ContextLines';
 // Determines the upper bound of lineno/colno that we will attempt to read. Large colno values are likely to be
-// minified code while large colno values are likely to be bundled code.
+// minified code while large lineno values are likely to be bundled code.
 // Exported for testing purposes.
 export const MAX_CONTEXTLINES_COLNO: number = 1000;
 export const MAX_CONTEXTLINES_LINENO: number = 10000;

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -1,97 +1,31 @@
 import { createReadStream } from 'node:fs';
-import { createInterface } from 'node:readline';
+import * as readline from 'node:readline';
 import { defineIntegration } from '@sentry/core';
 import type { Event, IntegrationFn, StackFrame } from '@sentry/types';
-import { LRUMap, logger, snipLine } from '@sentry/utils';
+import { logger, LRUMap, snipLine } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 
-const LRU_FILE_CONTENTS_CACHE = new LRUMap<string, Record<number, string>>(10);
-const LRU_FILE_CONTENTS_FS_READ_FAILED = new LRUMap<string, 1>(20);
 const DEFAULT_LINES_OF_CONTEXT = 7;
 const INTEGRATION_NAME = 'ContextLines';
-
-interface ContextLinesOptions {
-  /**
-   * Sets the number of context lines for each frame when loading a file.
-   * Defaults to 7.
-   *
-   * Set to 0 to disable loading and inclusion of source files.
-   **/
-  frameContextLines?: number;
-}
+const LRUFileContentCache = new LRUMap<string, Record<number, string>>(10);
 
 /**
- * Exported for testing purposes.
+ * Exists for testing purposes.
  */
 export function resetFileContentCache(): void {
-  LRU_FILE_CONTENTS_CACHE.clear();
+  LRUFileContentCache.clear();
 }
 
-/**
- * Get or init map value
- */
-function emplace<T extends LRUMap<K, V>, K extends string, V>(map: T, key: K, contents: V): V {
-  const value = map.get(key);
-
-  if (value === undefined) {
-    map.set(key, contents);
-    return contents;
-  }
-
-  return value;
-}
-
-/**
- * Determines if context lines should be skipped for a file.
- * - .min.(mjs|cjs|js) files are and not useful since they dont point to the original source
- * - node: prefixed modules are part of the runtime and cannot be resolved to a file
- * - data: skip json, wasm and inline js https://nodejs.org/api/esm.html#data-imports
- */
-function shouldSkipContextLinesForFile(path: string): boolean {
-  // Test the most common prefix and extension first. These are the ones we
-  // are most likely to see in user applications and are the ones we can break out of first.
-  if (path.startsWith('node:')) return true;
-  if (path.endsWith('.min.js')) return true;
-  if (path.endsWith('.min.cjs')) return true;
-  if (path.endsWith('.min.mjs')) return true;
-  if (path.startsWith('data:')) return true;
-  return false;
-}
-/**
- * Checks if we have all the contents that we need in the cache.
- */
-function rangeExistsInContentCache(file: string, range: ReadlineRange): boolean {
-  const contents = LRU_FILE_CONTENTS_CACHE.get(file);
-  if (contents === undefined) return false;
-
-  for (let i = range[0]; i <= range[1]; i++) {
-    if (contents[i] === undefined) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/**
- * Creates contiguous ranges of lines to read from a file. In the case where context lines overlap,
- * the ranges are merged to create a single range.
- */
 function makeLineReaderRanges(lines: number[], linecontext: number): ReadlineRange[] {
   if (!lines.length) {
     return [];
   }
 
-  let i = 0;
-  const line = lines[0];
-
-  if (typeof line !== 'number') {
-    return [];
-  }
-
-  let current = makeContextRange(line, linecontext);
   const out: ReadlineRange[] = [];
+  let i = 0;
+  let current = makeContextRange(lines[i], linecontext);
+
   // eslint-disable-next-line no-constant-condition
   while (true) {
     if (i === lines.length - 1) {
@@ -99,13 +33,11 @@ function makeLineReaderRanges(lines: number[], linecontext: number): ReadlineRan
       break;
     }
 
-    // If the next line falls into the current range, extend the current range to lineno + linecontext.
+    // We need to create contiguous ranges in cases where context lines overlap so that
+    // the final set of ranges is an increasing sequence of lines without overlaps.
     const next = lines[i + 1];
-    if (typeof next !== 'number') {
-      break;
-    }
     if (next <= current[1]) {
-      current[1] = next + linecontext;
+      current[1] = next + linecontext + 1;
     } else {
       out.push(current);
       current = makeContextRange(next, linecontext);
@@ -117,265 +49,57 @@ function makeLineReaderRanges(lines: number[], linecontext: number): ReadlineRan
   return out;
 }
 
-/**
- * Extracts lines from a file and stores them in a cache.
- */
-function getContextLinesFromFile(path: string, ranges: ReadlineRange[], output: Record<number, string>): Promise<void> {
-  return new Promise((resolve, _reject) => {
-    // It is important *not* to have any async code between createInterface and the 'line' event listener
-    // as it will cause the 'line' event to
-    // be emitted before the listener is attached.
-    const stream = createReadStream(path);
-    const lineReaded = createInterface({
-      input: stream,
-    });
-
-    // Init at zero and increment at the start of the loop because lines are 1 indexed.
-    let lineNumber = 0;
-    let currentRangeIndex = 0;
-    const range = ranges[currentRangeIndex];
-    if (range === undefined) {
-      // We should never reach this point, but if we do, we should resolve the promise to prevent it from hanging.
-      resolve();
-      return;
-    }
-    let rangeStart = range[0];
-    let rangeEnd = range[1];
-
-    // We use this inside Promise.all, so we need to resolve the promise even if there is an error
-    // to prevent Promise.all from short circuiting the rest.
-    function onStreamError(e: Error): void {
-      // Mark file path as failed to read and prevent multiple read attempts.
-      LRU_FILE_CONTENTS_FS_READ_FAILED.set(path, 1);
-      DEBUG_BUILD && logger.error(`Failed to read file: ${path}. Error: ${e}`);
-      lineReaded.close();
-      lineReaded.removeAllListeners();
-      resolve();
-    }
-
-    // We need to handle the error event to prevent the process from crashing in < Node 16
-    // https://github.com/nodejs/node/pull/31603
-    stream.on('error', onStreamError);
-    lineReaded.on('error', onStreamError);
-    lineReaded.on('close', resolve);
-
-    lineReaded.on('line', line => {
-      lineNumber++;
-      if (lineNumber < rangeStart) return;
-
-      // !Warning: This mutates the cache by storing the snipped line into the cache.
-      output[lineNumber] = snipLine(line, 0);
-
-      if (lineNumber >= rangeEnd) {
-        if (currentRangeIndex === ranges.length - 1) {
-          // We need to close the file stream and remove listeners, else the reader will continue to run our listener;
-          lineReaded.close();
-          lineReaded.removeAllListeners();
-          return;
-        }
-        currentRangeIndex++;
-        const range = ranges[currentRangeIndex];
-        if (range === undefined) {
-          // This should never happen as it means we have a bug in the context.
-          lineReaded.close();
-          lineReaded.removeAllListeners();
-          return;
-        }
-        rangeStart = range[0];
-        rangeEnd = range[1];
-      }
-    });
-  });
-}
-
-/**
- * Adds surrounding (context) lines of the line that an exception occurred on to the event.
- * This is done by reading the file line by line and extracting the lines. The extracted lines are stored in
- * a cache to prevent multiple reads of the same file. Failures to read a file are similarly cached to prevent multiple
- * failing reads from happening.
- */
-/* eslint-disable complexity */
-async function addSourceContext(event: Event, contextLines: number): Promise<Event> {
-  // keep a lookup map of which files we've already enqueued to read,
-  // so we don't enqueue the same file multiple times which would cause multiple i/o reads
-  const filesToLines: Record<string, number[]> = {};
-
-  if (contextLines > 0 && event.exception?.values) {
-    for (const exception of event.exception.values) {
-      if (!exception.stacktrace?.frames?.length) {
-        continue;
-      }
-
-      // Maps preserve insertion order, so we iterate in reverse, starting at the
-      // outermost frame and closer to where the exception has occurred (poor mans priority)
-      for (let i = exception.stacktrace.frames.length - 1; i >= 0; i--) {
-        const frame: StackFrame | undefined = exception.stacktrace.frames[i];
-        const filename = frame?.filename;
-
-        if (
-          !frame ||
-          typeof filename !== 'string' ||
-          typeof frame.lineno !== 'number' ||
-          shouldSkipContextLinesForFile(filename)
-        ) {
-          continue;
-        }
-
-        const filesToLinesOutput = filesToLines[filename];
-        if (!filesToLinesOutput) filesToLines[filename] = [];
-        // @ts-expect-error this is defined above
-        filesToLines[filename].push(frame.lineno);
-      }
-    }
-  }
-
-  const files = Object.keys(filesToLines);
-  if (files.length == 0) {
-    return event;
-  }
-
-  const readlinePromises: Promise<void>[] = [];
-  for (const file of files) {
-    // If we failed to read this before, dont try reading it again.
-    if (LRU_FILE_CONTENTS_FS_READ_FAILED.get(file)) {
-      continue;
-    }
-
-    const filesToLineRanges = filesToLines[file];
-    if (!filesToLineRanges) {
-      continue;
-    }
-
-    // Sort ranges so that they are sorted by line increasing order and match how the file is read.
-    filesToLineRanges.sort((a, b) => a - b);
-    // Check if the contents are already in the cache and if we can avoid reading the file again.
-    const ranges = makeLineReaderRanges(filesToLineRanges, contextLines);
-    if (ranges.every(r => rangeExistsInContentCache(file, r))) {
-      continue;
-    }
-
-    const cache = emplace(LRU_FILE_CONTENTS_CACHE, file, {});
-    readlinePromises.push(getContextLinesFromFile(file, ranges, cache));
-  }
-
-  // The promise rejections are caught in order to prevent them from short circuiting Promise.all
-  await Promise.all(readlinePromises).catch(() => {
-    DEBUG_BUILD && logger.log('Failed to read one or more source files and resolve context lines');
+// Stack trace comes in, parse it and extract stack filename + lines
+// in case we receive lines from multiple files, the final output
+// should contain files sorted by stack order importance - top first
+// and should contain.
+async function getContextLinesFromFile(
+  path: string,
+  ranges: ReadlineRange[],
+  output: Record<number, string>,
+): Promise<void> {
+  const fileStream = readline.createInterface({
+    input: createReadStream(path),
   });
 
-  // Perform the same loop as above, but this time we can assume all files are in the cache
-  // and attempt to add source context to frames.
-  if (contextLines > 0 && event.exception?.values) {
-    for (const exception of event.exception.values) {
-      if (exception.stacktrace && exception.stacktrace.frames && exception.stacktrace.frames.length > 0) {
-        addSourceContextToFrames(exception.stacktrace.frames, contextLines, LRU_FILE_CONTENTS_CACHE);
+  // Line numbers are 1 indexed
+  let lineNumber = 1;
+  let currentRangeIndex = 0;
+  let rangeStart = ranges[currentRangeIndex][0];
+  let rangeEnd = ranges[currentRangeIndex][1];
+
+  for await (const line of fileStream) {
+    lineNumber++;
+    if (lineNumber < rangeStart) {
+      continue;
+    }
+
+    output[lineNumber] = line;
+    // or if there are other ranges to process. If so, update the range
+    // and continue processing the file, else break from the loop.
+    if (lineNumber >= rangeEnd) {
+      if (currentRangeIndex === ranges.length - 1) {
+        break;
       }
-    }
-  }
-
-  return event;
-}
-/* eslint-enable complexity */
-
-/** Adds context lines to frames */
-function addSourceContextToFrames(
-  frames: StackFrame[],
-  contextLines: number,
-  cache: LRUMap<string, Record<number, string>>,
-): void {
-  for (const frame of frames) {
-    // Only add context if we have a filename and it hasn't already been added
-    if (frame.filename && frame.context_line === undefined && typeof frame.lineno === 'number') {
-      const contents = cache.get(frame.filename);
-      if (contents === undefined) {
-        continue;
-      }
-
-      addContextToFrame(frame.lineno, frame, contextLines, contents);
+      currentRangeIndex++;
+      rangeStart = ranges[currentRangeIndex][0];
+      rangeEnd = ranges[currentRangeIndex][1];
     }
   }
 }
 
-/**
- * Clears the context lines from a frame, used to reset a frame to its original state
- * if we fail to resolve all context lines for it.
- */
-function clearLineContext(frame: StackFrame): void {
-  delete frame.pre_context;
-  delete frame.context_line;
-  delete frame.post_context;
+interface ContextLinesOptions {
+  /**
+   * Sets the number of context lines for each frame when loading a file.
+   * Defaults to 7.
+   *
+   * Set to 0 to disable loading and inclusion of source files.
+   **/
+  frameContextLines?: number;
 }
 
-/**
- * Resolves context lines before and after the given line number and appends them to the frame;
- */
-export function addContextToFrame(
-  lineno: number,
-  frame: StackFrame,
-  contextLines: number,
-  contents: Record<number, string> | undefined,
-): void {
-  // When there is no line number in the frame, attaching context is nonsensical and will even break grouping.
-  // We already check for lineno before calling this, but since StackFrame lineno ism optional, we check it again.
-  if (frame.lineno === undefined || contents === undefined) {
-    DEBUG_BUILD && logger.error('Cannot resolve context for frame with no lineno or file contents');
-    return;
-  }
-
-  frame.pre_context = [];
-  for (let i = makeRangeStart(lineno, contextLines); i < lineno; i++) {
-    // We always expect the start context as line numbers cannot be negative. If we dont find a line, then
-    // something went wrong somewhere. Clear the context and return without adding any linecontext.
-    const line = contents[i];
-    if (line === undefined) {
-      clearLineContext(frame);
-      DEBUG_BUILD && logger.error(`Could not find line ${i} in file ${frame.filename}`);
-      return;
-    }
-
-    frame.pre_context.push(line);
-  }
-
-  // We should always have the context line. If we dont, something went wrong, so we clear the context and return
-  // without adding any linecontext.
-  if (contents[lineno] === undefined) {
-    clearLineContext(frame);
-    DEBUG_BUILD && logger.error(`Could not find line ${lineno} in file ${frame.filename}`);
-    return;
-  }
-
-  frame.context_line = contents[lineno];
-
-  const end = makeRangeEnd(lineno, contextLines);
-  frame.post_context = [];
-  for (let i = lineno + 1; i <= end; i++) {
-    // Since we dont track when the file ends, we cant clear the context if we dont find a line as it could
-    // just be that we reached the end of the file.
-    const line = contents[i];
-    if (line === undefined) {
-      break;
-    }
-    frame.post_context.push(line);
-  }
-}
-
-// Helper functions for generating line context ranges. They take a line number and the number of lines of context to
-// include before and after the line and generate an inclusive range of indices.
-type ReadlineRange = [start: number, end: number];
-// Compute inclusive end context range
-function makeRangeStart(line: number, linecontext: number): number {
-  return Math.max(1, line - linecontext);
-}
-// Compute inclusive start context range
-function makeRangeEnd(line: number, linecontext: number): number {
-  return line + linecontext;
-}
-// Determine start and end indices for context range (inclusive);
-function makeContextRange(line: number, linecontext: number): [start: number, end: number] {
-  return [makeRangeStart(line, linecontext), makeRangeEnd(line, linecontext)];
-}
-
-/** Exported only for tests, as a type-safe variant. */
+/** Exported on
+ * ly for tests, as a type-safe variant. */
 export const _contextLinesIntegration = ((options: ContextLinesOptions = {}) => {
   const contextLines = options.frameContextLines !== undefined ? options.frameContextLines : DEFAULT_LINES_OF_CONTEXT;
 
@@ -391,3 +115,126 @@ export const _contextLinesIntegration = ((options: ContextLinesOptions = {}) => 
  * Capture the lines before and after the frame's context.
  */
 export const contextLinesIntegration = defineIntegration(_contextLinesIntegration);
+
+async function addSourceContext(event: Event, contextLines: number): Promise<Event> {
+  // keep a lookup map of which files we've already enqueued to read,
+  // so we don't enqueue the same file multiple times which would cause multiple i/o reads
+  const filesToLines: Record<string, number[]> = {};
+
+  if (contextLines > 0 && event.exception?.values) {
+    for (const exception of event.exception.values) {
+      if (!exception.stacktrace?.frames) {
+        continue;
+      }
+
+      // Maps preserve insertion order, so we iterate in reverse, starting at the
+      // outermost frame and closer to where the exception has occurred (poor mans priority)
+      for (let i = exception.stacktrace.frames.length - 1; i >= 0; i--) {
+        const frame = exception.stacktrace.frames[i];
+
+        // Collecting context lines for minified code is useless.
+        if (frame.filename?.endsWith('.min.js')) {
+          continue;
+        }
+
+        if (frame.filename && typeof frame.lineno === 'number') {
+          if (!filesToLines[frame.filename]) filesToLines[frame.filename] = [];
+          filesToLines[frame.filename].push(frame.lineno);
+        }
+      }
+    }
+  }
+
+  const files = Object.keys(filesToLines);
+  if (files.length == 0) {
+    return event;
+  }
+
+  const readlinePromises: Promise<void>[] = [];
+  for (const file of files) {
+    // Sort ranges so that they are sorted by line increasing order and match how the file is read.
+    filesToLines[file].sort((a, b) => a - b);
+    const ranges = makeLineReaderRanges(filesToLines[file], contextLines);
+
+    let cache = LRUFileContentCache.get(file);
+    if (!cache) {
+      cache = {};
+      LRUFileContentCache.set(file, cache);
+    }
+    readlinePromises.push(getContextLinesFromFile(file, ranges, cache));
+  }
+
+  await Promise.all(readlinePromises).catch(() => {
+    // We don't want to error if we can't read the file.
+    DEBUG_BUILD && logger.log('Failed to read one or more source files and resolve context lines');
+  });
+
+  // Perform the same loop as above, but this time we can assume all files are in the cache
+  // and attempt to add source context to frames.
+  if (contextLines > 0 && event.exception?.values) {
+    for (const exception of event.exception.values) {
+      if (exception.stacktrace && exception.stacktrace.frames && exception.stacktrace.frames.length > 0) {
+        addSourceContextToFrames(exception.stacktrace.frames, LRUFileContentCache);
+      }
+    }
+  }
+
+  return event;
+}
+
+/** Adds context lines to frames */
+function addSourceContextToFrames(frames: StackFrame[], cache: LRUMap<string, Record<number, string>>): void {
+  for (const frame of frames) {
+    // Only add context if we have a filename and it hasn't already been added
+    if (frame.filename && frame.context_line === undefined && typeof frame.lineno === 'number') {
+      const contents = cache.get(frame.filename);
+      if (contents) {
+        addContextToFrame(frame.lineno, frame, contents);
+      }
+    }
+  }
+}
+
+/**
+ * Resolves context lines before and after the given line number and appends them to the frame;
+ */
+export function addContextToFrame(
+  lineno: number,
+  frame: StackFrame,
+  contents: Record<number, string> | undefined,
+): void {
+  // When there is no line number in the frame, attaching context is nonsensical and will even break grouping.
+  // We already check for lineno before calling this, but since StackFrame lineno ism optional, we check it again.
+  if (frame.lineno === undefined || contents === undefined) {
+    return;
+  }
+
+  frame.pre_context = [];
+  for (let i = makeRangeStart(lineno, DEFAULT_LINES_OF_CONTEXT); i < lineno; i++) {
+    if (contents[i]) {
+      frame.pre_context.push(snipLine(contents[i], 0));
+    }
+  }
+
+  frame.context_line = snipLine(contents[lineno] || '', frame.colno || 0);
+
+  frame.post_context = [];
+  for (let i = lineno + 1; i < makeRangeEnd(lineno, DEFAULT_LINES_OF_CONTEXT); i++) {
+    if (contents[i]) {
+      frame.post_context.push(snipLine(contents[i], 0));
+    }
+  }
+}
+
+// Helper functions for generating line context ranges. They take a line number and the number of lines of context to
+// include before and after the line and generate an inclusive range of indices.
+type ReadlineRange = [start: number, end: number];
+function makeRangeStart(line: number, linecontext: number): number {
+  return Math.max(1, line - linecontext);
+}
+function makeRangeEnd(line: number, linecontext: number): number {
+  return line + linecontext + 1;
+}
+function makeContextRange(line: number, linecontext: number): [start: number, end: number] {
+  return [makeRangeStart(line, linecontext), makeRangeEnd(line, linecontext)];
+}

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -29,21 +29,20 @@ export function resetFileContentCache(): void {
 
 /**
  * Determines if context lines should be skipped for a file.
- * - .min.js files are and not useful since they dont point to the original source
+ * - .min.(mjs|cjs|js) files are and not useful since they dont point to the original source
  * - node: prefixed modules are part of the runtime and cannot be resolved to a file
+ * - data: skip json, wasm and inline js https://nodejs.org/api/esm.html#data-imports
  */
+const SKIP_CONTEXTLINES_REGEXP = /^(node|data):|\.min\.(mjs|cjs|js$)/;
 function shouldSkipContextLinesForFile(path: string): boolean {
-  return path.endsWith('.min.js') || path.startsWith('node:');
+  return SKIP_CONTEXTLINES_REGEXP.test(path);
 }
 /**
  * Checks if we have all the contents that we need in the cache.
  */
 function rangeExistsInContentCache(file: string, range: ReadlineRange): boolean {
   const contents = LRU_FILE_CONTENTS_CACHE.get(file);
-
-  if (!contents) {
-    return false;
-  }
+  if (!contents) return false;
 
   for (let i = range[0]; i <= range[1]; i++) {
     if (!contents[i]) {

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -2,7 +2,10 @@ import * as fs from 'node:fs';
 import type { StackFrame } from '@sentry/types';
 import { parseStackFrames } from '@sentry/utils';
 
-import { _contextLinesIntegration, resetFileContentCache } from '../../src/integrations/contextlines';
+import {
+  _contextLinesIntegration,
+  resetFileContentCache,
+} from '../../src/integrations/contextlines';
 import { defaultStackParser } from '../../src/sdk/api';
 import { getError } from '../helpers/error';
 
@@ -49,12 +52,13 @@ describe('ContextLines', () => {
       const readStreamSpy = jest.spyOn(fs, 'createReadStream');
 
       await addContext(frames);
+
       const numCalls = readStreamSpy.mock.calls.length;
       await addContext(frames);
 
       // Calls to `readFile` shouldn't increase if there isn't a new error to
       // parse whose stacktrace contains a file we haven't yet seen
-      expect(readStreamSpy).toHaveBeenCalledTimes(numCalls);
+      expect(readStreamSpy).toHaveBeenCalledTimes(numCalls * 2);
     });
 
     test('parseStack with ESM module names', async () => {
@@ -101,16 +105,16 @@ describe('ContextLines', () => {
 
       await addContext(overlappingContextWithFirstError);
 
-      const innerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 1]!;
-      const outerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 2]!;
+      const innerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 1];
+      const outerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 2];
 
       expect(innerFrame.context_line).toBe("        return new Error('inner');");
-      expect(innerFrame.pre_context).toHaveLength(7);
-      expect(innerFrame.post_context).toHaveLength(7);
+      expect(innerFrame.pre_context).toHaveLength(7)
+      expect(innerFrame.post_context).toHaveLength(7)
 
       expect(outerFrame.context_line).toBe('        return inner();');
-      expect(outerFrame.pre_context).toHaveLength(7);
-      expect(outerFrame.post_context).toHaveLength(7);
+      expect(outerFrame.pre_context).toHaveLength(7)
+      expect(outerFrame.post_context).toHaveLength(7)
     });
 
     test('parseStack with error on first line errors', async () => {
@@ -118,15 +122,12 @@ describe('ContextLines', () => {
 
       await addContext(overlappingContextWithFirstError);
 
-      const errorFrame = overlappingContextWithFirstError.find(f => f.filename?.endsWith('error.ts'));
-
-      if (!errorFrame) {
-        throw new Error('Could not find error frame');
-      }
+      const errorFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 1];
+      console.log(errorFrame)
 
       expect(errorFrame.context_line).toBe("  return new Error('mock error');");
-      expect(errorFrame.pre_context).toHaveLength(2);
-      expect(errorFrame.post_context).toHaveLength(1);
+      expect(errorFrame.pre_context).toHaveLength(7)
+      expect(errorFrame.post_context).toHaveLength(7)
     });
 
     test('parseStack with duplicate files', async () => {
@@ -181,7 +182,7 @@ describe('ContextLines', () => {
       const frames = parseStackFrames(defaultStackParser, new Error('test'));
 
       await addContext(frames);
-      expect(readFileSpy).not.toHaveBeenCalled();
+      expect(readStreamSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -24,7 +24,7 @@ describe('ContextLines', () => {
 
   describe('lru file cache', () => {
     test('parseStack when file does not exist', async () => {
-      expect.assertions(4)
+      expect.assertions(4);
       const frames: StackFrame[] = [
         {
           colno: 1,
@@ -41,7 +41,7 @@ describe('ContextLines', () => {
       expect(frames[0].post_context).toBeUndefined();
       expect(frames[0].context_line).toBeUndefined();
       expect(readStreamSpy).toHaveBeenCalledTimes(1);
-    })
+    });
     test('parseStack with same file', async () => {
       expect.assertions(1);
 

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -26,26 +26,7 @@ describe('ContextLines', () => {
   });
 
   describe('lru file cache', () => {
-    test('parseStack when file does not exist', async () => {
-      expect.assertions(4);
-      const frames: StackFrame[] = [
-        {
-          colno: 1,
-          filename: 'file:///var/task/nonexistent.js',
-          lineno: 1,
-          function: 'fxn1',
-        },
-      ];
-
-      const readStreamSpy = jest.spyOn(fs, 'createReadStream');
-      await addContext(frames);
-
-      expect(frames[0]!.pre_context).toBeUndefined();
-      expect(frames[0]!.post_context).toBeUndefined();
-      expect(frames[0]!.context_line).toBeUndefined();
-      expect(readStreamSpy).toHaveBeenCalledTimes(1);
-    });
-    test('parseStack with same file', async () => {
+    test.only('parseStack with same file', async () => {
       expect.assertions(1);
 
       const frames = parseStackFrames(defaultStackParser, new Error('test'));

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import type { StackFrame } from '@sentry/types';
 import { parseStackFrames } from '@sentry/utils';
 
-import { _contextLinesIntegration, resetFileContentCache, MAX_CONTEXTLINES_COLNO } from '../../src/integrations/contextlines';
+import { _contextLinesIntegration, resetFileContentCache, MAX_CONTEXTLINES_COLNO, MAX_CONTEXTLINES_LINENO } from '../../src/integrations/contextlines';
 import { defaultStackParser } from '../../src/sdk/api';
 import { getError } from '../helpers/error';
 
@@ -23,13 +23,29 @@ describe('ContextLines', () => {
   });
 
   describe('limits', () => {
-    test('colno limit', async () => {
+    test(`colno above ${MAX_CONTEXTLINES_COLNO}`, async () => {
       expect.assertions(1);
       const frames: StackFrame[] = [
         {
           colno: MAX_CONTEXTLINES_COLNO + 1,
           filename: 'file:///var/task/index.js',
           lineno: 1,
+          function: 'fxn1',
+        },
+      ];
+
+      const readStreamSpy = jest.spyOn(fs, 'createReadStream');
+      await addContext(frames);
+      expect(readStreamSpy).not.toHaveBeenCalled();
+    })
+
+    test(`lineno above ${MAX_CONTEXTLINES_LINENO}`, async () => {
+      expect.assertions(1);
+      const frames: StackFrame[] = [
+        {
+          colno: 1,
+          filename: 'file:///var/task/index.js',
+          lineno: MAX_CONTEXTLINES_LINENO + 1,
           function: 'fxn1',
         },
       ];

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -2,10 +2,7 @@ import * as fs from 'node:fs';
 import type { StackFrame } from '@sentry/types';
 import { parseStackFrames } from '@sentry/utils';
 
-import {
-  _contextLinesIntegration,
-  resetFileContentCache,
-} from '../../src/integrations/contextlines';
+import { _contextLinesIntegration, resetFileContentCache } from '../../src/integrations/contextlines';
 import { defaultStackParser } from '../../src/sdk/api';
 import { getError } from '../helpers/error';
 
@@ -26,7 +23,7 @@ describe('ContextLines', () => {
   });
 
   describe('lru file cache', () => {
-    test.only('parseStack with same file', async () => {
+    test('parseStack with same file', async () => {
       expect.assertions(1);
 
       const frames = parseStackFrames(defaultStackParser, new Error('test'));
@@ -89,12 +86,12 @@ describe('ContextLines', () => {
       const outerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 2];
 
       expect(innerFrame.context_line).toBe("        return new Error('inner');");
-      expect(innerFrame.pre_context).toHaveLength(7)
-      expect(innerFrame.post_context).toHaveLength(7)
+      expect(innerFrame.pre_context).toHaveLength(7);
+      expect(innerFrame.post_context).toHaveLength(7);
 
       expect(outerFrame.context_line).toBe('        return inner();');
-      expect(outerFrame.pre_context).toHaveLength(7)
-      expect(outerFrame.post_context).toHaveLength(7)
+      expect(outerFrame.pre_context).toHaveLength(7);
+      expect(outerFrame.post_context).toHaveLength(7);
     });
 
     test('parseStack with error on first line errors', async () => {
@@ -102,15 +99,15 @@ describe('ContextLines', () => {
 
       await addContext(overlappingContextWithFirstError);
 
-      const errorFrame = overlappingContextWithFirstError.find(f => f.filename?.endsWith('error.ts'))
+      const errorFrame = overlappingContextWithFirstError.find(f => f.filename?.endsWith('error.ts'));
 
       if (!errorFrame) {
         throw new Error('Could not find error frame');
       }
 
       expect(errorFrame.context_line).toBe("  return new Error('mock error');");
-      expect(errorFrame.pre_context).toHaveLength(2)
-      expect(errorFrame.post_context).toHaveLength(1)
+      expect(errorFrame.pre_context).toHaveLength(2);
+      expect(errorFrame.post_context).toHaveLength(1);
     });
 
     test('parseStack with duplicate files', async () => {

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -2,7 +2,12 @@ import * as fs from 'node:fs';
 import type { StackFrame } from '@sentry/types';
 import { parseStackFrames } from '@sentry/utils';
 
-import { _contextLinesIntegration, resetFileContentCache, MAX_CONTEXTLINES_COLNO, MAX_CONTEXTLINES_LINENO } from '../../src/integrations/contextlines';
+import {
+  MAX_CONTEXTLINES_COLNO,
+  MAX_CONTEXTLINES_LINENO,
+  _contextLinesIntegration,
+  resetFileContentCache,
+} from '../../src/integrations/contextlines';
 import { defaultStackParser } from '../../src/sdk/api';
 import { getError } from '../helpers/error';
 
@@ -37,7 +42,7 @@ describe('ContextLines', () => {
       const readStreamSpy = jest.spyOn(fs, 'createReadStream');
       await addContext(frames);
       expect(readStreamSpy).not.toHaveBeenCalled();
-    })
+    });
 
     test(`lineno above ${MAX_CONTEXTLINES_LINENO}`, async () => {
       expect.assertions(1);
@@ -53,8 +58,8 @@ describe('ContextLines', () => {
       const readStreamSpy = jest.spyOn(fs, 'createReadStream');
       await addContext(frames);
       expect(readStreamSpy).not.toHaveBeenCalled();
-    })
-  })
+    });
+  });
 
   describe('lru file cache', () => {
     test('parseStack when file does not exist', async () => {

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -33,7 +33,6 @@ describe('ContextLines', () => {
       const readStreamSpy = jest.spyOn(fs, 'createReadStream');
 
       await addContext(frames);
-
       const numCalls = readStreamSpy.mock.calls.length;
       await addContext(frames);
 

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -181,7 +181,7 @@ describe('ContextLines', () => {
       const frames = parseStackFrames(defaultStackParser, new Error('test'));
 
       await addContext(frames);
-      expect(readStreamSpy).not.toHaveBeenCalled();
+      expect(readFileSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -23,6 +23,25 @@ describe('ContextLines', () => {
   });
 
   describe('lru file cache', () => {
+    test('parseStack when file does not exist', async () => {
+      expect.assertions(4)
+      const frames: StackFrame[] = [
+        {
+          colno: 1,
+          filename: 'file:///var/task/nonexistent.js',
+          lineno: 1,
+          function: 'fxn1',
+        },
+      ];
+
+      const readStreamSpy = jest.spyOn(fs, 'createReadStream');
+      await addContext(frames);
+
+      expect(frames[0].pre_context).toBeUndefined();
+      expect(frames[0].post_context).toBeUndefined();
+      expect(frames[0].context_line).toBeUndefined();
+      expect(readStreamSpy).toHaveBeenCalledTimes(1);
+    })
     test('parseStack with same file', async () => {
       expect.assertions(1);
 

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -37,9 +37,9 @@ describe('ContextLines', () => {
       const readStreamSpy = jest.spyOn(fs, 'createReadStream');
       await addContext(frames);
 
-      expect(frames[0].pre_context).toBeUndefined();
-      expect(frames[0].post_context).toBeUndefined();
-      expect(frames[0].context_line).toBeUndefined();
+      expect(frames[0]!.pre_context).toBeUndefined();
+      expect(frames[0]!.post_context).toBeUndefined();
+      expect(frames[0]!.context_line).toBeUndefined();
       expect(readStreamSpy).toHaveBeenCalledTimes(1);
     });
     test('parseStack with same file', async () => {
@@ -101,8 +101,8 @@ describe('ContextLines', () => {
 
       await addContext(overlappingContextWithFirstError);
 
-      const innerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 1];
-      const outerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 2];
+      const innerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 1]!;
+      const outerFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 2]!;
 
       expect(innerFrame.context_line).toBe("        return new Error('inner');");
       expect(innerFrame.pre_context).toHaveLength(7);

--- a/packages/node/test/integrations/contextlines.test.ts
+++ b/packages/node/test/integrations/contextlines.test.ts
@@ -58,7 +58,7 @@ describe('ContextLines', () => {
 
       // Calls to `readFile` shouldn't increase if there isn't a new error to
       // parse whose stacktrace contains a file we haven't yet seen
-      expect(readStreamSpy).toHaveBeenCalledTimes(numCalls * 2);
+      expect(readStreamSpy).toHaveBeenCalledTimes(numCalls);
     });
 
     test('parseStack with ESM module names', async () => {
@@ -122,12 +122,15 @@ describe('ContextLines', () => {
 
       await addContext(overlappingContextWithFirstError);
 
-      const errorFrame = overlappingContextWithFirstError[overlappingContextWithFirstError.length - 1];
-      console.log(errorFrame)
+      const errorFrame = overlappingContextWithFirstError.find(f => f.filename?.endsWith('error.ts'))
+
+      if (!errorFrame) {
+        throw new Error('Could not find error frame');
+      }
 
       expect(errorFrame.context_line).toBe("  return new Error('mock error');");
-      expect(errorFrame.pre_context).toHaveLength(7)
-      expect(errorFrame.post_context).toHaveLength(7)
+      expect(errorFrame.pre_context).toHaveLength(2)
+      expect(errorFrame.post_context).toHaveLength(1)
     });
 
     test('parseStack with duplicate files', async () => {


### PR DESCRIPTION
We want to have some safeguards in place to avoid reading minified files or large bundled files as we could incur a large processing time cost. The output of such files is likely to be less useful anyways, so contextlines would be low value