### PR TITLE
fix(sveltekit): add Vite peer dep for proper type resolution

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -31,7 +31,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@sveltejs/kit": "1.x || 2.x"
+    "@sveltejs/kit": "1.x || 2.x",
+    "vite": "*"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@sentry/core": "8.17.0",


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

---

Hello! I am in the process of setting up the SvelteKit plugin within a monorepo that includes multiple applications with multiple versions of Vite. I've found that because `@sentry/sveltekit` does not specify a peer dependency on `vite`, `pnpm` picks up the wrong `vite` version for the package's `import type { Plugin } from 'vite'` statement, causing type errors in my Vite config.

This PR adds a simple, optional peer dependency on Vite to `@sentry/sveltekit` to ensure that it picks up whatever version of Vite is being used in the specific package it's installed in, without auto-installing `vite` or anything disruptive like that. Let me know if you'd prefer specific versions spec'd rather than `*`, or if you'd prefer to not mark the dependency as `optional: true`

> [!NOTE]
> I set up Volta as instructed in the Contributing guide and used the spec'd versions of Node and yarn. None of `yarn build`, `yarn lint`, nor `yarn test` fully passed on my machine on a fresh copy of the `develop` branch
