### PR TITLE
fix(core): Pass origin as referrer for `lazyLoadIntegration`

### DIFF
--- a/packages/browser/src/utils/lazyLoadIntegration.ts
+++ b/packages/browser/src/utils/lazyLoadIntegration.ts
@@ -51,6 +51,7 @@ export async function lazyLoadIntegration(name: keyof typeof LazyLoadableIntegra
   const script = WINDOW.document.createElement('script');
   script.src = url;
   script.crossOrigin = 'anonymous';
+  script.referrerPolicy = 'origin';
 
   const waitForLoad = new Promise<void>((resolve, reject) => {
     script.addEventListener('load', () => resolve());


### PR DESCRIPTION
I was referred by support team to this repository in order to suggest a fix for an issue we encountered. In our case the referrer is not passed to the feedback script and thus results in a 403 (because we set allowed domains in our project settings). Consequently also the modal doesn't open and it's a bit disappointing for us since we would like to use the feature.
