### PR TITLE
test: Ensure browser-integration-tests cannot conflict due to build

### DIFF
--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import { expect } from '@playwright/test';
 
 import { TEST_HOST, sentryTest } from '../../../../utils/fixtures';
@@ -28,6 +28,8 @@ sentryTest('it does not download the SDK if the SDK was loaded in the meanwhile'
     });
   });
 
+  const tmpDir = await getLocalTestUrl({ testDir: __dirname, skipRouteHandler: true });
+
   await page.route(`${TEST_HOST}/*.*`, route => {
     const file = route.request().url().split('/').pop();
 
@@ -35,12 +37,13 @@ sentryTest('it does not download the SDK if the SDK was loaded in the meanwhile'
       cdnLoadedCount++;
     }
 
-    const filePath = path.resolve(__dirname, `./dist/${file}`);
+    const filePath = path.resolve(tmpDir, `./${file}`);
 
     return fs.existsSync(filePath) ? route.fulfill({ path: filePath }) : route.continue();
   });
 
-  const url = await getLocalTestUrl({ testDir: __dirname, skipRouteHandler: true });
+  const url = `${TEST_HOST}/index.html`;
+
   const req = await waitForErrorRequestOnUrl(page, url);
 
   const eventData = envelopeRequestParser(req);

--- a/dev-packages/browser-integration-tests/playwright.config.ts
+++ b/dev-packages/browser-integration-tests/playwright.config.ts
@@ -31,6 +31,7 @@ const config: PlaywrightTestConfig = {
   ],
 
   globalSetup: require.resolve('./playwright.setup.ts'),
+  globalTeardown: require.resolve('./playwright.teardown.ts'),
 };
 
 export default config;

