### PR TITLE
tests(e2e): Improve nestjs e2e test execution speed using flush()

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/errors.test.ts
@@ -66,7 +66,7 @@ test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
   await transactionEventPromise400;
   await transactionEventPromise500;
 
-  flush();
+  await flush();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -91,7 +91,7 @@ test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  flush();
+  await flush();
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/errors.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { flush } from '@sentry/core';
 
 test('Sends exception to Sentry', async ({ baseURL }) => {
   const errorEventPromise = waitForError('nestjs-basic', event => {
@@ -65,7 +66,7 @@ test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
   await transactionEventPromise400;
   await transactionEventPromise500;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  flush();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -90,7 +91,7 @@ test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  flush();
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/tests/errors.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { flush } from '@sentry/core';
 
 test('Sends unexpected exception to Sentry if thrown in module with global filter', async ({ baseURL }) => {
   const errorEventPromise = waitForError('nestjs-with-submodules', event => {
@@ -81,7 +82,7 @@ test('Does not send exception to Sentry if user-defined global exception filter 
 
   await transactionEventPromise;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  flush();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -111,7 +112,7 @@ test('Does not send exception to Sentry if user-defined local exception filter a
 
   await transactionEventPromise;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  flush();
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/tests/errors.test.ts
@@ -82,7 +82,7 @@ test('Does not send exception to Sentry if user-defined global exception filter 
 
   await transactionEventPromise;
 
-  flush();
+  await flush();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -112,7 +112,7 @@ test('Does not send exception to Sentry if user-defined local exception filter a
 
   await transactionEventPromise;
 
-  flush();
+  await flush();
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/errors.test.ts
@@ -66,7 +66,7 @@ test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
   await transactionEventPromise400;
   await transactionEventPromise500;
 
-  flush();
+  await flush();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -91,7 +91,7 @@ test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  flush();
+  await flush();
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/errors.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { flush } from '@sentry/core';
 
 test('Sends exception to Sentry', async ({ baseURL }) => {
   const errorEventPromise = waitForError('node-nestjs-basic', event => {
@@ -65,7 +66,7 @@ test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
   await transactionEventPromise400;
   await transactionEventPromise500;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  flush();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -90,7 +91,7 @@ test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  flush();
 
   expect(errorEventOccurred).toBe(false);
 });


### PR DESCRIPTION
Explicitly flushing removes the need to wait an arbitrary amount of time and therefore saves 20 seconds in runtime for each affected sample application.
