### PR TITLE
fix(nextjs): Widen removal of 404 transactions

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-13/tests/server/404.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-13/tests/server/404.test.ts
@@ -1,0 +1,23 @@
+import { test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('should create a transaction for a CJS pages router API endpoint', async ({ page }) => {
+  let received404Transaction = false;
+  waitForTransaction('nextjs-13', async transactionEvent => {
+    return transactionEvent.transaction === 'GET /404' || transactionEvent.transaction === 'GET /_not-found';
+  }).then(() => {
+    received404Transaction = true;
+  });
+
+  await page.goto('/page-that-doesnt-exist');
+
+  await new Promise<void>((resolve, reject) => {
+    setTimeout(() => {
+      if (received404Transaction) {
+        reject(new Error('received 404 transaction'));
+      } else {
+        resolve();
+      }
+    }, 5_000);
+  });
+});

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -219,8 +219,13 @@ export function init(options: NodeOptions): NodeClient | undefined {
             return null;
           }
 
-          // Filter out /404 transactions for pages-router which seem to be created excessively
-          if (event.transaction === '/404') {
+          // Filter out /404 transactions which seem to be created excessively
+          if (
+            // Pages router
+            event.transaction === '/404' ||
+            // App router (could be "GET /404", "POST /404", ...)
+            event.transaction?.match(/^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH) \/404$/)
+          ) {
             return null;
           }
 

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -224,7 +224,8 @@ export function init(options: NodeOptions): NodeClient | undefined {
             // Pages router
             event.transaction === '/404' ||
             // App router (could be "GET /404", "POST /404", ...)
-            event.transaction?.match(/^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH) \/404$/)
+            event.transaction?.match(/^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH) \/404$/) ||
+            event.transaction === 'GET /_not-found'
           ) {
             return null;
           }


### PR DESCRIPTION
On app router, transactions like `GET /404` get created that we don't like.