### PR TITLE
fix(replay): Fix types in WebVitalData

### DIFF
--- a/packages/replay-internal/src/types/performance.ts
+++ b/packages/replay-internal/src/types/performance.ts
@@ -114,7 +114,7 @@ export interface WebVitalData {
   /**
    * The layout shifts of a CLS metric
    */
-  attributions?: { value: number; sources?: number[] }[];
+  attributions?: { value: number; nodeIds?: number[] }[];
 }
 
 /**

--- a/packages/replay-internal/src/util/createPerformanceEntries.ts
+++ b/packages/replay-internal/src/util/createPerformanceEntries.ts
@@ -198,7 +198,7 @@ export function getLargestContentfulPaint(metric: Metric): ReplayPerformanceEntr
   return getWebVital(metric, 'largest-contentful-paint', node);
 }
 
-function isLayoutShift(entry: PerformanceEntry | LayoutShift): entry is LayoutShift {
+function isLayoutShift(entry: PerformanceEntry): entry is LayoutShift {
   return (entry as LayoutShift).sources !== undefined;
 }
 


### PR DESCRIPTION
Fixes attribution type: when adding an attribution in CLS we add {`value`, `nodeIds`} not {`value`, `sources`}