### PR TITLE
fix(browser): check supportedEntryTypes before caling the function

### DIFF
--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -218,6 +218,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
   if (
     enableLongAnimationFrame &&
     GLOBAL_OBJ.PerformanceObserver &&
+    PerformanceObserver.supportedEntryTypes &&
     PerformanceObserver.supportedEntryTypes.includes('long-animation-frame')
   ) {
     startTrackingLongAnimationFrames();


### PR DESCRIPTION
`PerformanceObserver` is available on iOS 11 and later, but
the `supportedEntryTypes` method is available on iOS 13 and later.

ref: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver

Therefore, a runtime error will occur if we use Sentry on iOS 11 or iOS 12.
