### PR TITLE
feat (feedback) - Make cropped screenshot area draggable

### DIFF
--- a/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
+++ b/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
@@ -82,7 +82,6 @@ export function ScreenshotEditorFactory({
     const croppingRef = hooks.useRef<HTMLCanvasElement>(null);
     const [croppingRect, setCroppingRect] = hooks.useState<Box>({ startX: 0, startY: 0, endX: 0, endY: 0 });
     const [confirmCrop, setConfirmCrop] = hooks.useState(false);
-    const [isDragging, setIsDragging] = hooks.useState(false);
     const [isResizing, setIsResizing] = hooks.useState(false);
 
     hooks.useEffect(() => {
@@ -198,16 +197,15 @@ export function ScreenshotEditorFactory({
       };
     }, []);
 
-    // DRAGGING FUNCTIONALITY
+    // DRAGGING FUNCTIONALITY.
     const initialPositionRef = hooks.useRef({ initialX: 0, initialY: 0 });
 
     function onDragStart(e: MouseEvent): void {
       if (isResizing) return;
 
-      setIsDragging(true);
       initialPositionRef.current = { initialX: e.clientX, initialY: e.clientY };
 
-      const handleMouseMove = (moveEvent: MouseEvent) => {
+      const handleMouseMove = (moveEvent: MouseEvent): void => {
         const cropCanvas = croppingRef.current;
         if (!cropCanvas) return;
 
@@ -240,8 +238,7 @@ export function ScreenshotEditorFactory({
         });
       };
 
-      const handleMouseUp = () => {
-        setIsDragging(false);
+      const handleMouseUp = (): void => {
         DOCUMENT.removeEventListener('mousemove', handleMouseMove);
         DOCUMENT.removeEventListener('mouseup', handleMouseUp);
       };
@@ -319,7 +316,11 @@ export function ScreenshotEditorFactory({
         <style dangerouslySetInnerHTML={styles} />
         <div class="editor__canvas-container" ref={canvasContainerRef}>
           <div class="editor__crop-container" style={{ position: 'absolute', zIndex: 1 }} ref={cropContainerRef}>
-            <canvas onMouseDown={onDragStart} style={{ position: 'absolute' }} ref={croppingRef}></canvas>
+            <canvas
+              onMouseDown={onDragStart}
+              style={{ position: 'absolute', cursor: confirmCrop ? 'move' : 'auto' }}
+              ref={croppingRef}
+            ></canvas>
             <CropCorner
               left={croppingRect.startX - CROP_BUTTON_BORDER}
               top={croppingRect.startY - CROP_BUTTON_BORDER}

--- a/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
+++ b/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
@@ -224,7 +224,7 @@ export function ScreenshotEditorFactory({
             0,
             Math.min(prev.startY + deltaY, cropCanvas.height / DPI - (prev.endY - prev.startY)),
           );
-          // Don't want to change size, just post
+          // Don't want to change size, just position
           const newEndX = newStartX + (prev.endX - prev.startX);
           const newEndY = newStartY + (prev.endY - prev.startY);
 


### PR DESCRIPTION
- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).fe

This addition adds an intuitive way to resize screenshots in the user feedback widget. The draggable area is bound by the canvas box (so it won't overflow) and is only draggable when cropped (when confirm/cancel buttons present) 

https://github.com/user-attachments/assets/7ddff991-a791-4d41-a2ad-b278e1ab4950

 