### PR TITLE
ci: Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -600,7 +600,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-traces
+          name: playwright-traces-job_browser_playwright_tests
           path: dev-packages/browser-integration-tests/test-results
           overwrite: true
 
@@ -651,7 +651,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-traces
+          name: playwright-traces-job_browser_loader_tests
           path: dev-packages/browser-integration-tests/test-results
           overwrite: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,11 +597,12 @@ jobs:
         run: yarn test:ci${{ matrix.project && format(' --project={0}', matrix.project) || '' }}${{ matrix.shard && format(' --shard={0}/{1}', matrix.shard, matrix.shards) || '' }}
 
       - name: Upload Playwright Traces
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-traces
           path: dev-packages/browser-integration-tests/test-results
+          overwrite: true
 
   job_browser_loader_tests:
     name: PW ${{ matrix.bundle }} Tests
@@ -647,11 +648,12 @@ jobs:
           cd dev-packages/browser-integration-tests
           yarn test:loader
       - name: Upload Playwright Traces
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-traces
           path: dev-packages/browser-integration-tests/test-results
+          overwrite: true
 
   job_check_for_faulty_dts:
     name: Check for faulty .d.ts files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -599,7 +599,7 @@ jobs:
 
       - name: Upload Playwright Traces
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: playwright-traces-job_browser_playwright_tests-${{ matrix.bundle}}-${{matrix.project}}-${{matrix.shard || '0'}}
           path: dev-packages/browser-integration-tests/test-results
@@ -651,7 +651,7 @@ jobs:
           yarn test:loader
       - name: Upload Playwright Traces
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: playwright-traces-job_browser_loader_tests-${{ matrix.bundle}}
           path: dev-packages/browser-integration-tests/test-results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           name: build-output
           path: ${{ env.CACHED_BUILD_PATHS }}
-          retention-days: 7
+          retention-days: 4
           compression-level: 6
           overwrite: true
 
@@ -345,6 +345,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
+          retention-days: 90
           path: |
             ${{ github.workspace }}/packages/browser/build/bundles/**
             ${{ github.workspace }}/packages/replay-internal/build/bundles/**
@@ -600,9 +601,10 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-traces-job_browser_playwright_tests
+          name: playwright-traces-job_browser_playwright_tests-${{ matrix.bundle}}-${{matrix.project}}-${{matrix.shard || '0'}}
           path: dev-packages/browser-integration-tests/test-results
           overwrite: true
+          retention-days: 7
 
   job_browser_loader_tests:
     name: PW ${{ matrix.bundle }} Tests
@@ -651,9 +653,10 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-traces-job_browser_loader_tests
+          name: playwright-traces-job_browser_loader_tests-${{ matrix.bundle}}
           path: dev-packages/browser-integration-tests/test-results
           overwrite: true
+          retention-days: 7
 
   job_check_for_faulty_dts:
     name: Check for faulty .d.ts files
@@ -1263,6 +1266,7 @@ jobs:
         with:
           name: ${{ steps.process.outputs.artifactName }}
           path: ${{ steps.process.outputs.artifactPath }}
+          retention-days: 7
 
   job_compile_bindings_profiling_node:
     name: Compile & Test Profiling Bindings (v${{ matrix.node }}) ${{ matrix.target_platform || matrix.os }}, ${{ matrix.node || matrix.container }}, ${{ matrix.arch || matrix.container }}, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }}


### PR DESCRIPTION
It keeps complaining that this is deprecated, so bumping this to v4.