### PR TITLE
fix(node): Ensure node-fetch does not emit spans without tracing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -895,6 +895,7 @@ jobs:
             'node-express-cjs-preload',
             'node-otel-sdk-node',
             'node-otel-custom-sampler',
+            'node-otel-without-tracing',
             'ember-classic',
             'ember-embroider',
             'nextjs-app-dir',

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ local.log
 .rpt2_cache
 
 lint-results.json
+trace.zip
 
 # legacy
 tmp.js

--- a/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/package.json
@@ -11,10 +11,10 @@
     "test:assert": "pnpm test"
   },
   "dependencies": {
-    "@opentelemetry/sdk-trace-node": "1.25.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
-    "@opentelemetry/instrumentation-undici": "0.4.0",
-    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/sdk-trace-node": "1.26.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.53.0",
+    "@opentelemetry/instrumentation-undici": "0.6.0",
+    "@opentelemetry/instrumentation": "0.53.0",
     "@sentry/core": "latest || *",
     "@sentry/node": "latest || *",
     "@sentry/opentelemetry": "latest || *",

--- a/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/src/instrument.ts
@@ -5,7 +5,7 @@ const { SentrySpanProcessor, SentryPropagator } = require('@sentry/opentelemetry
 const { UndiciInstrumentation } = require('@opentelemetry/instrumentation-undici');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 
-const sentryClient = Sentry.init({
+Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/scenario.ts
@@ -22,7 +22,7 @@ async function run(): Promise<void> {
   Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
 
   await makeHttpRequest(`${process.env.SERVER_URL}/api/v0`);
-  await makeHttpRequest(`${process.env.SERVER_URL}/api/v1`);
+  await makeHttpGet(`${process.env.SERVER_URL}/api/v1`);
   await makeHttpRequest(`${process.env.SERVER_URL}/api/v2`);
   await makeHttpRequest(`${process.env.SERVER_URL}/api/v3`);
 
@@ -44,5 +44,18 @@ function makeHttpRequest(url: string): Promise<void> {
         });
       })
       .end();
+  });
+}
+
+function makeHttpGet(url: string): Promise<void> {
+  return new Promise<void>(resolve => {
+    http.get(url, httpRes => {
+      httpRes.on('data', () => {
+        // we don't care about data
+      });
+      httpRes.on('end', () => {
+        resolve();
+      });
+    });
   });
 }

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/scenario.ts
@@ -13,7 +13,7 @@ import * as http from 'http';
 
 async function run(): Promise<void> {
   await makeHttpRequest(`${process.env.SERVER_URL}/api/v0`);
-  await makeHttpRequest(`${process.env.SERVER_URL}/api/v1`);
+  await makeHttpGet(`${process.env.SERVER_URL}/api/v1`);
   await makeHttpRequest(`${process.env.SERVER_URL}/api/v2`);
   await makeHttpRequest(`${process.env.SERVER_URL}/api/v3`);
 
@@ -35,5 +35,18 @@ function makeHttpRequest(url: string): Promise<void> {
         });
       })
       .end();
+  });
+}
+
+function makeHttpGet(url: string): Promise<void> {
+  return new Promise<void>(resolve => {
+    http.get(url, httpRes => {
+      httpRes.on('data', () => {
+        // we don't care about data
+      });
+      httpRes.on('end', () => {
+        resolve();
+      });
+    });
   });
 }

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/test.ts
@@ -38,6 +38,56 @@ test('outgoing http requests are correctly instrumented with tracing disabled', 
                 },
               ],
             },
+            breadcrumbs: [
+              {
+                message: 'manual breadcrumb',
+                timestamp: expect.any(Number),
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v0`,
+                  status_code: 404,
+                  ADDED_PATH: '/api/v0',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v1`,
+                  status_code: 404,
+                  ADDED_PATH: '/api/v1',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v2`,
+                  status_code: 404,
+                  ADDED_PATH: '/api/v2',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v3`,
+                  status_code: 404,
+                  ADDED_PATH: '/api/v3',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+            ],
           },
         })
         .start(closeTestServer);

--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -1,7 +1,18 @@
+import { context, propagation, trace } from '@opentelemetry/api';
 import type { UndiciRequest, UndiciResponse } from '@opentelemetry/instrumentation-undici';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, addBreadcrumb, defineIntegration } from '@sentry/core';
-import { addOpenTelemetryInstrumentation } from '@sentry/opentelemetry';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  addBreadcrumb,
+  defineIntegration,
+  getCurrentScope,
+  hasTracingEnabled,
+} from '@sentry/core';
+import {
+  addOpenTelemetryInstrumentation,
+  generateSpanContextForPropagationContext,
+  getPropagationContextFromSpan,
+} from '@sentry/opentelemetry';
 import type { IntegrationFn, SanitizedRequestData } from '@sentry/types';
 import { getBreadcrumbLogLevelFromHttpStatusCode, getSanitizedUrlString, parseUrl } from '@sentry/utils';
 
@@ -32,7 +43,44 @@ const _nativeNodeFetchIntegration = ((options: NodeFetchOptions = {}) => {
           const url = getAbsoluteUrl(request.origin, request.path);
           const shouldIgnore = _ignoreOutgoingRequests && url && _ignoreOutgoingRequests(url);
 
-          return !!shouldIgnore;
+          if (shouldIgnore) {
+            return true;
+          }
+
+          // If tracing is disabled, we still want to propagate traces
+          // So we do that manually here, matching what the instrumentation does otherwise
+          if (!hasTracingEnabled()) {
+            const ctx = context.active();
+            const addedHeaders: Record<string, string> = {};
+
+            // We generate a virtual span context from the active one,
+            // Where we attach the URL to the trace state, so the propagator can pick it up
+            const activeSpan = trace.getSpan(ctx);
+            const propagationContext = activeSpan
+              ? getPropagationContextFromSpan(activeSpan)
+              : getCurrentScope().getPropagationContext();
+
+            const spanContext = generateSpanContextForPropagationContext(propagationContext);
+            // We know that in practice we'll _always_ haven a traceState here
+            spanContext.traceState = spanContext.traceState?.set('sentry.url', url);
+            const ctxWithUrlTraceState = trace.setSpanContext(ctx, spanContext);
+
+            propagation.inject(ctxWithUrlTraceState, addedHeaders);
+
+            const requestHeaders = request.headers;
+            if (Array.isArray(requestHeaders)) {
+              Object.entries(addedHeaders).forEach(headers => requestHeaders.push(...headers));
+            } else {
+              request.headers += Object.entries(addedHeaders)
+                .map(([k, v]) => `${k}: ${v}\r\n`)
+                .join('');
+            }
+
+            // Prevent starting a span for this request
+            return true;
+          }
+
+          return false;
         },
         startSpanHook: () => {
           return {


### PR DESCRIPTION
Found this while working on https://github.com/getsentry/sentry-javascript/pull/13763.

Oops, the node-otel-without-tracing E2E test was not running on CI, we forgot to add it there - and it was actually failing since we switched to the new undici instrumentation :O

This PR ensures to add it to CI, and also fixes it. The main change for this is to ensure we do not emit any spans when tracing  is disabled, while still ensuring that trace propagation works as expected for this case.

I also pulled some general changes into this, which ensure that we patch both `http.get` and `http.request` properly.