### PR TITLE
ci: Update clear cache action to be smarter

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           node-version-file: 'package.json'
 
+      # TODO: Use cached version if possible (but never store cache)
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -2,8 +2,8 @@ name: "Action: Clear all GHA caches"
 on:
   workflow_dispatch:
     inputs:
-      clear_pending:
-        description: Delete caches of pending workflows
+      clear_pending_prs:
+        description: Delete caches of pending PR workflows
         type: boolean
         default: false
       clear_develop:
@@ -36,7 +36,7 @@ jobs:
       - name: Clear caches
         uses: ./dev-packages/clear-cache-gh-action
         with:
-          clear_pending: ${{ inputs.clear_pending }}
+          clear_pending_prs: ${{ inputs.clear_pending_prs }}
           clear_develop: ${{ inputs.clear_develop }}
           clear_branches: ${{ inputs.clear_branches }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,11 +1,37 @@
 name: "Action: Clear all GHA caches"
 on:
   workflow_dispatch:
+    inputs:
+      include_pending:
+        description: If caches of pending workflows should be deleted
+        type: boolean
+        default: false
+      include_develop:
+        description: If caches of the develop branch should be deleted
+        type: boolean
+        default: false
+  schedule:
+    # Run every day at midnight
+    - cron: '0 0 * * *'
 
 jobs:
   clear-caches:
     name: Delete all caches
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
       - name: Clear caches
-        uses: easimon/wipe-cache@v2
+        uses: ./dev-packages/clear-cache-gh-action
+        with:
+          include_pending: ${{ inputs.include_pending }}
+          include_develop: ${{ inputs.include_develop }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -3,13 +3,17 @@ on:
   workflow_dispatch:
     inputs:
       include_pending:
-        description: If caches of pending workflows should be deleted
+        description: Delete caches of pending workflows
         type: boolean
         default: false
       include_develop:
-        description: If caches of the develop branch should be deleted
+        description: Delete caches on develop branch
         type: boolean
         default: false
+      include_branches:
+        description: Delete caches on non-develop branches
+        type: boolean
+        default: true
   schedule:
     # Run every day at midnight
     - cron: '0 0 * * *'
@@ -34,4 +38,5 @@ jobs:
         with:
           include_pending: ${{ inputs.include_pending }}
           include_develop: ${{ inputs.include_develop }}
+          include_branches: ${{ inputs.include_branches }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Clear caches
+      - name: Delete GHA caches
         uses: ./dev-packages/clear-cache-gh-action
         with:
           clear_pending_prs: ${{ inputs.clear_pending_prs }}

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -2,15 +2,15 @@ name: "Action: Clear all GHA caches"
 on:
   workflow_dispatch:
     inputs:
-      include_pending:
+      clear_pending:
         description: Delete caches of pending workflows
         type: boolean
         default: false
-      include_develop:
+      clear_develop:
         description: Delete caches on develop branch
         type: boolean
         default: false
-      include_branches:
+      clear_branches:
         description: Delete caches on non-develop branches
         type: boolean
         default: true
@@ -36,7 +36,7 @@ jobs:
       - name: Clear caches
         uses: ./dev-packages/clear-cache-gh-action
         with:
-          include_pending: ${{ inputs.include_pending }}
-          include_develop: ${{ inputs.include_develop }}
-          include_branches: ${{ inputs.include_branches }}
+          clear_pending: ${{ inputs.clear_pending }}
+          clear_develop: ${{ inputs.clear_develop }}
+          clear_branches: ${{ inputs.clear_branches }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
-          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/dev-packages/clear-cache-gh-action/.eslintrc.cjs
+++ b/dev-packages/clear-cache-gh-action/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: ['../../.eslintrc.js'],
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 'latest',
+  },
+
+  overrides: [
+    {
+      files: ['*.mjs'],
+      extends: ['@sentry-internal/sdk/src/base'],
+    },
+  ],
+};

--- a/dev-packages/clear-cache-gh-action/action.yml
+++ b/dev-packages/clear-cache-gh-action/action.yml
@@ -12,10 +12,10 @@ inputs:
     required: false
     default: ""
     description: "If set, also clear caches from non-develop branches."
-  clear_pending:
+  clear_pending_prs:
     required: false
     default: ""
-    description: "If set, also clear caches from incomplete workflow runs."
+    description: "If set, also clear caches from pending PR workflow runs."
   workflow_name:
     required: false
     default: "CI: Build & Test"

--- a/dev-packages/clear-cache-gh-action/action.yml
+++ b/dev-packages/clear-cache-gh-action/action.yml
@@ -8,6 +8,10 @@ inputs:
     required: false
     default: ""
     description: "If set, also clear caches from develop branch."
+  clear_branches:
+    required: false
+    default: ""
+    description: "If set, also clear caches from non-develop branches."
   clear_pending:
     required: false
     default: ""

--- a/dev-packages/clear-cache-gh-action/action.yml
+++ b/dev-packages/clear-cache-gh-action/action.yml
@@ -1,0 +1,21 @@
+name: 'clear-cache-gh-action'
+description: 'Clear caches of the GitHub repository.'
+inputs:
+  github_token:
+    required: true
+    description: 'a github access token'
+  clear_develop:
+    required: false
+    default: ""
+    description: "If set, also clear caches from develop branch."
+  clear_pending:
+    required: false
+    default: ""
+    description: "If set, also clear caches from incomplete workflow runs."
+  workflow_name:
+    required: false
+    default: "CI: Build & Test"
+    description: The workflow to clear caches for.
+runs:
+  using: 'node20'
+  main: 'index.mjs'

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -107,14 +107,13 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
         }
       }
 
