### PR TITLE
fix(nestjs): Check arguments before instrumenting with `@Injectable`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
@@ -96,4 +96,24 @@ export class AppController {
   async exampleExceptionLocalFilter() {
     throw new ExampleExceptionLocalFilter();
   }
+
+  @Get('test-service-use')
+  testServiceWithUseMethod() {
+    return this.appService.use();
+  }
+
+  @Get('test-service-transform')
+  testServiceWithTransform() {
+    return this.appService.transform();
+  }
+
+  @Get('test-service-intercept')
+  testServiceWithIntercept() {
+    return this.appService.intercept();
+  }
+
+  @Get('test-service-canActivate')
+  testServiceWithCanActivate() {
+    return this.appService.canActivate();
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.service.ts
@@ -78,4 +78,20 @@ export class AppService {
   async killTestCron() {
     this.schedulerRegistry.deleteCronJob('test-cron-job');
   }
+
+  use() {
+    console.log('Test use!');
+  }
+
+  transform() {
+    console.log('Test transform!');
+  }
+
+  intercept() {
+    console.log('Test intercept!');
+  }
+
+  canActivate() {
+    console.log('Test canActivate!');
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/transactions.test.ts
@@ -707,3 +707,23 @@ test('API route transaction includes exactly one nest async interceptor span aft
   // 'Interceptor - After Route' is NOT the parent of 'test-controller-span'
   expect(testControllerSpan.parent_span_id).not.toBe(exampleInterceptorSpanAfterRouteId);
 });
+
+test('Calling use method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-use`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling transform method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-transform`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling intercept method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-intercept`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling canActivate method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-canActivate`);
+  expect(response.status).toBe(200);
+});

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.controller.ts
@@ -82,4 +82,24 @@ export class AppController {
   async flush() {
     await flush();
   }
+
+  @Get('test-service-use')
+  testServiceWithUseMethod() {
+    return this.appService.use();
+  }
+
+  @Get('test-service-transform')
+  testServiceWithTransform() {
+    return this.appService.transform();
+  }
+
+  @Get('test-service-intercept')
+  testServiceWithIntercept() {
+    return this.appService.intercept();
+  }
+
+  @Get('test-service-canActivate')
+  testServiceWithCanActivate() {
+    return this.appService.canActivate();
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/src/app.service.ts
@@ -78,4 +78,20 @@ export class AppService {
   async killTestCron() {
     this.schedulerRegistry.deleteCronJob('test-cron-job');
   }
+
+  use() {
+    console.log('Test use!');
+  }
+
+  transform() {
+    console.log('Test transform!');
+  }
+
+  intercept() {
+    console.log('Test intercept!');
+  }
+
+  canActivate() {
+    console.log('Test canActivate!');
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-nestjs-basic/tests/transactions.test.ts
@@ -705,3 +705,23 @@ test('API route transaction includes exactly one nest async interceptor span aft
   // 'Interceptor - After Route' is NOT the parent of 'test-controller-span'
   expect(testControllerSpan.parent_span_id).not.toBe(exampleInterceptorSpanAfterRouteId);
 });
+
+test('Calling use method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-use`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling transform method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-transform`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling intercept method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-intercept`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling canActivate method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-canActivate`);
+  expect(response.status).toBe(200);
+});

--- a/packages/node/src/integrations/tracing/nest/helpers.ts
+++ b/packages/node/src/integrations/tracing/nest/helpers.ts
@@ -53,3 +53,23 @@ export function instrumentObservable(observable: Observable<unknown>, activeSpan
     });
   }
 }
+
+/**
+ *
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-function-return-type
+export function getNextProxy(next: any, span: Span, prevSpan: undefined | Span) {
+  return new Proxy(next, {
+    apply: (originalNext, thisArgNext, argsNext) => {
+      span.end();
+
+      if (prevSpan) {
+        return withActiveSpan(prevSpan, () => {
+          return Reflect.apply(originalNext, thisArgNext, argsNext);
+        });
+      } else {
+        return Reflect.apply(originalNext, thisArgNext, argsNext);
+      }
+    },
+  });
+}

--- a/packages/node/src/integrations/tracing/nest/helpers.ts
+++ b/packages/node/src/integrations/tracing/nest/helpers.ts
@@ -1,7 +1,7 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, withActiveSpan } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
-import type { CatchTarget, InjectableTarget, Observable, Subscription } from './types';
+import type { CatchTarget, InjectableTarget, NextFunction, Observable, Subscription } from './types';
 
 const sentryPatched = 'sentryPatched';
 
@@ -55,10 +55,9 @@ export function instrumentObservable(observable: Observable<unknown>, activeSpan
 }
 
 /**
- *
+ * Proxies the next() call in a nestjs middleware to end the span when it is called.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-function-return-type
-export function getNextProxy(next: any, span: Span, prevSpan: undefined | Span) {
+export function getNextProxy(next: NextFunction, span: Span, prevSpan: undefined | Span): NextFunction {
   return new Proxy(next, {
     apply: (originalNext, thisArgNext, argsNext) => {
       span.end();

--- a/packages/node/src/integrations/tracing/nest/sentry-nest-instrumentation.ts
+++ b/packages/node/src/integrations/tracing/nest/sentry-nest-instrumentation.ts
@@ -111,7 +111,7 @@ export class SentryNestInstrumentation extends InstrumentationBase {
                 // Check that we can reasonably assume that the target is a middleware.
                 // Without these guards, instrumentation will fail if a function named 'use' on a service, which is
                 // decorated with @Injectable, is called.
-                if (!req || !res || !next || !(typeof next === 'function')) {
+                if (!req || !res || !next || typeof next !== 'function') {
                   return originalUse.apply(thisArgUse, argsUse);
                 }
 
@@ -198,7 +198,7 @@ export class SentryNestInstrumentation extends InstrumentationBase {
                 let afterSpan: Span;
 
                 // Check that we can reasonably assume that the target is an interceptor.
-                if (!context || !next || !(typeof next.handle === 'function')) {
+                if (!context || !next || typeof next.handle !== 'function') {
                   return originalIntercept.apply(thisArgIntercept, argsIntercept);
                 }
 

--- a/packages/node/src/integrations/tracing/nest/sentry-nest-instrumentation.ts
+++ b/packages/node/src/integrations/tracing/nest/sentry-nest-instrumentation.ts
@@ -110,14 +110,15 @@ export class SentryNestInstrumentation extends InstrumentationBase {
                 const [req, res, next, ...args] = argsUse;
                 const prevSpan = getActiveSpan();
 
-                // Only proxy actual middleware.
-                // Without this guard instrumentation will fail if a function called use on a service decorated
-                // with @Injectable is called.
+                // Check that we can reasonably assume that the target is a middleware.
+                // Without this guard, instrumentation will fail if a function named 'use' on a service, which is
+                // decorated with @Injectable, is called.
                 if (!(next satisfies NextFunction)) {
                   return originalUse.apply(thisArgUse, argsUse);
                 }
 
                 return startSpanManual(getMiddlewareSpanOptions(target), (span: Span) => {
+                  // proxy next to end span on call
                   const nextProxy = getNextProxy(next, span, prevSpan);
                   return originalUse.apply(thisArgUse, [req, res, nextProxy, args]);
                 });

--- a/packages/node/src/integrations/tracing/nest/types.ts
+++ b/packages/node/src/integrations/tracing/nest/types.ts
@@ -73,3 +73,8 @@ export interface CatchTarget {
     catch?: (...args: any[]) => any;
   };
 }
+
+/**
+ * Represents an express NextFunction.
+ */
+export type NextFunction = (err?: any) => void;


### PR DESCRIPTION
Before this fix, calling a `use` method on a service that does not implement the `NestMiddleware` interface resulted in an error. This is because we try to proxy the third argument to the function, which in middleware is an express `NextFunction`, but in other classes can be anything, potentially even undefined. 

This fix introduces a guard to verify that the argument we are trying to proxy is actually a `NextFunction`.

Added a test to verify that services with `use` work fine now. Also added additional tests to verify that this behavior does not occur for `canActivate` (guard), `intercept` (interceptor) and `transform` (pipe) methods.