### PR TITLE
ci: Don't fail profiling bindings job on cache miss

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1416,6 +1416,11 @@ jobs:
         with:
           ref: ${{ env.HEAD_COMMIT }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
       - name: Restore dependency cache
         uses: actions/cache/restore@v4
         id: restore-dependencies
@@ -1423,7 +1428,11 @@ jobs:
           path: ${{ env.CACHED_DEPENDENCY_PATHS }}
           key: ${{ needs.job_build.outputs.dependency_cache_key }}
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
+
+      - name: Install dependencies
+        if: steps.restore-dependencies.outputs.cache-hit != 'true'
+        run: yarn install --ignore-engines --frozen-lockfile
+        shell: bash
 
       - name: Restore build cache
         uses: actions/cache/restore@v4
@@ -1432,14 +1441,16 @@ jobs:
           path: ${{ env.CACHED_BUILD_PATHS }}
           key: ${{ needs.job_build.outputs.dependency_cache_key }}
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
+
+      - name: Build packages
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: steps.restore-build.outputs.cache-hit != 'true'
+        run: yarn build
 
       - name: Configure safe directory
         run: |
           git config --global --add safe.directory "*"
-
-      - name: Install yarn
-        run: npm i -g yarn@1.22.19 --force
 
       - name: Increase yarn network timeout on Windows
         if: contains(matrix.os, 'windows')
@@ -1451,15 +1462,6 @@ jobs:
         id: python-setup
         with:
           python-version: '3.8.10'
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Install Dependencies
-        if: steps.restore-dependencies.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --ignore-engines --ignore-scripts
 
       - name: Setup (arm64| ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }})
         if: matrix.arch == 'arm64' && !contains(matrix.container, 'alpine') && matrix.target_platform != 'darwin'


### PR DESCRIPTION
We don't want to straight up fail the profiling build step on cache misses but just regenerate the data.