### PR TITLE
chore: Fix up nuxt package versions

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/nuxt",
-  "version": "8.10.0",
+  "version": "8.11.0",
   "description": "Official Sentry SDK for Nuxt (EXPERIMENTAL)",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/nuxt",
@@ -30,13 +30,13 @@
     "nuxt": "3.x"
   },
   "dependencies": {
-    "@sentry/core": "8.10.0",
-    "@sentry/node": "8.10.0",
-    "@sentry/opentelemetry": "8.10.0",
-    "@sentry/types": "8.10.0",
-    "@sentry/utils": "8.10.0",
-    "@sentry/vite-plugin": "2.18.0",
-    "@sentry/vue": "8.10.0",
+    "@sentry/core": "8.11.0",
+    "@sentry/node": "8.11.0",
+    "@sentry/opentelemetry": "8.11.0",
+    "@sentry/types": "8.11.0",
+    "@sentry/utils": "8.11.0",
+    "@sentry/vite-plugin": "2.19.0",
+    "@sentry/vue": "8.11.0",
     "@nuxt/kit": "^3.12.2"
   },
   "devDependencies": {


### PR DESCRIPTION
We did not correctly handle this in the backmerge from the 8.11.0 release.