### PR TITLE
ci: Unflake #13177

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
@@ -23,24 +23,7 @@ test('correctly applies isolation scope even without tracing', done => {
         },
       },
     })
-    .expect({
-      event: {
-        transaction: 'GET /test/isolationScope/2',
-        tags: {
-          global: 'tag',
-          'isolation-scope': 'tag',
-          'isolation-scope-2': '2',
-        },
-        // Request is correctly set
-        request: {
-          url: expect.stringContaining('/test/isolationScope/2'),
-          headers: {
-            'user-agent': expect.stringContaining(''),
-          },
-        },
-      },
-    })
     .start(done);
 
-  runner.makeRequest('get', '/test/isolationScope/1').then(() => runner.makeRequest('get', '/test/isolationScope/2'));
+  runner.makeRequest('get', '/test/isolationScope/1');
 });


### PR DESCRIPTION
The node integration test runner depends on event order. We cannot assert on that.

Fixes https://github.com/getsentry/sentry-javascript/issues/13177