### PR TITLE
ci: Do not run external contributor job for bots

### DIFF
--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -18,7 +18,7 @@ jobs:
       && github.event.pull_request.author_association != 'COLLABORATOR'
       && github.event.pull_request.author_association != 'MEMBER'
       && github.event.pull_request.author_association != 'OWNER'
-      && github.actor != 'dependabot[bot]'
+      && endsWith(github.actor, '[bot]') == false
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node


### PR DESCRIPTION
While we specifically ignored dependabot, we did not ignore github bot. So now, just generally skipping this for any bot users.