### PR TITLE
fix(feedback): add a missing call of Actor.appendToDom method when DOMContentLoaded event is triggered

### DIFF
--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -282,7 +282,7 @@ export const buildFeedbackIntegration = ({
         }
 
         if (DOCUMENT.readyState === 'loading') {
-          DOCUMENT.addEventListener('DOMContentLoaded', () => _createActor().appendToDom);
+          DOCUMENT.addEventListener('DOMContentLoaded', () => _createActor().appendToDom());
         } else {
           _createActor().appendToDom();
         }


### PR DESCRIPTION
Fixing a missing paranthesis to call `appendToDom` on `DOMContentLoaded` event.


- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Fixes #12970 