### PR TITLE
ci: Fix permissions for external contributors PRs (for real?)

### DIFF
--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   external_contributor:
     name: External Contributors
+    permissions:
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-20.04
     if: |
       github.event.pull_request.author_association != 'COLLABORATOR'

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -14,6 +14,7 @@ jobs:
       contents: write
     runs-on: ubuntu-20.04
     if: |
+      github.event.pull_request.merged == true &&
       github.event.pull_request.author_association != 'COLLABORATOR'
       && github.event.pull_request.author_association != 'MEMBER'
       && github.event.pull_request.author_association != 'OWNER'


### PR DESCRIPTION
Another day, another try to fix this!

Now it failed like this https://github.com/getsentry/sentry-javascript/actions/runs/9804811101/job/27073251966, hopefully this change fixes this... we'll see!