### PR TITLE
ci: Run external-collaborator workflow on pull_request_target

### DIFF
--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -1,6 +1,6 @@
 name: "CI: Mention external contributors"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

You can see e.g. here: https://github.com/getsentry/sentry-javascript/actions/runs/9888865345/job/27313696886 that this lacks permissions when run as `pull_request`. Now, this should ran in the context of the base branch, which grants proper rights etc. and also prevents leaking etc.