### PR TITLE
fix(remix): Mark `isRemixV2` as optional in exposed types.

### DIFF
--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -17,7 +17,7 @@ export async function captureRemixServerException(
   err: unknown,
   name: string,
   request: Request,
-  isRemixV2: boolean,
+  isRemixV2?: boolean,
 ): Promise<void> {
   DEBUG_BUILD &&
     logger.warn(

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -22,7 +22,7 @@ export declare function captureRemixServerException(
   err: unknown,
   name: string,
   request: Request,
-  isRemixV2: boolean,
+  isRemixV2?: boolean,
 ): Promise<void>;
 
 // This variable is not a runtime variable but just a type to tell typescript that the methods below can either come

--- a/packages/remix/src/utils/errors.ts
+++ b/packages/remix/src/utils/errors.ts
@@ -172,7 +172,7 @@ export async function errorHandleDataFunction(
       // Remix v1 does not have a `handleError` function, so we capture all errors here.
       if (isRemixV2 ? isResponse(err) : true) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        captureRemixServerException(err, name, args.request);
+        captureRemixServerException(err, name, args.request, true);
       }
 
       throw err;


### PR DESCRIPTION
Marks `isRemixV2` as optional in the exposed types of `captureRemixServerException`. 

This is a follow-up on https://github.com/getsentry/sentry-javascript/pull/12497