### PR TITLE
feat(nestjs): Automatic instrumentation of nestjs guards 

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ExampleGuard } from './example.guard';
 
 @Controller()
 export class AppController {
@@ -13,6 +14,12 @@ export class AppController {
   @Get('test-middleware-instrumentation')
   testMiddlewareInstrumentation() {
     return this.appService.testMiddleware();
+  }
+
+  @Get('test-guard-instrumentation')
+  @UseGuards(ExampleGuard)
+  testGuardInstrumentation() {
+    return {};
   }
 
   @Get('test-exception/:id')

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/example.guard.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/example.guard.ts
@@ -1,0 +1,10 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+
+@Injectable()
+export class ExampleGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    Sentry.startSpan({ name: 'test-guard-span' }, () => {});
+    return true;
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/transactions.test.ts
@@ -132,7 +132,8 @@ test('API route transaction includes nest middleware span. Spans created in and 
     );
   });
 
-  await fetch(`${baseURL}/test-middleware-instrumentation`);
+  const response = await fetch(`${baseURL}/test-middleware-instrumentation`);
+  expect(response.status).toBe(200);
 
   const transactionEvent = await pageloadTransactionEventPromise;
 
@@ -211,7 +212,8 @@ test('API route transaction includes nest guard span and span started in guard i
     );
   });
 
-  await fetch(`${baseURL}/test-guard-instrumentation`);
+  const response = await fetch(`${baseURL}/test-guard-instrumentation`);
+  expect(response.status).toBe(200);
 
   const transactionEvent = await transactionEventPromise;
 

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/transactions.test.ts
@@ -200,3 +200,67 @@ test('API route transaction includes nest middleware span. Spans created in and 
   // 'ExampleMiddleware' is NOT the parent of 'test-controller-span'
   expect(testControllerSpan.parent_span_id).not.toBe(exampleMiddlewareSpanId);
 });
+
+test('API route transaction includes nest guard span and span started in guard is nested correctly', async ({
+  baseURL,
+}) => {
+  const transactionEventPromise = waitForTransaction('nestjs', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-guard-instrumentation'
+    );
+  });
+
+  await fetch(`${baseURL}/test-guard-instrumentation`);
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.any(String),
+          trace_id: expect.any(String),
+          data: {
+            'sentry.op': 'middleware.nestjs',
+            'sentry.origin': 'auto.middleware.nestjs',
+          },
+          description: 'ExampleGuard',
+          parent_span_id: expect.any(String),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware.nestjs',
+          origin: 'auto.middleware.nestjs',
+        },
+      ]),
+    }),
+  );
+
+  const exampleGuardSpan = transactionEvent.spans.find(span => span.description === 'ExampleGuard');
+  const exampleGuardSpanId = exampleGuardSpan?.span_id;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.any(String),
+          trace_id: expect.any(String),
+          data: expect.any(Object),
+          description: 'test-guard-span',
+          parent_span_id: expect.any(String),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+      ]),
+    }),
+  );
+
+  // verify correct span parent-child relationships
+  const testGuardSpan = transactionEvent.spans.find(span => span.description === 'test-guard-span');
+
+  // 'ExampleGuard' is the parent of 'test-guard-span'
+  expect(testGuardSpan.parent_span_id).toBe(exampleGuardSpanId);
+});

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ExampleGuard } from './example.guard';
 
 @Controller()
 export class AppController {
@@ -13,6 +14,12 @@ export class AppController {
   @Get('test-middleware-instrumentation')
   testMiddlewareInstrumentation() {
     return this.appService.testMiddleware();
+  }
+
+  @Get('test-guard-instrumentation')
+  @UseGuards(ExampleGuard)
+  testGuardInstrumentation() {
+    return {};
   }
 
   @Get('test-exception/:id')

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/example.guard.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/example.guard.ts
@@ -1,0 +1,10 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+
+@Injectable()
+export class ExampleGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    Sentry.startSpan({ name: 'test-guard-span' }, () => {});
+    return true;
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/transactions.test.ts
@@ -132,7 +132,8 @@ test('API route transaction includes nest middleware span. Spans created in and 
     );
   });
 
-  await fetch(`${baseURL}/test-middleware-instrumentation`);
+  const response = await fetch(`${baseURL}/test-middleware-instrumentation`);
+  expect(response.status).toBe(200);
 
   const transactionEvent = await transactionEventPromise;
 
@@ -211,7 +212,8 @@ test('API route transaction includes nest guard span and span started in guard i
     );
   });
 
