### PR TITLE
test: Remove explict casting of baseconfig in vite configs

### DIFF
--- a/packages/astro/vite.config.ts
+++ b/packages/astro/vite.config.ts
@@ -1,13 +1,9 @@
-import type { UserConfig } from 'vitest';
-
 import baseConfig from '../../vite/vite.config';
 
 export default {
   ...baseConfig,
   test: {
-    // test exists, no idea why TS doesn't recognize it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(baseConfig as UserConfig & { test: any }).test,
+    ...baseConfig.test,
     environment: 'jsdom',
   },
 };

--- a/packages/nestjs/vite.config.ts
+++ b/packages/nestjs/vite.config.ts
@@ -1,13 +1,10 @@
-import type { UserConfig } from 'vitest';
 import { defineConfig } from 'vitest/config';
 import baseConfig from '../../vite/vite.config';
 
 export default defineConfig({
   ...baseConfig,
   test: {
-    // test exists, no idea why TS doesn't recognize it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(baseConfig as UserConfig & { test: any }).test,
+    ...baseConfig.test,
     environment: 'node',
   },
 });

--- a/packages/replay-internal/vitest.config.ts
+++ b/packages/replay-internal/vitest.config.ts
@@ -1,4 +1,3 @@
-import type { UserConfig } from 'vitest';
 import { defineConfig } from 'vitest/config';
 
 import baseConfig from '../../vite/vite.config';
@@ -6,7 +5,7 @@ import baseConfig from '../../vite/vite.config';
 export default defineConfig({
   ...baseConfig,
   test: {
-    ...(baseConfig as UserConfig & { test: any }).test,
+    ...baseConfig.test,
     coverage: {},
     globals: true,
     setupFiles: ['./test.setup.ts'],

--- a/packages/solid/vite.config.ts
+++ b/packages/solid/vite.config.ts
@@ -1,14 +1,11 @@
 import solidPlugin from 'vite-plugin-solid';
-import type { UserConfig } from 'vitest';
 import baseConfig from '../../vite/vite.config';
 
 export default {
   ...baseConfig,
   plugins: [solidPlugin({ hot: !process.env.VITEST })],
   test: {
-    // test exists, no idea why TS doesn't recognize it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(baseConfig as UserConfig & { test: any }).test,
+    ...baseConfig.test,
     environment: 'jsdom',
   },
 };

--- a/packages/solidstart/vite.config.ts
+++ b/packages/solidstart/vite.config.ts
@@ -1,14 +1,11 @@
 import solidPlugin from 'vite-plugin-solid';
-import type { UserConfig } from 'vitest';
 import baseConfig from '../../vite/vite.config';
 
 export default {
   ...baseConfig,
   plugins: [solidPlugin({ hot: !process.env.VITEST })],
   test: {
-    // test exists, no idea why TS doesn't recognize it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(baseConfig as UserConfig & { test: any }).test,
+    ...baseConfig.test,
     environment: 'jsdom',
   },
 };

--- a/packages/svelte/vite.config.ts
+++ b/packages/svelte/vite.config.ts
@@ -1,14 +1,11 @@
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import type { UserConfig } from 'vitest';
 import baseConfig from '../../vite/vite.config';
 
 export default {
   ...baseConfig,
   plugins: [svelte({ hot: !process.env.VITEST })],
   test: {
-    // test exists, no idea why TS doesn't recognize it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(baseConfig as UserConfig & { test: any }).test,
+    ...baseConfig.test,
     environment: 'jsdom',
     alias: [{ find: /^svelte$/, replacement: 'svelte/internal' }],
   },

--- a/packages/sveltekit/vite.config.ts
+++ b/packages/sveltekit/vite.config.ts
@@ -1,16 +1,12 @@
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
-import type { UserConfig } from 'vitest';
-
 import baseConfig from '../../vite/vite.config';
 
 export default {
   ...baseConfig,
   test: {
-    // test exists, no idea why TS doesn't recognize it
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(baseConfig as UserConfig & { test: any }).test,
+    ...baseConfig.test,
     setupFiles: ['./test/vitest.setup.ts'],
     alias: [
       {


### PR DESCRIPTION
Something I noticed while doing my jest -> vitest conversions, we don't need this anymore.