### PR TITLE
fix(astro): Correctly extract request data

### DIFF
--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -224,9 +224,9 @@ describe('sentryMiddleware', () => {
         request: {
           method: 'GET',
           url: '/users',
-          headers: new Headers({
+          headers: {
             'some-header': 'some-value',
-          }),
+          },
         },
       });
       expect(next).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
builds on top of #13306, found while working on #13116

This PR ensures that we correctly extract the request data in our Astro middleware. Previously we didn't convert the `request.headers` object into a `Record<string, string>` but simply passed a `Headers` instance. This caused problems with the `requestDataIntegration` which doesn't handle the instance correctly. 
