### PR TITLE
ci: Streamline some caching

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,0 +1,29 @@
+name: "Install yarn dependencies"
+description: "Installs yarn dependencies and caches them."
+
+outputs:
+  cache_key:
+    description: "The dependency cache key"
+    value: ${{ steps.compute_lockfile_hash.outputs.hash }}
+
+runs:
+  using: "composite"
+  steps:
+      # we use a hash of yarn.lock as our cache key, because if it hasn't changed, our dependencies haven't changed,
+      # so no need to reinstall them
+    - name: Compute dependency cache key
+      id: compute_lockfile_hash
+      run: echo "hash=dependencies-${{ hashFiles('yarn.lock', 'packages/*/package.json', 'dev-packages/*/package.json') }}" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Check dependency cache
+      uses: actions/cache@v4
+      id: cache_dependencies
+      with:
+        path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+        key: ${{ steps.compute_lockfile_hash.outputs.hash }}
+
+    - name: Install dependencies
+      if: steps.cache_dependencies.outputs.cache-hit != 'true'
+      run: yarn install --ignore-engines --frozen-lockfile
+      shell: bash

--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -13,9 +13,22 @@ runs:
         run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT
         shell: bash
 
+      # We only want to store the cache if we are on the develop branch
       - name: Cache playwright binaries
         uses: actions/cache@v4
         id: playwright-cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # On non-develop branches, only restore playwright from cache, but do not store it
+      # This is done to avoid keeping too many copies of playwright in the cache from different branches
+      - name: Cache playwright binaries (restore only)
+        uses: actions/cache/restore@v4
+        id: playwright-cache-restore
+        if: github.event_name != 'push' || github.ref != 'refs/heads/develop'
         with:
           path: |
             ~/.cache/ms-playwright
@@ -24,10 +37,10 @@ runs:
       # We always install all browsers, if uncached
       - name: Install Playwright dependencies (uncached)
         run: npx playwright install chromium webkit firefox --with-deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && steps.playwright-cache-restore.outputs.cache-hit =! 'true'
         shell: bash
 
       - name: Install Playwright system dependencies only (cached)
         run: npx playwright install-deps ${{ inputs.browsers || 'chromium webkit firefox' }}
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        if: steps.playwright-cache.outputs.cache-hit == 'true' || && steps.playwright-cache-restore.outputs.cache-hit == 'true'
         shell: bash

--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -13,22 +13,9 @@ runs:
         run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> $GITHUB_OUTPUT
         shell: bash
 
-      # We only want to store the cache if we are on the develop branch
       - name: Cache playwright binaries
         uses: actions/cache@v4
         id: playwright-cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      # On non-develop branches, only restore playwright from cache, but do not store it
-      # This is done to avoid keeping too many copies of playwright in the cache from different branches
-      - name: Cache playwright binaries (restore only)
-        uses: actions/cache/restore@v4
-        id: playwright-cache-restore
-        if: github.event_name != 'push' || github.ref != 'refs/heads/develop'
         with:
           path: |
             ~/.cache/ms-playwright
@@ -37,10 +24,10 @@ runs:
       # We always install all browsers, if uncached
       - name: Install Playwright dependencies (uncached)
         run: npx playwright install chromium webkit firefox --with-deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true' && steps.playwright-cache-restore.outputs.cache-hit =! 'true'
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         shell: bash
 
       - name: Install Playwright system dependencies only (cached)
         run: npx playwright install-deps ${{ inputs.browsers || 'chromium webkit firefox' }}
-        if: steps.playwright-cache.outputs.cache-hit == 'true' || && steps.playwright-cache-restore.outputs.cache-hit == 'true'
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,22 +146,9 @@ jobs:
         with:
           node-version-file: 'package.json'
 
-        # we use a hash of yarn.lock as our cache key, because if it hasn't changed, our dependencies haven't changed,
-        # so no need to reinstall them
-      - name: Compute dependency cache key
-        id: compute_lockfile_hash
-        run: echo "hash=${{ hashFiles('yarn.lock', '**/package.json') }}" >> "$GITHUB_OUTPUT"
-
-      - name: Check dependency cache
-        uses: actions/cache@v4
-        id: cache_dependencies
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ steps.compute_lockfile_hash.outputs.hash }}
-
-      - name: Install dependencies
-        if: steps.cache_dependencies.outputs.cache-hit != 'true'
-        run: yarn install --ignore-engines --frozen-lockfile
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+        id: install_dependencies
 
       - name: Check for Affected Nx Projects
         uses: dkhunt27/action-nx-affected-list@v5.3
@@ -200,7 +187,7 @@ jobs:
         run: yarn build
 
     outputs:
-      dependency_cache_key: ${{ steps.compute_lockfile_hash.outputs.hash }}
+      dependency_cache_key: ${{ steps.install_dependencies.outputs.cache_key }}
       changed_node_integration: ${{ needs.job_get_metadata.outputs.changed_ci == 'true' || contains(steps.checkForAffected.outputs.affected, '@sentry-internal/node-integration-tests') }}
       changed_remix: ${{ needs.job_get_metadata.outputs.changed_ci == 'true' || contains(steps.checkForAffected.outputs.affected, '@sentry/remix') }}
       changed_node: ${{ needs.job_get_metadata.outputs.changed_ci == 'true' || contains(steps.checkForAffected.outputs.affected, '@sentry/node') }}
@@ -293,22 +280,9 @@ jobs:
         with:
           node-version-file: 'package.json'
 
-        # we use a hash of yarn.lock as our cache key, because if it hasn't changed, our dependencies haven't changed,
-        # so no need to reinstall them
-      - name: Compute dependency cache key
-        id: compute_lockfile_hash
-        run: echo "hash=${{ hashFiles('yarn.lock', '**/package.json') }}" >> "$GITHUB_OUTPUT"
-
-      - name: Check dependency cache
-        uses: actions/cache@v4
-        id: cache_dependencies
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ steps.compute_lockfile_hash.outputs.hash }}
-
-      - name: Install dependencies
-        if: steps.cache_dependencies.outputs.cache-hit != 'true'
-        run: yarn install --ignore-engines --frozen-lockfile
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+        id: install_dependencies
 
       - name: Check file formatting
         run: yarn lint:prettier && yarn lint:biome


### PR DESCRIPTION
This streamlines some caching stuff for CI:

1. Extract dependency installation & cache out into a composite action for reusability
2. Updated the cache key for dependencies to only include package & dev-package `package.json`, not the E2E test ones.