### PR TITLE
docs: Fix v7 changelog format and link

### DIFF
--- a/docs/changelog/v7.md
+++ b/docs/changelog/v7.md
@@ -1,7 +1,7 @@
 # Changelog for Sentry SDK 7.x
 
 Support for Sentry SDK v7 will be dropped soon. We recommend migrating to the latest version of the SDK. You can migrate
-from `v7` to `v8 of the SDK by following the [migration guide](../../MIGRATION.md).
+from `v7` of the SDK to `v8` by following the [migration guide](../../MIGRATION.md#upgrading-from-7x-to-8x).
 
 ## 7.118.0
 


### PR DESCRIPTION
Minor changes: I realized that the formatting was broken for `v8` and that the migration guide wasn't linking to the specific section like other changelogs.
