### PR TITLE
deps: Bump gatsby bundler plugins to 2.20.1 to fix error 

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -49,7 +49,7 @@
     "@sentry/react": "8.27.0",
     "@sentry/types": "8.27.0",
     "@sentry/utils": "8.27.0",
-    "@sentry/webpack-plugin": "2.16.0"
+    "@sentry/webpack-plugin": "2.20.1"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/13504

> Due to a racing condition, the version used in package @sentry/webpack-plugin for gatsby is causing the parameter filesToDeleteAfterUpload not working properly because the maps are being deleted before being uploaded to the server.

This bumps the dependency to the version it was fixed. Same version you guys already use in nextJs.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
