### PR TITLE
test(sveltekit): Switch to explicit vitest imports

### DIFF
--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -1,7 +1,12 @@
+/**
+ * @vitest-environment jsdom
+ */
+
 /* eslint-disable @typescript-eslint/unbound-method */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { Span } from '@sentry/types';
 import { writable } from 'svelte/store';
-import { vi } from 'vitest';
 
 import { navigating, page } from '$app/stores';
 

--- a/packages/sveltekit/test/client/fetch.test.ts
+++ b/packages/sveltekit/test/client/fetch.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { init } from '../../src/client/index';
 
 describe('instruments fetch', () => {

--- a/packages/sveltekit/test/client/handleError.test.ts
+++ b/packages/sveltekit/test/client/handleError.test.ts
@@ -1,6 +1,7 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import * as SentrySvelte from '@sentry/svelte';
 import type { HandleClientError, NavigationEvent } from '@sveltejs/kit';
-import { vi } from 'vitest';
 
 import { handleErrorWithSentry } from '../../src/client/handleError';
 

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -1,7 +1,8 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import * as SentrySvelte from '@sentry/svelte';
 import type { Load } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
-import { vi } from 'vitest';
 
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { wrapLoadWithSentry } from '../../src/client/load';

--- a/packages/sveltekit/test/client/sdk.test.ts
+++ b/packages/sveltekit/test/client/sdk.test.ts
@@ -1,7 +1,8 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import type { BrowserClient } from '@sentry/svelte';
 import * as SentrySvelte from '@sentry/svelte';
 import { SDK_VERSION, getClient, getCurrentScope, getGlobalScope, getIsolationScope } from '@sentry/svelte';
-import { vi } from 'vitest';
 
 import { init } from '../../src/client';
 

--- a/packages/sveltekit/test/common/utils.test.ts
+++ b/packages/sveltekit/test/common/utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { isHttpError, isRedirect } from '../../src/common/utils';
 
 describe('isRedirect', () => {

--- a/packages/sveltekit/test/index.test.ts
+++ b/packages/sveltekit/test/index.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import * as SentryClient from '../src/client';
 import * as SentryServer from '../src/server';
 

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   getRootSpan,

--- a/packages/sveltekit/test/server/handleError.test.ts
+++ b/packages/sveltekit/test/server/handleError.test.ts
@@ -1,6 +1,7 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import * as SentryNode from '@sentry/node';
 import type { HandleServerError, RequestEvent } from '@sveltejs/kit';
-import { vi } from 'vitest';
 
 import { handleErrorWithSentry } from '../../src/server/handleError';
 

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -8,7 +10,6 @@ import * as SentryNode from '@sentry/node';
 import type { Event } from '@sentry/types';
 import type { Load, ServerLoad } from '@sveltejs/kit';
 import { error, redirect } from '@sveltejs/kit';
-import { vi } from 'vitest';
 
 import { wrapLoadWithSentry, wrapServerLoadWithSentry } from '../../src/server/load';
 import { getDefaultNodeClientOptions } from '../utils';

--- a/packages/sveltekit/test/server/sdk.test.ts
+++ b/packages/sveltekit/test/server/sdk.test.ts
@@ -1,8 +1,9 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import * as SentryNode from '@sentry/node';
 import type { NodeClient } from '@sentry/node';
 import { SDK_VERSION, getClient } from '@sentry/node';
 
-import { vi } from 'vitest';
 import { init } from '../../src/server/sdk';
 
 const nodeInit = vi.spyOn(SentryNode, 'init');

--- a/packages/sveltekit/test/server/utils.test.ts
+++ b/packages/sveltekit/test/server/utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { getTracePropagationData } from '../../src/server/utils';
 
 const MOCK_REQUEST_EVENT: any = {

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { canWrapLoad, makeAutoInstrumentationPlugin } from '../../src/vite/autoInstrument';
 
@@ -12,7 +12,6 @@ let fileContent: string | undefined;
 vi.mock('fs', async () => {
   const actual = await vi.importActual('fs');
   return {
-    // @ts-expect-error this exists, I promise!
     ...actual,
     promises: {
       // @ts-expect-error this also exists, I promise!

--- a/packages/sveltekit/test/vite/detectAdapter.test.ts
+++ b/packages/sveltekit/test/vite/detectAdapter.test.ts
@@ -1,10 +1,10 @@
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { detectAdapter } from '../../src/vite/detectAdapter';
 
 let existsFile = true;
 const pkgJson = {
-  dependencies: {},
+  dependencies: {} as Record<string, string>,
 };
 describe('detectAdapter', () => {
   beforeEach(() => {

--- a/packages/sveltekit/test/vite/injectGlobalValues.test.ts
+++ b/packages/sveltekit/test/vite/injectGlobalValues.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { getGlobalValueInjectionCode } from '../../src/vite/injectGlobalValues';
 
 describe('getGlobalValueInjectionCode', () => {

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { Plugin } from 'vite';
 import * as autoInstrument from '../../src/vite/autoInstrument';
@@ -8,7 +8,6 @@ import * as sourceMaps from '../../src/vite/sourceMaps';
 vi.mock('fs', async () => {
   const actual = await vi.importActual('fs');
   return {
-    // @ts-expect-error this exists, I promise!
     ...actual,
     promises: {
       // @ts-expect-error this also exists, I promise!

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Plugin } from 'vite';
 import { makeCustomSentryVitePlugins } from '../../src/vite/sourceMaps';

--- a/packages/sveltekit/test/vite/svelteConfig.test.ts
+++ b/packages/sveltekit/test/vite/svelteConfig.test.ts
@@ -1,9 +1,9 @@
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { SupportedSvelteKitAdapters } from '../../src/vite/detectAdapter';
 import { getAdapterOutputDir, getHooksFileName, loadSvelteConfig } from '../../src/vite/svelteConfig';
 
-let existsFile;
+let existsFile: any;
 
 describe('loadSvelteConfig', () => {
   vi.mock('fs', () => {
@@ -25,7 +25,7 @@ describe('loadSvelteConfig', () => {
   // url apparently doesn't exist in the test environment, therefore we mock it:
   vi.mock('url', () => {
     return {
-      pathToFileURL: path => {
+      pathToFileURL: (path: string) => {
         return {
           href: path,
         };
@@ -58,7 +58,7 @@ describe('loadSvelteConfig', () => {
 describe('getAdapterOutputDir', () => {
   const mockedAdapter = {
     name: 'mocked-adapter',
-    adapt(builder) {
+    adapt(builder: any) {
       builder.writeClient('customBuildDir');
     },
   };

--- a/packages/sveltekit/tsconfig.test.json
+++ b/packages/sveltekit/tsconfig.test.json
@@ -5,6 +5,6 @@
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node", "vitest/globals"]
+    "types": ["node"]
   }
 }

--- a/packages/sveltekit/vite.config.ts
+++ b/packages/sveltekit/vite.config.ts
@@ -11,7 +11,6 @@ export default {
     // test exists, no idea why TS doesn't recognize it
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...(baseConfig as UserConfig & { test: any }).test,
-    environment: 'jsdom',
     setupFiles: ['./test/vitest.setup.ts'],
     alias: [
       {


### PR DESCRIPTION
As per https://vitest.dev/config/#globals

> By default, vitest does not provide global APIs for explicitness

I think we should follow vitest defaults here and explicitly import in the APIs that we need. This refactors our SvelteKit SDK tests to do so.

ref https://github.com/getsentry/sentry-javascript/issues/11084

This change also removes `environment: 'jsdom'` from the sveltekit global vite config in favour of explicitly adding jsdom environment via the `@vitest-environment` pragma to the specific test file that needs it. This should means that our server tests are not polluted with jsdom globals, and that future writers have to explicitly opt-in to the behaviour.