### PR TITLE
fix(gatsby): Fix assets path for sourcemaps upload

### DIFF
--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -12,7 +12,7 @@ exports.onCreateWebpackConfig = ({ getConfig, actions }, options) => {
         sentryWebpackPlugin({
           sourcemaps: {
             // Only include files from the build output directory
-            assets: ['public'],
+            assets: ['./public/**'],
             // Ignore files that aren't users' source code related
             ignore: [
               'polyfill-*', // related to polyfills


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/issues/13582#issuecomment-2331078028 correctly identified that this path is messed up.