### PR TITLE
fix(nuxt): Add module to build:transpile script

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -28,6 +28,19 @@ The minimum supported version of Nuxt is `3.0.0`.
 This package is a wrapper around `@sentry/node` for the server and `@sentry/vue` for the client side, with added
 functionality related to Nuxt.
 
+What is working:
+
+- Error Reporting
+
+What is partly working:
+
+- Tracing by setting `tracesSampleRate`
+
+What is not yet(!) included:
+
+- Source Maps
+- Connected Traces
+
 ## Automatic Setup
 
 todo: add wizard instructions

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -57,10 +57,10 @@
     "nuxt": "^3.12.2"
   },
   "scripts": {
-    "build": "run-p build:transpile build:types build:nuxt-module",
+    "build": "run-s build:types build:transpile",
     "build:dev": "yarn build",
     "build:nuxt-module": "nuxt-module-build build --outDir build/module",
-    "build:transpile": "rollup -c rollup.npm.config.mjs",
+    "build:transpile": "rollup -c rollup.npm.config.mjs && yarn build:nuxt-module",
     "build:types": "tsc -p tsconfig.types.json",
     "build:watch": "run-p build:transpile:watch build:types:watch",
     "build:dev:watch": "yarn build:watch",
@@ -84,10 +84,12 @@
       "build:transpile": {
         "dependsOn": [
           "^build:transpile",
-          "^build:types"
+          "^build:types",
+          "build:types"
         ],
         "outputs": [
-          "{projectRoot}/build",
+          "{projectRoot}/build/cjs",
+          "{projectRoot}/build/esm",
           "{projectRoot}/build/module"
         ]
       }


### PR DESCRIPTION
Adds the `module` folder to the build output when building packages in root-level.
