### PR TITLE
ref(profiling) use cleanup instead of destructor

### DIFF
--- a/packages/profiling-node/bindings/cpu_profiler.cc
+++ b/packages/profiling-node/bindings/cpu_profiler.cc
@@ -73,7 +73,7 @@ enum class ProfileStatus {
 
 class MeasurementsTicker {
 private:
-  uv_timer_t* timer;
+  uv_timer_t *timer;
   uint64_t period_ms;
   std::unordered_map<std::string,
                      const std::function<bool(uint64_t, v8::HeapStatistics &)>>
@@ -86,15 +86,14 @@ private:
 
 public:
   MeasurementsTicker(uv_loop_t *loop)
-      : period_ms(100),
-        isolate(v8::Isolate::GetCurrent()) {
+      : period_ms(100), isolate(v8::Isolate::GetCurrent()) {
     timer = new uv_timer_t;
     uv_timer_init(loop, timer);
-    uv_handle_set_data((uv_handle_t*)timer, this);
-    uv_ref((uv_handle_t*)timer);
+    uv_handle_set_data((uv_handle_t *)timer, this);
+    uv_ref((uv_handle_t *)timer);
   }
 
-  static void ticker(uv_timer_t*);
+  static void ticker(uv_timer_t *);
   // Memory listeners
   void heap_callback();
   void add_heap_listener(
@@ -114,15 +113,13 @@ public:
   size_t listener_count();
 
   ~MeasurementsTicker() {
-    uv_handle_t* handle = (uv_handle_t*)timer;
+    uv_handle_t *handle = (uv_handle_t *)timer;
 
     uv_timer_stop(timer);
     uv_unref(handle);
 
     if (!uv_is_closing(handle)) {
-      uv_close(handle, [](uv_handle_t *handle) {
-        delete handle;
-      });
+      uv_close(handle, [](uv_handle_t *handle) { delete handle; });
     }
   }
 };
@@ -212,12 +209,12 @@ void MeasurementsTicker::cpu_callback() {
   uv_free_cpu_info(cpu, count);
 };
 
-void MeasurementsTicker::ticker(uv_timer_t* handle) {
+void MeasurementsTicker::ticker(uv_timer_t *handle) {
   if (handle == nullptr) {
     return;
   }
 
-  MeasurementsTicker *self = static_cast<MeasurementsTicker*>(handle->data);
+  MeasurementsTicker *self = static_cast<MeasurementsTicker *>(handle->data);
   self->heap_callback();
   self->cpu_callback();
 }

--- a/packages/profiling-node/bindings/cpu_profiler.cc
+++ b/packages/profiling-node/bindings/cpu_profiler.cc
@@ -111,15 +111,9 @@ public:
 
   size_t listener_count();
 
-  ~MeasurementsTicker() {
+  void Cleanup() {
     uv_timer_stop(&timer);
-
-    auto handle = reinterpret_cast<uv_handle_t *>(&timer);
-
-    // Calling uv_close on an inactive handle will cause a segfault.
-    if (uv_is_active(handle)) {
-      uv_close(handle, nullptr);
-    }
+    uv_close(reinterpret_cast<uv_handle_t *>(&timer), nullptr);
   }
 };
 
@@ -1155,6 +1149,7 @@ void FreeAddonData(napi_env env, void *data, void *hint) {
     profiler->cpu_profiler = nullptr;
   }
 
+  profiler->measurements_ticker.Cleanup();
   delete profiler;
 }
 


### PR DESCRIPTION
I think what is happening is that by the time our close handler is called, the handler had already been deleted, which causes a use after free error. I also updated the code to check for is_closing which is what that underlying libuv method actually asserts on.

Fixes https://github.com/getsentry/sentry-javascript/pull/13661