### PR TITLE
ci: Do not run profiling node jobs on develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -500,7 +500,10 @@ jobs:
   job_profiling_node_unit_tests:
     name: Node Profiling Unit Tests
     needs: [job_get_metadata, job_build]
-    if: needs.job_build.outputs.changed_node == 'true' || needs.job_get_metadata.outputs.changed_profiling_node == 'true' || github.event_name != 'pull_request'
+    if: |
+      needs.job_build.outputs.changed_node == 'true' ||
+      needs.job_get_metadata.outputs.changed_profiling_node == 'true' ||
+      needs.job_get_metadata.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -1125,8 +1128,7 @@ jobs:
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
      (
         (needs.job_get_metadata.outputs.changed_profiling_node == 'true') ||
-        (needs.job_get_metadata.outputs.is_release == 'true') ||
-        (github.event_name != 'pull_request')
+        (needs.job_get_metadata.outputs.is_release == 'true')
       )
     needs: [job_get_metadata, job_build, job_e2e_prepare]
     runs-on: ubuntu-20.04
@@ -1290,8 +1292,7 @@ jobs:
     # Skip precompile unless we are on a release branch as precompile slows down CI times.
     if: |
       (needs.job_get_metadata.outputs.changed_profiling_node == 'true') ||
-      (needs.job_get_metadata.outputs.is_release == 'true') ||
-      (github.event_name != 'pull_request')
+      (needs.job_get_metadata.outputs.is_release == 'true')
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     timeout-minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -503,7 +503,7 @@ jobs:
     if: |
       needs.job_build.outputs.changed_node == 'true' ||
       needs.job_get_metadata.outputs.changed_profiling_node == 'true' ||
-      needs.job_get_metadata.outputs.is_release == 'true'
+      github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
This takes a lot of resources, and is only very rarely needed.

Now, it only always runs profiling node compilation on release branches, and on dedicated profiling-node changes.