### PR TITLE
fix(browser): Avoid showing browser extension error message in non-`window` global scopes

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -72,7 +72,12 @@ type Runtime = {
 };
 
 function shouldShowBrowserExtensionError(): boolean {
-  const windowWithMaybeExtension = WINDOW as typeof WINDOW & ExtensionProperties;
+  const windowWithMaybeExtension =
+    typeof WINDOW.window !== 'undefined' && (WINDOW as typeof WINDOW & ExtensionProperties);
+  if (!windowWithMaybeExtension) {
+    // No need to show the error if we're not in a browser window environment (e.g. service workers)
+    return false;
+  }
 
   const extensionKey = windowWithMaybeExtension.chrome ? 'chrome' : 'browser';
   const extensionObject = windowWithMaybeExtension[extensionKey];

--- a/packages/browser/test/sdk.test.ts
+++ b/packages/browser/test/sdk.test.ts
@@ -149,6 +149,7 @@ describe('init', () => {
       Object.defineProperty(WINDOW, 'chrome', { value: undefined, writable: true });
       Object.defineProperty(WINDOW, 'browser', { value: undefined, writable: true });
       Object.defineProperty(WINDOW, 'nw', { value: undefined, writable: true });
+      Object.defineProperty(WINDOW, 'window', { value: WINDOW, writable: true });
     });
 
     it('logs a browser extension error if executed inside a Chrome extension', () => {
@@ -221,6 +222,18 @@ describe('init', () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       Object.defineProperty(WINDOW, 'nw', { value: {} });
+
+      init(options);
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("doesn't log a browser extension error if the `window` object isn't defined", () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      Object.defineProperty(WINDOW, 'window', { value: undefined });
 
       init(options);
 

--- a/packages/browser/test/sdk.test.ts
+++ b/packages/browser/test/sdk.test.ts
@@ -231,7 +231,7 @@ describe('init', () => {
     });
 
     it("doesn't log a browser extension error if the `window` object isn't defined", () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       Object.defineProperty(WINDOW, 'window', { value: undefined });
 


### PR DESCRIPTION
This PR relaxes our browser extension detection check. The idea is to avoid showing the error message and blocking `Sentry.init` if the SDK is not initialized in a `window` global scope. For instance, this will allow `Sentry.init` to be executed in (service) workers. We likely don't need to worry about multiple SDK instance collisions in non-`window` global scopes.

We discussed this a bit internally and there are some caveats to this. Using the browser SDK in workers is a bit problematic as many global APIs are not available in there. However, we currently instruct users [to do just that](https://docs.sentry.io/platforms/javascript/best-practices/web-workers/). Long-term, it'd be valuable to have a worker SDK that doesn't expect certain browser/Window APIs to be present at all. 

 Reviewers, please roast me if this is not a good idea :D 

 fixes #13152 