### PR TITLE
test(vue): Switch to using vitest

### DIFF
--- a/packages/vue/jest.config.js
+++ b/packages/vue/jest.config.js
@@ -1,6 +1,0 @@
-const baseConfig = require('../../jest/jest.config.js');
-
-module.exports = {
-  ...baseConfig,
-  testEnvironment: 'jsdom',
-};

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -66,8 +66,8 @@
     "clean": "rimraf build coverage sentry-vue-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"
   },
   "volta": {

--- a/packages/vue/test/errorHandler.test.ts
+++ b/packages/vue/test/errorHandler.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
 import { setCurrentClient } from '@sentry/browser';
 
 import { attachErrorHandler } from '../src/errorhandler';
@@ -7,7 +9,7 @@ import { generateComponentTrace } from '../src/vendor/components';
 describe('attachErrorHandler', () => {
   describe('attachProps', () => {
     afterEach(() => {
-      jest.resetAllMocks();
+      vi.resetAllMocks();
     });
 
     describe("given I don't want to `attachProps`", () => {
@@ -325,13 +327,13 @@ const testHarness = ({
   enableConsole,
   vm,
 }: TestHarnessOpts) => {
-  jest.useFakeTimers();
-  const providedErrorHandlerSpy = jest.fn();
-  const warnHandlerSpy = jest.fn();
-  const consoleErrorSpy = jest.fn();
+  vi.useFakeTimers();
+  const providedErrorHandlerSpy = vi.fn();
+  const warnHandlerSpy = vi.fn();
+  const consoleErrorSpy = vi.fn();
 
   const client: any = {
-    captureException: jest.fn(async () => Promise.resolve()),
+    captureException: vi.fn(async () => Promise.resolve()),
   };
   setCurrentClient(client);
 
@@ -339,7 +341,7 @@ const testHarness = ({
     config: {
       silent: !!silent,
     },
-    mixin: jest.fn(),
+    mixin: vi.fn(),
   };
 
   if (enableErrorHandler) {
@@ -380,7 +382,7 @@ const testHarness = ({
       app.config.errorHandler(new DummyError(), vm, 'stub-lifecycle-hook');
 
       // and waits for internal timers
-      jest.runAllTimers();
+      vi.runAllTimers();
     },
     expect: {
       errorHandlerSpy: expect(providedErrorHandlerSpy),

--- a/packages/vue/test/integration/VueIntegration.test.ts
+++ b/packages/vue/test/integration/VueIntegration.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { Client } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import { createApp } from 'vue';
@@ -15,10 +21,10 @@ describe('Sentry.VueIntegration', () => {
   const globalRequest = globalThis.Request;
 
   beforeAll(() => {
-    globalThis.fetch = jest.fn();
+    globalThis.fetch = vi.fn();
     // @ts-expect-error This is a mock
-    globalThis.Response = jest.fn();
-    globalThis.Request = jest.fn();
+    globalThis.Response = vi.fn();
+    globalThis.Request = vi.fn();
   });
 
   afterAll(() => {
@@ -31,17 +37,17 @@ describe('Sentry.VueIntegration', () => {
     warnings = [];
     loggerWarnings = [];
 
-    jest.spyOn(logger, 'warn').mockImplementation((message: unknown) => {
+    vi.spyOn(logger, 'warn').mockImplementation((message: unknown) => {
       loggerWarnings.push(message);
     });
 
-    jest.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+    vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
       warnings.push(message);
     });
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
   });
 
   it('allows to initialize integration later', () => {

--- a/packages/vue/test/integration/init.test.ts
+++ b/packages/vue/test/integration/init.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { createApp } from 'vue';
 
 import type { Client } from '@sentry/types';
@@ -11,13 +17,13 @@ describe('Sentry.init', () => {
 
   beforeEach(() => {
     warnings = [];
-    jest.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+    vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
       warnings.push(message);
     });
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('does not warn when correctly setup (Vue 3)', () => {

--- a/packages/vue/test/vendor/components.test.ts
+++ b/packages/vue/test/vendor/components.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { formatComponentName } from '../../src/vendor/components';
 
 describe('formatComponentName', () => {

--- a/packages/vue/tsconfig.test.json
+++ b/packages/vue/tsconfig.test.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["test/**/*"],
+  "include": ["test/**/*", "vite.config.ts"],
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["jest"]
+    "types": []
 
     // other package-specific, test-specific options
   }

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -1,0 +1,5 @@
+import baseConfig from '../../vite/vite.config';
+
+export default {
+  ...baseConfig,
+};


### PR DESCRIPTION
Before: `Time: 3.935 s`

After: `Duration  1.55s (transform 961ms, setup 0ms, collect 3.56s, tests 127ms, environment 1.73s, prepare 367ms)`

If we remove the jsdom based tests it'll probably get even faster.

ref https://github.com/getsentry/sentry-javascript/issues/11084

earlier attempt: https://github.com/getsentry/sentry-javascript/pull/11071

I'll try to do a couple of these a week when I'm blocked on some of my other tasks.