### PR TITLE
chore: Add changelog entry for cloudflare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,26 @@
 # Changelog
 
-> [!IMPORTANT]  
+> [!IMPORTANT] Important
+>
 > If you are upgrading to the `8.x` versions of the SDK from `7.x` or below, make sure you follow our
 > [migration guide](https://docs.sentry.io/platforms/javascript/migration/) first.
 
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+
+- **Alpha release of Official Cloudflare SDK**
+  - feat(cloudflare): Add `withSentry` method (#13025)
+  - feat(cloudflare): Add cloudflare sdk scaffolding (#12953)
+  - feat(cloudflare): Add basic cloudflare package and tests (#12861)
+
+This release contains the alpha version of `@sentry/cloudflare`, our SDK for the
+[Cloudflare Workers JavaScript Runtime](https://developers.cloudflare.com/workers/)! For details on how to use it,
+please see the [README](./packages/cloudflare/README.md). Any feedback/bug reports are greatly appreciated, please
+[reach out on GitHub](https://github.com/getsentry/sentry-javascript/issues/12620).
+
+Please note that only Cloudflare Workers are tested and supported - official Cloudflare Pages support will come in an
+upcoming release.
 
 ## 8.20.0
 


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/12620

Explicitly add a changelog entry for cloudflare so it's ready to go whenever the team decides to do a release.