### PR TITLE
fix(node): Ensure `autoSessionTracking` is enabled by default

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -110,6 +110,7 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
   test('With session', done => {
     createRunner(__dirname, 'basic-session.js')
       .withMockSentryServer()
+      .unignore('session')
       .expect({
         session: {
           status: 'abnormal',

--- a/dev-packages/node-integration-tests/suites/esm/warn-esm/test.ts
+++ b/dev-packages/node-integration-tests/suites/esm/warn-esm/test.ts
@@ -13,7 +13,7 @@ test("warns if using ESM on Node.js versions that don't support `register()`", a
     return;
   }
 
-  const runner = createRunner(__dirname, 'server.mjs').ignore('session', 'sessions', 'event').start();
+  const runner = createRunner(__dirname, 'server.mjs').ignore('event').start();
 
   await runner.makeRequest('get', '/test/success');
 
@@ -26,7 +26,7 @@ test('does not warn if using ESM on Node.js versions that support `register()`',
     return;
   }
 
-  const runner = createRunner(__dirname, 'server.mjs').ignore('session', 'sessions', 'event').start();
+  const runner = createRunner(__dirname, 'server.mjs').ignore('event').start();
 
   await runner.makeRequest('get', '/test/success');
 
@@ -34,7 +34,7 @@ test('does not warn if using ESM on Node.js versions that support `register()`',
 });
 
 test('does not warn if using CJS', async () => {
-  const runner = createRunner(__dirname, 'server.js').ignore('session', 'sessions', 'event').start();
+  const runner = createRunner(__dirname, 'server.js').ignore('event').start();
 
   await runner.makeRequest('get', '/test/success');
 

--- a/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/test.ts
@@ -15,7 +15,6 @@ afterAll(() => {
  */
 test('withScope scope is NOT applied to thrown error caught by global handler', done => {
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('session', 'sessions')
     .expect({
       event: {
         exception: {
@@ -53,7 +52,6 @@ test('withScope scope is NOT applied to thrown error caught by global handler', 
  */
 test('isolation scope is applied to thrown error caught by global handler', done => {
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('session', 'sessions')
     .expect({
       event: {
         exception: {

--- a/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-0/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-0/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should capture and send Express controller error with txn name if tracesSampleRate is 0', done => {
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('session', 'sessions', 'transaction')
+    .ignore('transaction')
     .expect({
       event: {
         exception: {

--- a/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-unset/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-unset/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should capture and send Express controller error if tracesSampleRate is not set.', done => {
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('session', 'sessions', 'transaction')
+    .ignore('transaction')
     .expect({
       event: {
         exception: {

--- a/dev-packages/node-integration-tests/suites/express/multiple-init/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-init/test.ts
@@ -6,7 +6,6 @@ afterAll(() => {
 
 test('allows to call init multiple times', done => {
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('session', 'sessions')
     .expect({
       event: {
         exception: {

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should construct correct url with common infixes with multiple parameterized routers.', done => {
   createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'session', 'sessions')
+    .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
     .start(done)
     .makeRequest('get', '/api/v1/user/3212');

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should construct correct url with common infixes with multiple routers.', done => {
   createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'session', 'sessions')
+    .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api2/v1/test' } })
     .start(done)
     .makeRequest('get', '/api2/v1/test');

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should construct correct urls with multiple parameterized routers (use order reversed).', done => {
   createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'session', 'sessions')
+    .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
     .start(done)
     .makeRequest('get', '/api/v1/user/1234/');

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should construct correct urls with multiple parameterized routers.', done => {
   createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'session', 'sessions')
+    .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
     .start(done)
     .makeRequest('get', '/api/v1/user/1234/');

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should construct correct url with multiple parameterized routers of the same length (use order reversed).', done => {
   createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'session', 'sessions')
+    .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/:userId' } })
     .start(done)
     .makeRequest('get', '/api/v1/1234/');

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should construct correct url with multiple parameterized routers of the same length.', done => {
   createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'session', 'sessions')
+    .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/:userId' } })
     .start(done)
     .makeRequest('get', '/api/v1/1234/');

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/test.ts
@@ -6,7 +6,7 @@ afterAll(() => {
 
 test('should construct correct urls with multiple routers.', done => {
   createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'session', 'sessions')
+    .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/test' } })
     .start(done)
     .makeRequest('get', '/api/v1/test');

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/test.ts
@@ -28,7 +28,7 @@ conditionalTest({ min: 16 })('complex-router', () => {
           };
 
     createRunner(__dirname, 'server.ts')
-      .ignore('event', 'session', 'sessions')
+      .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
       .start(done)
       .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456');
@@ -54,7 +54,7 @@ conditionalTest({ min: 16 })('complex-router', () => {
           };
 
     createRunner(__dirname, 'server.ts')
-      .ignore('event', 'session', 'sessions')
+      .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
       .start(done)
       .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456?param=1');
@@ -80,7 +80,7 @@ conditionalTest({ min: 16 })('complex-router', () => {
           };
 
     createRunner(__dirname, 'server.ts')
-      .ignore('event', 'session', 'sessions')
+      .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
       .start(done)
       .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456/?param=1');

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/test.ts
@@ -27,7 +27,7 @@ conditionalTest({ min: 16 })('middle-layer-parameterized', () => {
           };
 
     createRunner(__dirname, 'server.ts')
-      .ignore('event', 'session', 'sessions')
+      .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
       .start(done)
       .makeRequest('get', '/api/v1/users/123/posts/456');

--- a/dev-packages/node-integration-tests/suites/express/span-isolationScope/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/span-isolationScope/test.ts
@@ -6,7 +6,6 @@ afterAll(() => {
 
 test('correctly applies isolation scope to span', done => {
   createRunner(__dirname, 'server.ts')
-    .ignore('session', 'sessions')
     .expect({
       transaction: {
         transaction: 'GET /test/isolationScope',

--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -8,7 +8,6 @@ describe('express tracing', () => {
   describe('CJS', () => {
     test('should create and send transactions for Express routes and spans for middlewares.', done => {
       createRunner(__dirname, 'server.js')
-        .ignore('session', 'sessions')
         .expect({
           transaction: {
             contexts: {
@@ -51,7 +50,6 @@ describe('express tracing', () => {
 
     test('should set a correct transaction name for routes specified in RegEx', done => {
       createRunner(__dirname, 'server.js')
-        .ignore('session', 'sessions')
         .expect({
           transaction: {
             transaction: 'GET /\\/test\\/regex/',
@@ -80,7 +78,6 @@ describe('express tracing', () => {
       'should set a correct transaction name for routes consisting of arrays of routes for %p',
       ((segment: string, done: () => void) => {
         createRunner(__dirname, 'server.js')
-          .ignore('session', 'sessions')
           .expect({
             transaction: {
               transaction: 'GET /test/array1,/\\/test\\/array[2-9]/',
@@ -117,7 +114,6 @@ describe('express tracing', () => {
       ['arr/requiredPath/optionalPath/lastParam'],
     ])('should handle more complex regexes in route arrays correctly for %p', ((segment: string, done: () => void) => {
       createRunner(__dirname, 'server.js')
-        .ignore('session', 'sessions')
         .expect({
           transaction: {
             transaction: 'GET /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?/',

--- a/dev-packages/node-integration-tests/suites/express/tracing/withError/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/withError/test.ts
@@ -8,7 +8,7 @@ describe('express tracing experimental', () => {
   describe('CJS', () => {
     test('should apply the scope transactionName to error events', done => {
       createRunner(__dirname, 'server.js')
-        .ignore('session', 'sessions', 'transaction')
+        .ignore('transaction')
         .expect({
           event: {
             exception: {

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
@@ -6,7 +6,6 @@ afterAll(() => {
 
 test('correctly applies isolation scope even without tracing', done => {
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('session', 'sessions')
     .expect({
       event: {
         transaction: 'GET /test/isolationScope/1',

--- a/dev-packages/node-integration-tests/suites/proxy/test.ts
+++ b/dev-packages/node-integration-tests/suites/proxy/test.ts
@@ -7,7 +7,6 @@ afterAll(() => {
 test('proxies sentry requests', done => {
   createRunner(__dirname, 'basic.js')
     .withMockSentryServer()
-    .ignore('session')
     .expect({
       event: {
         message: 'Hello, via proxy!',

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -41,7 +41,6 @@ conditionalTest({ min: 18 })('LocalVariables integration', () => {
 
   test('Should not include local variables by default', done => {
     createRunner(__dirname, 'no-local-variables.js')
-      .ignore('session')
       .expect({
         event: event => {
           for (const frame of event.exception?.values?.[0]?.stacktrace?.frames || []) {
@@ -53,10 +52,7 @@ conditionalTest({ min: 18 })('LocalVariables integration', () => {
   });
 
   test('Should include local variables when enabled', done => {
-    createRunner(__dirname, 'local-variables.js')
-      .ignore('session')
-      .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
-      .start(done);
+    createRunner(__dirname, 'local-variables.js').expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT }).start(done);
   });
 
   test('Should include local variables when instrumenting via --require', done => {
@@ -64,29 +60,22 @@ conditionalTest({ min: 18 })('LocalVariables integration', () => {
 
     createRunner(__dirname, 'local-variables-no-sentry.js')
       .withFlags(`--require=${requirePath}`)
-      .ignore('session')
       .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
       .start(done);
   });
 
   test('Should include local variables with ESM', done => {
-    createRunner(__dirname, 'local-variables-caught.mjs')
-      .ignore('session')
-      .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
-      .start(done);
+    createRunner(__dirname, 'local-variables-caught.mjs').expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT }).start(done);
   });
 
   conditionalTest({ min: 19 })('Node v19+', () => {
     test('Should not import inspector when not in use', done => {
-      createRunner(__dirname, 'deny-inspector.mjs').ensureNoErrorOutput().ignore('session').start(done);
+      createRunner(__dirname, 'deny-inspector.mjs').ensureNoErrorOutput().start(done);
     });
   });
 
   test('Includes local variables for caught exceptions when enabled', done => {
-    createRunner(__dirname, 'local-variables-caught.js')
-      .ignore('session')
-      .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
-      .start(done);
+    createRunner(__dirname, 'local-variables-caught.js').expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT }).start(done);
   });
 
   test('Should not leak memory', done => {

--- a/dev-packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
@@ -11,7 +11,8 @@ test('should aggregate successful and crashed sessions', async () => {
   });
 
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'event', 'session')
+    .ignore('transaction', 'event')
+    .unignore('sessions')
     .expectError()
     .expect({
       sessions: {

--- a/dev-packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
@@ -11,7 +11,8 @@ test('should aggregate successful, crashed and erroneous sessions', async () => 
   });
 
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'event', 'session')
+    .ignore('transaction', 'event')
+    .unignore('sessions')
     .expectError()
     .expect({
       sessions: {

--- a/dev-packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
@@ -11,7 +11,8 @@ test('should aggregate successful sessions', async () => {
   });
 
   const runner = createRunner(__dirname, 'server.ts')
-    .ignore('transaction', 'event', 'session')
+    .ignore('transaction', 'event')
+    .unignore('sessions')
     .expectError()
     .expect({
       sessions: {

--- a/dev-packages/node-integration-tests/suites/tracing/connect/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/connect/test.ts
@@ -47,7 +47,7 @@ describe('connect auto-instrumentation', () => {
 
   test('CJS - should capture errors in `connect` middleware.', done => {
     createRunner(__dirname, 'scenario.js')
-      .ignore('transaction', 'session', 'sessions')
+      .ignore('transaction')
       .expectError()
       .expect({ event: EXPECTED_EVENT })
       .start(done)
@@ -56,7 +56,7 @@ describe('connect auto-instrumentation', () => {
 
   test('CJS - should report errored transactions.', done => {
     createRunner(__dirname, 'scenario.js')
-      .ignore('event', 'session', 'sessions')
+      .ignore('event')
       .expect({ transaction: { transaction: 'GET /error' } })
       .expectError()
       .start(done)

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/test.ts
@@ -2,7 +2,7 @@ import { createRunner } from '../../../../utils/runner';
 
 test('envelope header for error event during active unsampled span is correct', done => {
   createRunner(__dirname, 'scenario.ts')
-    .ignore('session', 'sessions', 'transaction')
+    .ignore('transaction')
     .expectHeader({
       event: {
         trace: {

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/test.ts
@@ -2,7 +2,7 @@ import { createRunner } from '../../../../utils/runner';
 
 test('envelope header for error event during active span is correct', done => {
   createRunner(__dirname, 'scenario.ts')
-    .ignore('session', 'sessions', 'transaction')
+    .ignore('transaction')
     .expectHeader({
       event: {
         trace: {

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/test.ts
@@ -2,7 +2,6 @@ import { createRunner } from '../../../../utils/runner';
 
 test('envelope header for error events is correct', done => {
   createRunner(__dirname, 'scenario.ts')
-    .ignore('session', 'sessions')
     .expectHeader({
       event: {
         trace: {

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/test.ts
@@ -2,7 +2,6 @@ import { createRunner } from '../../../../utils/runner';
 
 test('envelope header for transaction event of route correct', done => {
   createRunner(__dirname, 'scenario.ts')
-    .ignore('session', 'sessions')
     .expectHeader({
       transaction: {
         trace: {

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/test.ts
@@ -2,7 +2,6 @@ import { createRunner } from '../../../../utils/runner';
 
 test('envelope header for transaction event with source=url correct', done => {
   createRunner(__dirname, 'scenario.ts')
-    .ignore('session', 'sessions')
     .expectHeader({
       transaction: {
         trace: {

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/test.ts
@@ -2,7 +2,6 @@ import { createRunner } from '../../../../utils/runner';
 
 test('envelope header for transaction event is correct', done => {
   createRunner(__dirname, 'scenario.ts')
-    .ignore('session', 'sessions')
     .expectHeader({
       transaction: {
         trace: {

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
@@ -14,7 +14,6 @@ describe('httpIntegration', () => {
     }
 
     createRunner(__dirname, 'server.js')
-      .ignore('session', 'sessions')
       .expect({
         transaction: {
           contexts: {
@@ -56,7 +55,6 @@ describe('httpIntegration', () => {
 
   test('allows to pass experimental config through to integration', done => {
     createRunner(__dirname, 'server-experimental.js')
-      .ignore('session', 'sessions')
       .expect({
         transaction: {
           contexts: {

--- a/dev-packages/node-integration-tests/suites/tracing/maxSpans/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/maxSpans/test.ts
@@ -8,7 +8,6 @@ test('it limits spans to 1000', done => {
   }
 
   createRunner(__dirname, 'scenario.ts')
-    .ignore('session', 'sessions')
     .expect({
       transaction: {
         transaction: 'parent',

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/test.ts
@@ -10,7 +10,6 @@ conditionalTest({ min: 18 })('outgoing fetch', () => {
         createRunner(__dirname, 'scenario.ts')
           .withEnv({ SERVER_URL })
           .ensureNoErrorOutput()
-          .ignore('session', 'sessions')
           .expect({
             event: {
               breadcrumbs: [

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-noSampleRate/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-noSampleRate/test.ts
@@ -34,7 +34,6 @@ conditionalTest({ min: 18 })('outgoing fetch', () => {
         createRunner(__dirname, 'scenario.ts')
           .withEnv({ SERVER_URL })
           .ensureNoErrorOutput()
-          .ignore('session', 'sessions')
           .expect({
             event: {
               exception: {

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-sampled-no-active-span/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-sampled-no-active-span/test.ts
@@ -29,7 +29,6 @@ conditionalTest({ min: 18 })('outgoing fetch', () => {
       .then(SERVER_URL => {
         createRunner(__dirname, 'scenario.ts')
           .withEnv({ SERVER_URL })
-          .ignore('session', 'sessions')
           .expect({
             event: {
               exception: {

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-unsampled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-unsampled/test.ts
@@ -29,7 +29,6 @@ conditionalTest({ min: 18 })('outgoing fetch', () => {
       .then(SERVER_URL => {
         createRunner(__dirname, 'scenario.ts')
           .withEnv({ SERVER_URL })
-          .ignore('session', 'sessions')
           .expect({
             event: {
               exception: {

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/test.ts
@@ -8,7 +8,6 @@ test('outgoing http requests create breadcrumbs', done => {
       createRunner(__dirname, 'scenario.ts')
         .withEnv({ SERVER_URL })
         .ensureNoErrorOutput()
-        .ignore('session', 'sessions')
         .expect({
           event: {
             breadcrumbs: [

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-noSampleRate/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-noSampleRate/test.ts
@@ -32,7 +32,6 @@ test('outgoing http requests are correctly instrumented without tracesSampleRate
       createRunner(__dirname, 'scenario.ts')
         .withEnv({ SERVER_URL })
         .ensureNoErrorOutput()
-        .ignore('session', 'sessions')
         .expect({
           event: {
             exception: {

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-no-active-span/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-no-active-span/test.ts
@@ -31,7 +31,6 @@ test('outgoing sampled http requests without active span are correctly instrumen
     .then(SERVER_URL => {
       createRunner(__dirname, 'scenario.ts')
         .withEnv({ SERVER_URL })
-        .ignore('session', 'sessions')
         .expect({
           event: {
             exception: {

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/test.ts
@@ -31,7 +31,6 @@ test('outgoing http requests are correctly instrumented when not sampled', done 
     .then(SERVER_URL => {
       createRunner(__dirname, 'scenario.ts')
         .withEnv({ SERVER_URL })
-        .ignore('session', 'sessions')
         .expect({
           event: {
             exception: {

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -164,7 +164,8 @@ export function createRunner(...paths: string[]) {
   const expectedEnvelopes: Expected[] = [];
   let expectedEnvelopeHeaders: ExpectedEnvelopeHeader[] | undefined = undefined;
   const flags: string[] = [];
-  const ignored: EnvelopeItemType[] = [];
+  // By default, we ignore session & sessions
+  const ignored: EnvelopeItemType[] = ['session', 'sessions'];
   let withEnv: Record<string, string> = {};
   let withSentryServer = false;
   let dockerOptions: DockerOptions | undefined;
@@ -207,6 +208,15 @@ export function createRunner(...paths: string[]) {
     },
     ignore: function (...types: EnvelopeItemType[]) {
       ignored.push(...types);
+      return this;
+    },
+    unignore: function (...types: EnvelopeItemType[]) {
+      for (const t of types) {
+        const pos = ignored.indexOf(t);
+        if (pos > -1) {
+          ignored.splice(pos, 1);
+        }
+      }
       return this;
     },
     withDockerCompose: function (options: DockerOptions) {

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -113,12 +113,12 @@ export function initWithoutDefaultIntegrations(options: NodeOptions | undefined 
  * Initialize Sentry for Node, without performance instrumentation.
  */
 function _init(
-  options: NodeOptions | undefined = {},
+  _options: NodeOptions | undefined = {},
   getDefaultIntegrationsImpl: (options: Options) => Integration[],
 ): NodeClient {
-  const clientOptions = getClientOptions(options, getDefaultIntegrationsImpl);
+  const options = getClientOptions(_options, getDefaultIntegrationsImpl);
 
-  if (clientOptions.debug === true) {
+  if (options.debug === true) {
     if (DEBUG_BUILD) {
       logger.enable();
     } else {
@@ -139,7 +139,7 @@ function _init(
   const scope = getCurrentScope();
   scope.update(options.initialScope);
 
-  const client = new NodeClient(clientOptions);
+  const client = new NodeClient(options);
   // The client is on the current scope, from where it generally is inherited
   getCurrentScope().setClient(client);
 

--- a/packages/node/test/integrations/express.test.ts
+++ b/packages/node/test/integrations/express.test.ts
@@ -74,7 +74,7 @@ describe('expressErrorHandler()', () => {
   });
 
   it('autoSessionTracking is enabled + requestHandler is not used -> does not set requestSession status on Crash', done => {
-    const options = getDefaultNodeClientOptions({ autoSessionTracking: false, release: '3.3' });
+    const options = getDefaultNodeClientOptions({ autoSessionTracking: true, release: '3.3' });
     client = new NodeClient(options);
     setCurrentClient(client);
 

--- a/packages/node/test/sdk/init.test.ts
+++ b/packages/node/test/sdk/init.test.ts
@@ -1,6 +1,6 @@
 import type { Integration } from '@sentry/types';
 
-import { getClient } from '../../src/';
+import { getClient, getIsolationScope } from '../../src/';
 import * as auto from '../../src/integrations/tracing';
 import { init } from '../../src/sdk';
 import { NodeClient } from '../../src/sdk/client';
@@ -34,112 +34,153 @@ describe('init()', () => {
     jest.clearAllMocks();
   });
 
-  it("doesn't install default integrations if told not to", () => {
-    init({ dsn: PUBLIC_DSN, defaultIntegrations: false });
+  describe('integrations', () => {
+    it("doesn't install default integrations if told not to", () => {
+      init({ dsn: PUBLIC_DSN, defaultIntegrations: false });
 
-    const client = getClient();
+      const client = getClient();
 
-    expect(client?.getOptions()).toEqual(
-      expect.objectContaining({
-        integrations: [],
-      }),
-    );
+      expect(client?.getOptions()).toEqual(
+        expect.objectContaining({
+          integrations: [],
+        }),
+      );
 
-    expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(0);
-  });
-
-  it('installs merged default integrations, with overrides provided through options', () => {
-    const mockDefaultIntegrations = [
-      new MockIntegration('Some mock integration 2.1'),
-      new MockIntegration('Some mock integration 2.2'),
-    ];
-
-    const mockIntegrations = [
-      new MockIntegration('Some mock integration 2.1'),
-      new MockIntegration('Some mock integration 2.3'),
-    ];
-
-    init({ dsn: PUBLIC_DSN, integrations: mockIntegrations, defaultIntegrations: mockDefaultIntegrations });
-
-    expect(mockDefaultIntegrations[0]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
-    expect(mockDefaultIntegrations[1]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(mockIntegrations[0]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(mockIntegrations[1]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(0);
-  });
-
-  it('installs integrations returned from a callback function', () => {
-    const mockDefaultIntegrations = [
-      new MockIntegration('Some mock integration 3.1'),
-      new MockIntegration('Some mock integration 3.2'),
-    ];
-
-    const newIntegration = new MockIntegration('Some mock integration 3.3');
-
-    init({
-      dsn: PUBLIC_DSN,
-      defaultIntegrations: mockDefaultIntegrations,
-      integrations: integrations => {
-        const newIntegrations = [...integrations];
-        newIntegrations[1] = newIntegration;
-        return newIntegrations;
-      },
+      expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(0);
     });
 
-    expect(mockDefaultIntegrations[0]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(mockDefaultIntegrations[1]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
-    expect(newIntegration.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(0);
-  });
+    it('installs merged default integrations, with overrides provided through options', () => {
+      const mockDefaultIntegrations = [
+        new MockIntegration('Some mock integration 2.1'),
+        new MockIntegration('Some mock integration 2.2'),
+      ];
 
-  it('installs performance default instrumentations if tracing is enabled', () => {
-    const autoPerformanceIntegration = new MockIntegration('Some mock integration 4.4');
+      const mockIntegrations = [
+        new MockIntegration('Some mock integration 2.1'),
+        new MockIntegration('Some mock integration 2.3'),
+      ];
 
-    mockAutoPerformanceIntegrations.mockReset().mockImplementation(() => [autoPerformanceIntegration]);
+      init({ dsn: PUBLIC_DSN, integrations: mockIntegrations, defaultIntegrations: mockDefaultIntegrations });
 
-    const mockIntegrations = [
-      new MockIntegration('Some mock integration 4.1'),
-      new MockIntegration('Some mock integration 4.3'),
-    ];
-
-    init({
-      dsn: PUBLIC_DSN,
-      integrations: mockIntegrations,
-      enableTracing: true,
+      expect(mockDefaultIntegrations[0]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
+      expect(mockDefaultIntegrations[1]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(mockIntegrations[0]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(mockIntegrations[1]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(0);
     });
 
-    expect(mockIntegrations[0]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(mockIntegrations[1]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(autoPerformanceIntegration.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
-    expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(1);
+    it('installs integrations returned from a callback function', () => {
+      const mockDefaultIntegrations = [
+        new MockIntegration('Some mock integration 3.1'),
+        new MockIntegration('Some mock integration 3.2'),
+      ];
 
-    const client = getClient();
-    expect(client?.getOptions()).toEqual(
-      expect.objectContaining({
-        integrations: expect.arrayContaining([mockIntegrations[0], mockIntegrations[1], autoPerformanceIntegration]),
-      }),
-    );
+      const newIntegration = new MockIntegration('Some mock integration 3.3');
+
+      init({
+        dsn: PUBLIC_DSN,
+        defaultIntegrations: mockDefaultIntegrations,
+        integrations: integrations => {
+          const newIntegrations = [...integrations];
+          newIntegrations[1] = newIntegration;
+          return newIntegrations;
+        },
+      });
+
+      expect(mockDefaultIntegrations[0]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(mockDefaultIntegrations[1]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
+      expect(newIntegration.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(0);
+    });
+
+    it('installs performance default instrumentations if tracing is enabled', () => {
+      const autoPerformanceIntegration = new MockIntegration('Some mock integration 4.4');
+
+      mockAutoPerformanceIntegrations.mockReset().mockImplementation(() => [autoPerformanceIntegration]);
+
+      const mockIntegrations = [
+        new MockIntegration('Some mock integration 4.1'),
+        new MockIntegration('Some mock integration 4.3'),
+      ];
+
+      init({
+        dsn: PUBLIC_DSN,
+        integrations: mockIntegrations,
+        enableTracing: true,
+      });
+
+      expect(mockIntegrations[0]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(mockIntegrations[1]?.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(autoPerformanceIntegration.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(1);
+
+      const client = getClient();
+      expect(client?.getOptions()).toEqual(
+        expect.objectContaining({
+          integrations: expect.arrayContaining([mockIntegrations[0], mockIntegrations[1], autoPerformanceIntegration]),
+        }),
+      );
+    });
   });
 
-  it('sets up OpenTelemetry by default', () => {
-    init({ dsn: PUBLIC_DSN });
+  describe('OpenTelemetry', () => {
+    it('sets up OpenTelemetry by default', () => {
+      init({ dsn: PUBLIC_DSN });
 
-    const client = getClient<NodeClient>();
+      const client = getClient<NodeClient>();
 
-    expect(client?.traceProvider).toBeDefined();
-  });
+      expect(client?.traceProvider).toBeDefined();
+    });
 
-  it('allows to opt-out of OpenTelemetry setup', () => {
-    init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: true });
+    it('allows to opt-out of OpenTelemetry setup', () => {
+      init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: true });
 
-    const client = getClient<NodeClient>();
+      const client = getClient<NodeClient>();
 
-    expect(client?.traceProvider).not.toBeDefined();
+      expect(client?.traceProvider).not.toBeDefined();
+    });
   });
 
   it('returns intiated client', () => {
     const client = init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: true });
 
     expect(client).toBeInstanceOf(NodeClient);
+  });
+
+  describe('autoSessionTracking', () => {
+    it('does not track session by default if no release is set', () => {
+      init({ dsn: PUBLIC_DSN });
+
+      const session = getIsolationScope().getSession();
+      expect(session).toBeUndefined();
+    });
+
+    it('tracks session by default if release is set', () => {
+      init({ dsn: PUBLIC_DSN, release: '1.2.3' });
+
+      const session = getIsolationScope().getSession();
+      expect(session).toBeDefined();
+    });
+
+    it('does not track session if no release is set even if autoSessionTracking=true', () => {
+      init({ dsn: PUBLIC_DSN, autoSessionTracking: true });
+
+      const session = getIsolationScope().getSession();
+      expect(session).toBeUndefined();
+    });
+
+    it('does not track session if autoSessionTracking=false', () => {
+      init({ dsn: PUBLIC_DSN, autoSessionTracking: false, release: '1.2.3' });
+
+      const session = getIsolationScope().getSession();
+      expect(session).toBeUndefined();
+    });
+
+    it('tracks session by default if autoSessionTracking=true & release is set', () => {
+      init({ dsn: PUBLIC_DSN, release: '1.2.3', autoSessionTracking: true });
+
+      const session = getIsolationScope().getSession();
+      expect(session).toBeDefined();
+    });
   });
 });

--- a/packages/node/test/sdk/init.test.ts
+++ b/packages/node/test/sdk/init.test.ts
@@ -149,6 +149,10 @@ describe('init()', () => {
 
   describe('autoSessionTracking', () => {
     it('does not track session by default if no release is set', () => {
+      // On CI, we always infer the release, so this does not work
+      if (process.env.CI) {
+        return;
+      }
       init({ dsn: PUBLIC_DSN });
 
       const session = getIsolationScope().getSession();
@@ -163,6 +167,11 @@ describe('init()', () => {
     });
 
     it('does not track session if no release is set even if autoSessionTracking=true', () => {
+      // On CI, we always infer the release, so this does not work
+      if (process.env.CI) {
+        return;
+      }
+
       init({ dsn: PUBLIC_DSN, autoSessionTracking: true });
 
       const session = getIsolationScope().getSession();


### PR DESCRIPTION
I noticed that we were not actually enabling auto session tracking correctly in node, because we did not check on the correct `options` object 😬 