### PR TITLE
fix(nuxt): Use correct server output file path

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -64,21 +64,23 @@ export default defineNuxtModule<ModuleOptions>({
       setupSourceMaps(moduleOptions, nuxt);
     }
 
-    if (serverConfigFile && serverConfigFile.includes('.server.config')) {
-      addServerConfigToBuild(moduleOptions, nuxt, serverConfigFile);
+    nuxt.hooks.hook('nitro:init', nitro => {
+      if (serverConfigFile && serverConfigFile.includes('.server.config')) {
+        addServerConfigToBuild(moduleOptions, nuxt, nitro, serverConfigFile);
 
-      if (moduleOptions.experimental_basicServerTracing) {
-        addSentryTopImport(moduleOptions, nuxt);
-      } else {
-        if (moduleOptions.debug) {
-          consoleSandbox(() => {
-            // eslint-disable-next-line no-console
-            console.log(
-              `[Sentry] Using your \`${serverConfigFile}\` file for the server-side Sentry configuration. In case you have a \`public/instrument.server\` file, the \`public/instrument.server\` file will be ignored. Make sure the file path in your node \`--import\` option matches the Sentry server config file in your \`.output\` folder and has a \`.mjs\` extension.`,
-            );
-          });
+        if (moduleOptions.experimental_basicServerTracing) {
+          addSentryTopImport(moduleOptions, nitro);
+        } else {
+          if (moduleOptions.debug) {
+            consoleSandbox(() => {
+              // eslint-disable-next-line no-console
+              console.log(
+                `[Sentry] Using your \`${serverConfigFile}\` file for the server-side Sentry configuration. In case you have a \`public/instrument.server\` file, the \`public/instrument.server\` file will be ignored. Make sure the file path in your node \`--import\` option matches the Sentry server config file in your \`.output\` folder and has a \`.mjs\` extension.`,
+              );
+            });
+          }
         }
       }
-    }
+    });
   },
 });

--- a/packages/nuxt/src/vite/addServerConfig.ts
+++ b/packages/nuxt/src/vite/addServerConfig.ts
@@ -32,9 +32,9 @@ export function addServerConfigToBuild(
      * This is necessary because we need to reference this file path in the node --import option.
      */
     nitro.hooks.hook('close', async () => {
-      const rootDirResolver = createResolver(nitro.options.rootDir);
+      const buildDirResolver = createResolver(nitro.options.buildDir);
       const serverDirResolver = createResolver(nitro.options.output.serverDir);
-      const source = rootDirResolver.resolve('.nuxt/dist/server/sentry.server.config.mjs');
+      const source = buildDirResolver.resolve('dist/server/sentry.server.config.mjs');
       const destination = serverDirResolver.resolve('sentry.server.config.mjs');
 
       try {


### PR DESCRIPTION
Depending on the [nitro preset](https://nitro.unjs.io/deploy), the build output changes. By using the `serverDir` option, the directory can be retrieved dynamically.