### PR TITLE
Revert "feat(core): Add `parentSpan` option to `startSpan*` APIs"

### DIFF
--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -271,17 +271,6 @@ describe('startSpan', () => {
     expect(getActiveSpan()).toBe(undefined);
   });
 
-  it('allows to pass a parentSpan', () => {
-    const parentSpan = new SentrySpan({ spanId: 'parent-span-id', sampled: true, name: 'parent-span' });
-
-    startSpan({ name: 'GET users/[id]', parentSpan }, span => {
-      expect(getActiveSpan()).toBe(span);
-      expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
-    });
-
-    expect(getActiveSpan()).toBe(undefined);
-  });
-
   it('allows to force a transaction with forceTransaction=true', async () => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 1.0 });
     client = new TestClient(options);
@@ -664,32 +653,19 @@ describe('startSpanManual', () => {
     const parentSpan = new SentrySpan({ spanId: 'parent-span-id', sampled: true });
     _setSpanForScope(manualScope, parentSpan);
 
-    startSpanManual({ name: 'GET users/[id]', scope: manualScope }, span => {
+    startSpanManual({ name: 'GET users/[id]', scope: manualScope }, (span, finish) => {
       expect(getCurrentScope()).not.toBe(initialScope);
       expect(getCurrentScope()).toBe(manualScope);
       expect(getActiveSpan()).toBe(span);
       expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
 
-      span.end();
+      finish();
 
       // Is still the active span
       expect(getActiveSpan()).toBe(span);
     });
 
     expect(getCurrentScope()).toBe(initialScope);
-    expect(getActiveSpan()).toBe(undefined);
-  });
-
-  it('allows to pass a parentSpan', () => {
-    const parentSpan = new SentrySpan({ spanId: 'parent-span-id', sampled: true, name: 'parent-span' });
-
-    startSpanManual({ name: 'GET users/[id]', parentSpan }, span => {
-      expect(getActiveSpan()).toBe(span);
-      expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
-
-      span.end();
-    });
-
     expect(getActiveSpan()).toBe(undefined);
   });
 
@@ -995,19 +971,6 @@ describe('startInactiveSpan', () => {
     expect(span).toBeDefined();
     expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
     expect(getActiveSpan()).toBeUndefined();
-
-    span.end();
-
-    expect(getActiveSpan()).toBeUndefined();
-  });
-
-  it('allows to pass a parentSpan', () => {
-    const parentSpan = new SentrySpan({ spanId: 'parent-span-id', sampled: true, name: 'parent-span' });
-
-    const span = startInactiveSpan({ name: 'GET users/[id]', parentSpan });
-
-    expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
-    expect(getActiveSpan()).toBe(undefined);
 
     span.end();
 

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -12,7 +12,7 @@ import {
   handleCallbackErrors,
   spanToJSON,
 } from '@sentry/core';
-import type { Client, Scope, Span as SentrySpan } from '@sentry/types';
+import type { Client, Scope } from '@sentry/types';
 import { continueTraceAsRemoteSpan, makeTraceState } from './propagator';
 
 import type { OpenTelemetryClient, OpenTelemetrySpanContext } from './types';
@@ -32,32 +32,27 @@ import { getSamplingDecision } from './utils/getSamplingDecision';
 export function startSpan<T>(options: OpenTelemetrySpanContext, callback: (span: Span) => T): T {
   const tracer = getTracer();
 
-  const { name, parentSpan: customParentSpan } = options;
+  const { name } = options;
 
-  // If `options.parentSpan` is defined, we want to wrap the callback in `withActiveSpan`
-  const wrapper = getActiveSpanWrapper<T>(customParentSpan);
+  const activeCtx = getContext(options.scope, options.forceTransaction);
+  const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
+  const ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
 
-  return wrapper(() => {
-    const activeCtx = getContext(options.scope, options.forceTransaction);
-    const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
-    const ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
+  const spanContext = getSpanContext(options);
 
-    const spanOptions = getSpanOptions(options);
+  return tracer.startActiveSpan(name, spanContext, ctx, span => {
+    _applySentryAttributesToSpan(span, options);
 
-    return tracer.startActiveSpan(name, spanOptions, ctx, span => {
-      _applySentryAttributesToSpan(span, options);
-
-      return handleCallbackErrors(
-        () => callback(span),
-        () => {
-          // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses
-          if (spanToJSON(span).status === undefined) {
-            span.setStatus({ code: SpanStatusCode.ERROR });
-          }
-        },
-        () => span.end(),
-      );
-    });
+    return handleCallbackErrors(
+      () => callback(span),
+      () => {
+        // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses
+        if (spanToJSON(span).status === undefined) {
+          span.setStatus({ code: SpanStatusCode.ERROR });
+        }
+      },
+      () => span.end(),
+    );
   });
 }
 
@@ -77,31 +72,26 @@ export function startSpanManual<T>(
 ): T {
   const tracer = getTracer();
 
-  const { name, parentSpan: customParentSpan } = options;
+  const { name } = options;
 
-  // If `options.parentSpan` is defined, we want to wrap the callback in `withActiveSpan`
-  const wrapper = getActiveSpanWrapper<T>(customParentSpan);
+  const activeCtx = getContext(options.scope, options.forceTransaction);
+  const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
+  const ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
 
-  return wrapper(() => {
-    const activeCtx = getContext(options.scope, options.forceTransaction);
-    const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
-    const ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
+  const spanContext = getSpanContext(options);
 
-    const spanOptions = getSpanOptions(options);
+  return tracer.startActiveSpan(name, spanContext, ctx, span => {
+    _applySentryAttributesToSpan(span, options);
 
-    return tracer.startActiveSpan(name, spanOptions, ctx, span => {
-      _applySentryAttributesToSpan(span, options);
-
-      return handleCallbackErrors(
-        () => callback(span, () => span.end()),
-        () => {
-          // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses
-          if (spanToJSON(span).status === undefined) {
-            span.setStatus({ code: SpanStatusCode.ERROR });
-          }
-        },
-      );
-    });
+    return handleCallbackErrors(
+      () => callback(span, () => span.end()),
+      () => {
+        // Only set the span status to ERROR when there wasn't any status set before, in order to avoid stomping useful span statuses
+        if (spanToJSON(span).status === undefined) {
+          span.setStatus({ code: SpanStatusCode.ERROR });
+        }
+      },
+    );
   });
 }
 
@@ -117,24 +107,19 @@ export function startSpanManual<T>(
 export function startInactiveSpan(options: OpenTelemetrySpanContext): Span {
   const tracer = getTracer();
 
-  const { name, parentSpan: customParentSpan } = options;
+  const { name } = options;
 
-  // If `options.parentSpan` is defined, we want to wrap the callback in `withActiveSpan`
-  const wrapper = getActiveSpanWrapper<Span>(customParentSpan);
+  const activeCtx = getContext(options.scope, options.forceTransaction);
+  const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
+  const ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
 
-  return wrapper(() => {
-    const activeCtx = getContext(options.scope, options.forceTransaction);
-    const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
-    const ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
+  const spanContext = getSpanContext(options);
 
-    const spanOptions = getSpanOptions(options);
+  const span = tracer.startSpan(name, spanContext, ctx);
 
-    const span = tracer.startSpan(name, spanOptions, ctx);
+  _applySentryAttributesToSpan(span, options);
 
-    _applySentryAttributesToSpan(span, options);
-
-    return span;
-  });
+  return span;
 }
 
 /**
@@ -164,7 +149,7 @@ function _applySentryAttributesToSpan(span: Span, options: OpenTelemetrySpanCont
   }
 }
 
-function getSpanOptions(options: OpenTelemetrySpanContext): SpanOptions {
+function getSpanContext(options: OpenTelemetrySpanContext): SpanOptions {
   const { startTime, attributes, kind } = options;
 
   // OTEL expects timestamps in ms, not seconds
@@ -203,7 +188,7 @@ function getContext(scope: Scope | undefined, forceTransaction: boolean | undefi
         sampled: propagationContext.sampled,
       });
 
-      const spanOptions: SpanContext = {
+      const spanContext: SpanContext = {
         traceId: propagationContext.traceId,
         spanId: propagationContext.parentSpanId || propagationContext.spanId,
         isRemote: true,
@@ -212,7 +197,7 @@ function getContext(scope: Scope | undefined, forceTransaction: boolean | undefi
       };
 
       // Add remote parent span context,
-      return trace.setSpanContext(ctx, spanOptions);
+      return trace.setSpanContext(ctx, spanContext);
     }
 
     // if we have no scope or client, we just return the context as-is
@@ -245,7 +230,7 @@ function getContext(scope: Scope | undefined, forceTransaction: boolean | undefi
     sampled,
   });
 
-  const spanOptions: SpanContext = {
+  const spanContext: SpanContext = {
     traceId,
     spanId,
     isRemote: true,
@@ -253,7 +238,7 @@ function getContext(scope: Scope | undefined, forceTransaction: boolean | undefi
     traceState,
   };
 
-  const ctxWithSpanContext = trace.setSpanContext(ctxWithoutSpan, spanOptions);
+  const ctxWithSpanContext = trace.setSpanContext(ctxWithoutSpan, spanContext);
 
   return ctxWithSpanContext;
 }
@@ -284,14 +269,4 @@ export function continueTrace<T>(options: Parameters<typeof baseContinueTrace>[0
   return baseContinueTrace(options, () => {
     return continueTraceAsRemoteSpan(context.active(), options, callback);
   });
-}
-
-function getActiveSpanWrapper<T>(parentSpan?: Span | SentrySpan): (callback: () => T) => T {
-  return parentSpan
-    ? (callback: () => T) => {
-        // We cast this, because the OTEL Span has a few more methods than our Span interface
-        // TODO: Add these missing methods to the Span interface
-        return withActiveSpan(parentSpan as Span, callback);
-      }
-    : (callback: () => T) => callback();
 }

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -310,21 +310,6 @@ describe('trace', () => {
       expect(getActiveSpan()).toBe(undefined);
     });
 
-    it('allows to pass a parentSpan', () => {
-      let parentSpan: Span;
-
-      startSpanManual({ name: 'detached' }, span => {
-        parentSpan = span;
-      });
-
-      startSpan({ name: 'GET users/[id]', parentSpan: parentSpan! }, span => {
-        expect(getActiveSpan()).toBe(span);
-        expect(spanToJSON(span).parent_span_id).toBe(parentSpan.spanContext().spanId);
-      });
-
-      expect(getActiveSpan()).toBe(undefined);
-    });
-
     it('allows to force a transaction with forceTransaction=true', async () => {
       const client = getClient()!;
       const transactionEvents: Event[] = [];
@@ -561,21 +546,6 @@ describe('trace', () => {
       expect(getSpanParentSpanId(span)).toBe(parentSpan.spanContext().spanId);
 
       expect(getCurrentScope()).toBe(initialScope);
-      expect(getActiveSpan()).toBe(undefined);
-    });
-
-    it('allows to pass a parentSpan', () => {
-      let parentSpan: Span;
-
-      startSpanManual({ name: 'detached' }, span => {
-        parentSpan = span;
-      });
-
-      const span = startInactiveSpan({ name: 'GET users/[id]', parentSpan: parentSpan! });
-
-      expect(getActiveSpan()).toBe(undefined);
-      expect(spanToJSON(span).parent_span_id).toBe(parentSpan!.spanContext().spanId);
-
       expect(getActiveSpan()).toBe(undefined);
     });
 
@@ -840,23 +810,6 @@ describe('trace', () => {
       });
 
       expect(getCurrentScope()).toBe(initialScope);
-      expect(getActiveSpan()).toBe(undefined);
-    });
-
-    it('allows to pass a parentSpan', () => {
-      let parentSpan: Span;
-
-      startSpanManual({ name: 'detached' }, span => {
-        parentSpan = span;
-      });
-
-      startSpanManual({ name: 'GET users/[id]', parentSpan: parentSpan! }, span => {
-        expect(getActiveSpan()).toBe(span);
-        expect(spanToJSON(span).parent_span_id).toBe(parentSpan.spanContext().spanId);
-
-        span.end();
-      });
-
       expect(getActiveSpan()).toBe(undefined);
     });
 

--- a/packages/types/src/startSpanOptions.ts
+++ b/packages/types/src/startSpanOptions.ts
@@ -1,5 +1,5 @@
 import type { Scope } from './scope';
-import type { Span, SpanAttributes, SpanTimeInput } from './span';
+import type { SpanAttributes, SpanTimeInput } from './span';
 
 export interface StartSpanOptions {
   /** A manually specified start time for the created `Span` object. */
@@ -16,12 +16,6 @@ export interface StartSpanOptions {
 
   /** An op for the span. This is a categorization for spans. */
   op?: string;
-
-  /**
-   * If provided, make the new span a child of this span.
-   * If this is not provided, the new span will be a child of the currently active span.
-   */
-  parentSpan?: Span;
 
   /**
    * If set to true, this span will be forced to be treated as a transaction in the Sentry UI, if possible and applicable.


### PR DESCRIPTION
Reverts getsentry/sentry-javascript#12567

Seems to have introduced test failures with esm preloading: https://github.com/getsentry/sentry-javascript/actions/runs/9599487906/job/26474052394

reverting this so we can unblock a release, we can investigate deeper afterwards.