### PR TITLE
fix(feedback): Send feedback rejects invalid responses 

### DIFF
--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -52,13 +52,15 @@ export const sendFeedback: SendFeedback = (
         response.statusCode < 300
       ) {
         resolve(eventId);
-      } else if (response && typeof response.statusCode === 'number' && response.statusCode === 0) {
+      }
+
+      if (response && typeof response.statusCode === 'number' && response.statusCode === 0) {
         return reject(
           'Unable to send Feedback. This is because of network issues, or because you are using an ad-blocker.',
         );
-      } else {
-        return reject('Unable to send Feedback. Invalid response from server.');
       }
+
+      return reject('Unable to send Feedback. Invalid response from server.');
     });
   });
 };

--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -48,16 +48,15 @@ export const sendFeedback: SendFeedback = (
       if (
         response &&
         typeof response.statusCode === 'number' &&
-        (response.statusCode >= 200 && response.statusCode < 300)
+        response.statusCode >= 200 &&
+        response.statusCode < 300
       ) {
-        resolve(eventId)
-      }
-      else if (response.statusCode === 0) {
+        resolve(eventId);
+      } else if (response.statusCode === 0) {
         return reject(
           'Unable to send Feedback. This is because of network issues, or because you are using an ad-blocker.',
         );
-      }
-      else {
+      } else {
         return reject('Unable to send Feedback. Invalid response from server.');
       }
     });

--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -48,17 +48,18 @@ export const sendFeedback: SendFeedback = (
       if (
         response &&
         typeof response.statusCode === 'number' &&
-        (response.statusCode < 200 || response.statusCode >= 300)
+        (response.statusCode >= 200 && response.statusCode < 300)
       ) {
-        if (response.statusCode === 0) {
-          return reject(
-            'Unable to send Feedback. This is because of network issues, or because you are using an ad-blocker.',
-          );
-        }
+        resolve(eventId)
+      }
+      else if (response.statusCode === 0) {
+        return reject(
+          'Unable to send Feedback. This is because of network issues, or because you are using an ad-blocker.',
+        );
+      }
+      else {
         return reject('Unable to send Feedback. Invalid response from server.');
       }
-
-      resolve(eventId);
     });
   });
 };

--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -52,7 +52,7 @@ export const sendFeedback: SendFeedback = (
         response.statusCode < 300
       ) {
         resolve(eventId);
-      } else if (response.statusCode === 0) {
+      } else if (response && typeof response.statusCode === 'number' && response.statusCode === 0) {
         return reject(
           'Unable to send Feedback. This is because of network issues, or because you are using an ad-blocker.',
         );

--- a/packages/feedback/src/modal/components/Dialog.css.ts
+++ b/packages/feedback/src/modal/components/Dialog.css.ts
@@ -100,8 +100,8 @@ const FORM = `
 }
 
 .form__right {
-  min-width: var(--form-width, 272px);
-  max-width: var(--form-width, 272px);
+  flex: 0 0 var(--form-width, 272px);
+  width: var(--form-width, 272px);
   display: flex;
   overflow: auto;
   flex-direction: column;

--- a/packages/feedback/src/modal/components/Dialog.css.ts
+++ b/packages/feedback/src/modal/components/Dialog.css.ts
@@ -101,6 +101,7 @@ const FORM = `
 
 .form__right {
   min-width: var(--form-width, 272px);
+  max-width: var(--form-width, 272px);
   display: flex;
   overflow: auto;
   flex-direction: column;

--- a/packages/feedback/src/modal/components/Form.tsx
+++ b/packages/feedback/src/modal/components/Form.tsx
@@ -128,7 +128,7 @@ export function Form({
           onSubmitSuccess(data);
         } catch (error) {
           DEBUG_BUILD && logger.error(error);
-          setError('There was a problem submitting feedback, please wait and try again.');
+          setError(error as string);
           onSubmitError(error as Error);
         }
       } catch {
@@ -228,7 +228,11 @@ function LabelText({
   label,
   isRequired,
   isRequiredLabel,
-}: { label: string; isRequired: boolean; isRequiredLabel: string }): VNode {
+}: {
+  label: string;
+  isRequired: boolean;
+  isRequiredLabel: string;
+}): VNode {
   return (
     <span class="form__label__text">
       {label}


### PR DESCRIPTION
`sendFeedback` rejects if the response isn't a valid status code. Also propagates message into form.
<img width="338" alt="image" src="https://github.com/getsentry/sentry-javascript/assets/55311782/ebb6126d-92ea-4593-9cec-3f3634cc1708">

Fixes https://github.com/getsentry/sentry-javascript/issues/12476