### PR TITLE
fix(feedback): Call dialog.close() in dialog close callbacks in _loadAndRenderDialog

### DIFF
--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -318,7 +318,21 @@ export const buildFeedbackIntegration = ({
       async createForm(
         optionOverrides: OverrideFeedbackConfiguration = {},
       ): Promise<ReturnType<FeedbackModalIntegration['createDialog']>> {
-        return _loadAndRenderDialog(mergeOptions(_options, optionOverrides));
+        const mergedOptions = mergeOptions(_options, optionOverrides);
+
+        const dialog = await _loadAndRenderDialog({
+          ...mergedOptions,
+          onFormClose: () => {
+            dialog && dialog.close();
+            mergedOptions.onFormClose && mergedOptions.onFormClose();
+          },
+          onFormSubmitted: () => {
+            dialog && dialog.close();
+            mergedOptions.onFormSubmitted && mergedOptions.onFormSubmitted();
+          },
+        });
+
+        return dialog;
       },
 
       /**

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -245,10 +245,6 @@ export const buildFeedbackIntegration = ({
         if (!dialog) {
           dialog = await _loadAndRenderDialog({
             ...mergedOptions,
-            onFormClose: () => {
-              dialog && dialog.removeFromDom();
-              mergedOptions.onFormClose && mergedOptions.onFormClose();
-            },
             onFormSubmitted: () => {
               dialog && dialog.removeFromDom();
               mergedOptions.onFormSubmitted && mergedOptions.onFormSubmitted();

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -209,12 +209,24 @@ export const buildFeedbackIntegration = ({
           logger.error('[Feedback] Missing feedback screenshot integration. Proceeding without screenshots.');
       }
 
-      return modalIntegration.createDialog({
-        options,
+      const dialog = modalIntegration.createDialog({
+        options: {
+          ...options,
+          onFormClose: () => {
+            dialog && dialog.close();
+            options.onFormClose && options.onFormClose();
+          },
+          onFormSubmitted: () => {
+            dialog && dialog.close();
+            options.onFormSubmitted && options.onFormSubmitted();
+          },
+        },
         screenshotIntegration: screenshotRequired ? screenshotIntegration : undefined,
         sendFeedback,
         shadow: _createShadow(options),
       });
+
+      return dialog;
     };
 
     const _attachTo = (el: Element | string, optionOverrides: OverrideFeedbackConfiguration = {}): Unsubscribe => {
@@ -234,7 +246,7 @@ export const buildFeedbackIntegration = ({
           dialog = await _loadAndRenderDialog({
             ...mergedOptions,
             onFormClose: () => {
-              dialog && dialog.close();
+              dialog && dialog.removeFromDom();
               mergedOptions.onFormClose && mergedOptions.onFormClose();
             },
             onFormSubmitted: () => {
@@ -318,21 +330,7 @@ export const buildFeedbackIntegration = ({
       async createForm(
         optionOverrides: OverrideFeedbackConfiguration = {},
       ): Promise<ReturnType<FeedbackModalIntegration['createDialog']>> {
-        const mergedOptions = mergeOptions(_options, optionOverrides);
-
-        const dialog = await _loadAndRenderDialog({
-          ...mergedOptions,
-          onFormClose: () => {
-            dialog && dialog.close();
-            mergedOptions.onFormClose && mergedOptions.onFormClose();
-          },
-          onFormSubmitted: () => {
-            dialog && dialog.close();
-            mergedOptions.onFormSubmitted && mergedOptions.onFormSubmitted();
-          },
-        });
-
-        return dialog;
+        return _loadAndRenderDialog(mergeOptions(_options, optionOverrides));
       },
 
       /**


### PR DESCRIPTION
Updates `_loadAndRenderDialog` to call `dialog.close()` in the `onFormClose` and `onFormSubmitted` callbacks.

Motivation: over at Codecov, we're modifying our user feedback setup so that we have two different feedback integrations, one using the default widget with `createWidget`, and one that is triggered by a button in our help dropdown with `createForm`. After adding these we noticed what seems to be a bug where the `createForm` form does not clear the `overflow: hidden` style on the body when the modal is closed, while the `createWidget` form does clear this style. We currently have added a callback on our end that manually resets the overflow style, but I'm currently revisiting this code again and I thought why not see if we can fix it upstream here 🙂

Here's a gif of the issue:

![Recording 2024-08-02 at 12 54 04](https://github.com/user-attachments/assets/b0efba64-5082-45fe-8591-5b4b91d412ef)

Digging into the code here, it seems that the `createForm` form is not getting a call to `dialog.close()` when the form is closed, unlike `_attachTo` does ([link](https://github.com/getsentry/sentry-javascript/blob/d866011648a1a8f5945a185d0d2d4c14799f351e/packages/feedback/src/core/integration.ts#L234-L244)). To fix, I've pulled the `dialog.close()` call out into `_loadAndRenderDialog`.
