### PR TITLE
test(replay): Switch to explicit vitest imports

### DIFF
--- a/packages/replay-internal/test/integration/autoSaveSession.test.ts
+++ b/packages/replay-internal/test/integration/autoSaveSession.test.ts
@@ -1,4 +1,8 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { EventType } from '@sentry-internal/rrweb';
 

--- a/packages/replay-internal/test/integration/beforeAddRecordingEvent.test.ts
+++ b/packages/replay-internal/test/integration/beforeAddRecordingEvent.test.ts
@@ -1,5 +1,9 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
 import type { MockInstance, MockedFunction } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as SentryBrowserUtils from '@sentry-internal/browser-utils';
 import * as SentryCore from '@sentry/core';

--- a/packages/replay-internal/test/integration/coreHandlers/handleAfterSendEvent.test.ts
+++ b/packages/replay-internal/test/integration/coreHandlers/handleAfterSendEvent.test.ts
@@ -1,5 +1,10 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
 import type { MockInstance } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { useFakeTimers } from '../../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay-internal/test/integration/coreHandlers/handleBeforeSendEvent.test.ts
+++ b/packages/replay-internal/test/integration/coreHandlers/handleBeforeSendEvent.test.ts
@@ -1,4 +1,8 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { handleBeforeSendEvent } from '../../../src/coreHandlers/handleBeforeSendEvent';
 import type { ReplayContainer } from '../../../src/replay';

--- a/packages/replay-internal/test/integration/coreHandlers/handleGlobalEvent.test.ts
+++ b/packages/replay-internal/test/integration/coreHandlers/handleGlobalEvent.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { getClient } from '@sentry/core';
 import type { Event } from '@sentry/types';
 

--- a/packages/replay-internal/test/integration/earlyEvents.test.ts
+++ b/packages/replay-internal/test/integration/earlyEvents.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { BASE_TIMESTAMP } from '..';
 import { resetSdkMock } from '../mocks/resetSdkMock';
 import { useFakeTimers } from '../utils/use-fake-timers';

--- a/packages/replay-internal/test/integration/errorSampleRate.test.ts
+++ b/packages/replay-internal/test/integration/errorSampleRate.test.ts
@@ -1,5 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { captureException, getClient } from '@sentry/core';
-import { vi } from 'vitest';
 
 import {
   BUFFER_CHECKOUT_TIME,

--- a/packages/replay-internal/test/integration/eventProcessors.test.ts
+++ b/packages/replay-internal/test/integration/eventProcessors.test.ts
@@ -1,4 +1,8 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getClient, getCurrentScope } from '@sentry/core';
 import type { Event } from '@sentry/types';

--- a/packages/replay-internal/test/integration/events.test.ts
+++ b/packages/replay-internal/test/integration/events.test.ts
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { MockInstance } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { getClient } from '@sentry/core';
 
 import { WINDOW } from '../../src/constants';

--- a/packages/replay-internal/test/integration/flush.test.ts
+++ b/packages/replay-internal/test/integration/flush.test.ts
@@ -1,5 +1,9 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
 import type { MockedFunction } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useFakeTimers } from '../utils/use-fake-timers';
 

--- a/packages/replay-internal/test/integration/getReplayId.test.ts
+++ b/packages/replay-internal/test/integration/getReplayId.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { mockSdk } from '../mocks/mockSdk';
 import { useFakeTimers } from '../utils/use-fake-timers';
 

--- a/packages/replay-internal/test/integration/integrationSettings.test.ts
+++ b/packages/replay-internal/test/integration/integrationSettings.test.ts
@@ -1,4 +1,9 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { MockInstance } from 'vitest';
 
 import { mockSdk } from '../index';

--- a/packages/replay-internal/test/integration/rateLimiting.test.ts
+++ b/packages/replay-internal/test/integration/rateLimiting.test.ts
@@ -1,3 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { MockedFunction } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { getClient } from '@sentry/core';
 import type { Transport, TransportMakeRequestResponse } from '@sentry/types';
 