-      // DRY RUN FOR NOW!
-      core.info(`> >>Would delete cache ${id} for ${ref}...`);
+      core.info(`> Clearing cache ${id}...`);
 
-      /*   await octokit.rest.actions.deleteActionsCacheById({
+      await octokit.rest.actions.deleteActionsCacheById({
         owner,
         repo,
         cache_id: id,
-      }); */
+      });
     }
   }
 }

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -10,7 +10,7 @@ async function run() {
   const githubToken = getInput('github_token');
   const clearDevelop = getInput('clear_develop', { type: 'boolean' });
   const clearBranches = getInput('clear_branches', { type: 'boolean', default: true });
-  const clearPending = getInput('clear_pending', { type: 'boolean' });
+  const clearPending = getInput('clear_pending_prs', { type: 'boolean' });
   const workflowName = getInput('workflow_name');
 
   const octokit = getOctokit(githubToken);

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -99,7 +99,7 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
           // as either the run may be in progress,
           // or failed - in which case we may want to re-run the workflow
           if (latestWorkflowRun.conclusion !== 'success') {
-            core.info(`> Keeping cache because latest workflow is ${latestWorkflowRun.status}.`);
+            core.info(`> Keeping cache because latest workflow is ${latestWorkflowRun.conclusion}.`);
             continue;
           }
 

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -9,6 +9,7 @@ async function run() {
 
   const githubToken = getInput('github_token');
   const clearDevelop = getInput('clear_develop', { type: 'boolean' });
+  const clearBranches = getInput('clear_branches', { type: 'boolean', default: true });
   const clearPending = getInput('clear_pending', { type: 'boolean' });
   const workflowName = getInput('workflow_name');
 
@@ -19,6 +20,7 @@ async function run() {
     owner,
     clearDevelop,
     clearPending,
+    clearBranches,
     workflowName,
   });
 }
