### PR TITLE
ref: Deprecate `enableTracing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@
 The `enableTracing` option has been deprecated and will be removed in the next major version. We recommend removing it
 in favor of the `tracesSampleRate` and `tracesSampler` options. If you want to enable performance monitoring, please set
 the `tracesSampleRate` to a sample rate of your choice, or provide a sampling function as `tracesSampler` option
-instead. If you wan't to disable performance monitoring, remove the `tracesSampler` option and set the
-`tracesSampleRate` to `0` or `undefined`.
+instead. If you wan't to disable performance monitoring, remove the `tracesSampler` and `tracesSampleRate` options.
 
 Work in this release was contributed by @GitSquared. Thank you for your contribution!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+### Important Changes
+
+- **ref: Deprecate `enableTracing` (12897)**
+
+The `enableTracing` option has been deprecated and will be removed in the next major version. We recommend removing it
+in favor of the `tracesSampleRate` and `tracesSampler` options. If you want to enable performance monitoring, please set
+the `tracesSampleRate` to a sample rate of your choice, or provide a sampling function as `tracesSampler` option
+instead. If you wan't to disable performance monitoring, remove the `tracesSampler` option and set the
+`tracesSampleRate` to `0` or `undefined`.
+
 Work in this release was contributed by @GitSquared. Thank you for your contribution!
 
 ## 8.17.0

--- a/packages/core/src/utils/hasTracingEnabled.ts
+++ b/packages/core/src/utils/hasTracingEnabled.ts
@@ -17,6 +17,7 @@ export function hasTracingEnabled(
   }
 
   const options = maybeOptions || getClientOptions();
+  // eslint-disable-next-line deprecation/deprecation
   return !!options && (options.enableTracing || 'tracesSampleRate' in options || 'tracesSampler' in options);
 }
 

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -92,6 +92,7 @@ function shouldAddPerformanceIntegrations(options: Options): boolean {
   }
 
   // We want to ensure `tracesSampleRate` is not just undefined/null here
+  // eslint-disable-next-line deprecation/deprecation
   return options.enableTracing || options.tracesSampleRate != null || 'tracesSampler' in options;
 }
 

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -89,9 +89,13 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   tracesSampleRate?: number;
 
   /**
-   * If this is enabled, transactions and trace data will be generated and captured.
+   * If this is enabled, spans and trace data will be generated and captured.
    * This will set the `tracesSampleRate` to the recommended default of `1.0` if `tracesSampleRate` is undefined.
    * Note that `tracesSampleRate` and `tracesSampler` take precedence over this option.
+   *
+   * @deprecated This option is deprecated and will be removed in the next major version. If you want to enable performance monitoring, please set the `tracesSampleRate` or
+   * `tracesSampler` options instead. If you wan't to disable performance monitoring, remove the `tracesSampler` option
+   * and set the `tracesSampleRate` to `0` or `undefined`.
    */
   enableTracing?: boolean;
 

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -93,9 +93,9 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    * This will set the `tracesSampleRate` to the recommended default of `1.0` if `tracesSampleRate` is undefined.
    * Note that `tracesSampleRate` and `tracesSampler` take precedence over this option.
    *
-   * @deprecated This option is deprecated and will be removed in the next major version. If you want to enable performance monitoring, please set the `tracesSampleRate` or
-   * `tracesSampler` options instead. If you wan't to disable performance monitoring, remove the `tracesSampler` option
-   * and set the `tracesSampleRate` to `0` or `undefined`.
+   * @deprecated This option is deprecated and will be removed in the next major version. If you want to enable performance
+   * monitoring, please use the `tracesSampleRate` or `tracesSampler` options instead. If you wan't to disable performance
+   * monitoring, remove the `tracesSampler` and `tracesSampleRate` options.
    */
   enableTracing?: boolean;
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/12883

The `enableTracing` option has been a source of confusion in combination with the existing `tracesSampleRate` and `tracesSampler` options. We are deprecating it in favor of the other options.