### PR TITLE
fix(browser-integration-tests): Fix feedback addon CDN bundle integration test setup

### DIFF
--- a/dev-packages/browser-integration-tests/utils/fixtures.ts
+++ b/dev-packages/browser-integration-tests/utils/fixtures.ts
@@ -68,12 +68,18 @@ const sentryTest = base.extend<TestFixtures>({
         // Ensure feedback can be lazy loaded
         await page.route(`https://browser.sentry-cdn.com/${SDK_VERSION}/feedback-modal.min.js`, route => {
           const filePath = path.resolve(testDir, './dist/feedback-modal.bundle.js');
-          return fs.existsSync(filePath) ? route.fulfill({ path: filePath }) : route.continue();
+          if (!fs.existsSync(filePath)) {
+            throw new Error(`Feedback modal bundle (${filePath}) not found`);
+          }
+          return route.fulfill({ path: filePath });
         });
 
         await page.route(`https://browser.sentry-cdn.com/${SDK_VERSION}/feedback-screenshot.min.js`, route => {
           const filePath = path.resolve(testDir, './dist/feedback-screenshot.bundle.js');
-          return fs.existsSync(filePath) ? route.fulfill({ path: filePath }) : route.continue();
+          if (!fs.existsSync(filePath)) {
+            throw new Error(`Feedback screenshot bundle (${filePath}) not found`);
+          }
+          return route.fulfill({ path: filePath });
         });
       }
 

--- a/dev-packages/browser-integration-tests/utils/generatePlugin.ts
+++ b/dev-packages/browser-integration-tests/utils/generatePlugin.ts
@@ -272,6 +272,19 @@ class SentryScenarioGenerationPlugin {
                 fileName,
               );
 
+              if (integration === 'feedback') {
+                addStaticAssetSymlink(
+                  this.localOutPath,
+                  path.resolve(PACKAGES_DIR, 'feedback', 'build/bundles/feedback-modal.js'),
+                  'feedback-modal.bundle.js',
+                );
+                addStaticAssetSymlink(
+                  this.localOutPath,
+                  path.resolve(PACKAGES_DIR, 'feedback', 'build/bundles/feedback-screenshot.js'),
+                  'feedback-screenshot.bundle.js',
+                );
+              }
+
               const integrationObject = createHtmlTagObject('script', {
                 src: fileName,
               });


### PR DESCRIPTION
This PR fixes a nasty problem in our browser integration test setup that caused our current release 8.21.0 to fail.

In #13081 we re-introduced testing against the feedback addon CDN bundles in our integration tests. This triggered a test fail on release branches but it remained undiscovered in `develop` and feature branches. Chain of events:

- The addon feedback CDN bundle now correctly exports the async feedback integration
- The async feedback integration lazy-loads the modal and screenshot integrations
- To avoid actually lazy loading these via http requests to the CDN but to test against the locally built versions, we added a couple of request interceptors in our `getLocalTestPath` fixture setup function.
- This interceptor however, would just silently fail if it didn't find the local version of the bundle [1] and forward the request.
- So, in `develop` and feature branches, unknowingly actually took the bundles from our CDN.
- On the release branch, we bump the version of the bundle we want to download from the CDN which does not exist
- So the request obviously fails, causing the bundle not to be loaded, causing the feedback UI not to be available, finally causing the test to fail

[1] Now, why was the file not present all of a sudden? because we only linked these files locally when we tested the SDK CDN bundle which already includes feedback. Since we disabled the addon CDN tests (or didn't test them at all before?) we just didn't symlink the necessary bundles into the test directory.

So to fix this, this PR:
- Adds the symlinks whenever we discover that `feedbackIntegration` is imported in a test app
- Stops forwarding the CDN bundle request to the actual CDN but throws a hard error. We should have never forwarded here because we'd unknowingly test against already published artifacts instead of the locally built ones.

