### PR TITLE
ci: Fix size-limit action on develop branches

### DIFF
--- a/dev-packages/size-limit-gh-action/index.mjs
+++ b/dev-packages/size-limit-gh-action/index.mjs
@@ -191,6 +191,7 @@ async function run() {
 }
 
 async function runSizeLimitOnComparisonBranch() {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const resultsFilePath = getResultsFilePath();
 
   const limit = new SizeLimitFormatter();


### PR DESCRIPTION
Noticed this was failing on develop e.g. here: https://github.com/getsentry/sentry-javascript/actions/runs/10699493008/job/29661468888