### PR TITLE
Remove private namespace `JSX`

### DIFF
--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -16,6 +16,7 @@ import {
 import type { Client, Integration, Span, TransactionSource } from '@sentry/types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
+import type { ReactElement } from 'react';
 
 import type { Action, Location } from './types';
 
@@ -32,7 +33,7 @@ export type RouteConfig = {
   [propName: string]: unknown;
   path?: string | string[];
   exact?: boolean;
-  component?: JSX.Element;
+  component?: ReactElement;
   routes?: RouteConfig[];
 };
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,5 +1,6 @@
 // Disabling `no-explicit-any` for the whole file as `any` has became common requirement.
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ReactElement } from 'react';
 
 export type Action = 'PUSH' | 'REPLACE' | 'POP';
 
@@ -67,7 +68,7 @@ export type UseNavigationType = () => Action;
 // react-router > 6.0.0 and >= 6.4.2.
 export type RouteObjectArrayAlias = any;
 export type RouteMatchAlias = any;
-export type CreateRoutesFromChildren = (children: JSX.Element[]) => RouteObjectArrayAlias;
+export type CreateRoutesFromChildren = (children: ReactElement[]) => RouteObjectArrayAlias;
 export type MatchRoutes = (
   routes: RouteObjectArrayAlias,
   location: Location,


### PR DESCRIPTION
Using React 19 release candidate, I find that the `JSX` namespace is now private and cannot be used by dependencies. Doing so produces build errors:

```
.../Yarn/Berry/cache/@sentry-react-npm-8.13.0-bd23d3c2da-10c0.zip/node_modules/@sentry/react/build/types/reactrouter.d.ts:19:17 - error TS2503: Cannot find namespace 'JSX'.

19     component?: JSX.Element;
                   ~~~

.../Yarn/Berry/cache/@sentry-react-npm-8.13.0-bd23d3c2da-10c0.zip/node_modules/@sentry/react/build/types/types.d.ts:51:51 - error TS2503: Cannot find namespace 'JSX'.

51 export type CreateRoutesFromChildren = (children: JSX.Element[]) => RouteObjectArrayAlias;
                                                     ~~~

Found 2 errors in 2 files.
```

This PR addresses this issue by replacing `JSX.Element` with the public type `ReactElement`.