### PR TITLE
fix(node): Pass inferred name & attributes to `tracesSampler`

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/server.js
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/server.js
@@ -1,0 +1,40 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+  tracesSampler: samplingContext => {
+    // The name we get here is inferred at span creation time
+    // At this point, we sadly do not have a http.route attribute yet,
+    // so we infer the name from the unparametrized route instead
+    return (
+      samplingContext.name === 'GET /test/123' &&
+      samplingContext.attributes['sentry.op'] === 'http.server' &&
+      samplingContext.attributes['http.method'] === 'GET'
+    );
+  },
+  debug: true,
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+const cors = require('cors');
+const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+
+const app = express();
+
+app.use(cors());
+
+app.get('/test/:id', (_req, res) => {
+  res.send('Success');
+});
+
+app.get('/test2', (_req, res) => {
+  res.send('Success');
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/test.ts
@@ -1,0 +1,24 @@
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
+
+describe('express tracesSampler', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  describe('CJS', () => {
+    test('correctly samples & passes data to tracesSampler', done => {
+      const runner = createRunner(__dirname, 'server.js')
+        .expect({
+          transaction: {
+            transaction: 'GET /test/:id',
+          },
+        })
+        .start(done);
+
+      // This is not sampled
+      runner.makeRequest('get', '/test2?q=1');
+      // This is sampled
+      runner.makeRequest('get', '/test/123?q=1');
+    });
+  });
+});

--- a/packages/opentelemetry/src/sampler.ts
+++ b/packages/opentelemetry/src/sampler.ts
@@ -70,10 +70,13 @@ export class SentrySampler implements Sampler {
     } = inferSpanData(spanName, spanAttributes, spanKind);
 
     const mergedAttributes = {
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
       ...inferredAttributes,
       ...spanAttributes,
     };
+
+    if (op) {
+      mergedAttributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] = op;
+    }
 
     const mutableSamplingDecision = { decision: true };
     this._client.emit(

--- a/packages/opentelemetry/src/sampler.ts
+++ b/packages/opentelemetry/src/sampler.ts
@@ -4,7 +4,12 @@ import { isSpanContextValid, trace } from '@opentelemetry/api';
 import { TraceState } from '@opentelemetry/core';
 import type { Sampler, SamplingResult } from '@opentelemetry/sdk-trace-base';
 import { SamplingDecision } from '@opentelemetry/sdk-trace-base';
-import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, hasTracingEnabled, sampleSpan } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  hasTracingEnabled,
+  sampleSpan,
+} from '@sentry/core';
 import type { Client, SpanAttributes } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import { SENTRY_TRACE_STATE_SAMPLED_NOT_RECORDING, SENTRY_TRACE_STATE_URL } from './constants';
@@ -13,6 +18,7 @@ import { SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic
 import { DEBUG_BUILD } from './debug-build';
 import { getPropagationContextFromSpan } from './propagator';
 import { getSamplingDecision } from './utils/getSamplingDecision';
+import { inferSpanData } from './utils/parseSpanDescription';
 import { setIsSetup } from './utils/setupCheck';
 
 /**
@@ -56,12 +62,25 @@ export class SentrySampler implements Sampler {
 
     const parentSampled = parentSpan ? getParentSampled(parentSpan, traceId, spanName) : undefined;
 
+    // We want to pass the inferred name & attributes to the sampler method
+    const {
+      description: inferredSpanName,
+      data: inferredAttributes,
+      op,
+    } = inferSpanData(spanName, spanAttributes, spanKind);
+
+    const mergedAttributes = {
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
+      ...inferredAttributes,
+      ...spanAttributes,
+    };
+
     const mutableSamplingDecision = { decision: true };
     this._client.emit(
       'beforeSampling',
       {
-        spanAttributes: spanAttributes,
-        spanName: spanName,
+        spanAttributes: mergedAttributes,
+        spanName: inferredSpanName,
         parentSampled: parentSampled,
         parentContext: parentContext,
       },
@@ -72,10 +91,10 @@ export class SentrySampler implements Sampler {
     }
 
     const [sampled, sampleRate] = sampleSpan(options, {
-      name: spanName,
-      attributes: spanAttributes,
+      name: inferredSpanName,
+      attributes: mergedAttributes,
       transactionContext: {
-        name: spanName,
+        name: inferredSpanName,
         parentSampled,
       },
       parentSampled,

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -1320,9 +1320,7 @@ describe('trace (sampling)', () => {
     expect(tracesSampler).toHaveBeenLastCalledWith({
       parentSampled: undefined,
       name: 'outer',
-      attributes: {
-        [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
-      },
+      attributes: {},
       transactionContext: { name: 'outer', parentSampled: undefined },
     });
 
@@ -1357,16 +1355,25 @@ describe('trace (sampling)', () => {
 
     mockSdkInit({ tracesSampler });
 
-    startSpan({ name: 'outer' }, outerSpan => {
-      expect(outerSpan).toBeDefined();
-    });
+    startSpan(
+      {
+        name: 'outer',
+        op: 'test.op',
+        attributes: { attr1: 'yes', attr2: 1 },
+      },
+      outerSpan => {
+        expect(outerSpan).toBeDefined();
+      },
+    );
 
-    expect(tracesSampler).toBeCalledTimes(1);
+    expect(tracesSampler).toHaveBeenCalledTimes(1);
     expect(tracesSampler).toHaveBeenLastCalledWith({
       parentSampled: undefined,
       name: 'outer',
       attributes: {
-        [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
+        attr1: 'yes',
+        attr2: 1,
+        'sentry.op': 'test.op',
       },
       transactionContext: { name: 'outer', parentSampled: undefined },
     });


### PR DESCRIPTION
Previously, we passed the span name directly to the `tracesSampler` as-is. However, this is not ideal because this does not match the name we actually send to sentry later, making this confusing. The reason is that we infer the name from the attributes for some types of spans, but we do that at export-time.

This PR adjust this so that we send the inferred name & attributes to the `tracesSampler`. This works reasonably enough. However, there is a big caveat: This still only has access to the initial attributes that a span has at creation time. This means that we'll never have e.g. the `http.route` correctly there, because all `http.server` spans originate from the http instrumentation where they do not have a route yet, and then more specific instrumentation (e.g. express or fastify) add the `http.route` to that span later. So the name will never be parametrized, for example, for `http.server` spans, which is not ideal (as it will still not match the final span exactly) but should still be better than what we had so far (where the name would always just be e.g. `GET`).

Fixes https://github.com/getsentry/sentry-javascript/issues/12944