### PR TITLE
fix(cdn): Do not mangle _metadata

### DIFF
--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -116,6 +116,8 @@ export function makeTerserPlugin() {
           '_integrations',
           // _meta is used to store metadata of replay network events
           '_meta',
+          // We store SDK metadata in the options
+          '_metadata',
           // Object we inject debug IDs into with bundler plugins
           '_sentryDebugIds',
           // These are used by instrument.ts in utils for identifying HTML elements & events


### PR DESCRIPTION
Noticed that this is mangled on the `options` in the CDN, which it probably shouldn't be...
