### PR TITLE
fix(browser): Allow SDK initialization in NW.js apps

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -63,6 +63,7 @@ function applyDefaultOptions(optionsArg: BrowserOptions = {}): BrowserOptions {
 type ExtensionProperties = {
   chrome?: Runtime;
   browser?: Runtime;
+  nw?: unknown;
 };
 type Runtime = {
   runtime?: {
@@ -85,7 +86,11 @@ function shouldShowBrowserExtensionError(): boolean {
   const isDedicatedExtensionPage =
     !!runtimeId && WINDOW === WINDOW.top && extensionProtocols.some(protocol => href.startsWith(`${protocol}//`));
 
-  return !!runtimeId && !isDedicatedExtensionPage;
+  // Running in NW.js, which appears like a browser extension but isn't is also fine
+  // see: https://github.com/getsentry/sentry-javascript/issues/12668
+  const isNWjs = typeof windowWithMaybeExtension.nw !== 'undefined';
+
+  return !!runtimeId && !isDedicatedExtensionPage && !isNWjs;
 }
 
 /**

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -86,7 +86,7 @@ function shouldShowBrowserExtensionError(): boolean {
   const isDedicatedExtensionPage =
     !!runtimeId && WINDOW === WINDOW.top && extensionProtocols.some(protocol => href.startsWith(`${protocol}//`));
 
-  // Running in NW.js, which appears like a browser extension but isn't is also fine
+  // Running the SDK in NW.js, which appears like a browser extension but isn't, is also fine
   // see: https://github.com/getsentry/sentry-javascript/issues/12668
   const isNWjs = typeof windowWithMaybeExtension.nw !== 'undefined';
 

--- a/packages/browser/test/unit/sdk.test.ts
+++ b/packages/browser/test/unit/sdk.test.ts
@@ -142,6 +142,7 @@ describe('init', () => {
     afterEach(() => {
       Object.defineProperty(WINDOW, 'chrome', { value: undefined, writable: true });
       Object.defineProperty(WINDOW, 'browser', { value: undefined, writable: true });
+      Object.defineProperty(WINDOW, 'nw', { value: undefined, writable: true });
     });
 
     it('logs a browser extension error if executed inside a Chrome extension', () => {
@@ -206,6 +207,18 @@ describe('init', () => {
       init(options);
 
       expect(consoleErrorSpy).toBeCalledTimes(0);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("doesn't log a browser extension error if executed inside an NW.js environment", () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      Object.defineProperty(WINDOW, 'nw', { value: {} });
+
+      init(options);
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();
     });


### PR DESCRIPTION
Looks like our browser extension check that blocks SDK initalization via `Sentry.init` also blocked initializing 
the SDK in NW.js apps. This PR adds a check for the `window.nw` property to handle this case.

Note: If we get more reports like this, we should consider adding a flag to force-init the SDK when this
check wrongfully blocks sdk init. For now though, I wanna hold off from expanding public API.

fixes https://github.com/getsentry/sentry-javascript/issues/12668
