### PR TITLE
feat(node): Upgrade import-in-the-middle to 1.11.0

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -92,7 +92,7 @@
     "@sentry/opentelemetry": "8.20.0",
     "@sentry/types": "8.20.0",
     "@sentry/utils": "8.20.0",
-    "import-in-the-middle": "^1.10.0"
+    "import-in-the-middle": "^1.11.0"
   },
   "devDependencies": {
     "@types/node": "^14.18.0"

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -126,18 +126,6 @@ other imports:
 }
 ```
 
-If you are getting an `import-in-the-middle` error message, add the package with a minimum version of `1.10.0` as a
-dependency to your `package.json`
-([issue reference](https://github.com/getsentry/sentry-javascript-examples/pull/38#issuecomment-2245259327)):
-
-```json
-{
-  "dependencies": {
-    "import-in-the-middle": "1.10.0"
-  }
-}
-```
-
 ## Uploading Source Maps
 
 To upload source maps, you can use the `sourceMapsUploadOptions` option inside the `sentry` options of your

--- a/yarn.lock
+++ b/yarn.lock
@@ -20493,10 +20493,10 @@ import-in-the-middle@1.7.1:
     cjs-module-lexer "^1.2.2"
     module-details-from-path "^1.0.3"
 
-import-in-the-middle@^1.10.0, import-in-the-middle@^1.8.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.10.0.tgz#f15b0841950ded8d899b635058da5646256949b1"
-  integrity sha512-Z1jumVdF2GwnnYfM0a/y2ts7mZbwFMgt5rRuVmLgobgahC6iKgN5MBuXjzfTIOUpq5LSU10vJIPpVKe0X89fIw==
+import-in-the-middle@^1.11.0, import-in-the-middle@^1.8.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.0.tgz#a94c4925b8da18256cde3b3b7b38253e6ca5e708"
+  integrity sha512-5DimNQGoe0pLUHbR9qK84iWaWjjbsxiqXnw6Qz64+azRgleqv9k2kTt5fw7QsOpmaGYtuxxursnPPsnTKEx10Q==
   dependencies:
     acorn "^8.8.2"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
ref https://github.com/nodejs/import-in-the-middle/releases/tag/import-in-the-middle-v1.11.0

ref https://github.com/getsentry/sentry-javascript/issues/12806

Bumping this for the bug fix, we can expose the `registerOptions` in another PR. 