### PR TITLE
fix(angular): Remove `afterSendEvent` listener once root injector is destroyed

### DIFF
--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import type { ErrorHandler as AngularErrorHandler } from '@angular/core';
+import type { ErrorHandler as AngularErrorHandler, OnDestroy } from '@angular/core';
 import { Inject, Injectable } from '@angular/core';
 import * as Sentry from '@sentry/browser';
 import type { ReportDialogOptions } from '@sentry/browser';
@@ -81,19 +81,26 @@ function isErrorOrErrorLikeObject(value: unknown): value is Error {
  * Implementation of Angular's ErrorHandler provider that can be used as a drop-in replacement for the stock one.
  */
 @Injectable({ providedIn: 'root' })
-class SentryErrorHandler implements AngularErrorHandler {
+class SentryErrorHandler implements AngularErrorHandler, OnDestroy {
   protected readonly _options: ErrorHandlerOptions;
 
-  /* indicates if we already registered our the afterSendEvent handler */
-  private _registeredAfterSendEventHandler;
+  /** The cleanup function is executed when the injector is destroyed. */
+  private _removeAfterSendEventListener?: VoidFunction;
 
   public constructor(@Inject('errorHandlerOptions') options?: ErrorHandlerOptions) {
-    this._registeredAfterSendEventHandler = false;
-
     this._options = {
       logErrors: true,
       ...options,
     };
+  }
+
+  /**
+   * Method executed when the injector is destroyed.
+   */
+  public ngOnDestroy(): void {
+    if (this._removeAfterSendEventListener) {
+      this._removeAfterSendEventListener();
+    }
   }
 
   /**
@@ -119,17 +126,14 @@ class SentryErrorHandler implements AngularErrorHandler {
     if (this._options.showDialog) {
       const client = Sentry.getClient();
 
-      if (client && !this._registeredAfterSendEventHandler) {
-        client.on('afterSendEvent', (event: Event) => {
+      if (client && !this._removeAfterSendEventListener) {
+        this._removeAfterSendEventListener = client.on('afterSendEvent', (event: Event) => {
           if (!event.type && event.event_id) {
             runOutsideAngular(() => {
               Sentry.showReportDialog({ ...this._options.dialogOptions, eventId: event.event_id! });
             });
           }
         });
-
-        // We only want to register this hook once in the lifetime of the error handler
-        this._registeredAfterSendEventHandler = true;
       } else if (!client) {
         runOutsideAngular(() => {
           Sentry.showReportDialog({ ...this._options.dialogOptions, eventId });

--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -85,7 +85,7 @@ class SentryErrorHandler implements AngularErrorHandler, OnDestroy {
   protected readonly _options: ErrorHandlerOptions;
 
   /** The cleanup function is executed when the injector is destroyed. */
-  private _removeAfterSendEventListener?: VoidFunction;
+  private _removeAfterSendEventListener?: () => void;
 
   public constructor(@Inject('errorHandlerOptions') options?: ErrorHandlerOptions) {
     this._options = {
@@ -130,7 +130,7 @@ class SentryErrorHandler implements AngularErrorHandler, OnDestroy {
         this._removeAfterSendEventListener = client.on('afterSendEvent', (event: Event) => {
           if (!event.type && event.event_id) {
             runOutsideAngular(() => {
-              Sentry.showReportDialog({ ...this._options.dialogOptions, eventId: event.event_id! });
+              Sentry.showReportDialog({ ...this._options.dialogOptions, eventId: event.event_id });
             });
           }
         });


### PR DESCRIPTION
In this commit, we added cleanup logic to handle the removal of `afterSendEvent`, which is set up within the Angular error handler. This fixes memory leaks that occur when the event is still being handled after the root view is removed.