### PR TITLE
fix(node): Ensure graphql options are correct when preloading

### DIFF
--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -40,6 +40,8 @@ const INTEGRATION_NAME = 'Graphql';
 export const instrumentGraphql = generateInstrumentOnce<GraphqlOptions>(
   INTEGRATION_NAME,
   (_options: GraphqlOptions = {}) => {
+    // We set default values here, which are used in the case that this is preloaded
+    // In that case, no options are passed in, and we want to use the defaults
     const options = {
       ignoreResolveSpans: true,
       ignoreTrivialResolveSpans: true,
@@ -85,10 +87,20 @@ export const instrumentGraphql = generateInstrumentOnce<GraphqlOptions>(
   },
 );
 
-const _graphqlIntegration = ((options: GraphqlOptions = {}) => {
+const _graphqlIntegration = ((_options: GraphqlOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
+      // We set defaults here, too, because otherwise we'd update the instrumentation config
+      // to the config without defaults, as `generateInstrumentOnce` automatically calls `setConfig(options)`
+      // when being called the second time
+      const options = {
+        ignoreResolveSpans: true,
+        ignoreTrivialResolveSpans: true,
+        useOperationNameForRootSpan: true,
+        ..._options,
+      };
+
       instrumentGraphql(options);
     },
   };

--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -40,14 +40,7 @@ const INTEGRATION_NAME = 'Graphql';
 export const instrumentGraphql = generateInstrumentOnce<GraphqlOptions>(
   INTEGRATION_NAME,
   (_options: GraphqlOptions = {}) => {
-    // We set default values here, which are used in the case that this is preloaded
-    // In that case, no options are passed in, and we want to use the defaults
-    const options = {
-      ignoreResolveSpans: true,
-      ignoreTrivialResolveSpans: true,
-      useOperationNameForRootSpan: true,
-      ..._options,
-    };
+    const options = getOptionsWithDefaults(_options);
 
     return new GraphQLInstrumentation({
       ...options,
@@ -87,21 +80,14 @@ export const instrumentGraphql = generateInstrumentOnce<GraphqlOptions>(
   },
 );
 
-const _graphqlIntegration = ((_options: GraphqlOptions = {}) => {
+const _graphqlIntegration = ((options: GraphqlOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
       // We set defaults here, too, because otherwise we'd update the instrumentation config
       // to the config without defaults, as `generateInstrumentOnce` automatically calls `setConfig(options)`
       // when being called the second time
-      const options = {
-        ignoreResolveSpans: true,
-        ignoreTrivialResolveSpans: true,
-        useOperationNameForRootSpan: true,
-        ..._options,
-      };
-
-      instrumentGraphql(options);
+      instrumentGraphql(getOptionsWithDefaults(options));
     },
   };
 }) satisfies IntegrationFn;
@@ -112,3 +98,12 @@ const _graphqlIntegration = ((_options: GraphqlOptions = {}) => {
  * Capture tracing data for GraphQL.
  */
 export const graphqlIntegration = defineIntegration(_graphqlIntegration);
+
+function getOptionsWithDefaults(options?: GraphqlOptions): GraphqlOptions {
+  return {
+    ignoreResolveSpans: true,
+    ignoreTrivialResolveSpans: true,
+    useOperationNameForRootSpan: true,
+    ...options,
+  };
+}

--- a/packages/node/src/otel/instrument.ts
+++ b/packages/node/src/otel/instrument.ts
@@ -1,7 +1,8 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { addOpenTelemetryInstrumentation } from '@sentry/opentelemetry';
 
-const INSTRUMENTED: Record<string, Instrumentation> = {};
+/** Exported only for tests. */
+export const INSTRUMENTED: Record<string, Instrumentation> = {};
 
 /**
  * Instrument an OpenTelemetry instrumentation once.

--- a/packages/node/test/integrations/tracing/graphql.test.ts
+++ b/packages/node/test/integrations/tracing/graphql.test.ts
@@ -1,0 +1,46 @@
+import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
+import { graphqlIntegration, instrumentGraphql } from '../../../src/integrations/tracing/graphql';
+import { INSTRUMENTED } from '../../../src/otel/instrument';
+
+jest.mock('@opentelemetry/instrumentation-graphql');
+
+describe('GraphQL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete INSTRUMENTED.Graphql;
+
+    (GraphQLInstrumentation as unknown as jest.SpyInstance).mockImplementation(() => {
+      return {
+        setTracerProvider: () => undefined,
+        setMeterProvider: () => undefined,
+        getConfig: () => ({}),
+        setConfig: () => ({}),
+        enable: () => undefined,
+      };
+    });
+  });
+
+  it('defaults are correct for instrumentGraphql', () => {
+    instrumentGraphql({ ignoreTrivialResolveSpans: false });
+
+    expect(GraphQLInstrumentation).toHaveBeenCalledTimes(1);
+    expect(GraphQLInstrumentation).toHaveBeenCalledWith({
+      ignoreResolveSpans: true,
+      ignoreTrivialResolveSpans: false,
+      useOperationNameForRootSpan: true,
+      responseHook: expect.any(Function),
+    });
+  });
+
+  it('defaults are correct for _graphqlIntegration', () => {
+    graphqlIntegration({ ignoreTrivialResolveSpans: false }).setupOnce!();
+
+    expect(GraphQLInstrumentation).toHaveBeenCalledTimes(1);
+    expect(GraphQLInstrumentation).toHaveBeenCalledWith({
+      ignoreResolveSpans: true,
+      ignoreTrivialResolveSpans: false,
+      useOperationNameForRootSpan: true,
+      responseHook: expect.any(Function),
+    });
+  });
+});


### PR DESCRIPTION
Noticed this by chance, due to the way `generateInstrumentOnce` works, we need to pass in the fully formed config.