### PR TITLE
test(solid): Switch to explicit vitest imports

### DIFF
--- a/packages/solid/test/errorboundary.test.tsx
+++ b/packages/solid/test/errorboundary.test.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type * as SentryBrowser from '@sentry/browser';
 import { createTransport, getCurrentScope, setCurrentClient } from '@sentry/core';
 import { render } from '@solidjs/testing-library';
 import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
 
 import { ErrorBoundary } from 'solid-js';
 import { BrowserClient, withSentryErrorBoundary } from '../src';

--- a/packages/solid/test/sdk.test.ts
+++ b/packages/solid/test/sdk.test.ts
@@ -1,7 +1,8 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { SDK_VERSION } from '@sentry/browser';
 import * as SentryBrowser from '@sentry/browser';
 
-import { vi } from 'vitest';
 import { init as solidInit } from '../src/sdk';
 
 const browserInit = vi.spyOn(SentryBrowser, 'init');

--- a/packages/solid/test/solidrouter.test.tsx
+++ b/packages/solid/test/solidrouter.test.tsx
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { spanToJSON } from '@sentry/browser';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -10,7 +12,6 @@ import {
 import type { MemoryHistory } from '@solidjs/router';
 import { MemoryRouter, Navigate, Route, createMemoryHistory } from '@solidjs/router';
 import { render } from '@solidjs/testing-library';
-import { vi } from 'vitest';
 
 import { BrowserClient } from '../src';
 import { solidRouterBrowserTracingIntegration, withSentryRouterRouting } from '../src/solidrouter';

--- a/packages/solid/tsconfig.test.json
+++ b/packages/solid/tsconfig.test.json
@@ -5,7 +5,7 @@
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["vitest/globals", "vite/client", "@testing-library/jest-dom"],
+    "types": ["vite/client", "@testing-library/jest-dom"],
 
     // other package-specific, test-specific options
     "jsx": "preserve",

--- a/packages/solid/vite.config.ts
+++ b/packages/solid/vite.config.ts
@@ -6,6 +6,5 @@ export default {
   plugins: [solidPlugin({ hot: !process.env.VITEST })],
   test: {
     ...baseConfig.test,
-    environment: 'jsdom',
   },
 };


### PR DESCRIPTION
As per https://vitest.dev/config/#globals

> By default, vitest does not provide global APIs for explicitness

I think we should follow vitest defaults here and explicitly import in the APIs that we need. This refactors our Solid SDK tests to do so.

ref https://github.com/getsentry/sentry-javascript/issues/11084

This change also removes `environment: 'jsdom'` from the vite config as it seems nothing needs this for solid. This should means that our tests are not polluted with jsdom globals, and that future writers have to explicitly opt-in to the behaviour.