### PR TITLE
docs: Remove alpha message for `@sentry/opentelemetry`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -818,10 +818,10 @@ jobs:
           pattern: profiling-node-binaries-${{ github.sha }}-*
           path: ${{ github.workspace }}/packages/profiling-node/lib/
           merge-multiple: true
-
-      - name: Build Profiling tarball
-        run: yarn build:tarball
       # End rebuild profiling
+
+      - name: Build tarballs
+        run: yarn build:tarball
 
       - name: Stores tarballs in cache
         uses: actions/cache/save@v4

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -12,8 +12,8 @@
 
 This package allows you to send your OpenTelemetry trace data to Sentry via OpenTelemetry SpanProcessors.
 
-This SDK is **considered experimental and in an alpha state**. It may experience breaking changes. Please reach out on
-[GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback/concerns.
+If you are using `@sentry/node`, OpenTelemetry support is included out of the box. This package is only necessary if you
+are setting up OpenTelemetry support for Sentry yourself.
 
 ## Installation
 


### PR DESCRIPTION
Noticed that we still called this out as alpha, even though it is not.