### PR TITLE
feat(cloudflare): instrument scheduled handler

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -47,10 +47,9 @@
     "@cloudflare/workers-types": "^4.x"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240722.0",
+    "@cloudflare/workers-types": "^4.20240725.0",
     "@types/node": "^14.18.0",
-    "miniflare": "^3.20240718.0",
-    "wrangler": "^3.65.1"
+    "wrangler": "^3.67.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/cloudflare/src/handler.ts
+++ b/packages/cloudflare/src/handler.ts
@@ -3,7 +3,14 @@ import type {
   ExportedHandlerFetchHandler,
   ExportedHandlerScheduledHandler,
 } from '@cloudflare/workers-types';
-import { captureException, flush, startSpan, withIsolationScope } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  captureException,
+  flush,
+  startSpan,
+  withIsolationScope,
+} from '@sentry/core';
 import { setAsyncLocalStorageAsyncContextStrategy } from './async';
 import type { CloudflareOptions } from './client';
 import { wrapRequestHandler } from './request';
@@ -71,6 +78,8 @@ export function withSentry<E extends ExportedHandler<any>>(
                 'faas.cron': event.cron,
                 'faas.time': new Date(event.scheduledTime).toISOString(),
                 'faas.trigger': 'timer',
+                [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.faas.cloudflare',
+                [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
               },
             },
             async () => {

--- a/packages/cloudflare/src/request.ts
+++ b/packages/cloudflare/src/request.ts
@@ -1,4 +1,4 @@
-import type { ExecutionContext, IncomingRequestCfProperties } from '@cloudflare/workers-types';
+import type { ExecutionContext, IncomingRequestCfProperties, Request, Response } from '@cloudflare/workers-types';
 
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -11,9 +11,10 @@ import {
   startSpan,
   withIsolationScope,
 } from '@sentry/core';
-import type { Scope, SpanAttributes } from '@sentry/types';
-import { stripUrlQueryAndFragment, winterCGRequestToRequestData } from '@sentry/utils';
+import type { SpanAttributes } from '@sentry/types';
+import { stripUrlQueryAndFragment } from '@sentry/utils';
 import type { CloudflareOptions } from './client';
+import { addCloudResourceContext, addCultureContext, addRequest } from './scope-utils';
 import { init } from './sdk';
 
 interface RequestHandlerWrapperOptions {
@@ -95,29 +96,4 @@ export function wrapRequestHandler(
       },
     );
   });
-}
-
-/**
- * Set cloud resource context on scope.
- */
-function addCloudResourceContext(scope: Scope): void {
-  scope.setContext('cloud_resource', {
-    'cloud.provider': 'cloudflare',
-  });
-}
-
-/**
- * Set culture context on scope
- */
-function addCultureContext(scope: Scope, cf: IncomingRequestCfProperties): void {
-  scope.setContext('culture', {
-    timezone: cf.timezone,
-  });
-}
-
-/**
- * Set request data on scope
- */
-function addRequest(scope: Scope, request: Request): void {
-  scope.setSDKProcessingMetadata({ request: winterCGRequestToRequestData(request) });
 }

--- a/packages/cloudflare/src/request.ts
+++ b/packages/cloudflare/src/request.ts
@@ -1,4 +1,4 @@
-import type { ExecutionContext, IncomingRequestCfProperties, Request, Response } from '@cloudflare/workers-types';
+import type { ExecutionContext, IncomingRequestCfProperties } from '@cloudflare/workers-types';
 
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,

--- a/packages/cloudflare/src/scope-utils.ts
+++ b/packages/cloudflare/src/scope-utils.ts
@@ -1,0 +1,29 @@
+import type { IncomingRequestCfProperties } from '@cloudflare/workers-types';
+
+import type { Scope } from '@sentry/types';
+import { winterCGRequestToRequestData } from '@sentry/utils';
+
+/**
+ * Set cloud resource context on scope.
+ */
+export function addCloudResourceContext(scope: Scope): void {
+  scope.setContext('cloud_resource', {
+    'cloud.provider': 'cloudflare',
+  });
+}
+
+/**
+ * Set culture context on scope
+ */
+export function addCultureContext(scope: Scope, cf: IncomingRequestCfProperties): void {
+  scope.setContext('culture', {
+    timezone: cf.timezone,
+  });
+}
+
+/**
+ * Set request data on scope
+ */
+export function addRequest(scope: Scope, request: Request): void {
+  scope.setSDKProcessingMetadata({ request: winterCGRequestToRequestData(request) });
+}

--- a/packages/cloudflare/src/sdk.ts
+++ b/packages/cloudflare/src/sdk.ts
@@ -7,9 +7,9 @@ import {
   linkedErrorsIntegration,
   requestDataIntegration,
 } from '@sentry/core';
