### PR TITLE
feat(feedback): Extra check for iPad in screenshot support

### DIFF
--- a/packages/feedback/src/util/isScreenshotSupported.ts
+++ b/packages/feedback/src/util/isScreenshotSupported.ts
@@ -17,6 +17,15 @@ export function isScreenshotSupported(): boolean {
   if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(NAVIGATOR.userAgent)) {
     return false;
   }
+  /**
+   * User agent on iPads show as Macintosh, so we need extra checks
+   *
+   * https://forums.developer.apple.com/forums/thread/119186
+   * https://stackoverflow.com/questions/60482650/how-to-detect-ipad-useragent-on-safari-browser
+   */
+  if (/Macintosh/i.test(NAVIGATOR.userAgent) && NAVIGATOR.maxTouchPoints && NAVIGATOR.maxTouchPoints > 1) {
+    return false;
+  }
   if (!isSecureContext) {
     return false;
   }


### PR DESCRIPTION
iPads on iPad OS 13+ will show up as Macintosh in the UserAgent since they show the desktop version of sites. This adds extra checks to distinguish if it's an iPad.

Fixes [JAVASCRIPT-2TNR](https://sentry.sentry.io/feedback/?feedbackSlug=javascript:5511454761&project=11276)
