### PR TITLE
test(browser): Fix flaky test in test/utils/lazyLoadIntegration.test.ts

### DIFF
--- a/packages/browser/test/utils/lazyLoadIntegration.test.ts
+++ b/packages/browser/test/utils/lazyLoadIntegration.test.ts
@@ -71,9 +71,11 @@ describe('lazyLoadIntegration', () => {
       httpClientIntegration: undefined,
     };
 
-    // We do not await here, as this this does not seem to work with JSDOM :(
-    // We have browser integration tests to check that this actually works
-    void lazyLoadIntegration('httpClientIntegration');
+    try {
+      await lazyLoadIntegration('httpClientIntegration');
+    } catch {
+      // skip
+    }
 
     expect(global.document.querySelectorAll('script')).toHaveLength(1);
     expect(global.document.querySelector('script')?.src).toEqual(


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/13184

We can now await here because we use `vitest`, so there should be no jsdom problems :)

But really these tests should live in playwright instead.