### PR TITLE
ci: Add some additional GH project automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check if PR is in project
+      continue-on-error: true
       id: check_project
       uses: github/update-project-action@main
       with:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   # Check if PR is in project
   check_project:
+    name: Check if PR is in project
     runs-on: ubuntu-latest
     steps:
     - name: Check if PR is in project
@@ -35,6 +36,7 @@ jobs:
 
   # When a PR is a draft, it should go into "In Progress"
   mark_as_in_progress:
+    name: "Mark as In Progress"
     needs: check_project
     if: |
       needs.check_project.outputs.is_in_project == '1'
@@ -54,6 +56,7 @@ jobs:
 
   # When a PR is not a draft, it should go into "In Review"
   mark_as_in_review:
+    name: "Mark as In Review"
     needs: check_project
     if: |
       needs.check_project.outputs.is_in_project == '1'
@@ -75,6 +78,7 @@ jobs:
   # By default, closed PRs go into "Ready for Release"
   # But if they are closed without merging, they should go into "Done"
   mark_as_done:
+    name: "Mark as Done"
     needs: check_project
     if: |
       needs.check_project.outputs.is_in_project == '1'

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update status to in_progress
-        uses: github/update-project-action@v3
+        uses: github/update-project-action@main
         with:
           github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           organization: getsentry
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Update status to in_review
         id: update_status
-        uses: github/update-project-action@v3
+        uses: github/update-project-action@main
         with:
           github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           organization: getsentry
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Update status to done
         id: update_status
-        uses: github/update-project-action@v3
+        uses: github/update-project-action@main
         with:
           github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           organization: getsentry

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -39,7 +39,7 @@ jobs:
           github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           organization: getsentry
           project_number: 31
-          content_id: ${{ github.event.number }}
+          content_id: ${{ github.event.pull_request.id }}
           field: Status
           value: "👀 In Review"
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -9,10 +9,38 @@ on:
       - converted_to_draft
 
 jobs:
+  # Check if PR is in project
+  check_project:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check if PR is in project
+      id: check_project
+      uses: github/update-project-action@main
+      with:
+        github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
+        organization: getsentry
+        project_number: 31
+        content_id: ${{ github.event.pull_request.node_id }}
+        field: Status
+        operation: read
+
+    - name: PR is not in project
+      if: failure()
+      run: echo "is_in_project=0" >> "$GITHUB_OUTPUT"
+
+    - name: PR is in project
+      if: success()
+      run: echo "is_in_project=1" >> "$GITHUB_OUTPUT"
+
+    outputs:
+      is_in_project: '${{ steps.check_project.outputs.is_in_project }}'
+
   # When a PR is a draft, it should go into "In Progress"
   mark_as_in_progress:
+    needs: check_project
     if: |
-      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'converted_to_draft')
+      needs.check_project.outputs.is_in_project == '1'
+      && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'converted_to_draft')
       && github.event.pull_request.draft == true
     runs-on: ubuntu-latest
     steps:
@@ -28,8 +56,10 @@ jobs:
 
   # When a PR is not a draft, it should go into "In Review"
   mark_as_in_review:
+    needs: check_project
     if: |
-      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+      needs.check_project.outputs.is_in_project == '1'
+      && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
       && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -47,8 +77,10 @@ jobs:
   # By default, closed PRs go into "Ready for Release"
   # But if they are closed without merging, they should go into "Done"
   mark_as_done:
+    needs: check_project
     if: |
-      github.event.action == 'closed' && github.event.pull_request.merged == false
+      needs.check_project.outputs.is_in_project == '1'
+      && github.event.action == 'closed' && github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - name: Update status to done

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -25,16 +25,13 @@ jobs:
         field: Status
         operation: read
 
-    - name: PR is not in project
-      if: failure()
-      run: echo "is_in_project=0" >> "$GITHUB_OUTPUT"
-
     - name: PR is in project
-      if: success()
+      if: steps.check_project.outputs.field_read_value
+      id: is_in_project
       run: echo "is_in_project=1" >> "$GITHUB_OUTPUT"
 
     outputs:
-      is_in_project: '${{ steps.check_project.outputs.is_in_project }}'
+      is_in_project: ${{ steps.is_in_project.outputs.is_in_project || '0' }}
 
   # When a PR is a draft, it should go into "In Progress"
   mark_as_in_progress:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -20,6 +20,7 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          project-location: getsentry
           project-number: 31
           column-name: "🏗 In Progress"
           issue-number: ${{ github.event.number }}
@@ -36,6 +37,7 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          project-location: getsentry
           project-number: 31
           column-name: "👀 In Review"
           issue-number: ${{ github.event.number }}
