### PR TITLE
fix(core): Remove `sampled` flag from dynamic sampling context in Tracing without Performance mode

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/server.js
@@ -4,18 +4,6 @@ const Sentry = require('@sentry/node');
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
-  beforeSend(event) {
-    if (!event.contexts.traceData) {
-      event.contexts = {
-        ...event.contexts,
-        traceData: {
-          ...Sentry.getTraceData(),
-          metaTags: Sentry.getTraceMetaTags(),
-        },
-      };
-    }
-    return event;
-  },
 });
 
 // express must be required after Sentry is initialized
@@ -24,11 +12,6 @@ const express = require('express');
 const app = express();
 
 app.get('/test', (_req, res) => {
-  Sentry.captureException(new Error('test error'));
-  res.status(200).send();
-});
-
-app.get('/test-scope', (_req, res) => {
   Sentry.withScope(scope => {
     scope.setContext('traceData', {
       ...Sentry.getTraceData(),

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/test.ts
@@ -30,31 +30,6 @@ describe('errors in TwP mode have same trace in trace context and getTraceData()
       .makeRequest('get', '/test');
   });
 
-  test('in incoming request with Custom Scope', done => {
-    createRunner(__dirname, 'server.js')
-      .expect({
-        event: event => {
-          const { contexts } = event;
-          const { trace_id, span_id } = contexts?.trace || {};
-          expect(trace_id).toMatch(/^[a-f0-9]{32}$/);
-          expect(span_id).toMatch(/^[a-f0-9]{16}$/);
-
-          const traceData = contexts?.traceData || {};
-
-          expect(traceData['sentry-trace']).toEqual(`${trace_id}-${span_id}`);
-
-          expect(traceData.baggage).toContain(`sentry-trace_id=${trace_id}`);
-          expect(traceData.baggage).not.toContain('sentry-sampled=');
-
-          expect(traceData.metaTags).toContain(`<meta name="sentry-trace" content="${trace_id}-${span_id}"/>`);
-          expect(traceData.metaTags).toContain(`sentry-trace_id=${trace_id}`);
-          expect(traceData.metaTags).not.toContain('sentry-sampled=');
-        },
-      })
-      .start(done)
-      .makeRequest('get', '/test-scope');
-  });
-
   test('outside of a request handler', done => {
     createRunner(__dirname, 'no-server.js')
       .expect({

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
@@ -27,5 +27,6 @@ describe('getTraceMetaTags', () => {
     expect(sentryBaggageContent).toContain('sentry-environment=production');
     expect(sentryBaggageContent).toContain('sentry-public_key=public');
     expect(sentryBaggageContent).toContain(`sentry-trace_id=${traceId}`);
+    expect(sentryBaggageContent).not.toContain('sentry-sampled=');
   });
 });


### PR DESCRIPTION
This PR fixes a bug in Core that surfaced in Node apps configured for Tracing without Performance. 

Previously, we'd incorrectly add`sampled: false` flag when creating the DSC from an active span if the application was configured for TwP. This is possible because in TwP, Otel still emits non-recording spans for the incoming requests. Our implementation in Core didn't account for this edge case yet.

This PR also adds a regression test and fixes some previously incorrectly passing tests.