### PR TITLE
test(e2e): Add e2e test for AWS lambda in ESM mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -995,6 +995,7 @@ jobs:
             'angular-17',
             'angular-18',
             'aws-lambda-layer-cjs',
+            'aws-serverless-esm',
             'node-express',
             'create-react-app',
             'create-next-app',

--- a/dev-packages/e2e-tests/package.json
+++ b/dev-packages/e2e-tests/package.json
@@ -23,7 +23,8 @@
     "esbuild": "0.20.0",
     "glob": "8.0.3",
     "ts-node": "10.9.1",
-    "yaml": "2.2.2"
+    "yaml": "2.2.2",
+    "rimraf": "^5.0.0"
   },
   "volta": {
     "extends": "../../package.json",

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/.npmrc
@@ -1,0 +1,2 @@
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/package.json
@@ -15,8 +15,7 @@
   "devDependencies": {
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@playwright/test": "^1.41.1",
-    "wait-port": "1.0.4",
-    "rimraf": "^5.0.8"
+    "wait-port": "1.0.4"
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "node-express-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node src/run.mjs",
+    "test": "playwright test",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "test:build": "pnpm install",
+    "test:assert": "pnpm test"
+  },
+  "dependencies": {
+    "@sentry/aws-serverless": "* || latest"
+  },
+  "devDependencies": {
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "@playwright/test": "^1.41.1",
+    "wait-port": "1.0.4",
+    "rimraf": "^5.0.8"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/playwright.config.ts
@@ -1,5 +1,4 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
-import { devices } from '@playwright/test';
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
 
 // Fix urls not resolving to localhost on Node v17+
 // See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
@@ -7,73 +6,22 @@ import { setDefaultResultOrder } from 'dns';
 setDefaultResultOrder('ipv4first');
 
 const eventProxyPort = 3031;
-const lambdaPort = 3030;
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-const config: PlaywrightTestConfig = {
-  testDir: './tests',
-  /* Maximum time one test can run for. */
-  timeout: 150_000,
-  expect: {
-    /**
-     * Maximum time expect() should wait for the condition to be met.
-     * For example in `await expect(locator).toHaveText();`
-     */
-    timeout: 5000,
-  },
-  /* Run tests in files in parallel */
-  fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: 0,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
-  use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
-
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: `http://localhost:${lambdaPort}`,
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
-  },
-
-  /* Configure projects for major browsers */
-  projects: [
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
+const config = getPlaywrightConfig(
+  { startCommand: '' },
+  {
+    /* Run your local dev server before starting the tests */
+    webServer: [
+      {
+        command: `node start-event-proxy.mjs && pnpm wait-port ${eventProxyPort}`,
+        port: eventProxyPort,
+        stdout: 'pipe',
       },
-    },
-    // For now we only test Chrome!
-    // {
-    //   name: 'firefox',
-    //   use: {
-    //     ...devices['Desktop Firefox'],
-    //   },
-    // },
-    // {
-    //   name: 'webkit',
-    //   use: {
-    //     ...devices['Desktop Safari'],
-    //   },
-    // },
-  ],
-
-  /* Run your local dev server before starting the tests */
-  webServer: [
-    {
-      command: `node start-event-proxy.mjs && pnpm wait-port ${eventProxyPort}`,
-      port: eventProxyPort,
-      stdout: 'pipe',
-    },
-  ],
-};
+    ],
+  },
+);
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/playwright.config.ts
@@ -1,0 +1,79 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+// Fix urls not resolving to localhost on Node v17+
+// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
+import { setDefaultResultOrder } from 'dns';
+setDefaultResultOrder('ipv4first');
+
+const eventProxyPort = 3031;
+const lambdaPort = 3030;
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 150_000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: 0,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'list',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: `http://localhost:${lambdaPort}`,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+    // For now we only test Chrome!
+    // {
+    //   name: 'firefox',
+    //   use: {
+    //     ...devices['Desktop Firefox'],
+    //   },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: {
+    //     ...devices['Desktop Safari'],
+    //   },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: [
+    {
+      command: `node start-event-proxy.mjs && pnpm wait-port ${eventProxyPort}`,
+      port: eventProxyPort,
+      stdout: 'pipe',
+    },
+  ],
+};
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/instrument.mjs
@@ -1,7 +1,0 @@
-import * as Sentry from '@sentry/aws-serverless';
-
-Sentry.init({
-  dsn: 'http://public@localhost:3031/1337',
-  tracesSampleRate: 1.0,
-  debug: true,
-});

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/instrument.mjs
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/aws-serverless';
+
+Sentry.init({
+  dsn: 'http://public@localhost:3031/1337',
+  tracesSampleRate: 1.0,
+  debug: true,
+});

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/lambda-function.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/lambda-function.mjs
@@ -1,0 +1,26 @@
+import * as http from 'node:http';
+import * as Sentry from '@sentry/aws-serverless';
+
+const handler = Sentry.wrapHandler(async () => {
+  await new Promise(resolve => {
+    const req = http.request(
+      {
+        host: 'example.com',
+      },
+      res => {
+        res.on('data', d => {
+          process.stdout.write(d);
+        });
+
+        res.on('end', () => {
+          resolve();
+        });
+      },
+    );
+    req.end();
+  });
+
+  Sentry.startSpan({ name: 'manual-span', op: 'manual' }, () => {});
+});
+
+export { handler };

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/package.json
@@ -1,0 +1,5 @@
+{
+  "//": "This is a mock package.json file which is usually created by AWS when deploying the lambda. OTEL instrumentation tries to read this file to get the lambda version",
+  "name": "lambda",
+  "version": "1.0.0"
+}

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/run-lambda.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/run-lambda.mjs
@@ -1,0 +1,10 @@
+import { handler } from './lambda-function.mjs';
+
+// Simulate minimal event and context objects being passed to the handler by the AWS runtime
+const event = {};
+const context = {
+  invokedFunctionArn: 'arn:aws:lambda:us-east-1:123453789012:function:my-lambda',
+  functionName: 'my-lambda',
+};
+
+await handler(event, context);

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/run.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/run.mjs
@@ -8,7 +8,9 @@ child_process.execSync('node ./src/run-lambda.mjs', {
     LAMBDA_TASK_ROOT: process.cwd(),
     _HANDLER: 'src/lambda-function.handler',
 
-    NODE_OPTIONS: '--import ./src/instrument.mjs',
+    NODE_OPTIONS: '--import @sentry/aws-serverless/awslambda-auto',
+    SENTRY_DSN: 'http://public@localhost:3031/1337',
+    SENTRY_TRACES_SAMPLE_RATE: '1.0',
   },
   cwd: process.cwd(),
 });

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/run.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/src/run.mjs
@@ -1,0 +1,14 @@
+import child_process from 'child_process';
+
+child_process.execSync('node ./src/run-lambda.mjs', {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    // On AWS, LAMBDA_TASK_ROOT is usually /var/task but for testing, we set it to the CWD to correctly apply our handler
+    LAMBDA_TASK_ROOT: process.cwd(),
+    _HANDLER: 'src/lambda-function.handler',
+
+    NODE_OPTIONS: '--import ./src/instrument.mjs',
+  },
+  cwd: process.cwd(),
+});

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/start-event-proxy.mjs
@@ -1,0 +1,7 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'aws-serverless-esm',
+  forwardToSentry: false,
+});

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-esm/tests/basic.test.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-esm/tests/basic.test.ts
@@ -1,0 +1,69 @@
+import * as child_process from 'child_process';
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('AWS Serverless SDK sends events in ESM mode', async ({ request }) => {
+  const transactionEventPromise = waitForTransaction('aws-serverless-esm', transactionEvent => {
+    return transactionEvent?.transaction === 'my-lambda';
+  });
+
+  // Waiting for 1s here because attaching the listener for events in `waitForTransaction` is not synchronous
+  // Since in this test, we don't start a browser via playwright, we don't have the usual delays (page.goto, etc)
+  // which are usually enough for us to never have noticed this race condition before.
+  // This is a workaround but probably sufficient as long as we only experience it in this test.
+  await new Promise<void>(resolve =>
+    setTimeout(() => {
+      resolve();
+    }, 1000),
+  );
+
+  child_process.execSync('pnpm start', {
+    stdio: 'ignore',
+  });
+
+  const transactionEvent = await transactionEventPromise;
+
+  // shows the SDK sent a transaction
+  expect(transactionEvent.transaction).toEqual('my-lambda'); // name should be the function name
+  expect(transactionEvent.contexts?.trace).toEqual({
+    data: {
+      'sentry.sample_rate': 1,
+      'sentry.source': 'component',
+      'sentry.origin': 'auto.function.serverless',
+      'sentry.op': 'function.aws.lambda',
+      'otel.kind': 'INTERNAL',
+    },
+    op: 'function.aws.lambda',
+    origin: 'auto.function.serverless',
+    span_id: expect.any(String),
+    status: 'ok',
+    trace_id: expect.any(String),
+  });
+
+  expect(transactionEvent.spans).toHaveLength(2);
+
+  // shows that the Otel Http instrumentation is working
+  expect(transactionEvent.spans).toContainEqual(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        'sentry.op': 'http.client',
+        'sentry.origin': 'auto.http.otel.http',
+        url: 'http://example.com/',
+      }),
+      description: 'GET http://example.com/',
+      op: 'http.client',
+    }),
+  );
+
+  // shows that the manual span creation is working
+  expect(transactionEvent.spans).toContainEqual(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        'sentry.op': 'manual',
+        'sentry.origin': 'manual',
+      }),
+      description: 'manual-span',
+      op: 'manual',
+    }),
+  );
+});

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -41,6 +41,9 @@
     "./awslambda-auto": {
       "require": {
         "default": "./build/npm/cjs/awslambda-auto.js"
+      },
+      "import": {
+        "default": "./build/npm/esm/awslambda-auto.js"
       }
     },
     "./dist/awslambda-auto": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9467,17 +9467,7 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/history-4@npm:@types/history@4.7.8":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
