### PR TITLE
fix(nextjs): Attempt to ignore critical dependency warnings

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -404,6 +404,22 @@ export type NextConfigFunction = (
  * Webpack config
  */
 
+// Note: The interface for `ignoreWarnings` is larger but we only need this. See https://webpack.js.org/configuration/other-options/#ignorewarnings
+export type IgnoreWarningsOption = (
+  | { module?: RegExp; message?: RegExp }
+  | ((
+      webpackError: {
+        module?: {
+          readableIdentifier: (idontfuckingknow: unknown) => string;
+        };
+        message: string;
+      },
+      compilation: {
+        requestShortener: unknown;
+      },
+    ) => boolean)
+)[];
+
 // The two possible formats for providing custom webpack config in `next.config.js`
 export type WebpackConfigFunction = (config: WebpackConfigObject, options: BuildContext) => WebpackConfigObject;
 export type WebpackConfigObject = {
@@ -413,7 +429,7 @@ export type WebpackConfigObject = {
   output: { filename: string; path: string };
   target: string;
   context: string;
-  ignoreWarnings?: { module?: RegExp }[]; // Note: The interface for `ignoreWarnings` is larger but we only need this. See https://webpack.js.org/configuration/other-options/#ignorewarnings
+  ignoreWarnings?: IgnoreWarningsOption;
   resolve?: {
     modules?: string[];
     alias?: { [key: string]: string | boolean };

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -410,7 +410,7 @@ export type IgnoreWarningsOption = (
   | ((
       webpackError: {
         module?: {
-          readableIdentifier: (idontfuckingknow: unknown) => string;
+          readableIdentifier: (requestShortener: unknown) => string;
         };
         message: string;
       },


### PR DESCRIPTION
Attempts to reliably fix https://github.com/getsentry/sentry-javascript/issues/12077

It seems like we are not catching _some_ instances of the warning, but I would like to try this solution.