### PR TITLE
fix(node-fetch): Use stringified origin url

### DIFF
--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -192,11 +192,11 @@ function getBreadcrumbData(request: FetchRequest): Partial<SanitizedRequestData>
 function getAbsoluteUrl(origin: string, path: string = '/'): string {
   const url = `${origin}`;
 
-  if (origin.endsWith('/') && path.startsWith('/')) {
+  if (url.endsWith('/') && path.startsWith('/')) {
     return `${url}${path.slice(1)}`;
   }
 
-  if (!origin.endsWith('/') && !path.startsWith('/')) {
+  if (!url.endsWith('/') && !path.startsWith('/')) {
     return `${url}/${path.slice(1)}`;
   }
 


### PR DESCRIPTION
Uses the stringified value of `origin` to call `.endsWith()`.

closes https://github.com/getsentry/sentry-javascript/issues/13574