### PR TITLE
feat(nextjs): Update `experimental_captureRequestError` to reflect `RequestInfo.path` change in Next.js canary

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
@@ -17,7 +17,7 @@
     "@types/node": "18.11.17",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
-    "next": "15.0.0-canary.77",
+    "next": "15.0.0-canary.112",
     "react": "beta",
     "react-dom": "beta",
     "typescript": "4.9.5"

--- a/packages/nextjs/src/common/captureRequestError.ts
+++ b/packages/nextjs/src/common/captureRequestError.ts
@@ -1,7 +1,7 @@
 import { captureException, withScope } from '@sentry/core';
 
 type RequestInfo = {
-  url: string;
+  path: string;
   method: string;
   headers: Record<string, string | string[] | undefined>;
 };
@@ -33,7 +33,7 @@ export function experimental_captureRequestError(
     });
 
     scope.setContext('nextjs', {
-      request_path: request.url,
+      request_path: request.path,
       router_kind: errorContext.routerKind,
       router_path: errorContext.routePath,
       route_type: errorContext.routeType,


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/68672 changed the name of a field. This PR updates `experimental_captureRequestError` to use the new field.

Fixes https://github.com/getsentry/sentry-javascript/issues/13332