### PR TITLE
fix(nextjs): Support automatic instrumentation for app directory with custom page extensions

### DIFF
--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -182,7 +182,8 @@ export default function wrappingLoader(
 
     const componentTypeMatch = path.posix
       .normalize(path.relative(appDir, this.resourcePath))
-      .match(/\/?([^/.]+)(?:\..*)?\.(?:js|ts|jsx|tsx)$/);
+      // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor
+      .match(new RegExp(`/\\/?([^/]+)\\.(?:${pageExtensionRegex})$`));
 
     if (componentTypeMatch && componentTypeMatch[1]) {
       let componentType: ServerComponentContext['componentType'];

--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -182,7 +182,7 @@ export default function wrappingLoader(
 
     const componentTypeMatch = path.posix
       .normalize(path.relative(appDir, this.resourcePath))
-      .match(/\/?([^/]+)\.(?:js|ts|jsx|tsx)$/);
+      .match(/\/?([^/.]+)(?:\..*)?\.(?:js|ts|jsx|tsx)$/);
 
     if (componentTypeMatch && componentTypeMatch[1]) {
       let componentType: ServerComponentContext['componentType'];

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -147,12 +147,12 @@ export function constructWebpackConfigFunction(
       );
     };
 
-    const possibleMiddlewareLocations = ['js', 'jsx', 'ts', 'tsx'].map(middlewareFileEnding => {
-      return path.join(middlewareLocationFolder, `middleware.${middlewareFileEnding}`);
-    });
     const isMiddlewareResource = (resourcePath: string): boolean => {
       const normalizedAbsoluteResourcePath = normalizeLoaderResourcePath(resourcePath);
-      return possibleMiddlewareLocations.includes(normalizedAbsoluteResourcePath);
+      return (
+        normalizedAbsoluteResourcePath.startsWith(middlewareLocationFolder) &&
+        !!normalizedAbsoluteResourcePath.match(/[\\/]middleware(\..*)?\.(js|jsx|ts|tsx)$/)
+      );
     };
 
     const isServerComponentResource = (resourcePath: string): boolean => {
@@ -163,7 +163,7 @@ export function constructWebpackConfigFunction(
       return (
         appDirPath !== undefined &&
         normalizedAbsoluteResourcePath.startsWith(appDirPath + path.sep) &&
-        !!normalizedAbsoluteResourcePath.match(/[\\/](page|layout|loading|head|not-found)\.(js|jsx|tsx)$/)
+        !!normalizedAbsoluteResourcePath.match(/[\\/](page|layout|loading|head|not-found)(?:\..*)?\.(?:js|jsx|tsx)$/)
       );
     };
 
@@ -172,7 +172,7 @@ export function constructWebpackConfigFunction(
       return (
         appDirPath !== undefined &&
         normalizedAbsoluteResourcePath.startsWith(appDirPath + path.sep) &&
-        !!normalizedAbsoluteResourcePath.match(/[\\/]route\.(js|jsx|ts|tsx)$/)
+        !!normalizedAbsoluteResourcePath.match(/[\\/]route(?:\..*)?\.(?:js|jsx|ts|tsx)$/)
       );
     };
 
@@ -285,10 +285,9 @@ export function constructWebpackConfigFunction(
     }
 
     if (appDirPath) {
-      const hasGlobalErrorFile = ['global-error.js', 'global-error.jsx', 'global-error.ts', 'global-error.tsx'].some(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        globalErrorFile => fs.existsSync(path.join(appDirPath!, globalErrorFile)),
-      );
+      const hasGlobalErrorFile = fs
+        .readdirSync(appDirPath)
+        .some(file => file.match(/^global-error(?:\..*)?\.(?:js|ts|jsx|tsx)$/));
 
       if (
         !hasGlobalErrorFile &&

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -147,12 +147,12 @@ export function constructWebpackConfigFunction(
       );
     };
 
+    const possibleMiddlewareLocations = pageExtensions.map(middlewareFileEnding => {
+      return path.join(middlewareLocationFolder, `middleware.${middlewareFileEnding}`);
+    });
     const isMiddlewareResource = (resourcePath: string): boolean => {
       const normalizedAbsoluteResourcePath = normalizeLoaderResourcePath(resourcePath);
-      return (
-        normalizedAbsoluteResourcePath.startsWith(middlewareLocationFolder) &&
-        !!normalizedAbsoluteResourcePath.match(/[\\/]middleware(\..*)?\.(js|jsx|ts|tsx)$/)
-      );
+      return possibleMiddlewareLocations.includes(normalizedAbsoluteResourcePath);
     };
 
     const isServerComponentResource = (resourcePath: string): boolean => {
@@ -163,7 +163,10 @@ export function constructWebpackConfigFunction(
       return (
         appDirPath !== undefined &&
         normalizedAbsoluteResourcePath.startsWith(appDirPath + path.sep) &&
-        !!normalizedAbsoluteResourcePath.match(/[\\/](page|layout|loading|head|not-found)(?:\..*)?\.(?:js|jsx|tsx)$/)
+        !!normalizedAbsoluteResourcePath.match(
+          // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor
+          new RegExp(`[\\\\/](page|layout|loading|head|not-found)\\.(${pageExtensionRegex})$`),
+        )
       );
     };
 
@@ -172,7 +175,10 @@ export function constructWebpackConfigFunction(
       return (
         appDirPath !== undefined &&
         normalizedAbsoluteResourcePath.startsWith(appDirPath + path.sep) &&
-        !!normalizedAbsoluteResourcePath.match(/[\\/]route(?:\..*)?\.(?:js|jsx|ts|tsx)$/)
+        !!normalizedAbsoluteResourcePath.match(
+          // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor
+          new RegExp(`[\\\\/]route\\.(${pageExtensionRegex})$`),
+        )
       );
     };
 
@@ -285,9 +291,12 @@ export function constructWebpackConfigFunction(
     }
 
     if (appDirPath) {
-      const hasGlobalErrorFile = fs
-        .readdirSync(appDirPath)
-        .some(file => file.match(/^global-error(?:\..*)?\.(?:js|ts|jsx|tsx)$/));
+      const hasGlobalErrorFile = pageExtensions
+        .map(extension => `global-error.${extension}`)
+        .some(
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          globalErrorFile => fs.existsSync(path.join(appDirPath!, globalErrorFile)),
+        );
 
       if (
         !hasGlobalErrorFile &&

--- a/packages/nextjs/test/config/fixtures.ts
+++ b/packages/nextjs/test/config/fixtures.ts
@@ -13,6 +13,7 @@ export const EDGE_SDK_CONFIG_FILE = 'sentry.edge.config.js';
 /** Mock next config object */
 export const userNextConfig: NextConfigObject = {
   publicRuntimeConfig: { location: 'dogpark', activities: ['fetch', 'chasing', 'digging'] },
+  pageExtensions: ['jsx', 'js', 'tsx', 'ts', 'custom.jsx', 'custom.js', 'custom.tsx', 'custom.ts'],
   webpack: (incomingWebpackConfig: WebpackConfigObject, _options: BuildContext) => ({
     ...incomingWebpackConfig,
     mode: 'universal-sniffing',

--- a/packages/nextjs/test/config/loaders.test.ts
+++ b/packages/nextjs/test/config/loaders.test.ts
@@ -14,6 +14,7 @@ import {
 import { materializeFinalWebpackConfig } from './testUtils';
 
 const existsSyncSpy = jest.spyOn(fs, 'existsSync');
+jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
 const lstatSyncSpy = jest.spyOn(fs, 'lstatSync');
 
 type MatcherResult = { pass: boolean; message: () => string };
@@ -97,6 +98,10 @@ describe('webpack loaders', () => {
         expectedWrappingTargetKind: 'page',
       },
       {
+        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/pages/testPage.custom.tsx',
+        expectedWrappingTargetKind: 'page',
+      },
+      {
         resourcePath: './src/pages/testPage.tsx',
         expectedWrappingTargetKind: 'page',
       },
@@ -134,6 +139,10 @@ describe('webpack loaders', () => {
         expectedWrappingTargetKind: 'middleware',
       },
       {
+        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/middleware.custom.js',
+        expectedWrappingTargetKind: 'middleware',
+      },
+      {
         resourcePath: './src/middleware.js',
         expectedWrappingTargetKind: 'middleware',
       },
@@ -163,7 +172,23 @@ describe('webpack loaders', () => {
         expectedWrappingTargetKind: 'api-route',
       },
       {
+        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/pages/api/nested/testApiRoute.custom.js',
+        expectedWrappingTargetKind: 'api-route',
+      },
+      {
+        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/nested/route.ts',
+        expectedWrappingTargetKind: 'route-handler',
+      },
+      {
+        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/nested/route.custom.ts',
+        expectedWrappingTargetKind: 'route-handler',
+      },
+      {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/page.js',
+        expectedWrappingTargetKind: 'server-component',
+      },
+      {
+        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/page.custom.js',
         expectedWrappingTargetKind: 'server-component',
       },
       {

--- a/packages/nextjs/test/config/loaders.test.ts
+++ b/packages/nextjs/test/config/loaders.test.ts
@@ -14,7 +14,6 @@ import {
 import { materializeFinalWebpackConfig } from './testUtils';
 
 const existsSyncSpy = jest.spyOn(fs, 'existsSync');
-jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
 const lstatSyncSpy = jest.spyOn(fs, 'lstatSync');
 
 type MatcherResult = { pass: boolean; message: () => string };
@@ -196,8 +195,8 @@ describe('webpack loaders', () => {
         expectedWrappingTargetKind: 'server-component',
       },
       {
-        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/nested/page.ts', // ts is not a valid file ending for pages in the app dir
-        expectedWrappingTargetKind: undefined,
+        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/nested/page.ts',
+        expectedWrappingTargetKind: 'server-component',
       },
       {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/(group)/nested/page.tsx',
@@ -205,7 +204,7 @@ describe('webpack loaders', () => {
       },
       {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/(group)/nested/loading.ts',
-        expectedWrappingTargetKind: undefined,
+        expectedWrappingTargetKind: 'server-component',
       },
       {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/layout.js',


### PR DESCRIPTION
This PR updates the regex and logic for detecting middleware, route handler, and server component files to support [custom page extensions](https://nextjs.org/docs/pages/api-reference/next-config-js/pageExtensions), such as `middleware.custom.ts` and `route.custom.ts`.

#### Changes Made
- Modified the `isRouteHandler` function to use a regex that matches custom page extensions for route handler files.
- Modified the `isMiddlewareResource` function to use a regex that matches custom page extensions for middleware files.
- Modified the `isServerComponent` function to use a regex that matches custom page extensions for server component files.
- modified `hasGlobalErrorFile` flag to account for custom page extensions 

#### Testing
- Verified the updated regex matches route handlers and middleware files with standard and custom extensions.
- Added new cases for server loaders tests to cover route handler files
- Updated and passed all test cases.
- Added a duplicate e2e nextjs project with page extensions enabled and it passes all tests #12864

### Checklist
- [x] Modified `isRouteHandler` function.
- [x] Modified `isMiddlewareResource` function.
- [x] Modified `isServerComponent` function.
- [x] Modified `hasGlobalErrorFile` flag.
- [x] Manual and automated testing completed.
- [x] e2e tests #12864


---

Please review and provide feedback. Thank you!