### PR TITLE
feat(nextjs): Stabilize `captureRequestError`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-13/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-13/instrumentation.ts
@@ -15,3 +15,5 @@ export function register() {
     });
   }
 }
+
+export const onRequestError = Sentry.captureRequestError;

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation.ts
@@ -19,3 +19,5 @@ export function register() {
     });
   }
 }
+
+export const onRequestError = Sentry.captureRequestError;

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/instrumentation.ts
@@ -10,4 +10,4 @@ export async function register() {
   }
 }
 
-export const onRequestError = Sentry.experimental_captureRequestError;
+export const onRequestError = Sentry.captureRequestError;

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation.ts
@@ -15,3 +15,5 @@ export function register() {
     });
   }
 }
+
+export const onRequestError = Sentry.captureRequestError;

--- a/packages/nextjs/src/common/captureRequestError.ts
+++ b/packages/nextjs/src/common/captureRequestError.ts
@@ -13,17 +13,9 @@ type ErrorContext = {
 };
 
 /**
- * Reports errors for the Next.js `onRequestError` instrumentation hook.
- *
- * Notice: This function is experimental and not intended for production use. Breaking changes may be done to this funtion in any release.
- *
- * @experimental
+ * Reports errors passed to the the Next.js `onRequestError` instrumentation hook.
  */
-export function experimental_captureRequestError(
-  error: unknown,
-  request: RequestInfo,
-  errorContext: ErrorContext,
-): void {
+export function captureRequestError(error: unknown, request: RequestInfo, errorContext: ErrorContext): void {
   withScope(scope => {
     scope.setSDKProcessingMetadata({
       request: {
@@ -48,3 +40,11 @@ export function experimental_captureRequestError(
     });
   });
 }
+
+/**
+ * Reports errors passed to the the Next.js `onRequestError` instrumentation hook.
+ *
+ * @deprecated Use `captureRequestError` instead.
+ */
+// TODO(v9): Remove this export
+export const experimental_captureRequestError = captureRequestError;

--- a/packages/nextjs/src/common/index.ts
+++ b/packages/nextjs/src/common/index.ts
@@ -11,4 +11,5 @@ export { wrapMiddlewareWithSentry } from './wrapMiddlewareWithSentry';
 export { wrapPageComponentWithSentry } from './wrapPageComponentWithSentry';
 export { wrapGenerationFunctionWithSentry } from './wrapGenerationFunctionWithSentry';
 export { withServerActionInstrumentation } from './withServerActionInstrumentation';
-export { experimental_captureRequestError } from './captureRequestError';
+// eslint-disable-next-line deprecation/deprecation
+export { experimental_captureRequestError, captureRequestError } from './captureRequestError';

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -141,4 +141,5 @@ export declare function wrapApiHandlerWithSentryVercelCrons<F extends (...args: 
  */
 export declare function wrapPageComponentWithSentry<C>(WrappingTarget: C): C;
 
-export { experimental_captureRequestError } from './common/captureRequestError';
+// eslint-disable-next-line deprecation/deprecation
+export { experimental_captureRequestError, captureRequestError } from './common/captureRequestError';


### PR DESCRIPTION
Next.js stabilized the `instrumentation.js` API so we can also stabilize `captureRequestError`: https://github.com/vercel/next.js/pull/68853

Ref https://github.com/getsentry/sentry-javascript/issues/8105#issuecomment-2324415563