### PR TITLE
feat(replay): Add "disableSandbox" flag to `logger`

### DIFF
--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -212,6 +212,16 @@ export class ReplayContainer implements ReplayContainerInterface {
     if (slowClickConfig) {
       this.clickDetector = new ClickDetector(this, slowClickConfig);
     }
+
+    if (this._options._experiments.captureExceptions) {
+      // We want to disable the logger's console sandbox so that
+      // it uses the Sentry-instrumented console fns in order to
+      // capture them as breadcrumbs. This way we can debug
+      // using these logging statements in the case where
+      // replays are failing to send, but we have a Sentry
+      // error.
+      logger.disableSandbox();
+    }
   }
 
   /** Get the event context. */

--- a/packages/utils/test/logger.test.ts
+++ b/packages/utils/test/logger.test.ts
@@ -1,0 +1,83 @@
+// import { GLOBAL_OBJ } from '../src';
+import { GLOBAL_OBJ } from '../src';
+import {CONSOLE_LEVELS, logger, originalConsoleMethods, consoleSandbox} from '../src/logger';
+
+jest.mock('../src/debug-build', () => {
+  return {
+    DEBUG_BUILD: true,
+  };
+});
+
+// jest.createMockFromModule<typeof import('../src/worldwide')>('../src/worldwide');
+
+
+describe('logger', () => {
+  const _console = GLOBAL_OBJ.console;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    logger.enable();
+  })
+
+  afterAll(() => {
+    jest.clearAllMocks();
+    GLOBAL_OBJ.console = _console;
+    CONSOLE_LEVELS.forEach(name => {
+      originalConsoleMethods[name] = undefined;
+    })
+  })
+
+  describe('consoleSandbox', () => {
+    beforeEach(() => {
+      CONSOLE_LEVELS.forEach(name => {
+        originalConsoleMethods[name] = jest.fn();
+        GLOBAL_OBJ.console[name] = jest.fn();
+      })
+    })
+
+    it('calls original console methods when used inside of consoleSandbox', () => {
+      consoleSandbox(() => {
+        console.log('hi');
+      })
+
+      expect(originalConsoleMethods.log).toHaveBeenLastCalledWith('hi');
+      expect(GLOBAL_OBJ.console.log).not.toHaveBeenCalled();
+    })
+  })
+
+  describe('logger', () => {
+    beforeEach(() => {
+      CONSOLE_LEVELS.forEach(name => {
+        originalConsoleMethods[name] = jest.fn();
+        GLOBAL_OBJ.console[name] = jest.fn();
+      })
+    })
+
+    it('can be disabled and enabled', () => {
+      logger.disable();
+      logger.log('hi');
+      expect(originalConsoleMethods.log).not.toHaveBeenCalled();
+      expect(GLOBAL_OBJ.console.log).not.toHaveBeenCalled();
+
+      logger.enable();
+      logger.log('hi');
+      expect(originalConsoleMethods.log).toHaveBeenCalledWith('Sentry Logger [log]:', 'hi');
+      expect(GLOBAL_OBJ.console.log).not.toHaveBeenCalled();
+    })
+
+    it('can disable sandbox', () => {
+      // Note that "original" in real world usage would refer to Sentry
+      // instrumented functions
+      logger.disableSandbox();
+      logger.log('hi');
+      expect(GLOBAL_OBJ.console.log).toHaveBeenCalledWith('Sentry Logger [log]:', 'hi');
+      expect(originalConsoleMethods.log).not.toHaveBeenCalled();
+
+      jest.resetAllMocks();
+      logger.enableSandbox();
+      logger.log('hi');
+      expect(originalConsoleMethods.log).toHaveBeenCalledWith('Sentry Logger [log]:', 'hi');
+      expect(GLOBAL_OBJ.console.log).not.toHaveBeenCalled();
+    })
+  });
+})


### PR DESCRIPTION
Add an option to toggle using the console sandbox for `logger`. The reason behind this is that we have an experimental option in replay to aid with debugging replays that do not get sent to Sentry. We want to be able to save normal Sentry breadcrumbs so that if we capture exceptions, those logging statements are included in the issue as breadcrumbs.