@@ -27,9 +29,9 @@ async function run() {
  * Clear caches.
  *
  * @param {ReturnType<import("@actions/github").getOctokit> } octokit
- * @param {{repo: string, owner: string, clearDevelop: boolean, clearPending: boolean, workflowName: string}} options
+ * @param {{repo: string, owner: string, clearDevelop: boolean, clearPending: boolean, clearBranches: boolean, workflowName: string}} options
  */
-async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPending, workflowName }) {
+async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPending, clearBranches, workflowName }) {
   for await (const response of octokit.paginate.iterator(octokit.rest.actions.getActionsCacheList, {
     owner,
     repo,
@@ -46,48 +48,62 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
         continue;
       }
 
-      // If clearPending is false, do not clear caches for pull requests that have pending checks.
+      // There are two fundamental paths here:
+      // If the cache belongs to a PR, we need to check if the PR has any pending workflows.
+      // Else, we assume the cache belongs to a branch, where we do not check for pending workflows
       const pull_number = /^refs\/pull\/(\d+)\/merge$/.exec(ref)?.[1];
-      if (!clearPending && pull_number) {
-        const pr = await octokit.rest.pulls.get({
-          owner,
-          repo,
-          pull_number,
-        });
+      if (pull_number) {
+        if (!clearPending) {
+          const pr = await octokit.rest.pulls.get({
+            owner,
+            repo,
+            pull_number,
+          });
 
-        const prBranch = pr.data.head.ref;
+          const prBranch = pr.data.head.ref;
 
-        // Check if PR has any pending workflows
-        const workflowRuns = await octokit.rest.actions.listWorkflowRunsForRepo({
-          repo,
-          owner,
-          branch: prBranch,
-        });
+          // Check if PR has any pending workflows
+          const workflowRuns = await octokit.rest.actions.listWorkflowRunsForRepo({
+            repo,
+            owner,
+            branch: prBranch,
+          });
 
-        // We only care about the relevant workflow
-        const relevantWorkflowRuns = workflowRuns.data.workflow_runs.filter(workflow => workflow.name === workflowName);
+          // We only care about the relevant workflow
+          const relevantWorkflowRuns = workflowRuns.data.workflow_runs.filter(
+            workflow => workflow.name === workflowName,
+          );
 
-        const latestWorkflowRun = relevantWorkflowRuns[0];
+          const latestWorkflowRun = relevantWorkflowRuns[0];
 
-        core.info(`> Latest relevant workflow run: ${latestWorkflowRun.html_url}`);
+          core.info(`> Latest relevant workflow run: ${latestWorkflowRun.html_url}`);
 
-        // No relevant workflow? Clear caches!
-        if (!latestWorkflowRun) {
-          core.info('> Clearing cache because no relevant workflow was found.');
-          continue;
+          // No relevant workflow? Clear caches!
+          if (!latestWorkflowRun) {
+            core.info('> Clearing cache because no relevant workflow was found.');
+            continue;
+          }
+
+          // If the latest run was not successful, keep caches
+          // as either the run may be in progress,
+          // or failed - in which case we may want to re-run the workflow
+          if (latestWorkflowRun.conclusion !== 'success') {
+            core.info(`> Keeping cache because latest workflow is ${latestWorkflowRun.status}.`);
+            continue;
+          }
+
+          core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.status}.`);
+        } else {
+          core.info('> Clearing cache of PR workflow run.');
         }
-
-        // If the latest run was not successful, keep caches
-        // as either the run may be in progress,
-        // or failed - in which case we may want to re-run the workflow
-        if (latestWorkflowRun.conclusion !== 'success') {
-          core.info(`> Keeping cache because latest workflow is ${latestWorkflowRun.status}.`);
-          continue;
-        }
-
-        core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.status}.`);
       } else {
-        core.info('Clearing cache because it is not a PR');
+        // This means this is not a pull request, so check clearBranches
+        if (clearBranches) {
+          core.info('> Clearing cache because it is not a PR.');
+        } else {
+          core.info('> Keeping cache for non-PR workflow run.');
+          continue;
+        }
       }
 
       // DRY RUN FOR NOW!

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -120,11 +120,11 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
 
       core.info(`> Clearing cache ${id}...`);
 
-      await octokit.rest.actions.deleteActionsCacheById({
+      /*  await octokit.rest.actions.deleteActionsCacheById({
         owner,
         repo,
         cache_id: id,
-      });
+      }); */
     }
   }
 }

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -1,0 +1,105 @@
+import * as core from '@actions/core';
+
+import { context, getOctokit } from '@actions/github';
+
+async function run() {
+  const { getInput } = core;
+
+  const { repo, owner } = context.repo;
+
+  const githubToken = getInput('github_token');
+  const clearDevelop = getInput('clear_develop', { type: 'boolean' });
+  const clearPending = getInput('clear_pending', { type: 'boolean' });
+  const workflowName = getInput('workflow_name');
+
+  const octokit = getOctokit(githubToken);
+
+  await clearGithubCaches(octokit, {
+    repo,
+    owner,
+    clearDevelop,
+    clearPending,
+    workflowName,
+  });
+}
+
+/**
+ * Clear caches.
+ *
+ * @param {ReturnType<import("@actions/github").getOctokit> } octokit
+ * @param {{repo: string, owner: string, clearDevelop: boolean, clearPending: boolean, workflowName: string}} options
+ */
+async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPending, workflowName }) {
+  for await (const response of octokit.paginate.iterator(octokit.rest.actions.getActionsCacheList, {
+    owner,
+    repo,
+  })) {
+    if (!response.data.length) {
+      break;
+    }
+
+    for (const { id, ref } of response.data) {
+      core.info(`Checking cache ${id} for ${ref}...`);
+      // Do not clear develop caches if clearDevelop is false.
+      if (!clearDevelop && ref === 'refs/head/develop') {
+        core.info('> Keeping cache because it is on develop.');
+        continue;
+      }
+
+      // If clearPending is false, do not clear caches for pull requests that have pending checks.
+      const pull_number = /^refs\/pull\/(\d+)\/merge$/.exec(ref)?.[1];
+      if (!clearPending && pull_number) {
+        const pr = await octokit.rest.pulls.get({
+          owner,
+          repo,
+          pull_number,
+        });
+
+        const prBranch = pr.data.head.ref;
+
+        // Check if PR has any pending workflows
+        const workflowRuns = await octokit.rest.actions.listWorkflowRunsForRepo({
+          repo,
+          owner,
+          branch: prBranch,
+        });
+
+        // We only care about the relevant workflow
+        const relevantWorkflowRuns = workflowRuns.data.workflow_runs.filter(workflow => workflow.name === workflowName);
+
+        const latestWorkflowRun = relevantWorkflowRuns[0];
+
+        core.info(`> Latest relevant workflow run: ${latestWorkflowRun.html_url}`);
+
+        // No relevant workflow? Clear caches!
+        if (!latestWorkflowRun) {
+          core.info('> Clearing cache because no relevant workflow was found.');
+          continue;
+        }
+
+        // If the latest run was not successful, keep caches
+        // as either the run may be in progress,
+        // or failed - in which case we may want to re-run the workflow
+        if (latestWorkflowRun.conclusion !== 'success') {
+          core.info(`> Keeping cache because latest workflow is ${latestWorkflowRun.status}.`);
+          continue;
+        }
+
+        core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.status}.`);
+      } else {
+        core.info('Clearing cache because it is not a PR');
+      }
+
+      // DRY RUN FOR NOW!
+      core.info(`Would delete cache ${id} for ${ref}...`);
+
+      /*   await octokit.rest.actions.deleteActionsCacheById({
+        owner,
+        repo,
+        cache_id: id,
+      }); */
+    }
+  }
+}
+
+run();

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -142,11 +142,11 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
         deletedCaches++;
         deletedSize += size_in_bytes;
 
-        /*  await octokit.rest.actions.deleteActionsCacheById({
-        owner,
-        repo,
-        cache_id: id,
-      }); */
+        await octokit.rest.actions.deleteActionsCacheById({
+          owner,
+          repo,
+          cache_id: id,
+        });
       } else {
         remainingCaches++;
         remainingSize += size_in_bytes;

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -120,11 +120,11 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
 
       core.info(`> Clearing cache ${id}...`);
 
-      /*  await octokit.rest.actions.deleteActionsCacheById({
+      await octokit.rest.actions.deleteActionsCacheById({
         owner,
         repo,
         cache_id: id,
-      }); */
+      });
     }
   }
 }

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -32,104 +32,104 @@ async function run() {
  * @param {{repo: string, owner: string, clearDevelop: boolean, clearPending: boolean, clearBranches: boolean, workflowName: string}} options
  */
 async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPending, clearBranches, workflowName }) {
+  let deletedCaches = 0;
+  let remainingCaches = 0;
+
+  let deletedSize = 0;
+  let remainingSize = 0;
+
+  /** @type {Map<number, ReturnType<typeof octokit.rest.pulls.get>>} */
+  const cachedPrs = new Map();
+  /** @type {Map<string, ReturnType<typeof octokit.rest.actions.listWorkflowRunsForRepo>>} */
+  const cachedWorkflows = new Map();
+
+  /**
+   * Clear caches.
+   *
+   * @param {{ref: string}} options
+   */
+  const shouldClearCache = async ({ ref }) => {
+    // Do not clear develop caches if clearDevelop is false.
+    if (!clearDevelop && ref === 'refs/heads/develop') {
+      core.info('> Keeping cache because it is on develop.');
+      return false;
+    }
+
+    // There are two fundamental paths here:
+    // If the cache belongs to a PR, we need to check if the PR has any pending workflows.
+    // Else, we assume the cache belongs to a branch, where we do not check for pending workflows
+    const pullNumber = /^refs\/pull\/(\d+)\/merge$/.exec(ref)?.[1];
+    const isPr = !!pullNumber;
+
+    // Case 1: This is a PR, and we do not want to clear pending PRs
+    // In this case, we need to fetch all PRs and workflow runs to check them
+    if (isPr && !clearPending) {
+      const pr =
+        cachedPrs.get(pullNumber) ||
+        (await octokit.rest.pulls.get({
+          owner,
+          repo,
+          pull_number: pullNumber,
+        }));
+      cachedPrs.set(pullNumber, pr);
+
+      const prBranch = pr.data.head.ref;
+
+      // Check if PR has any pending workflows
+      const workflowRuns =
+        cachedWorkflows.get(prBranch) ||
+        (await octokit.rest.actions.listWorkflowRunsForRepo({
+          repo,
+          owner,
+          branch: prBranch,
+        }));
+      cachedWorkflows.set(prBranch, workflowRuns);
+
+      // We only care about the relevant workflow
+      const relevantWorkflowRuns = workflowRuns.data.workflow_runs.filter(workflow => workflow.name === workflowName);
+
+      const latestWorkflowRun = relevantWorkflowRuns[0];
+
+      core.info(`> Latest relevant workflow run: ${latestWorkflowRun.html_url}`);
+
+      // No relevant workflow? Clear caches!
+      if (!latestWorkflowRun) {
+        core.info('> Clearing cache because no relevant workflow was found.');
+        return true;
+      }
+
+      // If the latest run was not successful, keep caches
+      // as either the run may be in progress,
+      // or failed - in which case we may want to re-run the workflow
+      if (latestWorkflowRun.conclusion !== 'success') {
+        core.info(`> Keeping cache because latest workflow is ${latestWorkflowRun.conclusion}.`);
+        return false;
+      }
+
+      core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.conclusion}.`);
+    } else if (isPr) {
+      // Case 2: This is a PR, but we do not want to clear pending PRs
+      // In this case, this cache should never be cleared
+      core.info('> Keeping cache of every PR workflow run.');
+      return false;
+    } else if (clearBranches) {
+      // Case 3: This is not a PR, and we want to clean branches
+      core.info('> Clearing cache because it is not a PR.');
+      return true;
+    } else {
+      // Case 4: This is not a PR, and we do not want to clean branches
+      core.info('> Keeping cache for non-PR workflow run.');
+      return false;
+    }
+  };
+
   for await (const response of octokit.paginate.iterator(octokit.rest.actions.getActionsCacheList, {
     owner,
     repo,
   })) {
-    /** @type {Map<number, ReturnType<typeof octokit.rest.pulls.get>>} */
-    const cachedPrs = new Map();
-    /** @type {Map<string, ReturnType<typeof octokit.rest.actions.listWorkflowRunsForRepo>>} */
-    const cachedWorkflows = new Map();
-
-    let deletedCaches = 0;
-    let remainingCaches = 0;
-
-    let deletedSize = 0;
-    let remainingSize = 0;
-
     if (!response.data.length) {
       break;
     }
-
-    /**
-     * Clear caches.
-     *
-     * @param {{ref: string}} options
-     */
-    const shouldClearCache = async ({ ref }) => {
-      // Do not clear develop caches if clearDevelop is false.
-      if (!clearDevelop && ref === 'refs/heads/develop') {
-        core.info('> Keeping cache because it is on develop.');
-        return false;
-      }
-
-      // There are two fundamental paths here:
-      // If the cache belongs to a PR, we need to check if the PR has any pending workflows.
-      // Else, we assume the cache belongs to a branch, where we do not check for pending workflows
-      const pullNumber = /^refs\/pull\/(\d+)\/merge$/.exec(ref)?.[1];
-      const isPr = !!pullNumber;
-
-      // Case 1: This is a PR, and we do not want to clear pending PRs
-      // In this case, we need to fetch all PRs and workflow runs to check them
-      if (isPr && !clearPending) {
-        const pr =
-          cachedPrs.get(pullNumber) ||
-          (await octokit.rest.pulls.get({
-            owner,
-            repo,
-            pull_number: pullNumber,
-          }));
-        cachedPrs.set(pullNumber, pr);
-
-        const prBranch = pr.data.head.ref;
-
-        // Check if PR has any pending workflows
-        const workflowRuns =
-          cachedWorkflows.get(prBranch) ||
-          (await octokit.rest.actions.listWorkflowRunsForRepo({
-            repo,
-            owner,
-            branch: prBranch,
-          }));
-        cachedWorkflows.set(prBranch, workflowRuns);
-
-        // We only care about the relevant workflow
-        const relevantWorkflowRuns = workflowRuns.data.workflow_runs.filter(workflow => workflow.name === workflowName);
-
-        const latestWorkflowRun = relevantWorkflowRuns[0];
-
-        core.info(`> Latest relevant workflow run: ${latestWorkflowRun.html_url}`);
-
-        // No relevant workflow? Clear caches!
-        if (!latestWorkflowRun) {
-          core.info('> Clearing cache because no relevant workflow was found.');
-          return true;
-        }
-
-        // If the latest run was not successful, keep caches
-        // as either the run may be in progress,
-        // or failed - in which case we may want to re-run the workflow
-        if (latestWorkflowRun.conclusion !== 'success') {
-          core.info(`> Keeping cache because latest workflow is ${latestWorkflowRun.conclusion}.`);
-          return false;
-        }
-
-        core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.conclusion}.`);
-      } else if (isPr) {
-        // Case 2: This is a PR, but we do not want to clear pending PRs
-        // In this case, this cache should never be cleared
-        core.info('> Keeping cache of every PR workflow run.');
-        return false;
-      } else if (clearBranches) {
-        // Case 3: This is not a PR, and we want to clean branches
-        core.info('> Clearing cache because it is not a PR.');
-        return true;
-      } else {
-        // Case 4: This is not a PR, and we do not want to clean branches
-        core.info('> Keeping cache for non-PR workflow run.');
-        return false;
-      }
-    };
 
     for (const { id, ref, size_in_bytes } of response.data) {
       core.info(`Checking cache ${id} for ${ref}...`);
@@ -152,15 +152,15 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
         remainingSize += size_in_bytes;
       }
     }
-
-    const format = new Intl.NumberFormat('en-US', {
-      style: 'decimal',
-    });
-
-    core.info('Summary:');
-    core.info(`Deleted ${deletedCaches} caches, freeing up ~${format.format(deletedSize / 1000 / 1000)} mb.`);
-    core.info(`Remaining ${remainingCaches} caches, using ~${format.format(remainingSize / 1000 / 1000)} mb.`);
   }
+
+  const format = new Intl.NumberFormat('en-US', {
+    style: 'decimal',
+  });
+
+  core.info('Summary:');
+  core.info(`Deleted ${deletedCaches} caches, freeing up ~${format.format(deletedSize / 1000 / 1000)} mb.`);
+  core.info(`Remaining ${remainingCaches} caches, using ~${format.format(remainingSize / 1000 / 1000)} mb.`);
 }
 
 run();

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -8,9 +8,9 @@ async function run() {
   const { repo, owner } = context.repo;
 
   const githubToken = getInput('github_token');
-  const clearDevelop = getInput('clear_develop', { type: 'boolean' });
-  const clearBranches = getInput('clear_branches', { type: 'boolean', default: true });
-  const clearPending = getInput('clear_pending_prs', { type: 'boolean' });
+  const clearDevelop = inputToBoolean(getInput('clear_develop', { type: 'boolean' }));
+  const clearBranches = inputToBoolean(getInput('clear_branches', { type: 'boolean', default: true }));
+  const clearPending = inputToBoolean(getInput('clear_pending_prs', { type: 'boolean' }));
   const workflowName = getInput('workflow_name');
 
   const octokit = getOctokit(githubToken);
@@ -94,7 +94,8 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
 
           core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.conclusion}.`);
         } else {
-          core.info('> Clearing cache of PR workflow run.');
+          core.info('> Keeping cache of every PR workflow run.');
+          continue;
         }
       } else {
         // This means this is not a pull request, so check clearBranches
@@ -107,7 +108,7 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
       }
 
       // DRY RUN FOR NOW!
