### PR TITLE
feat(profiling-node): Switch to using `createRequire`

### DIFF
--- a/packages/profiling-node/src/cpu_profiler.ts
+++ b/packages/profiling-node/src/cpu_profiler.ts
@@ -1,7 +1,9 @@
+import { createRequire } from 'node:module';
 import { arch as _arch, platform as _platform } from 'node:os';
 import { join, resolve } from 'node:path';
 import { env, versions } from 'node:process';
 import { threadId } from 'node:worker_threads';
+
 import { familySync } from 'detect-libc';
 import { getAbi } from 'node-abi';
 
@@ -28,6 +30,7 @@ const built_from_source_path = resolve(__dirname, '..', `./sentry_cpu_profiler-$
  */
 // eslint-disable-next-line complexity
 export function importCppBindingsModule(): PrivateV8CpuProfilerBindings {
+  const require = createRequire(import.meta.url);
   // If a binary path is specified, use that.
   if (env['SENTRY_PROFILER_BINARY_PATH']) {
     const envPath = env['SENTRY_PROFILER_BINARY_PATH'];


### PR DESCRIPTION
Using `createRequire` instead of `require` is more correct for the esm builds.

ref https://github.com/getsentry/sentry-javascript/pull/13030