### PR TITLE
fix(docs): Correct supported browsers due to `globalThis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1079,12 +1079,12 @@ with full support for ESM-based node apps using **Node.js 18.19.0 or higher**.
 [**ES2018+**](https://caniuse.com/?feats=mdn-javascript_builtins_regexp_dotall,js-regexp-lookbehind,mdn-javascript_builtins_regexp_named_capture_groups,mdn-javascript_builtins_regexp_property_escapes,mdn-javascript_builtins_symbol_asynciterator,mdn-javascript_functions_method_definitions_async_generator_methods,mdn-javascript_grammar_template_literals_template_literal_revision,mdn-javascript_operators_destructuring_rest_in_objects,mdn-javascript_operators_destructuring_rest_in_arrays,promise-finally)
 compatible browsers. New minimum browser versions:
 
-- Chrome 63
+- Chrome 71
 - Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
+- Safari 12.1, iOS Safari 12.2
+- Firefox 65
+- Opera 58
+- Samsung Internet 10
 
 For more details, please see the
 [version support section in our migration guide](./MIGRATION.md#1-version-support-changes).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,8 +25,10 @@ applies to `@sentry/node` and all of our node-based server-side sdks (`@sentry/n
 no longer test against Node 8, 10, or 12 and cannot guarantee that the SDK will work as expected on these versions.
 
 **Browser**: Our browser SDKs (`@sentry/browser`, `@sentry/react`, `@sentry/vue`, etc.) now require ES2018+
-compatibility plus support for `globalThis`. This means that we no longer support IE11 (end of an era). This also means
-that the Browser SDK requires the fetch API to be available in the environment.
+compatibility plus support for
+[`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis). This  means
+that we no longer support IE11 (end of an era). This also means that the Browser SDK requires the fetch API to be
+available in the environment.
 
 New minimum supported browsers:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -24,18 +24,18 @@ higher. Lower versions may continue to work, but may not support all features (e
 applies to `@sentry/node` and all of our node-based server-side sdks (`@sentry/nextjs`, `@sentry/serverless`, etc.). We
 no longer test against Node 8, 10, or 12 and cannot guarantee that the SDK will work as expected on these versions.
 
-**Browser**: Our browser SDKs (`@sentry/browser`, `@sentry/react`, `@sentry/vue`, etc.) now require ES2018+ compatible
-browsers. This means that we no longer support IE11 (end of an era). This also means that the Browser SDK requires the
-fetch API to be available in the environment.
+**Browser**: Our browser SDKs (`@sentry/browser`, `@sentry/react`, `@sentry/vue`, etc.) now require ES2018+
+compatibility plus support for `globalThis`. This means that we no longer support IE11 (end of an era). This also means
+that the Browser SDK requires the fetch API to be available in the environment.
 
 New minimum supported browsers:
 
-- Chrome 63
+- Chrome 71
 - Edge 79
-- Safari/iOS Safari 12
-- Firefox 58
-- Opera 50
-- Samsung Internet 8.2
+- Safari 12.1, iOS Safari 12.2
+- Firefox 65
+- Opera 58
+- Samsung Internet 10
 
 For IE11 support please transpile your code to ES5 using babel or similar and add required polyfills.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -26,7 +26,7 @@ no longer test against Node 8, 10, or 12 and cannot guarantee that the SDK will 
 
 **Browser**: Our browser SDKs (`@sentry/browser`, `@sentry/react`, `@sentry/vue`, etc.) now require ES2018+
 compatibility plus support for
-[`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis). This  means
+[`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis). This means
 that we no longer support IE11 (end of an era). This also means that the Browser SDK requires the fetch API to be
 available in the environment.
 


### PR DESCRIPTION
Before the v8 release we decided to use `globalThis` to simplify access the global object across all platforms and contexts.

`globalThis` is not ES2018 but we didn't consider this when the minimum supported browser versions were documented.