-  await fetch(`${baseURL}/test-guard-instrumentation`);
+  const response = await fetch(`${baseURL}/test-guard-instrumentation`);
+  expect(response.status).toBe(200);
 
   const transactionEvent = await transactionEventPromise;
 

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/transactions.test.ts
@@ -125,7 +125,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
 test('API route transaction includes nest middleware span. Spans created in and after middleware are nested correctly', async ({
   baseURL,
 }) => {
-  const pageloadTransactionEventPromise = waitForTransaction('nestjs', transactionEvent => {
+  const transactionEventPromise = waitForTransaction('nestjs', transactionEvent => {
     return (
       transactionEvent?.contexts?.trace?.op === 'http.server' &&
       transactionEvent?.transaction === 'GET /test-middleware-instrumentation'
@@ -134,7 +134,7 @@ test('API route transaction includes nest middleware span. Spans created in and 
 
   await fetch(`${baseURL}/test-middleware-instrumentation`);
 
-  const transactionEvent = await pageloadTransactionEventPromise;
+  const transactionEvent = await transactionEventPromise;
 
   expect(transactionEvent).toEqual(
     expect.objectContaining({
@@ -199,4 +199,68 @@ test('API route transaction includes nest middleware span. Spans created in and 
 
   // 'ExampleMiddleware' is NOT the parent of 'test-controller-span'
   expect(testControllerSpan.parent_span_id).not.toBe(exampleMiddlewareSpanId);
+});
+
+test('API route transaction includes nest guard span and span started in guard is nested correctly', async ({
+  baseURL,
+}) => {
+  const transactionEventPromise = waitForTransaction('nestjs', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-guard-instrumentation'
+    );
+  });
+
+  await fetch(`${baseURL}/test-guard-instrumentation`);
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.any(String),
+          trace_id: expect.any(String),
+          data: {
+            'sentry.op': 'middleware.nestjs',
+            'sentry.origin': 'auto.middleware.nestjs',
+          },
+          description: 'ExampleGuard',
+          parent_span_id: expect.any(String),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware.nestjs',
+          origin: 'auto.middleware.nestjs',
+        },
+      ]),
+    }),
+  );
+
+  const exampleGuardSpan = transactionEvent.spans.find(span => span.description === 'ExampleGuard');
+  const exampleGuardSpanId = exampleGuardSpan?.span_id;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.any(String),
+          trace_id: expect.any(String),
+          data: expect.any(Object),
+          description: 'test-guard-span',
+          parent_span_id: expect.any(String),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+      ]),
+    }),
+  );
+
+  // verify correct span parent-child relationships
+  const testGuardSpan = transactionEvent.spans.find(span => span.description === 'test-guard-span');
+
+  // 'ExampleGuard' is the parent of 'test-guard-span'
+  expect(testGuardSpan.parent_span_id).toBe(exampleGuardSpanId);
 });

--- a/packages/node/src/integrations/tracing/nest.ts
+++ b/packages/node/src/integrations/tracing/nest.ts
@@ -157,7 +157,7 @@ export class SentryNestInstrumentation extends InstrumentationBase {
                 const [req, res, next, ...args] = argsUse;
                 const prevSpan = getActiveSpan();
 
-                startSpanManual(
+                return startSpanManual(
                   {
                     name: target.name,
                     attributes: {
@@ -172,10 +172,10 @@ export class SentryNestInstrumentation extends InstrumentationBase {
 
                         if (prevSpan) {
                           withActiveSpan(prevSpan, () => {
-                            Reflect.apply(originalNext, thisArgNext, argsNext);
+                            return Reflect.apply(originalNext, thisArgNext, argsNext);
                           });
                         } else {
-                          Reflect.apply(originalNext, thisArgNext, argsNext);
+                          return Reflect.apply(originalNext, thisArgNext, argsNext);
                         }
                       },
                     });
@@ -196,7 +196,7 @@ export class SentryNestInstrumentation extends InstrumentationBase {
 
             target.prototype.canActivate = new Proxy(target.prototype.canActivate, {
               apply: (originalCanActivate, thisArgCanActivate, argsCanActivate) => {
-                startSpan(
+                return startSpan(
                   {
                     name: target.name,
                     attributes: {


### PR DESCRIPTION
Adds automatic instrumentation to `@sentry/nestjs`. Guards in nest have a `@Injectable` decorator and implement a `canActivate` function. So we can simply extend the existing instrumentation to add a proxy for `canActivate`.

Also fixed a mistake with the middleware instrumentation (missing return).

Screenshot from sample app:
![Screenshot 2024-07-31 at 13 03 12](https://github.com/user-attachments/assets/4aa3dd30-db8c-4021-9e42-acc55ae90616)
