### PR TITLE
feat(node): Allow to pass `registerEsmLoaderHooks` to preload

### DIFF
--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -63,6 +63,7 @@ export function maybeInitializeEsmLoader(esmHookConfig?: EsmLoaderHookOptions): 
 interface NodePreloadOptions {
   debug?: boolean;
   integrations?: string[];
+  registerEsmLoaderHooks?: EsmLoaderHookOptions;
 }
 
 /**
@@ -79,7 +80,7 @@ export function preloadOpenTelemetry(options: NodePreloadOptions = {}): void {
   }
 
   if (!isCjs()) {
-    maybeInitializeEsmLoader();
+    maybeInitializeEsmLoader(options.registerEsmLoaderHooks);
   }
 
   // These are all integrations that we need to pre-load to ensure they are set up before any other code runs


### PR DESCRIPTION
As mentioned in here: https://github.com/getsentry/sentry-javascript/issues/12912#issuecomment-2241308316 there is no way today to exclude/include esm modules when preloading today.

This PR adds the option to pass `registerEsmLoaderHooks` as option to `preloadOpenTelemetry`, which allows to exclude/include packages there as well. Users can then write their own custom `preload` script and configure this there, if wanted.

## Naming

I chose to use the same option naming here than for `init`, although the semantics are a bit different - here we can't actually disable the wrapping (because that's the only reason to even call this). We can also use a different name if we want, but I thought this would maybe be easier to understand that this is the same thing 🤔 