### PR TITLE
chore: Add cloudflare sdk to main README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+Work in this release was contributed by @KyGuy2002. Thank you for your contribution!
+
 ## 8.30.0
 
 ### Important Changes

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ package. Please refer to the README and instructions of those SDKs for more deta
   for native crashes
 - [`@sentry/bun`](https://github.com/getsentry/sentry-javascript/tree/master/packages/bun): SDK for Bun
 - [`@sentry/deno`](https://github.com/getsentry/sentry-javascript/tree/master/packages/deno): SDK for Deno
-- [`@sentry/cloudflare`](https://github.com/getsentry/sentry-javascript/tree/master/packages/cloudflare): SDK for Cloudflare
+- [`@sentry/cloudflare`](https://github.com/getsentry/sentry-javascript/tree/master/packages/cloudflare): SDK for
+  Cloudflare
 
 ## Version Support Policy
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ package. Please refer to the README and instructions of those SDKs for more deta
   for native crashes
 - [`@sentry/bun`](https://github.com/getsentry/sentry-javascript/tree/master/packages/bun): SDK for Bun
 - [`@sentry/deno`](https://github.com/getsentry/sentry-javascript/tree/master/packages/deno): SDK for Deno
+- [`@sentry/cloudflare`](https://github.com/getsentry/sentry-javascript/tree/master/packages/cloudflare): SDK for Cloudflare
 
 ## Version Support Policy
 


### PR DESCRIPTION
Supercedes https://github.com/getsentry/sentry-javascript/pull/13432

Adds cloudflare sdk to the readme list - thanks @KyGuy2002 for the PR!