### PR TITLE
chore(ci): Retain and upload traces on e2e-tests failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1002,6 +1002,15 @@ jobs:
         working-directory: dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}
         timeout-minutes: 5
         run: pnpm test:assert
+        
+      - name: Upload Playwright Traces
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-traces-job_e2e_playwright_tests-${{ matrix.test-application}}
+          path: dev-packages/e2e-tests/test-applications/${{ matrix.test-application}}/test-results
+          overwrite: true
+          retention-days: 7
 
   job_optional_e2e_tests:
     name: E2E ${{ matrix.label || matrix.test-application }} Test

--- a/dev-packages/test-utils/src/playwright-config.ts
+++ b/dev-packages/test-utils/src/playwright-config.ts
@@ -46,7 +46,7 @@ export function getPlaywrightConfig(
       baseURL: `http://localhost:${appPort}`,
 
       /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-      trace: 'on-first-retry',
+      trace: 'retain-on-failure',
     },
 
     /* Configure projects for major browsers */


### PR DESCRIPTION
Extracted this out of the solidstart vite plugin PR, I think it's worth having traces in general!