### PR TITLE
fix(node): Re-throw errors from koa error handler

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-koa/index.js
+++ b/dev-packages/e2e-tests/test-applications/node-koa/index.js
@@ -103,6 +103,12 @@ router1.get('/test-outgoing-http-external-disallowed', async ctx => {
   ctx.body = data;
 });
 
+router1.get('/test-assert/:condition', async ctx => {
+  ctx.body = 200;
+  const condition = ctx.params.condition !== 'false';
+  ctx.assert(condition, 400, 'ctx.assert failed');
+});
+
 app1.use(router1.routes()).use(router1.allowedMethods());
 
 app1.listen(port1);

--- a/dev-packages/e2e-tests/test-applications/node-koa/tests/assert.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-koa/tests/assert.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test('Returns 400 from failed assert', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('node-koa', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'ctx.assert failed';
+  });
+
+  const res = await fetch(`${baseURL}/test-assert/false`);
+  expect(res.status).toBe(400);
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('ctx.assert failed');
+
+  expect(errorEvent.request).toEqual({
+    method: 'GET',
+    cookies: {},
+    headers: expect.any(Object),
+    url: 'http://localhost:3030/test-assert/false',
+  });
+
+  expect(errorEvent.transaction).toEqual('GET /test-assert/:condition');
+
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: expect.any(String),
+    span_id: expect.any(String),
+  });
+});
+
+test('Returns 200 from successful assert', async ({ baseURL }) => {
+  const res = await fetch(`${baseURL}/test-assert/true`);
+  expect(res.status).toBe(200);
+});

--- a/packages/node/src/integrations/tracing/koa.ts
+++ b/packages/node/src/integrations/tracing/koa.ts
@@ -56,6 +56,7 @@ export const setupKoaErrorHandler = (app: { use: (arg0: (ctx: any, next: any) =>
       await next();
     } catch (error) {
       captureException(error);
+      throw error;
     }
   });
 


### PR DESCRIPTION
Fixes #12517 

Note: I did not yet any filtering for error status codes in this PR.