### PR TITLE
fix(remix): Ensure `origin` is correctly set for remix server spans

### DIFF
--- a/packages/remix/test/integration/test/server/instrumentation-otel/loader.test.ts
+++ b/packages/remix/test/integration/test/server/instrumentation-otel/loader.test.ts
@@ -103,15 +103,17 @@ describe('Remix API Loaders', () => {
           data: {
             'code.function': 'loader',
             'sentry.op': 'loader.remix',
+            'sentry.origin': 'auto.http.otel.remix',
           },
-          origin: 'manual',
+          origin: 'auto.http.otel.remix',
         },
         {
           data: {
             'code.function': 'loader',
             'sentry.op': 'loader.remix',
+            'sentry.origin': 'auto.http.otel.remix',
           },
-          origin: 'manual',
+          origin: 'auto.http.otel.remix',
         },
       ],
     });


### PR DESCRIPTION
Noticed here: https://github.com/getsentry/sentry-javascript/pull/13282 that we are not correctly setting origin for remix spans.