### PR TITLE
test(e2e): Don't run optional E2E tests on Dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1119,7 +1119,8 @@ jobs:
     # See: https://github.com/actions/runner/issues/2205
     if:
       always() && needs.job_e2e_prepare.result == 'success' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.actor != 'dependabot[bot]'
     needs: [job_get_metadata, job_build, job_e2e_prepare]
     runs-on: ubuntu-20.04
     timeout-minutes: 10


### PR DESCRIPTION
Came up in https://github.com/getsentry/sentry-javascript/pull/12791#issuecomment-2214548933. Dependabot PRs don't seem to have access to the repo secrets, hence causing the optional e2e tests to fail. This PR disables optional e2e tests for dependabot PRs. Our regular, required e2e tests are still executed normally.
