### PR TITLE
ci: Fix check for external contributors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'pull_request'
-      && (github.action == 'opened' || github.action == 'reopened')
+      && (github.event.action == 'opened' || github.event.action == 'reopened')
       && github.event.pull_request.author_association != 'COLLABORATOR'
       && github.event.pull_request.author_association != 'MEMBER'
       && github.event.pull_request.author_association != 'OWNER'


### PR DESCRIPTION
I noticed that this was not actually working, maybe the check here was wrong 🤔  According to here: https://stackoverflow.com/questions/61886993/in-github-actions-how-to-get-the-type-of-a-trigger-event-as-a-variable this should work!