### PR TITLE
ci: Small adaptions to external contributor workflow

### DIFF
--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -14,8 +14,8 @@ jobs:
       contents: write
     runs-on: ubuntu-20.04
     if: |
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.author_association != 'COLLABORATOR'
+      github.event.pull_request.merged == true
+      && github.event.pull_request.author_association != 'COLLABORATOR'
       && github.event.pull_request.author_association != 'MEMBER'
       && github.event.pull_request.author_association != 'OWNER'
       && github.actor != 'dependabot[bot]'
@@ -34,6 +34,8 @@ jobs:
         uses: ./dev-packages/external-contributor-gh-action
         with:
           name: ${{ github.event.pull_request.user.login }}
+          author_association: ${{ github.event.pull_request.author_association }}
+
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
@@ -42,5 +44,5 @@ jobs:
           branch: 'external-contributor/patch-${{ github.event.pull_request.user.login }}'
           base: 'develop'
           delete-branch: true
-          body: This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution.
+          body: "This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution. See #${{ github.event.pull_request.number }}"
 

--- a/dev-packages/external-contributor-gh-action/action.yml
+++ b/dev-packages/external-contributor-gh-action/action.yml
@@ -4,6 +4,9 @@ inputs:
   name:
     required: true
     description: 'The name of the external contributor'
+  author_association:
+    required: false
+    description: 'The association of the author'
 runs:
   using: 'node20'
   main: 'index.mjs'


### PR DESCRIPTION
This does two things:

1. Pass the author association to the step - we do not use it right now, but it will be logged at least, allowing us to debug this.
2. Include a reference to the merged PR in the PR body.