### PR TITLE
feat(node): Add `registerEsmLoaderHooks` option

### DIFF
--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -130,7 +130,7 @@ function _init(
     }
   }
 
-  if (!isCjs()) {
+  if (!isCjs() && options.registerEsmLoaderHooks !== false) {
     maybeInitializeEsmLoader();
   }
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -88,7 +88,8 @@ export interface BaseNodeOptions {
   /**
    * Whether to register ESM loader hooks to automatically instrument libraries.
    * This is necessary to auto instrument libraries that are loaded via ESM imports, but might it can cause issues
-   * with certain libraries.
+   * with certain libraries. If you run into problems running your app with this enabled,
+   * please raise an issue in https://github.com/getsentry/sentry-javascript.
    *
    * Defaults to `true`.
    */

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -85,6 +85,15 @@ export interface BaseNodeOptions {
    */
   maxSpanWaitDuration?: number;
 
+  /**
+   * Whether to register ESM loader hooks to automatically instrument libraries.
+   * This is necessary to auto instrument libraries that are loaded via ESM imports, but might it can cause issues
+   * with certain libraries.
+   *
+   * Defaults to `true`.
+   */
+  registerEsmLoaderHooks?: boolean;
+
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(this: void, error: Error): void;
 }


### PR DESCRIPTION
Currently the only way to disable ESM loader hook registration is to set:
```ts
globalThis._sentryEsmLoaderHookRegistered = true;
```

After this PR, you can set the new `registerEsmLoaderHooks` option to `false`:
```ts
import * as Sentry from '@sentry/node';

Sentry.init({
  dsn: '__DSN__', 
  registerEsmLoaderHooks: false,
});
```