### PR TITLE
deps(nextjs): Remove react peer dep and allow rc

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -86,8 +86,7 @@
     "next": "13.2.0"
   },
   "peerDependencies": {
-    "next": "^13.2.0 || ^14.0",
-    "react": "16.x || 17.x || 18.x",
+    "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0",
     "webpack": ">= 5.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
The react peer dep is implicitly covered by the react SDK and we would like to allow the release candidates for next 15.