### PR TITLE
feat(express): Allow to pass options to `setupExpressErrorHandler`

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/setupExpressErrorHandler/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/setupExpressErrorHandler/test.ts
@@ -1,0 +1,30 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+describe('express setupExpressErrorHandler', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  describe('CJS', () => {
+    test('allows to pass options to setupExpressErrorHandler', done => {
+      const runner = createRunner(__dirname, 'server.js')
+        .expect({
+          event: {
+            exception: {
+              values: [
+                {
+                  value: 'error_2',
+                },
+              ],
+            },
+          },
+        })
+        .start(done);
+
+      // this error is filtered & ignored
+      expect(() => runner.makeRequest('get', '/test1')).rejects.toThrow();
+      // this error is actually captured
+      expect(() => runner.makeRequest('get', '/test2')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -135,8 +135,11 @@ export function expressErrorHandler(options?: {
  * Setup an error handler for Express.
  * The error handler must be before any other middleware and after all controllers.
  */
-export function setupExpressErrorHandler(app: { use: (middleware: ExpressMiddleware) => unknown }): void {
-  app.use(expressErrorHandler());
+export function setupExpressErrorHandler(
+  app: { use: (middleware: ExpressMiddleware) => unknown },
+  options?: Parameters<typeof expressErrorHandler>[0],
+): void {
+  app.use(expressErrorHandler(options));
   ensureIsWrapped(app.use, 'express');
 }
 

--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -83,16 +83,18 @@ type ExpressMiddleware = (
   next: (error: MiddlewareError) => void,
 ) => void;
 
-/**
- * An Express-compatible error handler.
- */
-export function expressErrorHandler(options?: {
+interface ExpressHandlerOptions {
   /**
    * Callback method deciding whether error should be captured and sent to Sentry
    * @param error Captured middleware error
    */
   shouldHandleError?(this: void, error: MiddlewareError): boolean;
-}): ExpressMiddleware {
+}
+
+/**
+ * An Express-compatible error handler.
+ */
+export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressMiddleware {
   return function sentryErrorMiddleware(
     error: MiddlewareError,
     _req: http.IncomingMessage,
@@ -137,7 +139,7 @@ export function expressErrorHandler(options?: {
  */
 export function setupExpressErrorHandler(
   app: { use: (middleware: ExpressMiddleware) => unknown },
-  options?: Parameters<typeof expressErrorHandler>[0],
+  options?: ExpressHandlerOptions,
 ): void {
   app.use(expressErrorHandler(options));
   ensureIsWrapped(app.use, 'express');


### PR DESCRIPTION
Allows to pass this through to the underlying `expressErrorHandler`.

See https://github.com/getsentry/sentry-javascript/discussions/12715#discussioncomment-9965427
