### PR TITLE
fix: Guard getReader function for other fetch implementations

### DIFF
--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -116,7 +116,7 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
 }
 
 async function resolveResponse(res: Response | undefined, onFinishedResolving: () => void): Promise<void> {
-  if (res && res.body && typeof res.body.getReader === 'function') {
+  if (res && res.body && res.body.getReader) {
     const responseReader = res.body.getReader();
 
     // eslint-disable-next-line no-inner-declarations

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -116,7 +116,7 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
 }
 
 async function resolveResponse(res: Response | undefined, onFinishedResolving: () => void): Promise<void> {
-  if (res && res.body) {
+  if (res && res.body && typeof res.body.getReader === 'function') {
     const responseReader = res.body.getReader();
 
     // eslint-disable-next-line no-inner-declarations


### PR DESCRIPTION
fixes [#13220](https://github.com/getsentry/sentry-javascript/issues/13220)