### PR TITLE
chore(lint): Allow `ts-ignore` in Node integration tests

### DIFF
--- a/dev-packages/node-integration-tests/.eslintrc.js
+++ b/dev-packages/node-integration-tests/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
           'error',
           {
             'ts-ignore': 'allow-with-description',
+            'ts-expect-error': true,
           },
         ],
       },

--- a/dev-packages/node-integration-tests/.eslintrc.js
+++ b/dev-packages/node-integration-tests/.eslintrc.js
@@ -20,6 +20,14 @@ module.exports = {
       },
       rules: {
         '@typescript-eslint/typedef': 'off',
+        // Explicitly allow ts-ignore with description for Node integration tests
+        // Reason: We run these tests on TS3.8 which doesn't support `@ts-expect-error`
+        '@typescript-eslint/ban-ts-comment': [
+          'error',
+          {
+            'ts-ignore': 'allow-with-description',
+          },
+        ],
       },
     },
   ],

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/test.ts
@@ -16,7 +16,7 @@ describe('getTraceMetaTags', () => {
       baggage: 'sentry-environment=production',
     });
 
-    // @ts-expect-error - response is defined, types just don't reflect it
+    // @ts-ignore - response is defined, types just don't reflect it
     const html = response?.response as unknown as string;
 
     expect(html).toMatch(/<meta name="sentry-trace" content="cd7ee7a6fe3ebe7ab9c3271559bc203c-[a-z0-9]{16}-1"\/>/);

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/test.ts
@@ -16,8 +16,7 @@ describe('getTraceMetaTags', () => {
       baggage: 'sentry-environment=production',
     });
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error - response is defined, types just don't reflect it
     const html = response?.response as unknown as string;
 
     expect(html).toMatch(/<meta name="sentry-trace" content="cd7ee7a6fe3ebe7ab9c3271559bc203c-[a-z0-9]{16}-1"\/>/);


### PR DESCRIPTION
Discovered today that TS 3.8 doesn't understand `// @ts-expect-error`. Since we test on Node 22 also with TS 3.8, we shouldn't use `ts-expect-error` in test files as TS 3.8 would simply ignore the comment and throw a type error.

Instead, it's fine to use `@ts-ignore` in these test files. 