### PR TITLE
feat(browser): Add navigation `activationStart` timestamp to pageload span

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals/test.ts
@@ -83,7 +83,6 @@ sentryTest(
     // The delta should be less than 1ms if this flakes, we should increase the threshold
     expect(delta).toBeLessThanOrEqual(1);
 
-    expect(activationStart).toBeDefined();
     expect(activationStart).toBeGreaterThanOrEqual(0);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals/test.ts
@@ -59,23 +59,31 @@ sentryTest('paint web vitals values are greater than TTFB', async ({ browserName
   expect(fpValue).toBeGreaterThanOrEqual(ttfbValue!);
 });
 
-sentryTest('captures time origin as span attribute', async ({ getLocalTestPath, page }) => {
-  // Only run in chromium to ensure all vitals are present
-  if (shouldSkipTracingTest()) {
-    sentryTest.skip();
-  }
+sentryTest(
+  'captures time origin and navigation activationStart as span attributes',
+  async ({ getLocalTestPath, page }) => {
+    // Only run in chromium to ensure all vitals are present
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
-  const [eventData] = await Promise.all([getFirstSentryEnvelopeRequest<Event>(page), page.goto(url)]);
+    const url = await getLocalTestPath({ testDir: __dirname });
+    const [eventData] = await Promise.all([getFirstSentryEnvelopeRequest<Event>(page), page.goto(url)]);
 
-  const timeOriginAttribute = eventData.contexts?.trace?.data?.['performance.timeOrigin'];
-  const transactionStartTimestamp = eventData.start_timestamp;
+    const timeOriginAttribute = eventData.contexts?.trace?.data?.['performance.timeOrigin'];
+    const activationStart = eventData.contexts?.trace?.data?.['performance.activationStart'];
 
-  expect(timeOriginAttribute).toBeDefined();
-  expect(transactionStartTimestamp).toBeDefined();
+    const transactionStartTimestamp = eventData.start_timestamp;
 
-  const delta = Math.abs(transactionStartTimestamp! - timeOriginAttribute);
+    expect(timeOriginAttribute).toBeDefined();
+    expect(transactionStartTimestamp).toBeDefined();
 
-  // The delta should be less than 1ms if this flakes, we should increase the threshold
-  expect(delta).toBeLessThanOrEqual(1);
-});
+    const delta = Math.abs(transactionStartTimestamp! - timeOriginAttribute);
+
+    // The delta should be less than 1ms if this flakes, we should increase the threshold
+    expect(delta).toBeLessThanOrEqual(1);
+
+    expect(activationStart).toBeDefined();
+    expect(activationStart).toBeGreaterThanOrEqual(0);
+  },
+);

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/tests/transactions.test.ts
@@ -23,6 +23,7 @@ test('Captures a pageload transaction', async ({ page }) => {
       'sentry.sample_rate': 1,
       'sentry.source': 'route',
       'performance.timeOrigin': expect.any(Number),
+      'performance.activationStart': expect.any(Number),
     },
     op: 'pageload',
     span_id: expect.any(String),

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -17,6 +17,7 @@ import {
   addTtfbInstrumentationHandler,
 } from './instrument';
 import { getBrowserPerformanceAPI, isMeasurementValue, msToSec, startAndEndSpan } from './utils';
+import { getActivationStart } from './web-vitals/lib/getActivationStart';
 import { getNavigationEntry } from './web-vitals/lib/getNavigationEntry';
 import { getVisibilityWatcher } from './web-vitals/lib/getVisibilityWatcher';
 
@@ -382,6 +383,14 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
 
     // Set timeOrigin which denotes the timestamp which to base the LCP/FCP/FP/TTFB measurements on
     span.setAttribute('performance.timeOrigin', timeOrigin);
+
+    // In prerendering scenarios, where a page might be prefetched and pre-rendered before the user clicks the link,
+    // the navigation starts earlier than when the user clicks it. Web Vitals should always be based on the
+    // user-perceived time, so they are not reported from the actual start of the navigation, but rather from the
+    // time where the user actively started the navigation, for example by clicking a link.
+    // This is user action is called "activation" and the time between navigation and activation is stored in
+    // the `activationStart` attribute of the "navigation" PerformanceEntry.
+    span.setAttribute('performance.activationStart', getActivationStart());
 
     _setWebVitalAttributes(span);
   }


### PR DESCRIPTION
 In prerendering scenarios, where a page might be prefetched and pre-rendered before the user clicks a link, the performance API starts measuring the navigation earlier than when the user clicks it. Web Vital measurements however are always based on the user-perceived (loading) time, so they are not reported from the actual start of the navigation, but rather from the time where the user actively started the navigation, for example by clicking a link. This user action is called "activation" and the time between navigation start and activation is stored in the [`activationStart` attribute](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/activationStart) of the "navigation" PerformanceEntry.

This PR adds this `activationStart` property as it gets reported by the browser as `performance.activationStart` span attribute to the pageload span. The browser gives us a relative time in ms, based on the `startTime` attribute. The `startTime` attribute is [always 0](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/startTime#navigation) for navigation entry but in absolute numbers, it corresponds to `performance.timeOrigin` (which we already send as a span attribute since #13502). So if necessary, in the product, we can calculate the absolute timestamp via `performance.timeOrigin + performance.activationStart`.

We can use this attribute as a heuristic where to draw the vertical web vital lines for TTFB, LCP (and possibly FCP) from.

