### PR TITLE
test(nestjs): Switch to explicit vitest imports

### DIFF
--- a/packages/nestjs/test/sdk.test.ts
+++ b/packages/nestjs/test/sdk.test.ts
@@ -1,7 +1,8 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import * as SentryNode from '@sentry/node';
 import { SDK_VERSION } from '@sentry/utils';
 
-import { vi } from 'vitest';
 import { init as nestInit } from '../src/sdk';
 
 const nodeInit = vi.spyOn(SentryNode, 'init');

--- a/packages/nestjs/tsconfig.test.json
+++ b/packages/nestjs/tsconfig.test.json
@@ -4,9 +4,6 @@
   "include": ["test/**/*", "vite.config.ts"],
 
   "compilerOptions": {
-    // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["vitest/globals"]
-
     // other package-specific, test-specific options
   }
 }


### PR DESCRIPTION
As per https://vitest.dev/config/#globals

> By default, vitest does not provide global APIs for explicitness

I think we should follow vitest defaults here and explicitly import in the APIs that we need. This refactors our Nestjs SDK tests to do so.

ref https://github.com/getsentry/sentry-javascript/issues/11084