### PR TITLE
feat(node): Send client reports

### DIFF
--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/scenario.ts
@@ -1,0 +1,23 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async () => {
+  Sentry.init({
+    dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    transport: loggingTransport,
+    beforeSend(event) {
+      return !event.type ? null : event;
+    },
+  });
+
+  Sentry.captureException(new Error('this should get dropped by the event processor'));
+
+  await Sentry.flush();
+
+  Sentry.captureException(new Error('this should get dropped by the event processor'));
+  Sentry.captureException(new Error('this should get dropped by the event processor'));
+
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  Sentry.flush();
+})();

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/test.ts
@@ -1,0 +1,32 @@
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+test('should record client report for beforeSend', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .expect({
+      client_report: {
+        discarded_events: [
+          {
+            category: 'error',
+            quantity: 1,
+            reason: 'before_send',
+          },
+        ],
+      },
+    })
+    .expect({
+      client_report: {
+        discarded_events: [
+          {
+            category: 'error',
+            quantity: 2,
+            reason: 'before_send',
+          },
+        ],
+      },
+    })
+    .start(done);
+});

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/scenario.ts
@@ -1,0 +1,24 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+(async () => {
+  Sentry.init({
+    dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    transport: loggingTransport,
+  });
+
+  Sentry.addEventProcessor(event => {
+    return !event.type ? null : event;
+  });
+
+  Sentry.captureException(new Error('this should get dropped by the event processor'));
+
+  await Sentry.flush();
+
+  Sentry.captureException(new Error('this should get dropped by the event processor'));
+  Sentry.captureException(new Error('this should get dropped by the event processor'));
+
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  Sentry.flush();
+})();

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/test.ts
@@ -1,0 +1,32 @@
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+test('should record client report for event processors', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .expect({
+      client_report: {
+        discarded_events: [
+          {
+            category: 'error',
+            quantity: 1,
+            reason: 'event_processor',
+          },
+        ],
+      },
+    })
+    .expect({
+      client_report: {
+        discarded_events: [
+          {
+            category: 'error',
+            quantity: 2,
+            reason: 'event_processor',
+          },
+        ],
+      },
+    })
+    .start(done);
+});

--- a/dev-packages/node-integration-tests/suites/client-reports/periodic-send/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/periodic-send/scenario.ts
@@ -1,0 +1,13 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  transport: loggingTransport,
+  clientReportFlushInterval: 5000,
+  beforeSend(event) {
+    return !event.type ? null : event;
+  },
+});
+
+Sentry.captureException(new Error('this should get dropped by before send'));

--- a/dev-packages/node-integration-tests/suites/client-reports/periodic-send/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/periodic-send/test.ts
@@ -1,0 +1,21 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+test('should flush client reports automatically after the timeout interval', done => {
+  createRunner(__dirname, 'scenario.ts')
+    .expect({
+      client_report: {
+        discarded_events: [
+          {
+            category: 'error',
+            quantity: 1,
+            reason: 'before_send',
+          },
+        ],
+      },
+    })
+    .start(done);
+});

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -12,7 +12,7 @@ import type {
   SeverityLevel,
   UserFeedback,
 } from '@sentry/types';
-import { createClientReportEnvelope, dsnToString, getSDKSource, logger } from '@sentry/utils';
+import { getSDKSource, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
 import { eventFromException, eventFromMessage } from './eventbuilder';
@@ -117,31 +117,5 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
   protected _prepareEvent(event: Event, hint: EventHint, scope?: Scope): PromiseLike<Event | null> {
     event.platform = event.platform || 'javascript';
     return super._prepareEvent(event, hint, scope);
-  }
-
-  /**
-   * Sends client reports as an envelope.
-   */
-  private _flushOutcomes(): void {
-    const outcomes = this._clearOutcomes();
-
-    if (outcomes.length === 0) {
-      DEBUG_BUILD && logger.log('No outcomes to send');
-      return;
-    }
-
-    // This is really the only place where we want to check for a DSN and only send outcomes then
-    if (!this._dsn) {
-      DEBUG_BUILD && logger.log('No dsn provided, will not send outcomes');
-      return;
-    }
-
-    DEBUG_BUILD && logger.log('Sending outcomes:', outcomes);
-
-    const envelope = createClientReportEnvelope(outcomes, this._options.tunnel && dsnToString(this._dsn));
-
-    // sendEnvelope should not throw
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.sendEnvelope(envelope);
   }
 }

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -877,6 +877,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * Sends client reports as an envelope.
    */
   protected _flushOutcomes(): void {
+    DEBUG_BUILD && logger.log('Flushing outcomes...');
+
     const outcomes = this._clearOutcomes();
 
     if (outcomes.length === 0) {

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -36,7 +36,9 @@ import {
   addItemToEnvelope,
   checkOrSetAlreadyCaught,
   createAttachmentEnvelopeItem,
+  createClientReportEnvelope,
   dropUndefinedKeys,
+  dsnToString,
   isParameterizedString,
   isPlainObject,
   isPrimitive,
@@ -869,6 +871,32 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
         quantity,
       };
     });
