### PR TITLE
feat(node): Add `disableInstrumentationWarnings` option

### DIFF
--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -125,6 +125,12 @@ export interface BaseNodeOptions {
    */
   clientReportFlushInterval?: number;
 
+  /**
+   * By default, the SDK will try to identify problems with your instrumentation setup and warn you about it.
+   * If you want to disable these warnings, set this to `true`.
+   */
+  disableInstrumentationWarnings?: boolean;
+
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(this: void, error: Error): void;
 }

--- a/packages/node/test/utils/ensureIsWrapped.test.ts
+++ b/packages/node/test/utils/ensureIsWrapped.test.ts
@@ -1,0 +1,71 @@
+import { ensureIsWrapped } from '../../src/utils/ensureIsWrapped';
+import { cleanupOtel, mockSdkInit, resetGlobals } from '../helpers/mockSdkInit';
+
+const unwrappedFunction = () => {};
+
+// We simulate a wrapped function
+const wrappedfunction = Object.assign(() => {}, {
+  __wrapped: true,
+  __original: () => {},
+  __unwrap: () => {},
+});
+
+describe('ensureIsWrapped', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    cleanupOtel();
+    resetGlobals();
+  });
+
+  it('warns when the method is unwrapped', () => {
+    const spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockSdkInit({ tracesSampleRate: 1 });
+
+    ensureIsWrapped(unwrappedFunction, 'express');
+
+    expect(spyWarn).toHaveBeenCalledTimes(1);
+    expect(spyWarn).toHaveBeenCalledWith(
+      '[Sentry] express is not instrumented. This is likely because you required/imported express before calling `Sentry.init()`.',
+    );
+  });
+
+  it('does not warn when the method is wrapped', () => {
+    const spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockSdkInit({ tracesSampleRate: 1 });
+
+    ensureIsWrapped(wrappedfunction, 'express');
+
+    expect(spyWarn).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not warn without a client', () => {
+    const spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    resetGlobals();
+
+    ensureIsWrapped(wrappedfunction, 'express');
+
+    expect(spyWarn).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not warn without tracing', () => {
+    const spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockSdkInit({});
+
+    ensureIsWrapped(unwrappedFunction, 'express');
+
+    expect(spyWarn).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not warn if disableInstrumentationWarnings=true', () => {
+    const spyWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockSdkInit({ tracesSampleRate: 1, disableInstrumentationWarnings: true });
+
+    ensureIsWrapped(unwrappedFunction, 'express');
+
+    expect(spyWarn).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/13471

This can be used when you know what you're doing to avoid the warning log.