### PR TITLE
feat: Extend ESM hooks options for iitm v1.10.0

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -91,7 +91,8 @@
     "@sentry/core": "8.19.0",
     "@sentry/opentelemetry": "8.19.0",
     "@sentry/types": "8.19.0",
-    "@sentry/utils": "8.19.0"
+    "@sentry/utils": "8.19.0",
+    "import-in-the-middle": "^1.10.0"
   },
   "devDependencies": {
     "@types/node": "^14.18.0"

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -5,8 +5,8 @@ import type { ClientOptions, Options, SamplingContext, Scope, Span, TracePropaga
 import type { NodeTransportOptions } from './transports';
 
 export interface EsmLoaderHookOptions {
-  include?: string[];
-  exclude?: string[];
+  include?: Array<string | RegExp>;
+  exclude?: Array<string | RegExp>;
 }
 
 export interface BaseNodeOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20472,10 +20472,10 @@ import-in-the-middle@1.7.1:
     cjs-module-lexer "^1.2.2"
     module-details-from-path "^1.0.3"
 
-import-in-the-middle@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.8.1.tgz#8b51c2cc631b64e53e958d7048d2d9463ce628f8"
-  integrity sha512-yhRwoHtiLGvmSozNOALgjRPFI6uYsds60EoMqqnXyyv+JOIW/BrrLejuTGBt+bq0T5tLzOHrN0T7xYTm4Qt/ng==
+import-in-the-middle@^1.10.0, import-in-the-middle@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.10.0.tgz#f15b0841950ded8d899b635058da5646256949b1"
+  integrity sha512-Z1jumVdF2GwnnYfM0a/y2ts7mZbwFMgt5rRuVmLgobgahC6iKgN5MBuXjzfTIOUpq5LSU10vJIPpVKe0X89fIw==
   dependencies:
     acorn "^8.8.2"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
`import-in-the-middle@1.10.0` supports regular expressions for `include` and `exclude`.

Is there a risk here that users might not have the latest version of `import-in-the-middle` in their dependencies?