+  }
+
+  /**
+   * Sends client reports as an envelope.
+   */
+  protected _flushOutcomes(): void {
+    const outcomes = this._clearOutcomes();
+
+    if (outcomes.length === 0) {
+      DEBUG_BUILD && logger.log('No outcomes to send');
+      return;
+    }
+
+    // This is really the only place where we want to check for a DSN and only send outcomes then
+    if (!this._dsn) {
+      DEBUG_BUILD && logger.log('No dsn provided, will not send outcomes');
+      return;
+    }
+
+    DEBUG_BUILD && logger.log('Sending outcomes:', outcomes);
+
+    const envelope = createClientReportEnvelope(outcomes, this._options.tunnel && dsnToString(this._dsn));
+
+    // sendEnvelope should not throw
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.sendEnvelope(envelope);
   }
 
   /**

--- a/packages/node/src/sdk/client.ts
+++ b/packages/node/src/sdk/client.ts
@@ -37,6 +37,10 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
       // There is one mild concern here, being that if users periodically and unboundedly create new clients, we will
       // create more and more intervals, which may leak memory. In these situations, users are required to
       // call `client.close()` in order to dispose of the client resource.
+      // Users are already confronted with the same reality with the SessionFlusher at the time of writing this so the
+      // working theory is that this should be fine.
+      // Note: We have experimented with using `FinalizationRegisty` to clear the interval when the client is garbage
+      // collected, but it did not work, because the cleanup function never got called.
       this._clientReportInterval = setInterval(() => {
         DEBUG_BUILD && logger.log('Flushing client reports based on interval.');
         this._flushOutcomes();

--- a/packages/node/src/sdk/client.ts
+++ b/packages/node/src/sdk/client.ts
@@ -59,7 +59,9 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
       await spanProcessor.forceFlush();
     }
 
-    this._flushOutcomes();
+    if (this.getOptions().sendClientReports !== false) {
+      this._flushOutcomes();
+    }
 
     return super.flush(timeout);
   }

--- a/packages/node/src/sdk/client.ts
+++ b/packages/node/src/sdk/client.ts
@@ -6,12 +6,16 @@ import type { ServerRuntimeClientOptions } from '@sentry/core';
 import { SDK_VERSION, ServerRuntimeClient, applySdkMetadata } from '@sentry/core';
 import { logger } from '@sentry/utils';
 import { isMainThread, threadId } from 'worker_threads';
+import { DEBUG_BUILD } from '../debug-build';
 import type { NodeClientOptions } from '../types';
+
+const CLIENT_REPORT_FLUSH_INTERVAL_MS = 60_000; // 60s was chosen arbitrarily
 
 /** A client for using Sentry with Node & OpenTelemetry. */
 export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
   public traceProvider: BasicTracerProvider | undefined;
   private _tracer: Tracer | undefined;
+  private _clientReportInterval: NodeJS.Timeout | undefined;
 
   public constructor(options: NodeClientOptions) {
     const clientOptions: ServerRuntimeClientOptions = {
@@ -28,6 +32,18 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
     );
 
     super(clientOptions);
+
+    if (clientOptions.sendClientReports !== false) {
+      // There is one mild concern here, being that if users periodically and unboundedly create new clients, we will
+      // create more and more intervals, which may leak memory. In these situations, users are required to
+      // call `client.close()` in order to dispose of the client resource.
+      this._clientReportInterval = setInterval(() => {
+        DEBUG_BUILD && logger.log('Flushing client reports based on interval.');
+        this._flushOutcomes();
+      }, CLIENT_REPORT_FLUSH_INTERVAL_MS)
+        // Unref is critical, otherwise we stop the process from exiting by itself
+        .unref();
+    }
   }
 
   /** Get the OTEL tracer. */
