### PR TITLE
test(vercel-edge): Switch to using vitest

### DIFF
--- a/packages/vercel-edge/jest.config.js
+++ b/packages/vercel-edge/jest.config.js
@@ -1,7 +1,0 @@
-const baseConfig = require('../../jest/jest.config.js');
-
-module.exports = {
-  ...baseConfig,
-  // TODO: Fix tests to work with the Edge environment
-  // testEnvironment: '@edge-runtime/jest-environment',
-};

--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -44,8 +44,7 @@
     "@sentry/utils": "8.18.0"
   },
   "devDependencies": {
-    "@edge-runtime/jest-environment": "2.2.3",
-    "@edge-runtime/types": "2.2.3"
+    "@edge-runtime/types": "3.0.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",
@@ -63,8 +62,8 @@
     "clean": "rimraf build coverage sentry-vercel-edge-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"
   },
   "volta": {

--- a/packages/vercel-edge/test/async.test.ts
+++ b/packages/vercel-edge/test/async.test.ts
@@ -1,6 +1,7 @@
 import { Scope, getCurrentScope, getGlobalScope, getIsolationScope, withIsolationScope, withScope } from '@sentry/core';
 import { GLOBAL_OBJ } from '@sentry/utils';
 import { AsyncLocalStorage } from 'async_hooks';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { setAsyncLocalStorageAsyncContextStrategy } from '../src/async';
 
 describe('withScope()', () => {
@@ -13,67 +14,73 @@ describe('withScope()', () => {
     setAsyncLocalStorageAsyncContextStrategy();
   });
 
-  it('will make the passed scope the active scope within the callback', done => {
-    withScope(scope => {
-      expect(getCurrentScope()).toBe(scope);
-      done();
-    });
-  });
-
-  it('will pass a scope that is different from the current active isolation scope', done => {
-    withScope(scope => {
-      expect(getIsolationScope()).not.toBe(scope);
-      done();
-    });
-  });
-
-  it('will always make the inner most passed scope the current scope when nesting calls', done => {
-    withIsolationScope(_scope1 => {
-      withIsolationScope(scope2 => {
-        expect(getIsolationScope()).toBe(scope2);
+  it('will make the passed scope the active scope within the callback', () =>
+    new Promise<void>(done => {
+      withScope(scope => {
+        expect(getCurrentScope()).toBe(scope);
         done();
       });
-    });
-  });
+    }));
 
-  it('forks the scope when not passing any scope', done => {
-    const initialScope = getCurrentScope();
-    initialScope.setTag('aa', 'aa');
+  it('will pass a scope that is different from the current active isolation scope', () =>
+    new Promise<void>(done => {
+      withScope(scope => {
+        expect(getIsolationScope()).not.toBe(scope);
+        done();
+      });
+    }));
 
-    withScope(scope => {
-      expect(getCurrentScope()).toBe(scope);
-      scope.setTag('bb', 'bb');
-      expect(scope).not.toBe(initialScope);
-      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
-      done();
-    });
-  });
+  it('will always make the inner most passed scope the current scope when nesting calls', () =>
+    new Promise<void>(done => {
+      withIsolationScope(_scope1 => {
+        withIsolationScope(scope2 => {
+          expect(getIsolationScope()).toBe(scope2);
+          done();
+        });
+      });
+    }));
 
-  it('forks the scope when passing undefined', done => {
-    const initialScope = getCurrentScope();
-    initialScope.setTag('aa', 'aa');
+  it('forks the scope when not passing any scope', () =>
+    new Promise<void>(done => {
+      const initialScope = getCurrentScope();
+      initialScope.setTag('aa', 'aa');
 
-    withScope(undefined, scope => {
-      expect(getCurrentScope()).toBe(scope);
-      scope.setTag('bb', 'bb');
-      expect(scope).not.toBe(initialScope);
-      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
-      done();
-    });
-  });
+      withScope(scope => {
+        expect(getCurrentScope()).toBe(scope);
+        scope.setTag('bb', 'bb');
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+        done();
+      });
+    }));
 
-  it('sets the passed in scope as active scope', done => {
-    const initialScope = getCurrentScope();
-    initialScope.setTag('aa', 'aa');
+  it('forks the scope when passing undefined', () =>
+    new Promise<void>(done => {
+      const initialScope = getCurrentScope();
+      initialScope.setTag('aa', 'aa');
 
-    const customScope = new Scope();
+      withScope(undefined, scope => {
+        expect(getCurrentScope()).toBe(scope);
+        scope.setTag('bb', 'bb');
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+        done();
+      });
+    }));
 
-    withScope(customScope, scope => {
-      expect(getCurrentScope()).toBe(customScope);
-      expect(scope).toBe(customScope);
-      done();
-    });
-  });
+  it('sets the passed in scope as active scope', () =>
+    new Promise<void>(done => {
+      const initialScope = getCurrentScope();
+      initialScope.setTag('aa', 'aa');
+
+      const customScope = new Scope();
+
+      withScope(customScope, scope => {
+        expect(getCurrentScope()).toBe(customScope);
+        expect(scope).toBe(customScope);
+        done();
+      });
+    }));
 });
 
 describe('withIsolationScope()', () => {
@@ -86,65 +93,71 @@ describe('withIsolationScope()', () => {
     setAsyncLocalStorageAsyncContextStrategy();
   });
 
-  it('will make the passed isolation scope the active isolation scope within the callback', done => {
-    withIsolationScope(scope => {
-      expect(getIsolationScope()).toBe(scope);
-      done();
-    });
-  });
-
-  it('will pass an isolation scope that is different from the current active scope', done => {
-    withIsolationScope(scope => {
-      expect(getCurrentScope()).not.toBe(scope);
-      done();
-    });
-  });
-
-  it('will always make the inner most passed scope the current scope when nesting calls', done => {
-    withIsolationScope(_scope1 => {
-      withIsolationScope(scope2 => {
-        expect(getIsolationScope()).toBe(scope2);
+  it('will make the passed isolation scope the active isolation scope within the callback', () =>
+    new Promise<void>(done => {
+      withIsolationScope(scope => {
+        expect(getIsolationScope()).toBe(scope);
         done();
       });
-    });
-  });
+    }));
 
-  it('forks the isolation scope when not passing any isolation scope', done => {
-    const initialScope = getIsolationScope();
-    initialScope.setTag('aa', 'aa');
+  it('will pass an isolation scope that is different from the current active scope', () =>
+    new Promise<void>(done => {
+      withIsolationScope(scope => {
+        expect(getCurrentScope()).not.toBe(scope);
+        done();
+      });
+    }));
 
-    withIsolationScope(scope => {
-      expect(getIsolationScope()).toBe(scope);
-      scope.setTag('bb', 'bb');
-      expect(scope).not.toBe(initialScope);
-      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
-      done();
-    });
-  });
+  it('will always make the inner most passed scope the current scope when nesting calls', () =>
+    new Promise<void>(done => {
+      withIsolationScope(_scope1 => {
+        withIsolationScope(scope2 => {
+          expect(getIsolationScope()).toBe(scope2);
+          done();
+        });
+      });
+    }));
 
-  it('forks the isolation scope when passing undefined', done => {
-    const initialScope = getIsolationScope();
-    initialScope.setTag('aa', 'aa');
+  it('forks the isolation scope when not passing any isolation scope', () =>
+    new Promise<void>(done => {
+      const initialScope = getIsolationScope();
+      initialScope.setTag('aa', 'aa');
 
-    withIsolationScope(undefined, scope => {
-      expect(getIsolationScope()).toBe(scope);
-      scope.setTag('bb', 'bb');
-      expect(scope).not.toBe(initialScope);
-      expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
-      done();
-    });
-  });
+      withIsolationScope(scope => {
+        expect(getIsolationScope()).toBe(scope);
+        scope.setTag('bb', 'bb');
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+        done();
+      });
+    }));
 
-  it('sets the passed in isolation scope as active isolation scope', done => {
-    const initialScope = getIsolationScope();
-    initialScope.setTag('aa', 'aa');
+  it('forks the isolation scope when passing undefined', () =>
+    new Promise<void>(done => {
+      const initialScope = getIsolationScope();
+      initialScope.setTag('aa', 'aa');
 
-    const customScope = new Scope();
+      withIsolationScope(undefined, scope => {
+        expect(getIsolationScope()).toBe(scope);
+        scope.setTag('bb', 'bb');
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
+        done();
+      });
+    }));
 
-    withIsolationScope(customScope, scope => {
-      expect(getIsolationScope()).toBe(customScope);
-      expect(scope).toBe(customScope);
-      done();
-    });
-  });
+  it('sets the passed in isolation scope as active isolation scope', () =>
+    new Promise<void>(done => {
+      const initialScope = getIsolationScope();
+      initialScope.setTag('aa', 'aa');
+
+      const customScope = new Scope();
+
+      withIsolationScope(customScope, scope => {
+        expect(getIsolationScope()).toBe(customScope);
+        expect(scope).toBe(customScope);
+        done();
+      });
+    }));
 });

--- a/packages/vercel-edge/test/sdk.test.ts
+++ b/packages/vercel-edge/test/sdk.test.ts
@@ -1,9 +1,11 @@
+import { describe, expect, it, vi } from 'vitest';
+
 import * as SentryCore from '@sentry/core';
 import { init } from '../src/sdk';
 
 describe('init', () => {
   it('initializes and returns client', () => {
-    const initSpy = jest.spyOn(SentryCore, 'initAndBind');
+    const initSpy = vi.spyOn(SentryCore, 'initAndBind');
 
     expect(init({})).not.toBeUndefined();
     expect(initSpy).toHaveBeenCalledTimes(1);

--- a/packages/vercel-edge/test/transports/index.test.ts
+++ b/packages/vercel-edge/test/transports/index.test.ts
@@ -1,3 +1,5 @@
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
 import type { EventEnvelope, EventItem } from '@sentry/types';
 import { createEnvelope, serializeEnvelope } from '@sentry/utils';
 
@@ -23,7 +25,7 @@ class Headers {
   }
 }
 
-const mockFetch = jest.fn();
+const mockFetch = vi.fn();
 
 const oldFetch = global.fetch;
 global.fetch = mockFetch;
@@ -57,7 +59,7 @@ describe('Edge Transport', () => {
 
   it('sets rate limit headers', async () => {
     const headers = {
-      get: jest.fn(),
+      get: vi.fn(),
     };
 
     mockFetch.mockImplementationOnce(() =>
@@ -110,8 +112,8 @@ describe('IsolatedPromiseBuffer', () => {
   it('should not call tasks until drained', async () => {
     const ipb = new IsolatedPromiseBuffer();
 
-    const task1 = jest.fn(() => Promise.resolve({}));
-    const task2 = jest.fn(() => Promise.resolve({}));
+    const task1 = vi.fn(() => Promise.resolve({}));
+    const task2 = vi.fn(() => Promise.resolve({}));
 
     await ipb.add(task1);
     await ipb.add(task2);
@@ -128,10 +130,10 @@ describe('IsolatedPromiseBuffer', () => {
   it('should not allow adding more items than the specified limit', async () => {
     const ipb = new IsolatedPromiseBuffer(3);
 
-    const task1 = jest.fn(() => Promise.resolve({}));
-    const task2 = jest.fn(() => Promise.resolve({}));
-    const task3 = jest.fn(() => Promise.resolve({}));
-    const task4 = jest.fn(() => Promise.resolve({}));
+    const task1 = vi.fn(() => Promise.resolve({}));
+    const task2 = vi.fn(() => Promise.resolve({}));
+    const task3 = vi.fn(() => Promise.resolve({}));
+    const task4 = vi.fn(() => Promise.resolve({}));
 
     await ipb.add(task1);
     await ipb.add(task2);
@@ -143,8 +145,8 @@ describe('IsolatedPromiseBuffer', () => {
   it('should not throw when one of the tasks throws when drained', async () => {
     const ipb = new IsolatedPromiseBuffer();
 
-    const task1 = jest.fn(() => Promise.resolve({}));
-    const task2 = jest.fn(() => Promise.reject(new Error()));
+    const task1 = vi.fn(() => Promise.resolve({}));
+    const task2 = vi.fn(() => Promise.reject(new Error()));
 
     await ipb.add(task1);
     await ipb.add(task2);

--- a/packages/vercel-edge/test/wintercg-fetch.test.ts
+++ b/packages/vercel-edge/test/wintercg-fetch.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import * as sentryCore from '@sentry/core';
 import type { HandlerDataFetch, Integration } from '@sentry/types';
 import * as sentryUtils from '@sentry/utils';
@@ -12,15 +14,15 @@ class FakeClient extends VercelEdgeClient {
   }
 }
 
-const addFetchInstrumentationHandlerSpy = jest.spyOn(sentryUtils, 'addFetchInstrumentationHandler');
-const instrumentFetchRequestSpy = jest.spyOn(sentryCore, 'instrumentFetchRequest');
-const addBreadcrumbSpy = jest.spyOn(sentryCore, 'addBreadcrumb');
+const addFetchInstrumentationHandlerSpy = vi.spyOn(sentryUtils, 'addFetchInstrumentationHandler');
+const instrumentFetchRequestSpy = vi.spyOn(sentryCore, 'instrumentFetchRequest');
+const addBreadcrumbSpy = vi.spyOn(sentryCore, 'addBreadcrumb');
 
 describe('WinterCGFetch instrumentation', () => {
   let client: FakeClient;
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
 
     client = new FakeClient({
       dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -35,7 +37,7 @@ describe('WinterCGFetch instrumentation', () => {
       stackParser: createStackParser(),
     });
 
-    jest.spyOn(sentryCore, 'getClient').mockImplementation(() => client);
+    vi.spyOn(sentryCore, 'getClient').mockImplementation(() => client);
   });
 
   it('should call `instrumentFetchRequest` for outgoing fetch requests', () => {

--- a/packages/vercel-edge/tsconfig.test.json
+++ b/packages/vercel-edge/tsconfig.test.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["test/**/*"],
+  "include": ["test/**/*", "vite.config.ts"],
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node", "jest"]
+    "types": ["node"]
 
     // other package-specific, test-specific options
   }

--- a/packages/vercel-edge/vite.config.ts
+++ b/packages/vercel-edge/vite.config.ts
@@ -1,0 +1,5 @@
+import baseConfig from '../../vite/vite.config';
+
+export default {
+  ...baseConfig,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4008,40 +4008,17 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@edge-runtime/jest-environment@2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/jest-environment/-/jest-environment-2.2.3.tgz#2fef094d769f45b5018b33bdc58e664b35bbc312"
-  integrity sha512-5DEv8nzuMFGoVbNYbOz7/mileYSbq1/oIvisyTeSfyjId7Pc5Qh2t3BH7ixLa62aVz7oCQlALM4cYGbZQZw1YQ==
+"@edge-runtime/primitives@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-5.0.1.tgz#29e2de862d8e02d1e85fd8aa1c73afe0317e6740"
+  integrity sha512-qjqqCa9v3IE7Fo9OnmkIWg9l0WUu3uOfUYomuOVxaaHqlIvNI75E5IB0XNNDypz249ObRSmjRj8jLjkBUmFYYw==
+
+"@edge-runtime/types@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/types/-/types-3.0.1.tgz#907bd98ec551deba6fd26b72189fde651779191b"
+  integrity sha512-yZSWlGMQXXtpE4m1WYRpjA8V9+uU3uKHJzx9lngSYDZYYABuYxb2bICBwE1NQD0WS/u/PreP/83GcndezMFmnQ==
   dependencies:
-    "@edge-runtime/vm" "3.0.3"
-    "@jest/environment" "29.5.0"
-    "@jest/fake-timers" "29.5.0"
-    jest-mock "29.5.0"
-    jest-util "29.5.0"
-
-"@edge-runtime/primitives@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-3.0.3.tgz#adc6a4bd34c44faf81c954cf8e5816c7d408a1ea"
-  integrity sha512-YnfMWMRQABAH8IsnFMJWMW+SyB4ZeYBPnR7V0aqdnew7Pq60cbH5DyFjS/FhiLwvHQk9wBREmXD7PP0HooEQ1A==
-
-"@edge-runtime/primitives@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-4.0.1.tgz#12efffac1caa8a29ae8f86a3f87f20cc0ae07131"
-  integrity sha512-hxWUzx1SeyOed/Ea9Z6y6tyFKSj8gQWIdLilybTR2ene1IthLZE01A1SLGoch1szUdhFlUwpWDaYBYQw00lj2g==
-
-"@edge-runtime/types@2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/types/-/types-2.2.3.tgz#cb57b7215bcf406324ec591346b7b51c75a54bdf"
-  integrity sha512-zL0ENQWwdocECEQXVopGTfnqI0tJ8wzDOCoQymoc8MLRz+Zw2V1W0ex9vczniTUzB+H/P7ubMgx3GFzLp3NPBg==
-  dependencies:
-    "@edge-runtime/primitives" "4.0.1"
-
-"@edge-runtime/vm@3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@edge-runtime/vm/-/vm-3.0.3.tgz#92f1930d1eb8d0ccf6a3c165561cc22b2d9ddff8"
-  integrity sha512-SPfI1JeIRNs/4EEE2Oc0X6gG3RqjD1TnKu2lwmwFXq0435xgZGKhc3UiKkYAdoMn2dNFD73nlabMKHBRoMRpxg==
-  dependencies:
-    "@edge-runtime/primitives" "3.0.3"
+    "@edge-runtime/primitives" "5.0.1"
 
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
@@ -5664,16 +5641,6 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@29.5.0":
-  version "29.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.5.0.tgz#9152d56317c1fdb1af389c46640ba74ef0bb4c65"
-  integrity sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==
-  dependencies:
-    "@jest/fake-timers" "^29.5.0"
-    "@jest/types" "^29.5.0"
-    "@types/node" "*"
-    jest-mock "^29.5.0"
-
 "@jest/environment@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.5.1.tgz#d7425820511fe7158abbecc010140c3fd3be9c74"
@@ -5683,18 +5650,6 @@
     "@jest/types" "^27.5.1"
     "@types/node" "*"
     jest-mock "^27.5.1"
-
-"@jest/fake-timers@29.5.0":
-  version "29.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.5.0.tgz#d4d09ec3286b3d90c60bdcd66ed28d35f1b4dc2c"
-  integrity sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==
-  dependencies:
-    "@jest/types" "^29.5.0"
-    "@sinonjs/fake-timers" "^10.0.2"
-    "@types/node" "*"
-    jest-message-util "^29.5.0"
-    jest-mock "^29.5.0"
-    jest-util "^29.5.0"
 
 "@jest/fake-timers@^27.5.1":
   version "27.5.1"
@@ -5707,18 +5662,6 @@
     jest-message-util "^27.5.1"
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
-
-"@jest/fake-timers@^29.5.0":
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565"
-  integrity sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==
-  dependencies:
-    "@jest/types" "^29.6.3"
-    "@sinonjs/fake-timers" "^10.0.2"
-    "@types/node" "*"
-    jest-message-util "^29.7.0"
-    jest-mock "^29.7.0"
-    jest-util "^29.7.0"
 
 "@jest/globals@^27.5.1":
   version "27.5.1"
@@ -5833,18 +5776,6 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
-    chalk "^4.0.0"
-
-"@jest/types@^29.5.0", "@jest/types@^29.6.3":
-  version "29.6.3"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
-  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
-  dependencies:
-    "@jest/schemas" "^29.6.3"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
 "@josephg/resolvable@^1.0.0":
@@ -10120,13 +10051,6 @@
   version "16.0.4"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-"@types/yargs@^17.0.8":
-  version "17.0.24"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.24.tgz#b3ef8d50ad4aa6aecf6ddc97c580a00f5aa11902"
-  integrity sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -22452,30 +22376,6 @@ jest-message-util@^27.5.1:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-message-util@^29.5.0, jest-message-util@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
-  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
-  dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^29.6.3"
-    "@types/stack-utils" "^2.0.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.9"
-    micromatch "^4.0.4"
-    pretty-format "^29.7.0"
-    slash "^3.0.0"
-    stack-utils "^2.0.3"
-
-jest-mock@29.5.0:
-  version "29.5.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.5.0.tgz#26e2172bcc71d8b0195081ff1f146ac7e1518aed"
-  integrity sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==
-  dependencies:
-    "@jest/types" "^29.5.0"
-    "@types/node" "*"
-    jest-util "^29.5.0"
-
 jest-mock@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.5.1.tgz#19948336d49ef4d9c52021d34ac7b5f36ff967d6"
@@ -22483,15 +22383,6 @@ jest-mock@^27.5.1:
   dependencies:
     "@jest/types" "^27.5.1"
     "@types/node" "*"
-
-jest-mock@^29.5.0, jest-mock@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
-  integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==
-  dependencies:
-    "@jest/types" "^29.6.3"
-    "@types/node" "*"
-    jest-util "^29.7.0"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
@@ -22619,36 +22510,12 @@ jest-snapshot@^27.5.1:
     pretty-format "^27.5.1"
     semver "^7.3.2"
 
-jest-util@29.5.0:
-  version "29.5.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.5.0.tgz#24a4d3d92fc39ce90425311b23c27a6e0ef16b8f"
-  integrity sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==
-  dependencies:
-    "@jest/types" "^29.5.0"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    ci-info "^3.2.0"
-    graceful-fs "^4.2.9"
-    picomatch "^2.2.3"
-
 jest-util@^27.0.0, jest-util@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.5.1.tgz#3ba9771e8e31a0b85da48fe0b0891fb86c01c2f9"
   integrity sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==
   dependencies:
     "@jest/types" "^27.5.1"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    ci-info "^3.2.0"
-    graceful-fs "^4.2.9"
-    picomatch "^2.2.3"
-
-jest-util@^29.5.0, jest-util@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
-  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
-  dependencies:
-    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"


### PR DESCRIPTION
Before: `Time: 2.621 s`

After: `Duration 638ms (transform 343ms, setup 0ms, collect 1.61s, tests 22ms, environment 0ms, prepare 278ms)`

ref https://github.com/getsentry/sentry-javascript/issues/11084

Also removes `edge-runtime/jest-environment` which we weren't using anyway, removes a lot of unnecessary stuff in our `yarn.lock` (-151 lines!)