### PR TITLE
feat(core): Capture # of dropped spans through `beforeSendTransaction`

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -48,14 +48,14 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'replayCanvasIntegration'),
     gzip: true,
-    limit: '76 KB',
+    limit: '78 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'feedbackIntegration'),
     gzip: true,
-    limit: '89 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback, metrics)',

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -986,13 +986,15 @@ function processBeforeSend(
     }
 
     if (beforeSendTransaction) {
-      // We store the # of spans before processing in SDK metadata,
-      // so we can compare it afterwards to determine how many spans were dropped
-      const spanCountBefore = event.spans ? event.spans.length : 0;
-      event.sdkProcessingMetadata = {
-        ...event.sdkProcessingMetadata,
-        spanCountBeforeProcessing: spanCountBefore,
-      };
+      if (event.spans) {
+        // We store the # of spans before processing in SDK metadata,
+        // so we can compare it afterwards to determine how many spans were dropped
+        const spanCountBefore = event.spans.length;
+        event.sdkProcessingMetadata = {
+          ...event.sdkProcessingMetadata,
+          spanCountBeforeProcessing: spanCountBefore,
+        };
+      }
       return beforeSendTransaction(event, hint);
     }
   }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/12849.

This is a bit tricky because `beforeSendTransaction` can return a promise, so in order to avoid dealing with this I put the # of spans on the sdk metadata, and then compare that afterwards.