### PR TITLE
test: Fix tsconfig for browser-integration-tests

### DIFF
--- a/dev-packages/browser-integration-tests/tsconfig.json
+++ b/dev-packages/browser-integration-tests/tsconfig.json
@@ -6,8 +6,9 @@
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "noUncheckedIndexedAccess": false
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "suites", "loader-suites"]
+  "exclude": ["node_modules"]
 }

--- a/dev-packages/browser-integration-tests/tsconfig.json
+++ b/dev-packages/browser-integration-tests/tsconfig.json
@@ -9,5 +9,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "suites", "loader-suites"]
 }


### PR DESCRIPTION
Not sure how this worked before, but there was a bunch of stuff that conflicted with `noUncheckedIndexedAccess` :thinking:

Noticed this locally when running browser integration tests now.
