### PR TITLE
chore(repo): Add internal blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/internal.yml
+++ b/.github/ISSUE_TEMPLATE/internal.yml
@@ -1,0 +1,9 @@
+name: 💡 [Internal] Blank Issue
+description: Only for Sentry Employees! Create an issue without a template.
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true


### PR DESCRIPTION
With the new issues UI (beta), our previous way of skipping issue templates for internally created issues doesn't work anymore. So this PR adds a new template that essentially mimics a blank issue. I decided to do this rather than setting 

```
blank_issues_enabled: true
```

in `config.yml` so that we can change the name of the template and mark it clearly as internal-only. Let's hope this works reasonably well.