### PR TITLE
tests(e2e): Remove await timeout in nest e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
@@ -72,6 +72,6 @@ export class AppController {
 
   @Get('flush')
   async flush() {
-    flush();
+    await flush();
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Param, ParseIntPipe, UseGuards, UseInterceptors } from '@nestjs/common';
+import { flush } from '@sentry/nestjs';
 import { AppService } from './app.service';
 import { ExampleGuard } from './example.guard';
 import { ExampleInterceptor } from './example.interceptor';
@@ -67,5 +68,10 @@ export class AppController {
   @Get('kill-test-cron')
   async killTestCron() {
     this.appService.killTestCron();
+  }
+
+  @Get('flush')
+  async flush() {
+    flush();
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/errors.test.ts
@@ -65,7 +65,7 @@ test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
   await transactionEventPromise400;
   await transactionEventPromise500;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  await fetch(`${baseURL}/flush`);
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -90,7 +90,7 @@ test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  await fetch(`${baseURL}/flush`);
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/errors.test.ts
@@ -65,7 +65,7 @@ test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
   await transactionEventPromise400;
   await transactionEventPromise500;
 
-  await fetch(`${baseURL}/flush`);
+  (await fetch(`${baseURL}/flush`)).text();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -90,7 +90,7 @@ test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  await fetch(`${baseURL}/flush`);
+  (await fetch(`${baseURL}/flush`)).text();
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/src/app.controller.ts
@@ -18,6 +18,6 @@ export class AppController {
 
   @Get('flush')
   async flush() {
-    flush();
+    await flush();
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Param } from '@nestjs/common';
+import { flush } from '@sentry/nestjs';
 import { AppService } from './app.service';
 
 @Controller()
@@ -13,5 +14,10 @@ export class AppController {
   @Get('test-expected-exception/:id')
   async testExpectedException(@Param('id') id: string) {
     return this.appService.testExpectedException(id);
+  }
+
+  @Get('flush')
+  async flush() {
+    flush();
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/tests/errors.test.ts
@@ -111,7 +111,7 @@ test('Does not send exception to Sentry if user-defined local exception filter a
 
   await transactionEventPromise;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  await fetch(`${baseURL}/flush`);
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/tests/errors.test.ts
@@ -81,7 +81,7 @@ test('Does not send exception to Sentry if user-defined global exception filter 
 
   await transactionEventPromise;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  (await fetch(`${baseURL}/flush`)).text();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -111,7 +111,7 @@ test('Does not send exception to Sentry if user-defined local exception filter a
 
   await transactionEventPromise;
 
-  await fetch(`${baseURL}/flush`);
+  (await fetch(`${baseURL}/flush`)).text();
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
@@ -72,6 +72,6 @@ export class AppController {
 
   @Get('flush')
   async flush() {
-    flush();
+    await flush();
   }
 }

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Param, ParseIntPipe, UseGuards, UseInterceptors } from '@nestjs/common';
+import { flush } from '@sentry/nestjs';
 import { AppService } from './app.service';
 import { ExampleGuard } from './example.guard';
 import { ExampleInterceptor } from './example.interceptor';
@@ -67,5 +68,10 @@ export class AppController {
   @Get('kill-test-cron')
   async killTestCron() {
     this.appService.killTestCron();
+  }
+
+  @Get('flush')
+  async flush() {
+    flush();
   }
 }

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/errors.test.ts
@@ -65,7 +65,7 @@ test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
   await transactionEventPromise400;
   await transactionEventPromise500;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  await fetch(`${baseURL}/flush`);
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -90,7 +90,7 @@ test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  await fetch(`${baseURL}/flush`);
 
   expect(errorEventOccurred).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/errors.test.ts
@@ -65,7 +65,7 @@ test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
   await transactionEventPromise400;
   await transactionEventPromise500;
 
-  await fetch(`${baseURL}/flush`);
+  (await fetch(`${baseURL}/flush`)).text();
 
   expect(errorEventOccurred).toBe(false);
 });
@@ -90,7 +90,7 @@ test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
 
   await transactionEventPromise;
 
-  await fetch(`${baseURL}/flush`);
+  (await fetch(`${baseURL}/flush`)).text();
 
   expect(errorEventOccurred).toBe(false);
 });


### PR DESCRIPTION
Adding a separate flush endpoint that flushes the client in the application so that we can remove the timeout await and speed up tests.
