### PR TITLE
test(remix): Add dependency resolution overrides to fix breaking Node compatibility changes in dependencies

### DIFF
--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -36,7 +36,10 @@
     "@sentry/utils": "file:../../../utils",
     "@vanilla-extract/css": "1.13.0",
     "@vanilla-extract/integration": "6.2.4",
-    "@types/mime": "^3.0.0"
+    "@types/mime": "^3.0.0",
+    "@sentry/remix/glob": "<10.4.3",
+    "path-scurry/lru-cache": "10.2.0",
+    "jackspeak": "<3.4.1"
   },
   "engines": {
     "node": ">=14.18"

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -38,8 +38,8 @@
     "@vanilla-extract/integration": "6.2.4",
     "@types/mime": "^3.0.0",
     "@sentry/remix/glob": "<10.4.3",
-    "path-scurry/lru-cache": "10.2.0",
-    "jackspeak": "<3.4.1"
+    "jackspeak": "<3.4.1",
+    "**/path-scurry/lru-cache": "10.2.0"
   },
   "engines": {
     "node": ">=14.18"


### PR DESCRIPTION
This PR fixes our broken Remix v1 @ Node 16 integration test. Over the weekend, the following transitive dependencies received minor and patch releases which removed support for EOL Node versions. 

- `glob` (https://github.com/isaacs/node-glob/issues/596)
- `lru-cache` (https://github.com/isaacs/node-lru-cache/issues/340)
- `jackspeack` (https://github.com/isaacs/jackspeak/issues/13)

IMO this, despite the dropped versions being EOL, is a breaking change and a major inconvenience for a lot of users. I added comments/opened issues with the request to revert the Node version drops and do it in a major version instead. We're by far not the only affected ones. As our tests show, at least everyone using Remix@1 on Node 16 will be broken by this.

To fix, I added dependency resolutions, mostly scoped to specific packages that depend on one of the three packages. Global overrides for `glob` and `lru-cache` did not work because we have multiple dependencies depending on different major versions of said packages.   