### PR TITLE
fix(node): Replace dashes in `generic-pool` span origins with underscores

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
@@ -11,18 +11,18 @@ describe('genericPool auto instrumentation', () => {
       spans: expect.arrayContaining([
         expect.objectContaining({
           description: expect.stringMatching(/^generic-pool\.ac?quire/),
-          origin: 'auto.db.otel.generic-pool',
+          origin: 'auto.db.otel.generic_pool',
           data: {
-            'sentry.origin': 'auto.db.otel.generic-pool',
+            'sentry.origin': 'auto.db.otel.generic_pool',
           },
           status: 'ok',
         }),
 
         expect.objectContaining({
           description: expect.stringMatching(/^generic-pool\.ac?quire/),
-          origin: 'auto.db.otel.generic-pool',
+          origin: 'auto.db.otel.generic_pool',
           data: {
-            'sentry.origin': 'auto.db.otel.generic-pool',
+            'sentry.origin': 'auto.db.otel.generic_pool',
           },
           status: 'ok',
         }),

--- a/packages/node/src/integrations/tracing/genericPool.ts
+++ b/packages/node/src/integrations/tracing/genericPool.ts
@@ -25,7 +25,7 @@ const _genericPoolIntegration = (() => {
           spanDescription === 'generic-pool.aquire' || spanDescription === 'generic-pool.acquire';
 
         if (isGenericPoolSpan) {
-          span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.generic-pool');
+          span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.generic_pool');
         }
       });
     },


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/pull/13465#issuecomment-2327535609