### PR TITLE
ci: Fix adding bundle sizes to releases

### DIFF
--- a/.github/workflows/release-size-info.yml
+++ b/.github/workflows/release-size-info.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Update Github Release
         if: steps.get_version.outputs.version != ''
-        uses: getsentry/size-limit-release@fn/update-new-artifacts
+        uses: getsentry/size-limit-release@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/release-size-info.yml
+++ b/.github/workflows/release-size-info.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Update Github Release
         if: steps.get_version.outputs.version != ''
-        uses: getsentry/size-limit-release@v1
+        uses: getsentry/size-limit-release@fn/update-new-artifacts
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
Implements https://github.com/getsentry/size-limit-release/pull/6 

This is now working again: https://github.com/getsentry/sentry-javascript/actions/runs/11031636865