### PR TITLE
fix(bundle): Ensure CDN bundles do not overwrite `window.Sentry`

### DIFF
--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/init.js
@@ -1,0 +1,5 @@
+window.sentryOnLoad = function () {
+  Sentry.init({});
+
+  window.__sentryLoaded = true;
+}

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/subject.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/subject.js
@@ -1,0 +1,3 @@
+Sentry.forceLoad();
+
+Sentry.captureException('Test exception');

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/template.html
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script>
+      window.Sentry = {_customThingOnSentry: 'customThingOnSentry' };
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/test.ts
@@ -1,0 +1,24 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../utils/helpers';
+
+sentryTest('keeps data on window.Sentry intact', async ({ getLocalTestUrl, page }) => {
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const req = await waitForErrorRequestOnUrl(page, url);
+
+  const eventData = envelopeRequestParser(req);
+
+  expect(eventData.message).toBe('Test exception');
+
+  const customThingy = await page.evaluate('window.Sentry._customThingOnSentry');
+  expect(customThingy).toBe('customThingOnSentry');
+});

--- a/dev-packages/rollup-utils/bundleHelpers.mjs
+++ b/dev-packages/rollup-utils/bundleHelpers.mjs
@@ -48,6 +48,9 @@ export function makeBaseBundleConfig(options) {
     output: {
       format: 'iife',
       name: 'Sentry',
+      intro: () => {
+        return 'exports = window.Sentry || {};';
+      },
     },
     context: 'window',
     plugins: [rrwebBuildPlugin, markAsBrowserBuildPlugin],


### PR DESCRIPTION
v8 portion of https://github.com/getsentry/sentry-javascript/pull/12579 (not that relevant there because no Loader support yet, but still...)