--- a/dev-packages/browser-integration-tests/playwright.teardown.ts
+++ b/dev-packages/browser-integration-tests/playwright.teardown.ts
@@ -1,0 +1,5 @@
+import * as childProcess from 'child_process';
+
+export default function globalTeardown(): void {
+  childProcess.execSync('yarn clean', { stdio: 'inherit', cwd: process.cwd() });
+}

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/get/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/get/subject.js
@@ -1,3 +1,3 @@
-fetch('http://localhost:7654/foo').then(() => {
+fetch('http://sentry-test.io/foo').then(() => {
   Sentry.captureException('test error');
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/get/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/get/test.ts
@@ -31,7 +31,7 @@ sentryTest('captures Breadcrumb for basic GET request', async ({ getLocalTestUrl
     data: {
       method: 'GET',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/getWithRequestObj/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/getWithRequestObj/subject.js
@@ -1,3 +1,3 @@
-fetch(new Request('http://localhost:7654/foo')).then(() => {
+fetch(new Request('http://sentry-test.io/foo')).then(() => {
   Sentry.captureException('test error');
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/getWithRequestObj/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/getWithRequestObj/test.ts
@@ -31,7 +31,7 @@ sentryTest('captures Breadcrumb for basic GET request that uses request object',
     data: {
       method: 'GET',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/post/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/post/subject.js
@@ -1,4 +1,4 @@
-fetch('http://localhost:7654/foo', {
+fetch('http://sentry-test.io/foo', {
   method: 'POST',
   body: '{"my":"body"}',
   headers: {

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/post/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/post/test.ts
@@ -31,7 +31,7 @@ sentryTest('captures Breadcrumb for POST request', async ({ getLocalTestUrl, pag
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/get/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/get/subject.js
@@ -1,6 +1,6 @@
 const xhr = new XMLHttpRequest();
 
-xhr.open('GET', 'http://localhost:7654/foo');
+xhr.open('GET', 'http://sentry-test.io/foo');
 xhr.send();
 
 xhr.addEventListener('readystatechange', function () {

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/get/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/get/test.ts
@@ -32,7 +32,7 @@ sentryTest('captures Breadcrumb for basic GET request', async ({ getLocalTestUrl
     data: {
       method: 'GET',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/post/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/post/subject.js
@@ -1,6 +1,6 @@
 const xhr = new XMLHttpRequest();
 
-xhr.open('POST', 'http://localhost:7654/foo');
+xhr.open('POST', 'http://sentry-test.io/foo');
 xhr.setRequestHeader('Accept', 'application/json');
 xhr.setRequestHeader('Content-Type', 'application/json');
 xhr.send('{"my":"body"}');

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/post/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/post/test.ts
@@ -31,7 +31,7 @@ sentryTest('captures Breadcrumb for POST request', async ({ getLocalTestUrl, pag
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/axios/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/axios/subject.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 axios
-  .get('http://localhost:7654/foo', {
+  .get('http://sentry-test.io/foo', {
     headers: { Accept: 'application/json', 'Content-Type': 'application/json', Cache: 'no-cache' },
   })
   .then(response => {

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
@@ -44,7 +44,7 @@ sentryTest(
         ],
       },
       request: {
-        url: 'http://localhost:7654/foo',
+        url: 'http://sentry-test.io/foo',
         method: 'GET',
         headers: {
           accept: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/subject.js
@@ -1,4 +1,4 @@
-fetch('http://localhost:7654/foo', {
+fetch('http://sentry-test.io/foo', {
   method: 'GET',
   credentials: 'include',
   headers: {

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
@@ -46,7 +46,7 @@ sentryTest(
         ],
       },
       request: {
-        url: 'http://localhost:7654/foo',
+        url: 'http://sentry-test.io/foo',
         method: 'GET',
         headers: {
           accept: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withAbortController/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withAbortController/subject.js
@@ -10,7 +10,7 @@ const startFetch = e => {
       forceTransaction: true,
     },
     async () => {
-      await fetch('http://localhost:7654/foo', { signal })
+      await fetch('http://sentry-test.io/foo', { signal })
         .then(response => response.json())
         .then(data => {
           console.log('Fetch succeeded:', data);

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/subject.js
@@ -1,4 +1,4 @@
-const request = new Request('http://localhost:7654/foo', {
+const request = new Request('http://sentry-test.io/foo', {
   method: 'POST',
   credentials: 'include',
   headers: {

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/test.ts
@@ -42,7 +42,7 @@ sentryTest('works with a Request passed in', async ({ getLocalTestPath, page }) 
       ],
     },
     request: {
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
       method: 'POST',
       headers: {
         accept: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/subject.js
@@ -1,4 +1,4 @@
-const request = new Request('http://localhost:7654/foo', {
+const request = new Request('http://sentry-test.io/foo', {
   method: 'POST',
   credentials: 'include',
   headers: {

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/test.ts
@@ -44,7 +44,7 @@ sentryTest(
         ],
       },
       request: {
-        url: 'http://localhost:7654/foo',
+        url: 'http://sentry-test.io/foo',
         method: 'POST',
         headers: {
           accept: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/subject.js
@@ -1,4 +1,4 @@
-const request = new Request('http://localhost:7654/foo', {
+const request = new Request('http://sentry-test.io/foo', {
   method: 'POST',
   credentials: 'include',
   headers: {

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/test.ts
@@ -42,7 +42,7 @@ sentryTest('works with a Request (without body) & options passed in', async ({ g
       ],
     },
     request: {
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
       method: 'POST',
       headers: {
         accept: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/subject.js
@@ -1,6 +1,6 @@
 const xhr = new XMLHttpRequest();
 
-xhr.open('GET', 'http://localhost:7654/foo', true);
+xhr.open('GET', 'http://sentry-test.io/foo', true);
 xhr.withCredentials = true;
 xhr.setRequestHeader('Accept', 'application/json');
 xhr.setRequestHeader('Content-Type', 'application/json');

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/test.ts
@@ -42,7 +42,7 @@ sentryTest('works with httpClientIntegration', async ({ getLocalTestPath, page }
       ],
     },
     request: {
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
       method: 'GET',
       headers: {
         accept: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/subject.js
@@ -1,6 +1,6 @@
 const xhr = new XMLHttpRequest();
 
-xhr.open('GET', 'http://localhost:7654/foo', true);
+xhr.open('GET', 'http://sentry-test.io/foo', true);
 xhr.withCredentials = true;
 xhr.setRequestHeader('Accept', 'application/json');
 xhr.setRequestHeader('Content-Type', 'application/json');

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/test.ts
@@ -44,7 +44,7 @@ sentryTest(
         ],
       },
       request: {
-        url: 'http://localhost:7654/foo',
+        url: 'http://sentry-test.io/foo',
         method: 'GET',
         headers: {
           accept: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/public-api/init/built-pkg/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/init/built-pkg/test.ts
@@ -6,14 +6,14 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 
 // Regression test against https://github.com/getsentry/sentry-javascript/pull/1896
-sentryTest('should not contain tslib_1__default', async ({ getLocalTestPath }) => {
-  await getLocalTestPath({ testDir: __dirname });
+sentryTest('should not contain tslib_1__default', async ({ getLocalTestUrl }) => {
+  const tmpDir = await getLocalTestUrl({ testDir: __dirname, skipRouteHandler: true });
 
-  const initBundle = fs.readFileSync(path.join(__dirname, 'dist', 'init.bundle.js'), 'utf-8');
+  const initBundle = fs.readFileSync(path.join(tmpDir, 'init.bundle.js'), 'utf-8');
   expect(initBundle.length).toBeGreaterThan(0);
   expect(initBundle).not.toContain('tslib_1__default');
 
-  const subjectBundle = fs.readFileSync(path.join(__dirname, 'dist', 'subject.bundle.js'), 'utf-8');
+  const subjectBundle = fs.readFileSync(path.join(tmpDir, 'subject.bundle.js'), 'utf-8');
   expect(subjectBundle.length).toBeGreaterThan(0);
   expect(subjectBundle).not.toContain('tslib_1__default');
 });

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -34,7 +34,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
     timestamp: expect.any(Number),
     error_ids: [],
     trace_ids: [],
-    urls: [expect.stringContaining('/dist/index.html')],
+    urls: [expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/)],
     replay_id: expect.stringMatching(/\w{32}/),
     replay_start_timestamp: expect.any(Number),
     segment_id: 0,
@@ -57,7 +57,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringContaining('/dist/index.html'),
+      url: expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/),
       headers: {
         'User-Agent': expect.stringContaining(''),
       },
@@ -94,7 +94,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringContaining('/dist/index.html'),
+      url: expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/),
       headers: {
         'User-Agent': expect.stringContaining(''),
       },

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -34,7 +34,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
     timestamp: expect.any(Number),
     error_ids: [],
     trace_ids: [],
-    urls: [expect.stringContaining('/dist/index.html')],
+    urls: [expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/)],
     replay_id: expect.stringMatching(/\w{32}/),
     replay_start_timestamp: expect.any(Number),
     segment_id: 0,
@@ -57,7 +57,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringContaining('/dist/index.html'),
+      url: expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/),
       headers: {
         'User-Agent': expect.stringContaining(''),
       },
@@ -94,7 +94,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringContaining('/dist/index.html'),
+      url: expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/),
       headers: {
         'User-Agent': expect.stringContaining(''),
       },

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/init.js
@@ -6,7 +6,7 @@ window.Replay = Sentry.replayIntegration({
   flushMaxDelay: 200,
   minReplayDuration: 0,
 
-  networkDetailAllowUrls: ['http://localhost:7654/foo', 'http://sentry-test.io/foo'],
+  networkDetailAllowUrls: ['http://sentry-test.io/foo'],
   networkCaptureBodies: true,
 });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/test.ts
@@ -8,258 +8,14 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures text request body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
-  await page.route('**/foo', route => {
-    return route.fulfill({
-      status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
-  const requestPromise = waitForErrorRequest(page);
-  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
-    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
-  });
-
-  const url = await getLocalTestPath({ testDir: __dirname });
-  await page.goto(url);
-
-  await page.evaluate(() => {
-    /* eslint-disable */
-    fetch('http://localhost:7654/foo', {
-      method: 'POST',
-      body: 'input body',
-    }).then(() => {
-      // @ts-expect-error Sentry is a global
-      Sentry.captureException('test error');
-    });
-    /* eslint-enable */
-  });
-
-  const request = await requestPromise;
-  const eventData = envelopeRequestParser(request);
-
-  expect(eventData.exception?.values).toHaveLength(1);
-
-  expect(eventData?.breadcrumbs?.length).toBe(1);
-  expect(eventData!.breadcrumbs![0]).toEqual({
-    timestamp: expect.any(Number),
-    category: 'fetch',
-    type: 'http',
-    data: {
-      method: 'POST',
-      request_body_size: 10,
-      status_code: 200,
-      url: 'http://localhost:7654/foo',
-    },
-  });
-
-  const { replayRecordingSnapshots } = await replayRequestPromise;
-  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.fetch')).toEqual([
-    {
-      data: {
-        method: 'POST',
-        statusCode: 200,
-        request: {
-          size: 10,
-          headers: {},
-          body: 'input body',
-        },
-        response: additionalHeaders ? { headers: additionalHeaders } : undefined,
-      },
-      description: 'http://localhost:7654/foo',
-      endTimestamp: expect.any(Number),
-      op: 'resource.fetch',
-      startTimestamp: expect.any(Number),
-    },
-  ]);
-});
-
-sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browserName }) => {
-  if (shouldSkipReplayTest()) {
-    sentryTest.skip();
-  }
-
-  const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
-
-  await page.route('**/foo', route => {
-    return route.fulfill({
-      status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
-  const requestPromise = waitForErrorRequest(page);
-  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
-    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
-  });
-
-  const url = await getLocalTestPath({ testDir: __dirname });
-  await page.goto(url);
-
-  await page.evaluate(() => {
-    /* eslint-disable */
-    fetch('http://localhost:7654/foo', {
-      method: 'POST',
-      body: '{"foo":"bar"}',
-    }).then(() => {
-      // @ts-expect-error Sentry is a global
-      Sentry.captureException('test error');
-    });
-    /* eslint-enable */
-  });
-
-  const request = await requestPromise;
-  const eventData = envelopeRequestParser(request);
-
-  expect(eventData.exception?.values).toHaveLength(1);
-
-  expect(eventData?.breadcrumbs?.length).toBe(1);
-  expect(eventData!.breadcrumbs![0]).toEqual({
-    timestamp: expect.any(Number),
-    category: 'fetch',
-    type: 'http',
-    data: {
-      method: 'POST',
-      request_body_size: 13,
-      status_code: 200,
-      url: 'http://localhost:7654/foo',
-    },
-  });
-
-  const { replayRecordingSnapshots } = await replayRequestPromise;
-  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.fetch')).toEqual([
-    {
-      data: {
-        method: 'POST',
-        statusCode: 200,
-        request: {
-          size: 13,
-          headers: {},
-          body: { foo: 'bar' },
-        },
-        response: additionalHeaders ? { headers: additionalHeaders } : undefined,
-      },
-      description: 'http://localhost:7654/foo',
-      endTimestamp: expect.any(Number),
-      op: 'resource.fetch',
-      startTimestamp: expect.any(Number),
-    },
-  ]);
-});
-
-sentryTest('captures non-text request body', async ({ getLocalTestPath, page, browserName }) => {
-  if (shouldSkipReplayTest()) {
-    sentryTest.skip();
-  }
-
-  const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
-
-  await page.route('**/foo', route => {
-    return route.fulfill({
-      status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
-  const requestPromise = waitForErrorRequest(page);
-  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
-    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
-  });
-
-  const url = await getLocalTestPath({ testDir: __dirname });
-  await page.goto(url);
-
-  await page.evaluate(() => {
-    const body = new URLSearchParams();
-    body.append('name', 'Anne');
-    body.append('age', '32');
-
-    /* eslint-disable */
-    fetch('http://localhost:7654/foo', {
-      method: 'POST',
-      body: body,
-    }).then(() => {
-      // @ts-expect-error Sentry is a global
-      Sentry.captureException('test error');
-    });
-    /* eslint-enable */
-  });
-
-  const request = await requestPromise;
-  const eventData = envelopeRequestParser(request);
-
-  expect(eventData.exception?.values).toHaveLength(1);
-
-  expect(eventData?.breadcrumbs?.length).toBe(1);
-  expect(eventData!.breadcrumbs![0]).toEqual({
-    timestamp: expect.any(Number),
-    category: 'fetch',
-    type: 'http',
-    data: {
-      method: 'POST',
-      request_body_size: 16,
-      status_code: 200,
-      url: 'http://localhost:7654/foo',
-    },
-  });
-
-  const { replayRecordingSnapshots } = await replayRequestPromise;
-  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.fetch')).toEqual([
-    {
-      data: {
-        method: 'POST',
-        statusCode: 200,
-        request: {
-          size: 16,
-          headers: {},
-          body: 'name=Anne&age=32',
-        },
-        response: additionalHeaders ? { headers: additionalHeaders } : undefined,
-      },
-      description: 'http://localhost:7654/foo',
-      endTimestamp: expect.any(Number),
-      op: 'resource.fetch',
-      startTimestamp: expect.any(Number),
-    },
-  ]);
-});
-
-sentryTest('captures text request body when matching relative URL', async ({ getLocalTestUrl, page, browserName }) => {
-  if (shouldSkipReplayTest()) {
-    sentryTest.skip();
-  }
-
-  const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
-
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -282,7 +38,244 @@ sentryTest('captures text request body when matching relative URL', async ({ get
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
+    fetch('http://sentry-test.io/foo', {
+      method: 'POST',
+      body: 'input body',
+    }).then(() => {
+      // @ts-expect-error Sentry is a global
+      Sentry.captureException('test error');
+    });
+  });
+
+  const request = await requestPromise;
+  const eventData = envelopeRequestParser(request);
+
+  expect(eventData.exception?.values).toHaveLength(1);
+
+  expect(eventData?.breadcrumbs?.length).toBe(1);
+  expect(eventData!.breadcrumbs![0]).toEqual({
+    timestamp: expect.any(Number),
+    category: 'fetch',
+    type: 'http',
+    data: {
+      method: 'POST',
+      request_body_size: 10,
+      status_code: 200,
+      url: 'http://sentry-test.io/foo',
+    },
+  });
+
+  const { replayRecordingSnapshots } = await replayRequestPromise;
+  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.fetch')).toEqual([
+    {
+      data: {
+        method: 'POST',
+        statusCode: 200,
+        request: {
+          size: 10,
+          headers: {},
+          body: 'input body',
+        },
+        response: additionalHeaders ? { headers: additionalHeaders } : undefined,
+      },
+      description: 'http://sentry-test.io/foo',
+      endTimestamp: expect.any(Number),
+      op: 'resource.fetch',
+      startTimestamp: expect.any(Number),
+    },
+  ]);
+});
+
+sentryTest('captures JSON request body', async ({ getLocalTestUrl, page, browserName }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
+
+  await page.route('http://sentry-test.io/foo', route => {
+    return route.fulfill({
+      status: 200,
+    });
+  });
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const requestPromise = waitForErrorRequest(page);
+  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
+    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  await page.evaluate(() => {
+    fetch('http://sentry-test.io/foo', {
+      method: 'POST',
+      body: '{"foo":"bar"}',
+    }).then(() => {
+      // @ts-expect-error Sentry is a global
+      Sentry.captureException('test error');
+    });
+  });
+
+  const request = await requestPromise;
+  const eventData = envelopeRequestParser(request);
+
+  expect(eventData.exception?.values).toHaveLength(1);
+
+  expect(eventData?.breadcrumbs?.length).toBe(1);
+  expect(eventData!.breadcrumbs![0]).toEqual({
+    timestamp: expect.any(Number),
+    category: 'fetch',
+    type: 'http',
+    data: {
+      method: 'POST',
+      request_body_size: 13,
+      status_code: 200,
+      url: 'http://sentry-test.io/foo',
+    },
+  });
+
+  const { replayRecordingSnapshots } = await replayRequestPromise;
+  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.fetch')).toEqual([
+    {
+      data: {
+        method: 'POST',
+        statusCode: 200,
+        request: {
+          size: 13,
+          headers: {},
+          body: { foo: 'bar' },
+        },
+        response: additionalHeaders ? { headers: additionalHeaders } : undefined,
+      },
+      description: 'http://sentry-test.io/foo',
+      endTimestamp: expect.any(Number),
+      op: 'resource.fetch',
+      startTimestamp: expect.any(Number),
+    },
+  ]);
+});
+
+sentryTest('captures non-text request body', async ({ getLocalTestUrl, page, browserName }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
+
+  await page.route('http://sentry-test.io/foo', route => {
+    return route.fulfill({
+      status: 200,
+    });
+  });
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const requestPromise = waitForErrorRequest(page);
+  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
+    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  await page.evaluate(() => {
+    const body = new URLSearchParams();
+    body.append('name', 'Anne');
+    body.append('age', '32');
+
+    fetch('http://sentry-test.io/foo', {
+      method: 'POST',
+      body: body,
+    }).then(() => {
+      // @ts-expect-error Sentry is a global
+      Sentry.captureException('test error');
+    });
+  });
+
+  const request = await requestPromise;
+  const eventData = envelopeRequestParser(request);
+
+  expect(eventData.exception?.values).toHaveLength(1);
+
+  expect(eventData?.breadcrumbs?.length).toBe(1);
+  expect(eventData!.breadcrumbs![0]).toEqual({
+    timestamp: expect.any(Number),
+    category: 'fetch',
+    type: 'http',
+    data: {
+      method: 'POST',
+      request_body_size: 16,
+      status_code: 200,
+      url: 'http://sentry-test.io/foo',
+    },
+  });
+
+  const { replayRecordingSnapshots } = await replayRequestPromise;
+  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.fetch')).toEqual([
+    {
+      data: {
+        method: 'POST',
+        statusCode: 200,
+        request: {
+          size: 16,
+          headers: {},
+          body: 'name=Anne&age=32',
+        },
+        response: additionalHeaders ? { headers: additionalHeaders } : undefined,
+      },
+      description: 'http://sentry-test.io/foo',
+      endTimestamp: expect.any(Number),
+      op: 'resource.fetch',
+      startTimestamp: expect.any(Number),
+    },
+  ]);
+});
+
+sentryTest('captures text request body when matching relative URL', async ({ getLocalTestUrl, page, browserName }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
+
+  await page.route('http://sentry-test.io/foo', route => {
+    return route.fulfill({
+      status: 200,
+    });
+  });
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const requestPromise = waitForErrorRequest(page);
+  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
+    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  await page.evaluate(() => {
     fetch('/foo', {
       method: 'POST',
       body: 'input body',
@@ -290,7 +283,6 @@ sentryTest('captures text request body when matching relative URL', async ({ get
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -332,12 +324,12 @@ sentryTest('captures text request body when matching relative URL', async ({ get
   ]);
 });
 
-sentryTest('does not capture request body when URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest('does not capture request body when URL does not match', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
-  await page.route('**/bar', route => {
+  await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
     });
@@ -356,19 +348,17 @@ sentryTest('does not capture request body when URL does not match', async ({ get
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
-    fetch('http://localhost:7654/bar', {
+    fetch('http://sentry-test.io/bar', {
       method: 'POST',
       body: 'input body',
     }).then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -385,7 +375,7 @@ sentryTest('does not capture request body when URL does not match', async ({ get
       method: 'POST',
       request_body_size: 10,
       status_code: 200,
-      url: 'http://localhost:7654/bar',
+      url: 'http://sentry-test.io/bar',
     },
   });
 
@@ -409,7 +399,7 @@ sentryTest('does not capture request body when URL does not match', async ({ get
           },
         },
       },
-      description: 'http://localhost:7654/bar',
+      description: 'http://sentry-test.io/bar',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/init.js
@@ -6,7 +6,7 @@ window.Replay = Sentry.replayIntegration({
   flushMaxDelay: 200,
   minReplayDuration: 0,
 
-  networkDetailAllowUrls: ['http://localhost:7654/foo'],
+  networkDetailAllowUrls: ['http://sentry-test.io/foo'],
   networkRequestHeaders: ['X-Test-Header'],
 });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
@@ -8,14 +8,14 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('handles empty/missing request headers', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -32,19 +32,17 @@ sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, p
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
-      fetch('http://localhost:7654/foo', {
+      fetch('http://sentry-test.io/foo', {
         method: 'POST',
       }).then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
     replayRequestPromise,
@@ -62,7 +60,7 @@ sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, p
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -73,7 +71,7 @@ sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, p
         statusCode: 200,
         response: additionalHeaders ? { headers: additionalHeaders } : undefined,
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -81,14 +79,14 @@ sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, p
   ]);
 });
 
-sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers as POJO', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -107,13 +105,12 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, 
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
-      fetch('http://localhost:7654/foo', {
+      fetch('http://sentry-test.io/foo', {
         method: 'POST',
         headers: {
           Accept: 'application/json',
@@ -126,7 +123,6 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, 
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
     replayRequestPromise,
@@ -144,7 +140,7 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, 
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -162,7 +158,7 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, 
         },
         response: additionalHeaders ? { headers: additionalHeaders } : undefined,
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -170,14 +166,14 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, 
   ]);
 });
 
-sentryTest('captures request headers on Request', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers on Request', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -194,12 +190,12 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
     page.evaluate(() => {
-      const request = new Request('http://localhost:7654/foo', {
+      const request = new Request('http://sentry-test.io/foo', {
         method: 'POST',
         headers: {
           Accept: 'application/json',
@@ -208,12 +204,11 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
           'X-Custom-Header': 'foo',
         },
       });
-      /* eslint-disable */
+
       fetch(request).then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
     replayRequestPromise,
@@ -231,7 +226,7 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -248,7 +243,7 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
         },
         response: additionalHeaders ? { headers: additionalHeaders } : undefined,
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -256,14 +251,14 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
   ]);
 });
 
-sentryTest('captures request headers as Headers instance', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers as Headers instance', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -280,7 +275,7 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
 
@@ -292,15 +287,13 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
       headers.append('Cache', 'no-cache');
       headers.append('X-Custom-Header', 'foo');
 
-      /* eslint-disable */
-      fetch('http://localhost:7654/foo', {
+      fetch('http://sentry-test.io/foo', {
         method: 'POST',
         headers,
       }).then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
     replayRequestPromise,
@@ -318,7 +311,7 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -335,7 +328,7 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
         },
         response: additionalHeaders ? { headers: additionalHeaders } : undefined,
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -343,12 +336,12 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
   ]);
 });
 
-sentryTest('does not captures request headers if URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest('does not captures request headers if URL does not match', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
-  await page.route('**/bar', route => {
+  await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
     });
@@ -367,13 +360,12 @@ sentryTest('does not captures request headers if URL does not match', async ({ g
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
-      fetch('http://localhost:7654/bar', {
+      fetch('http://sentry-test.io/bar', {
         method: 'POST',
         headers: {
           Accept: 'application/json',
@@ -386,7 +378,6 @@ sentryTest('does not captures request headers if URL does not match', async ({ g
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
     replayRequestPromise,
@@ -404,7 +395,7 @@ sentryTest('does not captures request headers if URL does not match', async ({ g
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/bar',
+      url: 'http://sentry-test.io/bar',
     },
   });
 
@@ -426,7 +417,7 @@ sentryTest('does not captures request headers if URL does not match', async ({ g
           },
         },
       },
-      description: 'http://localhost:7654/bar',
+      description: 'http://sentry-test.io/bar',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
@@ -8,12 +8,12 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures request body size when body is sent', async ({ getLocalTestPath, page }) => {
+sentryTest('captures request body size when body is sent', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -32,20 +32,18 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
-      fetch('http://localhost:7654/foo', {
+      fetch('http://sentry-test.io/foo', {
         method: 'POST',
         body: '{"foo":"bar"}',
       }).then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
     replayRequestPromise,
@@ -64,7 +62,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
       method: 'POST',
       request_body_size: 13,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -87,7 +85,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -95,7 +93,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
   ]);
 });
 
-sentryTest('captures request size from non-text request body', async ({ getLocalTestPath, page }) => {
+sentryTest('captures request size from non-text request body', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -119,22 +117,20 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
       const blob = new Blob(['<html>Hello world!!</html>'], { type: 'text/html' });
 
-      fetch('http://localhost:7654/foo', {
+      fetch('http://sentry-test.io/foo', {
         method: 'POST',
         body: blob,
       }).then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
     replayRequestPromise,
@@ -153,7 +149,7 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
       method: 'POST',
       request_body_size: 26,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -176,7 +172,7 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/init.js
@@ -6,7 +6,7 @@ window.Replay = Sentry.replayIntegration({
   flushMaxDelay: 200,
   minReplayDuration: 0,
 
-  networkDetailAllowUrls: ['http://localhost:7654/foo'],
+  networkDetailAllowUrls: ['http://sentry-test.io/foo'],
   networkCaptureBodies: true,
 });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/test.ts
@@ -8,14 +8,14 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures text response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures text response body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: 'response body',
@@ -35,18 +35,16 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
-    fetch('http://localhost:7654/foo', {
+    fetch('http://sentry-test.io/foo', {
       method: 'POST',
     }).then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -63,7 +61,7 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
       method: 'POST',
       response_body_size: 13,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -82,7 +80,7 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
           body: 'response body',
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -90,14 +88,14 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
   ]);
 });
 
-sentryTest('captures JSON response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures JSON response body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: JSON.stringify({ res: 'this' }),
@@ -117,18 +115,16 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
-    fetch('http://localhost:7654/foo', {
+    fetch('http://sentry-test.io/foo', {
       method: 'POST',
     }).then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -145,7 +141,7 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
       method: 'POST',
       response_body_size: 14,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -164,7 +160,7 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
           body: { res: 'this' },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -172,14 +168,14 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
   ]);
 });
 
-sentryTest('captures non-text response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures non-text response body', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'application/octet-stream' } : {};
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: Buffer.from('<html>Hello world</html>'),
@@ -199,18 +195,16 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
-    fetch('http://localhost:7654/foo', {
+    fetch('http://sentry-test.io/foo', {
       method: 'POST',
     }).then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -227,7 +221,7 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
       method: 'POST',
       response_body_size: 24,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -246,7 +240,7 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
           body: '<html>Hello world</html>',
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -256,12 +250,12 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
 
 // This test is flaky
 // See: https://github.com/getsentry/sentry-javascript/issues/11136
-sentryTest.skip('does not capture response body when URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest.skip('does not capture response body when URL does not match', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
-  await page.route('**/bar', route => {
+  await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
       body: 'response body',
@@ -281,18 +275,16 @@ sentryTest.skip('does not capture response body when URL does not match', async 
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
-    fetch('http://localhost:7654/bar', {
+    fetch('http://sentry-test.io/bar', {
       method: 'POST',
     }).then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -309,7 +301,7 @@ sentryTest.skip('does not capture response body when URL does not match', async 
       method: 'POST',
       response_body_size: 13,
       status_code: 200,
-      url: 'http://localhost:7654/bar',
+      url: 'http://sentry-test.io/bar',
     },
   });
 
@@ -333,7 +325,7 @@ sentryTest.skip('does not capture response body when URL does not match', async 
           },
         },
       },
-      description: 'http://localhost:7654/bar',
+      description: 'http://sentry-test.io/bar',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/init.js
@@ -6,7 +6,7 @@ window.Replay = Sentry.replayIntegration({
   flushMaxDelay: 200,
   minReplayDuration: 0,
 
-  networkDetailAllowUrls: ['http://localhost:7654/foo'],
+  networkDetailAllowUrls: ['http://sentry-test.io/foo'],
   networkResponseHeaders: ['X-Test-Header'],
 });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
@@ -8,14 +8,14 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('handles empty headers', async ({ getLocalTestUrl, page, browserName }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -34,12 +34,12 @@ sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
     page.evaluate(() => {
-      fetch('http://localhost:7654/foo').then(() => {
+      fetch('http://sentry-test.io/foo').then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
@@ -59,7 +59,7 @@ sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName
     data: {
       method: 'GET',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -71,7 +71,7 @@ sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName
         statusCode: 200,
         response: additionalHeaders ? { headers: additionalHeaders } : undefined,
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -79,12 +79,12 @@ sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName
   ]);
 });
 
-sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response headers', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       headers: {
@@ -110,12 +110,12 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
     page.evaluate(() => {
-      fetch('http://localhost:7654/foo').then(() => {
+      fetch('http://sentry-test.io/foo').then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
@@ -135,7 +135,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
     data: {
       method: 'GET',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -153,7 +153,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -161,12 +161,12 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
   ]);
 });
 
-sentryTest('does not capture response headers if URL does not match', async ({ getLocalTestPath, page }) => {
+sentryTest('does not capture response headers if URL does not match', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
-  await page.route('**/bar', route => {
+  await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
       headers: {
@@ -192,12 +192,12 @@ sentryTest('does not capture response headers if URL does not match', async ({ g
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
     page.evaluate(() => {
-      fetch('http://localhost:7654/bar').then(() => {
+      fetch('http://sentry-test.io/bar').then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
@@ -217,7 +217,7 @@ sentryTest('does not capture response headers if URL does not match', async ({ g
     data: {
       method: 'GET',
       status_code: 200,
-      url: 'http://localhost:7654/bar',
+      url: 'http://sentry-test.io/bar',
     },
   });
 
@@ -236,7 +236,7 @@ sentryTest('does not capture response headers if URL does not match', async ({ g
           _meta: { warnings: ['URL_SKIPPED'] },
         },
       },
-      description: 'http://localhost:7654/bar',
+      description: 'http://sentry-test.io/bar',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
@@ -8,12 +8,12 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures response size from Content-Length header if available', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response size from Content-Length header if available', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: JSON.stringify({
@@ -40,17 +40,15 @@ sentryTest('captures response size from Content-Length header if available', asy
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
-      fetch('http://localhost:7654/foo').then(() => {
+      fetch('http://sentry-test.io/foo').then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
   ]);
@@ -68,7 +66,7 @@ sentryTest('captures response size from Content-Length header if available', asy
       method: 'GET',
       response_body_size: 789,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -92,7 +90,7 @@ sentryTest('captures response size from Content-Length header if available', asy
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -100,12 +98,12 @@ sentryTest('captures response size from Content-Length header if available', asy
   ]);
 });
 
-sentryTest('captures response size without Content-Length header', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response size without Content-Length header', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: JSON.stringify({
@@ -132,17 +130,15 @@ sentryTest('captures response size without Content-Length header', async ({ getL
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
-      fetch('http://localhost:7654/foo').then(() => {
+      fetch('http://sentry-test.io/foo').then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
   ]);
@@ -160,7 +156,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
       method: 'GET',
       status_code: 200,
       // NOT set here from body, as this would be async
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -184,7 +180,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),
@@ -192,7 +188,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
   ]);
 });
 
-sentryTest('captures response size from non-text response body', async ({ getLocalTestPath, page }) => {
+sentryTest('captures response size from non-text response body', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -221,19 +217,17 @@ sentryTest('captures response size from non-text response body', async ({ getLoc
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request, { replayRecordingSnapshots }] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
-      fetch('http://localhost:7654/foo', {
+      fetch('http://sentry-test.io/foo', {
         method: 'POST',
       }).then(() => {
         // @ts-expect-error Sentry is a global
         Sentry.captureException('test error');
       });
-      /* eslint-enable */
     }),
     requestPromise,
     replayRequestPromise,
@@ -251,7 +245,7 @@ sentryTest('captures response size from non-text response body', async ({ getLoc
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -274,7 +268,7 @@ sentryTest('captures response size from non-text response body', async ({ getLoc
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.fetch',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/test.ts
@@ -8,13 +8,13 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures correct timestamps', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -34,19 +34,17 @@ sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
-    fetch('http://localhost:7654/foo', {
+    fetch('http://sentry-test.io/foo', {
       method: 'POST',
       body: '{"foo":"bar"}',
     }).then(() => {
       // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/init.js
@@ -6,7 +6,7 @@ window.Replay = Sentry.replayIntegration({
   flushMaxDelay: 200,
   minReplayDuration: 0,
 
-  networkDetailAllowUrls: ['http://localhost:7654/foo', 'http://sentry-test.io/foo'],
+  networkDetailAllowUrls: ['http://sentry-test.io/foo'],
   networkCaptureBodies: true,
 });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/test.ts
@@ -8,13 +8,13 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures text request body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -33,14 +33,13 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.send('input body');
 
     xhr.addEventListener('readystatechange', function () {
@@ -49,7 +48,6 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -66,7 +64,7 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
       method: 'POST',
       request_body_size: 10,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -82,7 +80,7 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
           body: 'input body',
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -90,13 +88,13 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
   ]);
 });
 
-sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures JSON request body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -115,14 +113,13 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.send('{"foo":"bar"}');
 
     xhr.addEventListener('readystatechange', function () {
@@ -131,7 +128,6 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -148,7 +144,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
       method: 'POST',
       request_body_size: 13,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -164,7 +160,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
           body: { foo: 'bar' },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -172,7 +168,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
   ]);
 });
 
-sentryTest('captures non-text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures non-text request body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -197,18 +193,17 @@ sentryTest('captures non-text request body', async ({ getLocalTestPath, page, br
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
     const body = new URLSearchParams();
     body.append('name', 'Anne');
     body.append('age', '32');
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.send(body);
 
     xhr.addEventListener('readystatechange', function () {
@@ -217,7 +212,6 @@ sentryTest('captures non-text request body', async ({ getLocalTestPath, page, br
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -234,7 +228,7 @@ sentryTest('captures non-text request body', async ({ getLocalTestPath, page, br
       method: 'POST',
       request_body_size: 16,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -250,7 +244,7 @@ sentryTest('captures non-text request body', async ({ getLocalTestPath, page, br
           body: 'name=Anne&age=32',
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -264,7 +258,7 @@ sentryTest('captures text request body when matching relative URL', async ({ get
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -287,7 +281,6 @@ sentryTest('captures text request body when matching relative URL', async ({ get
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
     xhr.open('POST', '/foo');
@@ -299,7 +292,6 @@ sentryTest('captures text request body when matching relative URL', async ({ get
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -340,13 +332,13 @@ sentryTest('captures text request body when matching relative URL', async ({ get
   ]);
 });
 
-sentryTest('does not capture request body when URL does not match', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('does not capture request body when URL does not match', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/bar', route => {
+  await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
     });
@@ -365,14 +357,13 @@ sentryTest('does not capture request body when URL does not match', async ({ get
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/bar');
+    xhr.open('POST', 'http://sentry-test.io/bar');
     xhr.send('input body');
 
     xhr.addEventListener('readystatechange', function () {
@@ -381,7 +372,6 @@ sentryTest('does not capture request body when URL does not match', async ({ get
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -398,7 +388,7 @@ sentryTest('does not capture request body when URL does not match', async ({ get
       method: 'POST',
       request_body_size: 10,
       status_code: 200,
-      url: 'http://localhost:7654/bar',
+      url: 'http://sentry-test.io/bar',
     },
   });
 
@@ -422,7 +412,7 @@ sentryTest('does not capture request body when URL does not match', async ({ get
           },
         },
       },
-      description: 'http://localhost:7654/bar',
+      description: 'http://sentry-test.io/bar',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/init.js
@@ -6,7 +6,7 @@ window.Replay = Sentry.replayIntegration({
   flushMaxDelay: 200,
   minReplayDuration: 0,
 
-  networkDetailAllowUrls: ['http://localhost:7654/foo'],
+  networkDetailAllowUrls: ['http://sentry-test.io/foo'],
   networkRequestHeaders: ['X-Test-Header'],
 });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/test.ts
@@ -8,13 +8,13 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures request headers', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request headers', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -33,14 +33,13 @@ sentryTest('captures request headers', async ({ getLocalTestPath, page, browserN
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.setRequestHeader('Accept', 'application/json');
     xhr.setRequestHeader('Content-Type', 'application/json');
     xhr.setRequestHeader('Cache', 'no-cache');
@@ -53,7 +52,6 @@ sentryTest('captures request headers', async ({ getLocalTestPath, page, browserN
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -69,7 +67,7 @@ sentryTest('captures request headers', async ({ getLocalTestPath, page, browserN
     data: {
       method: 'POST',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -87,7 +85,7 @@ sentryTest('captures request headers', async ({ getLocalTestPath, page, browserN
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -95,98 +93,93 @@ sentryTest('captures request headers', async ({ getLocalTestPath, page, browserN
   ]);
 });
 
-sentryTest(
-  'does not capture request headers if URL does not match',
-  async ({ getLocalTestPath, page, browserName }) => {
-    // These are a bit flaky on non-chromium browsers
-    if (shouldSkipReplayTest() || browserName !== 'chromium') {
-      sentryTest.skip();
-    }
+sentryTest('does not capture request headers if URL does not match', async ({ getLocalTestUrl, page, browserName }) => {
+  // These are a bit flaky on non-chromium browsers
+  if (shouldSkipReplayTest() || browserName !== 'chromium') {
+    sentryTest.skip();
+  }
 
-    await page.route('**/bar', route => {
-      return route.fulfill({
-        status: 200,
-      });
+  await page.route('http://sentry-test.io/bar', route => {
+    return route.fulfill({
+      status: 200,
     });
+  });
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
     });
+  });
 
-    const requestPromise = waitForErrorRequest(page);
-    const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
-      return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
+  const requestPromise = waitForErrorRequest(page);
+  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
+    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  void page.evaluate(() => {
+    const xhr = new XMLHttpRequest();
+
+    xhr.open('POST', 'http://sentry-test.io/bar');
+    xhr.setRequestHeader('Accept', 'application/json');
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.setRequestHeader('Cache', 'no-cache');
+    xhr.setRequestHeader('X-Test-Header', 'test-value');
+    xhr.send();
+
+    xhr.addEventListener('readystatechange', function () {
+      if (xhr.readyState === 4) {
+        // @ts-expect-error Sentry is a global
+        setTimeout(() => Sentry.captureException('test error', 0));
+      }
     });
+  });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
-    await page.goto(url);
+  const [request] = await Promise.all([requestPromise]);
 
-    void page.evaluate(() => {
-      /* eslint-disable */
-      const xhr = new XMLHttpRequest();
+  const eventData = envelopeRequestParser(request);
 
-      xhr.open('POST', 'http://localhost:7654/bar');
-      xhr.setRequestHeader('Accept', 'application/json');
-      xhr.setRequestHeader('Content-Type', 'application/json');
-      xhr.setRequestHeader('Cache', 'no-cache');
-      xhr.setRequestHeader('X-Test-Header', 'test-value');
-      xhr.send();
+  expect(eventData.exception?.values).toHaveLength(1);
 
-      xhr.addEventListener('readystatechange', function () {
-        if (xhr.readyState === 4) {
-          // @ts-expect-error Sentry is a global
-          setTimeout(() => Sentry.captureException('test error', 0));
-        }
-      });
-      /* eslint-enable */
-    });
+  expect(eventData?.breadcrumbs?.length).toBe(1);
+  expect(eventData!.breadcrumbs![0]).toEqual({
+    timestamp: expect.any(Number),
+    category: 'xhr',
+    type: 'http',
+    data: {
+      method: 'POST',
+      status_code: 200,
+      url: 'http://sentry-test.io/bar',
+    },
+  });
 
-    const [request] = await Promise.all([requestPromise]);
-
-    const eventData = envelopeRequestParser(request);
-
-    expect(eventData.exception?.values).toHaveLength(1);
-
-    expect(eventData?.breadcrumbs?.length).toBe(1);
-    expect(eventData!.breadcrumbs![0]).toEqual({
-      timestamp: expect.any(Number),
-      category: 'xhr',
-      type: 'http',
+  const { replayRecordingSnapshots } = await replayRequestPromise;
+  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.xhr')).toEqual([
+    {
       data: {
         method: 'POST',
-        status_code: 200,
-        url: 'http://localhost:7654/bar',
-      },
-    });
-
-    const { replayRecordingSnapshots } = await replayRequestPromise;
-    expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.xhr')).toEqual([
-      {
-        data: {
-          method: 'POST',
-          statusCode: 200,
-          request: {
-            headers: {},
-            _meta: {
-              warnings: ['URL_SKIPPED'],
-            },
-          },
-          response: {
-            headers: {},
-            _meta: {
-              warnings: ['URL_SKIPPED'],
-            },
+        statusCode: 200,
+        request: {
+          headers: {},
+          _meta: {
+            warnings: ['URL_SKIPPED'],
           },
         },
-        description: 'http://localhost:7654/bar',
-        endTimestamp: expect.any(Number),
-        op: 'resource.xhr',
-        startTimestamp: expect.any(Number),
+        response: {
+          headers: {},
+          _meta: {
+            warnings: ['URL_SKIPPED'],
+          },
+        },
       },
-    ]);
-  },
-);
+      description: 'http://sentry-test.io/bar',
+      endTimestamp: expect.any(Number),
+      op: 'resource.xhr',
+      startTimestamp: expect.any(Number),
+    },
+  ]);
+});

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestSize/test.ts
@@ -8,13 +8,13 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures request body size when body is sent', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request body size when body is sent', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -33,15 +33,14 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   const [, request] = await Promise.all([
     page.evaluate(() => {
-      /* eslint-disable */
       const xhr = new XMLHttpRequest();
 
-      xhr.open('POST', 'http://localhost:7654/foo');
+      xhr.open('POST', 'http://sentry-test.io/foo');
       xhr.send('{"foo":"bar"}');
 
       xhr.addEventListener('readystatechange', function () {
@@ -50,7 +49,6 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
           setTimeout(() => Sentry.captureException('test error', 0));
         }
       });
-      /* eslint-enable */
     }),
     requestPromise,
   ]);
@@ -68,7 +66,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
       method: 'POST',
       request_body_size: 13,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -92,7 +90,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -100,7 +98,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
   ]);
 });
 
-sentryTest('captures request size from non-text request body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures request size from non-text request body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
@@ -125,16 +123,15 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
     const blob = new Blob(['<html>Hello world!!</html>'], { type: 'text/html' });
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.send(blob);
 
     xhr.addEventListener('readystatechange', function () {
@@ -143,7 +140,6 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -160,7 +156,7 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
       method: 'POST',
       request_body_size: 26,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -184,7 +180,7 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/init.js
@@ -6,7 +6,7 @@ window.Replay = Sentry.replayIntegration({
   flushMaxDelay: 200,
   minReplayDuration: 0,
 
-  networkDetailAllowUrls: ['http://localhost:7654/foo'],
+  networkDetailAllowUrls: ['http://sentry-test.io/foo'],
   networkCaptureBodies: true,
 });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/test.ts
@@ -8,13 +8,13 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures text response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures text response body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: 'response body',
@@ -37,14 +37,13 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.send();
 
     xhr.addEventListener('readystatechange', function () {
@@ -53,7 +52,6 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -70,7 +68,7 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
       method: 'POST',
       response_body_size: 13,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -86,7 +84,7 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
           body: 'response body',
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -94,13 +92,13 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
   ]);
 });
 
-sentryTest('captures JSON response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures JSON response body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: JSON.stringify({ res: 'this' }),
@@ -123,14 +121,13 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.send();
 
     xhr.addEventListener('readystatechange', function () {
@@ -139,7 +136,6 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -156,7 +152,7 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
       method: 'POST',
       response_body_size: 14,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -172,7 +168,7 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
           body: { res: 'this' },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -180,13 +176,13 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
   ]);
 });
 
-sentryTest('captures JSON response body when responseType=json', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures JSON response body when responseType=json', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: JSON.stringify({ res: 'this' }),
@@ -209,14 +205,13 @@ sentryTest('captures JSON response body when responseType=json', async ({ getLoc
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     // Setting this to json ensures that xhr.response returns a POJO
     xhr.responseType = 'json';
     xhr.send();
@@ -227,7 +222,6 @@ sentryTest('captures JSON response body when responseType=json', async ({ getLoc
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -244,7 +238,7 @@ sentryTest('captures JSON response body when responseType=json', async ({ getLoc
       method: 'POST',
       response_body_size: 14,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -260,7 +254,7 @@ sentryTest('captures JSON response body when responseType=json', async ({ getLoc
           body: { res: 'this' },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -268,13 +262,13 @@ sentryTest('captures JSON response body when responseType=json', async ({ getLoc
   ]);
 });
 
-sentryTest('captures non-text response body', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures non-text response body', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', async route => {
+  await page.route('http://sentry-test.io/foo', async route => {
     return route.fulfill({
       status: 200,
       body: Buffer.from('<html>Hello world</html>'),
@@ -297,14 +291,13 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.send();
 
     xhr.addEventListener('readystatechange', function () {
@@ -313,7 +306,6 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -330,7 +322,7 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
       method: 'POST',
       response_body_size: 24,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -346,7 +338,7 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
           body: '<html>Hello world</html>',
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -354,99 +346,94 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
   ]);
 });
 
-sentryTest(
-  'does not capture response body when URL does not match',
-  async ({ getLocalTestPath, page, browserName }) => {
-    // These are a bit flaky on non-chromium browsers
-    if (shouldSkipReplayTest() || browserName !== 'chromium') {
-      sentryTest.skip();
-    }
+sentryTest('does not capture response body when URL does not match', async ({ getLocalTestUrl, page, browserName }) => {
+  // These are a bit flaky on non-chromium browsers
+  if (shouldSkipReplayTest() || browserName !== 'chromium') {
+    sentryTest.skip();
+  }
 
-    await page.route('**/bar', route => {
-      return route.fulfill({
-        status: 200,
-        body: 'response body',
-        headers: {
-          'Content-Length': '',
-        },
-      });
+  await page.route('http://sentry-test.io/bar', route => {
+    return route.fulfill({
+      status: 200,
+      body: 'response body',
+      headers: {
+        'Content-Length': '',
+      },
     });
+  });
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
     });
+  });
 
-    const requestPromise = waitForErrorRequest(page);
-    const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
-      return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
+  const requestPromise = waitForErrorRequest(page);
+  const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
+    return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  void page.evaluate(() => {
+    const xhr = new XMLHttpRequest();
+
+    xhr.open('POST', 'http://sentry-test.io/bar');
+    xhr.send();
+
+    xhr.addEventListener('readystatechange', function () {
+      if (xhr.readyState === 4) {
+        // @ts-expect-error Sentry is a global
+        setTimeout(() => Sentry.captureException('test error', 0));
+      }
     });
+  });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
-    await page.goto(url);
+  const request = await requestPromise;
+  const eventData = envelopeRequestParser(request);
 
-    void page.evaluate(() => {
-      /* eslint-disable */
-      const xhr = new XMLHttpRequest();
+  expect(eventData.exception?.values).toHaveLength(1);
 
-      xhr.open('POST', 'http://localhost:7654/bar');
-      xhr.send();
+  expect(eventData?.breadcrumbs?.length).toBe(1);
+  expect(eventData!.breadcrumbs![0]).toEqual({
+    timestamp: expect.any(Number),
+    category: 'xhr',
+    type: 'http',
+    data: {
+      method: 'POST',
+      response_body_size: 13,
+      status_code: 200,
+      url: 'http://sentry-test.io/bar',
+    },
+  });
 
-      xhr.addEventListener('readystatechange', function () {
-        if (xhr.readyState === 4) {
-          // @ts-expect-error Sentry is a global
-          setTimeout(() => Sentry.captureException('test error', 0));
-        }
-      });
-      /* eslint-enable */
-    });
-
-    const request = await requestPromise;
-    const eventData = envelopeRequestParser(request);
-
-    expect(eventData.exception?.values).toHaveLength(1);
-
-    expect(eventData?.breadcrumbs?.length).toBe(1);
-    expect(eventData!.breadcrumbs![0]).toEqual({
-      timestamp: expect.any(Number),
-      category: 'xhr',
-      type: 'http',
+  const { replayRecordingSnapshots } = await replayRequestPromise;
+  expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.xhr')).toEqual([
+    {
       data: {
         method: 'POST',
-        response_body_size: 13,
-        status_code: 200,
-        url: 'http://localhost:7654/bar',
-      },
-    });
-
-    const { replayRecordingSnapshots } = await replayRequestPromise;
-    expect(getReplayPerformanceSpans(replayRecordingSnapshots).filter(span => span.op === 'resource.xhr')).toEqual([
-      {
-        data: {
-          method: 'POST',
-          statusCode: 200,
-          request: {
-            headers: {},
-            _meta: {
-              warnings: ['URL_SKIPPED'],
-            },
-          },
-          response: {
-            size: 13,
-            headers: {},
-            _meta: {
-              warnings: ['URL_SKIPPED'],
-            },
+        statusCode: 200,
+        request: {
+          headers: {},
+          _meta: {
+            warnings: ['URL_SKIPPED'],
           },
         },
-        description: 'http://localhost:7654/bar',
-        endTimestamp: expect.any(Number),
-        op: 'resource.xhr',
-        startTimestamp: expect.any(Number),
+        response: {
+          size: 13,
+          headers: {},
+          _meta: {
+            warnings: ['URL_SKIPPED'],
+          },
+        },
       },
-    ]);
-  },
-);
+      description: 'http://sentry-test.io/bar',
+      endTimestamp: expect.any(Number),
+      op: 'resource.xhr',
+      startTimestamp: expect.any(Number),
+    },
+  ]);
+});

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/init.js
@@ -6,7 +6,7 @@ window.Replay = Sentry.replayIntegration({
   flushMaxDelay: 200,
   minReplayDuration: 0,
 
-  networkDetailAllowUrls: ['http://localhost:7654/foo'],
+  networkDetailAllowUrls: ['http://sentry-test.io/foo'],
   networkResponseHeaders: ['X-Test-Header'],
 });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/test.ts
@@ -8,13 +8,13 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures response headers', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures response headers', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       headers: {
@@ -40,14 +40,13 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page, browser
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('GET', 'http://localhost:7654/foo');
+    xhr.open('GET', 'http://sentry-test.io/foo');
     xhr.send();
 
     xhr.addEventListener('readystatechange', function () {
@@ -56,7 +55,6 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page, browser
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -72,7 +70,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page, browser
     data: {
       method: 'GET',
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -90,7 +88,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page, browser
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -100,13 +98,13 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page, browser
 
 sentryTest(
   'does not capture response headers if URL does not match',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // These are a bit flaky on non-chromium browsers
     if (shouldSkipReplayTest() || browserName !== 'chromium') {
       sentryTest.skip();
     }
 
-    await page.route('**/bar', route => {
+    await page.route('http://sentry-test.io/bar', route => {
       return route.fulfill({
         status: 200,
         headers: {
@@ -132,14 +130,13 @@ sentryTest(
       return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     await page.evaluate(() => {
-      /* eslint-disable */
       const xhr = new XMLHttpRequest();
 
-      xhr.open('GET', 'http://localhost:7654/bar');
+      xhr.open('GET', 'http://sentry-test.io/bar');
       xhr.send();
 
       xhr.addEventListener('readystatechange', function () {
@@ -148,7 +145,6 @@ sentryTest(
           setTimeout(() => Sentry.captureException('test error', 0));
         }
       });
-      /* eslint-enable */
     });
 
     const request = await requestPromise;
@@ -164,7 +160,7 @@ sentryTest(
       data: {
         method: 'GET',
         status_code: 200,
-        url: 'http://localhost:7654/bar',
+        url: 'http://sentry-test.io/bar',
       },
     });
 
@@ -187,7 +183,7 @@ sentryTest(
             },
           },
         },
-        description: 'http://localhost:7654/bar',
+        description: 'http://sentry-test.io/bar',
         endTimestamp: expect.any(Number),
         op: 'resource.xhr',
         startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseSize/test.ts
@@ -10,13 +10,13 @@ import {
 
 sentryTest(
   'captures response size from Content-Length header if available',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // These are a bit flaky on non-chromium browsers
     if (shouldSkipReplayTest() || browserName !== 'chromium') {
       sentryTest.skip();
     }
 
-    await page.route('**/foo', route => {
+    await page.route('http://sentry-test.io/foo', route => {
       return route.fulfill({
         status: 200,
         headers: {
@@ -38,14 +38,13 @@ sentryTest(
       return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 
     await page.evaluate(() => {
-      /* eslint-disable */
       const xhr = new XMLHttpRequest();
 
-      xhr.open('GET', 'http://localhost:7654/foo');
+      xhr.open('GET', 'http://sentry-test.io/foo');
       xhr.send();
 
       xhr.addEventListener('readystatechange', function () {
@@ -54,7 +53,6 @@ sentryTest(
           setTimeout(() => Sentry.captureException('test error', 0));
         }
       });
-      /* eslint-enable */
     });
 
     const request = await requestPromise;
@@ -71,7 +69,7 @@ sentryTest(
         method: 'GET',
         response_body_size: 789,
         status_code: 200,
-        url: 'http://localhost:7654/foo',
+        url: 'http://sentry-test.io/foo',
       },
     });
 
@@ -95,7 +93,7 @@ sentryTest(
             },
           },
         },
-        description: 'http://localhost:7654/foo',
+        description: 'http://sentry-test.io/foo',
         endTimestamp: expect.any(Number),
         op: 'resource.xhr',
         startTimestamp: expect.any(Number),
@@ -104,13 +102,13 @@ sentryTest(
   },
 );
 
-sentryTest('captures response size without Content-Length header', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures response size without Content-Length header', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
       body: JSON.stringify({
@@ -135,14 +133,13 @@ sentryTest('captures response size without Content-Length header', async ({ getL
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('GET', 'http://localhost:7654/foo');
+    xhr.open('GET', 'http://sentry-test.io/foo');
     xhr.send();
 
     xhr.addEventListener('readystatechange', function () {
@@ -151,7 +148,6 @@ sentryTest('captures response size without Content-Length header', async ({ getL
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -159,8 +155,8 @@ sentryTest('captures response size without Content-Length header', async ({ getL
 
   expect(eventData.exception?.values).toHaveLength(1);
 
-  expect(eventData?.breadcrumbs?.length).toBe(1);
-  expect(eventData!.breadcrumbs![0]).toEqual({
+  expect(eventData.breadcrumbs?.length).toBe(1);
+  expect(eventData.breadcrumbs![0]).toEqual({
     timestamp: expect.any(Number),
     category: 'xhr',
     type: 'http',
@@ -168,7 +164,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
       method: 'GET',
       response_body_size: 29,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -192,7 +188,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),
@@ -200,13 +196,13 @@ sentryTest('captures response size without Content-Length header', async ({ getL
   ]);
 });
 
-sentryTest('captures response size for non-string bodies', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures response size for non-string bodies', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', async route => {
+  await page.route('http://sentry-test.io/foo', async route => {
     return route.fulfill({
       status: 200,
       body: Buffer.from('<html>Hello world</html>'),
@@ -229,14 +225,13 @@ sentryTest('captures response size for non-string bodies', async ({ getLocalTest
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   await page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.send();
 
     xhr.addEventListener('readystatechange', function () {
@@ -245,7 +240,6 @@ sentryTest('captures response size for non-string bodies', async ({ getLocalTest
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;
@@ -262,7 +256,7 @@ sentryTest('captures response size for non-string bodies', async ({ getLocalTest
       method: 'POST',
       response_body_size: 24,
       status_code: 200,
-      url: 'http://localhost:7654/foo',
+      url: 'http://sentry-test.io/foo',
     },
   });
 
@@ -286,7 +280,7 @@ sentryTest('captures response size for non-string bodies', async ({ getLocalTest
           },
         },
       },
-      description: 'http://localhost:7654/foo',
+      description: 'http://sentry-test.io/foo',
       endTimestamp: expect.any(Number),
       op: 'resource.xhr',
       startTimestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/test.ts
@@ -8,13 +8,13 @@ import {
   shouldSkipReplayTest,
 } from '../../../../../utils/replayHelpers';
 
-sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, browserName }) => {
+sentryTest('captures correct timestamps', async ({ getLocalTestUrl, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 
-  await page.route('**/foo', route => {
+  await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
     });
@@ -34,14 +34,13 @@ sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, brows
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 
   void page.evaluate(() => {
-    /* eslint-disable */
     const xhr = new XMLHttpRequest();
 
-    xhr.open('POST', 'http://localhost:7654/foo');
+    xhr.open('POST', 'http://sentry-test.io/foo');
     xhr.setRequestHeader('Accept', 'application/json');
     xhr.setRequestHeader('Content-Type', 'application/json');
     xhr.setRequestHeader('Cache', 'no-cache');
@@ -54,7 +53,6 @@ sentryTest('captures correct timestamps', async ({ getLocalTestPath, page, brows
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
-    /* eslint-enable */
   });
 
   const request = await requestPromise;

--- a/dev-packages/browser-integration-tests/suites/sessions/initial-scope/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/initial-scope/test.ts
@@ -16,14 +16,10 @@ sentryTest('should start a new session on pageload.', async ({ getLocalTestPath,
   expect(session.did).toBe('1337');
 });
 
-sentryTest('should start a new session with navigation.', async ({ getLocalTestPath, page, browserName }) => {
-  // Navigations get CORS error on Firefox and WebKit as we're using `file://` protocol.
-  if (browserName !== 'chromium') {
-    sentryTest.skip();
-  }
+sentryTest('should start a new session with navigation.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
-  await page.route('**/foo', (route: Route) => route.fulfill({ path: `${__dirname}/dist/index.html` }));
+  await page.route('**/foo', (route: Route) => route.continue({ url }));
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/sessions/start-session/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/start-session/test.ts
@@ -15,14 +15,9 @@ sentryTest('should start a new session on pageload.', async ({ getLocalTestPath,
   expect(session.status).toBe('ok');
 });
 
-sentryTest('should start a new session with navigation.', async ({ getLocalTestPath, page, browserName }) => {
-  // Navigations get CORS error on Firefox and WebKit as we're using `file://` protocol.
-  if (browserName !== 'chromium') {
-    sentryTest.skip();
-  }
-
-  const url = await getLocalTestPath({ testDir: __dirname });
-  await page.route('**/foo', (route: Route) => route.fulfill({ path: `${__dirname}/dist/index.html` }));
+sentryTest('should start a new session with navigation.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.route('**/foo', (route: Route) => route.continue({ url }));
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/sessions/v7-hub-start-session/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/v7-hub-start-session/test.ts
@@ -15,14 +15,9 @@ sentryTest('should start a new session on pageload.', async ({ getLocalTestPath,
   expect(session.status).toBe('ok');
 });
 
-sentryTest('should start a new session with navigation.', async ({ getLocalTestPath, page, browserName }) => {
-  // Navigations get CORS error on Firefox and WebKit as we're using `file://` protocol.
-  if (browserName !== 'chromium') {
-    sentryTest.skip();
-  }
-
-  const url = await getLocalTestPath({ testDir: __dirname });
-  await page.route('**/foo', (route: Route) => route.fulfill({ path: `${__dirname}/dist/index.html` }));
+sentryTest('should start a new session with navigation.', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.route('**/foo', (route: Route) => route.continue({ url }));
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({

--- a/dev-packages/browser-integration-tests/utils/fixtures.ts
+++ b/dev-packages/browser-integration-tests/utils/fixtures.ts
@@ -11,16 +11,19 @@ export const TEST_HOST = 'http://sentry-test.io';
 const getAsset = (assetDir: string, asset: string): string => {
   const assetPath = `${assetDir}/${asset}`;
 
+  // Try to find the asset in the same directory
   if (fs.existsSync(assetPath)) {
     return assetPath;
   }
 
+  // Else, try to find it in the parent directory
   const parentDirAssetPath = `${path.dirname(assetDir)}/${asset}`;
 
   if (fs.existsSync(parentDirAssetPath)) {
     return parentDirAssetPath;
   }
 
+  // Else use a static asset
   return `utils/defaults/${asset}`;
 };
 
@@ -54,34 +57,39 @@ const sentryTest = base.extend<TestFixtures>({
     return use(async ({ testDir, skipRouteHandler = false }) => {
       const pagePath = `${TEST_HOST}/index.html`;
 
-      await build(testDir);
+      const tmpDir = path.join(testDir, 'dist', crypto.randomUUID());
 
-      // Serve all assets under
-      if (!skipRouteHandler) {
-        await page.route(`${TEST_HOST}/*.*`, route => {
-          const file = route.request().url().split('/').pop();
-          const filePath = path.resolve(testDir, `./dist/${file}`);
+      await build(testDir, tmpDir);
 
-          return fs.existsSync(filePath) ? route.fulfill({ path: filePath }) : route.continue();
-        });
-
-        // Ensure feedback can be lazy loaded
-        await page.route(`https://browser.sentry-cdn.com/${SDK_VERSION}/feedback-modal.min.js`, route => {
-          const filePath = path.resolve(testDir, './dist/feedback-modal.bundle.js');
-          if (!fs.existsSync(filePath)) {
-            throw new Error(`Feedback modal bundle (${filePath}) not found`);
-          }
-          return route.fulfill({ path: filePath });
-        });
-
-        await page.route(`https://browser.sentry-cdn.com/${SDK_VERSION}/feedback-screenshot.min.js`, route => {
-          const filePath = path.resolve(testDir, './dist/feedback-screenshot.bundle.js');
-          if (!fs.existsSync(filePath)) {
-            throw new Error(`Feedback screenshot bundle (${filePath}) not found`);
-          }
-          return route.fulfill({ path: filePath });
-        });
+      // If skipping route handlers we return the tmp dir instead of adding the handler
+      // This way, this can be handled by the caller manually
+      if (skipRouteHandler) {
+        return tmpDir;
       }
+
+      await page.route(`${TEST_HOST}/*.*`, route => {
+        const file = route.request().url().split('/').pop();
+        const filePath = path.resolve(tmpDir, `./${file}`);
+
+        return fs.existsSync(filePath) ? route.fulfill({ path: filePath }) : route.continue();
+      });
+
+      // Ensure feedback can be lazy loaded
+      await page.route(`https://browser.sentry-cdn.com/${SDK_VERSION}/feedback-modal.min.js`, route => {
+        const filePath = path.resolve(tmpDir, './feedback-modal.bundle.js');
+        if (!fs.existsSync(filePath)) {
+          throw new Error(`Feedback modal bundle (${filePath}) not found`);
+        }
+        return route.fulfill({ path: filePath });
+      });
+
+      await page.route(`https://browser.sentry-cdn.com/${SDK_VERSION}/feedback-screenshot.min.js`, route => {
+        const filePath = path.resolve(tmpDir, './feedback-screenshot.bundle.js');
+        if (!fs.existsSync(filePath)) {
+          throw new Error(`Feedback screenshot bundle (${filePath}) not found`);
+        }
+        return route.fulfill({ path: filePath });
+      });
 
       return pagePath;
     });
@@ -89,9 +97,10 @@ const sentryTest = base.extend<TestFixtures>({
 
   getLocalTestPath: ({}, use) => {
     return use(async ({ testDir }) => {
-      const pagePath = `file:///${path.resolve(testDir, './dist/index.html')}`;
+      const tmpDir = path.join(testDir, 'dist', crypto.randomUUID());
+      const pagePath = `file:///${path.resolve(tmpDir, './index.html')}`;
 
-      await build(testDir);
+      await build(testDir, tmpDir);
 
       return pagePath;
     });
@@ -139,12 +148,12 @@ const sentryTest = base.extend<TestFixtures>({
 
 export { sentryTest };
 
-async function build(testDir: string): Promise<void> {
+async function build(testDir: string, tmpDir: string): Promise<void> {
   const subject = getAsset(testDir, 'subject.js');
   const template = getAsset(testDir, 'template.html');
   const init = getAsset(testDir, 'init.js');
 
-  await generatePage(init, subject, template, testDir);
+  await generatePage(init, subject, template, tmpDir);
 
   const additionalPages = fs
     .readdirSync(testDir)
@@ -155,6 +164,6 @@ async function build(testDir: string): Promise<void> {
     const subject = getAsset(testDir, 'subject.js');
     const pageFile = getAsset(testDir, pageFilename);
     const init = getAsset(testDir, 'init.js');
-    await generatePage(init, subject, pageFile, testDir, pageFilename);
+    await generatePage(init, subject, pageFile, tmpDir, pageFilename);
   }
 }

--- a/dev-packages/browser-integration-tests/utils/staticAssets.ts
+++ b/dev-packages/browser-integration-tests/utils/staticAssets.ts
@@ -27,16 +27,7 @@ export function addStaticAssetSymlink(localOutPath: string, originalPath: string
 
   // Only copy files once
   if (!fs.existsSync(newPath)) {
-    try {
-      fs.symlinkSync(originalPath, newPath);
-    } catch (error) {
-      // There must be some race condition here as some of our tests flakey
-      // because the file already exists. Let's catch and ignore
-      // only ignore these kind of errors
-      if (!`${error}`.includes('file already exists')) {
-        throw error;
-      }
-    }
+    fs.symlinkSync(originalPath, newPath);
   }
 
   symlinkAsset(newPath, path.join(localOutPath, fileName));
@@ -49,12 +40,5 @@ function symlinkAsset(originalPath: string, targetPath: string): void {
     // ignore errors here
   }
 
-  try {
-    fs.linkSync(originalPath, targetPath);
-  } catch (error) {
-    // only ignore these kind of errors
-    if (!`${error}`.includes('file already exists')) {
-      throw error;
-    }
-  }
+  fs.linkSync(originalPath, targetPath);
 }


### PR DESCRIPTION
This streamlines some stuff in our browser integration tests, to fix some flakiness (hopefully).

The biggest change is that instead of always building into `dist` for each test file, each test will now build into a random subfolder, e.g. `dist/abc`. This way, multiple tests in a single file will never conflict with each other.

Additionally it also streamlines some of the tests I encountered while looking at stuff, hopefully reducing flakes further.

Closes https://github.com/getsentry/sentry-javascript/issues/13321
