### PR TITLE
fix(nextjs): Only delete clientside bundle source maps with `sourcemaps.deleteFilesAfterUpload`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
@@ -22,10 +22,10 @@ assert.match(buildStdout, /(λ|ƒ) \/server-component\/parameter\/\[\.\.\.parame
 assert.match(buildStdout, /(λ|ƒ) \/server-component\/parameter\/\[parameter\]/);
 
 // Read the contents of the directory
-const files = fs.readdirSync(path.join(process.cwd(), '.next', 'server'));
+const files = fs.readdirSync(path.join(process.cwd(), '.next', 'static'));
 const mapFiles = files.filter(file => path.extname(file) === '.map');
 if (mapFiles.length > 0) {
-  throw new Error('.map files found even though `sourcemaps.deleteSourcemapsAfterUpload` option is set!');
+  throw new Error('Client bundle .map files found even though `sourcemaps.deleteSourcemapsAfterUpload` option is set!');
 }
 
 export {};

--- a/packages/nextjs/src/config/webpackPluginOptions.ts
+++ b/packages/nextjs/src/config/webpackPluginOptions.ts
@@ -76,9 +76,12 @@ export function getWebpackPluginOptions(
       ignore: sentryBuildOptions.sourcemaps?.ignore ?? sourcemapUploadIgnore,
       filesToDeleteAfterUpload: sentryBuildOptions.sourcemaps?.deleteSourcemapsAfterUpload
         ? [
-            path.join(distDirAbsPath, '**', '*.js.map'),
-            path.join(distDirAbsPath, '**', '*.mjs.map'),
-            path.join(distDirAbsPath, '**', '*.cjs.map'),
+            // We only care to delete client bundle source maps because they would be the ones being served.
+            // Removing the server source maps crashes Vercel builds for (thus far) unknown reasons:
+            // https://github.com/getsentry/sentry-javascript/issues/13099
+            path.join(distDirAbsPath, 'static', '**', '*.js.map'),
+            path.join(distDirAbsPath, 'static', '**', '*.mjs.map'),
+            path.join(distDirAbsPath, 'static', '**', '*.cjs.map'),
           ]
         : undefined,
       ...sentryBuildOptions.unstable_sentryWebpackPluginOptions?.sourcemaps,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/13099

For currently unknown reasons, deleting the serverside sourcmaps will crash Vercel deployments during build. Working theory is that some manifest references the files, and Vercel tries to upload the files but they're missing when Vercel gets to actually uploading them.