### PR TITLE
test(e2e): Run required E2E tests on PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -995,7 +995,6 @@ jobs:
             'angular-17',
             'angular-18',
             'aws-lambda-layer-cjs',
-            'cloudflare-astro',
             'node-express',
             'create-react-app',
             'create-next-app',
@@ -1113,16 +1112,6 @@ jobs:
         timeout-minutes: 5
         run: pnpm test:assert
 
-      - name: Deploy Astro to Cloudflare
-        uses: cloudflare/pages-action@v1
-        if: matrix.test-application == 'cloudflare-astro'
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
-          directory: dist
-          workingDirectory: dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}
-
   job_optional_e2e_tests:
     name: E2E ${{ matrix.label || matrix.test-application }} Test
     # We only run E2E tests for non-fork PRs because the E2E tests require secrets to work and they can't be accessed from forks
@@ -1148,6 +1137,7 @@ jobs:
       matrix:
         test-application:
           [
+            'cloudflare-astro',
             'react-send-to-sentry',
             'node-express-send-to-sentry',
             'debug-id-sourcemaps',
@@ -1213,6 +1203,16 @@ jobs:
         working-directory: dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}
         timeout-minutes: 5
         run: pnpm ${{ matrix.assert-command || 'test:assert' }}
+
+      - name: Deploy Astro to Cloudflare
+        uses: cloudflare/pages-action@v1
+        if: matrix.test-application == 'cloudflare-astro'
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+          directory: dist
+          workingDirectory: dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}
 
   job_profiling_e2e_tests:
     name: E2E ${{ matrix.label || matrix.test-application }} Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -913,8 +913,7 @@ jobs:
     # - AND if the profiling node bindings were either successful or skipped
     if: |
       always() && needs.job_build.result == 'success' &&
-      (needs.job_compile_bindings_profiling_node.result == 'success' || needs.job_compile_bindings_profiling_node.result == 'skipped') &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      (needs.job_compile_bindings_profiling_node.result == 'success' || needs.job_compile_bindings_profiling_node.result == 'skipped')
     needs: [job_get_metadata, job_build, job_compile_bindings_profiling_node]
     runs-on: ubuntu-20.04-large-js
     timeout-minutes: 15


### PR DESCRIPTION
This PR enables running E2E tests on PRs opened from forked repositories. Previously we excluded these because some E2E tests required secrets which are not available in the forks, causing e2e test runs to always fail. Now that we separated these tests from the e2e tests that don't require secrets (https://github.com/getsentry/sentry-javascript/pull/12259) we should be good to re-enable the required e2e tests for external PRs.

For this to work though, I had to move the "Astro Cloudflare" test to optional tests since it requires a cloudflare token for deployment. IMO this is fine because the test doesn't have any other real tests anyway and we should create a dedicated Astro e2e test app with tests instead and add it to the required test apps.

Tested this with my forked repo and it seems like all required e2e tests are passing: https://github.com/getsentry/sentry-javascript/pull/12794