### PR TITLE
fix(solidstart): Set proper sentry origin for solid router integration when used in solidstart sdk

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/performance.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/performance.client.test.ts
@@ -36,7 +36,7 @@ test('sends a navigation transaction', async ({ page }) => {
     contexts: {
       trace: {
         op: 'navigation',
-        origin: 'auto.navigation.solid.solidrouter',
+        origin: 'auto.navigation.solidstart.solidrouter',
       },
     },
     transaction: '/users/5',
@@ -62,7 +62,7 @@ test('updates the transaction when using the back button', async ({ page }) => {
     contexts: {
       trace: {
         op: 'navigation',
-        origin: 'auto.navigation.solid.solidrouter',
+        origin: 'auto.navigation.solidstart.solidrouter',
       },
     },
     transaction: '/users/6',
@@ -82,7 +82,7 @@ test('updates the transaction when using the back button', async ({ page }) => {
     contexts: {
       trace: {
         op: 'navigation',
-        origin: 'auto.navigation.solid.solidrouter',
+        origin: 'auto.navigation.solidstart.solidrouter',
       },
     },
     transaction: '/',

--- a/packages/solid/src/solidrouter.ts
+++ b/packages/solid/src/solidrouter.ts
@@ -33,11 +33,18 @@ function handleNavigation(location: string): void {
     return;
   }
 
+  // The solid router integration will be used for both solid and solid start.
+  // To avoid increasing the api surface with internal properties, we look at
+  // the sdk metadata.
+  const metaData = client.getSdkMetadata();
+  const { name } = (metaData && metaData.sdk) || {};
+  const framework = name && name.includes('solidstart') ? 'solidstart' : 'solid';
+
   startBrowserTracingNavigationSpan(client, {
     name: location,
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solid.solidrouter',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.navigation.${framework}.solidrouter`,
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
     },
   });

--- a/packages/solid/test/solidrouter.test.tsx
+++ b/packages/solid/test/solidrouter.test.tsx
@@ -44,6 +44,11 @@ describe('solidRouterBrowserTracingIntegration', () => {
       tracesSampleRate: 1,
       transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => Promise.resolve({})),
       stackParser: () => [],
+      _metadata: {
+        sdk: {
+          name: 'sentry.javascript.solid',
+        },
+      },
     });
   }
 

--- a/packages/solidstart/test/client/solidrouter.test.tsx
+++ b/packages/solidstart/test/client/solidrouter.test.tsx
@@ -44,6 +44,11 @@ describe('solidRouterBrowserTracingIntegration', () => {
       tracesSampleRate: 1,
       transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => Promise.resolve({})),
       stackParser: () => [],
+      _metadata: {
+        sdk: {
+          name: 'sentry.javascript.solidstart',
+        },
+      },
     });
   }
 
@@ -138,7 +143,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
         data: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solid.solidrouter',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solidstart.solidrouter',
         }),
       }),
     );
@@ -170,7 +175,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
         data: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solid.solidrouter',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solidstart.solidrouter',
         }),
       }),
     );


### PR DESCRIPTION
The `@sentry/solid/solidrouter` integration is used within the solid start sdk as well, so we need a way to update the `sentry.origin` for navigation spans to be for the correct framework.

I opted to read this out of the sdk metadata instead of exposing extra api surface and passing it through several levels.