### PR TITLE
feat(nestjs): Filter 4xx errors

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/app.controller.ts
@@ -45,6 +45,11 @@ export class AppController1 {
     return this.appService.testException(id);
   }
 
+  @Get("test-expected-exception/:id")
+  async testExpectedException(@Param("id") id: string) {
+    return this.appService.testExpectedException(id);
+  }
+
   @Get('test-outgoing-fetch-external-allowed')
   async testOutgoingFetchExternalAllowed() {
     return this.appService.testOutgoingFetchExternalAllowed();

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/app.controller.ts
@@ -45,8 +45,8 @@ export class AppController1 {
     return this.appService.testException(id);
   }
 
-  @Get("test-expected-exception/:id")
-  async testExpectedException(@Param("id") id: string) {
+  @Get('test-expected-exception/:id')
+  async testExpectedException(@Param('id') id: string) {
     return this.appService.testExpectedException(id);
   }
 

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/app.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import * as Sentry from '@sentry/nestjs';
 import { makeHttpRequest } from './utils';
 
@@ -50,6 +50,10 @@ export class AppService1 {
 
   testException(id: string) {
     throw new Error(`This is an exception with id ${id}`);
+  }
+
+  testExpectedException(id: string) {
+    throw new HttpException(`This is an expected exception with id ${id}`, HttpStatus.FORBIDDEN);
   }
 
   async testOutgoingFetchExternalAllowed() {

--- a/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
@@ -40,21 +40,19 @@ test('Does not send expected exception to Sentry', async ({ baseURL }) => {
   });
 
   const transactionEventPromise = waitForTransaction('nestjs', transactionEvent => {
-    return (
-      transactionEvent?.transaction === 'GET /test-expected-exception/123'
-    );
+    return transactionEvent?.transaction === 'GET /test-expected-exception/123';
   });
 
-  console.log("fetch");
+  console.log('fetch');
 
   const response = await fetch(`${baseURL}/test-expected-exception/123`);
   expect(response.status).toBe(403);
 
-  console.log("fetch done");
+  console.log('fetch done');
 
   await transactionEventPromise;
 
-  console.log("resolved promise");
+  console.log('resolved promise');
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
@@ -40,19 +40,13 @@ test('Does not send expected exception to Sentry', async ({ baseURL }) => {
   });
 
   const transactionEventPromise = waitForTransaction('nestjs', transactionEvent => {
-    return transactionEvent?.transaction === 'GET /test-expected-exception/123';
+    return transactionEvent?.transaction === 'GET /test-expected-exception/:id';
   });
-
-  console.log('fetch');
 
   const response = await fetch(`${baseURL}/test-expected-exception/123`);
   expect(response.status).toBe(403);
 
-  console.log('fetch done');
-
   await transactionEventPromise;
-
-  console.log('resolved promise');
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
@@ -11,6 +11,9 @@ test('Sends exception to Sentry', async ({ baseURL }) => {
 
   const errorEvent = await errorEventPromise;
 
+  console.log("UNEXPECTED EXCEPTION");
+  console.log(errorEvent);
+
   expect(errorEvent.exception?.values).toHaveLength(1);
   expect(errorEvent.exception?.values?.[0]?.value).toBe('This is an exception with id 123');
 
@@ -27,4 +30,20 @@ test('Sends exception to Sentry', async ({ baseURL }) => {
     trace_id: expect.any(String),
     span_id: expect.any(String),
   });
+});
+
+test('Does not send expected exception to Sentry', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('nestjs', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'This is an unexpected exception with id 123';
+  });
+
+  const response = await fetch(`${baseURL}/test-expected-exception/123`);
+  expect(response.status).toBe(403);
+
+  const errorEvent = await errorEventPromise;
+
+  console.log("EXPECTED EXCEPTION");
+  console.log(errorEvent);
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
@@ -36,7 +36,8 @@ test('Does not send expected exception to Sentry', async ({ baseURL }) => {
     if (!event.type && event.exception?.values?.[0]?.value === 'This is an expected exception with id 123') {
       errorEventOccurred = true;
     }
-    return false;
+
+    return event?.transaction === 'GET /test-expected-exception/:id';
   });
 
   const transactionEventPromise = waitForTransaction('nestjs', transactionEvent => {
@@ -47,6 +48,8 @@ test('Does not send expected exception to Sentry', async ({ baseURL }) => {
   expect(response.status).toBe(403);
 
   await transactionEventPromise;
+
+  await new Promise((resolve) => setTimeout(resolve, 10000));
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
@@ -49,7 +49,7 @@ test('Does not send expected exception to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  await new Promise((resolve) => setTimeout(resolve, 10000));
+  await new Promise(resolve => setTimeout(resolve, 10000));
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/packages/node/src/integrations/tracing/nest.ts
+++ b/packages/node/src/integrations/tracing/nest.ts
@@ -100,6 +100,12 @@ export function setupNestErrorHandler(app: MinimalNestJsApp, baseFilter: NestJsE
         const originalCatch = Reflect.get(target, prop, receiver);
 
         return (exception: unknown, host: unknown) => {
+          const status_code = (exception as { status?: number }).status;
+
+          if (status_code !== undefined && status_code >= 400 && status_code < 500) { // don't report expected errors
+            return originalCatch.apply(target, [exception, host]);
+          }
+
           captureException(exception);
           return originalCatch.apply(target, [exception, host]);
         };

--- a/packages/node/src/integrations/tracing/nest.ts
+++ b/packages/node/src/integrations/tracing/nest.ts
@@ -102,7 +102,8 @@ export function setupNestErrorHandler(app: MinimalNestJsApp, baseFilter: NestJsE
         return (exception: unknown, host: unknown) => {
           const status_code = (exception as { status?: number }).status;
 
-          if (status_code !== undefined && status_code >= 400 && status_code < 500) { // don't report expected errors
+          // don't report expected errors
+          if (status_code !== undefined && status_code >= 400 && status_code < 500) {
             return originalCatch.apply(target, [exception, host]);
           }
 


### PR DESCRIPTION
Small change filtering expected errors from being reported to sentry in the nestjs sdk.

Tested manually on my sample app.

Fixes https://github.com/getsentry/sentry-javascript/issues/12523