### PR TITLE
test: Run Next.js canary tests on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1067,6 +1067,10 @@ jobs:
             'react-send-to-sentry',
             'node-express-send-to-sentry',
             'debug-id-sourcemaps',
+            'nextjs-app-dir',
+            'nextjs-13',
+            'nextjs-14',
+            'nextjs-15',
           ]
         build-command:
           - false
@@ -1081,6 +1085,30 @@ jobs:
           - test-application: 'create-remix-app-legacy'
             assert-command: 'test:assert-sourcemaps'
             label: 'create-remix-app-legacy (sourcemaps)'
+          - test-application: 'nextjs-app-dir'
+            build-command: 'test:build-canary'
+            label: 'nextjs-app-dir (canary)'
+          - test-application: 'nextjs-app-dir'
+            build-command: 'test:build-latest'
+            label: 'nextjs-app-dir (latest)'
+          - test-application: 'nextjs-13'
+            build-command: 'test:build-canary'
+            label: 'nextjs-13 (canary)'
+          - test-application: 'nextjs-13'
+            build-command: 'test:build-latest'
+            label: 'nextjs-13 (latest)'
+          - test-application: 'nextjs-14'
+            build-command: 'test:build-canary'
+            label: 'nextjs-14 (canary)'
+          - test-application: 'nextjs-14'
+            build-command: 'test:build-latest'
+            label: 'nextjs-14 (latest)'
+          - test-application: 'nextjs-15'
+            build-command: 'test:build-canary'
+            label: 'nextjs-15 (canary)'
+          - test-application: 'nextjs-15'
+            build-command: 'test:build-latest'
+            label: 'nextjs-15 (latest)'
 
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})


### PR DESCRIPTION
Since we have a bunch of work planned for Next.js and Next.js conf is moving closer it would be good to check for any changes to be compatible with the most recent Next.js canaries.

Note: The tests are optional and non-blocking for any PRs.