### PR TITLE
ci: Fix external contributor workflow

### DIFF
--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -17,8 +17,6 @@ jobs:
       && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: Set up Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This failed (again) here: https://github.com/getsentry/sentry-javascript/actions/runs/9791997167/job/27036907594

Hopefully this fixes it...