### PR TITLE
test: Fix flakey Playwright tests due to static assets

### DIFF
--- a/dev-packages/browser-integration-tests/utils/staticAssets.ts
+++ b/dev-packages/browser-integration-tests/utils/staticAssets.ts
@@ -27,7 +27,16 @@ export function addStaticAssetSymlink(localOutPath: string, originalPath: string
 
   // Only copy files once
   if (!fs.existsSync(newPath)) {
-    fs.symlinkSync(originalPath, newPath);
+    try {
+      fs.symlinkSync(originalPath, newPath);
+    } catch (error) {
+      // There must be some race condition here as some of our tests flakey
+      // because the file already exists. Let's catch and ignore
+      // only ignore these kind of errors
+      if (!`${error}`.includes('file already exists')) {
+        throw error;
+      }
+    }
   }
 
   symlinkAsset(newPath, path.join(localOutPath, fileName));


### PR DESCRIPTION
Our playwright tests can be flakey caused by the build process when generating static assets. Even though we check if file exists before symlinking, it can at times fail because file already exists. I have not dug/thought about why this happens -- just catch/ignore and move on.

Closes https://github.com/getsentry/sentry-javascript/issues/11902