### PR TITLE
all-repos: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -708,7 +708,7 @@ jobs:
         working-directory: dev-packages/browser-integration-tests
         run: yarn test:ci${{ matrix.project && format(' --project={0}', matrix.project) || '' }}${{ matrix.shard && format(' --shard={0}/{1}', matrix.shard, matrix.shards) || '' }}
       - name: Upload Playwright Traces
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-traces
@@ -773,7 +773,7 @@ jobs:
           cd dev-packages/browser-integration-tests
           yarn test:loader
       - name: Upload Playwright Traces
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-traces
@@ -1614,7 +1614,7 @@ jobs:
       - name: Archive Binary
         # @TODO: v4 breaks convenient merging of same name artifacts
         # https://github.com/actions/upload-artifact/issues/478
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: profiling-node-binaries-${{ github.sha }}
           path: |


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos