### PR TITLE
Revert "build: Bump yarn to `1.22.22` and pnpm to `9.4.0`"

### DIFF
--- a/dev-packages/e2e-tests/package.json
+++ b/dev-packages/e2e-tests/package.json
@@ -27,6 +27,6 @@
   },
   "volta": {
     "extends": "../../package.json",
-    "pnpm": "9.4.0"
+    "pnpm": "8.15.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "volta": {
     "node": "18.20.3",
-    "yarn": "1.22.22"
+    "yarn": "1.22.19"
   },
   "workspaces": [
     "packages/angular",


### PR DESCRIPTION
Reverts getsentry/sentry-javascript#12731

It seems to fail the remix tests?