### PR TITLE
fix(node): Suppress tracing for transport request execution rather than transport creation

### DIFF
--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -1,5 +1,5 @@
 import { clearCachedImplementation, getNativeImplementation } from '@sentry-internal/browser-utils';
-import { createTransport, suppressTracing } from '@sentry/core';
+import { createTransport } from '@sentry/core';
 import type { Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
 import { rejectedSyncPromise } from '@sentry/utils';
 import type { WINDOW } from '../helpers';

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -1,5 +1,5 @@
 import { clearCachedImplementation, getNativeImplementation } from '@sentry-internal/browser-utils';
-import { createTransport } from '@sentry/core';
+import { createTransport, suppressTracing } from '@sentry/core';
 import type { Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
 import { rejectedSyncPromise } from '@sentry/utils';
 import type { WINDOW } from '../helpers';
@@ -47,16 +47,18 @@ export function makeFetchTransport(
     }
 
     try {
-      return nativeFetch(options.url, requestOptions).then(response => {
-        pendingBodySize -= requestSize;
-        pendingCount--;
-        return {
-          statusCode: response.status,
-          headers: {
-            'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
-            'retry-after': response.headers.get('Retry-After'),
-          },
-        };
+      return suppressTracing(() => {
+        return nativeFetch(options.url, requestOptions).then(response => {
+          pendingBodySize -= requestSize;
+          pendingCount--;
+          return {
+            statusCode: response.status,
+            headers: {
+              'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
+              'retry-after': response.headers.get('Retry-After'),
+            },
+          };
+        });
       });
     } catch (e) {
       clearCachedImplementation('fetch');

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -47,18 +47,17 @@ export function makeFetchTransport(
     }
 
     try {
-      return suppressTracing(() => {
-        return nativeFetch(options.url, requestOptions).then(response => {
-          pendingBodySize -= requestSize;
-          pendingCount--;
-          return {
-            statusCode: response.status,
-            headers: {
-              'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
-              'retry-after': response.headers.get('Retry-After'),
-            },
-          };
-        });
+      // TODO: This may need a `suppresTracing` call in the future when we switch the browser SDK to OTEL
+      return nativeFetch(options.url, requestOptions).then(response => {
+        pendingBodySize -= requestSize;
+        pendingCount--;
+        return {
+          statusCode: response.status,
+          headers: {
+            'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
+            'retry-after': response.headers.get('Retry-After'),
+          },
+        };
       });
     } catch (e) {
       clearCachedImplementation('fetch');

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -9,7 +9,6 @@ import {
   getCapturedScopesOnSpan,
   getCurrentScope,
   getIsolationScope,
-  isSentryRequestUrl,
   setCapturedScopesOnSpan,
 } from '@sentry/core';
 import { getClient } from '@sentry/opentelemetry';

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -102,10 +102,6 @@ export const instrumentHttp = Object.assign(
           return false;
         }
 
-        if (isSentryRequestUrl(url, getClient())) {
-          return true;
-        }
-
         const _ignoreOutgoingRequests = _httpOptions.ignoreOutgoingRequests;
         if (_ignoreOutgoingRequests && _ignoreOutgoingRequests(url, request)) {
           return true;

--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -79,11 +79,8 @@ export function makeNodeTransport(options: NodeTransportOptions): Transport {
     ? (new HttpsProxyAgent(proxy) as http.Agent)
     : new nativeHttpModule.Agent({ keepAlive, maxSockets: 30, timeout: 2000 });
 
-  // This ensures we do not generate any spans in OpenTelemetry for the transport
-  return suppressTracing(() => {
-    const requestExecutor = createRequestExecutor(options, options.httpModule ?? nativeHttpModule, agent);
-    return createTransport(options, requestExecutor);
-  });
+  const requestExecutor = createRequestExecutor(options, options.httpModule ?? nativeHttpModule, agent);
+  return createTransport(options, requestExecutor);
 }
 
 /**
@@ -122,54 +119,59 @@ function createRequestExecutor(
   const { hostname, pathname, port, protocol, search } = new URL(options.url);
   return function makeRequest(request: TransportRequest): Promise<TransportMakeRequestResponse> {
     return new Promise((resolve, reject) => {
-      let body = streamFromBody(request.body);
+      // This ensures we do not generate any spans in OpenTelemetry for the transport
+      suppressTracing(() => {
+        let body = streamFromBody(request.body);
 
-      const headers: Record<string, string> = { ...options.headers };
+        const headers: Record<string, string> = { ...options.headers };
 
-      if (request.body.length > GZIP_THRESHOLD) {
-        headers['content-encoding'] = 'gzip';
-        body = body.pipe(createGzip());
-      }
+        if (request.body.length > GZIP_THRESHOLD) {
+          headers['content-encoding'] = 'gzip';
+          body = body.pipe(createGzip());
+        }
 
-      const req = httpModule.request(
-        {
-          method: 'POST',
-          agent,
-          headers,
-          hostname,
-          path: `${pathname}${search}`,
-          port,
-          protocol,
-          ca: options.caCerts,
-        },
-        res => {
-          res.on('data', () => {
-            // Drain socket
-          });
+        const req = httpModule.request(
+          {
+            method: 'POST',
+            agent,
+            headers,
+            hostname,
+            path: `${pathname}${search}`,
+            port,
+            protocol,
+            ca: options.caCerts,
+          },
+          res => {
+            res.on('data', () => {
+              // Drain socket
+            });
 
-          res.on('end', () => {
-            // Drain socket
-          });
+            res.on('end', () => {
+              // Drain socket
+            });
 
-          res.setEncoding('utf8');
+            res.setEncoding('utf8');
 
-          // "Key-value pairs of header names and values. Header names are lower-cased."
-          // https://nodejs.org/api/http.html#http_message_headers
-          const retryAfterHeader = res.headers['retry-after'] ?? null;
-          const rateLimitsHeader = res.headers['x-sentry-rate-limits'] ?? null;
+            // "Key-value pairs of header names and values. Header names are lower-cased."
+            // https://nodejs.org/api/http.html#http_message_headers
+            const retryAfterHeader = res.headers['retry-after'] ?? null;
+            const rateLimitsHeader = res.headers['x-sentry-rate-limits'] ?? null;
 
-          resolve({
-            statusCode: res.statusCode,
-            headers: {
-              'retry-after': retryAfterHeader,
-              'x-sentry-rate-limits': Array.isArray(rateLimitsHeader) ? rateLimitsHeader[0] || null : rateLimitsHeader,
-            },
-          });
-        },
-      );
+            resolve({
+              statusCode: res.statusCode,
+              headers: {
+                'retry-after': retryAfterHeader,
+                'x-sentry-rate-limits': Array.isArray(rateLimitsHeader)
+                  ? rateLimitsHeader[0] || null
+                  : rateLimitsHeader,
+              },
+            });
+          },
+        );
 
-      req.on('error', reject);
-      body.pipe(req);
+        req.on('error', reject);
+        body.pipe(req);
+      });
     });
   };
 }

--- a/packages/vercel-edge/src/transports/index.ts
+++ b/packages/vercel-edge/src/transports/index.ts
@@ -1,4 +1,4 @@
-import { createTransport } from '@sentry/core';
+import { createTransport, suppressTracing } from '@sentry/core';
 import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
 import { SentryError } from '@sentry/utils';
 
@@ -89,14 +89,16 @@ export function makeEdgeTransport(options: VercelEdgeTransportOptions): Transpor
       ...options.fetchOptions,
     };
 
-    return fetch(options.url, requestOptions).then(response => {
-      return {
-        statusCode: response.status,
-        headers: {
-          'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
-          'retry-after': response.headers.get('Retry-After'),
-        },
-      };
+    return suppressTracing(() => {
+      return fetch(options.url, requestOptions).then(response => {
+        return {
+          statusCode: response.status,
+          headers: {
+            'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
+            'retry-after': response.headers.get('Retry-After'),
+          },
+        };
+      });
     });
   }
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/issues/13466#issuecomment-2312856449 correctly points out that we are suppressing tracing for the transport creation instead of the transport execution.

This PR wraps the code that is actually conducting the request with `suppressTracing` instead of the transport creation.

Fixes https://github.com/getsentry/sentry-javascript/issues/13466