### PR TITLE
feat(nestjs): Automatic instrumentation of nestjs interceptors before route execution

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, UseGuards, UseInterceptors } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ExampleGuard } from './example.guard';
+import { ExampleInterceptor } from './example.interceptor';
 
 @Controller()
 export class AppController {
@@ -13,13 +14,19 @@ export class AppController {
 
   @Get('test-middleware-instrumentation')
   testMiddlewareInstrumentation() {
-    return this.appService.testMiddleware();
+    return this.appService.testSpan();
   }
 
   @Get('test-guard-instrumentation')
   @UseGuards(ExampleGuard)
   testGuardInstrumentation() {
     return {};
+  }
+
+  @Get('test-interceptor-instrumentation')
+  @UseInterceptors(ExampleInterceptor)
+  testInterceptorInstrumentation() {
+    return this.appService.testSpan();
   }
 
   @Get('test-pipe-instrumentation/:id')

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.service.ts
@@ -21,7 +21,7 @@ export class AppService {
     });
   }
 
-  testMiddleware() {
+  testSpan() {
     // span that should not be a child span of the middleware span
     Sentry.startSpan({ name: 'test-controller-span' }, () => {});
   }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/example.interceptor.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/example.interceptor.ts
@@ -1,0 +1,10 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+
+@Injectable()
+export class ExampleInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    Sentry.startSpan({ name: 'test-interceptor-span' }, () => {});
+    return next.handle().pipe();
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/transactions.test.ts
@@ -354,8 +354,6 @@ test('API route transaction includes nest interceptor span. Spans created in and
 
   const transactionEvent = await pageloadTransactionEventPromise;
 
-  console.log(transactionEvent.spans);
-
   expect(transactionEvent).toEqual(
     expect.objectContaining({
       spans: expect.arrayContaining([

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Param, ParseIntPipe, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, UseGuards, UseInterceptors } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ExampleGuard } from './example.guard';
+import { ExampleInterceptor } from './example.interceptor';
 
 @Controller()
 export class AppController {
@@ -13,13 +14,19 @@ export class AppController {
 
   @Get('test-middleware-instrumentation')
   testMiddlewareInstrumentation() {
-    return this.appService.testMiddleware();
+    return this.appService.testSpan();
   }
 
   @Get('test-guard-instrumentation')
   @UseGuards(ExampleGuard)
   testGuardInstrumentation() {
     return {};
+  }
+
+  @Get('test-interceptor-instrumentation')
+  @UseInterceptors(ExampleInterceptor)
+  testInterceptorInstrumentation() {
+    return this.appService.testSpan();
   }
 
   @Get('test-pipe-instrumentation/:id')

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.service.ts
@@ -21,7 +21,7 @@ export class AppService {
     });
   }
 
-  testMiddleware() {
+  testSpan() {
     // span that should not be a child span of the middleware span
     Sentry.startSpan({ name: 'test-controller-span' }, () => {});
   }

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/example.interceptor.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/example.interceptor.ts
@@ -1,0 +1,10 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+
+@Injectable()
+export class ExampleInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    Sentry.startSpan({ name: 'test-interceptor-span' }, () => {});
+    return next.handle().pipe();
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/transactions.test.ts
@@ -354,8 +354,6 @@ test('API route transaction includes nest interceptor span. Spans created in and
 
   const transactionEvent = await pageloadTransactionEventPromise;
 
-  console.log(transactionEvent.spans);
-
   expect(transactionEvent).toEqual(
     expect.objectContaining({
       spans: expect.arrayContaining([

--- a/packages/nestjs/src/setup.ts
+++ b/packages/nestjs/src/setup.ts
@@ -32,6 +32,7 @@ import type { Observable } from 'rxjs';
  * Interceptor to add Sentry tracing capabilities to Nest.js applications.
  */
 class SentryTracingInterceptor implements NestInterceptor {
+  // used to exclude this class from being auto-instrumented
   public static readonly __SENTRY_INTERNAL__ = true;
 
   /**

--- a/packages/nestjs/src/setup.ts
+++ b/packages/nestjs/src/setup.ts
@@ -32,6 +32,8 @@ import type { Observable } from 'rxjs';
  * Interceptor to add Sentry tracing capabilities to Nest.js applications.
  */
 class SentryTracingInterceptor implements NestInterceptor {
+  public static readonly __SENTRY_INTERNAL__ = true;
+
   /**
    * Intercepts HTTP requests to set the transaction name for Sentry tracing.
    */


### PR DESCRIPTION
Adds automatic instrumentation of interceptors to `@sentry/nestjs`. Interceptors in nest have a `@Injectable` decorator and implement a `intercept` function. So we can simply extend the existing instrumentation to add a proxy for `intercept`.

Current screenshot from my sample app:
![Screenshot 2024-08-01 at 13 29 20](https://github.com/user-attachments/assets/048e5b12-b671-4ca6-b3bf-6be92e0ea014)

Remark: Interceptors allow users to add functionality before and after a route handler is called. This PR adds tracing to whatever happens before the route is executed. I am still figuring out how to trace any instructions after the route was executed. Will do that in a separate PR.
