### PR TITLE
test(ci): Use latest node 22 version again for Node unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -458,8 +458,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(lforst): Unpin Node.js version 22 when https://github.com/protobufjs/protobuf.js/issues/2025 is resolved which broke the nodejs tests
-        node: [14, 16, 18, 20, '22.6.0']
+        node: [14, 16, 18, 20, 22]
     steps:
       - name: Check out base commit (${{ github.event.pull_request.base.sha }})
         uses: actions/checkout@v4


### PR DESCRIPTION
Looks like the bug that made us pin to Node 22.6.0 in our Node unit tests was fixed and released in 22.8.0. This PR reverts the pin, meaning we test against the latest Node 22 version again.

draft until CI passes...