### PR TITLE
test(e2e): Add nestjs e2e test documenting errors not being properly caught in submodules

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs/src/app.module.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController1, AppController2 } from './app.controller';
 import { AppService1, AppService2 } from './app.service';
+import { TestModule } from './test-module/test.module';
 
 @Module({
-  imports: [ScheduleModule.forRoot()],
+  imports: [ScheduleModule.forRoot(), TestModule],
   controllers: [AppController1],
   providers: [AppService1],
 })

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { TestException } from './test.exception';
+
+@Controller('test-module')
+export class TestController {
+  constructor() {}
+
+  @Get()
+  getTest(): string {
+    throw new TestException();
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.exception.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.exception.ts
@@ -1,5 +1,5 @@
 export class TestException extends Error {
   constructor() {
-    super("Something went wrong in the test module!");
+    super('Something went wrong in the test module!');
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.exception.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.exception.ts
@@ -1,0 +1,5 @@
+export class TestException extends Error {
+  constructor() {
+    super("Something went wrong in the test module!");
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.filter.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.filter.ts
@@ -1,0 +1,13 @@
+import { ArgumentsHost, BadRequestException, Catch } from '@nestjs/common';
+import { TestException } from './test.exception';
+import { BaseExceptionFilter } from '@nestjs/core';
+
+@Catch(TestException)
+export class TestExceptionFilter extends BaseExceptionFilter {
+  catch (exception: unknown, host: ArgumentsHost) {
+    if (exception instanceof TestException) {
+      return super.catch(new BadRequestException(exception.message), host);
+    }
+    return super.catch(exception, host);
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.filter.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.filter.ts
@@ -1,10 +1,10 @@
 import { ArgumentsHost, BadRequestException, Catch } from '@nestjs/common';
-import { TestException } from './test.exception';
 import { BaseExceptionFilter } from '@nestjs/core';
+import { TestException } from './test.exception';
 
 @Catch(TestException)
 export class TestExceptionFilter extends BaseExceptionFilter {
-  catch (exception: unknown, host: ArgumentsHost) {
+  catch(exception: unknown, host: ArgumentsHost) {
     if (exception instanceof TestException) {
       return super.catch(new BadRequestException(exception.message), host);
     }

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.module.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
-import { TestController } from './test.controller';
 import { APP_FILTER } from '@nestjs/core';
+import { TestController } from './test.controller';
 import { TestExceptionFilter } from './test.filter';
 
 @Module({
@@ -10,7 +10,7 @@ import { TestExceptionFilter } from './test.filter';
     {
       provide: APP_FILTER,
       useClass: TestExceptionFilter,
-    }
-  ]
+    },
+  ],
 })
 export class TestModule {}

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.module.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/test-module/test.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TestController } from './test.controller';
+import { APP_FILTER } from '@nestjs/core';
+import { TestExceptionFilter } from './test.filter';
+
+@Module({
+  imports: [],
+  controllers: [TestController],
+  providers: [
+    {
+      provide: APP_FILTER,
+      useClass: TestExceptionFilter,
+    }
+  ]
+})
+export class TestModule {}

--- a/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
@@ -53,3 +53,32 @@ test('Does not send expected exception to Sentry', async ({ baseURL }) => {
 
   expect(errorEventOccurred).toBe(false);
 });
+
+test('Does not handle expected exception if exception is thrown in module', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('nestjs', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'Something went wrong in the test module!';
+  })
+
+  const response = await fetch(`${baseURL}/test-module`);
+  expect(response.status).toBe(500); // should be 400
+
+  // should never arrive, but does because the exception is not handled properly
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('Something went wrong in the test module!');
+
+  expect(errorEvent.request).toEqual({
+    method: 'GET',
+    cookies: {},
+    headers: expect.any(Object),
+    url: 'http://localhost:3030/test-module',
+  });
+
+  expect(errorEvent.transaction).toEqual('GET /test-module');
+
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: expect.any(String),
+    span_id: expect.any(String),
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/tests/errors.test.ts
@@ -57,7 +57,7 @@ test('Does not send expected exception to Sentry', async ({ baseURL }) => {
 test('Does not handle expected exception if exception is thrown in module', async ({ baseURL }) => {
   const errorEventPromise = waitForError('nestjs', event => {
     return !event.type && event.exception?.values?.[0]?.value === 'Something went wrong in the test module!';
-  })
+  });
 
   const response = await fetch(`${baseURL}/test-module`);
   expect(response.status).toBe(500); // should be 400


### PR DESCRIPTION
Related to [this issue](https://github.com/getsentry/sentry-javascript/issues/12351).

Currently errors in submodules are not properly handled in nest applications if a custom exception filter extending the BaseExceptionFilter is used, leading to expected exceptions not being caught correctly and therefore being returned as 500 and sent to Sentry.

This expands the sample nest application and adds an e2e test that documents this behavior that can be used to check that future improvements to the SDK actually work. Of course the test has to be adjusted in that case.