### PR TITLE
test(solidstart): Skip flaky test for now

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/performance.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/performance.client.test.ts
@@ -46,7 +46,9 @@ test('sends a navigation transaction', async ({ page }) => {
   });
 });
 
-test('updates the transaction when using the back button', async ({ page }) => {
+// TODO: This test is flaky as of now, so disabling it.
+// It often just times out on CI
+test.skip('updates the transaction when using the back button', async ({ page }) => {
   // Solid Router sends a `-1` navigation when using the back button.
   // The sentry solidRouterBrowserTracingIntegration tries to update such
   // transactions with the proper name once the `useLocation` hook triggers.


### PR DESCRIPTION
This just skips a flaky E2E solidstart test. It is not a super critical test, so I'd skip this for now until we have time to investigate the flakiness - e.g. see https://github.com/getsentry/sentry-javascript/actions/runs/10596825068/job/29365892465