-import type { Integration, Options } from '@sentry/types';
+import type { Integration } from '@sentry/types';
 import { stackParserFromStackParserOptions } from '@sentry/utils';
-import type { CloudflareClientOptions } from './client';
+import type { CloudflareClientOptions, CloudflareOptions } from './client';
 import { CloudflareClient } from './client';
 
 import { fetchIntegration } from './integrations/fetch';
@@ -17,7 +17,7 @@ import { makeCloudflareTransport } from './transport';
 import { defaultStackParser } from './vendor/stacktrace';
 
 /** Get the default integrations for the Cloudflare SDK. */
-export function getDefaultIntegrations(options: Options): Integration[] {
+export function getDefaultIntegrations(options: CloudflareOptions): Integration[] {
   const sendDefaultPii = options.sendDefaultPii ?? false;
   return [
     dedupeIntegration(),
@@ -32,7 +32,7 @@ export function getDefaultIntegrations(options: Options): Integration[] {
 /**
  * Initializes the cloudflare SDK.
  */
-export function init(options: Options): CloudflareClient | undefined {
+export function init(options: CloudflareOptions): CloudflareClient | undefined {
   if (options.defaultIntegrations === undefined) {
     options.defaultIntegrations = getDefaultIntegrations(options);
   }

--- a/packages/cloudflare/test/handler.test.ts
+++ b/packages/cloudflare/test/handler.test.ts
@@ -3,49 +3,221 @@
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ScheduledController } from '@cloudflare/workers-types';
+import * as SentryCore from '@sentry/core';
+import type { Event } from '@sentry/types';
+import { CloudflareClient } from '../src/client';
 import { withSentry } from '../src/handler';
 
 const MOCK_ENV = {
   SENTRY_DSN: 'https://public@dsn.ingest.sentry.io/1337',
 };
 
-describe('sentryPagesPlugin', () => {
+describe('withSentry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  test('gets env from handler', async () => {
-    const handler = {
-      fetch(_request, _env, _context) {
-        return new Response('test');
-      },
-    } satisfies ExportedHandler;
+  describe('fetch handler', () => {
+    test('executes options callback with env', async () => {
+      const handler = {
+        fetch(_request, _env, _context) {
+          return new Response('test');
+        },
+      } satisfies ExportedHandler<typeof MOCK_ENV>;
 
-    const optionsCallback = vi.fn().mockReturnValue({});
+      const optionsCallback = vi.fn().mockReturnValue({});
 
-    const wrappedHandler = withSentry(optionsCallback, handler);
-    await wrappedHandler.fetch(new Request('https://example.com'), MOCK_ENV, createMockExecutionContext());
+      const wrappedHandler = withSentry(optionsCallback, handler);
+      await wrappedHandler.fetch(new Request('https://example.com'), MOCK_ENV, createMockExecutionContext());
 
-    expect(optionsCallback).toHaveBeenCalledTimes(1);
-    expect(optionsCallback).toHaveBeenLastCalledWith(MOCK_ENV);
+      expect(optionsCallback).toHaveBeenCalledTimes(1);
+      expect(optionsCallback).toHaveBeenLastCalledWith(MOCK_ENV);
+    });
+
+    test('passes through the handler response', async () => {
+      const response = new Response('test');
+      const handler = {
+        async fetch(_request, _env, _context) {
+          return response;
+        },
+      } satisfies ExportedHandler<typeof MOCK_ENV>;
+
+      const wrappedHandler = withSentry(env => ({ dsn: env.SENTRY_DSN }), handler);
+      const result = await wrappedHandler.fetch(
+        new Request('https://example.com'),
+        MOCK_ENV,
+        createMockExecutionContext(),
+      );
+
+      expect(result).toBe(response);
+    });
   });
 
-  test('passes through the response from the handler', async () => {
-    const response = new Response('test');
-    const handler = {
-      async fetch(_request, _env, _context) {
-        return response;
-      },
-    } satisfies ExportedHandler;
+  describe('scheduled handler', () => {
+    test('executes options callback with env', async () => {
+      const handler = {
+        scheduled(_controller, _env, _context) {
+          return;
+        },
+      } satisfies ExportedHandler<typeof MOCK_ENV>;
 
-    const wrappedHandler = withSentry(() => ({}), handler);
-    const result = await wrappedHandler.fetch(
-      new Request('https://example.com'),
-      MOCK_ENV,
-      createMockExecutionContext(),
-    );
+      const optionsCallback = vi.fn().mockReturnValue({});
 
-    expect(result).toBe(response);
+      const wrappedHandler = withSentry(optionsCallback, handler);
+      await wrappedHandler.scheduled(createMockScheduledController(), MOCK_ENV, createMockExecutionContext());
+
+      expect(optionsCallback).toHaveBeenCalledTimes(1);
+      expect(optionsCallback).toHaveBeenLastCalledWith(MOCK_ENV);
+    });
+
+    test('flushes the event after the handler is done using the cloudflare context.waitUntil', async () => {
+      const handler = {
+        scheduled(_controller, _env, _context) {
+          return;
+        },
+      } satisfies ExportedHandler<typeof MOCK_ENV>;
+
+      const context = createMockExecutionContext();
+      const wrappedHandler = withSentry(env => ({ dsn: env.SENTRY_DSN }), handler);
+      await wrappedHandler.scheduled(createMockScheduledController(), MOCK_ENV, context);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(context.waitUntil).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(context.waitUntil).toHaveBeenLastCalledWith(expect.any(Promise));
+    });
+
+    test('creates a cloudflare client and sets it on the handler', async () => {
+      const initAndBindSpy = vi.spyOn(SentryCore, 'initAndBind');
+      const handler = {
+        scheduled(_controller, _env, _context) {
+          return;
+        },
+      } satisfies ExportedHandler<typeof MOCK_ENV>;
+
+      const wrappedHandler = withSentry(env => ({ dsn: env.SENTRY_DSN }), handler);
+      await wrappedHandler.scheduled(createMockScheduledController(), MOCK_ENV, createMockExecutionContext());
+
+      expect(initAndBindSpy).toHaveBeenCalledTimes(1);
+      expect(initAndBindSpy).toHaveBeenLastCalledWith(CloudflareClient, expect.any(Object));
+    });
+
+    describe('scope instrumentation', () => {
+      test('adds cloud resource context', async () => {
+        const handler = {
+          scheduled(_controller, _env, _context) {
+            SentryCore.captureMessage('cloud_resource');
+            return;
+          },
+        } satisfies ExportedHandler<typeof MOCK_ENV>;
+
+        let sentryEvent: Event = {};
+        const wrappedHandler = withSentry(
+          env => ({
+            dsn: env.SENTRY_DSN,
+            beforeSend(event) {
+              sentryEvent = event;
+              return null;
+            },
+          }),
+          handler,
+        );
+        await wrappedHandler.scheduled(createMockScheduledController(), MOCK_ENV, createMockExecutionContext());
+
+        expect(sentryEvent.contexts?.cloud_resource).toEqual({ 'cloud.provider': 'cloudflare' });
+      });
+    });
+
+    describe('error instrumentation', () => {
+      test('captures errors thrown by the handler', async () => {
+        const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException');
+        const error = new Error('test');
+
+        expect(captureExceptionSpy).not.toHaveBeenCalled();
+
+        const handler = {
+          scheduled(_controller, _env, _context) {
+            throw error;
+          },
+        } satisfies ExportedHandler<typeof MOCK_ENV>;
+
+        const wrappedHandler = withSentry(env => ({ dsn: env.SENTRY_DSN }), handler);
+        try {
+          await wrappedHandler.scheduled(createMockScheduledController(), MOCK_ENV, createMockExecutionContext());
+        } catch {
+          // ignore
+        }
+
+        expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+        expect(captureExceptionSpy).toHaveBeenLastCalledWith(error, {
+          mechanism: { handled: false, type: 'cloudflare' },
+        });
+      });
+
+      test('re-throws the error after capturing', async () => {
+        const error = new Error('test');
+        const handler = {
+          scheduled(_controller, _env, _context) {
+            throw error;
+          },
+        } satisfies ExportedHandler<typeof MOCK_ENV>;
+
+        const wrappedHandler = withSentry(env => ({ dsn: env.SENTRY_DSN }), handler);
+
+        let thrownError: Error | undefined;
+        try {
+          await wrappedHandler.scheduled(createMockScheduledController(), MOCK_ENV, createMockExecutionContext());
+        } catch (e: any) {
+          thrownError = e;
+        }
+
+        expect(thrownError).toBe(error);
+      });
+    });
+
+    describe('tracing instrumentation', () => {
+      test('creates a span that wraps scheduled invocation', async () => {
+        const handler = {
+          scheduled(_controller, _env, _context) {
+            return;
+          },
+        } satisfies ExportedHandler<typeof MOCK_ENV>;
+
+        let sentryEvent: Event = {};
+        const wrappedHandler = withSentry(
+          env => ({
+            dsn: env.SENTRY_DSN,
+            tracesSampleRate: 1,
+            beforeSendTransaction(event) {
+              sentryEvent = event;
+              return null;
+            },
+          }),
+          handler,
+        );
+
+        await wrappedHandler.scheduled(createMockScheduledController(), MOCK_ENV, createMockExecutionContext());
+
+        expect(sentryEvent.transaction).toEqual('Scheduled Cron 0 0 0 * * *');
+        expect(sentryEvent.spans).toHaveLength(0);
+        expect(sentryEvent.contexts?.trace).toEqual({
+          data: {
+            'sentry.origin': 'auto.faas.cloudflare',
+            'sentry.op': 'faas.cron',
+            'faas.cron': '0 0 0 * * *',
+            'faas.time': expect.any(String),
+            'faas.trigger': 'timer',
+            'sentry.sample_rate': 1,
+            'sentry.source': 'task',
+          },
+          op: 'faas.cron',
+          origin: 'auto.faas.cloudflare',
+          span_id: expect.any(String),
+          trace_id: expect.any(String),
+        });
+      });
+    });
   });
 });
 
@@ -53,5 +225,13 @@ function createMockExecutionContext(): ExecutionContext {
   return {
     waitUntil: vi.fn(),
     passThroughOnException: vi.fn(),
+  };
+}
+
+function createMockScheduledController(): ScheduledController {
+  return {
+    scheduledTime: 123,
+    cron: '0 0 0 * * *',
+    noRetry: vi.fn(),
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24347,10 +24347,10 @@ mini-css-extract-plugin@2.6.1, mini-css-extract-plugin@^2.5.2:
   dependencies:
     schema-utils "^4.0.0"
 
-miniflare@3.20240718.0, miniflare@^3.20240718.0:
-  version "3.20240718.0"
-  resolved "https://registry.yarnpkg.com/miniflare/-/miniflare-3.20240718.0.tgz#41561c6620b2b15803f5b3d2e903ed3af40f3b0b"
-  integrity sha512-TKgSeyqPBeT8TBLxbDJOKPWlq/wydoJRHjAyDdgxbw59N6wbP8JucK6AU1vXCfu21eKhrEin77ssXOpbfekzPA==
+miniflare@3.20240718.1:
+  version "3.20240718.1"
+  resolved "https://registry.yarnpkg.com/miniflare/-/miniflare-3.20240718.1.tgz#26ccb95be087cd99cd478dbf2e3a3d40f231bf45"
+  integrity sha512-mn3MjGnpgYvarCRTfz4TQyVyY8yW0zz7f8LOAPVai78IGC/lcVcyskZcuIr7Zovb2i+IERmmsJAiEPeZHIIKbA==
   dependencies:
     "@cspotcode/source-map-support" "0.8.1"
     acorn "^8.8.0"
@@ -34118,10 +34118,10 @@ workerpool@^6.4.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.4.0.tgz#f8d5cfb45fde32fa3b7af72ad617c3369567a462"
   integrity sha512-i3KR1mQMNwY2wx20ozq2EjISGtQWDIfV56We+yGJ5yDs8jTwQiLLaqHlkBHITlCuJnYlVRmXegxFxZg7gqI++A==
 
-wrangler@^3.65.1:
-  version "3.65.1"
-  resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-3.65.1.tgz#493bd92b504f9f056cd57bbe2d430797600c914b"
-  integrity sha512-Z5NyrbpGMQCpim/6VnI1im0/Weh5+CU1sdep1JbfFxHjn/Jt9K+MeUq+kCns5ubkkdRx2EYsusB/JKyX2JdJ4w==
+wrangler@^3.67.1:
+  version "3.67.1"
+  resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-3.67.1.tgz#c9bb344b70c8c2106ad33f03beaa063dd5b49526"
+  integrity sha512-lLVJxq/OZMfntvZ79WQJNC1OKfxOCs6PLfogqDBuPFEQ3L/Mwqvd9IZ0bB8ahrwUN/K3lSdDPXynk9HfcGZxVw==
   dependencies:
     "@cloudflare/kv-asset-handler" "0.3.4"
     "@esbuild-plugins/node-globals-polyfill" "^0.2.3"
@@ -34130,7 +34130,7 @@ wrangler@^3.65.1:
     chokidar "^3.5.3"
     date-fns "^3.6.0"
     esbuild "0.17.19"
-    miniflare "3.20240718.0"
+    miniflare "3.20240718.1"
     nanoid "^3.3.3"
     path-to-regexp "^6.2.0"
     resolve "^1.22.8"
@@ -34138,6 +34138,7 @@ wrangler@^3.65.1:
     selfsigned "^2.0.1"
     source-map "^0.6.1"
     unenv "npm:unenv-nightly@1.10.0-1717606461.a117952"
+    workerd "1.20240718.0"
     xxhash-wasm "^1.0.1"
   optionalDependencies:
     fsevents "~2.3.2"


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/13112

This PR adds instrumentation for the [`scheduled` handler](https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/) in cloudflare workers. This is used for cron triggers.

I elected to not do automatic cron instrumentation for now, this is tracked by https://github.com/getsentry/sentry-javascript/issues/13113. Instead I added manual instrumentation docs to the README, this will get copied to the sentry docs eventually.

ref https://github.com/getsentry/sentry-javascript/issues/12620