### PR TITLE
chore: Remove alpha note from cloudflare readme

### DIFF
--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -15,9 +15,6 @@
 - [Official SDK Docs](https://docs.sentry.io/quickstart/)
 - [TypeDoc](http://getsentry.github.io/sentry-javascript/)
 
-**Note: This SDK is in an alpha state. Please follow the
-[tracking GH issue](https://github.com/getsentry/sentry-javascript/issues/12620) for updates.**
-
 ## Install
 
 To get started, first install the `@sentry/cloudflare` package:


### PR DESCRIPTION
Removes alpha note from cloudflare sdk readme.

ref https://github.com/getsentry/sentry-javascript/issues/12620