### PR TITLE
ci: Refactor/fix external contribution handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,44 +229,6 @@ jobs:
           message: |
             ⚠️ This PR is opened against **master**. You probably want to open it against **develop**.
 
-  job_external_contributor:
-    name: External Contributors
-    needs: job_install_deps
-    runs-on: ubuntu-20.04
-    if: |
-      github.event_name == 'pull_request'
-      && (github.event.action == 'opened' || github.event.action == 'reopened')
-      && github.event.pull_request.author_association != 'COLLABORATOR'
-      && github.event.pull_request.author_association != 'MEMBER'
-      && github.event.pull_request.author_association != 'OWNER'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-      - name: Check dependency cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
-          fail-on-cache-miss: true
-
-      - name: Add external contributor to CHANGELOG.md
-        uses: ./dev-packages/external-contributor-gh-action
-        with:
-          name: ${{ github.event.pull_request.user.login }}
-      - name: Create PR with changes
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "ref: Add external contributor to CHANGELOG.md"
-          title: "ref: Add external contributor to CHANGELOG.md"
-          branch: 'external-contributor/patch-${{ github.event.pull_request.user.login }}'
-          delete-branch: true
-          body: This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution.
-
   job_build:
     name: Build
     needs: [job_get_metadata, job_install_deps]

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -1,11 +1,19 @@
 name: "CI: Mention external contributors"
 on:
   pull_request:
+    types:
+      - closed
+    branches:
+      - develop
 
 jobs:
   external_contributor:
     name: External Contributors
     runs-on: ubuntu-20.04
+    if: |
+      github.event.pull_request.author_association != 'COLLABORATOR'
+      && github.event.pull_request.author_association != 'MEMBER'
+      && github.event.pull_request.author_association != 'OWNER'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -1,10 +1,6 @@
 name: "CI: Mention external contributors"
 on:
   pull_request:
-    types:
-      - closed
-    branches:
-      - develop
 
 env:
   NX_CACHE_RESTORE_KEYS: |
@@ -16,10 +12,6 @@ jobs:
   external_contributor:
     name: External Contributors
     runs-on: ubuntu-20.04
-    if: |
-      github.event.pull_request.author_association != 'COLLABORATOR'
-      && github.event.pull_request.author_association != 'MEMBER'
-      && github.event.pull_request.author_association != 'OWNER'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -2,12 +2,6 @@ name: "CI: Mention external contributors"
 on:
   pull_request:
 
-env:
-  NX_CACHE_RESTORE_KEYS: |
-    nx-Linux-${{ github.ref }}-${{ github.sha }}
-    nx-Linux-${{ github.ref }}
-    nx-Linux
-
 jobs:
   external_contributor:
     name: External Contributors
@@ -24,12 +18,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: NX cache
-        uses: actions/cache/restore@v4
-        with:
-          path: .nxcache
-          key: nx-Linux-${{ github.ref }}-${{ github.sha }}
-          restore-keys: ${{ env.NX_CACHE_RESTORE_KEYS }}
 
       - name: Add external contributor to CHANGELOG.md
         uses: ./dev-packages/external-contributor-gh-action

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -1,0 +1,54 @@
+name: "CI: Mention external contributors"
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - develop
+
+env:
+  NX_CACHE_RESTORE_KEYS: |
+    nx-Linux-${{ github.ref }}-${{ github.sha }}
+    nx-Linux-${{ github.ref }}
+    nx-Linux
+
+jobs:
+  external_contributor:
+    name: External Contributors
+    runs-on: ubuntu-20.04
+    if: |
+      github.event.pull_request.author_association != 'COLLABORATOR'
+      && github.event.pull_request.author_association != 'MEMBER'
+      && github.event.pull_request.author_association != 'OWNER'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: NX cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .nxcache
+          key: nx-Linux-${{ github.ref }}-${{ github.sha }}
+          restore-keys: ${{ env.NX_CACHE_RESTORE_KEYS }}
+
+      - name: Add external contributor to CHANGELOG.md
+        uses: ./dev-packages/external-contributor-gh-action
+        with:
+          name: ${{ github.event.pull_request.user.login }}
+      - name: Create PR with changes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "ref: Add external contributor to CHANGELOG.md"
+          title: "ref: Add external contributor to CHANGELOG.md"
+          branch: 'external-contributor/patch-${{ github.event.pull_request.user.login }}'
+          delete-branch: true
+          body: This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution.
+

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -29,6 +29,7 @@ jobs:
           commit-message: "ref: Add external contributor to CHANGELOG.md"
           title: "ref: Add external contributor to CHANGELOG.md"
           branch: 'external-contributor/patch-${{ github.event.pull_request.user.login }}'
+          base: 'develop'
           delete-branch: true
           body: This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution.
 

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -14,6 +14,7 @@ jobs:
       github.event.pull_request.author_association != 'COLLABORATOR'
       && github.event.pull_request.author_association != 'MEMBER'
       && github.event.pull_request.author_association != 'OWNER'
+      && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +33,7 @@ jobs:
         with:
           name: ${{ github.event.pull_request.user.login }}
       - name: Create PR with changes
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           commit-message: "ref: Add external contributor to CHANGELOG.md"
           title: "ref: Add external contributor to CHANGELOG.md"


### PR DESCRIPTION
This should fix the old behavior...

previously, we made a PR against a PR branch when we detected that it was opened by an external contributor. This is problematic, turns out, because external contributors will usually have a fork of the repo and thus the action will fail.

Now, instead, we will make a PR against develop when a contributor PR is _merged_.

See example PR: https://github.com/getsentry/sentry-javascript/pull/12728