### PR TITLE
fix(deno): Publish from build directory

### DIFF
--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -41,7 +41,7 @@
     "build:types": "run-s deno-types build:types:tsc build:types:bundle",
     "build:types:tsc": "tsc -p tsconfig.types.json",
     "build:types:bundle": "rollup -c rollup.types.config.mjs",
-    "build:tarball": "node ./scripts/prepack.js && npm pack",
+    "build:tarball": "node ./scripts/prepack.js && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf build build-types build-test coverage sentry-deno-*.tgz",
     "prefix": "yarn deno-types",
@@ -55,7 +55,7 @@
     "test:types": "deno check ./build/index.mjs",
     "test:unit": "deno test --allow-read --allow-run",
     "test:unit:update": "deno test --allow-read --allow-write --allow-run -- --update",
-    "yalc:publish": "node ./scripts/prepack.js && yalc publish --push --sig"
+    "yalc:publish": "node ./scripts/prepack.js && yalc publish build --push --sig"
   },
   "volta": {
     "extends": "../../package.json"


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/12700 I adjusted the prepack script to bring back the build directory, but I forgot to adjust `npm pack X` to make sure we pack the tarball from the `build` directory. This patch fixes that.