### PR TITLE
ref(feedback): Let CropCorner inherit the existing h prop

### DIFF
--- a/packages/feedback/src/screenshot/components/CropCorner.tsx
+++ b/packages/feedback/src/screenshot/components/CropCorner.tsx
@@ -1,0 +1,38 @@
+import type { VNode, h as hType } from 'preact';
+
+interface FactoryParams {
+  h: typeof hType;
+}
+
+export default function CropCornerFactory({
+  h, // eslint-disable-line @typescript-eslint/no-unused-vars
+}: FactoryParams) {
+  return function CropCorner({
+    top,
+    left,
+    corner,
+    onGrabButton,
+  }: {
+    top: number;
+    left: number;
+    corner: string;
+    onGrabButton: (e: Event, corner: string) => void;
+  }): VNode {
+    return (
+      <button
+        class={`editor__crop-corner editor__crop-corner--${corner} `}
+        style={{
+          top: top,
+          left: left,
+        }}
+        onMouseDown={e => {
+          e.preventDefault();
+          onGrabButton(e, corner);
+        }}
+        onClick={e => {
+          e.preventDefault();
+        }}
+      ></button>
+    );
+  };
+}

--- a/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
+++ b/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
@@ -3,6 +3,7 @@ import type { FeedbackInternalOptions, FeedbackModalIntegration } from '@sentry/
 import type { ComponentType, VNode, h as hType } from 'preact';
 import type * as Hooks from 'preact/hooks';
 import { DOCUMENT, WINDOW } from '../../constants';
+import CropCornerFactory from './CropCorner';
 import { createScreenshotInputStyles } from './ScreenshotInput.css';
 import { useTakeScreenshotFactory } from './useTakeScreenshot';
 
@@ -62,7 +63,7 @@ const getContainedSize = (img: HTMLCanvasElement): Box => {
 };
 
 export function ScreenshotEditorFactory({
-  h, // eslint-disable-line @typescript-eslint/no-unused-vars
+  h,
   hooks,
   imageBuffer,
   dialog,
@@ -72,6 +73,7 @@ export function ScreenshotEditorFactory({
 
   return function ScreenshotEditor({ onError }: Props): VNode {
     const styles = hooks.useMemo(() => ({ __html: createScreenshotInputStyles().innerText }), []);
+    const CropCorner = CropCornerFactory({ h });
 
     const canvasContainerRef = hooks.useRef<HTMLDivElement>(null);
     const cropContainerRef = hooks.useRef<HTMLDivElement>(null);
@@ -325,33 +327,4 @@ export function ScreenshotEditorFactory({
       </div>
     );
   };
-}
-
-function CropCorner({
-  top,
-  left,
-  corner,
-  onGrabButton,
-}: {
-  top: number;
-  left: number;
-  corner: string;
-  onGrabButton: (e: Event, corner: string) => void;
-}): VNode {
-  return (
-    <button
-      class={`editor__crop-corner editor__crop-corner--${corner} `}
-      style={{
-        top: top,
-        left: left,
-      }}
-      onMouseDown={e => {
-        e.preventDefault();
-        onGrabButton(e, corner);
-      }}
-      onClick={e => {
-        e.preventDefault();
-      }}
-    ></button>
-  );
 }


### PR DESCRIPTION
I noticed this after https://github.com/getsentry/sentry-javascript/pull/12784, but the `<CropCorner>` wasn't inside the `ScreenshotEditorFactory()` function. So of course it wasn't getting access to the `h` ref that is passed in. That variable is what the `<div>` gets transpiled into -> it becomes `h.createElement('div')`.

So what i'm doing is moving `CropCorner` into a `CropCornerFactory` so we can pass `h` in and hopefully not have the extra `import .. from 'preact';`  in the 2nd bundle.

Related to https://github.com/getsentry/sentry-javascript/pull/12535