### PR TITLE
test(core): Improve offline transport test performance

### DIFF
--- a/packages/core/test/lib/transports/offline.test.ts
+++ b/packages/core/test/lib/transports/offline.test.ts
@@ -17,7 +17,7 @@ import {
   parseEnvelope,
 } from '@sentry/utils';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createTransport } from '../../../src';
 import type { CreateOfflineStore, OfflineTransportOptions } from '../../../src/transports/offline';
 import { START_DELAY, makeOfflineTransport } from '../../../src/transports/offline';
@@ -162,7 +162,9 @@ function waitUntil(fn: () => boolean, timeout: number): Promise<void> {
 }
 
 describe('makeOfflineTransport', () => {
-  it('Sends envelope and checks the store for further envelopes', async () => {
+  vi.useFakeTimers();
+
+  it('sends envelope and checks the store for further envelopes', async () => {
     const { getCalls, store } = createTestStore();
     const { getSendCount, baseTransport } = createTestTransport({ statusCode: 200 });
     let queuedCount = 0;
@@ -174,6 +176,9 @@ describe('makeOfflineTransport', () => {
         return true;
       },
     });
+
+    vi.runAllTimersAsync();
+
     const result = await transport.send(ERROR_ENVELOPE);
 
     expect(result).toEqual({ statusCode: 200 });
@@ -411,7 +416,7 @@ describe('makeOfflineTransport', () => {
     START_DELAY + 2_000,
   );
 
-  it.skip(
+  it(
     'Follows the Retry-After header',
     async () => {
       const { getCalls, store } = createTestStore(ERROR_ENVELOPE);


### PR DESCRIPTION
extracted from #13439 

based on #13458 

This PR significantly improves the performance of our offline transport unit tests. These tests were the bottleneck of our unit test performance previously, as they included actual multi-second timeouts. This PR converts the test to use vitest's fake timers which as far as I can tell, still tests the offline transport correctly but heavily increases performance.

Locally, I this brought down the runtime of the entire test suite from ~20s to ~6s.