### PR TITLE
ref(otel): Ensure we never swallow args for ContextManager

### DIFF
--- a/packages/opentelemetry/src/contextManager.ts
+++ b/packages/opentelemetry/src/contextManager.ts
@@ -31,8 +31,8 @@ export function wrapContextManagerClass<ContextManagerInstance extends ContextMa
 
   // @ts-expect-error TS does not like this, but we know this is fine
   class SentryContextManager extends ContextManagerClass {
-    public constructor() {
-      super();
+    public constructor(...args: unknown[]) {
+      super(...args);
       setIsSetup('SentryContextManager');
     }
     /**

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -155,7 +155,7 @@ export class SentryPropagator extends W3CBaggagePropagator {
 
     const propagationContext = propagationContextFromHeaders(sentryTrace, baggage);
 
-    // Add remote parent span context,
+    // Add remote parent span context
     const ctxWithSpanContext = getContextWithRemoteActiveSpan(context, { sentryTrace, baggage });
 
     // Also update the scope on the context (to be sure this is picked up everywhere)


### PR DESCRIPTION
This is more a safety thing that we do not swallow this accidentally in the future, that I noticed while looking through stuff.