### PR TITLE
feat(vercel-edge): Add dedupe as default integration

### DIFF
--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -1,4 +1,5 @@
 import {
+  dedupeIntegration,
   functionToStringIntegration,
   getIntegrationsToSetup,
   inboundFiltersIntegration,
@@ -25,6 +26,7 @@ const nodeStackParser = createStackParser(nodeStackLineParser());
 /** Get the default integrations for the browser SDK. */
 export function getDefaultIntegrations(options: Options): Integration[] {
   return [
+    dedupeIntegration(),
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),


### PR DESCRIPTION
Add the dedupe integration as a default integration to `vercel-edge`.

Saw this discrepancy while working on the cloudflare sdk.