-      core.info(`Would delete cache ${id} for ${ref}...`);
+      core.info(`> >>Would delete cache ${id} for ${ref}...`);
 
       /*   await octokit.rest.actions.deleteActionsCacheById({
         owner,
@@ -119,3 +120,15 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
 }
 
 run();
+
+function inputToBoolean(input) {
+  if (typeof input === 'boolean') {
+    return input;
+  }
+
+  if (typeof input === 'string') {
+    return input === 'true';
+  }
+
+  return false;
+}

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -107,20 +107,25 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
       }
 
       core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.conclusion}.`);
-    } else if (isPr) {
-      // Case 2: This is a PR, but we do not want to clear pending PRs
-      // In this case, this cache should never be cleared
-      core.info('> Keeping cache of every PR workflow run.');
-      return false;
-    } else if (clearBranches) {
-      // Case 3: This is not a PR, and we want to clean branches
+      return true;
+    }
+
+    // Case 2: This is a PR, but we do want to clear pending PRs
+    // In this case, this cache should always be cleared
+    if (isPr) {
+      core.info('> Clearing cache of every PR workflow run.');
+      return true;
+    }
+
+    // Case 3: This is not a PR, and we want to clean branches
+    if (clearBranches) {
       core.info('> Clearing cache because it is not a PR.');
       return true;
-    } else {
-      // Case 4: This is not a PR, and we do not want to clean branches
-      core.info('> Keeping cache for non-PR workflow run.');
-      return false;
     }
+
+    // Case 4: This is not a PR, and we do not want to clean branches
+    core.info('> Keeping cache for non-PR workflow run.');
+    return false;
   };
 
   for await (const response of octokit.paginate.iterator(octokit.rest.actions.getActionsCacheList, {

--- a/dev-packages/clear-cache-gh-action/index.mjs
+++ b/dev-packages/clear-cache-gh-action/index.mjs
@@ -43,7 +43,7 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
     for (const { id, ref } of response.data) {
       core.info(`Checking cache ${id} for ${ref}...`);
       // Do not clear develop caches if clearDevelop is false.
-      if (!clearDevelop && ref === 'refs/head/develop') {
+      if (!clearDevelop && ref === 'refs/heads/develop') {
         core.info('> Keeping cache because it is on develop.');
         continue;
       }
@@ -92,7 +92,7 @@ async function clearGithubCaches(octokit, { repo, owner, clearDevelop, clearPend
             continue;
           }
 
-          core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.status}.`);
+          core.info(`> Clearing cache because latest workflow run is ${latestWorkflowRun.conclusion}.`);
         } else {
           core.info('> Clearing cache of PR workflow run.');
         }

--- a/dev-packages/clear-cache-gh-action/package.json
+++ b/dev-packages/clear-cache-gh-action/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sentry-internal/clear-cache-gh-action",
+  "description": "An internal Github Action to clear GitHub caches.",
+  "version": "8.26.0",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "private": true,
+  "main": "index.mjs",
+  "type": "module",
+  "scripts": {
+    "lint": "eslint . --format stylish",
+    "fix": "eslint . --format stylish --fix"
+  },
+  "dependencies": {
+    "@actions/core": "1.10.1",
+    "@actions/github": "^5.0.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "dev-packages/overhead-metrics",
     "dev-packages/test-utils",
     "dev-packages/size-limit-gh-action",
+    "dev-packages/clear-cache-gh-action",
     "dev-packages/external-contributor-gh-action",
     "dev-packages/rollup-utils"
   ],


### PR DESCRIPTION
Previously, we had a CI action to manually clear all caches.

This PR adjusts this so this action can be used in a more granular way:

* By default, the action will now delete caches of any PR runs that are successful, as well as any caches of release branches.
* You can configure to also delete caches on the develop branch, and/or to also delete non-successful PR branches.

Additionally, this action will run every midnight, to automatically clear completed/outdated stuff.

The goal is to keep develop caches as long as possible, and clear out other caches, unless they failed (which indicates you may want to re-run some of the tests) and unless they are currently running (to not break ongoing tests). Ideally, we do not need to manually run this, but can rely on automated cleanup over night.