### PR TITLE
ci: Improve size-limit CI action

### DIFF
--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -362,9 +362,11 @@ export async function getArtifactsForBranchAndWorkflow(octokit, { owner, repo, w
     }
 
     // Do not allow downloading artifacts from a fork.
-    completedWorkflowRuns.push(
-      ...response.data.filter(workflowRun => workflowRun.head_repository.full_name === `${owner}/${repo}`),
-    );
+    const filtered = response.data.filter(workflowRun => workflowRun.head_repository.full_name === `${owner}/${repo}`);
+
+    console.log(JSON.stringify(filtered, null, 2));
+
+    completedWorkflowRuns.push(...filtered);
 
     if (completedWorkflowRuns.length) {
       break;

--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -151,7 +151,7 @@ async function execSizeLimit() {
   return { status, output };
 }
 
-const SIZE_RESULTS_HEADER = ['Path', 'Size', 'Change'];
+const SIZE_RESULTS_HEADER = ['Path', 'Size', '% Change', 'Change'];
 
 const EmptyResult = {
   name: '-',

--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -210,6 +210,7 @@ async function run() {
     let base;
     let current;
     let baseIsNotLatest = false;
+    let baseWorkflowRun;
 
     try {
       const artifacts = await getArtifactsForBranchAndWorkflow(octokit, {
@@ -219,11 +220,11 @@ async function run() {
         workflowName: `${process.env.GITHUB_WORKFLOW || ''}`,
       });
 
-      core.info(`Artifacts: ${JSON.stringify(artifacts, null, 2)}`);
-
       if (!artifacts) {
         throw new Error('No artifacts found');
       }
+
+      baseWorkflowRun = artifacts.workflowRun;
 
       await downloadOtherWorkflowArtifact(octokit, {
         ...repo,
@@ -270,6 +271,10 @@ async function run() {
       }
 
       bodyParts.push(markdownTable(limit.formatResults(base, current)));
+
+      if (baseWorkflowRun) {
+        bodyParts.push(`[View base workflow run](${baseWorkflowRun.html_url})`);
+      }
 
       const body = bodyParts.join('\r\n');
 

--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -266,7 +266,7 @@ async function run() {
 
       if (baseIsNotLatest) {
         bodyParts.push(
-          '⚠️ **Warning:** Base artifact is not the latest one, because the latest workflow run is not done yet. This may lead to incorrect results.',
+          '⚠️ **Warning:** Base artifact is not the latest one, because the latest workflow run is not done yet. This may lead to incorrect results. Try to re-run all tests to get up to date results.',
         );
       }
 

--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -386,6 +386,11 @@ async function getArtifactsForBranchAndWorkflow(octokit, { owner, repo, workflow
     // Do not allow downloading artifacts from a fork.
     const filtered = response.data.filter(workflowRun => workflowRun.head_repository.full_name === `${owner}/${repo}`);
 
+    // Sort to ensure the latest workflow run is the first
+    filtered.sort((a, b) => {
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
+
     // Store the first workflow run, to determine if this is the latest one...
     if (!latestWorkflowRun) {
       latestWorkflowRun = filtered[0];
@@ -416,6 +421,8 @@ async function getArtifactsForBranchAndWorkflow(octokit, { owner, repo, workflow
             workflowRun,
             isLatest: latestWorkflowRun.id === workflowRun.id,
           };
+        } else {
+          core.info(`No artifact found for ${artifactName}, trying next workflow run...`);
         }
       }
     }

--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -156,7 +156,6 @@ const SIZE_RESULTS_HEADER = ['Path', 'Size', '% Change', 'Change'];
 const EmptyResult = {
   name: '-',
   size: 0,
-  change: 0,
 };
 
 async function run() {
@@ -219,6 +218,8 @@ async function run() {
         branch: comparisonBranch,
         workflowName: `${process.env.GITHUB_WORKFLOW || ''}`,
       });
+
+      core.info(`Artifacts: ${JSON.stringify(artifacts, null, 2)}`);
 
       if (!artifacts) {
         throw new Error('No artifacts found');

--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -273,6 +273,7 @@ async function run() {
       bodyParts.push(markdownTable(limit.formatResults(base, current)));
 
       if (baseWorkflowRun) {
+        bodyParts.push('');
         bodyParts.push(`[View base workflow run](${baseWorkflowRun.html_url})`);
       }
 


### PR DESCRIPTION
This improves a few things in our size-limit CI action:

1. Show change in bytes, in addition to the change in percentage. 
2. Add a link below the table to the base comparison run.
3. If we detect that the workflow run we used as base is not the latest one, show a warning on top.

![image](https://github.com/user-attachments/assets/4678ff04-a463-4579-ad91-74cbf9b7d781)
