### PR TITLE
feat(node): Detect release from more providers

### DIFF
--- a/packages/node/src/sdk/api.ts
+++ b/packages/node/src/sdk/api.ts
@@ -7,6 +7,7 @@ import { createGetModuleFromFilename } from '../utils/module';
 /**
  * Returns a release dynamically from environment variables.
  */
+// eslint-disable-next-line complexity
 export function getSentryRelease(fallback?: string): string | undefined {
   // Always read first as Sentry takes this as precedence
   if (process.env.SENTRY_RELEASE) {
@@ -18,22 +19,91 @@ export function getSentryRelease(fallback?: string): string | undefined {
     return GLOBAL_OBJ.SENTRY_RELEASE.id;
   }
 
-  return (
+  // This list is in approximate alpha order, separated into 3 categories:
+  // 1. Git providers
+  // 2. CI providers with specific environment variables (has the provider name in the variable name)
+  // 3. CI providers with generic environment variables (checked for last to prevent possible false positives)
+
+  const possibleReleaseNameOfGitProvider =
     // GitHub Actions - https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
-    process.env.GITHUB_SHA ||
-    // Netlify - https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
-    process.env.COMMIT_REF ||
-    // Vercel - https://vercel.com/docs/v2/build-step#system-environment-variables
-    process.env.VERCEL_GIT_COMMIT_SHA ||
-    process.env.VERCEL_GITHUB_COMMIT_SHA ||
-    process.env.VERCEL_GITLAB_COMMIT_SHA ||
-    process.env.VERCEL_BITBUCKET_COMMIT_SHA ||
-    // Zeit (now known as Vercel)
-    process.env.ZEIT_GITHUB_COMMIT_SHA ||
-    process.env.ZEIT_GITLAB_COMMIT_SHA ||
-    process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
+    process.env['GITHUB_SHA'] ||
+    // GitLab CI - https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+    process.env['CI_MERGE_REQUEST_SOURCE_BRANCH_SHA'] ||
+    process.env['CI_BUILD_REF'] ||
+    process.env['CI_COMMIT_SHA'] ||
+    // Bitbucket - https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+    process.env['BITBUCKET_COMMIT'];
+
+  const possibleReleaseNameOfCiProvidersWithSpecificEnvVar =
+    // AppVeyor - https://www.appveyor.com/docs/environment-variables/
+    process.env['APPVEYOR_PULL_REQUEST_HEAD_COMMIT'] ||
+    process.env['APPVEYOR_REPO_COMMIT'] ||
+    // AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+    process.env['CODEBUILD_RESOLVED_SOURCE_VERSION'] ||
+    // AWS Amplify - https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html
+    process.env['AWS_COMMIT_ID'] ||
+    // Azure Pipelines - https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+    process.env['BUILD_SOURCEVERSION'] ||
+    // Bitrise - https://devcenter.bitrise.io/builds/available-environment-variables/
+    process.env['GIT_CLONE_COMMIT_HASH'] ||
+    // Buddy CI - https://buddy.works/docs/pipelines/environment-variables#default-environment-variables
+    process.env['BUDDY_EXECUTION_REVISION'] ||
+    // Builtkite - https://buildkite.com/docs/pipelines/environment-variables
+    process.env['BUILDKITE_COMMIT'] ||
+    // CircleCI - https://circleci.com/docs/variables/
+    process.env['CIRCLE_SHA1'] ||
+    // Cirrus CI - https://cirrus-ci.org/guide/writing-tasks/#environment-variables
+    process.env['CIRRUS_CHANGE_IN_REPO'] ||
+    // Codefresh - https://codefresh.io/docs/docs/codefresh-yaml/variables/
+    process.env['CF_REVISION'] ||
+    // Codemagic - https://docs.codemagic.io/yaml-basic-configuration/environment-variables/
+    process.env['CM_COMMIT'] ||
     // Cloudflare Pages - https://developers.cloudflare.com/pages/platform/build-configuration/#environment-variables
-    process.env.CF_PAGES_COMMIT_SHA ||
+    process.env['CF_PAGES_COMMIT_SHA'] ||
+    // Drone - https://docs.drone.io/pipeline/environment/reference/
+    process.env['DRONE_COMMIT_SHA'] ||
+    // Flightcontrol - https://www.flightcontrol.dev/docs/guides/flightcontrol/environment-variables#built-in-environment-variables
+    process.env['FC_GIT_COMMIT_SHA'] ||
+    // Heroku #1 https://devcenter.heroku.com/articles/heroku-ci
+    process.env['HEROKU_TEST_RUN_COMMIT_VERSION'] ||
+    // Heroku #2 https://docs.sentry.io/product/integrations/deployment/heroku/#configure-releases
+    process.env['HEROKU_SLUG_COMMIT'] ||
+    // Render - https://render.com/docs/environment-variables
+    process.env['RENDER_GIT_COMMIT'] ||
+    // Semaphore CI - https://docs.semaphoreci.com/ci-cd-environment/environment-variables
+    process.env['SEMAPHORE_GIT_SHA'] ||
+    // TravisCI - https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+    process.env['TRAVIS_PULL_REQUEST_SHA'] ||
+    // Vercel - https://vercel.com/docs/v2/build-step#system-environment-variables
+    process.env['VERCEL_GIT_COMMIT_SHA'] ||
+    process.env['VERCEL_GITHUB_COMMIT_SHA'] ||
+    process.env['VERCEL_GITLAB_COMMIT_SHA'] ||
+    process.env['VERCEL_BITBUCKET_COMMIT_SHA'] ||
+    // Zeit (now known as Vercel)
+    process.env['ZEIT_GITHUB_COMMIT_SHA'] ||
+    process.env['ZEIT_GITLAB_COMMIT_SHA'] ||
+    process.env['ZEIT_BITBUCKET_COMMIT_SHA'];
+
+  const possibleReleaseNameOfCiProvidersWithGenericEnvVar =
+    // CloudBees CodeShip - https://docs.cloudbees.com/docs/cloudbees-codeship/latest/pro-builds-and-configuration/environment-variables
+    process.env['CI_COMMIT_ID'] ||
+    // Coolify - https://coolify.io/docs/knowledge-base/environment-variables
+    process.env['SOURCE_COMMIT'] ||
+    // Heroku #3 https://devcenter.heroku.com/changelog-items/630
+    process.env['SOURCE_VERSION'] ||
+    // Jenkins - https://plugins.jenkins.io/git/#environment-variables
+    process.env['GIT_COMMIT'] ||
+    // Netlify - https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
+    process.env['COMMIT_REF'] ||
+    // TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html
+    process.env['BUILD_VCS_NUMBER'] ||
+    // Woodpecker CI - https://woodpecker-ci.org/docs/usage/environment
+    process.env['CI_COMMIT_SHA'];
+
+  return (
+    possibleReleaseNameOfGitProvider ||
+    possibleReleaseNameOfCiProvidersWithSpecificEnvVar ||
+    possibleReleaseNameOfCiProvidersWithGenericEnvVar ||
     fallback
   );
 }

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -82,6 +82,7 @@ export function init(options: VercelEdgeOptions = {}): void {
 /**
  * Returns a release dynamically from environment variables.
  */
+// eslint-disable-next-line complexity
 export function getSentryRelease(fallback?: string): string | undefined {
   // Always read first as Sentry takes this as precedence
   if (process.env.SENTRY_RELEASE) {
@@ -93,18 +94,91 @@ export function getSentryRelease(fallback?: string): string | undefined {
     return GLOBAL_OBJ.SENTRY_RELEASE.id;
   }
 
-  return (
+  // This list is in approximate alpha order, separated into 3 categories:
+  // 1. Git providers
+  // 2. CI providers with specific environment variables (has the provider name in the variable name)
+  // 3. CI providers with generic environment variables (checked for last to prevent possible false positives)
+
+  const possibleReleaseNameOfGitProvider =
     // GitHub Actions - https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
-    process.env.GITHUB_SHA ||
+    process.env['GITHUB_SHA'] ||
+    // GitLab CI - https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+    process.env['CI_MERGE_REQUEST_SOURCE_BRANCH_SHA'] ||
+    process.env['CI_BUILD_REF'] ||
+    process.env['CI_COMMIT_SHA'] ||
+    // Bitbucket - https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+    process.env['BITBUCKET_COMMIT'];
+
+  const possibleReleaseNameOfCiProvidersWithSpecificEnvVar =
+    // AppVeyor - https://www.appveyor.com/docs/environment-variables/
+    process.env['APPVEYOR_PULL_REQUEST_HEAD_COMMIT'] ||
+    process.env['APPVEYOR_REPO_COMMIT'] ||
+    // AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+    process.env['CODEBUILD_RESOLVED_SOURCE_VERSION'] ||
+    // AWS Amplify - https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html
+    process.env['AWS_COMMIT_ID'] ||
+    // Azure Pipelines - https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+    process.env['BUILD_SOURCEVERSION'] ||
+    // Bitrise - https://devcenter.bitrise.io/builds/available-environment-variables/
+    process.env['GIT_CLONE_COMMIT_HASH'] ||
+    // Buddy CI - https://buddy.works/docs/pipelines/environment-variables#default-environment-variables
+    process.env['BUDDY_EXECUTION_REVISION'] ||
+    // Builtkite - https://buildkite.com/docs/pipelines/environment-variables
+    process.env['BUILDKITE_COMMIT'] ||
+    // CircleCI - https://circleci.com/docs/variables/
+    process.env['CIRCLE_SHA1'] ||
+    // Cirrus CI - https://cirrus-ci.org/guide/writing-tasks/#environment-variables
+    process.env['CIRRUS_CHANGE_IN_REPO'] ||
+    // Codefresh - https://codefresh.io/docs/docs/codefresh-yaml/variables/
+    process.env['CF_REVISION'] ||
+    // Codemagic - https://docs.codemagic.io/yaml-basic-configuration/environment-variables/
+    process.env['CM_COMMIT'] ||
+    // Cloudflare Pages - https://developers.cloudflare.com/pages/platform/build-configuration/#environment-variables
+    process.env['CF_PAGES_COMMIT_SHA'] ||
+    // Drone - https://docs.drone.io/pipeline/environment/reference/
+    process.env['DRONE_COMMIT_SHA'] ||
+    // Flightcontrol - https://www.flightcontrol.dev/docs/guides/flightcontrol/environment-variables#built-in-environment-variables
+    process.env['FC_GIT_COMMIT_SHA'] ||
+    // Heroku #1 https://devcenter.heroku.com/articles/heroku-ci
+    process.env['HEROKU_TEST_RUN_COMMIT_VERSION'] ||
+    // Heroku #2 https://docs.sentry.io/product/integrations/deployment/heroku/#configure-releases
+    process.env['HEROKU_SLUG_COMMIT'] ||
+    // Render - https://render.com/docs/environment-variables
+    process.env['RENDER_GIT_COMMIT'] ||
+    // Semaphore CI - https://docs.semaphoreci.com/ci-cd-environment/environment-variables
+    process.env['SEMAPHORE_GIT_SHA'] ||
+    // TravisCI - https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+    process.env['TRAVIS_PULL_REQUEST_SHA'] ||
     // Vercel - https://vercel.com/docs/v2/build-step#system-environment-variables
-    process.env.VERCEL_GIT_COMMIT_SHA ||
-    process.env.VERCEL_GITHUB_COMMIT_SHA ||
-    process.env.VERCEL_GITLAB_COMMIT_SHA ||
-    process.env.VERCEL_BITBUCKET_COMMIT_SHA ||
+    process.env['VERCEL_GIT_COMMIT_SHA'] ||
+    process.env['VERCEL_GITHUB_COMMIT_SHA'] ||
+    process.env['VERCEL_GITLAB_COMMIT_SHA'] ||
+    process.env['VERCEL_BITBUCKET_COMMIT_SHA'] ||
     // Zeit (now known as Vercel)
-    process.env.ZEIT_GITHUB_COMMIT_SHA ||
-    process.env.ZEIT_GITLAB_COMMIT_SHA ||
-    process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
+    process.env['ZEIT_GITHUB_COMMIT_SHA'] ||
+    process.env['ZEIT_GITLAB_COMMIT_SHA'] ||
+    process.env['ZEIT_BITBUCKET_COMMIT_SHA'];
+
+  const possibleReleaseNameOfCiProvidersWithGenericEnvVar =
+    // CloudBees CodeShip - https://docs.cloudbees.com/docs/cloudbees-codeship/latest/pro-builds-and-configuration/environment-variables
+    process.env['CI_COMMIT_ID'] ||
+    // Coolify - https://coolify.io/docs/knowledge-base/environment-variables
+    process.env['SOURCE_COMMIT'] ||
+    // Heroku #3 https://devcenter.heroku.com/changelog-items/630
+    process.env['SOURCE_VERSION'] ||
+    // Jenkins - https://plugins.jenkins.io/git/#environment-variables
+    process.env['GIT_COMMIT'] ||
+    // Netlify - https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
+    process.env['COMMIT_REF'] ||
+    // TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html
+    process.env['BUILD_VCS_NUMBER'] ||
+    // Woodpecker CI - https://woodpecker-ci.org/docs/usage/environment
+    process.env['CI_COMMIT_SHA'];
+
+  return (
+    possibleReleaseNameOfGitProvider ||
+    possibleReleaseNameOfCiProvidersWithSpecificEnvVar ||
+    possibleReleaseNameOfCiProvidersWithGenericEnvVar ||
     fallback
   );
 }


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/12513

This PR upgrades release detection for Node and Vercel Edge SDKs.

This change adds release name detection for:

- GitLab CI
- AppVeyor
- AWS Amplify
- Azure Pipelines
- Bitrise
- Buddy CI
- Cirrus CI
- Codefresh
- Codemagic
- Semaphore CI
- Travis CI
- CloudBees CodeShip
- Coolify
- Jenkins
- TeamCity
- Woodpecker CI

Based on https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/549

Supercedes https://github.com/getsentry/sentry-javascript/pull/12507