### PR TITLE
test(replay): Switch to using vitest for replay worker

### DIFF
--- a/packages/replay-worker/jest.config.js
+++ b/packages/replay-worker/jest.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../jest/jest.config.js');

--- a/packages/replay-worker/package.json
+++ b/packages/replay-worker/package.json
@@ -32,8 +32,8 @@
     "clean": "rimraf build",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "test": "jest",
-    "test:watch": "jest --watch"
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/replay-worker/test/unit/Compressor.test.ts
+++ b/packages/replay-worker/test/unit/Compressor.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { decompressSync, strFromU8 } from 'fflate';
 
 import { Compressor } from '../../src/Compressor';

--- a/packages/replay-worker/tsconfig.test.json
+++ b/packages/replay-worker/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["test/**/*.ts"],
+  "include": ["test/**/*.ts", "vite.config.ts"],
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node"]
   }
 }

--- a/packages/replay-worker/vite.config.ts
+++ b/packages/replay-worker/vite.config.ts
@@ -1,0 +1,5 @@
+import baseConfig from '../../vite/vite.config';
+
+export default {
+  ...baseConfig,
+};


### PR DESCRIPTION
Before: `Time: 0.303 s`

After: `Duration  271ms (transform 28ms, setup 0ms, collect 26ms, tests 3ms, environment 0ms, prepare 68ms)`

ref https://github.com/getsentry/sentry-javascript/issues/11084