@@ -53,6 +55,7 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          project-location: getsentry
           project-number: 31
           column-name: "✅ Done"
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,61 @@
+name: "Automation: Update GH Project"
+on:
+  pull_request:
+    types:
+      - closed
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  # When a PR is a draft, it should go into "In Progress"
+  mark_as_in_progress:
+    if: |
+      (github.event.action == 'opened' || github.event.action == 'reopened')
+      && github.event.pull_request.draft == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update status to in_progress
+        id: update_status
+        uses: peter-evans/create-or-update-project-card@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          project-location: getsentry
+          project-number: 31
+          column-name: "🏗 In Progress"
+          issue-number: ${{ github.event.number }}
+
+  # When a PR is not a draft, it should go into "In Review"
+  mark_as_in_review:
+    if: |
+      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review')
+      && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update status to in_review
+        id: update_status
+        uses: peter-evans/create-or-update-project-card@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          project-location: getsentry
+          project-number: 31
+          column-name: "👀 In Review"
+          issue-number: ${{ github.event.number }}
+
+
+  # By default, closed PRs go into "Ready for Release"
+  # But if they are closed without merging, they should go into "Done"
+  mark_as_done:
+    if: |
+      github.event.action == 'closed' && github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update status to done
+        id: update_status
+        uses: peter-evans/create-or-update-project-card@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          project-location: getsentry
+          project-number: 31
+          column-name: "✅ Done"
+          issue-number: ${{ github.event.number }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update status to in_progress
-        id: update_status
-        uses: peter-evans/create-or-update-project-card@v3
+        uses: github/update-project-action@v3
         with:
-          token: ${{ secrets.GH_PROJECT_AUTOMATION }}
-          project-location: getsentry
-          project-number: 31
-          column-name: "🏗 In Progress"
-          issue-number: ${{ github.event.number }}
+          github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
+          organization: getsentry
+          project_number: 31
+          content_id: ${{ github.event.pull_request.node_id }}
+          field: Status
+          value: "🏗 In Progress"
 
   # When a PR is not a draft, it should go into "In Review"
   mark_as_in_review:
@@ -52,10 +52,12 @@ jobs:
     steps:
       - name: Update status to done
         id: update_status
-        uses: peter-evans/create-or-update-project-card@v3
+        uses: github/update-project-action@v3
         with:
-          token: ${{ secrets.GH_PROJECT_AUTOMATION }}
-          project-location: getsentry
-          project-number: 31
-          column-name: "✅ Done"
-          issue-number: ${{ github.event.number }}
+          github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
+          organization: getsentry
+          project_number: 31
+          content_id: ${{ github.event.pull_request.node_id }}
+          field: Status
+          value: "✅ Done"
+

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -39,7 +39,7 @@ jobs:
           github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           organization: getsentry
           project_number: 31
-          content_id: ${{ github.event.pull_request.id }}
+          content_id: ${{ github.event.pull_request.node_id }}
           field: Status
           value: "👀 In Review"
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -6,12 +6,13 @@ on:
       - opened
       - reopened
       - ready_for_review
+      - converted_to_draft
 
 jobs:
   # When a PR is a draft, it should go into "In Progress"
   mark_as_in_progress:
     if: |
-      (github.event.action == 'opened' || github.event.action == 'reopened')
+      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'converted_to_draft')
       && github.event.pull_request.draft == true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -20,7 +20,6 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          project-location: getsentry
           project-number: 31
           column-name: "🏗 In Progress"
           issue-number: ${{ github.event.number }}
@@ -37,7 +36,6 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          project-location: getsentry
           project-number: 31
           column-name: "👀 In Review"
           issue-number: ${{ github.event.number }}
@@ -55,7 +53,6 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          project-location: getsentry
           project-number: 31
           column-name: "✅ Done"
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -34,14 +34,14 @@ jobs:
     steps:
       - name: Update status to in_review
         id: update_status
-        uses: peter-evans/create-or-update-project-card@v3
+        uses: github/update-project-action@v3
         with:
-          token: ${{ secrets.GH_PROJECT_AUTOMATION }}
-          project-location: getsentry
-          project-number: 31
-          column-name: "👀 In Review"
-          issue-number: ${{ github.event.number }}
-
+          github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
+          organization: getsentry
+          project_number: 31
+          content_id: ${{ github.event.number }}
+          field: Status
+          value: "👀 In Review"
 
   # By default, closed PRs go into "Ready for Release"
   # But if they are closed without merging, they should go into "Done"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -25,7 +25,7 @@ jobs:
         field: Status
         operation: read
 
-    - name: PR is in project
+    - name: If project field is read, set is_in_project to 1
       if: steps.check_project.outputs.field_read_value
       id: is_in_project
       run: echo "is_in_project=1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -19,7 +19,7 @@ jobs:
         id: update_status
         uses: peter-evans/create-or-update-project-card@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           project-location: getsentry
           project-number: 31
           column-name: "🏗 In Progress"
@@ -36,7 +36,7 @@ jobs:
         id: update_status
         uses: peter-evans/create-or-update-project-card@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           project-location: getsentry
           project-number: 31
           column-name: "👀 In Review"
@@ -54,7 +54,7 @@ jobs:
         id: update_status
         uses: peter-evans/create-or-update-project-card@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           project-location: getsentry
           project-number: 31
           column-name: "✅ Done"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Check if PR is in project
       continue-on-error: true
       id: check_project
-      uses: github/update-project-action@main
+      uses: github/update-project-action@f980378bc179626af5b4e20ec05ec39c7f7a6f6d
       with:
         github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
         organization: getsentry
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update status to in_progress
-        uses: github/update-project-action@main
+        uses: github/update-project-action@f980378bc179626af5b4e20ec05ec39c7f7a6f6d
         with:
           github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           organization: getsentry
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Update status to in_review
         id: update_status
-        uses: github/update-project-action@main
+        uses: github/update-project-action@f980378bc179626af5b4e20ec05ec39c7f7a6f6d
         with:
           github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           organization: getsentry
@@ -87,7 +87,7 @@ jobs:
     steps:
       - name: Update status to done
         id: update_status
-        uses: github/update-project-action@main
+        uses: github/update-project-action@f980378bc179626af5b4e20ec05ec39c7f7a6f6d
         with:
           github_token: ${{ secrets.GH_PROJECT_AUTOMATION }}
           organization: getsentry


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-javascript/pull/13608, after some tweaks and a rebase!

* When a PR is opened in draft mode, move to "In Progress" on the board
* When a PR is opened for review, move to "In Review" on the board
* When a PR is closed but not merged, move it directly to "Done" (instead of "Ready for Release")

Note that for now, this only applies to PRs that are on the board themselves, not to PRs linked to an issue.