### PR TITLE
fix: Ensure invalid spans are ignored for trace propagation

### DIFF
--- a/packages/astro/src/server/meta.ts
+++ b/packages/astro/src/server/meta.ts
@@ -2,6 +2,7 @@ import {
   getDynamicSamplingContextFromClient,
   getDynamicSamplingContextFromSpan,
   getRootSpan,
+  spanIsValid,
   spanToTraceHeader,
 } from '@sentry/core';
 import type { Client, Scope, Span } from '@sentry/types';
@@ -35,15 +36,17 @@ export function getTracingMetaTags(
   const { dsc, sampled, traceId } = scope.getPropagationContext();
   const rootSpan = span && getRootSpan(span);
 
-  const sentryTrace = span ? spanToTraceHeader(span) : generateSentryTraceHeader(traceId, undefined, sampled);
+  const sentryTrace =
+    span && spanIsValid(span) ? spanToTraceHeader(span) : generateSentryTraceHeader(traceId, undefined, sampled);
 
-  const dynamicSamplingContext = rootSpan
-    ? getDynamicSamplingContextFromSpan(rootSpan)
-    : dsc
-      ? dsc
-      : client
-        ? getDynamicSamplingContextFromClient(traceId, client)
-        : undefined;
+  const dynamicSamplingContext =
+    rootSpan && spanIsValid(rootSpan)
+      ? getDynamicSamplingContextFromSpan(rootSpan)
+      : dsc
+        ? dsc
+        : client
+          ? getDynamicSamplingContextFromClient(traceId, client)
+          : undefined;
 
   const baggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
 

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -16,6 +16,7 @@ import {
   hasTracingEnabled,
   instrumentFetchRequest,
   setHttpStatus,
+  spanIsValid,
   spanToJSON,
   spanToTraceHeader,
   startInactiveSpan,
@@ -371,10 +372,15 @@ function addTracingHeadersToXhrRequest(xhr: SentryWrappedXMLHttpRequest, client:
   };
 
   const sentryTraceHeader =
-    span && hasTracingEnabled() ? spanToTraceHeader(span) : generateSentryTraceHeader(traceId, spanId, sampled);
+    span && spanIsValid(span) && hasTracingEnabled()
+      ? spanToTraceHeader(span)
+      : generateSentryTraceHeader(traceId, spanId, sampled);
 
   const sentryBaggageHeader = dynamicSamplingContextToSentryBaggageHeader(
-    dsc || (span ? getDynamicSamplingContextFromSpan(span) : getDynamicSamplingContextFromClient(traceId, client)),
+    dsc ||
+      (span && spanIsValid(span)
+        ? getDynamicSamplingContextFromSpan(span)
+        : getDynamicSamplingContextFromClient(traceId, client)),
   );
 
   setHeaderOnXhr(xhr, sentryTraceHeader, sentryBaggageHeader);

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -17,7 +17,7 @@ import {
 } from './tracing';
 import { SentryNonRecordingSpan } from './tracing/sentryNonRecordingSpan';
 import { hasTracingEnabled } from './utils/hasTracingEnabled';
-import { getActiveSpan, spanToTraceHeader } from './utils/spanUtils';
+import { getActiveSpan, spanIsValid, spanToTraceHeader } from './utils/spanUtils';
 
 type PolymorphicRequestHeaders =
   | Record<string, string | undefined>
@@ -138,10 +138,14 @@ export function addTracingHeadersToFetchRequest(
     ...scope.getPropagationContext(),
   };
 
-  const sentryTraceHeader = span ? spanToTraceHeader(span) : generateSentryTraceHeader(traceId, spanId, sampled);
+  const sentryTraceHeader =
+    span && spanIsValid(span) ? spanToTraceHeader(span) : generateSentryTraceHeader(traceId, spanId, sampled);
 
   const sentryBaggageHeader = dynamicSamplingContextToSentryBaggageHeader(
-    dsc || (span ? getDynamicSamplingContextFromSpan(span) : getDynamicSamplingContextFromClient(traceId, client)),
+    dsc ||
+      (span && spanIsValid(span)
+        ? getDynamicSamplingContextFromSpan(span)
+        : getDynamicSamplingContextFromClient(traceId, client)),
   );
 
   const headers =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,7 @@ export {
   getStatusMessage,
   getRootSpan,
   getActiveSpan,
+  spanIsValid,
   addChildSpanToSpan,
 } from './utils/spanUtils';
 export { parseSampleRate } from './utils/parseSampleRate';

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -25,7 +25,7 @@ import {
   registerSpanErrorInstrumentation,
 } from './tracing';
 import { _getSpanForScope } from './utils/spanOnScope';
-import { getRootSpan, spanToTraceContext } from './utils/spanUtils';
+import { getRootSpan, spanIsValid, spanToTraceContext } from './utils/spanUtils';
 
 export interface ServerRuntimeClientOptions extends ClientOptions<BaseTransportOptions> {
   platform?: string;
@@ -256,7 +256,7 @@ export class ServerRuntimeClient<
     }
 
     const span = _getSpanForScope(scope);
-    if (span) {
+    if (span && spanIsValid(span)) {
       const rootSpan = getRootSpan(span);
       const samplingContext = getDynamicSamplingContextFromSpan(rootSpan);
       return [samplingContext, spanToTraceContext(rootSpan)];

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -69,6 +69,16 @@ export function spanToTraceHeader(span: Span): string {
 }
 
 /**
+ * Spans may have an invalid trace ID/span ID, in some cases when they were not sampled.
+ */
+export function spanIsValid(span: Span): boolean {
+  return (
+    span.spanContext().spanId !== '0000000000000000' &&
+    span.spanContext().traceId !== '00000000000000000000000000000000'
+  );
+}
+
+/**
  * Convert a span time input intp a timestamp in seconds.
  */
 export function spanTimeInputToSeconds(input: SpanTimeInput | undefined): number {

--- a/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
@@ -1,4 +1,10 @@
-import { getActiveSpan, getDynamicSamplingContextFromSpan, getRootSpan, spanToTraceHeader } from '@sentry/core';
+import {
+  getActiveSpan,
+  getDynamicSamplingContextFromSpan,
+  getRootSpan,
+  spanIsValid,
+  spanToTraceHeader,
+} from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type App from 'next/app';
 
@@ -55,7 +61,7 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
           appGetInitialProps.pageProps = {};
         }
 
-        if (requestSpan) {
+        if (requestSpan && spanIsValid(requestSpan)) {
           const sentryTrace = spanToTraceHeader(requestSpan);
 
           // The Next.js serializer throws on undefined values so we need to guard for it (#12102)

--- a/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
@@ -1,4 +1,10 @@
-import { getActiveSpan, getDynamicSamplingContextFromSpan, getRootSpan, spanToTraceHeader } from '@sentry/core';
+import {
+  getActiveSpan,
+  getDynamicSamplingContextFromSpan,
+  getRootSpan,
+  spanIsValid,
+  spanToTraceHeader,
+} from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPageContext } from 'next';
 import type { ErrorProps } from 'next/error';
@@ -48,7 +54,7 @@ export function wrapErrorGetInitialPropsWithSentry(
         const activeSpan = getActiveSpan();
         const requestSpan = getSpanFromRequest(req) ?? (activeSpan ? getRootSpan(activeSpan) : undefined);
 
-        if (requestSpan) {
+        if (requestSpan && spanIsValid(requestSpan)) {
           const sentryTrace = spanToTraceHeader(requestSpan);
 
           // The Next.js serializer throws on undefined values so we need to guard for it (#12102)

--- a/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
@@ -1,4 +1,10 @@
-import { getActiveSpan, getDynamicSamplingContextFromSpan, getRootSpan, spanToTraceHeader } from '@sentry/core';
+import {
+  getActiveSpan,
+  getDynamicSamplingContextFromSpan,
+  getRootSpan,
+  spanIsValid,
+  spanToTraceHeader,
+} from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPage } from 'next';
 
@@ -44,7 +50,7 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
         const activeSpan = getActiveSpan();
         const requestSpan = getSpanFromRequest(req) ?? (activeSpan ? getRootSpan(activeSpan) : undefined);
 
-        if (requestSpan) {
+        if (requestSpan && spanIsValid(requestSpan)) {
           const sentryTrace = spanToTraceHeader(requestSpan);
 
           // The Next.js serializer throws on undefined values so we need to guard for it (#12102)

--- a/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
@@ -1,4 +1,10 @@
-import { getActiveSpan, getDynamicSamplingContextFromSpan, getRootSpan, spanToTraceHeader } from '@sentry/core';
+import {
+  getActiveSpan,
+  getDynamicSamplingContextFromSpan,
+  getRootSpan,
+  spanIsValid,
+  spanToTraceHeader,
+} from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { GetServerSideProps } from 'next';
 
@@ -39,7 +45,8 @@ export function wrapGetServerSidePropsWithSentry(
       if (serverSideProps && 'props' in serverSideProps) {
         const activeSpan = getActiveSpan();
         const requestSpan = getSpanFromRequest(req) ?? (activeSpan ? getRootSpan(activeSpan) : undefined);
-        if (requestSpan) {
+
+        if (requestSpan && spanIsValid(requestSpan)) {
           const sentryTrace = spanToTraceHeader(requestSpan);
 
           // The Next.js serializer throws on undefined values so we need to guard for it (#12102)

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -8,6 +8,7 @@ import {
   getRootSpan,
   hasTracingEnabled,
   setHttpStatus,
+  spanIsValid,
   spanToJSON,
   spanToTraceHeader,
   startSpan,
@@ -208,7 +209,7 @@ function getTraceAndBaggage(): {
     const span = getActiveSpan();
     const rootSpan = span && getRootSpan(span);
 
-    if (rootSpan) {
+    if (rootSpan && spanIsValid(rootSpan)) {
       const dynamicSamplingContext = getDynamicSamplingContextFromSpan(rootSpan);
 
       return {

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -7,6 +7,7 @@ import {
   getIsolationScope,
   getRootSpan,
   setHttpStatus,
+  spanIsValid,
   spanToTraceHeader,
   withIsolationScope,
 } from '@sentry/core';
@@ -115,7 +116,7 @@ export function addSentryCodeToPage(options: SentryHandleOptions): NonNullable<R
   return ({ html }) => {
     const activeSpan = getActiveSpan();
     const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
-    if (rootSpan) {
+    if (rootSpan && spanIsValid(rootSpan)) {
       const traceparentData = spanToTraceHeader(rootSpan);
       const dynamicSamplingContext = dynamicSamplingContextToSentryBaggageHeader(
         getDynamicSamplingContextFromSpan(rootSpan),


### PR DESCRIPTION
In OTEL, you can have invalid spans being created sometimes (e.g. when a non recording span is created that is not continuing anything). These spans have a 000 span/trace ID. We should consider this as "no span" in our trace propagation code, and use the propagation context one instead, as otherwise we send `000000-0000-0` headers everywhere 😬 

I'll need to add at least some tests for this, but want to see how much of an impact this is right now...