### PR TITLE
Revert "build: Pin to Node 22.4"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -519,7 +519,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20, 22.4]
+        node: [14, 16, 18, 20, 22]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -579,7 +579,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20, 22.4]
+        node: [14, 16, 18, 20, 22]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -816,12 +816,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20, 22.4]
+        node: [14, 16, 18, 20, 22]
         typescript:
           - false
         include:
           # Only check typescript for latest version (to streamline CI)
-          - node: 22.4
+          - node: 22
             typescript: '3.8'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
@@ -858,7 +858,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22.4]
+        node: [18, 20, 22]
         remix: [1, 2]
         # Remix v2 only supports Node 18+, so run 16 tests separately
         include:
@@ -1384,7 +1384,7 @@ jobs:
           - os: ubuntu-20.04
             node: 20
           - os: ubuntu-20.04
-            node: 22.4
+            node: 22
 
             # x64 musl
           - os: ubuntu-20.04
@@ -1398,7 +1398,7 @@ jobs:
             node: 20
           - os: ubuntu-20.04
             container: node:22-alpine3.18
-            node: 22.4
+            node: 22
 
             # arm64 glibc
           - os: ubuntu-20.04
@@ -1412,7 +1412,7 @@ jobs:
             node: 20
           - os: ubuntu-20.04
             arch: arm64
-            node: 22.4
+            node: 22
 
             # arm64 musl
           - os: ubuntu-20.04
@@ -1430,7 +1430,7 @@ jobs:
           - os: ubuntu-20.04
             arch: arm64
             container: node:22-alpine3.18
-            node: 22.4
+            node: 22
 
             # macos x64
           - os: macos-13
@@ -1443,7 +1443,7 @@ jobs:
             node: 20
             arch: x64
           - os: macos-13
-            node: 22.4
+            node: 22
             arch: x64
 
             # macos arm64
@@ -1461,7 +1461,7 @@ jobs:
             target_platform: darwin
           - os: macos-13
             arch: arm64
-            node: 22.4
+            node: 22
             target_platform: darwin
 
             # windows x64
@@ -1475,7 +1475,7 @@ jobs:
             node: 20
             arch: x64
           - os: windows-2022
-            node: 22.4
+            node: 22
             arch: x64
 
     steps:


### PR DESCRIPTION
Reverts https://github.com/getsentry/sentry-javascript/pull/12980

We no longer need to pin to Node 22.4 now that Node 22.5.1 has been released.

https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#22.5.1

