### PR TITLE
fix: Use `globalThis` for code injection

### DIFF
--- a/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
+++ b/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
@@ -18,13 +18,9 @@ export default function valueInjectionLoader(this: LoaderThis<LoaderOptions>, us
   // We do not want to cache injected values across builds
   this.cacheable(false);
 
-  // Define some global proxy that works on server and on the browser.
-  let injectedCode =
-    'var _sentryCollisionFreeGlobalObject = typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : {};\n';
-
-  Object.entries(values).forEach(([key, value]) => {
-    injectedCode += `_sentryCollisionFreeGlobalObject["${key}"] = ${JSON.stringify(value)};\n`;
-  });
+  const injectedCode = Object.entries(values)
+    .map(([key, value]) => `globalThis["${key}"] = ${JSON.stringify(value)};`)
+    .join('\n');
 
   return `${injectedCode}\n${userCode}`;
 }

--- a/packages/sveltekit/src/vite/injectGlobalValues.ts
+++ b/packages/sveltekit/src/vite/injectGlobalValues.ts
@@ -21,21 +21,9 @@ export function getGlobalValueInjectionCode(globalSentryValues: GlobalSentryValu
     return '';
   }
 
-  const sentryGlobal = '_global';
-
-  const globalCode = `var ${sentryGlobal} =
-  typeof window !== 'undefined' ?
-    window :
-    typeof globalThis !== 'undefined' ?
-      globalThis :
-      typeof global !== 'undefined' ?
-        global :
-        typeof self !== 'undefined' ?
-          self :
-          {};`;
   const injectedValuesCode = Object.entries(globalSentryValues)
-    .map(([key, value]) => `${sentryGlobal}["${key}"] = ${JSON.stringify(value)};`)
+    .map(([key, value]) => `globalThis["${key}"] = ${JSON.stringify(value)};`)
     .join('\n');
 
-  return `${globalCode}\n${injectedValuesCode}\n`;
+  return `${injectedValuesCode}\n`;
 }

--- a/packages/sveltekit/test/vite/injectGlobalValues.test.ts
+++ b/packages/sveltekit/test/vite/injectGlobalValues.test.ts
@@ -9,18 +9,8 @@ describe('getGlobalValueInjectionCode', () => {
       something: 'else',
       __sentry_sveltekit_output_dir: '.svelte-kit/output',
     });
-    expect(injectionCode).toEqual(`var _global =
-  typeof window !== 'undefined' ?
-    window :
-    typeof globalThis !== 'undefined' ?
-      globalThis :
-      typeof global !== 'undefined' ?
-        global :
-        typeof self !== 'undefined' ?
-          self :
-          {};
-_global["something"] = "else";
-_global["__sentry_sveltekit_output_dir"] = ".svelte-kit/output";
+    expect(injectionCode).toEqual(`globalThis["something"] = "else";
+globalThis["__sentry_sveltekit_output_dir"] = ".svelte-kit/output";
 `);
 
     // Check that the code above is in fact valid and works as expected


### PR DESCRIPTION
Since v8, all platforms and versions we support have support for `globalThis`. Since [this PR](https://github.com/getsentry/sentry-javascript/pull/11351) we also use `globalThis` when reading these injectected values.