### PR TITLE
feat(replay): Stop global event handling for paused replays

### DIFF
--- a/packages/replay-internal/src/coreHandlers/handleGlobalEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleGlobalEvent.ts
@@ -14,8 +14,8 @@ import { shouldSampleForBufferEvent } from './util/shouldSampleForBufferEvent';
 export function handleGlobalEventListener(replay: ReplayContainer): (event: Event, hint: EventHint) => Event | null {
   return Object.assign(
     (event: Event, hint: EventHint) => {
-      // Do nothing if replay has been disabled
-      if (!replay.isEnabled()) {
+      // Do nothing if replay has been disabled or paused
+      if (!replay.isEnabled() || replay.isPaused()) {
         return event;
       }
 

--- a/packages/replay-internal/test/integration/coreHandlers/handleGlobalEvent.test.ts
+++ b/packages/replay-internal/test/integration/coreHandlers/handleGlobalEvent.test.ts
@@ -397,4 +397,23 @@ describe('Integration | coreHandlers | handleGlobalEvent', () => {
 
     expect(handleGlobalEventListener(replay)(errorEvent, {})).toEqual(errorEvent);
   });
+
+  it('does not add replayId if replay is paused', async () => {
+    const transaction = Transaction();
+    const error = Error();
+
+    replay['_isPaused'] = true;
+
+    expect(handleGlobalEventListener(replay)(transaction, {})).toEqual(
+      expect.not.objectContaining({
+        // no tags at all here by default
+        tags: expect.anything(),
+      }),
+    );
+    expect(handleGlobalEventListener(replay)(error, {})).toEqual(
+      expect.objectContaining({
+        tags: expect.not.objectContaining({ replayId: expect.anything() }),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry-javascript/issues/13778

We're running into issues where we have replay session IDs span over hundreds of hours.
This PR is skips event processing for paused replays, which might be part of the issue.

