### PR TITLE
docs: Update readme to include v7 support time & some small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ convenient interface and improved consistency between various JavaScript environ
 
 ## Contents
 
-- [Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md)
+- [Contributing](https://github.com/getsentry/sentry-javascript/blob/develop/CONTRIBUTING.md)
 - [Supported Platforms](#supported-platforms)
 - [Installation and Usage](#installation-and-usage)
 - [Other Packages](#other-packages)
@@ -40,7 +40,6 @@ For each major JavaScript platform, there is a specific high-level SDK that prov
 package. Please refer to the README and instructions of those SDKs for more detailed information:
 
 - [`@sentry/browser`](https://github.com/getsentry/sentry-javascript/tree/master/packages/browser): SDK for Browsers
-- [`@sentry/bun`](https://github.com/getsentry/sentry-javascript/tree/master/packages/bun): SDK for Bun
 - [`@sentry/node`](https://github.com/getsentry/sentry-javascript/tree/master/packages/node): SDK for Node including
   integrations for Express
 - [`@sentry/angular`](https://github.com/getsentry/sentry-javascript/tree/master/packages/angular): Browser SDK for
@@ -52,6 +51,7 @@ package. Please refer to the README and instructions of those SDKs for more deta
 - [`@sentry/sveltekit`](https://github.com/getsentry/sentry-javascript/tree/master/packages/sveltekit): SDK for
   SvelteKit
 - [`@sentry/vue`](https://github.com/getsentry/sentry-javascript/tree/master/packages/vue): Browser SDK for Vue
+- [`@sentry/solid`](https://github.com/getsentry/sentry-javascript/tree/master/packages/solid): Browser SDK for Solid
 - [`@sentry/gatsby`](https://github.com/getsentry/sentry-javascript/tree/master/packages/gatsby): SDK for Gatsby
 - [`@sentry/nextjs`](https://github.com/getsentry/sentry-javascript/tree/master/packages/nextjs): SDK for Next.js
 - [`@sentry/remix`](https://github.com/getsentry/sentry-javascript/tree/master/packages/remix): SDK for Remix
@@ -64,6 +64,13 @@ package. Please refer to the README and instructions of those SDKs for more deta
   native crashes
 - [`@sentry/capacitor`](https://github.com/getsentry/sentry-capacitor): SDK for Capacitor Apps and Ionic with support
   for native crashes
+- [`@sentry/bun`](https://github.com/getsentry/sentry-javascript/tree/master/packages/bun): SDK for Bun
+- [`@sentry/deno`](https://github.com/getsentry/sentry-javascript/tree/master/packages/deno): SDK for Deno
+
+## Version Support Policy
+
+The current version of the SDK is 8.x. Version 7.x of the SDK will continue to receive critical bugfixes until end
+of 2024.
 
 ## Installation and Usage
 
@@ -77,14 +84,14 @@ yarn add @sentry/browser
 Setup and usage of these SDKs always follows the same principle.
 
 ```javascript
-import { init, captureMessage } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
 
-init({
+Sentry.init({
   dsn: '__DSN__',
   // ...
 });
 
-captureMessage('Hello, world!');
+Sentry.captureMessage('Hello, world!');
 ```
 
 ## Other Packages


### PR DESCRIPTION
We want to support v7 with critical bug fixes until EOY 2024. So we're explicitly stating this in the readme, and I also fixed/updated some other small things.