### PR TITLE
docs(nextjs): Clarify which API wrappers are intended for which router

### DIFF
--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -22,7 +22,9 @@ import {
 import { vercelWaitUntil } from './utils/vercelWaitUntil';
 
 /**
- * Wraps a Next.js route handler with performance and error instrumentation.
+ * Wraps a Next.js App Router Route handler with Sentry error and performance instrumentation.
+ *
+ * NOTICE: This wrapper is for App Router API routes. If you are looking to wrap Pages Router API routes use `wrapApiHandlerWithSentry` instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -41,7 +41,9 @@ export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metric
 export { withSentryConfig } from './config';
 
 /**
- * Wraps a Next.js API handler with Sentry error and performance instrumentation.
+ * Wraps a Next.js Pages Router API route with Sentry error and performance instrumentation.
+ *
+ * NOTICE: This wrapper is for Pages Router API routes. If you are looking to wrap App Router API routes use `wrapRouteHandlerWithSentry` instead.
  *
  * @param handler The handler exported from the API route file.
  * @param parameterizedRoute The page's parameterized route.


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/12865