### PR TITLE
ref(profiling) remove prebuilding by node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -545,7 +545,9 @@ jobs:
   job_profiling_node_unit_tests:
     name: Node Profiling Unit Tests
     needs: [job_get_metadata, job_build]
-    if: needs.job_get_metadata.outputs.changed_node == 'true' || needs.job_get_metadata.outputs.changed_profiling_node == 'true' || github.event_name != 'pull_request'
+    if:
+      needs.job_get_metadata.outputs.changed_node == 'true' || needs.job_get_metadata.outputs.changed_profiling_node ==
+      'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -621,7 +623,8 @@ jobs:
           yarn test:integration
 
   job_browser_playwright_tests:
-    name: Playwright (${{ matrix.bundle }}${{ matrix.shard && format(' {0}/{1}', matrix.shard, matrix.shards) || ''}}) Tests
+    name:
+      Playwright (${{ matrix.bundle }}${{ matrix.shard && format(' {0}/{1}', matrix.shard, matrix.shards) || ''}}) Tests
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-20.04-large-js
@@ -706,14 +709,15 @@ jobs:
         env:
           PW_BUNDLE: ${{ matrix.bundle }}
         working-directory: dev-packages/browser-integration-tests
-        run: yarn test:ci${{ matrix.project && format(' --project={0}', matrix.project) || '' }}${{ matrix.shard && format(' --shard={0}/{1}', matrix.shard, matrix.shards) || '' }}
+        run:
+          yarn test:ci${{ matrix.project && format(' --project={0}', matrix.project) || '' }}${{ matrix.shard &&
+          format(' --shard={0}/{1}', matrix.shard, matrix.shards) || '' }}
       - name: Upload Playwright Traces
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: playwright-traces
           path: dev-packages/browser-integration-tests/test-results
-
 
   job_browser_loader_tests:
     name: Playwright Loader (${{ matrix.bundle }}) Tests
@@ -803,7 +807,6 @@ jobs:
             echo "Found illegal TypeScript import statement."
             exit 1
           fi
-
 
   job_node_integration_tests:
     name:
@@ -1021,7 +1024,7 @@ jobs:
             'nuxt-3',
             'vue-3',
             'webpack-4',
-            'webpack-5'
+            'webpack-5',
           ]
         build-command:
           - false
@@ -1103,9 +1106,8 @@ jobs:
     # We need to add the `always()` check here because the previous step has this as well :(
     # See: https://github.com/actions/runner/issues/2205
     if:
