### PR TITLE
feat(nextjs): Emit warning when using turbopack

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -103,6 +103,15 @@ function getFinalConfigObject(
     );
   }
 
+  if (process.env.TURBOPACK && !process.env.SENTRY_SUPPRESS_TURBOPACK_WARNING) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[@sentry/nextjs] WARNING: You are using the Sentry SDK with \`next ${
+        process.env.NODE_ENV === 'development' ? 'dev' : 'build'
+      } --turbo\`. The Sentry SDK doesn't yet fully support Turbopack. The SDK will not be loaded in the browser, and serverside instrumentation will be inaccurate or incomplete. Production builds will still fully work. If you are just trying out Sentry or attempting to configure the SDK, we recommend temporarily removing the \`--turbo\` flag while you are developing locally. Follow this issue for progress on Sentry + Turbopack: https://github.com/getsentry/sentry-javascript/issues/8105. (You can suppress this warning by setting SENTRY_SUPPRESS_TURBOPACK_WARNING=1 as environment variable)`,
+    );
+  }
+
   return {
     ...incomingUserNextConfigObject,
     webpack: constructWebpackConfigFunction(incomingUserNextConfigObject, userSentryOptions),


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/8105

Emit a warning about certain incompatibilities when we detect a turbopack build (dev or prod build).