### PR TITLE
fix(nestjs): do not make SentryTraced() decorated functions async

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/app.service.ts
@@ -104,7 +104,7 @@ export class AppService1 {
   }
 
   async testSpanDecoratorSync() {
-    const returned = this.getString()
+    const returned = this.getString();
     // Will fail if getString() is async, because returned will be a Promise<>
     return returned.result;
   }

--- a/dev-packages/e2e-tests/test-applications/nestjs/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs/src/app.service.ts
@@ -99,12 +99,14 @@ export class AppService1 {
   }
 
   @SentryTraced('return a string')
-  getString(): string {
-    return 'test';
+  getString(): { result: string } {
+    return { result: 'test' };
   }
 
   async testSpanDecoratorSync() {
-    return this.getString();
+    const returned = this.getString()
+    // Will fail if getString() is async, because returned will be a Promise<>
+    return returned.result;
   }
 
   /*

--- a/packages/nestjs/src/span-decorator.ts
+++ b/packages/nestjs/src/span-decorator.ts
@@ -6,7 +6,7 @@ import { startSpan } from '@sentry/node';
 export function SentryTraced(op: string = 'function') {
   return function (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const originalMethod = descriptor.value as (...args: any[]) => Promise<any>;
+    const originalMethod = descriptor.value as (...args: any[]) => Promise<any> | any; // function can be sync or async
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     descriptor.value = function (...args: any[]) {
@@ -15,7 +15,7 @@ export function SentryTraced(op: string = 'function') {
           op: op,
           name: propertyKey,
         },
-        async () => {
+        () => {
           return originalMethod.apply(this, args);
         },
       );


### PR DESCRIPTION
_Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:_

- [x] _If you've added code that should be tested, please add tests._
- [x] _Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`)._

---

**The `SentryTraced()` decorator in the `@sentry/nestjs` package (introduced in #12721) stealthily turns any decorated function asynchronous.**

We experienced issues on a production Nest app due to this - it's a bit sneaky because the Typescript compiler doesn't understand (or check at all?) that the decorator changes the function signature.

There was a test written to check sync support, but since the tests are end-to-end and always go through a first layer of async functions, the returned `Promise<>` from the supposedly sync test function was just unwrapped later without any issues.

**This PR:**
- Fixes the `testSpanDecoratorSync` to fail if the decorated test function is not sync
- Fixes the decorator itself by returning the decorated function without always marking it with `async`

Thank you!