### PR TITLE
feat(devcontainer): add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+# Use Ubuntu as the base image
+FROM ubuntu:24.04
+
+# Set to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install necessary dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    python3 \
+    python3-setuptools \
+    build-essential \
+    libvips-dev \
+    zip
+
+# install volta
+RUN curl https://get.volta.sh | bash
+# needed by volta() function
+ENV VOLTA_HOME /$HOME/.volta
+# make sure packages managed by volta will be in PATH
+ENV PATH $VOLTA_HOME/bin:$PATH
+
+# enable to run E2E tests locally
+#RUN export VOLTA_FEATURE_PNPM=1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "sentry-javascript",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "biomejs.biome",
+        "dbaeumer.vscode-eslint",
+        "augustocdias.tasks-shell-input",
+        "denoland.vscode-deno",
+        "orta.vscode-jest",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+  "mounts": ["source=${localWorkspaceFolder}/,target=/workspace,type=bind,consistency=cached"],
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && yarn config set cache-folder /workspace/.yarncache"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ packages/deno/lib.deno.d.ts
 
 # gatsby
 packages/gatsby/gatsby-node.d.ts
+
+# devcontainer-yarn-cache
+.yarncache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,6 @@
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
-  "cSpell.words": ["arrayify", "OTEL"]
+  "cSpell.words": ["arrayify", "OTEL"],
+  "dev.containers.defaultExtensions": ["mutantdino.resourcemonitor"]
 }

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
 env: NODE_OPTIONS --stack-trace-limit=10000
+network-timeout: 600000


### PR DESCRIPTION
I tried building the sentry-javascript repo locally but had multiple dependency issues.
Therefore I created a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers), which includes all needed dependencies.

In the Dockerfile are now also all needed dependencies shown.

As written in the [contribution guide](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) you only have to run `yarn` which installs the dependencies and with `yarn build` to start the build.

At the moment the docker image is built locally, but in the future, it can be built in the ci and provided by the GitHub container registry.

I tested it on my MacBook Air M1.