### PR TITLE
test: Increase timeout for redis-cache test & docker-compose

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/test.ts
@@ -1,7 +1,7 @@
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(75000);
+jest.setTimeout(90000);
 
 describe('redis cache auto instrumentation', () => {
   afterAll(() => {

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -124,7 +124,7 @@ async function runDockerCompose(options: DockerOptions): Promise<VoidFunction> {
     const timeout = setTimeout(() => {
       close();
       reject(new Error('Timed out waiting for docker-compose'));
-    }, 60_000);
+    }, 75_000);
 
     function newData(data: Buffer): void {
       const text = data.toString('utf8');


### PR DESCRIPTION
Noticed e.g. here: https://github.com/getsentry/sentry-javascript/actions/runs/10594383971/job/29358138105 that this was timing out some times, so increasing the timeout a bit...