### PR TITLE
feat(solidstart): Add `sentrySolidStartVite` plugin to simplify source maps upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1003,7 +1003,7 @@ jobs:
         working-directory: dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}
         timeout-minutes: 5
         run: pnpm test:assert
-        
+
       - name: Upload Playwright Traces
         uses: actions/upload-artifact@v4
         if: failure()

--- a/dev-packages/e2e-tests/test-applications/solidstart/app.config.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/app.config.ts
@@ -1,3 +1,8 @@
+import { sentrySolidStartVite } from '@sentry/solidstart';
 import { defineConfig } from '@solidjs/start/config';
 
-export default defineConfig({});
+export default defineConfig({
+  vite: {
+    plugins: [sentrySolidStartVite({})],
+  },
+});

--- a/dev-packages/e2e-tests/test-applications/solidstart/app.config.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/app.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from '@solidjs/start/config';
 
 export default defineConfig({
   vite: {
-    plugins: [sentrySolidStartVite({})],
+    plugins: [sentrySolidStartVite()],
   },
 });

--- a/dev-packages/e2e-tests/test-applications/solidstart/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart/package.json
@@ -3,14 +3,19 @@
   "version": "0.0.0",
   "scripts": {
     "clean": "pnpx rimraf node_modules pnpm-lock.yaml .vinxi .output",
+    "clean:build": "pnpx rimraf .vinxi .output",
     "dev": "NODE_OPTIONS='--import ./src/instrument.server.mjs' vinxi dev",
     "build": "vinxi build",
     "//": [
       "We are using `vinxi dev` to start the server because `vinxi start` is experimental and ",
       "doesn't correctly resolve modules for @sentry/solidstart/solidrouter.",
-      "This is currently not an issue outside of our repo. See: https://github.com/nksaraf/vinxi/issues/177"
+      "This is currently not an issue outside of our repo. See: https://github.com/nksaraf/vinxi/issues/177",
+      "We run the build command to ensure building succeeds. However, keeping",
+      "build output around slows down the vite dev server when using `@sentry/vite-plugin` so we clear it out",
+      "before actually running the tests.",
+      "Cleaning the build output should be removed once we can use `vinxi start`."
     ],
-    "preview": "HOST=localhost PORT=3030 NODE_OPTIONS='--import ./src/instrument.server.mjs' vinxi dev",
+    "preview": "pnpm clean:build && HOST=localhost PORT=3030 NODE_OPTIONS='--import ./src/instrument.server.mjs' vinxi dev",
     "start": "HOST=localhost PORT=3030 NODE_OPTIONS='--import ./src/instrument.server.mjs' vinxi start",
     "test:prod": "TEST_ENV=production playwright test",
     "test:build": "pnpm install && npx playwright install && pnpm build",

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/routes/client-error.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/routes/client-error.tsx
@@ -1,75 +1,15 @@
-import * as Sentry from '@sentry/solidstart';
-import type { ParentProps } from 'solid-js';
-import { ErrorBoundary, createSignal, onMount } from 'solid-js';
-
-const SentryErrorBoundary = Sentry.withSentryErrorBoundary(ErrorBoundary);
-
-const [count, setCount] = createSignal(1);
-const [caughtError, setCaughtError] = createSignal(false);
-
 export default function ClientErrorPage() {
   return (
-    <SampleErrorBoundary>
-      {caughtError() && (
-        <Throw error={`Error ${count()} thrown from Sentry ErrorBoundary in Solid Start E2E test app`} />
-      )}
-      <section class="bg-gray-100 text-gray-700 p-8">
-        <div class="flex flex-col items-start space-x-2">
-          <button
-            class="border rounded-lg px-2 mb-2 border-red-500 text-red-500 cursor-pointer"
-            id="caughtErrorBtn"
-            onClick={() => setCaughtError(true)}
-          >
-            Throw caught error
-          </button>
-        </div>
-        <div class="flex flex-col items-start space-x-2">
-          <button
-            class="border rounded-lg px-2 mb-2 border-red-500 text-red-500 cursor-pointer"
-            id="errorBtn"
-            onClick={() => {
-              throw new Error('Error thrown from Solid Start E2E test app');
-            }}
-          >
-            Throw uncaught error
-          </button>
-        </div>
-      </section>
-    </SampleErrorBoundary>
-  );
-}
-
-function Throw(props: { error: string }) {
-  onMount(() => {
-    throw new Error(props.error);
-  });
-  return null;
-}
-
-function SampleErrorBoundary(props: ParentProps) {
-  return (
-    <SentryErrorBoundary
-      fallback={(error, reset) => (
-        <section class="bg-gray-100 text-gray-700 p-8">
-          <h1 class="text-2xl font-bold">Error Boundary Fallback</h1>
-          <div class="flex items-center space-x-2 mb-4">
-            <code>{error.message}</code>
-          </div>
-          <button
-            id="errorBoundaryResetBtn"
-            class="border rounded-lg px-2 border-gray-900"
-            onClick={() => {
-              setCount(count() + 1);
-              setCaughtError(false);
-              reset();
-            }}
-          >
-            Reset
-          </button>
-        </section>
-      )}
-    >
-      {props.children}
-    </SentryErrorBoundary>
+    <div class="flex flex-col items-start space-x-2">
+      <button
+        class="border rounded-lg px-2 mb-2 border-red-500 text-red-500 cursor-pointer"
+        id="errorBtn"
+        onClick={() => {
+          throw new Error('Uncaught error thrown from Solid Start E2E test app');
+        }}
+      >
+        Throw uncaught error
+      </button>
+    </div>
   );
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/routes/error-boundary.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/routes/error-boundary.tsx
@@ -1,0 +1,64 @@
+import * as Sentry from '@sentry/solidstart';
+import type { ParentProps } from 'solid-js';
+import { ErrorBoundary, createSignal, onMount } from 'solid-js';
+
+const SentryErrorBoundary = Sentry.withSentryErrorBoundary(ErrorBoundary);
+
+const [count, setCount] = createSignal(1);
+const [caughtError, setCaughtError] = createSignal(false);
+
+export default function ErrorBoundaryTestPage() {
+  return (
+    <SampleErrorBoundary>
+      {caughtError() && (
+        <Throw error={`Error ${count()} thrown from Sentry ErrorBoundary in Solid Start E2E test app`} />
+      )}
+      <section class="bg-gray-100 text-gray-700 p-8">
+        <div class="flex flex-col items-start space-x-2">
+          <button
+            class="border rounded-lg px-2 mb-2 border-red-500 text-red-500 cursor-pointer"
+            id="caughtErrorBtn"
+            onClick={() => setCaughtError(true)}
+          >
+            Throw caught error
+          </button>
+        </div>
+      </section>
+    </SampleErrorBoundary>
+  );
+}
+
+function Throw(props: { error: string }) {
+  onMount(() => {
+    throw new Error(props.error);
+  });
+  return null;
+}
+
+function SampleErrorBoundary(props: ParentProps) {
+  return (
+    <SentryErrorBoundary
+      fallback={(error, reset) => (
+        <section class="bg-gray-100 text-gray-700 p-8">
+          <h1 class="text-2xl font-bold">Error Boundary Fallback</h1>
+          <div class="flex items-center space-x-2 mb-4">
+            <code>{error.message}</code>
+          </div>
+          <button
+            id="errorBoundaryResetBtn"
+            class="border rounded-lg px-2 border-gray-900"
+            onClick={() => {
+              setCount(count() + 1);
+              setCaughtError(false);
+              reset();
+            }}
+          >
+            Reset
+          </button>
+        </section>
+      )}
+    >
+      {props.children}
+    </SentryErrorBoundary>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/routes/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/routes/index.tsx
@@ -15,6 +15,9 @@ export default function Home() {
           <A href="/server-error">Server error</A>
         </li>
         <li>
+          <A href="/error-boundary">Error Boundary</A>
+        </li>
+        <li>
           <A id="navLink" href="/users/5">
             User 5
           </A>

--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/errorboundary.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/errorboundary.test.ts
@@ -10,7 +10,7 @@ test('captures an exception', async ({ page }) => {
     );
   });
 
-  await page.goto('/client-error');
+  await page.goto('/error-boundary');
   await page.locator('#caughtErrorBtn').click();
   const errorEvent = await errorEventPromise;
 
@@ -27,7 +27,7 @@ test('captures an exception', async ({ page }) => {
         },
       ],
     },
-    transaction: '/client-error',
+    transaction: '/error-boundary',
   });
 });
 
