### PR TITLE
feat(core): Use the `ignoreErrors` logic for failed transactions

### DIFF
--- a/dev-packages/browser-integration-tests/README.md
+++ b/dev-packages/browser-integration-tests/README.md
@@ -100,3 +100,15 @@ occur while writing tests for Sentry Browser SDK.
   - If a `subject.js` is defined for the test case.
   - If either of `init.js` or `subject.js` contain non-browser code.
   - If the webpack configuration is valid.
+
+- #### Debugging Tests
+
+  To debug one or multiple test scenarios, you can use playwright's UI mode. This opens a simulated browser window with
+  console logs, a timeline of the page and how it was rendered, a list of steps within the test and filtering
+  capabilities to run the specific test. This is really helpful to understand what happened during the test or for
+  example when a timeout occurred.
+
+  To use UI mode, simply call `yarn test --ui` and filter on the test in the UI.
+
+  Note: passing [the `-g` flag](#running-tests-locally) along with the `--ui` command doesn't give you an advantage as
+  you have to filter on the test again in the UI.

--- a/packages/core/src/tracing/errors.ts
+++ b/packages/core/src/tracing/errors.ts
@@ -11,7 +11,7 @@ import { DEBUG_BUILD } from '../debug-build';
 import { getActiveSpan, getRootSpan } from '../utils/spanUtils';
 import { getClient } from '../currentScopes';
 import { SPAN_STATUS_ERROR } from './spanstatus';
-import { HandlerDataError } from '@sentry/types';
+import { type HandlerDataError } from '@sentry/types';
 
 let errorsInstrumented = false;
 

--- a/packages/core/src/tracing/errors.ts
+++ b/packages/core/src/tracing/errors.ts
@@ -4,6 +4,7 @@ import {
   addGlobalErrorInstrumentationHandler,
   addGlobalUnhandledRejectionInstrumentationHandler,
   logger,
+  stringMatchesSomePattern,
 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
@@ -67,22 +68,7 @@ function _isIgnoredError(error: any): boolean {
     return false;
   }
 
-  const errorsToIgnore = options.ignoreErrors;
-  if (!errorsToIgnore) {
-    return false;
-  }
-
-  for (const errorToIgnore of errorsToIgnore) {
-    if (typeof errorToIgnore === 'string' && errorMessage.includes(errorToIgnore)) {
-      return true;
-    }
-
-    if (errorToIgnore instanceof RegExp && errorToIgnore.test(errorMessage)) {
-      return true;
-    }
-  }
-
-  return false;
+  return stringMatchesSomePattern(errorMessage, options.ignoreErrors);
 }
 
 function _errorMessage(error: any): string {


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Hello there!

This change tries to fix a behavior with the transactions feature.

The behavior is straightforward: it happens when we have some entries in our `ignoreErrors`, but when some of these errors happen, the transactions are still being marked with the `internal_error` status.

This is harmful in our case because we have some alerts set up for `%` of transaction failures, but we don't care about some of the errors that happen.

This pretty much a feature request disguised as a PR. If someone from product sees this, I would love to read if that's the right idea our you folks have something else in mind.

Thank you!