-
-"@types/history-5@npm:@types/history@4.7.8":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
-
-"@types/history@*":
+"@types/history-4@npm:@types/history@4.7.8", "@types/history-5@npm:@types/history@4.7.8", "@types/history@*":
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
   integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
@@ -9836,15 +9826,7 @@
     "@types/history" "^3"
     "@types/react" "*"
 
-"@types/react-router-4@npm:@types/react-router@5.1.14":
-  version "5.1.14"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.14.tgz#e0442f4eb4c446541ad7435d44a97f8fe6df40da"
-  integrity sha512-LAJpqYUaCTMT2anZheoidiIymt8MuX286zoVFPM3DVb23aQBH0mAkFvzpd4LKqiolV8bBtZWT5Qp7hClCNDENw==
-  dependencies:
-    "@types/history" "*"
-    "@types/react" "*"
-
-"@types/react-router-5@npm:@types/react-router@5.1.14":
+"@types/react-router-4@npm:@types/react-router@5.1.14", "@types/react-router-5@npm:@types/react-router@5.1.14":
   version "5.1.14"
   resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.14.tgz#e0442f4eb4c446541ad7435d44a97f8fe6df40da"
   integrity sha512-LAJpqYUaCTMT2anZheoidiIymt8MuX286zoVFPM3DVb23aQBH0mAkFvzpd4LKqiolV8bBtZWT5Qp7hClCNDENw==
