### PR TITLE
feat(browser): allow sentry in safari extension background page

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -85,7 +85,7 @@ function shouldShowBrowserExtensionError(): boolean {
   const runtimeId = extensionObject && extensionObject.runtime && extensionObject.runtime.id;
   const href = (WINDOW.location && WINDOW.location.href) || '';
 
-  const extensionProtocols = ['chrome-extension:', 'moz-extension:', 'ms-browser-extension:'];
+  const extensionProtocols = ['chrome-extension:', 'moz-extension:', 'ms-browser-extension:', 'safari-web-extension:'];
 
   // Running the SDK in a dedicated extension page and calling Sentry.init is fine; no risk of data leakage
   const isDedicatedExtensionPage =

--- a/packages/browser/test/sdk.test.ts
+++ b/packages/browser/test/sdk.test.ts
@@ -185,7 +185,7 @@ describe('init', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it.each(['chrome-extension', 'moz-extension', 'ms-browser-extension'])(
+    it.each(['chrome-extension', 'moz-extension', 'ms-browser-extension', 'safari-web-extension'])(
       "doesn't log a browser extension error if executed inside an extension running in a dedicated page (%s)",
       extensionProtocol => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
Add `safari-web-extension:` to the list of allowed extension protocols. This chage should allow sentry/browser to work in safari browser extensions.