### PR TITLE
fix(replay): Consider more things as DOM mutations for dead clicks

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration'),
     gzip: true,
-    limit: '73 KB',
+    limit: '75 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - with treeshaking flags',

--- a/packages/replay-internal/src/coreHandlers/handleClick.ts
+++ b/packages/replay-internal/src/coreHandlers/handleClick.ts
@@ -40,6 +40,17 @@ type IncrementalMouseInteractionRecordingEvent = IncrementalRecordingEvent & {
   data: { type: MouseInteractions; id: number };
 };
 
+/** Any IncrementalSource for rrweb that we interpret as a kind of mutation. */
+const IncrementalMutationSources = new Set([
+  IncrementalSource.Mutation,
+  IncrementalSource.StyleSheetRule,
+  IncrementalSource.StyleDeclaration,
+  IncrementalSource.AdoptedStyleSheet,
+  IncrementalSource.CanvasMutation,
+  IncrementalSource.Selection,
+  IncrementalSource.MediaInteraction,
+]);
+
 /** Handle a click. */
 export function handleClick(clickDetector: ReplayClickDetector, clickBreadcrumb: Breadcrumb, node: HTMLElement): void {
   clickDetector.handleClick(clickBreadcrumb, node);
@@ -324,7 +335,7 @@ export function updateClickDetectorForRecordingEvent(clickDetector: ReplayClickD
     }
 
     const { source } = event.data;
-    if (source === IncrementalSource.Mutation) {
+    if (IncrementalMutationSources.has(source)) {
       clickDetector.registerMutation(event.timestamp);
     }
 


### PR DESCRIPTION
Previously, we only considered `Mutation` style changes of rrweb as "DOM mutations" for dead click detection.
However, after closer inspection, there are also some other types of changes that we may consider as DOM mutations. By including these we can hopefully reduce some false positives.

Not quite sure how to test this 🤔 It's probably also OK to just ship this, as the worst-case scenario is that we have some false-negatives and do not capture certain things, but our general goal here is to be rather on the cautious side, so I think that is acceptable.

Possibly fixes https://github.com/getsentry/sentry-javascript/issues/9755