### PR TITLE
fix(browser): Guard for `this._flushOutcomes` if old `BaseClient`s are floating around

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -65,7 +65,11 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
     if (opts.sendClientReports && WINDOW.document) {
       WINDOW.document.addEventListener('visibilitychange', () => {
         if (WINDOW.document.visibilityState === 'hidden') {
-          this._flushOutcomes();
+          // Theoretically and strictly speaking this check is unnecessary use people that have old BaseClients floating
+          // around may not have the method. We guard for its existence to prevent these users from throwing here and eating up quota.
+          if (this._flushOutcomes) {
+            this._flushOutcomes();
+          }
         }
       });
     }

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -65,7 +65,7 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
     if (opts.sendClientReports && WINDOW.document) {
       WINDOW.document.addEventListener('visibilitychange', () => {
         if (WINDOW.document.visibilityState === 'hidden') {
-          // Theoretically and strictly speaking this check is unnecessary use people that have old BaseClients floating
+          // Theoretically and strictly speaking this check is unnecessary but people that have old BaseClients floating
           // around may not have the method. We guard for its existence to prevent these users from throwing here and eating up quota.
           if (this._flushOutcomes) {
             this._flushOutcomes();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/13083