### PR TITLE
test(core): Switch to vitest

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../jest/jest.config.js');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,8 +58,8 @@
     "clean": "rimraf build coverage sentry-core-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "test": "jest",
-    "test:watch": "jest --watch",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"
   },
   "volta": {

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -1,6 +1,7 @@
 import type { DsnComponents, SdkInfo } from '@sentry/types';
 import { makeDsn } from '@sentry/utils';
 
+import { describe, expect, it, test } from 'vitest';
 import { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from '../../src/api';
 
 const ingestDsn = 'https://abc@xxxx.ingest.sentry.io:1234/subpath/123';

--- a/packages/core/test/lib/attachments.test.ts
+++ b/packages/core/test/lib/attachments.test.ts
@@ -1,5 +1,6 @@
 import { parseEnvelope } from '@sentry/utils';
 
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createTransport } from '../../src/transports/base';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
@@ -10,7 +11,7 @@ describe('Attachments', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   test('actually end up in envelope', async () => {

--- a/packages/core/test/lib/carrier.test.ts
+++ b/packages/core/test/lib/carrier.test.ts
@@ -1,4 +1,5 @@
 import { SDK_VERSION } from '@sentry/utils';
+import { describe, expect, it } from 'vitest';
 import { getSentryCarrier } from '../../src/carrier';
 
 describe('getSentryCarrier', () => {

--- a/packages/core/test/lib/checkin.test.ts
+++ b/packages/core/test/lib/checkin.test.ts
@@ -1,5 +1,6 @@
 import type { SerializedCheckIn } from '@sentry/types';
 
+import { describe, expect, test } from 'vitest';
 import { createCheckInEnvelope } from '../../src/checkin';
 
 describe('createCheckInEnvelope', () => {

--- a/packages/core/test/lib/envelope.test.ts
+++ b/packages/core/test/lib/envelope.test.ts
@@ -11,6 +11,8 @@ import {
 import { createEventEnvelope, createSpanEnvelope } from '../../src/envelope';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 const testDsn: DsnComponents = { protocol: 'https', projectId: 'abc', host: 'testry.io', publicKey: 'pubKey123' };
 
 describe('createEventEnvelope', () => {
@@ -185,7 +187,7 @@ describe('createSpanEnvelope', () => {
   });
 
   it('calls `beforeSendSpan` and uses original span without any changes', () => {
-    const beforeSendSpan = jest.fn(span => span);
+    const beforeSendSpan = vi.fn(span => span);
     const options = getDefaultTestClientOptions({ dsn: 'https://domain/123', beforeSendSpan });
     const client = new TestClient(options);
 
@@ -217,7 +219,7 @@ describe('createSpanEnvelope', () => {
   });
 
   it('calls `beforeSendSpan` and uses the modified span', () => {
-    const beforeSendSpan = jest.fn(span => {
+    const beforeSendSpan = vi.fn(span => {
       span.description = `mutated description: ${span.description}`;
       return span;
     });

--- a/packages/core/test/lib/feedback.test.ts
+++ b/packages/core/test/lib/feedback.test.ts
@@ -1,4 +1,5 @@
 import type { Span } from '@sentry/types';
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import {
   Scope,
   addBreadcrumb,
@@ -35,7 +36,7 @@ describe('captureFeedback', () => {
     setCurrentClient(client);
     client.init();
 
-    const mockTransport = jest.spyOn(client.getTransport()!, 'send');
+    const mockTransport = vi.spyOn(client.getTransport()!, 'send');
 
     const eventId = captureFeedback({
       message: 'test',
@@ -90,7 +91,7 @@ describe('captureFeedback', () => {
     setCurrentClient(client);
     client.init();
 
-    const mockTransport = jest.spyOn(client.getTransport()!, 'send');
+    const mockTransport = vi.spyOn(client.getTransport()!, 'send');
 
     const eventId = captureFeedback({
       name: 'doe',
@@ -155,7 +156,7 @@ describe('captureFeedback', () => {
     setCurrentClient(client);
     client.init();
 
-    const mockTransport = jest.spyOn(client.getTransport()!, 'send');
+    const mockTransport = vi.spyOn(client.getTransport()!, 'send');
 
     const attachment1 = new Uint8Array([1, 2, 3, 4, 5]);
     const attachment2 = new Uint8Array([6, 7, 8, 9]);
@@ -248,7 +249,7 @@ describe('captureFeedback', () => {
     setCurrentClient(client);
     client.init();
 
-    const mockTransport = jest.spyOn(client.getTransport()!, 'send');
+    const mockTransport = vi.spyOn(client.getTransport()!, 'send');
 
     const traceId = '4C79F60C11214EB38604F4AE0781BFB2';
     const spanId = 'FA90FDEAD5F74052';
@@ -322,7 +323,7 @@ describe('captureFeedback', () => {
     setCurrentClient(client);
     client.init();
 
-    const mockTransport = jest.spyOn(client.getTransport()!, 'send');
+    const mockTransport = vi.spyOn(client.getTransport()!, 'send');
 
     let span: Span | undefined;
     const eventId = startSpan({ name: 'test-span' }, _span => {
@@ -392,7 +393,7 @@ describe('captureFeedback', () => {
     setCurrentClient(client);
     client.init();
 
-    const mockTransport = jest.spyOn(client.getTransport()!, 'send');
+    const mockTransport = vi.spyOn(client.getTransport()!, 'send');
 
     withIsolationScope(isolationScope => {
       isolationScope.setTag('test-1', 'tag');
@@ -478,8 +479,8 @@ describe('captureFeedback', () => {
     const scope = new Scope();
     scope.setClient(client2);
 
-    const mockTransport = jest.spyOn(client.getTransport()!, 'send');
-    const mockTransport2 = jest.spyOn(client2.getTransport()!, 'send');
+    const mockTransport = vi.spyOn(client.getTransport()!, 'send');
+    const mockTransport2 = vi.spyOn(client2.getTransport()!, 'send');
 
     const eventId = captureFeedback(
       {

--- a/packages/core/test/lib/hint.test.ts
+++ b/packages/core/test/lib/hint.test.ts
@@ -5,8 +5,10 @@ import { initAndBind } from '../../src/sdk';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 import { AddAttachmentTestIntegration } from '../mocks/integration';
 
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
 const PUBLIC_DSN = 'https://username@domain/123';
-const sendEvent = jest.spyOn(TestClient.prototype, 'sendEvent');
+const sendEvent = vi.spyOn(TestClient.prototype, 'sendEvent');
 
 describe('Hint', () => {
   beforeEach(() => {
@@ -15,7 +17,7 @@ describe('Hint', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     // @ts-expect-error for testing
     delete GLOBAL_OBJ.__SENTRY__;
   });

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -2,6 +2,7 @@ import type { Integration, Options } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import { getCurrentScope } from '../../src/currentScopes';
 
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { addIntegration, getIntegrationsToSetup, installedIntegrations, setupIntegration } from '../../src/integration';
 import { setCurrentClient } from '../../src/sdk';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
@@ -339,7 +340,7 @@ describe('setupIntegration', () => {
   it('works with a minimal integration', () => {
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
+      setupOnce = vi.fn();
     }
 
     const client = getTestClient();
@@ -355,7 +356,7 @@ describe('setupIntegration', () => {
   it('only calls setupOnce a single time', () => {
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
+      setupOnce = vi.fn();
     }
 
     const client1 = getTestClient();
@@ -382,8 +383,8 @@ describe('setupIntegration', () => {
   it('calls setup for each client', () => {
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
-      setup = jest.fn();
+      setupOnce = vi.fn();
+      setup = vi.fn();
     }
 
     const client1 = getTestClient();
@@ -420,8 +421,8 @@ describe('setupIntegration', () => {
   it('binds preprocessEvent for each client', () => {
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
-      preprocessEvent = jest.fn();
+      setupOnce = vi.fn();
+      preprocessEvent = vi.fn();
     }
 
     const client1 = getTestClient();
@@ -472,8 +473,8 @@ describe('setupIntegration', () => {
   it('allows to mutate events in preprocessEvent', async () => {
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
-      preprocessEvent = jest.fn(event => {
+      setupOnce = vi.fn();
+      preprocessEvent = vi.fn(event => {
         event.event_id = 'mutated';
       });
     }
@@ -485,7 +486,7 @@ describe('setupIntegration', () => {
 
     setupIntegration(client, integration, integrationIndex);
 
-    const sendEvent = jest.fn();
+    const sendEvent = vi.fn();
     client.sendEvent = sendEvent;
 
     client.captureEvent({ event_id: '1a' });
@@ -500,8 +501,8 @@ describe('setupIntegration', () => {
   it('binds processEvent for each client', () => {
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
-      processEvent = jest.fn(event => {
+      setupOnce = vi.fn();
+      processEvent = vi.fn(event => {
         return event;
       });
     }
@@ -554,8 +555,8 @@ describe('setupIntegration', () => {
   it('allows to mutate events in processEvent', async () => {
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
-      processEvent = jest.fn(_event => {
+      setupOnce = vi.fn();
+      processEvent = vi.fn(_event => {
         return { event_id: 'mutated' };
       });
     }
@@ -567,7 +568,7 @@ describe('setupIntegration', () => {
 
     setupIntegration(client, integration, integrationIndex);
 
-    const sendEvent = jest.fn();
+    const sendEvent = vi.fn();
     client.sendEvent = sendEvent;
 
     client.captureEvent({ event_id: '1a' });
@@ -582,8 +583,8 @@ describe('setupIntegration', () => {
   it('allows to drop events in processEvent', async () => {
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
-      processEvent = jest.fn(_event => {
+      setupOnce = vi.fn();
+      processEvent = vi.fn(_event => {
         return null;
       });
     }
@@ -595,7 +596,7 @@ describe('setupIntegration', () => {
 
     setupIntegration(client, integration, integrationIndex);
 
-    const sendEvent = jest.fn();
+    const sendEvent = vi.fn();
     client.sendEvent = sendEvent;
 
     client.captureEvent({ event_id: '1a' });
@@ -612,15 +613,15 @@ describe('addIntegration', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('works with a client setup', () => {
-    const warnings = jest.spyOn(logger, 'warn');
+    const warnings = vi.spyOn(logger, 'warn');
 
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
+      setupOnce = vi.fn();
     }
 
     const client = getTestClient();
@@ -634,10 +635,10 @@ describe('addIntegration', () => {
   });
 
   it('works without a client setup', () => {
-    const warnings = jest.spyOn(logger, 'warn');
+    const warnings = vi.spyOn(logger, 'warn');
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
+      setupOnce = vi.fn();
     }
 
     getCurrentScope().setClient(undefined);
@@ -651,9 +652,9 @@ describe('addIntegration', () => {
   });
 
   it('triggers all hooks', () => {
-    const setup = jest.fn();
-    const setupOnce = jest.fn();
-    const setupAfterAll = jest.fn();
+    const setup = vi.fn();
+    const setupOnce = vi.fn();
+    const setupAfterAll = vi.fn();
 
     class CustomIntegration implements Integration {
       name = 'test';
@@ -675,13 +676,13 @@ describe('addIntegration', () => {
   });
 
   it('does not trigger hooks if already installed', () => {
-    const logs = jest.spyOn(logger, 'log');
+    const logs = vi.spyOn(logger, 'log');
 
     class CustomIntegration implements Integration {
       name = 'test';
-      setupOnce = jest.fn();
-      setup = jest.fn();
-      afterAllSetup = jest.fn();
+      setupOnce = vi.fn();
+      setup = vi.fn();
+      afterAllSetup = vi.fn();
     }
 
     const client = getTestClient();

--- a/packages/core/test/lib/integrations/captureconsole.test.ts
+++ b/packages/core/test/lib/integrations/captureconsole.test.ts
@@ -13,14 +13,17 @@ import * as SentryCore from '../../../src/exports';
 
 import { captureConsoleIntegration } from '../../../src/integrations/captureconsole';
 
-const mockConsole: { [key in ConsoleLevel]: jest.Mock<any> } = {
-  debug: jest.fn(),
-  log: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-  assert: jest.fn(),
-  info: jest.fn(),
-  trace: jest.fn(),
+import type { Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockConsole: { [key in ConsoleLevel]: Mock<any> } = {
+  debug: vi.fn(),
+  log: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  assert: vi.fn(),
+  info: vi.fn(),
+  trace: vi.fn(),
 };
 
 describe('CaptureConsole setup', () => {
@@ -31,23 +34,23 @@ describe('CaptureConsole setup', () => {
   let mockClient: Client;
 
   const mockScope = {
-    setExtra: jest.fn(),
-    addEventProcessor: jest.fn(),
+    setExtra: vi.fn(),
+    addEventProcessor: vi.fn(),
   };
 
-  const captureMessage = jest.fn();
-  const captureException = jest.fn();
-  const withScope = jest.fn(callback => {
+  const captureMessage = vi.fn();
+  const captureException = vi.fn();
+  const withScope = vi.fn(callback => {
     return callback(mockScope);
   });
 
   beforeEach(() => {
     mockClient = {} as Client;
 
-    jest.spyOn(SentryCore, 'captureMessage').mockImplementation(captureMessage);
-    jest.spyOn(SentryCore, 'captureException').mockImplementation(captureException);
-    jest.spyOn(CurrentScopes, 'getClient').mockImplementation(() => mockClient);
-    jest.spyOn(CurrentScopes, 'withScope').mockImplementation(withScope);
+    vi.spyOn(SentryCore, 'captureMessage').mockImplementation(captureMessage);
+    vi.spyOn(SentryCore, 'captureException').mockImplementation(captureException);
+    vi.spyOn(CurrentScopes, 'getClient').mockImplementation(() => mockClient);
+    vi.spyOn(CurrentScopes, 'withScope').mockImplementation(withScope);
 
     CONSOLE_LEVELS.forEach(key => {
       originalConsoleMethods[key] = mockConsole[key];
@@ -55,7 +58,7 @@ describe('CaptureConsole setup', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
 
     CONSOLE_LEVELS.forEach(key => {
       originalConsoleMethods[key] = _originalConsoleMethods[key];
@@ -135,7 +138,7 @@ describe('CaptureConsole setup', () => {
 
     expect(mockScope.addEventProcessor).toHaveBeenCalledTimes(1);
 
-    const addedEventProcessor = (mockScope.addEventProcessor as jest.Mock).mock.calls[0][0];
+    const addedEventProcessor = (mockScope.addEventProcessor as Mock).mock.calls[0][0];
     const someEvent: Event = {};
     addedEventProcessor(someEvent);
 
@@ -264,7 +267,7 @@ describe('CaptureConsole setup', () => {
   it('should call the original console function when console members are called', () => {
     // Mock console log to test if it was called
     const originalConsoleLog = GLOBAL_OBJ.console.log;
-    const mockConsoleLog = jest.fn();
+    const mockConsoleLog = vi.fn();
     GLOBAL_OBJ.console.log = mockConsoleLog;
 
     const captureConsole = captureConsoleIntegration({ levels: ['log'] });
@@ -309,7 +312,7 @@ describe('CaptureConsole setup', () => {
   });
 
   it("marks captured exception's mechanism as unhandled", () => {
-    // const addExceptionMechanismSpy = jest.spyOn(utils, 'addExceptionMechanism');
+    // const addExceptionMechanismSpy = vi.spyOn(utils, 'addExceptionMechanism');
 
     const captureConsole = captureConsoleIntegration({ levels: ['error'] });
     captureConsole.setup?.(mockClient);
@@ -317,7 +320,7 @@ describe('CaptureConsole setup', () => {
     const someError = new Error('some error');
     GLOBAL_OBJ.console.error(someError);
 
-    const addedEventProcessor = (mockScope.addEventProcessor as jest.Mock).mock.calls[0][0];
+    const addedEventProcessor = (mockScope.addEventProcessor as Mock).mock.calls[0][0];
     const someEvent: Event = {
       exception: {
         values: [{}],

--- a/packages/core/test/lib/integrations/debug.test.ts
+++ b/packages/core/test/lib/integrations/debug.test.ts
@@ -1,5 +1,6 @@
 import type { Client, Event, EventHint } from '@sentry/types';
 
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { debugIntegration } from '../../../src/integrations/debug';
 
 function testEventLogged(
@@ -26,7 +27,7 @@ function testEventLogged(
 }
 
 // Replace console log with a mock so we can check for invocations
-const mockConsoleLog = jest.fn();
+const mockConsoleLog = vi.fn();
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const originalConsoleLog = global.console.log;
 global.console.log = mockConsoleLog;
@@ -38,7 +39,7 @@ describe('Debug integration setup should register an event processor that', () =
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('logs an event', () => {

--- a/packages/core/test/lib/integrations/dedupe.test.ts
+++ b/packages/core/test/lib/integrations/dedupe.test.ts
@@ -1,5 +1,6 @@
 import type { Event as SentryEvent, Exception, StackFrame, Stacktrace } from '@sentry/types';
 
+import { describe, expect, it } from 'vitest';
 import { _shouldDropEvent, dedupeIntegration } from '../../../src/integrations/dedupe';
 
 type EventWithException = SentryEvent & {

--- a/packages/core/test/lib/integrations/extraerrordata.test.ts
+++ b/packages/core/test/lib/integrations/extraerrordata.test.ts
@@ -2,6 +2,7 @@ import type { Event as SentryEvent, ExtendedError } from '@sentry/types';
 
 import { extraErrorDataIntegration } from '../../../src/integrations/extraerrordata';
 
+import { beforeEach, describe, expect, it } from 'vitest';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 const extraErrorData = extraErrorDataIntegration();

--- a/packages/core/test/lib/integrations/functiontostring.test.ts
+++ b/packages/core/test/lib/integrations/functiontostring.test.ts
@@ -1,4 +1,5 @@
 import { fill } from '@sentry/utils';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
 import { getClient, getCurrentScope, setCurrentClient } from '../../../src';
 import { functionToStringIntegration } from '../../../src/integrations/functiontostring';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -1,5 +1,6 @@
 import type { Event, EventProcessor } from '@sentry/types';
 
+import { describe, expect, it } from 'vitest';
 import type { InboundFiltersOptions } from '../../../src/integrations/inboundfilters';
 import { inboundFiltersIntegration } from '../../../src/integrations/inboundfilters';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';

--- a/packages/core/test/lib/integrations/metadata.test.ts
+++ b/packages/core/test/lib/integrations/metadata.test.ts
@@ -1,6 +1,7 @@
 import type { Event } from '@sentry/types';
 import { GLOBAL_OBJ, createStackParser, nodeStackLineParser, parseEnvelope } from '@sentry/utils';
 
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { captureException, createTransport, moduleMetadataIntegration, setCurrentClient } from '../../../src';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
@@ -18,7 +19,7 @@ describe('ModuleMetadata integration', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   test('Adds and removes metadata from stack frames', done => {

--- a/packages/core/test/lib/integrations/requestdata.test.ts
+++ b/packages/core/test/lib/integrations/requestdata.test.ts
@@ -4,9 +4,10 @@ import * as sentryUtils from '@sentry/utils';
 import type { RequestDataIntegrationOptions } from '../../../src';
 import { requestDataIntegration, setCurrentClient } from '../../../src';
 
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
-const addRequestDataToEventSpy = jest.spyOn(sentryUtils, 'addRequestDataToEvent');
+const addRequestDataToEventSpy = vi.spyOn(sentryUtils, 'addRequestDataToEvent');
 
 const headers = { ears: 'furry', nose: 'wet', tongue: 'spotted', cookie: 'favorite=zukes' };
 const method = 'wagging';
@@ -53,7 +54,7 @@ describe('`RequestData` integration', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('option conversion', () => {

--- a/packages/core/test/lib/integrations/rewriteframes.test.ts
+++ b/packages/core/test/lib/integrations/rewriteframes.test.ts
@@ -1,5 +1,6 @@
 import type { Event, StackFrame } from '@sentry/types';
 
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { generateIteratee, rewriteFramesIntegration } from '../../../src/integrations/rewriteframes';
 
 let rewriteFrames: ReturnType<typeof rewriteFramesIntegration>;

--- a/packages/core/test/lib/integrations/sessiontiming.test.ts
+++ b/packages/core/test/lib/integrations/sessiontiming.test.ts
@@ -1,4 +1,5 @@
 import type { Event } from '@sentry/types';
+import { describe, expect, it } from 'vitest';
 import { sessionTimingIntegration } from '../../../src/integrations/sessiontiming';
 
 const sessionTiming = sessionTimingIntegration();

--- a/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
+++ b/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
@@ -3,6 +3,8 @@ import { GLOBAL_OBJ, createStackParser, nodeStackLineParser } from '@sentry/util
 import { thirdPartyErrorFilterIntegration } from '../../../src/integrations/third-party-errors-filter';
 import { addMetadataToStackFrames } from '../../../src/metadata';
 
+import { beforeEach, describe, expect, it } from 'vitest';
+
 function clone<T>(data: T): T {
   return JSON.parse(JSON.stringify(data));
 }

--- a/packages/core/test/lib/integrations/zoderrrors.test.ts
+++ b/packages/core/test/lib/integrations/zoderrrors.test.ts
@@ -1,5 +1,6 @@
 import type { Event, EventHint } from '@sentry/types';
 
+import { describe, expect, test } from 'vitest';
 import { applyZodErrorsToEvent } from '../../../src/integrations/zoderrors';
 
 // Simplified type definition

--- a/packages/core/test/lib/metadata.test.ts
+++ b/packages/core/test/lib/metadata.test.ts
@@ -1,6 +1,7 @@
 import type { Event } from '@sentry/types';
 import { GLOBAL_OBJ, createStackParser, nodeStackLineParser } from '@sentry/utils';
 
+import { beforeEach, describe, expect, it } from 'vitest';
 import { addMetadataToStackFrames, getMetadataForUrl, stripMetadataFromStackFrames } from '../../src/metadata';
 
 const parser = createStackParser(nodeStackLineParser());

--- a/packages/core/test/lib/metrics/aggregator.test.ts
+++ b/packages/core/test/lib/metrics/aggregator.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { MetricsAggregator } from '../../../src/metrics/aggregator';
 import { MAX_WEIGHT } from '../../../src/metrics/constants';
 import { CounterMetric } from '../../../src/metrics/instance';
@@ -10,7 +11,7 @@ describe('MetricsAggregator', () => {
   const options = getDefaultTestClientOptions({ tracesSampleRate: 0.0 });
 
   beforeEach(() => {
-    jest.useFakeTimers('legacy');
+    vi.useFakeTimers();
     testClient = new TestClient(options);
   });
 
@@ -81,12 +82,13 @@ describe('MetricsAggregator', () => {
 
   describe('close', () => {
     test('should flush immediately', () => {
-      const capture = jest.spyOn(testClient, 'sendEnvelope');
+      const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+      const capture = vi.spyOn(testClient, 'sendEnvelope');
       const aggregator = new MetricsAggregator(testClient);
       aggregator.add('c', 'requests', 1);
       aggregator.close();
       // It should clear the interval.
-      expect(clearInterval).toHaveBeenCalled();
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
       expect(capture).toBeCalled();
       expect(capture).toBeCalledTimes(1);
     });
@@ -94,7 +96,8 @@ describe('MetricsAggregator', () => {
 
   describe('flush', () => {
     test('should flush immediately', () => {
-      const capture = jest.spyOn(testClient, 'sendEnvelope');
+      const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+      const capture = vi.spyOn(testClient, 'sendEnvelope');
       const aggregator = new MetricsAggregator(testClient);
       aggregator.add('c', 'requests', 1);
       aggregator.flush();
@@ -104,14 +107,14 @@ describe('MetricsAggregator', () => {
       capture.mockReset();
       aggregator.close();
       // It should clear the interval.
-      expect(clearInterval).toHaveBeenCalled();
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
 
       // It shouldn't be called since it's been already flushed.
       expect(capture).toBeCalledTimes(0);
     });
 
     test('should not capture if empty', () => {
-      const capture = jest.spyOn(testClient, 'sendEnvelope');
+      const capture = vi.spyOn(testClient, 'sendEnvelope');
       const aggregator = new MetricsAggregator(testClient);
       aggregator.add('c', 'requests', 1);
       aggregator.flush();
@@ -124,7 +127,7 @@ describe('MetricsAggregator', () => {
 
   describe('add', () => {
     test('it should respect the max weight and flush if exceeded', () => {
-      const capture = jest.spyOn(testClient, 'sendEnvelope');
+      const capture = vi.spyOn(testClient, 'sendEnvelope');
       const aggregator = new MetricsAggregator(testClient);
 
       for (let i = 0; i < MAX_WEIGHT; i++) {

--- a/packages/core/test/lib/metrics/browser-aggregator.test.ts
+++ b/packages/core/test/lib/metrics/browser-aggregator.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { BrowserMetricsAggregator } from '../../../src/metrics/browser-aggregator';
 import { CounterMetric } from '../../../src/metrics/instance';
 import { serializeMetricBuckets } from '../../../src/metrics/utils';

--- a/packages/core/test/lib/metrics/timing.test.ts
+++ b/packages/core/test/lib/metrics/timing.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getCurrentScope, getIsolationScope, setCurrentClient } from '../../../src';
 import { MetricsAggregator } from '../../../src/metrics/aggregator';
 import { metrics as metricsCore } from '../../../src/metrics/exports';
@@ -28,7 +29,7 @@ describe('metrics.timing', () => {
     const res = metricsDefault.timing('t1', 10);
     expect(res).toStrictEqual(undefined);
 
-    const sendSpy = jest.spyOn(testClient.getTransport()!, 'send');
+    const sendSpy = vi.spyOn(testClient.getTransport()!, 'send');
 
     metricsCore.getMetricsAggregatorForClient(testClient, MetricsAggregator)!.flush();
 
@@ -43,7 +44,7 @@ describe('metrics.timing', () => {
     const res = metricsDefault.timing('t1', 10, 'hour');
     expect(res).toStrictEqual(undefined);
 
-    const sendSpy = jest.spyOn(testClient.getTransport()!, 'send');
+    const sendSpy = vi.spyOn(testClient.getTransport()!, 'send');
 
     metricsCore.getMetricsAggregatorForClient(testClient, MetricsAggregator)!.flush();
 
@@ -60,7 +61,7 @@ describe('metrics.timing', () => {
     });
     expect(res).toStrictEqual(undefined);
 
-    const sendSpy = jest.spyOn(testClient.getTransport()!, 'send');
+    const sendSpy = vi.spyOn(testClient.getTransport()!, 'send');
 
     metricsCore.getMetricsAggregatorForClient(testClient, MetricsAggregator)!.flush();
 
@@ -83,7 +84,7 @@ describe('metrics.timing', () => {
     });
     expect(res).toStrictEqual('oho');
 
-    const sendSpy = jest.spyOn(testClient.getTransport()!, 'send');
+    const sendSpy = vi.spyOn(testClient.getTransport()!, 'send');
 
     metricsCore.getMetricsAggregatorForClient(testClient, MetricsAggregator)!.flush();
 
@@ -102,7 +103,7 @@ describe('metrics.timing', () => {
     expect(res).toBeInstanceOf(Promise);
     expect(await res).toStrictEqual('oho');
 
-    const sendSpy = jest.spyOn(testClient.getTransport()!, 'send');
+    const sendSpy = vi.spyOn(testClient.getTransport()!, 'send');
 
     metricsCore.getMetricsAggregatorForClient(testClient, MetricsAggregator)!.flush();
 

--- a/packages/core/test/lib/metrics/utils.test.ts
+++ b/packages/core/test/lib/metrics/utils.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import {
   COUNTER_METRIC_TYPE,
   DISTRIBUTION_METRIC_TYPE,
@@ -15,7 +16,7 @@ describe('getBucketKey', () => {
     [DISTRIBUTION_METRIC_TYPE, 'lcp', 'second', { a: '1', b: '2', c: '3' }, 'dlcpseconda,1,b,2,c,3'],
     [DISTRIBUTION_METRIC_TYPE, 'lcp', 'second', { numericKey: '2' }, 'dlcpsecondnumericKey,2'],
     [SET_METRIC_TYPE, 'important_org_ids', 'none', { numericKey: '2' }, 'simportant_org_idsnonenumericKey,2'],
-  ])('should return', (metricType, name, unit, tags, expected) => {
+  ])('should return (%s, %s, %s, %s) -> %s', (metricType, name, unit, tags, expected) => {
     expect(getBucketKey(metricType, name, unit, tags)).toEqual(expected);
   });
 

--- a/packages/core/test/lib/prepareEvent.test.ts
+++ b/packages/core/test/lib/prepareEvent.test.ts
@@ -11,6 +11,7 @@ import type {
 import { GLOBAL_OBJ, createStackParser } from '@sentry/utils';
 import { getGlobalScope, getIsolationScope } from '../../src';
 
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Scope } from '../../src/scope';
 import {
   applyDebugIds,
@@ -197,7 +198,7 @@ describe('prepareEvent', () => {
   });
 
   it('works without any scope data', async () => {
-    const eventProcessor = jest.fn((a: unknown) => a) as EventProcessor;
+    const eventProcessor = vi.fn((a: unknown) => a) as EventProcessor;
 
     const scope = new Scope();
 
@@ -242,9 +243,9 @@ describe('prepareEvent', () => {
     const breadcrumb3 = { message: '3', timestamp: 123 } as Breadcrumb;
     const breadcrumb4 = { message: '4', timestamp: 123 } as Breadcrumb;
 
-    const eventProcessor1 = jest.fn((a: unknown) => a) as EventProcessor;
-    const eventProcessor2 = jest.fn((b: unknown) => b) as EventProcessor;
-    const eventProcessor3 = jest.fn((b: unknown) => b) as EventProcessor;
+    const eventProcessor1 = vi.fn((a: unknown) => a) as EventProcessor;
+    const eventProcessor2 = vi.fn((b: unknown) => b) as EventProcessor;
+    const eventProcessor3 = vi.fn((b: unknown) => b) as EventProcessor;
 
     const attachment1 = { filename: '1' } as Attachment;
     const attachment2 = { filename: '2' } as Attachment;
@@ -326,8 +327,8 @@ describe('prepareEvent', () => {
     const breadcrumb2 = { message: '2', timestamp: 222 } as Breadcrumb;
     const breadcrumb3 = { message: '3', timestamp: 333 } as Breadcrumb;
 
-    const eventProcessor1 = jest.fn((a: unknown) => a) as EventProcessor;
-    const eventProcessor2 = jest.fn((a: unknown) => a) as EventProcessor;
+    const eventProcessor1 = vi.fn((a: unknown) => a) as EventProcessor;
+    const eventProcessor2 = vi.fn((a: unknown) => a) as EventProcessor;
 
     const attachmentGlobal = { filename: 'global scope attachment' } as Attachment;
     const attachmentIsolation = { filename: 'isolation scope attachment' } as Attachment;
@@ -490,7 +491,7 @@ describe('prepareEvent', () => {
       const captureContextScope = new Scope();
       captureContextScope.setTags({ foo: 'bar' });
 
-      const captureContext = jest.fn(passedScope => {
+      const captureContext = vi.fn(passedScope => {
         expect(passedScope).toEqual(scope);
         return captureContextScope;
       });

--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -8,6 +8,7 @@ import {
   withScope,
 } from '../../src';
 
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { Scope } from '../../src/scope';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 import { clearGlobalScope } from './clear-global-scope';
@@ -347,7 +348,7 @@ describe('Scope', () => {
     });
 
     test('given callback function, pass it the scope and returns original or modified scope', () => {
-      const cb = jest
+      const cb = vi
         .fn()
         .mockImplementationOnce(v => v)
         .mockImplementationOnce(v => {
@@ -365,7 +366,7 @@ describe('Scope', () => {
     });
 
     test('given callback function, when it doesnt return instanceof Scope, ignore it and return original scope', () => {
-      const cb = jest.fn().mockImplementationOnce(_v => 'wat');
+      const cb = vi.fn().mockImplementationOnce(_v => 'wat');
       const updatedScope = scope.update(cb);
       expect(cb).toHaveBeenCalledWith(scope);
       expect(updatedScope).toEqual(scope);
@@ -571,7 +572,7 @@ describe('Scope', () => {
 
   describe('.captureException()', () => {
     it('should call captureException() on client with newly generated event ID if not explicitly passed in', () => {
-      const fakeCaptureException = jest.fn(() => 'mock-event-id');
+      const fakeCaptureException = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureException: fakeCaptureException,
       } as unknown as Client;
@@ -600,7 +601,7 @@ describe('Scope', () => {
     });
 
     it('should pass exception to captureException() on client', () => {
-      const fakeCaptureException = jest.fn(() => 'mock-event-id');
+      const fakeCaptureException = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureException: fakeCaptureException,
       } as unknown as Client;
@@ -615,7 +616,7 @@ describe('Scope', () => {
     });
 
     it('should call captureException() on client with a synthetic exception', () => {
-      const fakeCaptureException = jest.fn(() => 'mock-event-id');
+      const fakeCaptureException = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureException: fakeCaptureException,
       } as unknown as Client;
@@ -632,7 +633,7 @@ describe('Scope', () => {
     });
 
     it('should pass the original exception to captureException() on client', () => {
-      const fakeCaptureException = jest.fn(() => 'mock-event-id');
+      const fakeCaptureException = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureException: fakeCaptureException,
       } as unknown as Client;
@@ -650,7 +651,7 @@ describe('Scope', () => {
     });
 
     it('should forward hint to captureException() on client', () => {
-      const fakeCaptureException = jest.fn(() => 'mock-event-id');
+      const fakeCaptureException = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureException: fakeCaptureException,
       } as unknown as Client;
@@ -669,7 +670,7 @@ describe('Scope', () => {
 
   describe('.captureMessage()', () => {
     it('should call captureMessage() on client with newly generated event ID if not explicitly passed in', () => {
-      const fakeCaptureMessage = jest.fn(() => 'mock-event-id');
+      const fakeCaptureMessage = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureMessage: fakeCaptureMessage,
       } as unknown as Client;
@@ -695,7 +696,7 @@ describe('Scope', () => {
     });
 
     it('should pass exception to captureMessage() on client', () => {
-      const fakeCaptureMessage = jest.fn(() => 'mock-event-id');
+      const fakeCaptureMessage = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureMessage: fakeCaptureMessage,
       } as unknown as Client;
@@ -708,7 +709,7 @@ describe('Scope', () => {
     });
 
     it('should call captureMessage() on client with a synthetic exception', () => {
-      const fakeCaptureMessage = jest.fn(() => 'mock-event-id');
+      const fakeCaptureMessage = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureMessage: fakeCaptureMessage,
       } as unknown as Client;
@@ -726,7 +727,7 @@ describe('Scope', () => {
     });
 
     it('should pass the original exception to captureMessage() on client', () => {
-      const fakeCaptureMessage = jest.fn(() => 'mock-event-id');
+      const fakeCaptureMessage = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureMessage: fakeCaptureMessage,
       } as unknown as Client;
@@ -744,7 +745,7 @@ describe('Scope', () => {
     });
 
     it('should forward level and hint to captureMessage() on client', () => {
-      const fakeCaptureMessage = jest.fn(() => 'mock-event-id');
+      const fakeCaptureMessage = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureMessage: fakeCaptureMessage,
       } as unknown as Client;
@@ -764,7 +765,7 @@ describe('Scope', () => {
 
   describe('.captureEvent()', () => {
     it('should call captureEvent() on client with newly generated event ID if not explicitly passed in', () => {
-      const fakeCaptureEvent = jest.fn(() => 'mock-event-id');
+      const fakeCaptureEvent = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureEvent: fakeCaptureEvent,
       } as unknown as Client;
@@ -789,7 +790,7 @@ describe('Scope', () => {
     });
 
     it('should pass event to captureEvent() on client', () => {
-      const fakeCaptureEvent = jest.fn(() => 'mock-event-id');
+      const fakeCaptureEvent = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureEvent: fakeCaptureEvent,
       } as unknown as Client;
@@ -804,7 +805,7 @@ describe('Scope', () => {
     });
 
     it('should forward hint to captureEvent() on client', () => {
-      const fakeCaptureEvent = jest.fn(() => 'mock-event-id');
+      const fakeCaptureEvent = vi.fn(() => 'mock-event-id');
       const fakeClient = {
         captureEvent: fakeCaptureEvent,
       } as unknown as Client;
@@ -861,30 +862,35 @@ describe('withScope()', () => {
     getGlobalScope().clear();
   });
 
-  it('will make the passed scope the active scope within the callback', done => {
+  it('makes the passed scope the active scope within the callback', () => {
+    expect.assertions(1);
+
     withScope(scope => {
       expect(getCurrentScope()).toBe(scope);
-      done();
     });
   });
 
-  it('will pass a scope that is different from the current active isolation scope', done => {
+  it('passes a scope that is different from the current active isolation scope', () => {
+    expect.assertions(1);
+
     withScope(scope => {
       expect(getIsolationScope()).not.toBe(scope);
-      done();
     });
   });
 
-  it('will always make the inner most passed scope the current isolation scope when nesting calls', done => {
+  it('always makes the inner most passed scope the current isolation scope when nesting calls', () => {
+    expect.assertions(1);
+
     withIsolationScope(_scope1 => {
       withIsolationScope(scope2 => {
         expect(getIsolationScope()).toBe(scope2);
-        done();
       });
     });
   });
 
-  it('forks the scope when not passing any scope', done => {
+  it('forks the scope when not passing any scope', () => {
+    expect.assertions(3);
+
     const initialScope = getCurrentScope();
     initialScope.setTag('aa', 'aa');
 
@@ -893,11 +899,12 @@ describe('withScope()', () => {
       scope.setTag('bb', 'bb');
       expect(scope).not.toBe(initialScope);
       expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
-      done();
     });
   });
 
-  it('forks the scope when passing undefined', done => {
+  it('forks the scope when passing undefined', () => {
+    expect.assertions(3);
+
     const initialScope = getCurrentScope();
     initialScope.setTag('aa', 'aa');
 
@@ -906,11 +913,12 @@ describe('withScope()', () => {
       scope.setTag('bb', 'bb');
       expect(scope).not.toBe(initialScope);
       expect(scope.getScopeData().tags).toEqual({ aa: 'aa', bb: 'bb' });
-      done();
     });
   });
 
-  it('sets the passed in scope as active scope', done => {
+  it('sets the passed in scope as active scope', () => {
+    expect.assertions(2);
+
     const initialScope = getCurrentScope();
     initialScope.setTag('aa', 'aa');
 
@@ -919,7 +927,6 @@ describe('withScope()', () => {
     withScope(customScope, scope => {
       expect(getCurrentScope()).toBe(customScope);
       expect(scope).toBe(customScope);
-      done();
     });
   });
 });
@@ -931,58 +938,64 @@ describe('withIsolationScope()', () => {
     getGlobalScope().clear();
   });
 
-  it('will make the passed isolation scope the active isolation scope within the callback', done => {
+  it('makes the passed isolation scope the active isolation scope within the callback', () => {
+    expect.assertions(1);
+
     withIsolationScope(scope => {
       expect(getIsolationScope()).toBe(scope);
-      done();
     });
   });
 
-  it('will pass an isolation scope that is different from the current active scope', done => {
+  it('passes an isolation scope that is different from the current active scope', () => {
+    expect.assertions(1);
+
     withIsolationScope(scope => {
       expect(getCurrentScope()).not.toBe(scope);
-      done();
     });
   });
 
-  it('will always make the inner most passed scope the current scope when nesting calls', done => {
+  it('always makes the inner most passed scope the current scope when nesting calls', () => {
+    expect.assertions(1);
+
     withIsolationScope(_scope1 => {
       withIsolationScope(scope2 => {
         expect(getIsolationScope()).toBe(scope2);
-        done();
       });
     });
   });
 
   // Note: This is expected! In browser, we do not actually fork this
-  it('does not fork isolation scope when not passing any isolation scope', done => {
+  it('does not fork the isolation scope when not passing any isolation scope', () => {
+    expect.assertions(2);
+
     const isolationScope = getIsolationScope();
 
     withIsolationScope(scope => {
       expect(getIsolationScope()).toBe(scope);
       expect(scope).toBe(isolationScope);
-      done();
     });
   });
 
-  it('does not fork isolation scope when passing undefined', done => {
+  it('does not fork isolation scope when passing undefined', () => {
+    expect.assertions(2);
+
     const isolationScope = getIsolationScope();
 
     withIsolationScope(undefined, scope => {
       expect(getIsolationScope()).toBe(scope);
       expect(scope).toBe(isolationScope);
-      done();
     });
   });
 
-  it('ignores passed in isolation scope', done => {
+  it('ignores passed in isolation scope', () => {
+    expect.assertions(2);
+
     const isolationScope = getIsolationScope();
     const customIsolationScope = new Scope();
 
     withIsolationScope(customIsolationScope, scope => {
       expect(getIsolationScope()).toBe(isolationScope);
       expect(scope).toBe(isolationScope);
-      done();
     });
   });
 

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -1,6 +1,8 @@
 import type { Client, Integration } from '@sentry/types';
 import { captureCheckIn, getCurrentScope, setCurrentClient } from '../../src';
 
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { installedIntegrations } from '../../src/integration';
 import { initAndBind } from '../../src/sdk';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
@@ -12,7 +14,7 @@ const PUBLIC_DSN = 'https://username@domain/123';
 
 export class MockIntegration implements Integration {
   public name: string;
-  public setupOnce: () => void = jest.fn();
+  public setupOnce: () => void = vi.fn();
   public constructor(name: string) {
     this.name = name;
   }
@@ -32,8 +34,8 @@ describe('SDK', () => {
       ];
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, integrations });
       initAndBind(TestClient, options);
-      expect((integrations[0]?.setupOnce as jest.Mock).mock.calls.length).toBe(1);
-      expect((integrations[1]?.setupOnce as jest.Mock).mock.calls.length).toBe(1);
+      expect((integrations[0]?.setupOnce as Mock).mock.calls.length).toBe(1);
+      expect((integrations[1]?.setupOnce as Mock).mock.calls.length).toBe(1);
     });
 
     test('calls hooks in the correct order', () => {
@@ -41,21 +43,21 @@ describe('SDK', () => {
 
       const integration1 = {
         name: 'integration1',
-        setupOnce: jest.fn(() => list.push('setupOnce1')),
-        afterAllSetup: jest.fn(() => list.push('afterAllSetup1')),
+        setupOnce: vi.fn(() => list.push('setupOnce1')),
+        afterAllSetup: vi.fn(() => list.push('afterAllSetup1')),
       } satisfies Integration;
 
       const integration2 = {
         name: 'integration2',
-        setupOnce: jest.fn(() => list.push('setupOnce2')),
-        setup: jest.fn(() => list.push('setup2')),
-        afterAllSetup: jest.fn(() => list.push('afterAllSetup2')),
+        setupOnce: vi.fn(() => list.push('setupOnce2')),
+        setup: vi.fn(() => list.push('setup2')),
+        afterAllSetup: vi.fn(() => list.push('afterAllSetup2')),
       } satisfies Integration;
 
       const integration3 = {
         name: 'integration3',
-        setupOnce: jest.fn(() => list.push('setupOnce3')),
-        setup: jest.fn(() => list.push('setup3')),
+        setupOnce: vi.fn(() => list.push('setupOnce3')),
+        setup: vi.fn(() => list.push('setup3')),
       } satisfies Integration;
 
       const integrations: Integration[] = [integration1, integration2, integration3];

--- a/packages/core/test/lib/serverruntimeclient.test.ts
+++ b/packages/core/test/lib/serverruntimeclient.test.ts
@@ -1,5 +1,6 @@
 import type { Event, EventHint } from '@sentry/types';
 
+import { describe, expect, it, test, vi } from 'vitest';
 import { createTransport } from '../../src';
 import type { ServerRuntimeClientOptions } from '../../src/server-runtime-client';
 import { ServerRuntimeClient } from '../../src/server-runtime-client';
@@ -77,7 +78,7 @@ describe('ServerRuntimeClient', () => {
       });
       client = new ServerRuntimeClient(options);
 
-      const sendEnvelopeSpy = jest.spyOn(client, 'sendEnvelope');
+      const sendEnvelopeSpy = vi.spyOn(client, 'sendEnvelope');
 
       const id = client.captureCheckIn(
         { monitorSlug: 'foo', status: 'in_progress' },
@@ -147,7 +148,7 @@ describe('ServerRuntimeClient', () => {
       const options = getDefaultClientOptions({ dsn: PUBLIC_DSN, serverName: 'bar', enabled: false });
       client = new ServerRuntimeClient(options);
 
-      const sendEnvelopeSpy = jest.spyOn(client, 'sendEnvelope');
+      const sendEnvelopeSpy = vi.spyOn(client, 'sendEnvelope');
 
       client.captureCheckIn({ monitorSlug: 'foo', status: 'in_progress' });
 

--- a/packages/core/test/lib/session.test.ts
+++ b/packages/core/test/lib/session.test.ts
@@ -3,6 +3,8 @@ import { timestampInSeconds } from '@sentry/utils';
 
 import { closeSession, makeSession, updateSession } from '../../src/session';
 
+import { describe, expect, it, test } from 'vitest';
+
 describe('Session', () => {
   it('initializes with the proper defaults', () => {
     const newSession = makeSession();

--- a/packages/core/test/lib/sessionflusher.test.ts
+++ b/packages/core/test/lib/sessionflusher.test.ts
@@ -2,20 +2,23 @@ import type { Client } from '@sentry/types';
 
 import { SessionFlusher } from '../../src/sessionflusher';
 
+import type { Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
 describe('Session Flusher', () => {
-  let sendSession: jest.Mock;
+  let sendSession: Mock;
   let mockClient: Client;
 
   beforeEach(() => {
-    jest.useFakeTimers();
-    sendSession = jest.fn(() => Promise.resolve({ status: 'success' }));
+    vi.useFakeTimers();
+    sendSession = vi.fn(() => Promise.resolve({ status: 'success' }));
     mockClient = {
       sendSession,
     } as unknown as Client;
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
   test('test incrementSessionStatusCount updates the internal SessionFlusher state', () => {
@@ -56,27 +59,27 @@ describe('Session Flusher', () => {
 
   test('flush is called every 60 seconds after initialisation of an instance of SessionFlusher', () => {
     const flusher = new SessionFlusher(mockClient, { release: '1.0.0', environment: 'dev' });
-    const flusherFlushFunc = jest.spyOn(flusher, 'flush');
-    jest.advanceTimersByTime(59000);
+    const flusherFlushFunc = vi.spyOn(flusher, 'flush');
+    vi.advanceTimersByTime(59000);
     expect(flusherFlushFunc).toHaveBeenCalledTimes(0);
-    jest.advanceTimersByTime(2000);
+    vi.advanceTimersByTime(2000);
     expect(flusherFlushFunc).toHaveBeenCalledTimes(1);
-    jest.advanceTimersByTime(58000);
+    vi.advanceTimersByTime(58000);
     expect(flusherFlushFunc).toHaveBeenCalledTimes(1);
-    jest.advanceTimersByTime(2000);
+    vi.advanceTimersByTime(2000);
     expect(flusherFlushFunc).toHaveBeenCalledTimes(2);
   });
 
   test('sendSessions is called on flush if sessions were captured', () => {
     const flusher = new SessionFlusher(mockClient, { release: '1.0.0', environment: 'dev' });
-    const flusherFlushFunc = jest.spyOn(flusher, 'flush');
+    const flusherFlushFunc = vi.spyOn(flusher, 'flush');
     const date = new Date('2021-04-08T12:18:23.043Z');
     (flusher as any)._incrementSessionStatusCount('ok', date);
     (flusher as any)._incrementSessionStatusCount('ok', date);
 
     expect(sendSession).toHaveBeenCalledTimes(0);
 
-    jest.advanceTimersByTime(61000);
+    vi.advanceTimersByTime(61000);
 
     expect(flusherFlushFunc).toHaveBeenCalledTimes(1);
     expect(sendSession).toHaveBeenCalledWith(
@@ -89,10 +92,10 @@ describe('Session Flusher', () => {
 
   test('sendSessions is not called on flush if no sessions were captured', () => {
     const flusher = new SessionFlusher(mockClient, { release: '1.0.0', environment: 'dev' });
-    const flusherFlushFunc = jest.spyOn(flusher, 'flush');
+    const flusherFlushFunc = vi.spyOn(flusher, 'flush');
 
     expect(sendSession).toHaveBeenCalledTimes(0);
-    jest.advanceTimersByTime(61000);
+    vi.advanceTimersByTime(61000);
     expect(flusherFlushFunc).toHaveBeenCalledTimes(1);
     expect(sendSession).toHaveBeenCalledTimes(0);
   });
@@ -105,7 +108,7 @@ describe('Session Flusher', () => {
 
   test('calling close on SessionFlusher will force call flush', () => {
     const flusher = new SessionFlusher(mockClient, { release: '1.0.x' });
-    const flusherFlushFunc = jest.spyOn(flusher, 'flush');
+    const flusherFlushFunc = vi.spyOn(flusher, 'flush');
     const date = new Date('2021-04-08T12:18:23.043Z');
     (flusher as any)._incrementSessionStatusCount('ok', date);
     (flusher as any)._incrementSessionStatusCount('ok', date);

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -1,4 +1,5 @@
 import type { Span, SpanContextData, TransactionSource } from '@sentry/types';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -17,7 +18,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
   });
 
   test('uses frozen DSC from span', () => {

--- a/packages/core/test/lib/tracing/errors.test.ts
+++ b/packages/core/test/lib/tracing/errors.test.ts
@@ -1,16 +1,17 @@
 import type { HandlerDataError, HandlerDataUnhandledRejection } from '@sentry/types';
 import { setCurrentClient, spanToJSON, startInactiveSpan, startSpan } from '../../../src';
 
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { _resetErrorsInstrumented, registerSpanErrorInstrumentation } from '../../../src/tracing/errors';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
-const mockAddGlobalErrorInstrumentationHandler = jest.fn();
-const mockAddGlobalUnhandledRejectionInstrumentationHandler = jest.fn();
+const mockAddGlobalErrorInstrumentationHandler = vi.fn();
+const mockAddGlobalUnhandledRejectionInstrumentationHandler = vi.fn();
 let mockErrorCallback: (data: HandlerDataError) => void = () => {};
 let mockUnhandledRejectionCallback: (data: HandlerDataUnhandledRejection) => void = () => {};
 
-jest.mock('@sentry/utils', () => {
-  const actual = jest.requireActual('@sentry/utils');
+vi.mock('@sentry/utils', async () => {
+  const actual = await vi.importActual('@sentry/utils');
   return {
     ...actual,
     addGlobalErrorInstrumentationHandler: (callback: () => void) => {

--- a/packages/core/test/lib/tracing/sentryNonRecordingSpan.test.ts
+++ b/packages/core/test/lib/tracing/sentryNonRecordingSpan.test.ts
@@ -1,4 +1,5 @@
 import type { Span } from '@sentry/types';
+import { describe, expect, it } from 'vitest';
 import { SPAN_STATUS_ERROR } from '../../../src/tracing';
 import { SentryNonRecordingSpan } from '../../../src/tracing/sentryNonRecordingSpan';
 import { TRACE_FLAG_NONE, spanIsSampled, spanToJSON } from '../../../src/utils/spanUtils';

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -1,4 +1,5 @@
 import { timestampInSeconds } from '@sentry/utils';
+import { describe, expect, it, test, vi } from 'vitest';
 import { setCurrentClient } from '../../../src';
 import { SentrySpan } from '../../../src/tracing/sentrySpan';
 import { SPAN_STATUS_ERROR } from '../../../src/tracing/spanstatus';
@@ -101,7 +102,7 @@ describe('SentrySpan', () => {
       setCurrentClient(client);
 
       // @ts-expect-error Accessing private transport API
-      const mockSend = jest.spyOn(client._transport, 'send');
+      const mockSend = vi.spyOn(client._transport, 'send');
 
       const notSampledSpan = new SentrySpan({
         name: 'not-sampled',
@@ -125,7 +126,7 @@ describe('SentrySpan', () => {
     });
 
     test('sends the span if `beforeSendSpan` does not modify the span ', () => {
-      const beforeSendSpan = jest.fn(span => span);
+      const beforeSendSpan = vi.fn(span => span);
       const client = new TestClient(
         getDefaultTestClientOptions({
           dsn: 'https://username@domain/123',
@@ -136,7 +137,7 @@ describe('SentrySpan', () => {
       setCurrentClient(client);
 
       // @ts-expect-error Accessing private transport API
-      const mockSend = jest.spyOn(client._transport, 'send');
+      const mockSend = vi.spyOn(client._transport, 'send');
       const span = new SentrySpan({
         name: 'test',
         isStandalone: true,
@@ -149,7 +150,7 @@ describe('SentrySpan', () => {
     });
 
     test('does not send the span if `beforeSendSpan` drops the span', () => {
-      const beforeSendSpan = jest.fn(() => null);
+      const beforeSendSpan = vi.fn(() => null);
       const client = new TestClient(
         getDefaultTestClientOptions({
           dsn: 'https://username@domain/123',
@@ -159,9 +160,9 @@ describe('SentrySpan', () => {
       );
       setCurrentClient(client);
 
-      const recordDroppedEventSpy = jest.spyOn(client, 'recordDroppedEvent');
+      const recordDroppedEventSpy = vi.spyOn(client, 'recordDroppedEvent');
       // @ts-expect-error Accessing private transport API
-      const mockSend = jest.spyOn(client._transport, 'send');
+      const mockSend = vi.spyOn(client._transport, 'send');
       const span = new SentrySpan({
         name: 'test',
         isStandalone: true,

--- a/packages/core/test/lib/tracing/spanstatus.test.ts
+++ b/packages/core/test/lib/tracing/spanstatus.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { SentrySpan, setHttpStatus, spanToJSON } from '../../../src/index';
 
 describe('setHttpStatus', () => {

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1,4 +1,5 @@
 import type { Event, Span, StartSpanOptions } from '@sentry/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -12,6 +13,7 @@ import {
   spanToJSON,
   withScope,
 } from '../../../src';
+
 import { getAsyncContextStrategy } from '../../../src/asyncContext';
 import {
   SentrySpan,
@@ -53,7 +55,7 @@ describe('startSpan', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe.each([
@@ -476,7 +478,7 @@ describe('startSpan', () => {
   });
 
   it('samples with a tracesSampler', () => {
-    const tracesSampler = jest.fn(() => {
+    const tracesSampler = vi.fn(() => {
       return true;
     });
 
@@ -503,7 +505,7 @@ describe('startSpan', () => {
   });
 
   it('includes the scope at the time the span was started when finished', async () => {
-    const beforeSendTransaction = jest.fn(event => event);
+    const beforeSendTransaction = vi.fn(event => event);
 
     const client = new TestClient(
       getDefaultTestClientOptions({
@@ -553,7 +555,7 @@ describe('startSpan', () => {
 
     const carrier = getMainCarrier();
 
-    const customFn = jest.fn((_options: StartSpanOptions, callback: (span: Span) => string) => {
+    const customFn = vi.fn((_options: StartSpanOptions, callback: (span: Span) => string) => {
       callback(staticSpan);
       return 'aha';
     }) as typeof startSpan;
@@ -929,7 +931,7 @@ describe('startSpanManual', () => {
 
     const carrier = getMainCarrier();
 
-    const customFn = jest.fn((_options: StartSpanOptions, callback: (span: Span) => string) => {
+    const customFn = vi.fn((_options: StartSpanOptions, callback: (span: Span) => string) => {
       callback(staticSpan);
       return 'aha';
     }) as unknown as typeof startSpanManual;
@@ -1238,7 +1240,7 @@ describe('startInactiveSpan', () => {
   });
 
   it('includes the scope at the time the span was started when finished', async () => {
-    const beforeSendTransaction = jest.fn(event => event);
+    const beforeSendTransaction = vi.fn(event => event);
 
     const client = new TestClient(
       getDefaultTestClientOptions({
@@ -1295,7 +1297,7 @@ describe('startInactiveSpan', () => {
 
     const carrier = getMainCarrier();
 
-    const customFn = jest.fn((_options: StartSpanOptions) => {
+    const customFn = vi.fn((_options: StartSpanOptions) => {
       return staticSpan;
     }) as unknown as typeof startInactiveSpan;
 
@@ -1458,7 +1460,7 @@ describe('getActiveSpan', () => {
 
     const carrier = getMainCarrier();
 
-    const customFn = jest.fn(() => {
+    const customFn = vi.fn(() => {
       return staticSpan;
     }) as typeof getActiveSpan;
 
@@ -1525,7 +1527,7 @@ describe('withActiveSpan()', () => {
 
     const carrier = getMainCarrier();
 
-    const customFn = jest.fn((_span: Span | null, callback: (scope: Scope) => string) => {
+    const customFn = vi.fn((_span: Span | null, callback: (scope: Scope) => string) => {
       callback(staticScope);
       return 'aha';
     }) as typeof withActiveSpan;
@@ -1557,7 +1559,7 @@ describe('span hooks', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('correctly emits span hooks', () => {
@@ -1608,7 +1610,7 @@ describe('suppressTracing', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('works for a root span', () => {

--- a/packages/core/test/lib/transports/base.test.ts
+++ b/packages/core/test/lib/transports/base.test.ts
@@ -1,6 +1,7 @@
 import type { AttachmentItem, EventEnvelope, EventItem, TransportMakeRequestResponse } from '@sentry/types';
 import type { PromiseBuffer } from '@sentry/utils';
 import { createEnvelope, resolvedSyncPromise, serializeEnvelope } from '@sentry/utils';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createTransport } from '../../../src/transports/base';
 
@@ -37,8 +38,8 @@ describe('createTransport', () => {
   it('flushes the buffer', async () => {
     const mockBuffer: PromiseBuffer<TransportMakeRequestResponse> = {
       $: [],
-      add: jest.fn(),
-      drain: jest.fn(),
+      add: vi.fn(),
+      drain: vi.fn(),
     };
     const transport = createTransport(transportOptions, _ => resolvedSyncPromise({}), mockBuffer);
     /* eslint-disable @typescript-eslint/unbound-method */
@@ -93,11 +94,11 @@ describe('createTransport', () => {
           transportResponse = res;
         }
 
-        const mockRequestExecutor = jest.fn(_ => {
+        const mockRequestExecutor = vi.fn(_ => {
           return resolvedSyncPromise(transportResponse);
         });
 
-        const mockRecordDroppedEventCallback = jest.fn();
+        const mockRecordDroppedEventCallback = vi.fn();
 
         const transport = createTransport({ recordDroppedEvent: mockRecordDroppedEventCallback }, mockRequestExecutor);
 
@@ -108,7 +109,7 @@ describe('createTransport', () => {
         const { retryAfterSeconds, beforeLimit, withinLimit, afterLimit } = setRateLimitTimes();
         const [transport, setTransportResponse, requestExecutor, recordDroppedEventCallback] = createTestTransport({});
 
-        const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => beforeLimit);
+        const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => beforeLimit);
 
         await transport.send(ERROR_ENVELOPE);
         expect(requestExecutor).toHaveBeenCalledTimes(1);
@@ -157,7 +158,7 @@ describe('createTransport', () => {
           },
         });
 
-        const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => beforeLimit);
+        const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => beforeLimit);
 
         await transport.send(ERROR_ENVELOPE);
         expect(requestExecutor).toHaveBeenCalledTimes(1);
@@ -207,7 +208,7 @@ describe('createTransport', () => {
           },
         });
 
-        const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => beforeLimit);
+        const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => beforeLimit);
 
         await transport.send(ERROR_ENVELOPE);
         expect(requestExecutor).toHaveBeenCalledTimes(1);
@@ -271,7 +272,7 @@ describe('createTransport', () => {
           },
         });
 
-        const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => beforeLimit);
+        const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => beforeLimit);
 
         await transport.send(ERROR_ENVELOPE);
         expect(requestExecutor).toHaveBeenCalledTimes(1);

--- a/packages/core/test/lib/transports/multiplexed.test.ts
+++ b/packages/core/test/lib/transports/multiplexed.test.ts
@@ -12,6 +12,8 @@ import { createClientReportEnvelope, createEnvelope, dsnFromString, parseEnvelop
 import { createTransport, getEnvelopeEndpointWithUrlEncodedAuth, makeMultiplexedTransport } from '../../../src';
 import { eventFromEnvelope } from '../../../src/transports/multiplexed';
 
+import { describe, expect, it, vi } from 'vitest';
+
 const DSN1 = 'https://1234@5678.ingest.sentry.io/4321';
 const DSN1_URL = getEnvelopeEndpointWithUrlEncodedAuth(dsnFromString(DSN1)!);
 
@@ -88,7 +90,7 @@ describe('makeMultiplexedTransport', () => {
 
   it('Falls back to options DSN when a matched DSN is invalid', async () => {
     // Hide warning logs in the test
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect.assertions(1);
 
@@ -102,7 +104,7 @@ describe('makeMultiplexedTransport', () => {
     const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
     await transport.send(ERROR_ENVELOPE);
 
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('DSN can be overridden via match callback', async () => {

--- a/packages/core/test/lib/transports/offline.test.ts
+++ b/packages/core/test/lib/transports/offline.test.ts
@@ -17,6 +17,7 @@ import {
   parseEnvelope,
 } from '@sentry/utils';
 
+import { describe, expect, it } from 'vitest';
 import { createTransport } from '../../../src';
 import type { CreateOfflineStore, OfflineTransportOptions } from '../../../src/transports/offline';
 import { START_DELAY, makeOfflineTransport } from '../../../src/transports/offline';
@@ -410,7 +411,6 @@ describe('makeOfflineTransport', () => {
     START_DELAY + 2_000,
   );
 
-  // eslint-disable-next-line jest/no-disabled-tests
   it.skip(
     'Follows the Retry-After header',
     async () => {

--- a/packages/core/test/lib/utils/applyScopeDataToEvent.test.ts
+++ b/packages/core/test/lib/utils/applyScopeDataToEvent.test.ts
@@ -7,6 +7,8 @@ import {
   mergeScopeData,
 } from '../../../src/utils/applyScopeDataToEvent';
 
+import { describe, expect, it } from 'vitest';
+
 describe('mergeArray', () => {
   it.each([
     [[], [], undefined],

--- a/packages/core/test/lib/utils/handleCallbackErrors.test.ts
+++ b/packages/core/test/lib/utils/handleCallbackErrors.test.ts
@@ -1,10 +1,11 @@
+import { describe, expect, it, vi } from 'vitest';
 import { handleCallbackErrors } from '../../../src/utils/handleCallbackErrors';
 
 describe('handleCallbackErrors', () => {
   it('works with a simple callback', () => {
-    const onError = jest.fn();
+    const onError = vi.fn();
 
-    const fn = jest.fn(() => 'aa');
+    const fn = vi.fn(() => 'aa');
 
     const res = handleCallbackErrors(fn, onError);
 
@@ -16,9 +17,9 @@ describe('handleCallbackErrors', () => {
   it('triggers onError when callback has sync error', () => {
     const error = new Error('test error');
 
-    const onError = jest.fn();
+    const onError = vi.fn();
 
-    const fn = jest.fn(() => {
+    const fn = vi.fn(() => {
       throw error;
     });
 
@@ -30,9 +31,9 @@ describe('handleCallbackErrors', () => {
   });
 
   it('works with an async callback', async () => {
-    const onError = jest.fn();
+    const onError = vi.fn();
 
-    const fn = jest.fn(async () => 'aa');
+    const fn = vi.fn(async () => 'aa');
 
     const res = handleCallbackErrors(fn, onError);
 
@@ -46,11 +47,11 @@ describe('handleCallbackErrors', () => {
   });
 
   it('triggers onError when callback returns promise that rejects', async () => {
-    const onError = jest.fn();
+    const onError = vi.fn();
 
     const error = new Error('test error');
 
-    const fn = jest.fn(async () => {
+    const fn = vi.fn(async () => {
       await new Promise(resolve => setTimeout(resolve, 10));
       throw error;
     });
@@ -70,10 +71,10 @@ describe('handleCallbackErrors', () => {
 
   describe('onFinally', () => {
     it('triggers after successfuly sync callback', () => {
-      const onError = jest.fn();
-      const onFinally = jest.fn();
+      const onError = vi.fn();
+      const onFinally = vi.fn();
 
-      const fn = jest.fn(() => 'aa');
+      const fn = vi.fn(() => 'aa');
 
       const res = handleCallbackErrors(fn, onError, onFinally);
 
@@ -86,10 +87,10 @@ describe('handleCallbackErrors', () => {
     it('triggers after error in sync callback', () => {
       const error = new Error('test error');
 
-      const onError = jest.fn();
-      const onFinally = jest.fn();
+      const onError = vi.fn();
+      const onFinally = vi.fn();
 
-      const fn = jest.fn(() => {
+      const fn = vi.fn(() => {
         throw error;
       });
 
@@ -102,10 +103,10 @@ describe('handleCallbackErrors', () => {
     });
 
     it('triggers after successful async callback', async () => {
-      const onError = jest.fn();
-      const onFinally = jest.fn();
+      const onError = vi.fn();
+      const onFinally = vi.fn();
 
-      const fn = jest.fn(async () => 'aa');
+      const fn = vi.fn(async () => 'aa');
 
       const res = handleCallbackErrors(fn, onError, onFinally);
 
@@ -122,12 +123,12 @@ describe('handleCallbackErrors', () => {
     });
 
     it('triggers after error in async callback', async () => {
-      const onError = jest.fn();
-      const onFinally = jest.fn();
+      const onError = vi.fn();
+      const onFinally = vi.fn();
 
       const error = new Error('test error');
 
-      const fn = jest.fn(async () => {
+      const fn = vi.fn(async () => {
         await new Promise(resolve => setTimeout(resolve, 10));
         throw error;
       });

--- a/packages/core/test/lib/utils/hasTracingEnabled.test.ts
+++ b/packages/core/test/lib/utils/hasTracingEnabled.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { hasTracingEnabled } from '../../../src';
 
 describe('hasTracingEnabled', () => {

--- a/packages/core/test/lib/utils/isSentryRequestUrl.test.ts
+++ b/packages/core/test/lib/utils/isSentryRequestUrl.test.ts
@@ -1,5 +1,6 @@
 import type { Client } from '@sentry/types';
 
+import { describe, expect, it } from 'vitest';
 import { isSentryRequestUrl } from '../../../src';
 
 describe('isSentryRequestUrl', () => {

--- a/packages/core/test/lib/utils/meta.test.ts
+++ b/packages/core/test/lib/utils/meta.test.ts
@@ -1,9 +1,10 @@
+import { describe, expect, it, vi } from 'vitest';
 import { getTraceMetaTags } from '../../../src/utils/meta';
 import * as TraceDataModule from '../../../src/utils/traceData';
 
 describe('getTraceMetaTags', () => {
   it('renders baggage and sentry-trace values to stringified Html meta tags', () => {
-    jest.spyOn(TraceDataModule, 'getTraceData').mockReturnValueOnce({
+    vi.spyOn(TraceDataModule, 'getTraceData').mockReturnValueOnce({
       'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
       baggage: 'sentry-environment=production',
     });
@@ -13,7 +14,7 @@ describe('getTraceMetaTags', () => {
   });
 
   it('renders just sentry-trace values to stringified Html meta tags', () => {
-    jest.spyOn(TraceDataModule, 'getTraceData').mockReturnValueOnce({
+    vi.spyOn(TraceDataModule, 'getTraceData').mockReturnValueOnce({
       'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
     });
 
@@ -23,7 +24,7 @@ describe('getTraceMetaTags', () => {
   });
 
   it('returns an empty string if neither sentry-trace nor baggage values are available', () => {
-    jest.spyOn(TraceDataModule, 'getTraceData').mockReturnValueOnce({});
+    vi.spyOn(TraceDataModule, 'getTraceData').mockReturnValueOnce({});
 
     expect(getTraceMetaTags()).toBe('');
   });

--- a/packages/core/test/lib/utils/parameterize.test.ts
+++ b/packages/core/test/lib/utils/parameterize.test.ts
@@ -1,5 +1,6 @@
 import type { ParameterizedString } from '@sentry/types';
 
+import { describe, expect, test } from 'vitest';
 import { parameterize } from '../../../src/utils/parameterize';
 
 describe('parameterize()', () => {

--- a/packages/core/test/lib/utils/parseSampleRate.test.ts
+++ b/packages/core/test/lib/utils/parseSampleRate.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { parseSampleRate } from '../../../src/utils/parseSampleRate';
 
 describe('parseSampleRate', () => {

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -16,6 +16,8 @@ import type { OpenTelemetrySdkTraceBaseSpan } from '../../../src/utils/spanUtils
 import { getRootSpan, spanIsSampled, spanTimeInputToSeconds, spanToJSON } from '../../../src/utils/spanUtils';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
+import { beforeEach, describe, expect, it, test } from 'vitest';
+
 describe('spanToTraceHeader', () => {
   test('simple', () => {
     const span = new SentrySpan();

--- a/packages/core/test/lib/utils/traceData.test.ts
+++ b/packages/core/test/lib/utils/traceData.test.ts
@@ -3,6 +3,7 @@ import * as SentryCoreCurrentScopes from '../../../src/currentScopes';
 import * as SentryCoreTracing from '../../../src/tracing';
 import * as SentryCoreSpanUtils from '../../../src/utils/spanUtils';
 
+import { describe, expect, it, vi } from 'vitest';
 import { isValidBaggageString } from '../../../src/utils/traceData';
 
 const TRACE_FLAG_SAMPLED = 1;
@@ -24,11 +25,11 @@ const mockedScope = {
 describe('getTraceData', () => {
   it('returns the tracing data from the span, if a span is available', () => {
     {
-      jest.spyOn(SentryCoreTracing, 'getDynamicSamplingContextFromSpan').mockReturnValueOnce({
+      vi.spyOn(SentryCoreTracing, 'getDynamicSamplingContextFromSpan').mockReturnValueOnce({
         environment: 'production',
       });
-      jest.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => mockedSpan);
-      jest.spyOn(SentryCoreCurrentScopes, 'getCurrentScope').mockImplementationOnce(() => mockedScope);
+      vi.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => mockedSpan);
+      vi.spyOn(SentryCoreCurrentScopes, 'getCurrentScope').mockImplementationOnce(() => mockedScope);
 
       const data = getTraceData();
 
@@ -40,8 +41,8 @@ describe('getTraceData', () => {
   });
 
   it('returns propagationContext DSC data if no span is available', () => {
-    jest.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => undefined);
-    jest.spyOn(SentryCoreCurrentScopes, 'getCurrentScope').mockImplementationOnce(
+    vi.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => undefined);
+    vi.spyOn(SentryCoreCurrentScopes, 'getCurrentScope').mockImplementationOnce(
       () =>
         ({
           getPropagationContext: () => ({
@@ -56,7 +57,7 @@ describe('getTraceData', () => {
           }),
         }) as any,
     );
-    jest.spyOn(SentryCoreCurrentScopes, 'getClient').mockImplementationOnce(() => mockedClient);
+    vi.spyOn(SentryCoreCurrentScopes, 'getClient').mockImplementationOnce(() => mockedClient);
 
     const traceData = getTraceData();
 
@@ -67,13 +68,13 @@ describe('getTraceData', () => {
   });
 
   it('returns only the `sentry-trace` value if no DSC is available', () => {
-    jest.spyOn(SentryCoreTracing, 'getDynamicSamplingContextFromClient').mockReturnValueOnce({
+    vi.spyOn(SentryCoreTracing, 'getDynamicSamplingContextFromClient').mockReturnValueOnce({
       trace_id: '',
       public_key: undefined,
     });
 
     // @ts-expect-error - we don't need to provide all the properties
-    jest.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => ({
+    vi.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => ({
       isRecording: () => true,
       spanContext: () => {
         return {
@@ -84,8 +85,8 @@ describe('getTraceData', () => {
       },
     }));
 
-    jest.spyOn(SentryCoreCurrentScopes, 'getCurrentScope').mockImplementationOnce(() => mockedScope);
-    jest.spyOn(SentryCoreCurrentScopes, 'getClient').mockImplementationOnce(() => mockedClient);
+    vi.spyOn(SentryCoreCurrentScopes, 'getCurrentScope').mockImplementationOnce(() => mockedScope);
+    vi.spyOn(SentryCoreCurrentScopes, 'getClient').mockImplementationOnce(() => mockedClient);
 
     const traceData = getTraceData();
 
@@ -95,13 +96,13 @@ describe('getTraceData', () => {
   });
 
   it('returns only the `sentry-trace` tag if no DSC is available without a client', () => {
-    jest.spyOn(SentryCoreTracing, 'getDynamicSamplingContextFromClient').mockReturnValueOnce({
+    vi.spyOn(SentryCoreTracing, 'getDynamicSamplingContextFromClient').mockReturnValueOnce({
       trace_id: '',
       public_key: undefined,
     });
 
     // @ts-expect-error - we don't need to provide all the properties
-    jest.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => ({
+    vi.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => ({
       isRecording: () => true,
       spanContext: () => {
         return {
@@ -111,8 +112,8 @@ describe('getTraceData', () => {
         };
       },
     }));
-    jest.spyOn(SentryCoreCurrentScopes, 'getCurrentScope').mockImplementationOnce(() => mockedScope);
-    jest.spyOn(SentryCoreCurrentScopes, 'getClient').mockImplementationOnce(() => undefined);
+    vi.spyOn(SentryCoreCurrentScopes, 'getCurrentScope').mockImplementationOnce(() => mockedScope);
+    vi.spyOn(SentryCoreCurrentScopes, 'getClient').mockImplementationOnce(() => undefined);
 
     const traceData = getTraceData();
 
@@ -124,7 +125,7 @@ describe('getTraceData', () => {
 
   it('returns an empty object if the `sentry-trace` value is invalid', () => {
     // @ts-expect-error - we don't need to provide all the properties
-    jest.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => ({
+    vi.spyOn(SentryCoreSpanUtils, 'getActiveSpan').mockImplementationOnce(() => ({
       isRecording: () => true,
       spanContext: () => {
         return {

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -6,8 +6,6 @@
   "compilerOptions": {
     "lib": ["DOM", "ES2018"],
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node", "jest"]
-
-    // other package-specific, test-specific options
+    "types": ["node"]
   }
 }

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import baseConfig from '../../vite/vite.config';
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
+    },
+  },
+});


### PR DESCRIPTION
Extracted from #13439 

This PR converts the jest test in our core package to vitest.

Locally, this reduced the test run time from ~60s to ~20s, so by ~3x. In a follow-up PR, I'm gonna improve the offline transport tests to use fake timers which should further decrease test runtime. 

closes https://github.com/getsentry/sentry-javascript/issues/13434