### PR TITLE
fix(browser): Fix bug causing unintentional dropping of transactions

### DIFF
--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -287,7 +287,13 @@ export function addPerformanceEntries(span: Span): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   performanceEntries.slice(_performanceCursor).forEach((entry: Record<string, any>) => {
     const startTime = msToSec(entry.startTime);
-    const duration = msToSec(entry.duration);
+    const duration = msToSec(
+      // Inexplicibly, Chrome sometimes emits a negative duration. We need to work around this.
+      // There is a SO post attempting to explain this, but it leaves one with open questions: https://stackoverflow.com/questions/23191918/peformance-getentries-and-negative-duration-display
+      // The way we clamp the value is probably not accurate, since we have observed this happen for things that may take a while to load, like for example the replay worker.
+      // TODO: Investigate why this happens and how to properly mitigate. For now, this is a workaround to prevent transactions being dropped due to negative duration spans.
+      entry.duration < 0 ? 0 : entry.duration,
+    );
 
     if (op === 'navigation' && transactionStartTime && timeOrigin + startTime < transactionStartTime) {
       return;

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -292,7 +292,7 @@ export function addPerformanceEntries(span: Span): void {
       // There is a SO post attempting to explain this, but it leaves one with open questions: https://stackoverflow.com/questions/23191918/peformance-getentries-and-negative-duration-display
       // The way we clamp the value is probably not accurate, since we have observed this happen for things that may take a while to load, like for example the replay worker.
       // TODO: Investigate why this happens and how to properly mitigate. For now, this is a workaround to prevent transactions being dropped due to negative duration spans.
-      entry.duration < 0 ? 0 : entry.duration,
+      Math.max(0, entry.duration),
     );
 
     if (op === 'navigation' && transactionStartTime && timeOrigin + startTime < transactionStartTime) {


### PR DESCRIPTION
We saw instances of pageload transactions being dropped because they contained spans with negative durations (`timestamp` < `start_timestamp`).

After investigating it seems like performance entries by the browser are emitted with a negative duration. We could only observe this happening in Chrome.

The particular environment this could be (flakily) reproduced is on Chrome, for the scaffold Next.js app, with the Sentry SDK and Replay installed. The negative duration span that was recorded was for the replay worker resource.

[Other people](https://stackoverflow.com/questions/23191918/peformance-getentries-and-negative-duration-display) also seem to be running into this but so far I don't really understand why the duration is negative and how we would mitigate this properly. This PR is more of a hot-fix than anything else.

Attempts to fix: https://github.com/getsentry/sentry-javascript/issues/12914