### PR TITLE
fix(replays): Improve replay web vital types

### DIFF
--- a/packages/replay-internal/src/types/performance.ts
+++ b/packages/replay-internal/src/types/performance.ts
@@ -110,11 +110,11 @@ export interface WebVitalData {
   /**
    * The recording id of the web vital nodes. -1 if not found
    */
-  nodeIds: number[] | undefined;
+  nodeIds?: number[];
   /**
    * The layout shifts of a CLS metric
    */
-  attributions: { value: number; nodeIds: number[] | undefined }[] | undefined;
+  attributions?: { value: number; nodeIds: number[] | undefined }[];
 }
 
 /**

--- a/packages/replay-internal/src/types/performance.ts
+++ b/packages/replay-internal/src/types/performance.ts
@@ -110,11 +110,11 @@ export interface WebVitalData {
   /**
    * The recording id of the web vital nodes. -1 if not found
    */
-  nodeIds?: number[];
+  nodeIds: number[] | undefined;
   /**
    * The layout shifts of a CLS metric
    */
-  attributions?: { value: number; nodeIds?: number[] }[];
+  attributions: { value: number; nodeIds: number[] | undefined }[] | undefined;
 }
 
 /**

--- a/packages/replay-internal/src/util/createPerformanceEntries.ts
+++ b/packages/replay-internal/src/util/createPerformanceEntries.ts
@@ -60,7 +60,7 @@ interface LayoutShiftAttribution {
 
 interface Attribution {
   value: number;
-  nodeIds?: number[];
+  nodeIds: number[] | undefined;
 }
 
 /**
@@ -220,9 +220,10 @@ export function getCumulativeLayoutShift(metric: Metric): ReplayPerformanceEntry
           }
         }
       }
-      layoutShifts.push({ value: entry.value, nodeIds });
+      layoutShifts.push({ value: entry.value, nodeIds: nodeIds.length ? nodeIds : undefined });
     }
   }
+
   return getWebVital(metric, 'cumulative-layout-shift', nodes, layoutShifts);
 }
 
@@ -258,7 +259,7 @@ function getWebVital(
 
   const end = getAbsoluteTime(value);
 
-  const data: ReplayPerformanceEntry<WebVitalData> = {
+ return {
     type: 'web-vital',
     name,
     start: end,
@@ -271,6 +272,4 @@ function getWebVital(
       attributions,
     },
   };
-
-  return data;
 }

--- a/packages/replay-internal/src/util/createPerformanceEntries.ts
+++ b/packages/replay-internal/src/util/createPerformanceEntries.ts
@@ -259,7 +259,7 @@ function getWebVital(
 
   const end = getAbsoluteTime(value);
 
- return {
+  return {
     type: 'web-vital',
     name,
     start: end,

--- a/packages/replay-internal/src/util/createPerformanceEntries.ts
+++ b/packages/replay-internal/src/util/createPerformanceEntries.ts
@@ -58,11 +58,6 @@ interface LayoutShiftAttribution {
   currentRect: DOMRectReadOnly;
 }
 
-interface Attribution {
-  value: number;
-  nodeIds: number[] | undefined;
-}
-
 /**
  * Handler creater for web vitals
  */
@@ -206,7 +201,7 @@ function isLayoutShift(entry: PerformanceEntry): entry is LayoutShift {
  * Add a CLS event to the replay based on a CLS metric.
  */
 export function getCumulativeLayoutShift(metric: Metric): ReplayPerformanceEntry<WebVitalData> {
-  const layoutShifts: Attribution[] = [];
+  const layoutShifts: WebVitalData['attributions'] = [];
   const nodes: Node[] = [];
   for (const entry of metric.entries) {
     if (isLayoutShift(entry)) {
@@ -252,7 +247,7 @@ function getWebVital(
   metric: Metric,
   name: string,
   nodes: Node[] | undefined,
-  attributions?: Attribution[],
+  attributions?: WebVitalData['attributions'],
 ): ReplayPerformanceEntry<WebVitalData> {
   const value = metric.value;
   const rating = metric.rating;


### PR DESCRIPTION
Removes optional types so that type mismatches would be caught by typescript

Follow up to https://github.com/getsentry/sentry-javascript/pull/13573
