### PR TITLE
fix(browser): Try multiple options for `lazyLoadIntegration` script parent element lookup

### DIFF
--- a/packages/browser/src/utils/lazyLoadIntegration.ts
+++ b/packages/browser/src/utils/lazyLoadIntegration.ts
@@ -1,6 +1,5 @@
 import { SDK_VERSION, getClient } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/types';
-import { logger } from '@sentry/utils';
 import type { BrowserClient } from '../client';
 import { WINDOW } from '../helpers';
 
@@ -70,12 +69,12 @@ export async function lazyLoadIntegration(
   });
 
   const currentScript = WINDOW.document.currentScript;
-  const parent = (currentScript && currentScript.parentElement) || WINDOW.document.body || WINDOW.document.head;
+  const parent = WINDOW.document.body || WINDOW.document.head || (currentScript && currentScript.parentElement);
 
   if (parent) {
     parent.appendChild(script);
   } else {
-    logger.error(`Could not find parent element to insert lazy-loaded ${name} script`);
+    throw new Error(`Could not find parent element to insert lazy-loaded ${name} script`);
   }
 
   try {

--- a/packages/browser/src/utils/lazyLoadIntegration.ts
+++ b/packages/browser/src/utils/lazyLoadIntegration.ts
@@ -1,5 +1,6 @@
 import { SDK_VERSION, getClient } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/types';
+import { logger } from '@sentry/utils';
 import type { BrowserClient } from '../client';
 import { WINDOW } from '../helpers';
 
@@ -71,11 +72,11 @@ export async function lazyLoadIntegration(
   const currentScript = WINDOW.document.currentScript;
   const parent = (currentScript && currentScript.parentElement) || WINDOW.document.body || WINDOW.document.head;
 
-  if (!parent) {
-    throw new Error(`Could not find parent element to insert lazy-loaded ${name} script`);
+  if (parent) {
+    parent.appendChild(script);
+  } else {
+    logger.error(`Could not find parent element to insert lazy-loaded ${name} script`);
   }
-
-  parent.appendChild(script);
 
   try {
     await waitForLoad;

--- a/packages/browser/src/utils/lazyLoadIntegration.ts
+++ b/packages/browser/src/utils/lazyLoadIntegration.ts
@@ -1,6 +1,5 @@
 import { SDK_VERSION, getClient } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/types';
-import { logger } from '@sentry/utils';
 import type { BrowserClient } from '../client';
 import { WINDOW } from '../helpers';
 

--- a/packages/browser/src/utils/lazyLoadIntegration.ts
+++ b/packages/browser/src/utils/lazyLoadIntegration.ts
@@ -1,5 +1,6 @@
 import { SDK_VERSION, getClient } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/types';
+import { logger } from '@sentry/utils';
 import type { BrowserClient } from '../client';
 import { WINDOW } from '../helpers';
 
@@ -68,7 +69,14 @@ export async function lazyLoadIntegration(
     script.addEventListener('error', reject);
   });
 
-  WINDOW.document.body.appendChild(script);
+  const currentScript = WINDOW.document.currentScript;
+  const parent = (currentScript && currentScript.parentElement) || WINDOW.document.body || WINDOW.document.head;
+
+  if (!parent) {
+    throw new Error(`Could not find parent element to insert lazy-loaded ${name} script`);
+  }
+
+  parent.appendChild(script);
 
   try {
     await waitForLoad;


### PR DESCRIPTION
This PR makes our `lazyLoadIntegration` a bit more robust when trying to find the parent element to inject the script tag of the integration CDN bundle. It looks like some browsers don't automatically set `document.body` if the html page doesn't contain a `<body>` tag. Unfortunately, I couldn't reproduce this with Chrome, FF or Safari, so my running theory is that this is rather an exotic browser.

Anyway, for now the order of looking up parent elements is:

1. `document.body`
2. `document.head`
3. `document.currentScript.parentElement`

Unfortunately, I couldn't find a way to test these branches since neither chromium (integration tests) nor JSDOM (unit tests) allow unsetting `document.body|head`. I think we _should_ be fine with leaving this specific change untested but I can also spend some more time to try and figure out some way to test this...

closes https://github.com/getsentry/sentry-javascript/issues/13707