### PR TITLE
feat(core): Adapt spans for client-side fetch to streaming responses

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -15,7 +15,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration'),
     gzip: true,
-    limit: '35 KB',
+    limit: '36 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay)',
@@ -29,7 +29,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration'),
     gzip: true,
-    limit: '65 KB',
+    limit: '66 KB',
     modifyWebpackConfig: function (config) {
       const webpack = require('webpack');
       config.plugins.push(

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -48,14 +48,14 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'replayCanvasIntegration'),
     gzip: true,
-    limit: '76 KB',
+    limit: '77 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'feedbackIntegration'),
     gzip: true,
-    limit: '89 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback, metrics)',
@@ -107,7 +107,7 @@ module.exports = [
     import: createImport('init', 'ErrorBoundary', 'reactRouterV6BrowserTracingIntegration'),
     ignore: ['react/jsx-runtime'],
     gzip: true,
-    limit: '38 KB',
+    limit: '39 KB',
   },
   // Vue SDK (ESM)
   {

--- a/dev-packages/e2e-tests/test-applications/react-router-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/package.json
@@ -46,7 +46,8 @@
   "devDependencies": {
     "@playwright/test": "^1.44.1",
     "@sentry-internal/test-utils": "link:../../../test-utils",
-    "serve": "14.0.1"
+    "serve": "14.0.1",
+    "npm-run-all2": "^6.2.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/react-router-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/package.json
@@ -6,6 +6,7 @@
     "@sentry/react": "latest || *",
     "@types/react": "18.0.0",
     "@types/react-dom": "18.0.0",
+    "express": "4.19.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "^6.4.1",
@@ -14,7 +15,7 @@
   },
   "scripts": {
     "build": "react-scripts build",
-    "start": "serve -s build",
+    "start": "concurrently \"node server/app.js\" \"serve -s build\"",
     "test": "playwright test",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "test:build": "pnpm install && npx playwright install && pnpm build",
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@playwright/test": "^1.44.1",
     "@sentry-internal/test-utils": "link:../../../test-utils",
+    "concurrently": "^8.2.2",
     "serve": "14.0.1"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/react-router-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/package.json
@@ -15,7 +15,9 @@
   },
   "scripts": {
     "build": "react-scripts build",
-    "start": "concurrently \"node server/app.js\" \"serve -s build\"",
+    "start": "run-p start:client start:server",
+    "start:client": "node server/app.js",
+    "start:server": "serve -s build",
     "test": "playwright test",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "test:build": "pnpm install && npx playwright install && pnpm build",
@@ -44,7 +46,6 @@
   "devDependencies": {
     "@playwright/test": "^1.44.1",
     "@sentry-internal/test-utils": "link:../../../test-utils",
-    "concurrently": "^8.2.2",
     "serve": "14.0.1"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/react-router-6/server/app.js
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/server/app.js
@@ -11,7 +11,7 @@ const wait = time => {
   });
 };
 
-async function eventsHandler(request, response) {
+async function sseHandler(request, response, timeout = false) {
   response.headers = {
     'Content-Type': 'text/event-stream',
     Connection: 'keep-alive',
@@ -30,12 +30,17 @@ async function eventsHandler(request, response) {
 
   for (let index = 0; index < 10; index++) {
     response.write(`data: ${new Date().toISOString()}\n\n`);
+    if (timeout) {
+      await wait(10000);
+    }
   }
 
   response.end();
 }
 
-app.get('/sse', eventsHandler);
+app.get('/sse', (req, res) => sseHandler(req, res));
+
+app.get('/sse-timeout', (req, res) => sseHandler(req, res, true));
 
 app.listen(PORT, () => {
   console.log(`SSE service listening at http://localhost:${PORT}`);

--- a/dev-packages/e2e-tests/test-applications/react-router-6/server/app.js
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/server/app.js
@@ -1,0 +1,42 @@
+const express = require('express');
+
+const app = express();
+const PORT = 8080;
+
+const wait = time => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, time);
+  });
+};
+
+async function eventsHandler(request, response) {
+  response.headers = {
+    'Content-Type': 'text/event-stream',
+    Connection: 'keep-alive',
+    'Cache-Control': 'no-cache',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  response.setHeader('Cache-Control', 'no-cache');
+  response.setHeader('Content-Type', 'text/event-stream');
+  response.setHeader('Access-Control-Allow-Origin', '*');
+  response.setHeader('Connection', 'keep-alive');
+
+  response.flushHeaders();
+
+  await wait(2000);
+
+  for (let index = 0; index < 10; index++) {
+    response.write(`data: ${new Date().toISOString()}\n\n`);
+  }
+
+  response.end();
+}
+
+app.get('/sse', eventsHandler);
+
+app.listen(PORT, () => {
+  console.log(`SSE service listening at http://localhost:${PORT}`);
+});

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/index.tsx
@@ -11,6 +11,7 @@ import {
   useNavigationType,
 } from 'react-router-dom';
 import Index from './pages/Index';
+import SSE from './pages/SSE';
 import User from './pages/User';
 
 const replay = Sentry.replayIntegration();
@@ -48,6 +49,7 @@ root.render(
     <SentryRoutes>
       <Route path="/" element={<Index />} />
       <Route path="/user/:id" element={<User />} />
+      <Route path="/sse" element={<SSE />} />
     </SentryRoutes>
   </BrowserRouter>,
 );

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/SSE.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/SSE.tsx
@@ -2,10 +2,11 @@ import * as Sentry from '@sentry/react';
 // biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
-const fetchSSE = async () => {
+const fetchSSE = async ({ timeout }: { timeout: boolean }) => {
   Sentry.startSpanManual({ name: 'sse stream using fetch' }, async span => {
     const res = await Sentry.startSpan({ name: 'sse fetch call' }, async () => {
-      return await fetch('http://localhost:8080/sse');
+      const endpoint = `http://localhost:8080/${timeout ? 'sse-timeout' : 'sse'}`;
+      return await fetch(endpoint);
     });
 
     const stream = res.body;
@@ -34,9 +35,14 @@ const fetchSSE = async () => {
 
 const SSE = () => {
   return (
-    <button id="fetch-button" onClick={fetchSSE}>
-      Fetch SSE
-    </button>
+    <>
+      <button id="fetch-button" onClick={() => fetchSSE({ timeout: false })}>
+        Fetch SSE
+      </button>
+      <button id="fetch-timeout-button" onClick={() => fetchSSE({ timeout: true })}>
+        Fetch timeout SSE
+      </button>
+    </>
   );
 };
 

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/SSE.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/SSE.tsx
@@ -1,0 +1,43 @@
+import * as Sentry from '@sentry/react';
+// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
+import * as React from 'react';
+
+const fetchSSE = async () => {
+  Sentry.startSpanManual({ name: 'sse stream using fetch' }, async span => {
+    const res = await Sentry.startSpan({ name: 'sse fetch call' }, async () => {
+      return await fetch('http://localhost:8080/sse');
+    });
+
+    const stream = res.body;
+    const reader = stream?.getReader();
+
+    const readChunk = async () => {
+      const readRes = await reader?.read();
+      if (readRes?.done) {
+        return;
+      }
+
+      new TextDecoder().decode(readRes?.value);
+
+      await readChunk();
+    };
+
+    try {
+      await readChunk();
+    } catch (error) {
+      console.error('Could not fetch sse', error);
+    }
+
+    span.end();
+  });
+};
+
+const SSE = () => {
+  return (
+    <button id="fetch-button" onClick={fetchSSE}>
+      Fetch SSE
+    </button>
+  );
+};
+
+export default SSE;

--- a/dev-packages/e2e-tests/test-applications/react-router-6/tests/sse.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/tests/sse.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+import { SpanJSON } from '@sentry/types';
+
+test('Waits for sse streaming when creating spans', async ({ page }) => {
+  await page.goto('/sse');
+
+  const transactionPromise = waitForTransaction('react-router-6', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  });
+
+  const fetchButton = page.locator('id=fetch-button');
+  await fetchButton.click();
+
+  const rootSpan = await transactionPromise;
+  const sseFetchCall = rootSpan.spans?.filter(span => span.description === 'sse fetch call')[0] as SpanJSON;
+  const httpGet = rootSpan.spans?.filter(span => span.description === 'GET http://localhost:8080/sse')[0] as SpanJSON;
+
+  expect(sseFetchCall).not.toBeUndefined();
+  expect(httpGet).not.toBeUndefined();
+
+  expect(sseFetchCall?.timestamp).not.toBeUndefined();
+  expect(sseFetchCall?.start_timestamp).not.toBeUndefined();
+  expect(httpGet?.timestamp).not.toBeUndefined();
+  expect(httpGet?.start_timestamp).not.toBeUndefined();
+
+  // http headers get sent instantly from the server
+  const resolveDuration = Math.round((sseFetchCall.timestamp as number) - sseFetchCall.start_timestamp);
+
+  // body streams after 2s
+  const resolveBodyDuration = Math.round((httpGet.timestamp as number) - httpGet.start_timestamp);
+
+  expect(resolveDuration).toBe(0);
+  expect(resolveBodyDuration).toBe(2);
+});

--- a/dev-packages/e2e-tests/test-applications/react-router-6/tests/sse.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/tests/sse.test.ts
@@ -16,13 +16,13 @@ test('Waits for sse streaming when creating spans', async ({ page }) => {
   const sseFetchCall = rootSpan.spans?.filter(span => span.description === 'sse fetch call')[0] as SpanJSON;
   const httpGet = rootSpan.spans?.filter(span => span.description === 'GET http://localhost:8080/sse')[0] as SpanJSON;
 
-  expect(sseFetchCall).not.toBeUndefined();
-  expect(httpGet).not.toBeUndefined();
+  expect(sseFetchCall).toBeDefined();
+  expect(httpGet).toBeDefined();
 
-  expect(sseFetchCall?.timestamp).not.toBeUndefined();
-  expect(sseFetchCall?.start_timestamp).not.toBeUndefined();
-  expect(httpGet?.timestamp).not.toBeUndefined();
-  expect(httpGet?.start_timestamp).not.toBeUndefined();
+  expect(sseFetchCall?.timestamp).toBeDefined();
+  expect(sseFetchCall?.start_timestamp).toBeDefined();
+  expect(httpGet?.timestamp).toBeDefined();
+  expect(httpGet?.start_timestamp).toBeDefined();
 
   // http headers get sent instantly from the server
   const resolveDuration = Math.round((sseFetchCall.timestamp as number) - sseFetchCall.start_timestamp);
@@ -50,13 +50,13 @@ test('Aborts when stream takes longer than 5s', async ({ page }) => {
     span => span.description === 'GET http://localhost:8080/sse-timeout',
   )[0] as SpanJSON;
 
-  expect(sseFetchCall).not.toBeUndefined();
-  expect(httpGet).not.toBeUndefined();
+  expect(sseFetchCall).toBeDefined();
+  expect(httpGet).toBeDefined();
 
-  expect(sseFetchCall?.timestamp).not.toBeUndefined();
-  expect(sseFetchCall?.start_timestamp).not.toBeUndefined();
-  expect(httpGet?.timestamp).not.toBeUndefined();
-  expect(httpGet?.start_timestamp).not.toBeUndefined();
+  expect(sseFetchCall?.timestamp).toBeDefined();
+  expect(sseFetchCall?.start_timestamp).toBeDefined();
+  expect(httpGet?.timestamp).toBeDefined();
+  expect(httpGet?.start_timestamp).toBeDefined();
 
   // http headers get sent instantly from the server
   const resolveDuration = Math.round((sseFetchCall.timestamp as number) - sseFetchCall.start_timestamp);

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -398,7 +398,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         registerInpInteractionListener();
       }
 
-      instrumentOutgoingRequests({
+      instrumentOutgoingRequests(client, {
         traceFetch,
         traceXHR,
         tracePropagationTargets: client.getOptions().tracePropagationTargets,

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -121,7 +121,8 @@ export function instrumentOutgoingRequests(_options?: Partial<RequestInstrumenta
 
   if (traceFetch) {
     if (client) {
-      // Keeping track of http requests, whose body payloads resolved later than the intial resolved request (e.g. SSE)
+      // Keeping track of http requests, whose body payloads resolved later than the intial resolved request
+      // e.g. streaming using server sent events (SSE)
       client.addEventProcessor(event => {
         if (event.type === 'transaction' && event.spans) {
           event.spans.forEach(span => {

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -127,7 +127,7 @@ export function instrumentOutgoingRequests(_options?: Partial<RequestInstrumenta
           event.spans.forEach(span => {
             if (span.op === 'http.client') {
               const updatedTimestamp = spanIdToEndTimestamp.get(span.span_id);
-              if (updatedTimestamp !== undefined) {
+              if (updatedTimestamp) {
                 span.timestamp = updatedTimestamp / 1000;
                 spanIdToEndTimestamp.delete(span.span_id);
               }

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -60,7 +60,7 @@ describe('browserTracingIntegration', () => {
       return createdRootSpan as Span;
     });
 
-  const fakeClient = { getOptions: () => ({}), on: () => {} };
+  const fakeClient = { getOptions: () => ({}), on: () => {}, addEventProcessor: () => {} };
 
   const mockedRoutingSpan = {
     end: () => {},

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -1,9 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { HandlerDataFetch } from '@sentry/types';
 
-import { DEBUG_BUILD } from '../debug-build';
 import { isError } from '../is';
-import { logger } from '../logger';
 import { addNonEnumerableProperty, fill } from '../object';
 import { supportsNativeFetch } from '../supports';
 import { timestampInSeconds } from '../time';
@@ -82,7 +80,6 @@ function instrumentFetch(handlerType: 'fetch' | 'fetch-body-resolved'): void {
               clonedResponseForResolving = response.clone();
             } catch (e) {
               // noop
-              DEBUG_BUILD && logger.warn('Failed to clone response body.');
             }
 
             await resolveResponse(clonedResponseForResolving, () => {

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -55,7 +55,7 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void): void {
         startTimestamp: timestampInSeconds() * 1000,
       };
 
-      // if there is no callback, fetch is instrumented
+      // if there is no callback, fetch is instrumented directly
       if (!onFetchResolved) {
         triggerHandlers('fetch', {
           ...handlerData,

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -38,7 +38,6 @@ export function addFetchEndInstrumentationHandler(handler: (data: HandlerDataFet
   maybeInstrument(type, () => instrumentFetch(streamHandler));
 }
 
-// function instrumentFetch(handlerType: 'fetch' | 'fetch-body-resolved'): void {
 function instrumentFetch(onFetchResolved?: (response: Response) => void): void {
   if (!supportsNativeFetch()) {
     return;

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -27,7 +27,7 @@ export function addFetchInstrumentationHandler(handler: (data: HandlerDataFetch)
 }
 
 /**
- * Add an instrumentation handler for long-lived fetch requests, like consuming SSE via fetch.
+ * Add an instrumentation handler for long-lived fetch requests, like consuming server-sent events (SSE) via fetch.
  * The handler will resolve the request body and emit the actual `endTimestamp`, so that the
  * span can be updated accordingly.
  *

--- a/packages/utils/src/instrument/handlers.ts
+++ b/packages/utils/src/instrument/handlers.ts
@@ -2,7 +2,15 @@ import { DEBUG_BUILD } from '../debug-build';
 import { logger } from '../logger';
 import { getFunctionName } from '../stacktrace';
 
-export type InstrumentHandlerType = 'console' | 'dom' | 'fetch' | 'history' | 'xhr' | 'error' | 'unhandledrejection';
+export type InstrumentHandlerType =
+  | 'console'
+  | 'dom'
+  | 'fetch'
+  | 'fetch-body-resolved'
+  | 'history'
+  | 'xhr'
+  | 'error'
+  | 'unhandledrejection';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type InstrumentHandlerCallback = (data: any) => void;
 

--- a/packages/utils/src/instrument/index.ts
+++ b/packages/utils/src/instrument/index.ts
@@ -1,5 +1,5 @@
 import { addConsoleInstrumentationHandler } from './console';
-import { addFetchInstrumentationHandler } from './fetch';
+import { addFetchEndInstrumentationHandler, addFetchInstrumentationHandler } from './fetch';
 import { addGlobalErrorInstrumentationHandler } from './globalError';
 import { addGlobalUnhandledRejectionInstrumentationHandler } from './globalUnhandledRejection';
 import { addHandler, maybeInstrument, resetInstrumentationHandlers, triggerHandlers } from './handlers';
@@ -14,4 +14,5 @@ export {
   triggerHandlers,
   // Only exported for tests
   resetInstrumentationHandlers,
+  addFetchEndInstrumentationHandler,
 };


### PR DESCRIPTION
This PR makes spans for client-side fetch calls more accurate by cloning the response and adapting the span `endTimestamp` when the stream has been resolved.

fixes [#12640](https://github.com/getsentry/sentry-javascript/issues/12640)