### PR TITLE
ref: Update http instrumentation name for logging

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,5 +1,5 @@
 import type { ClientRequest, IncomingMessage, RequestOptions, ServerResponse } from 'node:http';
-import type { Span} from '@opentelemetry/api';
+import type { Span } from '@opentelemetry/api';
 import { diag } from '@opentelemetry/api';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { addOpenTelemetryInstrumentation } from '@sentry/opentelemetry';

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -24,7 +24,7 @@ import { getRequestUrl } from '../utils/getRequestUrl';
 
 const INTEGRATION_NAME = 'Http';
 
-const INSTRUMENTATION_NAME = '@opentelemetry/instrumentation-http-sentry';
+const INSTRUMENTATION_NAME = '@opentelemetry_sentry-patched/instrumentation-http';
 
 interface HttpOptions {
   /**


### PR DESCRIPTION
With this change, it is easier to figure out from logs if the correct or incorrect http instrumentation is added.

Now, if you see e.g. this in the logs, if users have enabled logs (`debug: true` if not using `skipOpenTelemetrySetup: true`, else using native OTEL debug logs with e.g. `diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG)`):

```js
@opentelemetry/instrumentation-http-sentry Applying instrumentation patch for nodejs core module on require hook { module: 'http' }
@opentelemetry/instrumentation-http Applying instrumentation patch for nodejs core module on require hook { module: 'http' }
```

you can tell that that it has been double instrumenting this incorrectly. You should never see the `@opentelemetry/instrumentation-http` entry anymore, otherwise something is wrong there.

This came out of https://github.com/getsentry/sentry-docs/pull/11378, I looked into various ways to debug this but there is not really an API provided by OTEL that allows us to figure this out 😬 