### PR TITLE
ci: Remove deprecated macos runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1476,20 +1476,6 @@ jobs:
             container: node:22-alpine3.18
             node: 22
 
-            # macos x64
-          - os: macos-11
-            node: 16
-            arch: x64
-          - os: macos-11
-            node: 18
-            arch: x64
-          - os: macos-11
-            node: 20
-            arch: x64
-          - os: macos-11
-            node: 22
-            arch: x64
-
             # macos arm64
           - os: macos-12
             arch: arm64


### PR DESCRIPTION
The release pipeline is currently failing due to scheduled fails for runners that use the `macos-11` image.

See: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal

Not sure if the fix here is just to remove them, but this would un-block the release pipeline for now.