### PR TITLE
fix(browser): Initialize default integration if `defaultIntegrations: undefined`

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration'),
     gzip: true,
-    limit: '72 KB',
+    limit: '73 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - with treeshaking flags',

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -57,6 +57,14 @@ function applyDefaultOptions(optionsArg: BrowserOptions = {}): BrowserOptions {
     sendClientReports: true,
   };
 
+  // TODO: Instead of dropping just `defaultIntegrations`, we should simply
+  // call `dropUndefinedKeys` on the entire `optionsArg`.
+  // However, for this to work we need to adjust the `hasTracingEnabled()` logic
+  // first as it differentiates between `undefined` and the key not being in the object.
+  if (optionsArg.defaultIntegrations === undefined) {
+    delete optionsArg.defaultIntegrations;
+  }
+
   return { ...defaultOptions, ...optionsArg };
 }
 

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -61,7 +61,7 @@ function applyDefaultOptions(optionsArg: BrowserOptions = {}): BrowserOptions {
   // call `dropUndefinedKeys` on the entire `optionsArg`.
   // However, for this to work we need to adjust the `hasTracingEnabled()` logic
   // first as it differentiates between `undefined` and the key not being in the object.
-  if (optionsArg.defaultIntegrations === undefined) {
+  if (optionsArg.defaultIntegrations == null) {
     delete optionsArg.defaultIntegrations;
   }
 

--- a/packages/browser/test/sdk.test.ts
+++ b/packages/browser/test/sdk.test.ts
@@ -6,6 +6,7 @@
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as SentryCore from '@sentry/core';
 import { Scope, createTransport } from '@sentry/core';
 import type { Client, Integration } from '@sentry/types';
 import { resolvedSyncPromise } from '@sentry/utils';
@@ -79,6 +80,18 @@ describe('init', () => {
     expect(DEFAULT_INTEGRATIONS[1]!.setupOnce as Mock).toHaveBeenCalledTimes(1);
   });
 
+  it('installs default integrations if `defaultIntegrations: undefined`', () => {
+    // @ts-expect-error this is fine for testing
+    const initAndBindSpy = vi.spyOn(SentryCore, 'initAndBind').mockImplementationOnce(() => {});
+    const options = getDefaultBrowserOptions({ dsn: PUBLIC_DSN, defaultIntegrations: undefined });
+    init(options);
+
+    expect(initAndBindSpy).toHaveBeenCalledTimes(1);
+
+    const optionsPassed = initAndBindSpy.mock.calls[0]?.[1];
+    expect(optionsPassed?.integrations?.length).toBeGreaterThan(0);
+  });
+
   test("doesn't install default integrations if told not to", () => {
     const DEFAULT_INTEGRATIONS: Integration[] = [
       new MockIntegration('MockIntegration 0.3'),
@@ -150,6 +163,7 @@ describe('init', () => {
       Object.defineProperty(WINDOW, 'browser', { value: undefined, writable: true });
       Object.defineProperty(WINDOW, 'nw', { value: undefined, writable: true });
       Object.defineProperty(WINDOW, 'window', { value: WINDOW, writable: true });
+      vi.clearAllMocks();
     });
 
     it('logs a browser extension error if executed inside a Chrome extension', () => {


### PR DESCRIPTION
While working on E2E tests for TwP in meta frameworks, I noticed that we have erroneous logic in the browser SDK init code: If users or our higher-level SDKs pass `defaultIntegrations: undefined` to the Browser SDK's init options, it deactivates all default integrations. As per our docs, this should only happen if you explicitly pass `defaultIntegrations: false`. 

This is caused by us spreading user-passed options over default SDK options, meaning previously set default options get overridden by users options being explicitly `undefined` instead of not set. 

This PR fixes this by removing the `defaultIntegrations` key from the user options object before merging the options together. Long-term, we need to fix this properly for all user-passed options. This is blocked on https://github.com/getsentry/sentry-javascript/issues/13262