### PR TITLE
fix(sveltekit): update wrapServerRouteWithSentry to respect ParamMatchers

### DIFF
--- a/packages/sveltekit/src/server/serverRoute.ts
+++ b/packages/sveltekit/src/server/serverRoute.ts
@@ -27,9 +27,9 @@ type PatchedServerRouteEvent = RequestEvent & { __sentry_wrapped__?: boolean };
  *
  * @returns a wrapped version of your server route handler
  */
-export function wrapServerRouteWithSentry(
-  originalRouteHandler: (request: RequestEvent) => Promise<Response>,
-): (requestEvent: RequestEvent) => Promise<Response> {
+export function wrapServerRouteWithSentry<T extends RequestEvent>(
+  originalRouteHandler: (request: T) => Promise<Response>,
+): (requestEvent: T) => Promise<Response> {
   return new Proxy(originalRouteHandler, {
     apply: async (wrappingTarget, thisArg, args) => {
       const event = args[0] as PatchedServerRouteEvent;


### PR DESCRIPTION
SvelteKit narrows the type of event.params based on ParamMatchers that are defined in the path, by making the function generic we can respect the narrowed type

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Follow up to  #13247