### PR TITLE
Fix config example in README.md for Nuxt

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -96,7 +96,7 @@ Add a `sentry.client.config.(js|ts)` file to the root of your project:
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
-  dsn: env.DSN,
+  dsn: process.env.DSN,
 });
 ```
 


### PR DESCRIPTION
Config example fix. env.DSN was missing process prefix.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
