### PR TITLE
test(astro): Switch to explicit vitest imports

### DIFF
--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import type { BrowserClient } from '@sentry/browser';
 import {
   browserTracingIntegration,
@@ -8,9 +10,8 @@ import {
 } from '@sentry/browser';
 import * as SentryBrowser from '@sentry/browser';
 import { SDK_VERSION, getClient } from '@sentry/browser';
-import { vi } from 'vitest';
 
-import { init } from '../../../astro/src/client/sdk';
+import { init } from '../../src/client/sdk';
 
 const browserInit = vi.spyOn(SentryBrowser, 'init');
 
@@ -66,7 +67,7 @@ describe('Sentry client SDK', () => {
           ...tracingOptions,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
+        const integrationsToInit = browserInit.mock.calls[0]![0]?.defaultIntegrations;
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
 
         expect(integrationsToInit).toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
@@ -82,7 +83,7 @@ describe('Sentry client SDK', () => {
           ...tracingOptions,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations || [];
+        const integrationsToInit = browserInit.mock.calls[0]![0]?.defaultIntegrations || [];
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
@@ -90,20 +91,20 @@ describe('Sentry client SDK', () => {
       });
 
       it("doesn't add browserTracingIntegration if `__SENTRY_TRACING__` is set to false", () => {
-        globalThis.__SENTRY_TRACING__ = false;
+        (globalThis as any).__SENTRY_TRACING__ = false;
 
         init({
           dsn: 'https://public@dsn.ingest.sentry.io/1337',
           enableTracing: true,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations || [];
+        const integrationsToInit = browserInit.mock.calls[0]![0]?.defaultIntegrations || [];
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeUndefined();
 
-        delete globalThis.__SENTRY_TRACING__;
+        delete (globalThis as any).__SENTRY_TRACING__;
       });
 
       it('Overrides the automatically default browserTracingIntegration instance with a a user-provided browserTracingIntegration instance', () => {

--- a/packages/astro/test/integration/index.files.test.ts
+++ b/packages/astro/test/integration/index.files.test.ts
@@ -1,12 +1,10 @@
-import { vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { sentryAstro } from '../../src/integration';
 
-vi.mock('fs', async () => {
-  const actual = await vi.importActual('fs');
+vi.mock('fs', async requireActual => {
   return {
-    // @ts-expect-error - just mocking around
-    ...actual,
+    ...(await requireActual<any>()),
     existsSync: vi.fn(p => p.endsWith('js')),
   };
 });

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { sentryAstro } from '../../src/integration';
 
@@ -294,7 +294,7 @@ describe('sentryAstro integration', () => {
 
   it.each([{ output: 'static' }, { output: undefined }])(
     "doesn't add middleware if in static mode (config %s)",
-    async config => {
+    async (config: any) => {
       const integration = sentryAstro({});
       const addMiddleware = vi.fn();
       const updateConfig = vi.fn();

--- a/packages/astro/test/integration/middleware/index.test.ts
+++ b/packages/astro/test/integration/middleware/index.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { onRequest } from '../../../src/integration/middleware';
 

--- a/packages/astro/test/integration/snippets.test.ts
+++ b/packages/astro/test/integration/snippets.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest';
+
 import { buildClientSnippet, buildSdkInitFileImportSnippet, buildServerSnippet } from '../../src/integration/snippets';
 
 const allSdkOptions = {

--- a/packages/astro/tsconfig.test.json
+++ b/packages/astro/tsconfig.test.json
@@ -5,6 +5,6 @@
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node", "vitest/globals"]
+    "types": ["node"]
   }
 }

--- a/packages/astro/vite.config.ts
+++ b/packages/astro/vite.config.ts
@@ -4,6 +4,5 @@ export default {
   ...baseConfig,
   test: {
     ...baseConfig.test,
-    environment: 'jsdom',
   },
 };


### PR DESCRIPTION
As per https://vitest.dev/config/#globals

> By default, vitest does not provide global APIs for explicitness

I think we should follow vitest defaults here and explicitly import in the APIs that we need. This refactors our Astro SDK tests to do so.

ref https://github.com/getsentry/sentry-javascript/issues/11084

I also went ahead and fixed up some TS errors in some tests.

This change also removes `environment: 'jsdom'` from the vite config as it seems nothing needs this for astro. This should means that our tests are not polluted with jsdom globals, and that future writers have to explicitly opt-in to the behaviour.