-      always() && needs.job_e2e_prepare.result == 'success' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      github.actor != 'dependabot[bot]'
+      always() && needs.job_e2e_prepare.result == 'success' && (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
     needs: [job_get_metadata, job_build, job_e2e_prepare]
     runs-on: ubuntu-20.04
     timeout-minutes: 10
@@ -1122,12 +1124,7 @@ jobs:
       fail-fast: false
       matrix:
         test-application:
-          [
-            'cloudflare-astro',
-            'react-send-to-sentry',
-            'node-express-send-to-sentry',
-            'debug-id-sourcemaps',
-          ]
+          ['cloudflare-astro', 'react-send-to-sentry', 'node-express-send-to-sentry', 'debug-id-sourcemaps']
         build-command:
           - false
         assert-command:
@@ -1208,13 +1205,10 @@ jobs:
     # See: https://github.com/actions/runner/issues/2205
     if:
       # Only run profiling e2e tests if profiling node bindings have changed
-      always() && needs.job_e2e_prepare.result == 'success' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-     (
-        (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||
-        (needs.job_get_metadata.outputs.is_release == 'true') ||
-        (github.event_name != 'pull_request')
-      )
+      always() && needs.job_e2e_prepare.result == 'success' && (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository) && (
+      (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||
+      (needs.job_get_metadata.outputs.is_release == 'true') || (github.event_name != 'pull_request') )
     needs: [job_get_metadata, job_build, job_e2e_prepare]
     runs-on: ubuntu-20.04
     timeout-minutes: 10
@@ -1260,7 +1254,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/packages/*/*.tgz
           key: ${{ env.BUILD_CACHE_TARBALL_KEY }}
-          fail-on-cache-miss : true
+          fail-on-cache-miss: true
 
       - name: Get node version
         id: versions
@@ -1361,7 +1355,10 @@ jobs:
           path: ${{ steps.process.outputs.artifactPath }}
 
   job_compile_bindings_profiling_node:
-    name: Compile & Test Profiling Bindings (v${{ matrix.node }}) ${{ matrix.target_platform || matrix.os }}, ${{ matrix.node || matrix.container }}, ${{ matrix.arch || matrix.container }}, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }}
+    name:
+      Compile & Test Profiling Bindings (v${{ matrix.node }}) ${{ matrix.target_platform || matrix.os }}, ${{
+      matrix.node || matrix.container }}, ${{ matrix.arch || matrix.container }}, ${{ contains(matrix.container,
+      'alpine') && 'musl' || 'glibc'  }}
     needs: [job_get_metadata, job_install_deps, job_build]
     # Compiling bindings can be very slow (especially on windows), so only run precompile
     # Skip precompile unless we are on a release branch as precompile slows down CI times.
@@ -1376,26 +1373,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-            # x64 glibc
-          - os: ubuntu-20.04
-            node: 16
-          - os: ubuntu-20.04
-            node: 18
-          - os: ubuntu-20.04
-            node: 20
+          # x64 glibc
           - os: ubuntu-20.04
             node: 22
 
             # x64 musl
-          - os: ubuntu-20.04
-            container: node:16-alpine3.16
-            node: 16
-          - os: ubuntu-20.04
-            container: node:18-alpine3.17
-            node: 18
-          - os: ubuntu-20.04
-            container: node:20-alpine3.17
-            node: 20
           - os: ubuntu-20.04
             container: node:22-alpine3.18
             node: 22
@@ -1403,30 +1385,9 @@ jobs:
             # arm64 glibc
           - os: ubuntu-20.04
             arch: arm64
-            node: 16
-          - os: ubuntu-20.04
-            arch: arm64
-            node: 18
-          - os: ubuntu-20.04
-            arch: arm64
-            node: 20
-          - os: ubuntu-20.04
-            arch: arm64
             node: 22
 
             # arm64 musl
-          - os: ubuntu-20.04
-            container: node:16-alpine3.16
-            arch: arm64
-            node: 16
-          - os: ubuntu-20.04
-            arch: arm64
-            container: node:18-alpine3.17
-            node: 18
-          - os: ubuntu-20.04
-            arch: arm64
-            container: node:20-alpine3.17
-            node: 20
           - os: ubuntu-20.04
             arch: arm64
             container: node:22-alpine3.18
@@ -1434,46 +1395,16 @@ jobs:
 
             # macos x64
           - os: macos-13
-            node: 16
-            arch: x64
-          - os: macos-13
-            node: 18
-            arch: x64
-          - os: macos-13
-            node: 20
-            arch: x64
-          - os: macos-13
             node: 22
             arch: x64
 
             # macos arm64
           - os: macos-13
             arch: arm64
-            node: 16
-            target_platform: darwin
-          - os: macos-13
-            arch: arm64
-            node: 18
-            target_platform: darwin
-          - os: macos-13
-            arch: arm64
-            node: 20
-            target_platform: darwin
-          - os: macos-13
-            arch: arm64
             node: 22
             target_platform: darwin
 
             # windows x64
-          - os: windows-2022
-            node: 16
-            arch: x64
-          - os: windows-2022
-            node: 18
-            arch: x64
-          - os: windows-2022
-            node: 20
-            arch: x64
           - os: windows-2022
             node: 22
             arch: x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1221,6 +1221,7 @@ jobs:
       fail-fast: false
       matrix:
         test-application: ['node-profiling']
+        node: [14, 16, 18, 20, 22]
         build-command:
           - false
         label:
@@ -1236,7 +1237,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'dev-packages/e2e-tests/package.json'
+          node-version: ${{ matrix.node }}
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:

--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -79,12 +79,10 @@
     "@sentry/node": "8.20.0",
     "@sentry/types": "8.20.0",
     "@sentry/utils": "8.20.0",
-    "detect-libc": "^2.0.2",
-    "node-abi": "^3.61.0"
+    "detect-libc": "^2.0.2"
   },
   "devDependencies": {
     "@types/node": "16.18.70",
-    "@types/node-abi": "^3.0.3",
     "clang-format": "^1.8.0",
     "cross-env": "^7.0.3",
     "node-gyp": "^9.4.1",

--- a/packages/profiling-node/scripts/binaries.js
+++ b/packages/profiling-node/scripts/binaries.js
@@ -1,7 +1,6 @@
 const os = require('os');
 const path = require('path');
 
-const abi = require('node-abi');
 const libc = require('detect-libc');
 
 function getModuleName() {
@@ -10,11 +9,11 @@ function getModuleName() {
   const arch = process.env['BUILD_ARCH'] || os.arch();
 
   if (platform === 'darwin' && arch === 'arm64') {
-    const identifier = [platform, 'arm64', abi.getAbi(process.versions.node, 'node')].filter(Boolean).join('-');
+    const identifier = [platform, 'arm64'].filter(Boolean).join('-');
     return `sentry_cpu_profiler-${identifier}.node`;
   }
 
-  const identifier = [platform, arch, stdlib, abi.getAbi(process.versions.node, 'node')].filter(Boolean).join('-');
+  const identifier = [platform, arch, stdlib].filter(Boolean).join('-');
 
   return `sentry_cpu_profiler-${identifier}.node`;
 }

--- a/packages/profiling-node/src/cpu_profiler.ts
+++ b/packages/profiling-node/src/cpu_profiler.ts
@@ -1,9 +1,8 @@
 import { arch as _arch, platform as _platform } from 'node:os';
 import { join, resolve } from 'node:path';
-import { env, versions } from 'node:process';
+import { env } from 'node:process';
 import { threadId } from 'node:worker_threads';
 import { familySync } from 'detect-libc';
-import { getAbi } from 'node-abi';
 
 import { GLOBAL_OBJ, logger } from '@sentry/utils';
 import { DEBUG_BUILD } from './debug-build';
@@ -18,8 +17,7 @@ import type { ProfileFormat } from './types';
 const stdlib = familySync();
 const platform = process.env['BUILD_PLATFORM'] || _platform();
 const arch = process.env['BUILD_ARCH'] || _arch();
-const abi = getAbi(versions.node, 'node');
-const identifier = [platform, arch, stdlib, abi].filter(c => c !== undefined && c !== null).join('-');
+const identifier = [platform, arch, stdlib].filter(c => c !== undefined && c !== null).join('-');
 
 const built_from_source_path = resolve(__dirname, '..', `./sentry_cpu_profiler-${identifier}`);
 
@@ -44,112 +42,35 @@ export function importCppBindingsModule(): PrivateV8CpuProfilerBindings {
   // This is for cases where precompiled binaries were not provided, but may have been compiled from source.
   if (platform === 'darwin') {
     if (arch === 'x64') {
-      if (abi === '93') {
-        return require('../sentry_cpu_profiler-darwin-x64-93.node');
-      }
-      if (abi === '108') {
-        return require('../sentry_cpu_profiler-darwin-x64-108.node');
-      }
-      if (abi === '115') {
-        return require('../sentry_cpu_profiler-darwin-x64-115.node');
-      }
-      if (abi === '127') {
-        return require('../sentry_cpu_profiler-darwin-x64-127.node');
-      }
+      return require('../sentry_cpu_profiler-darwin-x64.node');
     }
 
     if (arch === 'arm64') {
-      if (abi === '93') {
-        return require('../sentry_cpu_profiler-darwin-arm64-93.node');
-      }
-      if (abi === '108') {
-        return require('../sentry_cpu_profiler-darwin-arm64-108.node');
-      }
-      if (abi === '115') {
-        return require('../sentry_cpu_profiler-darwin-arm64-115.node');
-      }
-      if (abi === '127') {
-        return require('../sentry_cpu_profiler-darwin-arm64-127.node');
-      }
+      return require('../sentry_cpu_profiler-darwin-arm64.node');
     }
   }
 
   if (platform === 'win32') {
     if (arch === 'x64') {
-      if (abi === '93') {
-        return require('../sentry_cpu_profiler-win32-x64-93.node');
-      }
-      if (abi === '108') {
-        return require('../sentry_cpu_profiler-win32-x64-108.node');
-      }
-      if (abi === '115') {
-        return require('../sentry_cpu_profiler-win32-x64-115.node');
-      }
-      if (abi === '127') {
-        return require('../sentry_cpu_profiler-win32-x64-127.node');
-      }
+      return require('../sentry_cpu_profiler-win32-x64.node');
     }
   }
 
   if (platform === 'linux') {
     if (arch === 'x64') {
       if (stdlib === 'musl') {
-        if (abi === '93') {
-          return require('../sentry_cpu_profiler-linux-x64-musl-93.node');
-        }
-        if (abi === '108') {
-          return require('../sentry_cpu_profiler-linux-x64-musl-108.node');
-        }
-        if (abi === '115') {
-          return require('../sentry_cpu_profiler-linux-x64-musl-115.node');
-        }
-        if (abi === '127') {
-          return require('../sentry_cpu_profiler-linux-x64-musl-127.node');
-        }
+        return require('../sentry_cpu_profiler-linux-x64-musl.node');
       }
       if (stdlib === 'glibc') {
-        if (abi === '93') {
-          return require('../sentry_cpu_profiler-linux-x64-glibc-93.node');
-        }
-        if (abi === '108') {
-          return require('../sentry_cpu_profiler-linux-x64-glibc-108.node');
-        }
-        if (abi === '115') {
-          return require('../sentry_cpu_profiler-linux-x64-glibc-115.node');
-        }
-        if (abi === '127') {
-          return require('../sentry_cpu_profiler-linux-x64-glibc-127.node');
-        }
+        return require('../sentry_cpu_profiler-linux-x64-glibc.node');
       }
     }
     if (arch === 'arm64') {
       if (stdlib === 'musl') {
-        if (abi === '93') {
-          return require('../sentry_cpu_profiler-linux-arm64-musl-93.node');
-        }
-        if (abi === '108') {
-          return require('../sentry_cpu_profiler-linux-arm64-musl-108.node');
-        }
-        if (abi === '115') {
-          return require('../sentry_cpu_profiler-linux-arm64-musl-115.node');
-        }
-        if (abi === '127') {
-          return require('../sentry_cpu_profiler-linux-arm64-musl-127.node');
-        }
+        return require('../sentry_cpu_profiler-linux-arm64-musl.node');
       }
       if (stdlib === 'glibc') {
-        if (abi === '93') {
-          return require('../sentry_cpu_profiler-linux-arm64-glibc-93.node');
-        }
-        if (abi === '108') {
-          return require('../sentry_cpu_profiler-linux-arm64-glibc-108.node');
-        }
-        if (abi === '115') {
-          return require('../sentry_cpu_profiler-linux-arm64-glibc-115.node');
-        }
-        if (abi === '127') {
-          return require('../sentry_cpu_profiler-linux-arm64-glibc-127.node');
-        }
+        return require('../sentry_cpu_profiler-linux-arm64-glibc.node');
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9726,11 +9726,6 @@
   dependencies:
     "@types/unist" "^2"
 
-"@types/node-abi@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/node-abi/-/node-abi-3.0.3.tgz#a8334d75fe45ccd4cdb2a6c1ae82540a7a76828c"
-  integrity sha512-5oos6sivyXcDEuVC5oX3+wLwfgrGZu4NIOn826PGAjPCHsqp2zSPTGU7H1Tv+GZBOiDUY3nBXY1MdaofSEt4fw==
-
 "@types/node-cron@^3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@types/node-cron/-/node-cron-3.0.11.tgz#70b7131f65038ae63cfe841354c8aba363632344"
@@ -25016,13 +25011,6 @@ node-abi@^3.3.0:
   version "3.47.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.47.0.tgz#6cbfa2916805ae25c2b7156ca640131632eb05e8"
   integrity sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==
-  dependencies:
-    semver "^7.3.5"
-
-node-abi@^3.61.0:
-  version "3.61.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.61.0.tgz#9248f8b8e35dbae2fafeecd6240c5a017ea23f3f"
-  integrity sha512-dYDO1rxzvMXjEMi37PBeFuYgwh3QZpsw/jt+qOmnRSwiV4z4c+OLoRlTa3V8ID4TrkSQpzCVc9OI2sstFaINfQ==
   dependencies:
     semver "^7.3.5"
 


### PR DESCRIPTION
This needs to be tested so that we can see if there were changes inside v8 that that may have broke compatibility with these APIs, but it would be nice if we could just ship a single binary per os/arch/stdlib and remove the node module version from the build matrix

