### PR TITLE
fix(cloudflare): Guard `context.waitUntil` call in request handler

### DIFF
--- a/packages/cloudflare/src/request.ts
+++ b/packages/cloudflare/src/request.ts
@@ -89,7 +89,7 @@ export function wrapRequestHandler(
               captureException(e, { mechanism: { handled: false, type: 'cloudflare' } });
               throw e;
             } finally {
-              context.waitUntil(flush(2000));
+              context?.waitUntil(flush(2000));
             }
           },
         );

--- a/packages/cloudflare/src/request.ts
+++ b/packages/cloudflare/src/request.ts
@@ -31,7 +31,13 @@ export function wrapRequestHandler(
   handler: (...args: unknown[]) => Response | Promise<Response>,
 ): Promise<Response> {
   return withIsolationScope(async isolationScope => {
-    const { options, request, context } = wrapperOptions;
+    const { options, request } = wrapperOptions;
+
+    // In certain situations, the passed context can become undefined.
+    // For example, for Astro while prerendering pages at build time.
+    // see: https://github.com/getsentry/sentry-javascript/issues/13217
+    const context = wrapperOptions.context as ExecutionContext | undefined;
+
     const client = init(options);
     isolationScope.setClient(client);
 

--- a/packages/cloudflare/test/request.test.ts
+++ b/packages/cloudflare/test/request.test.ts
@@ -45,6 +45,15 @@ describe('withSentry', () => {
     expect(context.waitUntil).toHaveBeenLastCalledWith(expect.any(Promise));
   });
 
+  test("doesn't error if context is undefined", () => {
+    expect(() =>
+      wrapRequestHandler(
+        { options: MOCK_OPTIONS, request: new Request('https://example.com'), context: undefined as any },
+        () => new Response('test'),
+      ),
+    ).not.toThrow();
+  });
+
   test('creates a cloudflare client and sets it on the handler', async () => {
     const initAndBindSpy = vi.spyOn(SentryCore, 'initAndBind');
     await wrapRequestHandler(


### PR DESCRIPTION
This PR guards the call for `context.waitUntil` in the CF request handler wrapper. Our public API requires `context` to be present, however, in certain cases like Astro during build (prerendering), `context` becomes `undefined`. This might [change in the future](https://github.com/getsentry/sentry-javascript/issues/13217#issuecomment-2317092450) with Astro 5 but for now let's guard the invokation of `context.waitUntil` against context being `undefined`.

Note: I opted to leave `context` required in the public options because I don't think we should suggest users that it's optional to pass it in. Happy to change that if reviewers prefer to make it optional.  

ref https://github.com/getsentry/sentry-javascript/issues/13217