### PR TITLE
feat(opentelemetry): Allow skipping of span data inference

### DIFF
--- a/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
+++ b/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
@@ -132,6 +132,27 @@ describe('parseSpanDescription', () => {
         source: 'route',
       },
     ],
+    [
+      "should not do any data parsing when the 'sentry.skip_span_data_inference' attribute is set",
+      {
+        'sentry.skip_span_data_inference': true,
+
+        // All of these should be ignored
+        [SEMATTRS_HTTP_METHOD]: 'GET',
+        [SEMATTRS_DB_SYSTEM]: 'mysql',
+        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+      },
+      'test name',
+      undefined,
+      {
+        op: undefined,
+        description: 'test name',
+        source: 'custom',
+        data: {
+          'sentry.skip_span_data_inference': undefined,
+        },
+      },
+    ],
   ])('%s', (_, attributes, name, kind, expected) => {
     const actual = parseSpanDescription({ attributes, kind, name } as unknown as Span);
     expect(actual).toEqual(expected);


### PR DESCRIPTION
Allows skipping the automatic span data inference by setting a `sentry.skip_span_data_inference` attribute on the span in question.

The attribute is intentionally not exported as a semantic attribute because this is intended to be intimite API.