### PR TITLE
chore(ci): Adjust contribution message for multiple contributors

### DIFF
--- a/dev-packages/external-contributor-gh-action/index.mjs
+++ b/dev-packages/external-contributor-gh-action/index.mjs
@@ -48,7 +48,7 @@ async function run() {
     const newContributors = formatter.format(users);
     const newChangelog = changelogStr.replace(
       contributorMessageRegex,
-      `Work in this release was contributed by ${newContributors}. Thank you for your contribution!`,
+      `Work in this release was contributed by ${newContributors}. Thank you for your contributions!`,
     );
 
     fs.writeFile(changelogFilePath, newChangelog);


### PR DESCRIPTION
Tiny PR but just noticed that we should write "thank you for your contribution**s**" if we credit multiple contributors in a changelog entry. 