### PR TITLE
fix(tracing): Fix flakey web vitals LCP test

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -9,23 +9,22 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
-  const imageSrc = 'https://example.com/path/to/image.png';
-  const imageResponsePromise = page.waitForResponse(imageSrc);
   page.route('**', route => route.continue());
   page.route('**/path/to/image.png', async (route: Route) => {
     return route.fulfill({ path: `${__dirname}/assets/sentry-logo-600x179.png` });
   });
 
   const url = await getLocalTestPath({ testDir: __dirname });
-  const [eventData, imageResponse] = await Promise.all([
+  const [eventData] = await Promise.all([
     getFirstSentryEnvelopeRequest<Event>(page),
     page.goto(url),
-    imageResponsePromise,
+    // Clicking the button before image loads will result in the button being the LCP
+    page.waitForFunction(() => {
+      const images = Array.from(document.querySelectorAll('img'));
+      return images.every(img => img.complete);
+    }),
   ]);
 
-  await imageResponse?.finished();
-
-  // Clicking the button before image loads will result in the button being the LCP
   await page.locator('button').click();
 
   expect(eventData.measurements).toBeDefined();
@@ -33,5 +32,5 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
 
   expect(eventData.contexts?.trace?.data?.['lcp.element']).toBe('body > img');
   expect(eventData.contexts?.trace?.data?.['lcp.size']).toBe(107400);
-  expect(eventData.contexts?.trace?.data?.['lcp.url']).toBe(imageSrc);
+  expect(eventData.contexts?.trace?.data?.['lcp.url']).toBe('https://example.com/path/to/image.png');
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -9,7 +9,7 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
-
+  const imageSrc = 'https://example.com/path/to/image.png';
   page.route('**', route => route.continue());
   page.route('**/path/to/image.png', async (route: Route) => {
     return route.fulfill({ path: `${__dirname}/assets/sentry-logo-600x179.png` });
@@ -19,6 +19,7 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   const [eventData] = await Promise.all([
     getFirstSentryEnvelopeRequest<Event>(page),
     page.goto(url),
+    page.waitForResponse(imageSrc),
     page.locator('button').click(),
   ]);
 
@@ -27,5 +28,5 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
 
   expect(eventData.contexts?.trace?.data?.['lcp.element']).toBe('body > img');
   expect(eventData.contexts?.trace?.data?.['lcp.size']).toBe(107400);
-  expect(eventData.contexts?.trace?.data?.['lcp.url']).toBe('https://example.com/path/to/image.png');
+  expect(eventData.contexts?.trace?.data?.['lcp.url']).toBe(imageSrc);
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -22,6 +22,7 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
     page.waitForResponse(imageSrc),
   ]);
 
+  // Clicking the button before image loads will result in the button being the LCP
   await page.locator('button').click();
 
   expect(eventData.measurements).toBeDefined();

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -14,6 +14,8 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
     return route.fulfill({ path: `${__dirname}/assets/sentry-logo-600x179.png` });
   });
 
+  page.on('console', msg => console.log(msg.text()));
+
   const url = await getLocalTestPath({ testDir: __dirname });
   const [eventData] = await Promise.all([getFirstSentryEnvelopeRequest<Event>(page), page.goto(url)]);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -15,18 +15,15 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   });
 
   const url = await getLocalTestPath({ testDir: __dirname });
-  const [eventData] = await Promise.all([
-    getFirstSentryEnvelopeRequest<Event>(page),
-    page.goto(url),
-    // Clicking the button before image loads will result in the button being the LCP
-    page.waitForFunction(() => {
-      const images = Array.from(document.querySelectorAll('img'));
-      return images.every(img => img.complete);
-    }),
-  ]);
+  const [eventData] = await Promise.all([getFirstSentryEnvelopeRequest<Event>(page), page.goto(url)]);
 
-  console.log(eventData.contexts?.trace);
-  expect(eventData.contexts?.trace?.data?.['lcp.element']).toBe('body > img');
+  // Clicking the button before image loads will result in the button being the LCP
+  await page.waitForFunction(() => {
+    const images = Array.from(document.querySelectorAll('img'));
+    return images.every(img => img.complete);
+  }),
+    expect(eventData.contexts?.trace?.data?.['lcp.element']).toBe('body > img');
+
   await page.locator('button').click();
 
   expect(eventData.measurements).toBeDefined();

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -20,8 +20,9 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
     getFirstSentryEnvelopeRequest<Event>(page),
     page.goto(url),
     page.waitForResponse(imageSrc),
-    page.locator('button').click(),
   ]);
+
+  await page.locator('button').click();
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.lcp?.value).toBeDefined();

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -25,6 +25,8 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
     }),
   ]);
 
+  console.log(eventData.contexts?.trace);
+  expect(eventData.contexts?.trace?.data?.['lcp.element']).toBe('body > img');
   await page.locator('button').click();
 
   expect(eventData.measurements).toBeDefined();

--- a/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
@@ -60,7 +60,6 @@ export const onLCP = (onReport: LCPReportCallback, opts: ReportOpts = {}) => {
           // clamped at 0.
           metric.value = Math.max(lastEntry.startTime - getActivationStart(), 0);
           metric.entries = [lastEntry];
-          console.log(lastEntry);
           report();
         }
       }

--- a/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
@@ -60,6 +60,7 @@ export const onLCP = (onReport: LCPReportCallback, opts: ReportOpts = {}) => {
           // clamped at 0.
           metric.value = Math.max(lastEntry.startTime - getActivationStart(), 0);
           metric.entries = [lastEntry];
+          console.log(lastEntry);
           report();
         }
       }


### PR DESCRIPTION
This has been super flakey for me... its possible that we were clicking button before image has loaded so that it thinks the LCP is the button.

Closes #13115
