### PR TITLE
docs(nuxt): Consistently use `SENTRY_DSN` env var in README examples

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -108,7 +108,7 @@ Add an `instrument.server.mjs` file to your `public` folder:
 import * as Sentry from '@sentry/nuxt';
 
 // Only run `init` when DSN is available
-if (process.env.SENTRY_DSN) {
+if (process.env.DSN) {
   Sentry.init({
     dsn: process.env.DSN,
   });

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -96,7 +96,7 @@ Add a `sentry.client.config.(js|ts)` file to the root of your project:
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
-  dsn: process.env.DSN,
+  dsn: process.env.SENTRY_DSN,
 });
 ```
 
@@ -107,10 +107,10 @@ Add an `instrument.server.mjs` file to your `public` folder:
 ```javascript
 import * as Sentry from '@sentry/nuxt';
 
-// Only run `init` when DSN is available
-if (process.env.DSN) {
+// Only run `init` when process.env.SENTRY_DSN is available.
+if (process.env.SENTRY_DSN) {
   Sentry.init({
-    dsn: process.env.DSN,
+    dsn: process.env.SENTRY_DSN,
   });
 }
 ```


### PR DESCRIPTION
Mismatch in env var names in Readme. One was called DSN, the other SENTRY_DSN.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
