### PR TITLE
feat(core): Add OpenTelemetry-specific `getTraceData` implementation

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/server.js
@@ -4,7 +4,6 @@ const Sentry = require('@sentry/node');
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
-  debug: true,
 });
 
 // express must be required after Sentry is initialized
@@ -30,5 +29,4 @@ app.get('/test', (_req, res) => {
 
 Sentry.setupExpressErrorHandler(app);
 
-// TODO: remove port again
-startExpressServerAndSendPortToRunner(app, 3000);
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/server.js
@@ -1,0 +1,34 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  transport: loggingTransport,
+  debug: true,
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+
+const app = express();
+
+app.get('/test', (_req, res) => {
+  res.send({
+    response: `
+    <html>
+      <head>
+        ${Sentry.getTraceMetaTags()}
+      </head>
+      <body>
+        Hi :)
+      </body>
+    </html>
+    `,
+  });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+// TODO: remove port again
+startExpressServerAndSendPortToRunner(app, 3000);

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
@@ -1,0 +1,33 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+describe('getTraceMetaTags', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  test('injects sentry tracing <meta> tags without sampled flag for Tracing Without Performance', async () => {
+    const runner = createRunner(__dirname, 'server.js').start();
+
+    const response = await runner.makeRequest('get', '/test');
+
+    // @ts-ignore - response is defined, types just don't reflect it
+    const html = response?.response as unknown as string;
+
+    console.log(html);
+
+    const [_, traceId, spanId] = html.match(/<meta name="sentry-trace" content="([a-f0-9]{32})-([a-f0-9]{16})"\/>/) || [
+      undefined,
+      undefined,
+      undefined,
+    ];
+
+    expect(traceId).toBeDefined();
+    expect(spanId).toBeDefined();
+
+    const sentryBaggageContent = html.match(/<meta name="baggage" content="(.*)"\/>/)?.[1];
+
+    expect(sentryBaggageContent).toEqual(
+      `sentry-environment=production,sentry-public_key=public,sentry-trace_id=${traceId}`,
+    );
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
@@ -13,9 +13,7 @@ describe('getTraceMetaTags', () => {
     // @ts-ignore - response is defined, types just don't reflect it
     const html = response?.response as unknown as string;
 
-    console.log(html);
-
-    const [_, traceId, spanId] = html.match(/<meta name="sentry-trace" content="([a-f0-9]{32})-([a-f0-9]{16})"\/>/) || [
+    const [, traceId, spanId] = html.match(/<meta name="sentry-trace" content="([a-f0-9]{32})-([a-f0-9]{16})"\/>/) || [
       undefined,
       undefined,
       undefined,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
@@ -24,8 +24,8 @@ describe('getTraceMetaTags', () => {
 
     const sentryBaggageContent = html.match(/<meta name="baggage" content="(.*)"\/>/)?.[1];
 
-    expect(sentryBaggageContent).toEqual(
-      `sentry-environment=production,sentry-public_key=public,sentry-trace_id=${traceId}`,
-    );
+    expect(sentryBaggageContent).toContain('sentry-environment=production');
+    expect(sentryBaggageContent).toContain('sentry-public_key=public');
+    expect(sentryBaggageContent).toContain(`sentry-trace_id=${traceId}`);
   });
 });

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -1,4 +1,5 @@
 import type { Scope } from '@sentry/types';
+import { getTraceData } from '../utils/traceData';
 import type {
   startInactiveSpan,
   startSpan,
@@ -64,4 +65,7 @@ export interface AsyncContextStrategy {
 
   /** Suppress tracing in the given callback, ensuring no spans are generated inside of it.  */
   suppressTracing?: typeof suppressTracing;
+
+  /** get trace data as serialized string values for propagation via `sentry-trace` and `baggage` */
+  getTraceData?: typeof getTraceData;
 }

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -1,5 +1,5 @@
 import type { Scope } from '@sentry/types';
-import { getTraceData } from '../utils/traceData';
+import type { getTraceData } from '../utils/traceData';
 import type {
   startInactiveSpan,
   startSpan,

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -66,6 +66,6 @@ export interface AsyncContextStrategy {
   /** Suppress tracing in the given callback, ensuring no spans are generated inside of it.  */
   suppressTracing?: typeof suppressTracing;
 
-  /** get trace data as serialized string values for propagation via `sentry-trace` and `baggage` */
+  /** Get trace data as serialized string values for propagation via `sentry-trace` and `baggage`. */
   getTraceData?: typeof getTraceData;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export type { OfflineStore, OfflineTransportOptions } from './transports/offline
 export type { ServerRuntimeClientOptions } from './server-runtime-client';
 export type { RequestDataIntegrationOptions } from './integrations/requestdata';
 export type { IntegrationIndex } from './integration';
+export type { TraceData } from './utils/traceData';
 
 export * from './tracing';
 export * from './semanticAttributes';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,10 @@
-export type { ClientClass } from './sdk';
+export type { ClientClass as SentryCoreCurrentScopes } from './sdk';
 export type { AsyncContextStrategy } from './asyncContext/types';
 export type { Carrier } from './carrier';
 export type { OfflineStore, OfflineTransportOptions } from './transports/offline';
 export type { ServerRuntimeClientOptions } from './server-runtime-client';
 export type { RequestDataIntegrationOptions } from './integrations/requestdata';
 export type { IntegrationIndex } from './integration';
-export type { TraceData } from './utils/traceData';
 
 export * from './tracing';
 export * from './semanticAttributes';

--- a/packages/core/src/utils/meta.ts
+++ b/packages/core/src/utils/meta.ts
@@ -1,4 +1,3 @@
-import type { Client, Scope, Span } from '@sentry/types';
 import { getTraceData } from './traceData';
 
 /**
@@ -22,8 +21,8 @@ import { getTraceData } from './traceData';
  * ```
  *
  */
-export function getTraceMetaTags(span?: Span, scope?: Scope, client?: Client): string {
-  return Object.entries(getTraceData(span, scope, client))
+export function getTraceMetaTags(): string {
+  return Object.entries(getTraceData())
     .map(([key, value]) => `<meta name="${key}" content="${value}"/>`)
     .join('\n');
 }

--- a/packages/core/src/utils/traceData.ts
+++ b/packages/core/src/utils/traceData.ts
@@ -1,4 +1,4 @@
-import type { Client, Scope, Span } from '@sentry/types';
+import type { SerializedTraceData } from '@sentry/types';
 import {
   TRACEPARENT_REGEXP,
   dynamicSamplingContextToSentryBaggageHeader,
@@ -11,11 +11,6 @@ import { getClient, getCurrentScope } from '../currentScopes';
 import { getDynamicSamplingContextFromClient, getDynamicSamplingContextFromSpan } from '../tracing';
 import { getActiveSpan, getRootSpan, spanToTraceHeader } from './spanUtils';
 
-export type TraceData = {
-  'sentry-trace'?: string;
-  baggage?: string;
-};
-
 /**
  * Extracts trace propagation data from the current span or from the client's scope (via transaction or propagation
  * context) and serializes it to `sentry-trace` and `baggage` values to strings. These values can be used to propagate
@@ -24,35 +19,31 @@ export type TraceData = {
  * This function also applies some validation to the generated sentry-trace and baggage values to ensure that
  * only valid strings are returned.
  *
- * @param span a span to take the trace data from. By default, the currently active span is used.
- * @param scope the scope to take trace data from By default, the active current scope is used.
- * @param client the SDK's client to take trace data from. By default, the current client is used.
- *
  * @returns an object with the tracing data values. The object keys are the name of the tracing key to be used as header
  * or meta tag name.
  */
-export function getTraceData(span?: Span, scope?: Scope, client?: Client): TraceData {
+export function getTraceData(): SerializedTraceData {
   const carrier = getMainCarrier();
   const acs = getAsyncContextStrategy(carrier);
   if (acs.getTraceData) {
-    return acs.getTraceData(span, scope, client);
+    return acs.getTraceData();
   }
 
-  const clientToUse = client || getClient();
-  const scopeToUse = scope || getCurrentScope();
-  const spanToUse = span || getActiveSpan();
+  const client = getClient();
+  const scope = getCurrentScope();
+  const span = getActiveSpan();
 
-  const { dsc, sampled, traceId } = scopeToUse.getPropagationContext();
-  const rootSpan = spanToUse && getRootSpan(spanToUse);
+  const { dsc, sampled, traceId } = scope.getPropagationContext();
+  const rootSpan = span && getRootSpan(span);
 
-  const sentryTrace = spanToUse ? spanToTraceHeader(spanToUse) : generateSentryTraceHeader(traceId, undefined, sampled);
+  const sentryTrace = span ? spanToTraceHeader(span) : generateSentryTraceHeader(traceId, undefined, sampled);
 
   const dynamicSamplingContext = rootSpan
     ? getDynamicSamplingContextFromSpan(rootSpan)
     : dsc
       ? dsc
-      : clientToUse
-        ? getDynamicSamplingContextFromClient(traceId, clientToUse)
+      : client
+        ? getDynamicSamplingContextFromClient(traceId, client)
         : undefined;
 
   const baggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,6 +1,6 @@
 import * as api from '@opentelemetry/api';
 import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
-import type { getTraceData as defaultGetTraceData, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
+import type { withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
 import type { Scope } from '@sentry/types';
 
 import {
@@ -104,9 +104,9 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     startInactiveSpan,
     getActiveSpan,
     suppressTracing,
+    getTraceData,
     // The types here don't fully align, because our own `Span` type is narrower
     // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
     withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,
-    getTraceData: getTraceData as typeof defaultGetTraceData,
   });
 }

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,6 +1,6 @@
 import * as api from '@opentelemetry/api';
 import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
-import type { withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
+import type { getTraceData as defaultGetTraceData, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
 import type { Scope } from '@sentry/types';
 
 import {
@@ -12,6 +12,7 @@ import { startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from '.
 import type { CurrentScopes } from './types';
 import { getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
+import { getTraceData } from './utils/getTraceData';
 import { suppressTracing } from './utils/suppressTracing';
 
 /**
@@ -102,9 +103,10 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     startSpanManual,
     startInactiveSpan,
     getActiveSpan,
+    suppressTracing,
     // The types here don't fully align, because our own `Span` type is narrower
     // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
     withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,
-    suppressTracing: suppressTracing,
+    getTraceData: getTraceData as typeof defaultGetTraceData,
   });
 }

--- a/packages/opentelemetry/src/utils/getTraceData.ts
+++ b/packages/opentelemetry/src/utils/getTraceData.ts
@@ -1,7 +1,6 @@
 import * as api from '@opentelemetry/api';
-import type { Span } from '@opentelemetry/api';
-import type { TraceData } from '@sentry/core';
 import { getCurrentScope } from '@sentry/core';
+import type { SerializedTraceData } from '@sentry/types';
 import { getPropagationContextFromSpan } from '../propagator';
 import { generateSpanContextForPropagationContext } from './generateSpanContextForPropagationContext';
 
@@ -9,9 +8,9 @@ import { generateSpanContextForPropagationContext } from './generateSpanContextF
  * Otel-specific implementation of `getTraceData`.
  * @see `@sentry/core` version of `getTraceData` for more information
  */
-export function getTraceData(span?: Span): TraceData {
+export function getTraceData(): SerializedTraceData {
   const ctx = api.context.active();
-  const spanToUse = span || api.trace.getSpan(ctx);
+  const spanToUse = api.trace.getSpan(ctx);
 
   // This should never happen, given we always create an ambient non-recording span if there's no active span.
   if (!spanToUse) {

--- a/packages/opentelemetry/src/utils/getTraceData.ts
+++ b/packages/opentelemetry/src/utils/getTraceData.ts
@@ -7,16 +7,9 @@ import { dropUndefinedKeys } from '@sentry/utils';
  * @see `@sentry/core` version of `getTraceData` for more information
  */
 export function getTraceData(): SerializedTraceData {
-  const context = api.context.active();
-
-  // This should never happen, given we always create an ambient non-recording span if there's no active span.
-  if (!context) {
-    return {};
-  }
-
   const headersObject: Record<string, string> = {};
 
-  api.propagation.inject(context, headersObject);
+  api.propagation.inject(api.context.active(), headersObject);
 
   if (!headersObject['sentry-trace']) {
     return {};

--- a/packages/opentelemetry/src/utils/getTraceData.ts
+++ b/packages/opentelemetry/src/utils/getTraceData.ts
@@ -1,0 +1,40 @@
+import * as api from '@opentelemetry/api';
+import type { Span } from '@opentelemetry/api';
+import type { TraceData } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
+import { getPropagationContextFromSpan } from '../propagator';
+import { generateSpanContextForPropagationContext } from './generateSpanContextForPropagationContext';
+
+/**
+ * Otel-specific implementation of `getTraceData`.
+ * @see `@sentry/core` version of `getTraceData` for more information
+ */
+export function getTraceData(span?: Span): TraceData {
+  const ctx = api.context.active();
+  const spanToUse = span || api.trace.getSpan(ctx);
+
+  // This should never happen, given we always create an ambient non-recording span if there's no active span.
+  if (!spanToUse) {
+    return {};
+  }
+  const headersObject: Record<string, string> = {};
+
+  const propagationContext = spanToUse
+    ? getPropagationContextFromSpan(spanToUse)
+    : getCurrentScope().getPropagationContext();
+
+  const spanContext = generateSpanContextForPropagationContext(propagationContext);
+
+  const context = api.trace.setSpanContext(ctx, spanContext);
+
+  api.propagation.inject(context, headersObject);
+
+  if (!headersObject['sentry-trace']) {
+    return {};
+  }
+
+  return {
+    'sentry-trace': headersObject['sentry-trace'],
+    baggage: headersObject['baggage'],
+  };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -121,7 +121,7 @@ export type { SpanStatus } from './spanStatus';
 export type { TimedEvent } from './timedEvent';
 export type { StackFrame } from './stackframe';
 export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
-export type { PropagationContext, TracePropagationTargets } from './tracing';
+export type { PropagationContext, TracePropagationTargets, SerializedTraceData } from './tracing';
 export type { StartSpanOptions } from './startSpanOptions';
 export type {
   TraceparentData,

--- a/packages/types/src/tracing.ts
+++ b/packages/types/src/tracing.ts
@@ -42,3 +42,12 @@ export interface PropagationContext {
    */
   dsc?: Partial<DynamicSamplingContext>;
 }
+
+/**
+ * An object holding trace data, like span and trace ids, sampling decision, and dynamic sampling context
+ * in a serialized form. Both keys are expected to be used as Http headers or Html meta tags.
+ */
+export interface SerializedTraceData {
+  'sentry-trace'?: string;
+  baggage?: string;
+}


### PR DESCRIPTION
This PR adds an Otel-specific version of `getTraceData` and adds the `getTraceData` function to the `AsyncContextStrategy` interface. This allows us to dynamically choose either the default implementation (which works correctly for browser/non-POTEL SDKs) and the Otel-specific version.

Our previous, universal implementation of  `getTraceData` didn't propagate the correct trace data in POTEL SDKs in Tracing Without Performance mode. The reason is that even in TwP mode, we start a non-recording span which is available via `getActiveSpan`. The previous implementation would therefore incorrectly take trace data from this span and even more incorrectly add a negative sampling decision to the trace data instead of deferring it.

Another change in this PR is that I removed the optional parameters for `getTraceData` and `getTraceMetaTags`. This is breaking but the function wasn't documented publicly at all yet. The reason is that this was premature API expansion because we realized we didn't need this functionality in our internal use cases. Furthermore, it would have severely complicated obtaining the correct trace data in the Otel implementation. 