### PR TITLE
feat(nuxt): Add connected tracing meta tags

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -60,7 +60,13 @@ function findDefaultSdkInitFile(type: 'server' | 'client'): string | undefined {
 
   const cwd = process.cwd();
   const filePath = possibleFileExtensions
-    .map(e => path.resolve(path.join(cwd, `sentry.${type}.config.${e}`)))
+    .map(e =>
+      path.resolve(
+        type === 'server'
+          ? path.join(cwd, 'public', `instrument.${type}.${e}`)
+          : path.join(cwd, `sentry.${type}.config.${e}`),
+      ),
+    )
     .find(filename => fs.existsSync(filename));
 
   return filePath ? path.basename(filePath) : undefined;

--- a/packages/nuxt/src/runtime/plugins/sentry.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry.server.ts
@@ -1,7 +1,8 @@
 import { captureException } from '@sentry/node';
 import { H3Error } from 'h3';
 import { defineNitroPlugin } from 'nitropack/runtime';
-import { extractErrorContext } from '../utils';
+import type { NuxtRenderHTMLContext } from 'nuxt/app';
+import { addSentryTracingMetaTags, extractErrorContext } from '../utils';
 
 export default defineNitroPlugin(nitroApp => {
   nitroApp.hooks.hook('error', (error, errorContext) => {
@@ -19,5 +20,10 @@ export default defineNitroPlugin(nitroApp => {
       captureContext: { contexts: { nuxt: structuredContext } },
       mechanism: { handled: false },
     });
+  });
+
+  // @ts-expect-error - 'render:html' is a valid hook name in the Nuxt context
+  nitroApp.hooks.hook('render:html', (html: NuxtRenderHTMLContext) => {
+    addSentryTracingMetaTags(html.head);
   });
 });

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -45,11 +45,8 @@ export function addSentryTracingMetaTags(head: NuxtRenderHTMLContext['head']): v
     const dynamicSamplingContext = dynamicSamplingContextToSentryBaggageHeader(
       getDynamicSamplingContextFromSpan(rootSpan),
     );
-    const contentMeta = [
-      `<meta name="sentry-trace" content="${traceParentData}"/>`,
-      `<meta name="baggage" content="${dynamicSamplingContext}"/>`,
-    ];
 
-    head.push(...contentMeta);
+    head.push(`<meta name="sentry-trace" content="${traceParentData}"/>`);
+    head.push(`<meta name="baggage" content="${dynamicSamplingContext}"/>`);
   }
 }

--- a/packages/nuxt/test/server/runtime/plugin.test.ts
+++ b/packages/nuxt/test/server/runtime/plugin.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { addSentryTracingMetaTags } from '../../../src/runtime/utils';
+
+const mockReturns = vi.hoisted(() => {
+  return {
+    traceHeader: 'trace-header',
+    baggageHeader: 'baggage-header',
+  };
+});
+
+vi.mock('@sentry/core', async () => {
+  const actual = await vi.importActual('@sentry/core');
+
+  return {
+    ...actual,
+    getActiveSpan: vi.fn().mockReturnValue({ spanId: '123' }),
+    getRootSpan: vi.fn().mockReturnValue({ spanId: 'root123' }),
+    spanToTraceHeader: vi.fn(() => mockReturns.traceHeader),
+  };
+});
+
+vi.mock('@sentry/opentelemetry', async () => {
+  const actual = await vi.importActual('@sentry/opentelemetry');
+
+  return {
+    ...actual,
+    getDynamicSamplingContextFromSpan: vi.fn().mockReturnValue('contextValue'),
+  };
+});
+
+vi.mock('@sentry/utils', async () => {
+  const actual = await vi.importActual('@sentry/utils');
+
+  return {
+    ...actual,
+    dynamicSamplingContextToSentryBaggageHeader: vi.fn().mockReturnValue(mockReturns.baggageHeader),
+  };
+});
+
+describe('addSentryTracingMetaTags', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should add meta tags when there is an active root span', () => {
+    const head: string[] = [];
+    addSentryTracingMetaTags(head);
+
+    expect(head).toContain(`<meta name="sentry-trace" content="${mockReturns.traceHeader}"/>`);
+    expect(head).toContain(`<meta name="baggage" content="${mockReturns.baggageHeader}"/>`);
+  });
+
+  it('should not add meta tags when there is no active root span', () => {
+    vi.doMock('@sentry/core', async () => {
+      const actual = await vi.importActual('@sentry/core');
+
+      return {
+        ...actual,
+        getActiveSpan: vi.fn().mockReturnValue(undefined),
+      };
+    });
+
+    const head: string[] = [];
+    addSentryTracingMetaTags(head);
+
+    expect(head).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Also changes the `findDefaultSdkInitFile` function as the backend-related file is located and named differently than the client config file (`sentry.client.config.ts` and `public/instrument.server.mjs`).

closes https://github.com/getsentry/sentry-javascript/issues/13097
