### PR TITLE
ref(node): Add error message to NodeFetch log

### DIFF
--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -74,7 +74,7 @@ const _nativeNodeFetchIntegration = ((options: NodeFetchOptions = {}) => {
       } as any);
     } catch (error) {
       // Could not load instrumentation
-      DEBUG_BUILD && logger.log('Could not load NodeFetch instrumentation.');
+      DEBUG_BUILD && logger.log('Error while loading NodeFetch instrumentation: \n', error);
     }
   }
 


### PR DESCRIPTION
While debugging, it is hard to find the reason why `NodeFetch` is not loading.

ref https://github.com/getsentry/sentry-javascript/issues/12603

