### PR TITLE
fix(deno): Don't rely on `Deno.permissions.querySync`

### DIFF
--- a/packages/deno/src/client.ts
+++ b/packages/deno/src/client.ts
@@ -4,6 +4,11 @@ import { SDK_VERSION, ServerRuntimeClient } from '@sentry/core';
 import type { DenoClientOptions } from './types';
 
 function getHostName(): string | undefined {
+  // Deno.permissions.querySync is not available on Deno Deploy
+  if (!Deno.permissions.querySync) {
+    return undefined;
+  }
+
   const result = Deno.permissions.querySync({ name: 'sys', kind: 'hostname' });
   return result.state === 'granted' ? Deno.hostname() : undefined;
 }

--- a/packages/deno/src/integrations/context.ts
+++ b/packages/deno/src/integrations/context.ts
@@ -16,8 +16,8 @@ function getOSName(): string {
   }
 }
 
-function getOSRelease(): string | undefined {
-  return Deno.permissions.querySync({ name: 'sys', kind: 'osRelease' }).state === 'granted'
+async function getOSRelease(): Promise<string | undefined> {
+  return (await Deno.permissions.query({ name: 'sys', kind: 'osRelease' })).state === 'granted'
     ? Deno.osRelease()
     : undefined;
 }
@@ -35,7 +35,7 @@ async function addDenoRuntimeContext(event: Event): Promise<Event> {
       },
       os: {
         name: getOSName(),
-        version: getOSRelease(),
+        version: await getOSRelease(),
       },
       v8: {
         name: 'v8',

--- a/packages/deno/src/integrations/normalizepaths.ts
+++ b/packages/deno/src/integrations/normalizepaths.ts
@@ -42,6 +42,11 @@ function appRootFromErrorStack(error: Error): string | undefined {
 }
 
 function getCwd(): string | undefined {
+  // Deno.permissions.querySync is not available on Deno Deploy
+  if (!Deno.permissions.querySync) {
+    return undefined;
+  }
+
   // We don't want to prompt for permissions so we only get the cwd if
   // permissions are already granted
   const permission = Deno.permissions.querySync({ name: 'read', path: './' });


### PR DESCRIPTION
This fix isn't perfect but it will at least unblock people on Deno deploy.

Fixes https://github.com/getsentry/sentry-javascript/issues/10521