### PR TITLE
fix(angular): Guard `ErrorEvent` check in ErrorHandler to avoid throwing in Node environments

### DIFF
--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -39,7 +39,8 @@ function extractHttpModuleError(error: HttpErrorResponse): string | Error {
   }
 
   // ... or an`ErrorEvent`, which can provide us with the message but no stack...
-  if (error.error instanceof ErrorEvent && error.error.message) {
+  // guarding `ErrorEvent` against `undefined` as it's not defined in Node environments
+  if (typeof ErrorEvent !== 'undefined' && error.error instanceof ErrorEvent && error.error.message) {
     return error.error.message;
   }
 

--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -45,6 +45,11 @@ describe('SentryErrorHandler', () => {
   });
 
   describe('handleError method', () => {
+    const originalErrorEvent = globalThis.ErrorEvent;
+    afterEach(() => {
+      globalThis.ErrorEvent = originalErrorEvent;
+    });
+
     it('extracts `null` error', () => {
       createErrorHandler().handleError(null);
 
@@ -221,6 +226,18 @@ describe('SentryErrorHandler', () => {
 
       expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
       expect(captureExceptionSpy).toHaveBeenCalledWith('Handled unknown error', captureExceptionEventHint);
+    });
+
+    it('handles ErrorEvent being undefined', () => {
+      const httpErr = new ErrorEvent('http', { message: 'sentry-http-test' });
+      const err = new HttpErrorResponse({ error: httpErr });
+
+      // @ts-expect-error - this is fine in this test
+      delete globalThis.ErrorEvent;
+
+      expect(() => {
+        createErrorHandler().handleError(err);
+      }).not.toThrow();
     });
 
     it('extracts an Error with `ngOriginalError`', () => {


### PR DESCRIPTION
Small fix for a "bug" mentioned in https://github.com/getsentry/sentry-javascript/issues/12757#issuecomment-2220585593

This PR adds a guard for referencing `ErrorEvent` which is only available in browser environments but not in Node. Now, the errorHandler, as well as `@sentry/angular` in general is only expected to be run in browser environments. So this fix is technically not necessary at the moment but people nevertheless use `@sentry/angular` in Node environments so let's make their lives a bit easier. 