### PR TITLE
fix(ci): GH dropped macos-11 at the end of June 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1388,16 +1388,16 @@ jobs:
             node: 22
 
             # macos x64
-          - os: macos-11
+          - os: macos-12
             node: 16
             arch: x64
-          - os: macos-11
+          - os: macos-12
             node: 18
             arch: x64
-          - os: macos-11
+          - os: macos-12
             node: 20
             arch: x64
-          - os: macos-11
+          - os: macos-12
             node: 22
             arch: x64
 


### PR DESCRIPTION
5 days after the previous v7 release github removed the macos-11 runners.

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal

```
In January 2024, GitHub announced the [deprecation of macOS 11](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) and the removal of the runner image by June 2024. The macOS 11 runner image will be removed on 6/28/2024. We recommend updating workflows to use macos-14, macos-13, macos-12, or macos-latest. Reminder emails will be sent to those who have used the macOS 11 runner image in the past 30 days. Jobs using macOS 11 will temporarily fail during scheduled time periods to raise awareness of the upcoming removal. The schedule can be found below:

June 17 2024, 8:00 AM – 2:00 PM EST
June 19 2024, 12:00 PM – 6:00 PM EST
June 24 2024, 3:00 AM – 9:00 PM EST
June 26 2024, 8:00 AM – 2:00 PM EST
```