### PR TITLE
fix(nuxt): Use absolute path for client config

### DIFF
--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -22,7 +22,5 @@ export function findDefaultSdkInitFile(type: 'server' | 'client'): string | unde
     }
   }
 
-  const filePath = filePaths.find(filename => fs.existsSync(filename));
-
-  return filePath ? filePath : undefined;
+  return filePaths.find(filename => fs.existsSync(filename));
 }

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -24,5 +24,5 @@ export function findDefaultSdkInitFile(type: 'server' | 'client'): string | unde
 
   const filePath = filePaths.find(filename => fs.existsSync(filename));
 
-  return filePath ? path.basename(filePath) : undefined;
+  return filePath ? filePath : undefined;
 }

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -10,26 +10,26 @@ describe('findDefaultSdkInitFile', () => {
   });
 
   it.each(['ts', 'js', 'mjs', 'cjs', 'mts', 'cts'])(
-    'should return the server file with .%s extension if it exists',
+    'should return the server file path with .%s extension if it exists',
     ext => {
       vi.spyOn(fs, 'existsSync').mockImplementation(filePath => {
         return !(filePath instanceof URL) && filePath.includes(`sentry.server.config.${ext}`);
       });
 
       const result = findDefaultSdkInitFile('server');
-      expect(result).toBe(`sentry.server.config.${ext}`);
+      expect(result).toMatch(`packages/nuxt/sentry.server.config.${ext}`);
     },
   );
 
   it.each(['ts', 'js', 'mjs', 'cjs', 'mts', 'cts'])(
-    'should return the client file with .%s extension if it exists',
+    'should return the client file path with .%s extension if it exists',
     ext => {
       vi.spyOn(fs, 'existsSync').mockImplementation(filePath => {
         return !(filePath instanceof URL) && filePath.includes(`sentry.client.config.${ext}`);
       });
 
       const result = findDefaultSdkInitFile('client');
-      expect(result).toBe(`sentry.client.config.${ext}`);
+      expect(result).toMatch(`packages/nuxt/sentry.client.config.${ext}`);
     },
   );
 
@@ -47,7 +47,7 @@ describe('findDefaultSdkInitFile', () => {
     expect(result).toBeUndefined();
   });
 
-  it('should return the server config file if server.config and instrument exist', () => {
+  it('should return the server config file path if server.config and instrument exist', () => {
     vi.spyOn(fs, 'existsSync').mockImplementation(filePath => {
       return (
         !(filePath instanceof URL) &&
@@ -56,6 +56,6 @@ describe('findDefaultSdkInitFile', () => {
     });
 
     const result = findDefaultSdkInitFile('server');
-    expect(result).toBe('sentry.server.config.js');
+    expect(result).toMatch('packages/nuxt/sentry.server.config.js');
   });
 });


### PR DESCRIPTION
The `buildDir` can be changed in Nuxt and Adding the client config with a relative path worked so far as the `buildDir` in Nuxt v3 is [`/<rootDir>/.nuxt`](https://nuxt.com/docs/api/nuxt-config#builddir) but the `buildDir` can be modified by the user and is also different in Nuxt v4 ([`/<rootDir>/node_modules/.cache/nuxt/.nuxt`](https://github.com/nuxt/nuxt/blob/f56c05d39de5223c5fa8603ed216e91747937d54/packages/kit/src/loader/config.ts#L54)). 

By using the absolute path, the client config can be injected correctly with all `buildDir` variations