### PR TITLE
fix: incorrect property name in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ import * as Sentry from '@sentry/node';
 
 Sentry.init({
   dsn: '__PUBLIC_DSN__',
-  registerEsmLoaderHooks: { onlyHookedModules: true },
+  registerEsmLoaderHooks: { onlyIncludeInstrumentedModules: true },
 });
 ```
 


### PR DESCRIPTION
I failed to update the description in my PR when we improved the property name after some discussion in the PR, so the wrong property name was used in the changelog:

https://github.com/getsentry/sentry-javascript/blob/bcf571d9954094be76a99edbb12c23eff7f7b5dc/packages/node/src/types.ts#L20

Thanks to @torickjdavis for reporting this [here](https://github.com/getsentry/sentry-javascript/issues/12414#issuecomment-2339236336)!

