### PR TITLE
feat(node): Add `useOperationNameForRootSpan` to`graphqlIntegration`

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/apollo-server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/apollo-server.js
@@ -1,29 +1,33 @@
 const { ApolloServer, gql } = require('apollo-server');
+const Sentry = require('@sentry/node');
 
-module.exports = () =>
-  new ApolloServer({
-    typeDefs: gql`type Query {
+module.exports = () => {
+  return Sentry.startSpan({ name: 'Test Server Start' }, () => {
+    return new ApolloServer({
+      typeDefs: gql`type Query {
     hello: String
     world: String
   }
   type Mutation {
     login(email: String): String
   }`,
-    resolvers: {
-      Query: {
-        hello: () => {
-          return 'Hello!';
+      resolvers: {
+        Query: {
+          hello: () => {
+            return 'Hello!';
+          },
+          world: () => {
+            return 'World!';
+          },
         },
-        world: () => {
-          return 'World!';
+        Mutation: {
+          login: async (_, { email }) => {
+            return `${email}--token`;
+          },
         },
       },
-      Mutation: {
-        login: async (_, { email }) => {
-          return `${email}--token`;
-        },
-      },
-    },
-    introspection: false,
-    debug: false,
+      introspection: false,
+      debug: false,
+    });
   });
+};

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/apollo-server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/apollo-server.js
@@ -1,0 +1,29 @@
+const { ApolloServer, gql } = require('apollo-server');
+
+module.exports = () =>
+  new ApolloServer({
+    typeDefs: gql`type Query {
+    hello: String
+    world: String
+  }
+  type Mutation {
+    login(email: String): String
+  }`,
+    resolvers: {
+      Query: {
+        hello: () => {
+          return 'Hello!';
+        },
+        world: () => {
+          return 'World!';
+        },
+      },
+      Mutation: {
+        login: async (_, { email }) => {
+          return `${email}--token`;
+        },
+      },
+    },
+    introspection: false,
+    debug: false,
+  });

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario-mutation.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario-mutation.js
@@ -13,6 +13,7 @@ setInterval(() => {}, 1000);
 
 async function run() {
   const { gql } = require('apollo-server');
+  const server = require('./apollo-server')();
 
   await Sentry.startSpan(
     {
@@ -20,8 +21,6 @@ async function run() {
       op: 'transaction',
     },
     async span => {
-      const server = require('./apollo-server')();
-
       // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
       await server.executeOperation({
         query: gql`mutation Mutation($email: String){

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario-query.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario-query.js
@@ -12,14 +12,14 @@ Sentry.init({
 setInterval(() => {}, 1000);
 
 async function run() {
+  const server = require('./apollo-server')();
+
   await Sentry.startSpan(
     {
       name: 'Test Transaction',
       op: 'transaction',
     },
     async span => {
-      const server = require('./apollo-server')();
-
       // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
       await server.executeOperation({
         query: '{hello}',

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario-query.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario-query.js
@@ -12,28 +12,13 @@ Sentry.init({
 setInterval(() => {}, 1000);
 
 async function run() {
-  const { ApolloServer, gql } = require('apollo-server');
-
   await Sentry.startSpan(
     {
       name: 'Test Transaction',
       op: 'transaction',
     },
     async span => {
-      const typeDefs = gql`type Query { hello: String }`;
-
-      const resolvers = {
-        Query: {
-          hello: () => {
-            return 'Hello world!';
-          },
-        },
-      };
-
-      const server = new ApolloServer({
-        typeDefs,
-        resolvers,
-      });
+      const server = require('./apollo-server')();
 
       // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
       await server.executeOperation({

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
@@ -1,7 +1,7 @@
 import { createRunner } from '../../../utils/runner';
 
 describe('GraphQL/Apollo Tests', () => {
-  test('CJS - should instrument GraphQL queries used from Apollo Server.', done => {
+  test('should instrument GraphQL queries used from Apollo Server.', done => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -21,7 +21,7 @@ describe('GraphQL/Apollo Tests', () => {
     createRunner(__dirname, 'scenario-query.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
   });
 
-  test('CJS - should instrument GraphQL mutations used from Apollo Server.', done => {
+  test('should instrument GraphQL mutations used from Apollo Server.', done => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
@@ -1,5 +1,10 @@
 import { createRunner } from '../../../utils/runner';
 
+// Graphql Instrumentation emits some spans by default on server start
+const EXPECTED_START_SERVER_TRANSACTION = {
+  transaction: 'Test Server Start',
+};
+
 describe('GraphQL/Apollo Tests', () => {
   test('should instrument GraphQL queries used from Apollo Server.', done => {
     const EXPECTED_TRANSACTION = {
@@ -18,7 +23,10 @@ describe('GraphQL/Apollo Tests', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-query.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+    createRunner(__dirname, 'scenario-query.js')
+      .expect({ transaction: EXPECTED_START_SERVER_TRANSACTION })
+      .expect({ transaction: EXPECTED_TRANSACTION })
+      .start(done);
   });
 
   test('should instrument GraphQL mutations used from Apollo Server.', done => {
@@ -39,6 +47,9 @@ describe('GraphQL/Apollo Tests', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-mutation.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+    createRunner(__dirname, 'scenario-mutation.js')
+      .expect({ transaction: EXPECTED_START_SERVER_TRANSACTION })
+      .expect({ transaction: EXPECTED_TRANSACTION })
+      .start(done);
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-invalid-root-span.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-invalid-root-span.js
@@ -1,0 +1,34 @@
+const Sentry = require('@sentry/node');
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+
+const client = Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  integrations: [Sentry.graphqlIntegration({ useOperationNameForRootSpan: true })],
+  transport: loggingTransport,
+});
+
+const tracer = client.tracer;
+
+// Stop the process from exiting before the transaction is sent
+setInterval(() => {}, 1000);
+
+async function run() {
+  await tracer.startActiveSpan('test span name', async span => {
+    const server = require('../apollo-server')();
+
+    // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
+    await server.executeOperation({
+      query: 'query GetHello {hello}',
+    });
+
+    setTimeout(() => {
+      span.end();
+      server.stop();
+    }, 500);
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-invalid-root-span.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-invalid-root-span.js
@@ -15,9 +15,9 @@ const tracer = client.tracer;
 setInterval(() => {}, 1000);
 
 async function run() {
-  await tracer.startActiveSpan('test span name', async span => {
-    const server = require('../apollo-server')();
+  const server = require('../apollo-server')();
 
+  await tracer.startActiveSpan('test span name', async span => {
     // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
     await server.executeOperation({
       query: 'query GetHello {hello}',

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-multiple-operations-many.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-multiple-operations-many.js
@@ -24,14 +24,12 @@ async function run() {
       attributes: { 'http.method': 'GET', 'http.route': '/test-graphql' },
     },
     async span => {
-      // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
-      await server.executeOperation({
-        query: 'query GetWorld {world}',
-      });
-
-      await server.executeOperation({
-        query: 'query GetHello {hello}',
-      });
+      for (let i = 1; i < 10; i++) {
+        // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
+        await server.executeOperation({
+          query: `query GetHello${i} {hello}`,
+        });
+      }
 
       setTimeout(() => {
         span.end();

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-multiple-operations.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-multiple-operations.js
@@ -26,7 +26,11 @@ async function run() {
     async span => {
       // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
       await server.executeOperation({
-        query: 'query {hello}',
+        query: 'query GetHello {hello}',
+      });
+
+      await server.executeOperation({
+        query: 'query GetWorld {world}',
       });
 
       setTimeout(() => {

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-mutation.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-mutation.js
@@ -16,16 +16,15 @@ setInterval(() => {}, 1000);
 
 async function run() {
   const { gql } = require('apollo-server');
+  const server = require('../apollo-server')();
 
   await tracer.startActiveSpan(
     'test span name',
     {
       kind: 1,
-      attributes: { 'http.method': 'GET' },
+      attributes: { 'http.method': 'GET', 'http.route': '/test-graphql' },
     },
     async span => {
-      const server = require('../apollo-server')();
-
       // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
       await server.executeOperation({
         query: gql`mutation TestMutation($email: String){

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-mutation.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-mutation.js
@@ -1,12 +1,15 @@
 const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
-Sentry.init({
+const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,
+  integrations: [Sentry.graphqlIntegration({ useOperationNameForRootSpan: true })],
   transport: loggingTransport,
 });
+
+const tracer = client.tracer;
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
@@ -14,17 +17,18 @@ setInterval(() => {}, 1000);
 async function run() {
   const { gql } = require('apollo-server');
 
-  await Sentry.startSpan(
+  await tracer.startActiveSpan(
+    'test span name',
     {
-      name: 'Test Transaction',
-      op: 'transaction',
+      kind: 1,
+      attributes: { 'http.method': 'GET' },
     },
     async span => {
-      const server = require('./apollo-server')();
+      const server = require('../apollo-server')();
 
       // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
       await server.executeOperation({
-        query: gql`mutation Mutation($email: String){
+        query: gql`mutation TestMutation($email: String){
           login(email: $email)
         }`,
         variables: { email: 'test@email.com' },

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-query.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-query.js
@@ -15,15 +15,15 @@ const tracer = client.tracer;
 setInterval(() => {}, 1000);
 
 async function run() {
+  const server = require('../apollo-server')();
+
   await tracer.startActiveSpan(
     'test span name',
     {
       kind: 1,
-      attributes: { 'http.method': 'GET' },
+      attributes: { 'http.method': 'GET', 'http.route': '/test-graphql' },
     },
     async span => {
-      const server = require('../apollo-server')();
-
       // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
       await server.executeOperation({
         query: 'query GetHello {hello}',

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-query.js
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/scenario-query.js
@@ -1,33 +1,32 @@
 const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
-Sentry.init({
+const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,
+  integrations: [Sentry.graphqlIntegration({ useOperationNameForRootSpan: true })],
   transport: loggingTransport,
 });
+
+const tracer = client.tracer;
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
 
 async function run() {
-  const { gql } = require('apollo-server');
-
-  await Sentry.startSpan(
+  await tracer.startActiveSpan(
+    'test span name',
     {
-      name: 'Test Transaction',
-      op: 'transaction',
+      kind: 1,
+      attributes: { 'http.method': 'GET' },
     },
     async span => {
-      const server = require('./apollo-server')();
+      const server = require('../apollo-server')();
 
       // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
       await server.executeOperation({
-        query: gql`mutation Mutation($email: String){
-          login(email: $email)
-        }`,
-        variables: { email: 'test@email.com' },
+        query: 'query GetHello {hello}',
       });
 
       setTimeout(() => {

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/test.ts
@@ -1,0 +1,88 @@
+import { createRunner } from '../../../../utils/runner';
+
+describe('GraphQL/Apollo Tests > useOperationNameForRootSpan', () => {
+  test('useOperationNameForRootSpan works with single query operation', done => {
+    const EXPECTED_TRANSACTION = {
+      transaction: 'query GetHello',
+      spans: expect.arrayContaining([
+        expect.objectContaining({
+          data: {
+            'graphql.operation.name': 'GetHello',
+            'graphql.operation.type': 'query',
+            'graphql.source': 'query GetHello {hello}',
+            'sentry.origin': 'auto.graphql.otel.graphql',
+          },
+          description: 'query GetHello',
+          status: 'ok',
+          origin: 'auto.graphql.otel.graphql',
+        }),
+      ]),
+    };
+
+    createRunner(__dirname, 'scenario-query.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+  });
+
+  test('useOperationNameForRootSpan works with single mutation operation', done => {
+    const EXPECTED_TRANSACTION = {
+      transaction: 'mutation TestMutation',
+      spans: expect.arrayContaining([
+        expect.objectContaining({
+          data: {
+            'graphql.operation.name': 'TestMutation',
+            'graphql.operation.type': 'mutation',
+            'graphql.source': `mutation TestMutation($email: String) {
+  login(email: $email)
+}`,
+            'sentry.origin': 'auto.graphql.otel.graphql',
+          },
+          description: 'mutation TestMutation',
+          status: 'ok',
+          origin: 'auto.graphql.otel.graphql',
+        }),
+      ]),
+    };
+
+    createRunner(__dirname, 'scenario-mutation.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+  });
+
+  test('useOperationNameForRootSpan ignores an invalid root span', done => {
+    const EXPECTED_TRANSACTION = {
+      transaction: 'test span name',
+      spans: expect.arrayContaining([
+        expect.objectContaining({
+          data: {
+            'graphql.operation.name': 'GetHello',
+            'graphql.operation.type': 'query',
+            'graphql.source': 'query GetHello {hello}',
+            'sentry.origin': 'auto.graphql.otel.graphql',
+          },
+          description: 'query GetHello',
+          status: 'ok',
+          origin: 'auto.graphql.otel.graphql',
+        }),
+      ]),
+    };
+
+    createRunner(__dirname, 'scenario-invalid-root-span.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+  });
+
+  test('useOperationNameForRootSpan works with single query operation without name', done => {
+    const EXPECTED_TRANSACTION = {
+      transaction: 'query',
+      spans: expect.arrayContaining([
+        expect.objectContaining({
+          data: {
+            'graphql.operation.type': 'query',
+            'graphql.source': 'query {hello}',
+            'sentry.origin': 'auto.graphql.otel.graphql',
+          },
+          description: 'query',
+          status: 'ok',
+          origin: 'auto.graphql.otel.graphql',
+        }),
+      ]),
+    };
+
+    createRunner(__dirname, 'scenario-no-operation-name.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/test.ts
@@ -105,7 +105,7 @@ describe('GraphQL/Apollo Tests > useOperationNameForRootSpan', () => {
 
   test('useOperationNameForRootSpan works with multiple query operations', done => {
     const EXPECTED_TRANSACTION = {
-      transaction: 'GET /test-graphql (query GetHello)',
+      transaction: 'GET /test-graphql (query GetHello, query GetWorld)',
       spans: expect.arrayContaining([
         expect.objectContaining({
           data: {
@@ -133,6 +133,18 @@ describe('GraphQL/Apollo Tests > useOperationNameForRootSpan', () => {
     };
 
     createRunner(__dirname, 'scenario-multiple-operations.js')
+      .expect({ transaction: EXPECTED_START_SERVER_TRANSACTION })
+      .expect({ transaction: EXPECTED_TRANSACTION })
+      .start(done);
+  });
+
+  test('useOperationNameForRootSpan works with more than 5 query operations', done => {
+    const EXPECTED_TRANSACTION = {
+      transaction:
+        'GET /test-graphql (query GetHello1, query GetHello2, query GetHello3, query GetHello4, query GetHello5, +4)',
+    };
+
+    createRunner(__dirname, 'scenario-multiple-operations-many.js')
       .expect({ transaction: EXPECTED_START_SERVER_TRANSACTION })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start(done);

--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -30,8 +30,6 @@ interface GraphqlOptions {
    * If this is enabled, a http.server root span containing this span will automatically be renamed to include the operation name.
    * Set this to `false` if you do not want this behavior, and want to keep the default http.server span name.
    *
-   * If there are multiple operations in a single http.server request, the first one will take precedence.
-   *
    * Defaults to true.
    */
   useOperationNameForRootSpan?: boolean;

--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -1,5 +1,7 @@
+import { SpanKind } from '@opentelemetry/api';
 import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
-import { defineIntegration } from '@sentry/core';
+import { defineIntegration, getRootSpan, spanToJSON } from '@sentry/core';
+import { spanHasKind } from '@sentry/opentelemetry';
 import type { IntegrationFn } from '@sentry/types';
 import { generateInstrumentOnce } from '../../otel/instrument';
 
@@ -18,6 +20,17 @@ interface GraphqlOptions {
    * This option can reduce noise and number of spans created.
    */
   ignoreTrivalResolveSpans?: boolean;
+
+  /**
+   * By default, an incoming GraphQL request will have a http.server root span,
+   * which has one or multiple GraphQL operation spans as children.
+   * If you want your http.server root span to have the name of the GraphQL operation,
+   * you can opt-in to this behavior by setting this option to true.
+   *
+   * Please note that this may not work as expected if you have multiple GraphQL operations -
+   * the last operation to come in will determine the root span name in this scenario.
+   */
+  useOperationNameForRootSpan?: boolean;
 }
 
 const INTEGRATION_NAME = 'Graphql';
@@ -28,6 +41,7 @@ export const instrumentGraphql = generateInstrumentOnce<GraphqlOptions>(
     const options = {
       ignoreResolveSpans: true,
       ignoreTrivialResolveSpans: true,
+      useOperationNameForRootSpan: false,
       ..._options,
     };
 
@@ -35,6 +49,28 @@ export const instrumentGraphql = generateInstrumentOnce<GraphqlOptions>(
       ...options,
       responseHook(span) {
         addOriginToSpan(span, 'auto.graphql.otel.graphql');
+
+        const attributes = spanToJSON(span).data || {};
+
+        // If operation.name is not set, we fall back to use operation.type only
+        const operationType = attributes['graphql.operation.type'];
+        const operationName = attributes['graphql.operation.name'];
+
+        if (options.useOperationNameForRootSpan && operationType) {
+          const rootSpanName = `${operationType}${operationName ? ` ${operationName}` : ''}`;
+          const rootSpan = getRootSpan(span);
+
+          // We guard to only do this on http.server spans
+          if (
+            spanToJSON(rootSpan).data?.['http.method'] &&
+            spanHasKind(rootSpan) &&
+            rootSpan.kind === SpanKind.SERVER
+          ) {
+            // Ensure the default http.server span name inferral is skipped
+            rootSpan.setAttribute('sentry.skip_span_data_inference', true);
+            rootSpan.updateName(rootSpanName);
+          }
+        }
       },
     });
   },

--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -19,7 +19,7 @@ interface GraphqlOptions {
    * If the property is not a function, it's not very interesting to trace.
    * This option can reduce noise and number of spans created.
    */
-  ignoreTrivalResolveSpans?: boolean;
+  ignoreTrivialResolveSpans?: boolean;
 
   /**
    * By default, an incoming GraphQL request will have a http.server root span,

--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -30,6 +30,8 @@ interface GraphqlOptions {
    * If this is enabled, a http.server root span containing this span will automatically be renamed to include the operation name.
    * Set this to `false` if you do not want this behavior, and want to keep the default http.server span name.
    *
+   * If there are multiple operations in a single http.server request, the first one will take precedence.
+   *
    * Defaults to true.
    */
   useOperationNameForRootSpan?: boolean;

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -1,4 +1,4 @@
-export { parseSpanDescription } from './utils/parseSpanDescription';
+export { SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION } from './semanticAttributes';
 
 export { getRequestSpanData } from './utils/getRequestSpanData';
 

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -1,3 +1,5 @@
+export { parseSpanDescription } from './utils/parseSpanDescription';
+
 export { getRequestSpanData } from './utils/getRequestSpanData';
 
 export type { OpenTelemetryClient } from './types';

--- a/packages/opentelemetry/src/semanticAttributes.ts
+++ b/packages/opentelemetry/src/semanticAttributes.ts
@@ -1,2 +1,5 @@
 /** If this attribute is true, it means that the parent is a remote span. */
 export const SEMANTIC_ATTRIBUTE_SENTRY_PARENT_IS_REMOTE = 'sentry.parentIsRemote';
+
+// These are not standardized yet, but used by the graphql instrumentation
+export const SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION = 'sentry.graphql.operation';

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -137,15 +137,15 @@ export function descriptionForHttpMethod(
     return { op: opParts.join('.'), description: name, source: 'custom' };
   }
 
-  const graphqlOperations = attributes[SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION];
+  const graphqlOperationsAttribute = attributes[SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION];
 
   // Ex. GET /api/users
   const baseDescription = `${httpMethod} ${urlPath}`;
 
   // When the http span has a graphql operation, append it to the description
   // We add these in the graphqlIntegration
-  const description = graphqlOperations
-    ? `${baseDescription} (${getGraphqlOperationNames(graphqlOperations)})`
+  const description = graphqlOperationsAttribute
+    ? `${baseDescription} (${getGraphqlOperationNamesFromAttribute(graphqlOperationsAttribute)})`
     : baseDescription;
 
   // If `httpPath` is a root path, then we can categorize the transaction source as route.
@@ -171,7 +171,7 @@ export function descriptionForHttpMethod(
   };
 }
 
-function getGraphqlOperationNames(attr: AttributeValue): string {
+function getGraphqlOperationNamesFromAttribute(attr: AttributeValue): string {
   if (Array.isArray(attr)) {
     const sorted = attr.slice().sort();
 

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -176,7 +176,7 @@ function getGraphqlOperationNamesFromAttribute(attr: AttributeValue): string {
     const sorted = attr.slice().sort();
 
     // Up to 5 items, we just add all of them
-    if (sorted.length < 5) {
+    if (sorted.length <= 5) {
       return sorted.join(', ');
     } else {
       // Else, we add the first 5 and the diff of other operations

--- a/packages/opentelemetry/src/utils/spanTypes.ts
+++ b/packages/opentelemetry/src/utils/spanTypes.ts
@@ -22,7 +22,7 @@ export function spanHasAttributes<SpanType extends AbstractSpan>(
  */
 export function spanHasKind<SpanType extends AbstractSpan>(span: SpanType): span is SpanType & { kind: SpanKind } {
   const castSpan = span as ReadableSpan;
-  return 'kind' in castSpan;
+  return typeof castSpan.kind === 'number';
 }
 
 /**

--- a/packages/opentelemetry/src/utils/spanTypes.ts
+++ b/packages/opentelemetry/src/utils/spanTypes.ts
@@ -22,7 +22,7 @@ export function spanHasAttributes<SpanType extends AbstractSpan>(
  */
 export function spanHasKind<SpanType extends AbstractSpan>(span: SpanType): span is SpanType & { kind: SpanKind } {
   const castSpan = span as ReadableSpan;
-  return !!castSpan.kind;
+  return 'kind' in castSpan;
 }
 
 /**

--- a/packages/opentelemetry/test/utils/spanTypes.test.ts
+++ b/packages/opentelemetry/test/utils/spanTypes.test.ts
@@ -24,6 +24,7 @@ describe('spanTypes', () => {
     it.each([
       [{}, false],
       [{ kind: null }, false],
+      [{ kind: 0 }, true],
       [{ kind: 'TEST_KIND' }, true],
     ])('works with %p', (span, expected) => {
       const castSpan = span as unknown as Span;

--- a/packages/opentelemetry/test/utils/spanTypes.test.ts
+++ b/packages/opentelemetry/test/utils/spanTypes.test.ts
@@ -25,7 +25,8 @@ describe('spanTypes', () => {
       [{}, false],
       [{ kind: null }, false],
       [{ kind: 0 }, true],
-      [{ kind: 'TEST_KIND' }, true],
+      [{ kind: 5 }, true],
+      [{ kind: 'TEST_KIND' }, false],
     ])('works with %p', (span, expected) => {
       const castSpan = span as unknown as Span;
       const actual = spanHasKind(castSpan);


### PR DESCRIPTION
This introduces a new option for the `graphqlIntegration`, `useOperationNameForRootSpan`, which is by default `true` but can be disabled in integration settings like this: `Sentry.graphqlIntegration({ useOperationNameForRootSpan: true })`.

With this setting enabled, the graphql instrumentation will update the `http.server` root span it is in (if there is one)  will be appended to the span name. So instead of having all root spans be `POST /graphql`, the names will now be e.g. `POST /graphql (query MyQuery)`.

If there are multiple operations in a single http request, they will be appended like `POST /graphql (query Query1, query Query2)`, up to a limit of 5, at which point they will be appended as `+2` or similar.

Closes https://github.com/getsentry/sentry-javascript/issues/13238