### PR TITLE
test(ci): Pin Node 22 unit test Node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,7 +456,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20, 22]
+        #TODO: unpin 22 once Node bug is fixed
+        node: [14, 16, 18, 20, '22.6.0']
     steps:
       - name: Check out base commit (${{ github.event.pull_request.base.sha }})
         uses: actions/checkout@v4


### PR DESCRIPTION
There's a bug in Node 22.7.0 with protobuf which we're running into: https://github.com/protobufjs/protobuf.js/issues/2025

Once the bug is fixed, we should revert this PR.

h/t @lforst for figuring this out; I'm just merging it into develop 😅 