### PR TITLE
fix(nuxt): Don't restrict source map assets upload

### DIFF
--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -39,7 +39,7 @@ export function setupSourceMaps(moduleOptions: SentryNuxtModuleOptions, nuxt: Nu
       }
 
       // Add Sentry plugin
-      nitroConfig.rollupConfig.plugins.push(sentryRollupPlugin(getPluginOptions(moduleOptions, true)));
+      nitroConfig.rollupConfig.plugins.push(sentryRollupPlugin(getPluginOptions(moduleOptions)));
 
       // Enable source maps
       nitroConfig.rollupConfig.output = nitroConfig?.rollupConfig?.output || {};
@@ -58,10 +58,7 @@ function normalizePath(path: string): string {
   return path.replace(/^(\.\.\/)+/, './');
 }
 
-function getPluginOptions(
-  moduleOptions: SentryNuxtModuleOptions,
-  _isNitro = false,
-): SentryVitePluginOptions | SentryRollupPluginOptions {
+function getPluginOptions(moduleOptions: SentryNuxtModuleOptions): SentryVitePluginOptions | SentryRollupPluginOptions {
   const sourceMapsUploadOptions = moduleOptions.sourceMapsUploadOptions || {};
 
   return {
@@ -70,8 +67,8 @@ function getPluginOptions(
     authToken: sourceMapsUploadOptions.authToken ?? process.env.SENTRY_AUTH_TOKEN,
     telemetry: sourceMapsUploadOptions.telemetry ?? true,
     sourcemaps: {
-      // The server/client files are in different places depending on the nitro preset (e.g. '.output/server' or '.netlify/functions-internal/server'
-      // We cannot determine automatically how the build folder looks like (depends on the preset), so we have to accept that sourcemaps are generated multiple times (with Vite for Nuxt and Rollup for Nitro).
+      // The server/client files are in different places depending on the nitro preset (e.g. '.output/server' or '.netlify/functions-internal/server')
+      // We cannot determine automatically how the build folder looks like (depends on the preset), so we have to accept that sourcemaps are uploaded multiple times (with the vitePlugin for Nuxt and the rollupPlugin for Nitro).
       // If we could know where the server/client assets are located, we could do something like this (based on the Nitro preset): isNitro ? ['./.output/server/**/*'] : ['./.output/public/**/*'],
       assets: sourceMapsUploadOptions.sourcemaps?.assets ?? undefined,
       ignore: sourceMapsUploadOptions.sourcemaps?.ignore ?? undefined,

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -60,7 +60,7 @@ function normalizePath(path: string): string {
 
 function getPluginOptions(
   moduleOptions: SentryNuxtModuleOptions,
-  isNitro = false,
+  _isNitro = false,
 ): SentryVitePluginOptions | SentryRollupPluginOptions {
   const sourceMapsUploadOptions = moduleOptions.sourceMapsUploadOptions || {};
 
@@ -70,8 +70,10 @@ function getPluginOptions(
     authToken: sourceMapsUploadOptions.authToken ?? process.env.SENTRY_AUTH_TOKEN,
     telemetry: sourceMapsUploadOptions.telemetry ?? true,
     sourcemaps: {
-      assets:
-        sourceMapsUploadOptions.sourcemaps?.assets ?? isNitro ? ['./.output/server/**/*'] : ['./.output/public/**/*'],
+      // The server/client files are in different places depending on the nitro preset (e.g. '.output/server' or '.netlify/functions-internal/server'
+      // We cannot determine automatically how the build folder looks like (depends on the preset), so we have to accept that sourcemaps are generated multiple times (with Vite for Nuxt and Rollup for Nitro).
+      // If we could know where the server/client assets are located, we could do something like this (based on the Nitro preset): isNitro ? ['./.output/server/**/*'] : ['./.output/public/**/*'],
+      assets: sourceMapsUploadOptions.sourcemaps?.assets ?? undefined,
       ignore: sourceMapsUploadOptions.sourcemaps?.ignore ?? undefined,
       filesToDeleteAfterUpload: sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload ?? undefined,
       rewriteSources: (source: string) => normalizePath(source),


### PR DESCRIPTION
Source maps generated by Vite are only for the Nuxt-part of the application whereas source maps generated by Rollup are only for the Nitro-part of the application. The Nuxt-part of the application has some overlap with the Nitro-part and so it **would** be nice to specify the client/server folder in the `assets` option, but the output is different for every Nitro preset (the files are always located under a different path). 

Should fix https://github.com/getsentry/sentry-javascript/issues/13703
