### PR TITLE
feat(core): Return array or string from getTraceMetaTags()

### DIFF
--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -188,7 +188,7 @@ function addMetaTagToHead(htmlChunk: string, scope: Scope, client: Client, span?
   if (typeof htmlChunk !== 'string') {
     return htmlChunk;
   }
-  const metaTags = getTraceMetaTags(span, scope, client);
+  const metaTags = getTraceMetaTags({ span, scope, client });
 
   if (!metaTags) {
     return htmlChunk;

--- a/packages/core/src/utils/meta.ts
+++ b/packages/core/src/utils/meta.ts
@@ -1,8 +1,11 @@
 import type { Client, Scope, Span } from '@sentry/types';
 import { getTraceData } from './traceData';
 
+// Function overloads
+export function getTraceMetaTags(params?: { span?: Span; scope?: Scope; client?: Client; asArray: true }): string[];
+export function getTraceMetaTags(params?: { span?: Span; scope?: Scope; client?: Client; asArray?: false }): string;
 /**
- * Returns a string of meta tags that represent the current trace data.
+ * Returns a string or string[] of meta tags that represent the current trace data.
  *
  * You can use this to propagate a trace from your server-side rendered Html to the browser.
  * This function returns up to two meta tags, `sentry-trace` and `baggage`, depending on the
@@ -22,8 +25,15 @@ import { getTraceData } from './traceData';
  * ```
  *
  */
-export function getTraceMetaTags(span?: Span, scope?: Scope, client?: Client): string {
-  return Object.entries(getTraceData(span, scope, client))
-    .map(([key, value]) => `<meta name="${key}" content="${value}"/>`)
-    .join('\n');
+export function getTraceMetaTags({
+  span,
+  scope,
+  client,
+  asArray,
+}: { span?: Span; scope?: Scope; client?: Client; asArray?: boolean } = {}): string | string[] {
+  const traceTags = Object.entries(getTraceData(span, scope, client)).map(
+    ([key, value]) => `<meta name="${key}" content="${value}"/>`,
+  );
+
+  return asArray ? traceTags : traceTags.join('\n');
 }

--- a/packages/core/test/lib/utils/meta.test.ts
+++ b/packages/core/test/lib/utils/meta.test.ts
@@ -12,6 +12,20 @@ describe('getTraceMetaTags', () => {
 <meta name="baggage" content="sentry-environment=production"/>`);
   });
 
+  it('returns baggage and sentry-trace values to stringified Html meta tag array', () => {
+    jest.spyOn(TraceDataModule, 'getTraceData').mockReturnValueOnce({
+      'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
+      baggage: 'sentry-environment=production',
+    });
+
+    const metaTags = getTraceMetaTags({ asArray: true });
+
+    expect(metaTags).toContain('<meta name="baggage" content="sentry-environment=production"/>');
+    expect(metaTags).toContain(
+      '<meta name="sentry-trace" content="12345678901234567890123456789012-1234567890123456-1"/>',
+    );
+  });
+
   it('renders just sentry-trace values to stringified Html meta tags', () => {
     jest.spyOn(TraceDataModule, 'getTraceData').mockReturnValueOnce({
       'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',


### PR DESCRIPTION
Changing the function signature for the convenience of returning a string or an array of strings.
