### PR TITLE
feat(node): Allow to pass instrumentation config to `httpIntegration`

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -1,6 +1,6 @@
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-describe('express tracing experimental', () => {
+describe('express tracing', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-experimental.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-experimental.js
@@ -1,0 +1,38 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  // disable attaching headers to /test/* endpoints
+  tracePropagationTargets: [/^(?!.*test).*$/],
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+
+  integrations: [
+    Sentry.httpIntegration({
+      instrumentation: {
+        _experimentalConfig: {
+          serverName: 'sentry-test-server-name',
+        },
+      },
+    }),
+  ],
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+const cors = require('cors');
+const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+
+const app = express();
+
+app.use(cors());
+
+app.get('/test', (_req, res) => {
+  res.send({ response: 'response 1' });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server.js
@@ -1,0 +1,58 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  // disable attaching headers to /test/* endpoints
+  tracePropagationTargets: [/^(?!.*test).*$/],
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+
+  integrations: [
+    Sentry.httpIntegration({
+      instrumentation: {
+        requestHook: (span, req) => {
+          span.setAttribute('attr1', 'yes');
+          Sentry.setExtra('requestHookCalled', {
+            url: req.url,
+            method: req.method,
+          });
+        },
+        responseHook: (span, res) => {
+          span.setAttribute('attr2', 'yes');
+          Sentry.setExtra('responseHookCalled', {
+            url: res.req.url,
+            method: res.req.method,
+          });
+        },
+        applyCustomAttributesOnSpan: (span, req, res) => {
+          span.setAttribute('attr3', 'yes');
+          Sentry.setExtra('applyCustomAttributesOnSpanCalled', {
+            reqUrl: req.url,
+            reqMethod: req.method,
+            resUrl: res.req.url,
+            resMethod: res.req.method,
+          });
+        },
+      },
+    }),
+  ],
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+const cors = require('cors');
+const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+
+const app = express();
+
+app.use(cors());
+
+app.get('/test', (_req, res) => {
+  res.send({ response: 'response 1' });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
@@ -6,6 +6,13 @@ describe('httpIntegration', () => {
   });
 
   test('allows to pass instrumentation options to integration', done => {
+    // response shape seems different on Node 14, so we skip this there
+    const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
+    if (nodeMajorVersion <= 14) {
+      done();
+      return;
+    }
+
     createRunner(__dirname, 'server.js')
       .ignore('session', 'sessions')
       .expect({

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
@@ -1,0 +1,73 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+describe('httpIntegration', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  test('allows to pass instrumentation options to integration', done => {
+    createRunner(__dirname, 'server.js')
+      .ignore('session', 'sessions')
+      .expect({
+        transaction: {
+          contexts: {
+            trace: {
+              span_id: expect.any(String),
+              trace_id: expect.any(String),
+              data: {
+                url: expect.stringMatching(/\/test$/),
+                'http.response.status_code': 200,
+                attr1: 'yes',
+                attr2: 'yes',
+                attr3: 'yes',
+              },
+              op: 'http.server',
+              status: 'ok',
+            },
+          },
+          extra: {
+            requestHookCalled: {
+              url: expect.stringMatching(/\/test$/),
+              method: 'GET',
+            },
+            responseHookCalled: {
+              url: expect.stringMatching(/\/test$/),
+              method: 'GET',
+            },
+            applyCustomAttributesOnSpanCalled: {
+              reqUrl: expect.stringMatching(/\/test$/),
+              reqMethod: 'GET',
+              resUrl: expect.stringMatching(/\/test$/),
+              resMethod: 'GET',
+            },
+          },
+        },
+      })
+      .start(done)
+      .makeRequest('get', '/test');
+  });
+
+  test('allows to pass experimental config through to integration', done => {
+    createRunner(__dirname, 'server-experimental.js')
+      .ignore('session', 'sessions')
+      .expect({
+        transaction: {
+          contexts: {
+            trace: {
+              span_id: expect.any(String),
+              trace_id: expect.any(String),
+              data: {
+                url: expect.stringMatching(/\/test$/),
+                'http.response.status_code': 200,
+                'http.server_name': 'sentry-test-server-name',
+              },
+              op: 'http.server',
+              status: 'ok',
+            },
+          },
+        },
+      })
+      .start(done)
+      .makeRequest('get', '/test');
+  });
+});

--- a/packages/nextjs/src/server/httpIntegration.ts
+++ b/packages/nextjs/src/server/httpIntegration.ts
@@ -22,19 +22,7 @@ class CustomNextjsHttpIntegration extends HttpInstrumentation {
   }
 }
 
-interface HttpOptions {
-  /**
-   * Whether breadcrumbs should be recorded for requests.
-   * Defaults to true
-   */
-  breadcrumbs?: boolean;
-
-  /**
-   * Do not capture spans or breadcrumbs for outgoing HTTP requests to URLs where the given callback returns `true`.
-   * This controls both span & breadcrumb creation - spans will be non recording if tracing is disabled.
-   */
-  ignoreOutgoingRequests?: (url: string) => boolean;
-}
+type HttpOptions = Parameters<typeof originalHttpIntegration>[0];
 
 /**
  * The http integration instruments Node's internal http and https modules.

--- a/packages/remix/src/utils/integrations/http.ts
+++ b/packages/remix/src/utils/integrations/http.ts
@@ -16,19 +16,7 @@ class RemixHttpIntegration extends HttpInstrumentation {
   }
 }
 
-interface HttpOptions {
-  /**
-   * Whether breadcrumbs should be recorded for requests.
-   * Defaults to true
-   */
-  breadcrumbs?: boolean;
-
-  /**
-   * Do not capture spans or breadcrumbs for outgoing HTTP requests to URLs where the given callback returns `true`.
-   * This controls both span & breadcrumb creation - spans will be non recording if tracing is disabled.
-   */
-  ignoreOutgoingRequests?: (url: string) => boolean;
-}
+type HttpOptions = Parameters<typeof originalHttpIntegration>[0];
 
 /**
  * The http integration instruments Node's internal http and https modules.


### PR DESCRIPTION
Today, it is not (easily) possible to use custom config for the OTEL HttpInstrumentation. We depend on our own integration for various things, so overwriting this will lead to lots of problems.

With this PR, you can now pass some config through directly, in an "allowlisted" way, + there is an escape hatch to add arbitrary other config:

```js
Sentry.init({
  integrations: [
    Sentry.httpIntegration({ instrumentation: {
      // these three are "vetted"
      requestHook: (span, req) => span.setAttribute('custom', req.method),
      responseHook: (span, res) => span.setAttribute('custom', res.method),
      applyCustomAttributesOnSpan: (span, req, res) => span.setAttribute('custom', req.method),
      // escape hatch: Can add arbitrary other config that is passed through
      _experimentalConfig: {
        serverName: 'xxx'
      }
    })
  ]
});
```

Closes https://github.com/getsentry/sentry-javascript/issues/12672