@@ -44,9 +60,8 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
     return tracer;
   }
 
-  /**
-   * @inheritDoc
-   */
+  // Eslint ignore explanation: This is already documented in super.
+  // eslint-disable-next-line jsdoc/require-jsdoc
   public async flush(timeout?: number): Promise<boolean> {
     const provider = this.traceProvider;
     const spanProcessor = provider?.activeSpanProcessor;
@@ -55,6 +70,18 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
       await spanProcessor.forceFlush();
     }
 
+    this._flushOutcomes();
+
     return super.flush(timeout);
+  }
+
+  // Eslint ignore explanation: This is already documented in super.
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  public close(timeout?: number | undefined): PromiseLike<boolean> {
+    if (this._clientReportInterval) {
+      clearInterval(this._clientReportInterval);
+    }
+
+    return super.close(timeout);
   }
 }

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -230,6 +230,7 @@ function getClientOptions(
     transport: makeNodeTransport,
     dsn: process.env.SENTRY_DSN,
     environment: process.env.SENTRY_ENVIRONMENT,
+    sendClientReports: true,
   });
 
   const overwriteOptions = dropUndefinedKeys({

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -154,6 +154,8 @@ function _init(
     startSessionTracking();
   }
 
+  client.startClientReportTracking();
+
   updateScopeFromEnvVariables();
 
   if (options.spotlight) {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -109,6 +109,11 @@ export interface BaseNodeOptions {
    */
   registerEsmLoaderHooks?: boolean | EsmLoaderHookOptions;
 
+  /**
+   * Configures in which interval client reports will be flushed. Defaults to `60_000` (milliseconds).
+   */
+  clientReportFlushInterval?: number;
+
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(this: void, error: Error): void;
 }

--- a/packages/node/test/helpers/mockSdkInit.ts
+++ b/packages/node/test/helpers/mockSdkInit.ts
@@ -20,10 +20,10 @@ export function mockSdkInit(options?: Partial<NodeClientOptions>) {
   init({
     dsn: PUBLIC_DSN,
     defaultIntegrations: false,
-    ...options,
     // We are disabling client reports because we would be acquiring resources with every init call and that would leak
     // memory every time we call init in the tests
     sendClientReports: false,
+    ...options,
   });
 }
 

--- a/packages/node/test/helpers/mockSdkInit.ts
+++ b/packages/node/test/helpers/mockSdkInit.ts
@@ -17,7 +17,14 @@ export function resetGlobals(): void {
 
 export function mockSdkInit(options?: Partial<NodeClientOptions>) {
   resetGlobals();
-  init({ dsn: PUBLIC_DSN, defaultIntegrations: false, ...options });
+  init({
+    dsn: PUBLIC_DSN,
+    defaultIntegrations: false,
+    ...options,
+    // We are disabling client reports because we would be acquiring resources with every init call and that would leak
+    // memory every time we call init in the tests
+    sendClientReports: false,
+  });
 }
 
 export function cleanupOtel(_provider?: BasicTracerProvider): void {

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -31,8 +31,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   autoSessionTracking?: boolean;
 
   /**
-   * Send SDK Client Reports.
-   * By default, Client Reports are enabled.
+   * Send SDK Client Reports. When calling `Sentry.init()`, this option defaults to `true`.
    */
   sendClientReports?: boolean;
 


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/12822

This PR adds client reports to the Node.js SDK.

Client reports must be enabled via the `startClientReportTracking()` method on the `NodeClient`. This is due to the fact that client reports (or rather the `setInterval` that is required for periodically sending them) is acquiring a resource that needs cleanup. If somebody were to create clients over and over again, without calling `client.close()` they would be leaking memory.

If `startClientReportTracking()` is called, the client will flush all client reports
- every 60 seconds.
- on `process.on('beforeExit')`, which is when the event loop has run out of things to do.

Out of the box, the Node.js SDK's `Sentry.init()` will call `startClientReportTracking()`, since there we can assume that users are using a singular client.

We are also introducing a new option for the Node.js SDK called `clientReportFlushInterval` that will control the flush interval of the periodic client report flushing.