### PR TITLE
feat(core): Allow adding measurements without global client

### DIFF
--- a/packages/core/src/tracing/measurement.ts
+++ b/packages/core/src/tracing/measurement.ts
@@ -8,8 +8,7 @@ import { getActiveSpan, getRootSpan } from '../utils/spanUtils';
 /**
  * Adds a measurement to the current active transaction.
  */
-export function setMeasurement(name: string, value: number, unit: MeasurementUnit): void {
-  const activeSpan = getActiveSpan();
+export function setMeasurement(name: string, value: number, unit: MeasurementUnit, activeSpan = getActiveSpan()): void {
   const rootSpan = activeSpan && getRootSpan(activeSpan);
 
   if (rootSpan) {

--- a/packages/core/src/tracing/measurement.ts
+++ b/packages/core/src/tracing/measurement.ts
@@ -6,7 +6,8 @@ import {
 import { getActiveSpan, getRootSpan } from '../utils/spanUtils';
 
 /**
- * Adds a measurement to the current active transaction.
+ * Adds a measurement to the active transaction on the current global scope. You can optionally pass in a different span
+ * as the 4th parameter.
  */
 export function setMeasurement(name: string, value: number, unit: MeasurementUnit, activeSpan = getActiveSpan()): void {
   const rootSpan = activeSpan && getRootSpan(activeSpan);


### PR DESCRIPTION
While working on updating [`sentry-javascript-bundler-plugins` to use v8 of the JavaScript SDK](https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/579), I found that I was unable to set measurements as the global client is not used.

If you're not using a global client, there is currently no way to add measurements because `Sentry.setMeasurement()` relies on `getActiveSpan()` which in turn relies on `getCurrentScope()`.

This PR moves the `activeSpan` into the last parameter which defaults to `getActiveSpan()`. 