@@ -19643,6 +19625,18 @@ glob@^10.3.4:
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
 
+glob@^10.3.7:
+  version "10.4.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
+  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
 glob@^5.0.10:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
@@ -29020,7 +29014,7 @@ react-is@^18.0.0:
   dependencies:
     "@remix-run/router" "1.0.2"
 
-"react-router-6@npm:react-router@6.3.0":
+"react-router-6@npm:react-router@6.3.0", react-router@6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
   integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
@@ -29034,13 +29028,6 @@ react-router-dom@^6.2.2:
   dependencies:
     history "^5.2.0"
     react-router "6.3.0"
-
-react-router@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
-  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
-  dependencies:
-    history "^5.2.0"
 
 react@^18.0.0:
   version "18.0.0"
@@ -29963,6 +29950,13 @@ rimraf@^4.4.1:
   integrity sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==
   dependencies:
     glob "^9.2.0"
+
+rimraf@^5.0.0:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.9.tgz#c3baa1b886eadc2ec7981a06a593c3d01134ffe9"
+  integrity sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==
+  dependencies:
+    glob "^10.3.7"
 
 rimraf@~2.6.2:
   version "2.6.3"
@@ -31567,16 +31561,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -31688,14 +31673,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -34788,16 +34766,7 @@ workerpool@^6.4.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.4.0.tgz#f8d5cfb45fde32fa3b7af72ad617c3369567a462"
   integrity sha512-i3KR1mQMNwY2wx20ozq2EjISGtQWDIfV56We+yGJ5yDs8jTwQiLLaqHlkBHITlCuJnYlVRmXegxFxZg7gqI++A==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This PR adds an E2E test app that simulates running an AWS lambda function in ESM mode. At the same time, this test app represents the state of how to manually use the `@sentry/aws-serverless` SDK for ESM-based lambda functions. For the moment, the plan is to document this as follows:

1. Install `@sentry/aws-serverless` with the package manager of your choice
2. Add the following environment variables to your lambda environment:
   - `NODE_OPTIONS: '--import @sentry/aws-serverless/awslambda-auto`
   - `SENTRY_DSN: '<your-dsn>'`
   - `SENTRY_TRACES_SAMPLE_RATE: '1.0'`
3. wrap your lambda handler function with `Sentry.wrapHandler`
4. ensure that when deploying your function, the `node_modules` directory is deployed alongside your lambda code

Unfortunately, we can't get around  highest friction points:

- manually adding the `Sentry.wrapHandler` wrapper
- ensuring the SDK + dependencies in `node_modules` are deployed alongside lambda code

This, we'll only get rid off with an ESM lambda layer, and possibly not at all for the `Sentry.wrapHandler` part.

ref #12409 