### PR TITLE
feat(vue): Only start UI spans if parent is available

### DIFF
--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -114,6 +114,8 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
               attributes: {
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.vue',
               },
+              // UI spans should only be created if there is an active root span (transaction)
+              onlyIfParent: true,
             });
           }
         } else {


### PR DESCRIPTION
UI spans make sense if they are a child of e.g. a pageload root span. This change ensures UI spans are not created as root spans.

ref https://github.com/getsentry/sentry-javascript/issues/13546
