### PR TITLE
fix(nuxt): Add import line for disabled `autoImport`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3/app.vue
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/app.vue
@@ -4,7 +4,7 @@
       <nav>
         <ul>
           <li><NuxtLink to="/fetch-server-error">Fetch Server Error</NuxtLink></li>
-          <li><NuxtLink to="/param-error/1234">Fetch Param Server Error</NuxtLink></li>
+          <li><NuxtLink to="/test-param/1234">Fetch Param</NuxtLink></li>
           <li><NuxtLink to="/client-error">Client Error</NuxtLink></li>
         </ul>
       </nav>

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/nuxt.config.ts
@@ -1,4 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   modules: ['@sentry/nuxt/module'],
+  imports: {
+    autoImport: false,
+  },
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/pages/fetch-server-error.vue
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/pages/fetch-server-error.vue
@@ -5,6 +5,8 @@
 </template>
 
 <script setup lang="ts">
+import { useFetch} from '#imports'
+
 const fetchData = async () => {
   await useFetch('/api/server-error');
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/pages/test-param/[param].vue
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/pages/test-param/[param].vue
@@ -6,6 +6,8 @@
 </template>
 
 <script setup lang="ts">
+import { useRoute, useFetch } from '#imports'
+
 const route = useRoute();
 const param = route.params.param;
 

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/server/api/param-error/[param].ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/server/api/param-error/[param].ts
@@ -1,3 +1,5 @@
+import { defineEventHandler } from '#imports';
+
 export default defineEventHandler(_e => {
   throw new Error('Nuxt 3 Param Server error');
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/server/api/server-error.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/server/api/server-error.ts
@@ -1,3 +1,5 @@
+import { defineEventHandler } from '#imports';
+
 export default defineEventHandler(event => {
   throw new Error('Nuxt 3 Server error');
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/server/api/test-param/[param].ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/server/api/test-param/[param].ts
@@ -1,3 +1,5 @@
+import { defineEventHandler, getRouterParam } from '#imports';
+
 export default defineEventHandler(event => {
   const param = getRouterParam(event, 'param');
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -28,6 +28,7 @@ export default defineNuxtModule<ModuleOptions>({
         filename: 'sentry-client-config.mjs',
         getContents: () =>
           `import "${buildDirResolver.resolve(`/${clientConfigFile}`)}"\n` +
+          'import { defineNuxtPlugin } from "#imports"\n' +
           'export default defineNuxtPlugin(() => {})',
       });
 
@@ -43,6 +44,7 @@ export default defineNuxtModule<ModuleOptions>({
         filename: 'sentry-server-config.mjs',
         getContents: () =>
           `import "${buildDirResolver.resolve(`/${serverConfigFile}`)}"\n` +
+          'import { defineNuxtPlugin } from "#imports"\n' +
           'export default defineNuxtPlugin(() => {})',
       });
 


### PR DESCRIPTION
Adds explicit imports in case `autoImport` is disabled (Nuxt docs [here](https://nuxt.com/docs/guide/concepts/auto-imports#disabling-auto-imports)). Disabled `autoImport` in the E2E test to verify.

fixes https://github.com/getsentry/sentry-javascript/issues/13302