@@ -14,7 +21,7 @@ async function advanceTimers(time: number) {
   await new Promise(process.nextTick);
 }
 
-type MockTransportSend = vi.MockedFunction<Transport['send']>;
+type MockTransportSend = MockedFunction<Transport['send']>;
 
 describe('Integration | rate-limiting behaviour', () => {
   let replay: ReplayContainer;

--- a/packages/replay-internal/test/integration/rrweb.test.ts
+++ b/packages/replay-internal/test/integration/rrweb.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { resetSdkMock } from '../mocks/resetSdkMock';
 import { useFakeTimers } from '../utils/use-fake-timers';
 
@@ -15,7 +21,7 @@ describe('Integration | rrweb', () => {
         stickySession: false,
       },
     });
-    expect(mockRecord.mock.calls[0][0]).toMatchInlineSnapshot(`
+    expect(mockRecord.mock.calls[0]?.[0]).toMatchInlineSnapshot(`
       {
         "blockSelector": ".sentry-block,[data-sentry-block],base[href="/"],img,image,svg,video,object,picture,embed,map,audio,link[rel="icon"],link[rel="apple-touch-icon"]",
         "collectFonts": true,

--- a/packages/replay-internal/test/integration/sampling.test.ts
+++ b/packages/replay-internal/test/integration/sampling.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { getClient } from '@sentry/core';
 import { resetSdkMock } from '../mocks/resetSdkMock';
 import { useFakeTimers } from '../utils/use-fake-timers';

--- a/packages/replay-internal/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay-internal/test/integration/sendReplayEvent.test.ts
@@ -1,5 +1,9 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
 import type { MockInstance, MockedFunction } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as SentryBrowserUtils from '@sentry-internal/browser-utils';
 import * as SentryCore from '@sentry/core';

--- a/packages/replay-internal/test/integration/session.test.ts
+++ b/packages/replay-internal/test/integration/session.test.ts
@@ -1,4 +1,8 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getClient } from '@sentry/core';
 import type { Transport } from '@sentry/types';

--- a/packages/replay-internal/test/integration/shouldFilterRequest.test.ts
+++ b/packages/replay-internal/test/integration/shouldFilterRequest.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { shouldFilterRequest } from '../../src/util/shouldFilterRequest';
 import { mockSdk } from '../index';
 

--- a/packages/replay-internal/test/integration/start.test.ts
+++ b/packages/replay-internal/test/integration/start.test.ts
@@ -1,4 +1,8 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getClient } from '@sentry/core';
 import type { Transport } from '@sentry/types';

--- a/packages/replay-internal/test/integration/stop.test.ts
+++ b/packages/replay-internal/test/integration/stop.test.ts
@@ -1,5 +1,9 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
 import type { MockInstance, MockedFunction } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as SentryBrowserUtils from '@sentry-internal/browser-utils';
 

--- a/packages/replay-internal/test/unit/coreHandlers/handleBreadcrumbs.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleBreadcrumbs.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { CONSOLE_ARG_MAX_SIZE } from '../../../src/constants';
 import { normalizeBreadcrumb, normalizeConsoleBreadcrumb } from '../../../src/coreHandlers/handleBreadcrumbs';
 

--- a/packages/replay-internal/test/unit/coreHandlers/handleClick.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleClick.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
+
 import { useFakeTimers } from '../../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay-internal/test/unit/coreHandlers/handleDom.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleDom.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, test } from 'vitest';
+
 import type { HandlerDataDom } from '@sentry/types';
 
 import { handleDom } from '../../../src/coreHandlers/handleDom';

--- a/packages/replay-internal/test/unit/coreHandlers/handleKeyboardEvent.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleKeyboardEvent.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+
 import { getKeyboardBreadcrumb } from '../../../src/coreHandlers/handleKeyboardEvent';
 
 describe('Unit | coreHandlers | handleKeyboardEvent', () => {

--- a/packages/replay-internal/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { SENTRY_XHR_DATA_KEY } from '@sentry-internal/browser-utils';
 import type {
   Breadcrumb,

--- a/packages/replay-internal/test/unit/coreHandlers/util/addBreadcrumbEvent.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/util/addBreadcrumbEvent.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { BASE_TIMESTAMP } from '../../..';
 import { addBreadcrumbEvent } from '../../../../src/coreHandlers/util/addBreadcrumbEvent';
 import type { EventBufferArray } from '../../../../src/eventBuffer/EventBufferArray';

--- a/packages/replay-internal/test/unit/coreHandlers/util/fetchUtils.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/util/fetchUtils.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it, vi } from 'vitest';
+
 import { useFakeTimers } from '../../../utils/use-fake-timers';
 
 useFakeTimers();
-
-import { vi } from 'vitest';
 
 import { _getResponseInfo } from '../../../../src/coreHandlers/util/fetchUtils';
 

--- a/packages/replay-internal/test/unit/coreHandlers/util/getAttributesToRecord.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/util/getAttributesToRecord.test.ts
@@ -1,3 +1,5 @@
+import { expect, it } from 'vitest';
+
 import { getAttributesToRecord } from '../../../../src/coreHandlers/util/getAttributesToRecord';
 
 it('records only included attributes', function () {

--- a/packages/replay-internal/test/unit/coreHandlers/util/networkUtils.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/util/networkUtils.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+
 import { NETWORK_BODY_MAX_SIZE } from '../../../../src/constants';
 import {
   buildNetworkRequestOrResponse,

--- a/packages/replay-internal/test/unit/coreHandlers/util/xhrUtils.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/util/xhrUtils.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+
 import { _parseXhrResponse } from '../../../../src/coreHandlers/util/xhrUtils';
 
 describe('Unit | coreHandlers | util | xhrUtils', () => {

--- a/packages/replay-internal/test/unit/eventBuffer/EventBufferArray.test.ts
+++ b/packages/replay-internal/test/unit/eventBuffer/EventBufferArray.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { REPLAY_MAX_EVENT_BUFFER_SIZE } from '../../../src/constants';
 import { createEventBuffer } from '../../../src/eventBuffer';
 import { EventBufferSizeExceededError } from '../../../src/eventBuffer/error';

--- a/packages/replay-internal/test/unit/eventBuffer/EventBufferCompressionWorker.test.ts
+++ b/packages/replay-internal/test/unit/eventBuffer/EventBufferCompressionWorker.test.ts
@@ -1,4 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ */
+
 import 'jsdom-worker';
+
+import { describe, expect, it, vi } from 'vitest';
 
 import { BASE_TIMESTAMP } from '../..';
 import { REPLAY_MAX_EVENT_BUFFER_SIZE } from '../../../src/constants';

--- a/packages/replay-internal/test/unit/eventBuffer/EventBufferProxy.test.ts
+++ b/packages/replay-internal/test/unit/eventBuffer/EventBufferProxy.test.ts
@@ -1,4 +1,11 @@
+/**
+ * @vitest-environment jsdom
+ */
+
 import 'jsdom-worker';
+
+import type { MockInstance } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BASE_TIMESTAMP } from '../..';
 import { EventBufferProxy } from '../../../src/eventBuffer/EventBufferProxy';

--- a/packages/replay-internal/test/unit/multipleInstances.test.ts
+++ b/packages/replay-internal/test/unit/multipleInstances.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { replayIntegration } from '../../src/integration';
 
 describe('Unit | multipleInstances', () => {

--- a/packages/replay-internal/test/unit/session/createSession.test.ts
+++ b/packages/replay-internal/test/unit/session/createSession.test.ts
@@ -1,4 +1,9 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { MockedFunction } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import * as Sentry from '@sentry/core';
 
@@ -16,7 +21,7 @@ vi.mock('@sentry/utils', async () => {
   };
 });
 
-type CaptureEventMockType = vi.MockedFunction<typeof Sentry.captureEvent>;
+type CaptureEventMockType = MockedFunction<typeof Sentry.captureEvent>;
 
 describe('Unit | session | createSession', () => {
   const captureEventMock: CaptureEventMockType = vi.fn();

--- a/packages/replay-internal/test/unit/session/fetchSession.test.ts
+++ b/packages/replay-internal/test/unit/session/fetchSession.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
 import { REPLAY_SESSION_KEY, WINDOW } from '../../../src/constants';
 import { fetchSession } from '../../../src/session/fetchSession';
 

--- a/packages/replay-internal/test/unit/session/loadOrCreateSession.test.ts
+++ b/packages/replay-internal/test/unit/session/loadOrCreateSession.test.ts
@@ -1,4 +1,9 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { MockedFunction } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { MAX_REPLAY_DURATION, SESSION_IDLE_EXPIRE_DURATION, WINDOW } from '../../../src/constants';
 import { makeSession } from '../../../src/session/Session';
@@ -51,8 +56,8 @@ describe('Unit | session | loadOrCreateSession', () => {
 
   afterEach(() => {
     WINDOW.sessionStorage.clear();
-    (CreateSession.createSession as vi.MockedFunction<typeof CreateSession.createSession>).mockClear();
-    (FetchSession.fetchSession as vi.MockedFunction<typeof FetchSession.fetchSession>).mockClear();
+    (CreateSession.createSession as MockedFunction<typeof CreateSession.createSession>).mockClear();
+    (FetchSession.fetchSession as MockedFunction<typeof FetchSession.fetchSession>).mockClear();
   });
 
   describe('stickySession: false', () => {

--- a/packages/replay-internal/test/unit/session/saveSession.test.ts
+++ b/packages/replay-internal/test/unit/session/saveSession.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
 import { REPLAY_SESSION_KEY, WINDOW } from '../../../src/constants';
 import { makeSession } from '../../../src/session/Session';
 import { saveSession } from '../../../src/session/saveSession';

--- a/packages/replay-internal/test/unit/session/sessionSampling.test.ts
+++ b/packages/replay-internal/test/unit/session/sessionSampling.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { makeSession } from '../../../src/session/Session';
 import { getSessionSampleType } from '../../../src/session/createSession';
 

--- a/packages/replay-internal/test/unit/util/addEvent.test.ts
+++ b/packages/replay-internal/test/unit/util/addEvent.test.ts
@@ -1,6 +1,10 @@
+/**
+ * @vitest-environment jsdom
+ */
+
 import 'jsdom-worker';
 
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BASE_TIMESTAMP } from '../..';
 import { MAX_REPLAY_DURATION, REPLAY_MAX_EVENT_BUFFER_SIZE, SESSION_IDLE_PAUSE_DURATION } from '../../../src/constants';

--- a/packages/replay-internal/test/unit/util/createPerformanceEntry.test.ts
+++ b/packages/replay-internal/test/unit/util/createPerformanceEntry.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useFakeTimers } from '../../utils/use-fake-timers';
 

--- a/packages/replay-internal/test/unit/util/createReplayEnvelope.test.ts
+++ b/packages/replay-internal/test/unit/util/createReplayEnvelope.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import type { ReplayEvent } from '@sentry/types';
 import { makeDsn } from '@sentry/utils';
 

--- a/packages/replay-internal/test/unit/util/debounce.test.ts
+++ b/packages/replay-internal/test/unit/util/debounce.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it, vi } from 'vitest';
+
 import { useFakeTimers } from '../../utils/use-fake-timers';
 
 useFakeTimers();
-
-import { vi } from 'vitest';
 
 import { debounce } from '../../../src/util/debounce';
 

--- a/packages/replay-internal/test/unit/util/getPrivacyOptions.test.ts
+++ b/packages/replay-internal/test/unit/util/getPrivacyOptions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getPrivacyOptions } from '../../../src/util/getPrivacyOptions';
 

--- a/packages/replay-internal/test/unit/util/getReplay.test.ts
+++ b/packages/replay-internal/test/unit/util/getReplay.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { getCurrentScope } from '@sentry/core';
 import { replayIntegration } from '../../../src/integration';
 import { getReplay } from '../../../src/util/getReplay';

--- a/packages/replay-internal/test/unit/util/handleRecordingEmit.test.ts
+++ b/packages/replay-internal/test/unit/util/handleRecordingEmit.test.ts
@@ -1,4 +1,9 @@
-import { vi } from 'vitest';
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { MockInstance } from 'vitest';
 
 import { EventType } from '@sentry-internal/rrweb';

--- a/packages/replay-internal/test/unit/util/isExpired.test.ts
+++ b/packages/replay-internal/test/unit/util/isExpired.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { isExpired } from '../../../src/util/isExpired';
 
 describe('Unit | util | isExpired', () => {

--- a/packages/replay-internal/test/unit/util/isSampled.test.ts
+++ b/packages/replay-internal/test/unit/util/isSampled.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test, vi } from 'vitest';
+
 import { isSampled } from '../../../src/util/isSampled';
 
 // Note Math.random generates a value from 0 (inclusive) to <1 (1 exclusive).

--- a/packages/replay-internal/test/unit/util/isSessionExpired.test.ts
+++ b/packages/replay-internal/test/unit/util/isSessionExpired.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { MAX_REPLAY_DURATION } from '../../../src/constants';
 import { makeSession } from '../../../src/session/Session';
 import { isSessionExpired } from '../../../src/util/isSessionExpired';

--- a/packages/replay-internal/test/unit/util/maskAttribute.test.ts
+++ b/packages/replay-internal/test/unit/util/maskAttribute.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, test } from 'vitest';
+
 import { maskAttribute } from '../../../src/util/maskAttribute';
 
 describe('maskAttribute', () => {

--- a/packages/replay-internal/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay-internal/test/unit/util/prepareReplayEvent.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getClient, getCurrentScope, setCurrentClient } from '@sentry/core';
 import type { ReplayEvent } from '@sentry/types';

--- a/packages/replay-internal/test/unit/util/throttle.test.ts
+++ b/packages/replay-internal/test/unit/util/throttle.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, vi } from 'vitest';
+
 import { BASE_TIMESTAMP } from '../..';
 import { SKIPPED, THROTTLED, throttle } from '../../../src/util/throttle';
 import { useFakeTimers } from '../../utils/use-fake-timers';

--- a/packages/replay-internal/test/utils/use-fake-timers.ts
+++ b/packages/replay-internal/test/utils/use-fake-timers.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 vi.mock('@sentry-internal/browser-utils', async () => ({
   ...(await vi.importActual('@sentry-internal/browser-utils')),
-  setTimeout: (...args) => {
+  setTimeout: (...args: any[]) => {
     return setTimeout.call(global, ...args);
   },
 }));

--- a/packages/replay-internal/tsconfig.test.json
+++ b/packages/replay-internal/tsconfig.test.json
@@ -4,7 +4,7 @@
   "include": ["test/**/*.ts", "vitest.config.ts", "test.setup.ts"],
 
   "compilerOptions": {
-    "types": ["node", "jest"],
+    "types": ["node"],
     "esModuleInterop": true,
     "allowJs": true,
     "noImplicitAny": true,

--- a/packages/replay-internal/vitest.config.ts
+++ b/packages/replay-internal/vitest.config.ts
@@ -6,10 +6,7 @@ export default defineConfig({
   ...baseConfig,
   test: {
     ...baseConfig.test,
-    coverage: {},
-    globals: true,
     setupFiles: ['./test.setup.ts'],
     reporters: ['default'],
-    environment: 'jsdom',
   },
 });


### PR DESCRIPTION
As per https://vitest.dev/config/#globals

> By default, vitest does not provide global APIs for explicitness

I think we should follow vitest defaults here and explicitly import in the APIs that we need. This refactors our Replay SDK tests to do so.

ref https://github.com/getsentry/sentry-javascript/issues/11084

This change also removes `environment: 'jsdom'` from the vite config in favour of explicitly adding jsdom environment via the `@vitest-environment` pragma to the specific test file that needs it. This should means that our non-browser tests are not polluted with jsdom globals, and that future writers have to explicitly opt-in to the behaviour.