@@ -40,7 +40,7 @@ test('captures a second exception after resetting the boundary', async ({ page }
     );
   });
 
-  await page.goto('/client-error');
+  await page.goto('/error-boundary');
   await page.locator('#caughtErrorBtn').click();
   const firstErrorEvent = await firstErrorEventPromise;
 
@@ -57,7 +57,7 @@ test('captures a second exception after resetting the boundary', async ({ page }
         },
       ],
     },
-    transaction: '/client-error',
+    transaction: '/error-boundary',
   });
 
   const secondErrorEventPromise = waitForError('solidstart', errorEvent => {
@@ -85,6 +85,6 @@ test('captures a second exception after resetting the boundary', async ({ page }
         },
       ],
     },
-    transaction: '/client-error',
+    transaction: '/error-boundary',
   });
 });

--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/errors.client.test.ts
@@ -18,7 +18,6 @@ test.describe('client-side errors', () => {
             type: 'Error',
             value: 'Uncaught error thrown from Solid Start E2E test app',
             mechanism: {
-              type: 'instrument',
               handled: false,
             },
           },

--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/errors.client.test.ts
@@ -4,7 +4,7 @@ import { waitForError } from '@sentry-internal/test-utils';
 test.describe('client-side errors', () => {
   test('captures error thrown on click', async ({ page }) => {
     const errorPromise = waitForError('solidstart', async errorEvent => {
-      return errorEvent?.exception?.values?.[0]?.value === 'Error thrown from Solid Start E2E test app';
+      return errorEvent?.exception?.values?.[0]?.value === 'Uncaught error thrown from Solid Start E2E test app';
     });
 
     await page.goto(`/client-error`);
@@ -16,7 +16,7 @@ test.describe('client-side errors', () => {
         values: [
           {
             type: 'Error',
-            value: 'Error thrown from Solid Start E2E test app',
+            value: 'Uncaught error thrown from Solid Start E2E test app',
             mechanism: {
               type: 'instrument',
               handled: false,

--- a/packages/solidstart/.eslintrc.js
+++ b/packages/solidstart/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
       files: ['src/vite/**', 'src/server/**'],
       rules: {
         '@sentry-internal/sdk/no-optional-chaining': 'off',
+        '@sentry-internal/sdk/no-nullish-coalescing': 'off',
       },
     },
   ],

--- a/packages/solidstart/README.md
+++ b/packages/solidstart/README.md
@@ -157,58 +157,36 @@ render(
 );
 ```
 
-# Sourcemaps and Releases
+## Uploading Source Maps
 
-To generate and upload source maps of your Solid Start app use our Vite bundler plugin.
-
-1. Install the Sentry Vite plugin
-
-```bash
-# Using npm
-npm install @sentry/vite-plugin --save-dev
-
-# Using yarn
-yarn add @sentry/vite-plugin --dev
-```
-
-2. Configure the vite plugin
-
-To upload source maps you have to configure an auth token. Auth tokens can be passed to the plugin explicitly with the
-`authToken` option, with a `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the
-working directory when building your project. We recommend you add the auth token to your CI/CD environment as an
-environment variable.
+To upload source maps, add the `sentrySolidStartVite` plugin from `@sentry/solidstart` to your `app.config.ts` and configure
+an auth token. Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a
+`SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when
+building your project. We recommend you add the auth token to your CI/CD environment as an environment variable.
 
 Learn more about configuring the plugin in our
 [Sentry Vite Plugin documentation](https://www.npmjs.com/package/@sentry/vite-plugin).
 
-```bash
-// .env.sentry-build-plugin
-SENTRY_AUTH_TOKEN=<your auth token>
-SENTRY_ORG=<your org>
-SENTRY_PROJECT=<your project name>
-```
-
-3. Finally, add the plugin to your `app.config.ts` file.
-
-```javascript
+```typescript
+// app.config.ts
 import { defineConfig } from '@solidjs/start/config';
-import { sentryVitePlugin } from '@sentry/vite-plugin';
+import { sentrySolidStartVite } from '@sentry/solidstart';
 
 export default defineConfig({
-  // rest of your config
   // ...
 
   vite: {
-    build: {
-      sourcemap: true,
-    },
     plugins: [
-      sentryVitePlugin({
-        org: process.env.SENTRY_ORG,
-        project: process.env.SENTRY_PROJECT,
-        authToken: process.env.SENTRY_AUTH_TOKEN,
+      sentrySolidStartVite({
+        sourceMapsUploadOptions: {
+          org: process.env.SENTRY_ORG,
+          project: process.env.SENTRY_PROJECT,
+          authToken: process.env.SENTRY_AUTH_TOKEN,
+        },
+        debug: true,
       }),
     ],
   },
+  // ...
 });
 ```

--- a/packages/solidstart/README.md
+++ b/packages/solidstart/README.md
@@ -178,11 +178,9 @@ export default defineConfig({
   vite: {
     plugins: [
       sentrySolidStartVite({
-        sourceMapsUploadOptions: {
-          org: process.env.SENTRY_ORG,
-          project: process.env.SENTRY_PROJECT,
-          authToken: process.env.SENTRY_AUTH_TOKEN,
-        },
+        org: process.env.SENTRY_ORG,
+        project: process.env.SENTRY_PROJECT,
+        authToken: process.env.SENTRY_AUTH_TOKEN,
         debug: true,
       }),
     ],

--- a/packages/solidstart/README.md
+++ b/packages/solidstart/README.md
@@ -159,8 +159,8 @@ render(
 
 ## Uploading Source Maps
 
-To upload source maps, add the `sentrySolidStartVite` plugin from `@sentry/solidstart` to your `app.config.ts` and configure
-an auth token. Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a
+To upload source maps, add the `sentrySolidStartVite` plugin from `@sentry/solidstart` to your `app.config.ts` and
+configure an auth token. Auth tokens can be passed to the plugin explicitly with the `authToken` option, with a
 `SENTRY_AUTH_TOKEN` environment variable, or with an `.env.sentry-build-plugin` file in the working directory when
 building your project. We recommend you add the auth token to your CI/CD environment as an environment variable.
 

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -39,17 +39,6 @@
         "require": "./build/cjs/index.server.js"
       }
     },
-    "./middleware": {
-      "types": "./middleware.d.ts",
-      "import": {
-        "types": "./middleware.d.ts",
-        "default": "./build/esm/middleware.js"
-      },
-      "require": {
-        "types": "./middleware.d.ts",
-        "default": "./build/cjs/middleware.js"
-      }
-    },
     "./solidrouter": {
       "types": "./solidrouter.d.ts",
       "browser": {

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -106,7 +106,7 @@
     "build:transpile:watch": "rollup -c rollup.npm.config.mjs --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:tarball": "npm pack",
-    "circularDepCheck": "madge --circular src/index.client.ts && madge --circular src/index.server.ts && madge --circular src/index.types.ts && madge --circular src/solidrouter.client.ts && madge --circular src/solidrouter.server.ts && madge --circular src/solidrouter.ts && madge --circular src/middleware.ts",
+    "circularDepCheck": "madge --circular src/index.client.ts && madge --circular src/index.server.ts && madge --circular src/index.types.ts && madge --circular src/solidrouter.client.ts && madge --circular src/solidrouter.server.ts && madge --circular src/solidrouter.ts",
     "clean": "rimraf build coverage sentry-solidstart-*.tgz ./*.d.ts ./*.d.ts.map ./client ./server",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -39,6 +39,17 @@
         "require": "./build/cjs/index.server.js"
       }
     },
+    "./middleware": {
+      "types": "./middleware.d.ts",
+      "import": {
+        "types": "./middleware.d.ts",
+        "default": "./build/esm/middleware.js"
+      },
+      "require": {
+        "types": "./middleware.d.ts",
+        "default": "./build/cjs/middleware.js"
+      }
+    },
     "./solidrouter": {
       "types": "./solidrouter.d.ts",
       "browser": {
@@ -95,7 +106,7 @@
     "build:transpile:watch": "rollup -c rollup.npm.config.mjs --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:tarball": "npm pack",
-    "circularDepCheck": "madge --circular src/index.client.ts && madge --circular src/index.server.ts && madge --circular src/index.types.ts && madge --circular src/solidrouter.client.ts && madge --circular src/solidrouter.server.ts && madge --circular src/solidrouter.ts",
+    "circularDepCheck": "madge --circular src/index.client.ts && madge --circular src/index.server.ts && madge --circular src/index.types.ts && madge --circular src/solidrouter.client.ts && madge --circular src/solidrouter.server.ts && madge --circular src/solidrouter.ts && madge --circular src/middleware.ts",
     "clean": "rimraf build coverage sentry-solidstart-*.tgz ./*.d.ts ./*.d.ts.map ./client ./server",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",

--- a/packages/solidstart/src/index.server.ts
+++ b/packages/solidstart/src/index.server.ts
@@ -1,1 +1,2 @@
 export * from './server';
+export * from './vite';

--- a/packages/solidstart/src/index.types.ts
+++ b/packages/solidstart/src/index.types.ts
@@ -3,6 +3,7 @@
 // exports in this file - which we do below.
 export * from './client';
 export * from './server';
+export * from './vite';
 
 import type { Integration, Options, StackParser } from '@sentry/types';
 

--- a/packages/solidstart/src/vite/index.ts
+++ b/packages/solidstart/src/vite/index.ts
@@ -1,0 +1,1 @@
+export * from './sentrySolidStartVite';

--- a/packages/solidstart/src/vite/sentrySolidStartVite.ts
+++ b/packages/solidstart/src/vite/sentrySolidStartVite.ts
@@ -10,7 +10,7 @@ export const sentrySolidStartVite = (options: SentrySolidStartPluginOptions): Pl
 
   if (process.env.NODE_ENV !== 'development') {
     if (options.sourceMapsUploadOptions?.enabled ?? true) {
-      sentryPlugins.push(...makeSourceMapsVitePlugin({ ...options.sourceMapsUploadOptions, debug: options.debug }));
+      sentryPlugins.push(...makeSourceMapsVitePlugin(options));
     }
   }
 

--- a/packages/solidstart/src/vite/sentrySolidStartVite.ts
+++ b/packages/solidstart/src/vite/sentrySolidStartVite.ts
@@ -1,0 +1,18 @@
+import type { Plugin } from 'vite';
+import { makeSourceMapsVitePlugin } from './sourceMaps';
+import type { SentrySolidStartPluginOptions } from './types';
+
+/**
+ * Various Sentry vite plugins to be used for SolidStart.
+ */
+export const sentrySolidStartVite = (options: SentrySolidStartPluginOptions): Plugin[] => {
+  const sentryPlugins: Plugin[] = [];
+
+  if (process.env.NODE_ENV !== 'development') {
+    if (options.sourceMapsUploadOptions?.enabled ?? true) {
+      sentryPlugins.push(...makeSourceMapsVitePlugin({ ...options.sourceMapsUploadOptions, debug: options.debug }));
+    }
+  }
+
+  return sentryPlugins;
+};

--- a/packages/solidstart/src/vite/sentrySolidStartVite.ts
+++ b/packages/solidstart/src/vite/sentrySolidStartVite.ts
@@ -5,7 +5,7 @@ import type { SentrySolidStartPluginOptions } from './types';
 /**
  * Various Sentry vite plugins to be used for SolidStart.
  */
-export const sentrySolidStartVite = (options: SentrySolidStartPluginOptions): Plugin[] => {
+export const sentrySolidStartVite = (options: SentrySolidStartPluginOptions = {}): Plugin[] => {
   const sentryPlugins: Plugin[] = [];
 
   if (process.env.NODE_ENV !== 'development') {

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -1,0 +1,56 @@
+import { sentryVitePlugin } from '@sentry/vite-plugin';
+import type { Plugin } from 'vite';
+import type { SourceMapsOptions } from './types';
+
+/**
+ * A Sentry plugin for SolidStart to enable source maps and use
+ * @sentry/vite-plugin to automatically upload source maps to Sentry.
+ * @param {SourceMapsOptions} options
+ */
+export function makeSourceMapsVitePlugin(options: SourceMapsOptions): Plugin[] {
+  return [
+    {
+      name: 'sentry-solidstart-source-maps',
+      apply: 'build',
+      enforce: 'post',
+      config(config) {
+        const sourceMapsPreviouslyNotEnabled = !config.build?.sourcemap;
+        if (options.debug && sourceMapsPreviouslyNotEnabled) {
+          // eslint-disable-next-line no-console
+          console.log('[Sentry SolidStart Plugin] Enabling source map generation');
+          if (!options.sourcemaps?.filesToDeleteAfterUpload) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[Sentry SolidStart PLugin] We recommend setting the \`sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload\` option to clean up source maps after uploading.
+[Sentry SolidStart Plugin] Otherwise, source maps might be deployed to production, depending on your configuration`,
+            );
+          }
+        }
+        return {
+          ...config,
+          build: {
+            ...config.build,
+            sourcemap: true,
+          },
+        };
+      },
+    },
+    ...sentryVitePlugin({
+      org: options.org ?? process.env.SENTRY_ORG,
+      project: options.project ?? process.env.SENTRY_PROJECT,
+      authToken: options.authToken ?? process.env.SENTRY_AUTH_TOKEN,
+      telemetry: options.telemetry ?? true,
+      sourcemaps: {
+        assets: options.sourcemaps?.assets ?? undefined,
+        ignore: options.sourcemaps?.ignore ?? undefined,
+        filesToDeleteAfterUpload: options.sourcemaps?.filesToDeleteAfterUpload ?? undefined,
+      },
+      _metaOptions: {
+        telemetry: {
+          metaFramework: 'solidstart',
+        },
+      },
+      debug: options.debug ?? false,
+    }),
+  ];
+}

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -18,10 +18,10 @@ export function makeSourceMapsVitePlugin(options: SourceMapsOptions): Plugin[] {
         if (options.debug && sourceMapsPreviouslyNotEnabled) {
           // eslint-disable-next-line no-console
           console.log('[Sentry SolidStart Plugin] Enabling source map generation');
-          if (!options.sourcemaps?.filesToDeleteAfterUpload) {
+          if (!options.filesToDeleteAfterUpload) {
             // eslint-disable-next-line no-console
             console.warn(
-              `[Sentry SolidStart PLugin] We recommend setting the \`sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload\` option to clean up source maps after uploading.
+              `[Sentry SolidStart PLugin] We recommend setting the \`sourceMapsUploadOptions.filesToDeleteAfterUpload\` option to clean up source maps after uploading.
 [Sentry SolidStart Plugin] Otherwise, source maps might be deployed to production, depending on your configuration`,
             );
           }
@@ -41,9 +41,7 @@ export function makeSourceMapsVitePlugin(options: SourceMapsOptions): Plugin[] {
       authToken: options.authToken ?? process.env.SENTRY_AUTH_TOKEN,
       telemetry: options.telemetry ?? true,
       sourcemaps: {
-        assets: options.sourcemaps?.assets ?? undefined,
-        ignore: options.sourcemaps?.ignore ?? undefined,
-        filesToDeleteAfterUpload: options.sourcemaps?.filesToDeleteAfterUpload ?? undefined,
+        filesToDeleteAfterUpload: options.filesToDeleteAfterUpload ?? undefined,
         ...options.unstable_sentryVitePluginOptions?.sourcemaps,
       },
       _metaOptions: {

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -37,20 +37,21 @@ export function makeSourceMapsVitePlugin(options: SentrySolidStartPluginOptions)
       },
     },
     ...sentryVitePlugin({
+      authToken: authToken ?? process.env.SENTRY_AUTH_TOKEN,
+      bundleSizeOptimizations: options.bundleSizeOptimizations,
+      debug: debug ?? false,
       org: org ?? process.env.SENTRY_ORG,
       project: project ?? process.env.SENTRY_PROJECT,
-      authToken: authToken ?? process.env.SENTRY_AUTH_TOKEN,
-      telemetry: sourceMapsUploadOptions?.telemetry ?? true,
       sourcemaps: {
         filesToDeleteAfterUpload: sourceMapsUploadOptions?.filesToDeleteAfterUpload ?? undefined,
         ...sourceMapsUploadOptions?.unstable_sentryVitePluginOptions?.sourcemaps,
       },
+      telemetry: sourceMapsUploadOptions?.telemetry ?? true,
       _metaOptions: {
         telemetry: {
           metaFramework: 'solidstart',
         },
       },
-      debug: debug ?? false,
       ...sourceMapsUploadOptions?.unstable_sentryVitePluginOptions,
     }),
   ];

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -44,6 +44,7 @@ export function makeSourceMapsVitePlugin(options: SourceMapsOptions): Plugin[] {
         assets: options.sourcemaps?.assets ?? undefined,
         ignore: options.sourcemaps?.ignore ?? undefined,
         filesToDeleteAfterUpload: options.sourcemaps?.filesToDeleteAfterUpload ?? undefined,
+        ...options.unstable_sentryVitePluginOptions?.sourcemaps,
       },
       _metaOptions: {
         telemetry: {
@@ -51,6 +52,7 @@ export function makeSourceMapsVitePlugin(options: SourceMapsOptions): Plugin[] {
         },
       },
       debug: options.debug ?? false,
+      ...options.unstable_sentryVitePluginOptions,
     }),
   ];
 }

--- a/packages/solidstart/src/vite/types.ts
+++ b/packages/solidstart/src/vite/types.ts
@@ -10,28 +10,6 @@ export type SourceMapsOptions = {
   enabled?: boolean;
 
   /**
-   * The auth token to use when uploading source maps to Sentry.
-   *
-   * Instead of specifying this option, you can also set the `SENTRY_AUTH_TOKEN` environment variable.
-   *
-   * To create an auth token, follow this guide:
-   * @see https://docs.sentry.io/product/accounts/auth-tokens/#organization-auth-tokens
-   */
-  authToken?: string;
-
-  /**
-   * The organization slug of your Sentry organization.
-   * Instead of specifying this option, you can also set the `SENTRY_ORG` environment variable.
-   */
-  org?: string;
-
-  /**
-   * The project slug of your Sentry project.
-   * Instead of specifying this option, you can also set the `SENTRY_PROJECT` environment variable.
-   */
-  project?: string;
-
-  /**
    * If this flag is `true`, the Sentry plugin will collect some telemetry data and send it to Sentry.
    * It will not collect any sensitive or user-specific data.
    *
@@ -63,18 +41,34 @@ export type SourceMapsOptions = {
    * Furthermore, some options are untested with SvelteKit specifically. Use with caution.
    */
   unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>;
-
-  /**
-   * Enable debug functionality of the SDK during build-time.
-   * Enabling this will give you logs about source maps.
-   */
-  debug?: boolean;
 };
 
 /**
  *  Build options for the Sentry module. These options are used during build-time by the Sentry SDK.
  */
 export type SentrySolidStartPluginOptions = {
+  /**
+   * The auth token to use when uploading source maps to Sentry.
+   *
+   * Instead of specifying this option, you can also set the `SENTRY_AUTH_TOKEN` environment variable.
+   *
+   * To create an auth token, follow this guide:
+   * @see https://docs.sentry.io/product/accounts/auth-tokens/#organization-auth-tokens
+   */
+  authToken?: string;
+
+  /**
+   * The organization slug of your Sentry organization.
+   * Instead of specifying this option, you can also set the `SENTRY_ORG` environment variable.
+   */
+  org?: string;
+
+  /**
+   * The project slug of your Sentry project.
+   * Instead of specifying this option, you can also set the `SENTRY_PROJECT` environment variable.
+   */
+  project?: string;
+
   /**
    * Options for the Sentry Vite plugin to customize the source maps upload process.
    */

--- a/packages/solidstart/src/vite/types.ts
+++ b/packages/solidstart/src/vite/types.ts
@@ -1,0 +1,94 @@
+export type SourceMapsOptions = {
+  /**
+   * If this flag is `true`, and an auth token is detected, the Sentry SDK will
+   * automatically generate and upload source maps to Sentry during a production build.
+   *
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
+   * The auth token to use when uploading source maps to Sentry.
+   *
+   * Instead of specifying this option, you can also set the `SENTRY_AUTH_TOKEN` environment variable.
+   *
+   * To create an auth token, follow this guide:
+   * @see https://docs.sentry.io/product/accounts/auth-tokens/#organization-auth-tokens
+   */
+  authToken?: string;
+
+  /**
+   * The organization slug of your Sentry organization.
+   * Instead of specifying this option, you can also set the `SENTRY_ORG` environment variable.
+   */
+  org?: string;
+
+  /**
+   * The project slug of your Sentry project.
+   * Instead of specifying this option, you can also set the `SENTRY_PROJECT` environment variable.
+   */
+  project?: string;
+
+  /**
+   * If this flag is `true`, the Sentry plugin will collect some telemetry data and send it to Sentry.
+   * It will not collect any sensitive or user-specific data.
+   *
+   * @default true
+   */
+  telemetry?: boolean;
+
+  /**
+   * Options related to sourcemaps
+   */
+  sourcemaps?: {
+    /**
+     * A glob or an array of globs that specify the build artifacts and source maps that will be uploaded to Sentry.
+     *
+     * The globbing patterns must follow the implementation of the `glob` package.
+     * @see https://www.npmjs.com/package/glob#glob-primer
+     */
+    assets?: string | Array<string>;
+
+    /**
+     * A glob or an array of globs that specifies which build artifacts should not be uploaded to Sentry.
+     *
+     * @default [] - By default no files are ignored. Thus, all files matching the `assets` glob
+     * or the default value for `assets` are uploaded.
+     *
+     * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
+     */
+    ignore?: string | Array<string>;
+
+    /**
+     * A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact
+     * upload to Sentry has been completed.
+     *
+     * @default [] - By default no files are deleted.
+     *
+     * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
+     */
+    filesToDeleteAfterUpload?: string | Array<string>;
+  };
+
+  /**
+   * Enable debug functionality of the SDK during build-time.
+   * Enabling this will give you logs about source maps.
+   */
+  debug?: boolean;
+};
+
+/**
+ *  Build options for the Sentry module. These options are used during build-time by the Sentry SDK.
+ */
+export type SentrySolidStartPluginOptions = {
+  /**
+   * Options for the Sentry Vite plugin to customize the source maps upload process.
+   */
+  sourceMapsUploadOptions?: SourceMapsOptions;
+
+  /**
+   * Enable debug functionality of the SDK during build-time.
+   * Enabling this will give you, for example logs about source maps.
+   */
+  debug?: boolean;
+};

--- a/packages/solidstart/src/vite/types.ts
+++ b/packages/solidstart/src/vite/types.ts
@@ -1,3 +1,5 @@
+import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
+
 export type SourceMapsOptions = {
   /**
    * If this flag is `true`, and an auth token is detected, the Sentry SDK will
@@ -69,6 +71,21 @@ export type SourceMapsOptions = {
      */
     filesToDeleteAfterUpload?: string | Array<string>;
   };
+
+  /**
+   * Options to further customize the Sentry Vite Plugin (@sentry/vite-plugin) behavior directly.
+   * Options specified in this object take precedence over the options specified in
+   * the `sourcemaps` and `release` objects.
+   *
+   * @see https://www.npmjs.com/package/@sentry/vite-plugin/v/2.22.2#options which lists all available options.
+   *
+   * Warning: Options within this object are subject to change at any time.
+   * We DO NOT guarantee semantic versioning for these options, meaning breaking
+   * changes can occur at any time within a major SDK version.
+   *
+   * Furthermore, some options are untested with SvelteKit specifically. Use with caution.
+   */
+  unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>;
 
   /**
    * Enable debug functionality of the SDK during build-time.

--- a/packages/solidstart/src/vite/types.ts
+++ b/packages/solidstart/src/vite/types.ts
@@ -1,6 +1,6 @@
 import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 
-export type SourceMapsOptions = {
+type SourceMapsOptions = {
   /**
    * If this flag is `true`, and an auth token is detected, the Sentry SDK will
    * automatically generate and upload source maps to Sentry during a production build.
@@ -43,6 +43,47 @@ export type SourceMapsOptions = {
   unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>;
 };
 
+type BundleSizeOptimizationOptions = {
+  /**
+   * If set to `true`, the plugin will attempt to tree-shake (remove) any debugging code within the Sentry SDK.
+   * Note that the success of this depends on tree shaking being enabled in your build tooling.
+   *
+   * Setting this option to `true` will disable features like the SDK's `debug` option.
+   */
+  excludeDebugStatements?: boolean;
+
+  /**
+   * If set to true, the plugin will try to tree-shake tracing statements out.
+   * Note that the success of this depends on tree shaking generally being enabled in your build.
+   * Attention: DO NOT enable this when you're using any performance monitoring-related SDK features (e.g. Sentry.startSpan()).
+   */
+  excludeTracing?: boolean;
+
+  /**
+   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay Shadow DOM recording functionality.
+   * Note that the success of this depends on tree shaking being enabled in your build tooling.
+   *
+   * This option is safe to be used when you do not want to capture any Shadow DOM activity via Sentry Session Replay.
+   */
+  excludeReplayShadowDom?: boolean;
+
+  /**
+   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay `iframe` recording functionality.
+   * Note that the success of this depends on tree shaking being enabled in your build tooling.
+   *
+   * You can safely do this when you do not want to capture any `iframe` activity via Sentry Session Replay.
+   */
+  excludeReplayIframe?: boolean;
+
+  /**
+   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay's Compression Web Worker.
+   * Note that the success of this depends on tree shaking being enabled in your build tooling.
+   *
+   * **Notice:** You should only do use this option if you manually host a compression worker and configure it in your Sentry Session Replay integration config via the `workerUrl` option.
+   */
+  excludeReplayWorker?: boolean;
+};
+
 /**
  *  Build options for the Sentry module. These options are used during build-time by the Sentry SDK.
  */
@@ -73,6 +114,11 @@ export type SentrySolidStartPluginOptions = {
    * Options for the Sentry Vite plugin to customize the source maps upload process.
    */
   sourceMapsUploadOptions?: SourceMapsOptions;
+
+  /**
+   * Options for the Sentry Vite plugin to customize bundle size optimizations.
+   */
+  bundleSizeOptimizations?: BundleSizeOptimizationOptions;
 
   /**
    * Enable debug functionality of the SDK during build-time.

--- a/packages/solidstart/src/vite/types.ts
+++ b/packages/solidstart/src/vite/types.ts
@@ -40,37 +40,14 @@ export type SourceMapsOptions = {
   telemetry?: boolean;
 
   /**
-   * Options related to sourcemaps
+   * A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact
+   * upload to Sentry has been completed.
+   *
+   * @default [] - By default no files are deleted.
+   *
+   * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
    */
-  sourcemaps?: {
-    /**
-     * A glob or an array of globs that specify the build artifacts and source maps that will be uploaded to Sentry.
-     *
-     * The globbing patterns must follow the implementation of the `glob` package.
-     * @see https://www.npmjs.com/package/glob#glob-primer
-     */
-    assets?: string | Array<string>;
-
-    /**
-     * A glob or an array of globs that specifies which build artifacts should not be uploaded to Sentry.
-     *
-     * @default [] - By default no files are ignored. Thus, all files matching the `assets` glob
-     * or the default value for `assets` are uploaded.
-     *
-     * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
-     */
-    ignore?: string | Array<string>;
-
-    /**
-     * A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact
-     * upload to Sentry has been completed.
-     *
-     * @default [] - By default no files are deleted.
-     *
-     * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
-     */
-    filesToDeleteAfterUpload?: string | Array<string>;
-  };
+  filesToDeleteAfterUpload?: string | Array<string>;
 
   /**
    * Options to further customize the Sentry Vite Plugin (@sentry/vite-plugin) behavior directly.

--- a/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
+++ b/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
@@ -12,7 +12,6 @@ import {
 import { NodeClient } from '@sentry/node';
 import { redirect } from '@solidjs/router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { solidRouterBrowserTracingIntegration } from '../../src/client/solidrouter';
 
 const mockCaptureException = vi.spyOn(SentryNode, 'captureException').mockImplementation(() => '');
 const mockFlush = vi.spyOn(SentryNode, 'flush').mockImplementation(async () => true);
@@ -98,7 +97,6 @@ describe('withServerActionInstrumentation', () => {
     setCurrentClient(client);
 
     client.on('spanStart', span => spanStartMock(spanToJSON(span)));
-    client.addIntegration(solidRouterBrowserTracingIntegration());
 
     await serverActionGetPrefecture();
     expect(spanStartMock).toHaveBeenCalledWith(

--- a/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
+++ b/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
@@ -10,9 +10,9 @@ import {
   spanToJSON,
 } from '@sentry/node';
 import { NodeClient } from '@sentry/node';
-import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidrouter';
 import { redirect } from '@solidjs/router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { solidRouterBrowserTracingIntegration } from '../../src/client/solidrouter';
 
 const mockCaptureException = vi.spyOn(SentryNode, 'captureException').mockImplementation(() => '');
 const mockFlush = vi.spyOn(SentryNode, 'flush').mockImplementation(async () => true);

--- a/packages/solidstart/test/vite/sentrySolidStartVite.test.ts
+++ b/packages/solidstart/test/vite/sentrySolidStartVite.test.ts
@@ -31,8 +31,8 @@ describe('sentrySolidStartVite()', () => {
       'sentry-vite-release-injection-plugin',
       'sentry-debug-id-upload-plugin',
       'sentry-vite-debug-id-injection-plugin',
-      'sentry-file-deletion-plugin',
       'sentry-vite-debug-id-upload-plugin',
+      'sentry-file-deletion-plugin',
     ]);
   });
 

--- a/packages/solidstart/test/vite/sentrySolidStartVite.test.ts
+++ b/packages/solidstart/test/vite/sentrySolidStartVite.test.ts
@@ -11,12 +11,9 @@ vi.spyOn(console, 'warn').mockImplementation(() => {
 
 function getSentrySolidStartVitePlugins(options?: Parameters<typeof sentrySolidStartVite>[0]): Plugin[] {
   return sentrySolidStartVite({
-    sourceMapsUploadOptions: {
-      authToken: 'token',
-      org: 'org',
-      project: 'project',
-      ...options?.sourceMapsUploadOptions,
-    },
+    project: 'project',
+    org: 'org',
+    authToken: 'token',
     ...options,
   });
 }

--- a/packages/solidstart/test/vite/sentrySolidStartVite.test.ts
+++ b/packages/solidstart/test/vite/sentrySolidStartVite.test.ts
@@ -1,0 +1,53 @@
+import type { Plugin } from 'vite';
+import { describe, expect, it, vi } from 'vitest';
+import { sentrySolidStartVite } from '../../src/vite/sentrySolidStartVite';
+
+vi.spyOn(console, 'log').mockImplementation(() => {
+  /* noop */
+});
+vi.spyOn(console, 'warn').mockImplementation(() => {
+  /* noop */
+});
+
+function getSentrySolidStartVitePlugins(options?: Parameters<typeof sentrySolidStartVite>[0]): Plugin[] {
+  return sentrySolidStartVite({
+    sourceMapsUploadOptions: {
+      authToken: 'token',
+      org: 'org',
+      project: 'project',
+      ...options?.sourceMapsUploadOptions,
+    },
+    ...options,
+  });
+}
+
+describe('sentrySolidStartVite()', () => {
+  it('returns an array of vite plugins', () => {
+    const plugins = getSentrySolidStartVitePlugins();
+    const names = plugins.map(plugin => plugin.name);
+    expect(names).toEqual([
+      'sentry-solidstart-source-maps',
+      'sentry-telemetry-plugin',
+      'sentry-vite-release-injection-plugin',
+      'sentry-debug-id-upload-plugin',
+      'sentry-vite-debug-id-injection-plugin',
+      'sentry-file-deletion-plugin',
+      'sentry-vite-debug-id-upload-plugin',
+    ]);
+  });
+
+  it("returns an empty array if source maps upload isn't enabled", () => {
+    const plugins = getSentrySolidStartVitePlugins({ sourceMapsUploadOptions: { enabled: false } });
+    expect(plugins).toHaveLength(0);
+  });
+
+  it('returns an empty array if `NODE_ENV` is development', async () => {
+    const previousEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    const plugins = getSentrySolidStartVitePlugins({ sourceMapsUploadOptions: { enabled: true } });
+    expect(plugins).toHaveLength(0);
+
+    process.env.NODE_ENV = previousEnv;
+  });
+});

--- a/packages/solidstart/test/vite/sourceMaps.test.ts
+++ b/packages/solidstart/test/vite/sourceMaps.test.ts
@@ -41,6 +41,9 @@ describe('makeSourceMapsVitePlugin()', () => {
       sourceMapsUploadOptions: {
         filesToDeleteAfterUpload: ['baz/*.js'],
       },
+      bundleSizeOptimizations: {
+        excludeTracing: true,
+      },
     });
 
     expect(sentryVitePluginSpy).toHaveBeenCalledWith(
@@ -50,6 +53,9 @@ describe('makeSourceMapsVitePlugin()', () => {
         sourcemaps: {
           filesToDeleteAfterUpload: ['baz/*.js'],
         },
+        bundleSizeOptimizations: {
+          excludeTracing: true,
+        },
       }),
     );
   });
@@ -58,11 +64,17 @@ describe('makeSourceMapsVitePlugin()', () => {
     makeSourceMapsVitePlugin({
       org: 'my-org',
       authToken: 'my-token',
+      bundleSizeOptimizations: {
+        excludeTracing: true,
+      },
       sourceMapsUploadOptions: {
         unstable_sentryVitePluginOptions: {
           org: 'unstable-org',
           sourcemaps: {
             assets: ['unstable/*.js'],
+          },
+          bundleSizeOptimizations: {
+            excludeTracing: false,
           },
         },
       },
@@ -72,6 +84,9 @@ describe('makeSourceMapsVitePlugin()', () => {
       expect.objectContaining({
         org: 'unstable-org',
         authToken: 'my-token',
+        bundleSizeOptimizations: {
+          excludeTracing: false,
+        },
         sourcemaps: {
           assets: ['unstable/*.js'],
         },

--- a/packages/solidstart/test/vite/sourceMaps.test.ts
+++ b/packages/solidstart/test/vite/sourceMaps.test.ts
@@ -38,11 +38,7 @@ describe('makeSourceMapsVitePlugin()', () => {
     makeSourceMapsVitePlugin({
       org: 'my-org',
       authToken: 'my-token',
-      sourcemaps: {
-        assets: ['foo/*.js'],
-        ignore: ['bar/*.js'],
-        filesToDeleteAfterUpload: ['baz/*.js'],
-      },
+      filesToDeleteAfterUpload: ['baz/*.js'],
     });
 
     expect(sentryVitePluginSpy).toHaveBeenCalledWith(
@@ -50,8 +46,6 @@ describe('makeSourceMapsVitePlugin()', () => {
         org: 'my-org',
         authToken: 'my-token',
         sourcemaps: {
-          assets: ['foo/*.js'],
-          ignore: ['bar/*.js'],
           filesToDeleteAfterUpload: ['baz/*.js'],
         },
       }),
@@ -62,9 +56,6 @@ describe('makeSourceMapsVitePlugin()', () => {
     makeSourceMapsVitePlugin({
       org: 'my-org',
       authToken: 'my-token',
-      sourcemaps: {
-        assets: ['foo/*.js'],
-      },
       unstable_sentryVitePluginOptions: {
         org: 'unstable-org',
         sourcemaps: {

--- a/packages/solidstart/test/vite/sourceMaps.test.ts
+++ b/packages/solidstart/test/vite/sourceMaps.test.ts
@@ -38,7 +38,9 @@ describe('makeSourceMapsVitePlugin()', () => {
     makeSourceMapsVitePlugin({
       org: 'my-org',
       authToken: 'my-token',
-      filesToDeleteAfterUpload: ['baz/*.js'],
+      sourceMapsUploadOptions: {
+        filesToDeleteAfterUpload: ['baz/*.js'],
+      },
     });
 
     expect(sentryVitePluginSpy).toHaveBeenCalledWith(
@@ -56,10 +58,12 @@ describe('makeSourceMapsVitePlugin()', () => {
     makeSourceMapsVitePlugin({
       org: 'my-org',
       authToken: 'my-token',
-      unstable_sentryVitePluginOptions: {
-        org: 'unstable-org',
-        sourcemaps: {
-          assets: ['unstable/*.js'],
+      sourceMapsUploadOptions: {
+        unstable_sentryVitePluginOptions: {
+          org: 'unstable-org',
+          sourcemaps: {
+            assets: ['unstable/*.js'],
+          },
         },
       },
     });

--- a/packages/solidstart/test/vite/sourceMaps.test.ts
+++ b/packages/solidstart/test/vite/sourceMaps.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeSourceMapsVitePlugin } from '../../src/vite/sourceMaps';
+import * as sourceMaps from '../../src/vite/sourceMaps';
+
+const mockedSentryVitePlugin = {
+  name: 'sentry-vite-debug-id-upload-plugin',
+  writeBundle: vi.fn(),
+};
+
+vi.mock('@sentry/vite-plugin', async () => {
+  const original = (await vi.importActual('@sentry/vite-plugin')) as any;
+
+  return {
+    ...original,
+    sentryVitePlugin: () => [mockedSentryVitePlugin],
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('makeSourceMapsVitePlugin()', () => {
+  it('returns a plugin to set `sourcemaps` to `true`', async () => {
+    const [sourceMapsConfigPlugin, sentryVitePlugin] = makeSourceMapsVitePlugin({});
+
+    expect(sourceMapsConfigPlugin?.name).toEqual('sentry-solidstart-source-maps');
+    expect(sourceMapsConfigPlugin?.apply).toEqual('build');
+    expect(sourceMapsConfigPlugin?.enforce).toEqual('post');
+    expect(sourceMapsConfigPlugin?.config).toEqual(expect.any(Function));
+
+    expect(sentryVitePlugin).toEqual(mockedSentryVitePlugin);
+  });
+
+  it('passes user-specified vite plugin options to vite plugin plugin', async () => {
+    const makePluginSpy = vi.spyOn(sourceMaps, 'makeSourceMapsVitePlugin');
+
+    makeSourceMapsVitePlugin({
+      org: 'my-org',
+      authToken: 'my-token',
+      sourcemaps: {
+        assets: ['foo/*.js'],
+        ignore: ['bar/*.js'],
+        filesToDeleteAfterUpload: ['baz/*.js'],
+      },
+    });
+
+    expect(makePluginSpy).toHaveBeenCalledWith({
+      org: 'my-org',
+      authToken: 'my-token',
+      sourcemaps: {
+        assets: ['foo/*.js'],
+        ignore: ['bar/*.js'],
+        filesToDeleteAfterUpload: ['baz/*.js'],
+      },
+    });
+  });
+});

--- a/packages/solidstart/test/vite/sourceMaps.test.ts
+++ b/packages/solidstart/test/vite/sourceMaps.test.ts
@@ -1,4 +1,4 @@
-import { SentryVitePluginOptions } from '@sentry/vite-plugin';
+import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeSourceMapsVitePlugin } from '../../src/vite/sourceMaps';
 


### PR DESCRIPTION
This plugin simplifies source maps upload by using `@sentry/vite-plugin` and enabling source map generation by default.

Usage:
```js
import { defineConfig } from '@solidjs/start/config'
import { sentrySolidStartVite } from '@sentry/solidstart'

export default defineConfig({
  vite: {
    plugins: [
      sentrySolidStartVite({
        sourceMapsUploadOptions: {
          enabled: true,
          org: process.env.SENTRY_ORG,
          project: process.env.SENTRY_PROJECT,
          authToken: process.env.SENTRY_AUTH_TOKEN,
        },
        debug: true,
      }),
    ],
  }
})
```

Closes: #12553