### PR TITLE
test(nextjs): Fix Next.js canary tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/app/propagation/test-outgoing-fetch-external-disallowed/route.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/app/propagation/test-outgoing-fetch-external-disallowed/route.ts
@@ -3,8 +3,8 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const data = await fetch(`http://localhost:3030/propagation/test-outgoing-fetch-external-disallowed/check`).then(
-    res => res.json(),
-  );
+  const data = await fetch(`http://localhost:3030/propagation/test-outgoing-fetch-external-disallowed/check`, {
+    cache: 'no-store',
+  }).then(res => res.json());
   return NextResponse.json(data);
 }

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/app/propagation/test-outgoing-fetch/route.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/app/propagation/test-outgoing-fetch/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const data = await fetch(`http://localhost:3030/propagation/test-outgoing-fetch/check`).then(res => res.json());
+  const data = await fetch(`http://localhost:3030/propagation/test-outgoing-fetch/check`, { cache: 'no-store' }).then(
+    res => res.json(),
+  );
   return NextResponse.json(data);
 }

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/client-errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/client-errors.test.ts
@@ -6,6 +6,7 @@ const packageJson = require('../package.json');
 test('Sends a client-side exception to Sentry', async ({ page }) => {
   const nextjsVersion = packageJson.dependencies.next;
   const nextjsMajor = Number(nextjsVersion.split('.')[0]);
+  const isDevMode = process.env.TEST_ENV === 'development';
 
   await page.goto('/');
 
@@ -28,8 +29,9 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
   expect(errorEvent.transaction).toEqual('/');
 
   expect(errorEvent.contexts?.trace).toEqual({
-    // Next.js >= 15 propagates a trace ID to the client via a meta tag.
-    parent_span_id: nextjsMajor >= 15 ? expect.any(String) : undefined,
+    // Next.js >= 15 propagates a trace ID to the client via a meta tag. Also, only dev mode emits a meta tag because
+    // the requested page is static and only in dev mode SSR is kicked off.
+    parent_span_id: nextjsMajor >= 15 && isDevMode ? expect.any(String) : undefined,
     trace_id: expect.any(String),
     span_id: expect.any(String),
   });

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
@@ -4,6 +4,9 @@ import { waitForTransaction } from '@sentry-internal/test-utils';
 const packageJson = require('../package.json');
 
 test('Sends a pageload transaction', async ({ page }) => {
+  const nextjsVersion = packageJson.dependencies.next;
+  const nextjsMajor = Number(nextjsVersion.split('.')[0]);
+
   const pageloadTransactionEventPromise = waitForTransaction('nextjs-app-dir', transactionEvent => {
     return transactionEvent?.contexts?.trace?.op === 'pageload' && transactionEvent?.transaction === '/';
   });
@@ -23,6 +26,8 @@ test('Sends a pageload transaction', async ({ page }) => {
           version: expect.any(String),
         },
         trace: {
+          // Next.js >= 15 propagates a trace ID to the client via a meta tag.
+          parent_span_id: nextjsMajor >= 15 ? expect.any(String) : undefined,
           span_id: expect.any(String),
           trace_id: expect.any(String),
           op: 'pageload',

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
@@ -6,6 +6,7 @@ const packageJson = require('../package.json');
 test('Sends a pageload transaction', async ({ page }) => {
   const nextjsVersion = packageJson.dependencies.next;
   const nextjsMajor = Number(nextjsVersion.split('.')[0]);
+  const isDevMode = process.env.TEST_ENV === 'development';
 
   const pageloadTransactionEventPromise = waitForTransaction('nextjs-app-dir', transactionEvent => {
     return transactionEvent?.contexts?.trace?.op === 'pageload' && transactionEvent?.transaction === '/';
@@ -26,8 +27,9 @@ test('Sends a pageload transaction', async ({ page }) => {
           version: expect.any(String),
         },
         trace: {
-          // Next.js >= 15 propagates a trace ID to the client via a meta tag.
-          parent_span_id: nextjsMajor >= 15 ? expect.any(String) : undefined,
+          // Next.js >= 15 propagates a trace ID to the client via a meta tag. Also, only dev mode emits a meta tag because
+          // the requested page is static and only in dev mode SSR is kicked off.
+          parent_span_id: nextjsMajor >= 15 && isDevMode ? expect.any(String) : undefined,
           span_id: expect.any(String),
           trace_id: expect.any(String),
           op: 'pageload',


### PR DESCRIPTION
Fixes canary tests in 2 ways:
- Makes fetch requests for propagation non-static.
- Checks for the client trace metadata that was introduced in Next.js 15.

Fixes https://github.com/getsentry/sentry-javascript/issues/12489
Fixes https://github.com/getsentry/sentry-javascript/issues/12501