### PR TITLE
feat(internal): Add `preprocessAddBreadcrumb` client event

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -411,6 +411,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   public on(hook: 'afterSendEvent', callback: (event: Event, sendResponse: TransportMakeRequestResponse) => void): void;
 
   /** @inheritdoc */
+  public on(hook: 'preprocessAddBreadcrumb', callback: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => void): void;
+
+  /** @inheritdoc */
   public on(hook: 'beforeAddBreadcrumb', callback: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => void): void;
 
   /** @inheritdoc */
@@ -494,6 +497,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
   /** @inheritdoc */
   public emit(hook: 'afterSendEvent', event: Event, sendResponse: TransportMakeRequestResponse): void;
+
+  /** @inheritdoc */
+  public emit(hook: 'preprocessAddBreadcrumb', breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void;
 
   /** @inheritdoc */
   public emit(hook: 'beforeAddBreadcrumb', breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void;

--- a/packages/core/src/breadcrumbs.ts
+++ b/packages/core/src/breadcrumbs.ts
@@ -26,6 +26,11 @@ export function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): vo
 
   const timestamp = dateTimestampInSeconds();
   const mergedBreadcrumb = { timestamp, ...breadcrumb };
+
+  if (client.emit) {
+    client.emit('preprocessAddBreadcrumb', mergedBreadcrumb, hint);
+  }
+
   const finalBreadcrumb = beforeBreadcrumb
     ? (consoleSandbox(() => beforeBreadcrumb(mergedBreadcrumb, hint)) as Breadcrumb | null)
     : mergedBreadcrumb;

--- a/packages/core/test/lib/integrations/breadcrumbs.test.ts
+++ b/packages/core/test/lib/integrations/breadcrumbs.test.ts
@@ -1,0 +1,20 @@
+import {  addBreadcrumb, flush, setCurrentClient } from '../../../src';
+import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
+
+describe('Breadcrumbs', () => {
+  it('addBreadcrumb should emit `preprocessAddBreadcrumb` event', async () => {
+    const onPreprocessAddBreadcrumb = jest.fn();
+
+    const client = new TestClient(getDefaultTestClientOptions());
+    setCurrentClient(client);
+    client.init();
+
+    client.on('preprocessAddBreadcrumb', onPreprocessAddBreadcrumb);
+
+    addBreadcrumb({ message: 'test breadcrumb' }, { data: 'test hint' });
+    await flush(2000);
+
+    expect(onPreprocessAddBreadcrumb).toHaveBeenCalledTimes(1);
+    expect(onPreprocessAddBreadcrumb).toBeCalledWith({ message: 'test breadcrumb' }, { data: 'test hint' });
+  });
+});

--- a/packages/core/test/lib/integrations/breadcrumbs.test.ts
+++ b/packages/core/test/lib/integrations/breadcrumbs.test.ts
@@ -15,6 +15,9 @@ describe('Breadcrumbs', () => {
     await flush(2000);
 
     expect(onPreprocessAddBreadcrumb).toHaveBeenCalledTimes(1);
-    expect(onPreprocessAddBreadcrumb).toBeCalledWith({ message: 'test breadcrumb' }, { data: 'test hint' });
+    expect(onPreprocessAddBreadcrumb).toBeCalledWith(
+      { message: 'test breadcrumb', timestamp: expect.any(Number) },
+      { data: 'test hint' },
+    );
   });
 });

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -237,6 +237,11 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   on(hook: 'afterSendEvent', callback: (event: Event, sendResponse: TransportMakeRequestResponse) => void): void;
 
   /**
+   * Register a callback when a breadcrumb is to be added.
+   */
+  on(hook: 'preprocessAddBreadcrumb', callback: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => void): void;
+
+  /**
    * Register a callback before a breadcrumb is added.
    */
   on(hook: 'beforeAddBreadcrumb', callback: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => void): void;
@@ -329,6 +334,12 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * second argument.
    */
   emit(hook: 'afterSendEvent', event: Event, sendResponse: TransportMakeRequestResponse): void;
+
+  /**
+   * Fire a hook for when a breadcrumb to be added. This can be used by the SDK before user finalizes the breadcrumb
+   * in `beforeBreadcrumb` callback. This is used in SDK which require different handling of breadcrumbs like RN, Capacitor...
+   */
+  emit(hook: 'preprocessAddBreadcrumb', breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void;
 
   /**
    * Fire a hook for when a breadcrumb is added. Expects the breadcrumb as second argument.


### PR DESCRIPTION
This PR add `preprocessAddBreadcrumb` to the code `addBreadcrumb` function, this let's JS SDKs depending on the JS core adjust breadcrumbs if needed.

For example React Native needs to enrich network breadcrumbs data for Mobile Replay.

The existing hook `beforeAddBreadcrumb` is executed after `beforeBreadcrumb` and that's why is doesn't work for RN use-case. RN will add data to the breadcrumb and this should be available to users in `beforeBreadcrumb` should they decide to remove or alter the information.