### PR TITLE
Loosen @sentry/nextjs webpack peer dependency

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -92,7 +92,7 @@
   },
   "peerDependencies": {
     "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0",
-    "webpack": "5.94.0"
+    "webpack": "^5.94.0"
   },
   "peerDependenciesMeta": {
     "webpack": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -92,7 +92,7 @@
   },
   "peerDependencies": {
     "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0",
-    "webpack": "^5.94.0"
+    "webpack": ">=5.0.0"
   },
   "peerDependenciesMeta": {
     "webpack": {


### PR DESCRIPTION
The peer dependency introduced in https://github.com/getsentry/sentry-javascript/pull/13571 seems to be too strict.
After installing the latest next version (14.2.13) and @sentry/next version (8.32.0), I get the following:
```sh
└─┬ @sentry/nextjs 8.32.0
  └── ✕ unmet peer webpack@5.94.0: found 5.95.0
```