### PR TITLE
backport(tracing): Report dropped spans for transactions

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -93,7 +93,7 @@ module.exports = [
     name: '@sentry/browser (incl. Tracing) - ES6 CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.tracing.min.js',
     gzip: true,
-    limit: '37 KB',
+    limit: '38 KB',
   },
   {
     name: '@sentry/browser - ES6 CDN Bundle (gzipped)',
@@ -115,7 +115,7 @@ module.exports = [
     path: 'packages/browser/build/bundles/bundle.tracing.min.js',
     gzip: false,
     brotli: false,
-    limit: '112 KB',
+    limit: '113 KB',
   },
   {
     name: '@sentry/browser - ES6 CDN Bundle (minified & uncompressed)',

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -942,6 +942,15 @@ function processBeforeSend(
   }
 
   if (isTransactionEvent(event) && beforeSendTransaction) {
+    if (event.spans) {
+      // We store the # of spans before processing in SDK metadata,
+      // so we can compare it afterwards to determine how many spans were dropped
+      const spanCountBefore = event.spans.length;
+      event.sdkProcessingMetadata = {
+        ...event.sdkProcessingMetadata,
+        spanCountBeforeProcessing: spanCountBefore,
+      };
+    }
     return beforeSendTransaction(event, hint);
   }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -419,10 +419,12 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   /**
    * @inheritDoc
    */
-  public recordDroppedEvent(reason: EventDropReason, category: DataCategory, _event?: Event): void {
-    // Note: we use `event` in replay, where we overwrite this hook.
-
+  public recordDroppedEvent(reason: EventDropReason, category: DataCategory, eventOrCount?: Event | number): void {
     if (this._options.sendClientReports) {
+      // TODO v9: We do not need the `event` passed as third argument anymore, and can possibly remove this overload
+      // If event is passed as third argument, we assume this is a count of 1
+      const count = typeof eventOrCount === 'number' ? eventOrCount : 1;
+
       // We want to track each category (error, transaction, session, replay_event) separately
       // but still keep the distinction between different type of outcomes.
       // We could use nested maps, but it's much easier to read and type this way.
@@ -430,10 +432,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       // would be `Partial<Record<SentryRequestType, Partial<Record<Outcome, number>>>>`
       // With typescript 4.1 we could even use template literal types
       const key = `${reason}:${category}`;
-      DEBUG_BUILD && logger.log(`Adding outcome: "${key}"`);
-
-      // The following works because undefined + 1 === NaN and NaN is falsy
-      this._outcomes[key] = this._outcomes[key] + 1 || 1;
+      DEBUG_BUILD && logger.log(`Recording outcome: "${key}"${count > 1 ? ` (${count} times)` : ''}`);
+      this._outcomes[key] = (this._outcomes[key] || 0) + count;
     }
   }
 
@@ -778,12 +778,30 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       .then(processedEvent => {
         if (processedEvent === null) {
           this.recordDroppedEvent('before_send', dataCategory, event);
+          if (isTransaction) {
+            const spans = event.spans || [];
+            // the transaction itself counts as one span, plus all the child spans that are added
+            const spanCount = 1 + spans.length;
+            this.recordDroppedEvent('before_send', 'span', spanCount);
+          }
           throw new SentryError(`${beforeSendLabel} returned \`null\`, will not send event.`, 'log');
         }
 
         const session = scope && scope.getSession();
         if (!isTransaction && session) {
           this._updateSessionFromEvent(session, processedEvent);
+        }
+
+        if (isTransaction) {
+          const spanCountBefore =
+            (processedEvent.sdkProcessingMetadata && processedEvent.sdkProcessingMetadata.spanCountBeforeProcessing) ||
+            0;
+          const spanCountAfter = processedEvent.spans ? processedEvent.spans.length : 0;
+
+          const droppedSpanCount = spanCountBefore - spanCountAfter;
+          if (droppedSpanCount > 0) {
+            this.recordDroppedEvent('before_send', 'span', droppedSpanCount);
+          }
         }
 
         // None of the Sentry built event processor will update transaction name,

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,7 +1,7 @@
 import type { Client, Envelope, Event, Span, Transaction } from '@sentry/types';
 import { SentryError, SyncPromise, dsnToString, logger } from '@sentry/utils';
 
-import { Hub, Scope, makeSession, setGlobalScope } from '../../src';
+import { Hub, Scope, Span as CoreSpan, makeSession, setGlobalScope } from '../../src';
 import * as integrationModule from '../../src/integration';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 import { AdHocIntegration, TestIntegration } from '../mocks/integration';
@@ -1006,7 +1006,7 @@ describe('BaseClient', () => {
 
     test('calls `beforeSendTransaction` and drops spans', () => {
       const beforeSendTransaction = jest.fn(event => {
-        event.spans = [{ span_id: 'span5', trace_id: 'trace1', start_timestamp: 1234 }];
+        event.spans = [new CoreSpan({ spanId: 'span5', traceId: 'trace1', startTimestamp: 1234 })];
         return event;
       });
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSendTransaction });
@@ -1016,9 +1016,9 @@ describe('BaseClient', () => {
         transaction: '/dogs/are/great',
         type: 'transaction',
         spans: [
-          { span_id: 'span1', trace_id: 'trace1', start_timestamp: 1234 },
-          { span_id: 'span2', trace_id: 'trace1', start_timestamp: 1234 },
-          { span_id: 'span3', trace_id: 'trace1', start_timestamp: 1234 },
+          new CoreSpan({ spanId: 'span1', traceId: 'trace1', startTimestamp: 1234 }),
+          new CoreSpan({ spanId: 'span2', traceId: 'trace1', startTimestamp: 1234 }),
+          new CoreSpan({ spanId: 'span3', traceId: 'trace1', startTimestamp: 1234 }),
         ],
       });
 
@@ -1026,6 +1026,31 @@ describe('BaseClient', () => {
       expect(TestClient.instance!.event!.spans?.length).toBe(1);
 
       expect(client['_outcomes']).toEqual({ 'before_send:span': 2 });
+    });
+
+    test('calls `beforeSendTransaction` and drops spans + 1 if tx null', () => {
+      const beforeSendTransaction = jest.fn(() => {
+        return null;
+      });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSendTransaction });
+      const client = new TestClient(options);
+
+      client.captureEvent({
+        transaction: '/dogs/are/great',
+        type: 'transaction',
+        spans: [
+          new CoreSpan({ spanId: 'span1', traceId: 'trace1', startTimestamp: 1234 }),
+          new CoreSpan({ spanId: 'span2', traceId: 'trace1', startTimestamp: 1234 }),
+          new CoreSpan({ spanId: 'span3', traceId: 'trace1', startTimestamp: 1234 }),
+        ],
+      });
+
+      expect(beforeSendTransaction).toHaveBeenCalled();
+
+      expect(client['_outcomes']).toEqual({
+        'before_send:span': 4,
+        'before_send:transaction': 1,
+      });
     });
 
     test('calls `beforeSend` and discards the event', () => {

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1028,45 +1028,6 @@ describe('BaseClient', () => {
       expect(client['_outcomes']).toEqual({ 'before_send:span': 2 });
     });
 
-    test('calls `beforeSendSpan` and uses the modified spans', () => {
-      expect.assertions(3);
-
-      const beforeSendSpan = jest.fn(span => {
-        span.data = { version: 'bravo' };
-        return span;
-      });
-
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSendSpan });
-      const client = new TestClient(options);
-      const transaction: Event = {
-        transaction: '/cats/are/great',
-        type: 'transaction',
-        spans: [
-          {
-            description: 'first span',
-            span_id: '9e15bf99fbe4bc80',
-            start_timestamp: 1591603196.637835,
-            trace_id: '86f39e84263a4de99c326acab3bfe3bd',
-          },
-          {
-            description: 'second span',
-            span_id: 'aa554c1f506b0783',
-            start_timestamp: 1591603196.637835,
-            trace_id: '86f39e84263a4de99c326acab3bfe3bd',
-          },
-        ],
-      };
-
-      client.captureEvent(transaction);
-
-      expect(beforeSendSpan).toHaveBeenCalledTimes(2);
-      const capturedEvent = TestClient.instance!.event!;
-      for (const [idx, span] of capturedEvent.spans!.entries()) {
-        const originalSpan = transaction.spans![idx];
-        expect(span).toEqual({ ...originalSpan, data: { version: 'bravo' } });
-      }
-    });
-
     test('calls `beforeSend` and discards the event', () => {
       expect.assertions(4);
 

--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -110,6 +110,7 @@ describe('Integration | Transactions', () => {
           }),
           sampleRate: 1,
           source: 'task',
+          spanCountBeforeProcessing: 2,
           spanMetadata: expect.any(Object),
           requestPath: 'test-path',
         },


### PR DESCRIPTION
- backport https://github.com/getsentry/sentry-javascript/pull/12751
- https://github.com/getsentry/sentry-javascript/commit/df45d65885764be2ca75c1b5122e7746c07efd59


Some SDK can't get this from v8 in timely fashion:
- https://github.com/getsentry/sentry-capacitor/issues/693
- https://github.com/getsentry/sentry-react-native/issues/3944