### PR TITLE
test(browser): Add integration test for `httpContextIntegration`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/httpContext/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpContext/init.js
@@ -1,0 +1,20 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+const integrations = Sentry.getDefaultIntegrations({}).filter(
+  defaultIntegration => defaultIntegration.name === 'HttpContext',
+);
+
+const client = new Sentry.BrowserClient({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  transport: Sentry.makeFetchTransport,
+  stackParser: Sentry.defaultStackParser,
+  integrations: integrations,
+});
+
+const scope = new Sentry.Scope();
+scope.setClient(client);
+client.init();
+
+window._sentryScope = scope;

--- a/dev-packages/browser-integration-tests/suites/integrations/httpContext/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpContext/subject.js
@@ -1,0 +1,1 @@
+window._sentryScope.captureException(new Error('client init'));

--- a/dev-packages/browser-integration-tests/suites/integrations/httpContext/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpContext/test.ts
@@ -1,0 +1,26 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+
+sentryTest('httpContextIntegration captures user-agent and referrer', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page);
+
+  // Simulate document.referrer being set to test full functionality of the integration
+  await page.goto(url, { referer: 'https://sentry.io/' });
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+
+  expect(errorEvent.request).toEqual({
+    headers: {
+      'User-Agent': expect.any(String),
+      Referer: 'https://sentry.io/',
+    },
+    url: expect.any(String),
+  });
+});


### PR DESCRIPTION
While investigating #13536 I wrote a quick integration test to check that the `httpContextIntegration` works as expected. This PR adds said test to our browser integration tests. We have other tests in which we implicitly check that url and user-agent are set but none for `referer`, so I think this test has value.