### PR TITLE
fix(nestjs): Preserve original function name on `SentryTraced` functions

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.controller.ts
@@ -116,4 +116,9 @@ export class AppController {
   testServiceWithCanActivate() {
     return this.appService.canActivate();
   }
+
+  @Get('test-function-name')
+  testFunctionName() {
+    return this.appService.getFunctionName();
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.service.ts
@@ -58,6 +58,11 @@ export class AppService {
     return { result: 'test' };
   }
 
+  @SentryTraced('return the function name')
+  getFunctionName(): { result: string } {
+    return { result: this.getFunctionName.name };
+  }
+
   async testSpanDecoratorSync() {
     const returned = this.getString();
     // Will fail if getString() is async, because returned will be a Promise<>

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/span-decorator.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/span-decorator.test.ts
@@ -70,3 +70,10 @@ test('Transaction includes span and correct value for decorated sync function', 
     ]),
   );
 });
+
+test('preserves original function name on decorated functions', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-function-name`);
+  const body = await response.json();
+
+  expect(body.result).toEqual('getFunctionName');
+});

--- a/packages/nestjs/src/decorators/sentry-traced.ts
+++ b/packages/nestjs/src/decorators/sentry-traced.ts
@@ -20,6 +20,10 @@ export function SentryTraced(op: string = 'function') {
         },
       );
     };
+
+    // preserve the original name on the decorated function
+    Object.defineProperty(descriptor.value, 'name', { value: originalMethod.name, configurable: true });
+
     return descriptor;
   };
 }

--- a/packages/nestjs/src/decorators/sentry-traced.ts
+++ b/packages/nestjs/src/decorators/sentry-traced.ts
@@ -22,7 +22,12 @@ export function SentryTraced(op: string = 'function') {
     };
 
     // preserve the original name on the decorated function
-    Object.defineProperty(descriptor.value, 'name', { value: originalMethod.name, configurable: true });
+    Object.defineProperty(descriptor.value, 'name', {
+      value: originalMethod.name,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    });
 
     return descriptor;
   };


### PR DESCRIPTION
This PR preserves the `name` for functions that are decorated with `@SentryTraced`.

fixes https://github.com/getsentry/sentry-javascript/issues/13683