### PR TITLE
test(nestjs): Fix e2e test dependency to allow prereleases

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-graphql/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-graphql/package.json
@@ -21,7 +21,8 @@
     "@nestjs/core": "^10.3.10",
     "@nestjs/graphql": "^12.2.0",
     "@nestjs/platform-express": "^10.3.10",
-    "@sentry/nestjs": "^8.21.0",
+    "@sentry/nestjs": "latest || *",
+    "@sentry/types": "latest || *",
     "graphql": "^16.9.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"


### PR DESCRIPTION
This fails e.g. here https://github.com/getsentry/sentry-javascript/actions/runs/10964808053/job/30450399966 for prereleases right now, because the prerelease in the verdaccio registry does not match the required range.