### PR TITLE
Revert "build: Bump node to 22.5.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "yalc:publish": "lerna run yalc:publish"
   },
   "volta": {
-    "node": "22.5.1",
+    "node": "18.20.3",
     "yarn": "1.22.22"
   },
   "workspaces": [


### PR DESCRIPTION
Reverts getsentry/sentry-javascript#13118

There has been quite a bit of segmentation faults in CI after this PR was merged.

I tried spending time to look into this in more detail, but it didn't get far, so not worrying about this too much for now. Let's revert and re-examine later.