### PR TITLE
fix(v7/bundle): Ensure CDN bundles do not overwrite `window.Sentry`

### DIFF
--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/init.js
@@ -1,0 +1,5 @@
+window.sentryOnLoad = function () {
+  Sentry.init({});
+
+  window.__sentryLoaded = true;
+}

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/subject.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/subject.js
@@ -1,0 +1,3 @@
+Sentry.forceLoad();
+
+Sentry.captureException('Test exception');

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/template.html
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script>
+      window.Sentry = {_customThingOnSentry: 'customThingOnSentry' };
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/test.ts
@@ -1,0 +1,24 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../utils/helpers';
+
+sentryTest('keeps data on window.Sentry intact', async ({ getLocalTestUrl, page }) => {
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const req = await waitForErrorRequestOnUrl(page, url);
+
+  const eventData = envelopeRequestParser(req);
+
+  expect(eventData.message).toBe('Test exception');
+
+  const customThingy = await page.evaluate('window.Sentry._customThingOnSentry');
+  expect(customThingy).toBe('customThingOnSentry');
+});

--- a/dev-packages/rollup-utils/bundleHelpers.mjs
+++ b/dev-packages/rollup-utils/bundleHelpers.mjs
@@ -54,6 +54,9 @@ export function makeBaseBundleConfig(options) {
         // Add polyfills for ES6 array/string methods at the end of the bundle
         return isEs5 ? getEs5Polyfills() : '';
       },
+      intro: () => {
+        return 'exports = window.Sentry || {};';
+      },
     },
     context: 'window',
     plugins: [rrwebBuildPlugin, markAsBrowserBuildPlugin],


### PR DESCRIPTION
This was brought up in Slack - turns out we were always overwriting `window.Sentry` when a CDN bundle was loaded. This means that if a user e.g. loaded an integration via CDN, which is put on `window.Sentry`, this was overwritten if the loader fetched the base CDN bundle later.

This _probably_ did not come up earlier because we may handle `Sentry.Integrations` specially, but not sure. This fix should ensure this works as expected!