### PR TITLE
ci: Store build output as artifacts instead of cache

### DIFF
--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -11,15 +11,13 @@ runs:
           path: ${{ env.CACHED_DEPENDENCY_PATHS }}
           key: ${{ env.DEPENDENCY_CACHE_KEY }}
 
-      - name: Check build cache
-        uses: actions/cache/restore@v4
-        id: build-cache
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.BUILD_CACHE_KEY }}
+          name: build-output
 
       - name: Check if caches are restored
         uses: actions/github-script@v6
-        if: steps.dep-cache.outputs.cache-hit != 'true' || steps.build-cache.outputs.cache-hit != 'true'
+        if: steps.dep-cache.outputs.cache-hit != 'true'
         with:
-          script: core.setFailed('Dependency or build cache could not be restored - please re-run ALL jobs.')
+          script: core.setFailed('Dependency cache could not be restored - please re-run ALL jobs.')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ env:
     ${{ github.workspace }}/packages/utils/cjs
     ${{ github.workspace }}/packages/utils/esm
 
-  BUILD_CACHE_KEY: build-cache-${{ github.event.inputs.commit || github.sha }}
   BUILD_CACHE_TARBALL_KEY: tarball-${{ github.event.inputs.commit || github.sha }}
 
   # GH will use the first restore-key it finds that matches
@@ -160,12 +159,6 @@ jobs:
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ env.HEAD_COMMIT }}
 
-      - name: Check build cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.BUILD_CACHE_KEY }}
-
       - name: NX cache
         uses: actions/cache@v4
         # Disable cache when:
@@ -192,7 +185,9 @@ jobs:
         with:
           name: build-output
           path: ${{ env.CACHED_BUILD_PATHS }}
-          retention-days: 2
+          retention-days: 7
+          compression-level: 6
+          overwrite: true
 
     outputs:
       dependency_cache_key: ${{ steps.install_dependencies.outputs.cache_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,6 @@ jobs:
 
       - name: Check build cache
         uses: actions/cache@v4
-        id: cache_built_packages
         with:
           path: ${{ env.CACHED_BUILD_PATHS }}
           key: ${{ env.BUILD_CACHE_KEY }}
@@ -187,6 +186,13 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: yarn build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          retention-days: 2
 
     outputs:
       dependency_cache_key: ${{ steps.install_dependencies.outputs.cache_key }}


### PR DESCRIPTION
This PR changes it so that the build output is kept as an artifact, not a cache. This way, this should never be lost on us.

We keep the NX cache as before.

I chose a retention period of 7 days, which means that after 7 days you could no longer re-run a workflow partially. IMHO that's a reasonable start, we can adjust this if needed.