### PR TITLE
fix(profiling-node): Use correct getGlobalScope import

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -1,10 +1,16 @@
-import { defineIntegration, getCurrentScope, getIsolationScope, getRootSpan, spanToJSON } from '@sentry/core';
+import {
+  defineIntegration,
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  getRootSpan,
+  spanToJSON,
+} from '@sentry/core';
 import type { NodeClient } from '@sentry/node';
 import type { Event, Integration, IntegrationFn, Profile, ProfileChunk, Span } from '@sentry/types';
 
 import { LRUMap, logger, uuid4 } from '@sentry/utils';
 
-import { getGlobalScope } from '../../core/src/currentScopes';
 import { CpuProfilerBindings } from './cpu_profiler';
 import { DEBUG_BUILD } from './debug-build';
 import { NODE_MAJOR, NODE_VERSION } from './nodeVersion';


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/12468#issuecomment-2178865905

We need to import from `@sentry/core` instead of a relative import otherwise the types break.