### PR TITLE
fix(build) upgrade deprecated runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1477,33 +1477,33 @@ jobs:
             node: 22
 
             # macos x64
-          - os: macos-11
+          - os: macos-13
             node: 16
             arch: x64
-          - os: macos-11
+          - os: macos-13
             node: 18
             arch: x64
-          - os: macos-11
+          - os: macos-13
             node: 20
             arch: x64
-          - os: macos-11
+          - os: macos-13
             node: 22
             arch: x64
 
             # macos arm64
-          - os: macos-12
+          - os: macos-13
             arch: arm64
             node: 16
             target_platform: darwin
-          - os: macos-12
+          - os: macos-13
             arch: arm64
             node: 18
             target_platform: darwin
-          - os: macos-12
+          - os: macos-13
             arch: arm64
             node: 20
             target_platform: darwin
-          - os: macos-12
+          - os: macos-13
             arch: arm64
             node: 22
             target_platform: darwin


### PR DESCRIPTION
11 and 12 are soon to be [deprecated](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners) so we need to upgrade them