### PR TITLE
feat(node): Option to only wrap instrumented modules

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express-esm-loader/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-loader/src/instrument.mjs
@@ -5,4 +5,5 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,
+  registerEsmLoaderHooks: { onlyHookedModules: true },
 });

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-loader/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-loader/src/instrument.mjs
@@ -5,5 +5,5 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,
-  registerEsmLoaderHooks: { onlyHookedModules: true },
+  registerEsmLoaderHooks: { onlyIncludeInstrumentedModules: true },
 });

--- a/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/app.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/app.mjs
@@ -3,10 +3,10 @@ import * as Sentry from '@sentry/node';
 import * as iitm from 'import-in-the-middle';
 
 new iitm.Hook((_, name) => {
-  if(name !== 'http') {
+  if (name !== 'http') {
     throw new Error(`'http' should be the only hooked modules but we just hooked '${name}'`);
   }
-})
+});
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -19,4 +19,3 @@ Sentry.init({
 await import('./sub-module.mjs');
 await import('http');
 await import('os');
-

--- a/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/app.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/app.mjs
@@ -1,0 +1,22 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+import * as iitm from 'import-in-the-middle';
+
+new iitm.Hook((_, name) => {
+  if(name !== 'http') {
+    throw new Error(`'http' should be the only hooked modules but we just hooked '${name}'`);
+  }
+})
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  autoSessionTracking: false,
+  transport: loggingTransport,
+  registerEsmLoaderHooks: { onlyIncludeInstrumentedModules: true },
+});
+
+await import('./sub-module.mjs');
+await import('http');
+await import('os');
+

--- a/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/sub-module.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/sub-module.mjs
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.assert(true);

--- a/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/test.ts
+++ b/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/test.ts
@@ -1,0 +1,12 @@
+import { conditionalTest } from '../../../utils';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+conditionalTest({ min: 18 })('import-in-the-middle', () => {
+  test('onlyIncludeInstrumentedModules', done => {
+    createRunner(__dirname, 'app.mjs').ensureNoErrorOutput().start(done);
+  });
+});

--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -42,12 +42,7 @@ interface RegisterOptions {
 }
 
 function getRegisterOptions(esmHookConfig?: EsmLoaderHookOptions): RegisterOptions {
-  // There was no specific config so empty options
-  if (!esmHookConfig) {
-    return {};
-  }
-
-  if (esmHookConfig.onlyHookedModules) {
+  if (esmHookConfig?.onlyHookedModules) {
     const { addHookMessagePort } = createAddHookMessageChannel();
     // If the user supplied include, we need to use that as a starting point or use an empty array to ensure no modules
     // are wrapped if they are not hooked

--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -33,7 +33,7 @@ export function initOpenTelemetry(client: NodeClient): void {
 }
 
 type ImportInTheMiddleInitData = Pick<EsmLoaderHookOptions, 'include' | 'exclude'> & {
-  addHookMessagePort?: MessagePort;
+  addHookMessagePort?: unknown;
 };
 
 interface RegisterOptions {

--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -42,7 +42,7 @@ interface RegisterOptions {
 }
 
 function getRegisterOptions(esmHookConfig?: EsmLoaderHookOptions): RegisterOptions {
-  if (esmHookConfig?.onlyHookedModules) {
+  if (esmHookConfig?.onlyIncludeInstrumentedModules) {
     const { addHookMessagePort } = createAddHookMessageChannel();
     // If the user supplied include, we need to use that as a starting point or use an empty array to ensure no modules
     // are wrapped if they are not hooked

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -6,7 +6,17 @@ import type { NodeTransportOptions } from './transports';
 
 export interface EsmLoaderHookOptions {
   include?: Array<string | RegExp>;
-  exclude?: Array<string | RegExp>;
+  exclude?: Array<string | RegExp> /**
+   * When set to `true`, `import-in-the-middle` will only wrap ESM modules that are specifically hooked by OpenTelemetry
+   * instrumentations. This feature is useful to avoid issues where `import-in-the-middle` is not compatible with some
+   * of your dependencies.
+   *
+   * **Note**: This feature will only work if you `init` the SDK before the instrumented modules are loaded via the Node
+   * `--import` CLI flag or `init` is called before loading your app via async `import()`.
+   *
+   * Defaults to `false`.
+   */;
+  onlyHookedModules?: boolean;
 }
 
 export interface BaseNodeOptions {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -17,7 +17,7 @@ export interface EsmLoaderHookOptions {
    *
    * Defaults to `false`.
    */;
-  onlyHookedModules?: boolean;
+  onlyIncludeInstrumentedModules?: boolean;
 }
 
 export interface BaseNodeOptions {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -7,12 +7,13 @@ import type { NodeTransportOptions } from './transports';
 export interface EsmLoaderHookOptions {
   include?: Array<string | RegExp>;
   exclude?: Array<string | RegExp> /**
-   * When set to `true`, `import-in-the-middle` will only wrap ESM modules that are specifically hooked by OpenTelemetry
-   * instrumentations. This feature is useful to avoid issues where `import-in-the-middle` is not compatible with some
-   * of your dependencies.
+   * When set to `true`, `import-in-the-middle` will only wrap ESM modules that are specifically instrumented by
+   * OpenTelemetry plugins. This is useful to avoid issues where `import-in-the-middle` is not compatible with some of
+   * your dependencies.
    *
-   * **Note**: This feature will only work if you `init` the SDK before the instrumented modules are loaded via the Node
-   * `--import` CLI flag or `init` is called before loading your app via async `import()`.
+   * **Note**: This feature will only work if you `Sentry.init()` the SDK before the instrumented modules are loaded.
+   * This can be achieved via the Node `--import` CLI flag or by loading your app via async `import()` after calling
+   * `Sentry.init()`.
    *
    * Defaults to `false`.
    */;


### PR DESCRIPTION
Likely closes many issues but I don't want to auto-close anything specific here. We should probably confirm the issues are closed individually. 

`import-in-the-middle` by default wraps every ES module with a wrapping module that later allows it exports to be modified. This has issues though because the wrapping output of `import-in-the-middle` is not compatible with all modules. 

To help work around this I [added a feature](https://github.com/nodejs/import-in-the-middle/pull/146) to `import-in-the-middle` that allows us to only wrap modules that we specifically need to instrument.

```ts
import * as Sentry from '@sentry/node';

Sentry.init({
  dsn: '__DSN__',
  registerEsmLoaderHooks: { onlyHookedModules: true },
});
```

So far I've only changed the express integration test to use this new mode.