### PR TITLE
feat(nestjs): Automatic instrumentation of nestjs pipes

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
@@ -22,7 +22,7 @@ export class AppController {
     return {};
   }
 
-  @Get('test-pipe-instrumentation')
+  @Get('test-pipe-instrumentation/:id')
   testPipeInstrumentation(@Param('id', ParseIntPipe) id: number) {
     return { value: id };
   }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ExampleGuard } from './example.guard';
 
@@ -20,6 +20,11 @@ export class AppController {
   @UseGuards(ExampleGuard)
   testGuardInstrumentation() {
     return {};
+  }
+
+  @Get('test-pipe-instrumentation')
+  testPipeInstrumentation(@Param('id', ParseIntPipe) id: number) {
+    return { value: id };
   }
 
   @Get('test-exception/:id')

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ExampleGuard } from './example.guard';
 
@@ -20,6 +20,11 @@ export class AppController {
   @UseGuards(ExampleGuard)
   testGuardInstrumentation() {
     return {};
+  }
+
+  @Get('test-pipe-instrumentation/:id')
+  testPipeInstrumentation(@Param('id', ParseIntPipe) id: number) {
+    return { value: id };
   }
 
   @Get('test-exception/:id')


### PR DESCRIPTION
Adds automatic instrumentation of pipes to `@sentry/nestjs`. Pipes in nest have a `@Injectable` decorator and implement a `transform` function. So we can simply extend the existing instrumentation to add a proxy for `transform`.

Screenshot from sample app:
![Screenshot 2024-07-31 at 15 36 45](https://github.com/user-attachments/assets/66310d52-5c5f-4e53-99de-0639e89bbfb4)
