### PR TITLE
fix(ci): Fix incorrect `changed_any_code` check in `job_build`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     if: |
-      (needs.job_get_metadata.outputs.changed_any_code) &&
+      needs.job_get_metadata.outputs.changed_any_code == 'true' &&
       (needs.job_get_metadata.outputs.is_gitflow_sync == 'false' && needs.job_get_metadata.outputs.has_gitflow_label == 'false')
     steps:
       - name: Check out base commit (${{ github.event.pull_request.base.sha }})


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/13351 still triggered the `job_build` job  because I forgot to explicitly check for `true` in the if condition.

Also made a minor simplifcation to the condition I missed in the PR review suggestion in https://github.com/getsentry/sentry-javascript/pull/13340
