### PR TITLE
fix(node): Update OpenTelemetry instrumentation package for solidstart and opentelemetry

### DIFF
--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.25.1",
-    "@opentelemetry/instrumentation": "^0.52.1",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/sdk-trace-base": "^1.25.1",
     "@opentelemetry/semantic-conventions": "^1.25.1"
   },

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -66,7 +66,7 @@
     }
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.1",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@sentry/core": "8.29.0",
     "@sentry/node": "8.29.0",
     "@sentry/opentelemetry": "8.29.0",


### PR DESCRIPTION
Looks like we overlooked two packages when updating deps previously in #13587.

See: https://github.com/getsentry/sentry-javascript/pull/13587#issuecomment-2339419127

Closes: #13219