### PR TITLE
test(replay-canvas): Switch to using vitest

### DIFF
--- a/packages/replay-canvas/.eslintrc.js
+++ b/packages/replay-canvas/.eslintrc.js
@@ -5,18 +5,4 @@
 
 module.exports = {
   extends: ['../../.eslintrc.js'],
-  overrides: [
-    {
-      files: ['src/**/*.ts'],
-    },
-    {
-      files: ['jest.setup.ts', 'jest.config.ts'],
-      parserOptions: {
-        project: ['tsconfig.test.json'],
-      },
-      rules: {
-        'no-console': 'off',
-      },
-    },
-  ],
 };

--- a/packages/replay-canvas/jest.config.js
+++ b/packages/replay-canvas/jest.config.js
@@ -1,6 +1,0 @@
-const baseConfig = require('../../jest/jest.config.js');
-
-module.exports = {
-  ...baseConfig,
-  testEnvironment: 'jsdom',
-};

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -47,8 +47,8 @@
     "clean": "rimraf build sentry-replay-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"
   },
   "publishConfig": {
@@ -65,7 +65,6 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@babel/core": "^7.17.5",
     "@sentry-internal/rrweb": "2.25.0"
   },
   "dependencies": {

--- a/packages/replay-canvas/test/canvas.test.ts
+++ b/packages/replay-canvas/test/canvas.test.ts
@@ -1,10 +1,16 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, expect, it, vi } from 'vitest';
+
 import { CanvasManager } from '@sentry-internal/rrweb';
 import { _replayCanvasIntegration, replayCanvasIntegration } from '../src/canvas';
 
-jest.mock('@sentry-internal/rrweb');
+vi.mock('@sentry-internal/rrweb');
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  vi.clearAllMocks();
 });
 
 it('initializes with default options', () => {

--- a/packages/replay-canvas/tsconfig.test.json
+++ b/packages/replay-canvas/tsconfig.test.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["test/**/*.ts", "jest.config.ts", "jest.setup.ts"],
+  "include": ["test/**/*.ts", "vite.config.ts"],
 
   "compilerOptions": {
     "lib": ["DOM", "ES2018"],
-    "types": ["node", "jest"],
+    "types": ["node"],
     "esModuleInterop": true,
     "allowJs": true,
     "noImplicitAny": true,

--- a/packages/replay-canvas/vite.config.ts
+++ b/packages/replay-canvas/vite.config.ts
@@ -1,0 +1,5 @@
+import baseConfig from '../../vite/vite.config';
+
+export default {
+  ...baseConfig,
+};


### PR DESCRIPTION
Before: `Time:        2.026 s`

After: `Duration  960ms (transform 291ms, setup 0ms, collect 446ms, tests 5ms, environment 283ms, prepare 65ms)`

ref https://github.com/getsentry/sentry-javascript/issues/11084

Also:

- removes unused `@babel/core` dev dep
- removes unused eslintrc logic