### PR TITLE
fix(fetch): Fix memory leak when handling endless streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-6/tests/sse.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/tests/sse.test.ts
@@ -45,7 +45,6 @@ test('Waits for sse streaming when sse has been explicitly aborted', async ({ pa
   await fetchButton.click();
 
   const rootSpan = await transactionPromise;
-  console.log(JSON.stringify(rootSpan, null, 2));
   const sseFetchCall = rootSpan.spans?.filter(span => span.description === 'sse fetch call')[0] as SpanJSON;
   const httpGet = rootSpan.spans?.filter(span => span.description === 'GET http://localhost:8080/sse')[0] as SpanJSON;
 
@@ -71,7 +70,7 @@ test('Waits for sse streaming when sse has been explicitly aborted', async ({ pa
   expect(consoleBreadcrumb?.message).toBe('Could not fetch sse AbortError: BodyStreamBuffer was aborted');
 });
 
-test('Aborts when stream takes longer than 5s', async ({ page }) => {
+test('Aborts when stream takes longer than 5s, by not updating the span duration', async ({ page }) => {
   await page.goto('/sse');
 
   const transactionPromise = waitForTransaction('react-router-6', async transactionEvent => {
@@ -102,5 +101,5 @@ test('Aborts when stream takes longer than 5s', async ({ page }) => {
   const resolveBodyDuration = Math.round((httpGet.timestamp as number) - httpGet.start_timestamp);
 
   expect(resolveDuration).toBe(0);
-  expect(resolveBodyDuration).toBe(7);
+  expect(resolveBodyDuration).toBe(0);
 });

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -122,13 +122,13 @@ async function resolveResponse(res: Response | undefined, onFinishedResolving: (
     // NOTE: Still looking for a better solution to handle endless streams (e.g., CCTV).
     //       Currently, this implementation does not trigger onFinishedResolving
     //       for streams that never end, as the 'done' condition is never met.
-    let reading = true
+    let reading = true;
     while (reading) {
       try {
         // abort reading if read op takes more than 5s
         const { done } = await Promise.race([
           responseReader.read(),
-          new Promise<{ done: boolean }>((resolve) => setTimeout(() => resolve({ done: true }), 5000)),
+          new Promise<{ done: boolean }>(resolve => setTimeout(() => resolve({ done: true }), 5000)),
         ]);
 
         if (done) reading = false;

--- a/packages/utils/src/instrument/fetch.ts
+++ b/packages/utils/src/instrument/fetch.ts
@@ -141,6 +141,7 @@ async function resolveResponse(res: Response | undefined, onFinishedResolving: (
           });
         }, 5000);
 
+        // This .read() call will reject/throw when we abort due to timeouts through `body.cancel()`
         const { done } = await responseReader.read();
 
         clearTimeout(chunkTimeout);
@@ -159,7 +160,7 @@ async function resolveResponse(res: Response | undefined, onFinishedResolving: (
     clearTimeout(maxFetchDurationTimeout);
 
     responseReader.releaseLock();
-    responseReader.cancel().then(null, () => {
+    body.cancel().then(null, () => {
       // noop on error
     });
   }


### PR DESCRIPTION
This is a quick fix to address a memory overflow issue caused by the recursive approach when handling endless streams (e.g., CCTV).   

However, this is not a perfect solution, as this approach still does not trigger the onFinishedResolving callback for streams that never terminate.

Fixes GH-13806

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

The lints didn't pass but they are unrelated to the changes in this commit?  
![image](https://github.com/user-attachments/assets/e5486c96-b26a-4b3f-9d50-3d8ae22cb83e)

