### PR TITLE
feat(replay): Add context when capturing exceptions

### DIFF
--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -246,7 +246,13 @@ export class ReplayContainer implements ReplayContainerInterface {
     DEBUG_BUILD && logger.error('[Replay]', error);
 
     if (DEBUG_BUILD && this._options._experiments && this._options._experiments.captureExceptions) {
-      captureException(error);
+      captureException(error, {
+        contexts: {
+          __sentry_sdk: {
+            package: 'replay',
+          },
+        },
+      });
     }
   }
 


### PR DESCRIPTION
Adding a context will allow us to re-route these exceptions in relay into a Sentry project. This means that we can ask customers to opt-in to send us replay SDK exceptions and not consume their data.
