### PR TITLE
fix(node): Update OpenTelemetry instrumentation package for solidstart and opentelemetry

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7273,7 +7273,7 @@
     semver "^7.5.2"
     shimmer "^1.2.1"
 
-"@opentelemetry/instrumentation@^0.49 || ^0.50 || ^0.51 || ^0.52.0", "@opentelemetry/instrumentation@^0.52.1":
+"@opentelemetry/instrumentation@^0.49 || ^0.50 || ^0.51 || ^0.52.0":
   version "0.52.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz#2e7e46a38bd7afbf03cf688c862b0b43418b7f48"
   integrity sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==


### PR DESCRIPTION
Part 2 because I forgot to update the lockfile in the [previous PR](https://github.com/getsentry/sentry-javascript/pull/13640).