### PR TITLE
feat(feedback): Improve error message for 403 errors

### DIFF
--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -64,6 +64,18 @@ export const sendFeedback: SendFeedback = (
         );
       }
 
+      if (response && typeof response.statusCode === 'number' && response.statusCode === 0) {
+        return reject(
+          'Unable to send Feedback. This is because of network issues, or because you are using an ad-blocker.',
+        );
+      }
+
+      if (response && typeof response.statusCode === 'number' && response.statusCode === 403) {
+        return reject(
+          'Unable to send Feedback. This could be because this domain is not in your list of allowed domains.',
+        );
+      }
+
       return reject(
         'Unable to send Feedback. This could be because of network issues, or because you are using an ad-blocker',
       );

--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -64,12 +64,6 @@ export const sendFeedback: SendFeedback = (
         );
       }
 
-      if (response && typeof response.statusCode === 'number' && response.statusCode === 0) {
-        return reject(
-          'Unable to send Feedback. This is because of network issues, or because you are using an ad-blocker.',
-        );
-      }
-
       if (response && typeof response.statusCode === 'number' && response.statusCode === 403) {
         return reject(
           'Unable to send Feedback. This could be because this domain is not in your list of allowed domains.',


### PR DESCRIPTION
If the domain is not in `Allowed Domains` in the Sentry project settings, it would cause a 403 error. The default setting is `*` so this only occurs when the user changes these settings.

Fixes https://github.com/getsentry/sentry-javascript/issues/9856
