### PR TITLE
feat(astro): Always add BrowserTracing

### DIFF
--- a/packages/astro/src/client/sdk.ts
+++ b/packages/astro/src/client/sdk.ts
@@ -4,7 +4,7 @@ import {
   getDefaultIntegrations as getBrowserDefaultIntegrations,
   init as initBrowserSdk,
 } from '@sentry/browser';
-import { applySdkMetadata, hasTracingEnabled } from '@sentry/core';
+import { applySdkMetadata } from '@sentry/core';
 import type { Client, Integration } from '@sentry/types';
 
 // Tree-shakable guard to remove all code related to tracing
@@ -26,14 +26,12 @@ export function init(options: BrowserOptions): Client | undefined {
   return initBrowserSdk(opts);
 }
 
-function getDefaultIntegrations(options: BrowserOptions): Integration[] | undefined {
+function getDefaultIntegrations(options: BrowserOptions): Integration[] {
   // This evaluates to true unless __SENTRY_TRACING__ is text-replaced with "false",
-  // in which case everything inside will get treeshaken away
+  // in which case everything inside will get tree-shaken away
   if (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) {
-    if (hasTracingEnabled(options)) {
-      return [...getBrowserDefaultIntegrations(options), browserTracingIntegration()];
-    }
+    return [...getBrowserDefaultIntegrations(options), browserTracingIntegration()];
+  } else {
+    return getBrowserDefaultIntegrations(options);
   }
-
-  return undefined;
 }

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -53,6 +53,7 @@ describe('Sentry client SDK', () => {
         ['tracesSampleRate', { tracesSampleRate: 0 }],
         ['tracesSampler', { tracesSampler: () => 1.0 }],
         ['enableTracing', { enableTracing: true }],
+        ['no tracing option set', {}],
       ])('adds browserTracingIntegration if tracing is enabled via %s', (_, tracingOptions) => {
         init({
           dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -64,22 +65,6 @@ describe('Sentry client SDK', () => {
 
         expect(integrationsToInit).toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeDefined();
-      });
-
-      it.each([
-        ['enableTracing', { enableTracing: false }],
-        ['no tracing option set', {}],
-      ])("doesn't add browserTracingIntegration if tracing is disabled via %s", (_, tracingOptions) => {
-        init({
-          dsn: 'https://public@dsn.ingest.sentry.io/1337',
-          ...tracingOptions,
-        });
-
-        const integrationsToInit = browserInit.mock.calls[0]![0]?.defaultIntegrations || [];
-        const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
-
-        expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
-        expect(browserTracing).toBeUndefined();
       });
 
       it("doesn't add browserTracingIntegration if `__SENTRY_TRACING__` is set to false", () => {


### PR DESCRIPTION
The bundler-plugins still refer to the option as `excludePerformanceMonitoring` ([here](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/packages/bundler-plugin-core/src/types.ts#L260)), but this is going to be renamed to `excludeTracing`, so I already used the new naming as discussed with @Lms24 and @mydea.

closes https://github.com/getsentry/sentry-javascript/issues/13013
