### PR TITLE
fix(core): Ensure standalone spans respect sampled flag

### DIFF
--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -261,7 +261,15 @@ export class SentrySpan implements Span {
 
     // if this is a standalone span, we send it immediately
     if (this._isStandaloneSpan) {
-      sendSpanEnvelope(createSpanEnvelope([this], client));
+      if (this._sampled) {
+        sendSpanEnvelope(createSpanEnvelope([this], client));
+      } else {
+        DEBUG_BUILD &&
+          logger.log('[Tracing] Discarding standalone span because its trace was not chosen to be sampled.');
+        if (client) {
+          client.recordDroppedEvent('sample_rate', 'span');
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
@edwardgou-sentry pointed out that `sendSpanEnvelope` immediately sends spans without checking for `this._sampled`, which means you can't use `tracesSampler` to filter them. This changes that!

We also record client outcomes for `sample_rate` with spans.