### PR TITLE
ref(core): Reduce `hasTracingEnabled` size

### DIFF
--- a/packages/core/src/utils/hasTracingEnabled.ts
+++ b/packages/core/src/utils/hasTracingEnabled.ts
@@ -16,12 +16,8 @@ export function hasTracingEnabled(
     return false;
   }
 
-  const options = maybeOptions || getClientOptions();
+  const client = getClient();
+  const options = maybeOptions || (client && client.getOptions());
   // eslint-disable-next-line deprecation/deprecation
   return !!options && (options.enableTracing || 'tracesSampleRate' in options || 'tracesSampler' in options);
-}
-
-function getClientOptions(): Options | undefined {
-  const client = getClient();
-  return client && client.getOptions();
 }


### PR DESCRIPTION
A very small PR that should shave off a couple of bytes of `hasTracingEnabled`.

Inlining the function removes the function declaration from the bundle.