### PR TITLE
build: Pin to Node 22.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -519,7 +519,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20, 22]
+        node: [14, 16, 18, 20, 22.4]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -579,7 +579,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20, 22]
+        node: [14, 16, 18, 20, 22.4]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -843,12 +843,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20, 22]
+        node: [14, 16, 18, 20, 22.4]
         typescript:
           - false
         include:
           # Only check typescript for latest version (to streamline CI)
-          - node: 22
+          - node: 22.4
             typescript: '3.8'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
@@ -885,7 +885,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22]
+        node: [18, 20, 22.4]
         remix: [1, 2]
         # Remix v2 only supports Node 18+, so run 16 tests separately
         include:
@@ -1409,7 +1409,7 @@ jobs:
           - os: ubuntu-20.04
             node: 20
           - os: ubuntu-20.04
-            node: 22
+            node: 22.4
 
             # x64 musl
           - os: ubuntu-20.04
@@ -1423,7 +1423,7 @@ jobs:
             node: 20
           - os: ubuntu-20.04
             container: node:22-alpine3.18
-            node: 22
+            node: 22.4
 
             # arm64 glibc
           - os: ubuntu-20.04
@@ -1437,7 +1437,7 @@ jobs:
             node: 20
           - os: ubuntu-20.04
             arch: arm64
-            node: 22
+            node: 22.4
 
             # arm64 musl
           - os: ubuntu-20.04
@@ -1455,7 +1455,7 @@ jobs:
           - os: ubuntu-20.04
             arch: arm64
             container: node:22-alpine3.18
-            node: 22
+            node: 22.4
 
             # macos x64
           - os: macos-13
@@ -1468,7 +1468,7 @@ jobs:
             node: 20
             arch: x64
           - os: macos-13
-            node: 22
+            node: 22.4
             arch: x64
 
             # macos arm64
@@ -1486,7 +1486,7 @@ jobs:
             target_platform: darwin
           - os: macos-13
             arch: arm64
-            node: 22
+            node: 22.4
             target_platform: darwin
 
             # windows x64
@@ -1500,7 +1500,7 @@ jobs:
             node: 20
             arch: x64
           - os: windows-2022
-            node: 22
+            node: 22.4
             arch: x64
 
     steps:


### PR DESCRIPTION
Let's pin to Node `22.4` - there's a regression with `22.5` that affects us https://github.com/nodejs/node/issues/53902

We can revert this pin after they do a Node.js release.