### PR TITLE
ci: Ensure cache save happens after install step

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -21,15 +21,6 @@ runs:
             ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
-      # Only store cache on develop branch
-      - name: Store cached playwright binaries
-        uses: actions/cache/save@v4
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
       # We always install all browsers, if uncached
       - name: Install Playwright dependencies (uncached)
         run: npx playwright install chromium webkit firefox --with-deps
@@ -40,3 +31,12 @@ runs:
         run: npx playwright install-deps ${{ inputs.browsers || 'chromium webkit firefox' }}
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         shell: bash
+
+      # Only store cache on develop branch
+      - name: Store cached playwright binaries
+        uses: actions/cache/save@v4
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}


### PR DESCRIPTION
Noticed e.g. here: https://github.com/getsentry/sentry-javascript/actions/runs/10594383971/job/29359100222 that saving of the cache was not working. I guess this only works for the combined restore/save step, but here it expects that the cached data is there immediately (which makes sense!).