### PR TITLE
build: Bump yarn to `1.22.22` and pnpm to `9.4.0`

### DIFF
--- a/dev-packages/e2e-tests/package.json
+++ b/dev-packages/e2e-tests/package.json
@@ -27,6 +27,6 @@
   },
   "volta": {
     "extends": "../../package.json",
-    "pnpm": "8.15.8"
+    "pnpm": "9.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "volta": {
     "node": "18.20.3",
-    "yarn": "1.22.19"
+    "yarn": "1.22.22"
   },
   "workspaces": [
     "packages/angular",


### PR DESCRIPTION
This is just used internally, but we may as well be up to date there.