### PR TITLE
meta(changelog): Add PR link to changelog entry

### DIFF
--- a/scripts/get-commit-list.ts
+++ b/scripts/get-commit-list.ts
@@ -24,8 +24,11 @@ function run(): void {
 
   newCommits.sort((a, b) => a.localeCompare(b));
 
+  const issueUrl = 'https://github.com/getsentry/sentry-javascript/pull/';
+  const newCommitsWithLink = newCommits.map(commit => commit.replace(/#(\d+)/, `[#$1](${issueUrl}$1)`));
+
   // eslint-disable-next-line no-console
-  console.log(newCommits.join('\n'));
+  console.log(newCommitsWithLink.join('\n'));
 }
 
 run();


### PR DESCRIPTION
Adds the PR link to the changelog for easier access.

An entry would look like this:

> - feat(node): Add `dataloader` integration ([#13664](https://github.com/getsentry/sentry-javascript/pull/13664))
> ```
> - feat(node): Add `dataloader` integration ([#13664](https://github.com/getsentry/sentry-javascript/pull/13664))
> ```
