### PR TITLE
Revert "fix(remix): add esm export for node"

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -28,9 +28,6 @@
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"
       },
-      "import": {
-        "default": "./build/esm/index.server.js"
-      },
       "node": "./build/cjs/index.server.js"
     },
     "./import": {


### PR DESCRIPTION
Reverts getsentry/sentry-javascript#12663

This seems to break the e2e tests.