### PR TITLE
test: Fix e2e test race condition by buffering events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
               - 'packages/rollup-utils/**'
               - 'packages/utils/**'
               - 'packages/types/**'
+              - 'dev-packages/test-utils/**'
             browser: &browser
               - *shared
               - 'packages/browser/**'

--- a/dev-packages/e2e-tests/test-applications/react-router-6/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/tests/transactions.test.ts
@@ -56,7 +56,7 @@ test('sends a navigation transaction with a parameterized URL', async ({ page })
 });
 
 test('sends an INP span', async ({ page }) => {
-  const inpSpanPromise = waitForEnvelopeItem('react-router-6', item => {
+  const inpSpanPromise = waitForEnvelopeItem('react-router-6', Date.now(), item => {
     return item[0].type === 'span';
   });
 

--- a/dev-packages/e2e-tests/test-applications/react-router-6/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/tests/transactions.test.ts
@@ -56,7 +56,7 @@ test('sends a navigation transaction with a parameterized URL', async ({ page })
 });
 
 test('sends an INP span', async ({ page }) => {
-  const inpSpanPromise = waitForEnvelopeItem('react-router-6', Date.now(), item => {
+  const inpSpanPromise = waitForEnvelopeItem('react-router-6', item => {
     return item[0].type === 'span';
   });
 

--- a/dev-packages/test-utils/src/event-proxy-server.ts
+++ b/dev-packages/test-utils/src/event-proxy-server.ts
@@ -138,7 +138,7 @@ export async function startProxyServer(
     eventCallbackListeners.add(callbackListener);
 
     eventBuffer.forEach(bufferedEvent => {
-      if (bufferedEvent.timestamp > listenerTimestamp) {
+      if (bufferedEvent.timestamp >= listenerTimestamp) {
         callbackListener(bufferedEvent.data);
       }
     });


### PR DESCRIPTION
Makes e2e tests less flakey by adding an event buffer that is used to send events to callback listeners that have not managed to connect in time for a particular events.

We do this by letting the event listeners also send along a timestamp from which point onwards they would like to receive events.

The race condition would have happened when a listener is registered and an event is triggered right after, meaning the event would escape the provided callback because the listener hasn't connected yet. Slim chance but happens.

We will consume more memory by buffering but it is hopefully managable. GH runners are free right?