### PR TITLE
fix(browser): Ensure `wrap()` only returns functions

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -64,7 +64,13 @@ export function wrap(
     // the original wrapper.
     const wrapper = fn.__sentry_wrapped__;
     if (wrapper) {
-      return wrapper;
+      if (typeof wrapper === 'function') {
+        return wrapper;
+      } else {
+        // If we find that the `__sentry_wrapped__` function is not a function at the time of accessing it, it means
+        // that something messed with it. In that case we want to return the originally passed function.
+        return fn;
+      }
     }
 
     // We don't wanna wrap it twice

--- a/packages/browser/test/integrations/helpers.test.ts
+++ b/packages/browser/test/integrations/helpers.test.ts
@@ -174,4 +174,17 @@ describe('internal wrap()', () => {
     expect(wrapped.__sentry_original__).toBe(fn);
     expect(fn.__sentry_wrapped__).toBe(wrapped);
   });
+
+  it('should only return __sentry_wrapped__ when it is a function', () => {
+    const fn = (() => 1337) as WrappedFunction;
+
+    wrap(fn);
+    expect(fn).toHaveProperty('__sentry_wrapped__');
+    fn.__sentry_wrapped__ = 'something that is not a function' as any;
+
+    const wrapped = wrap(fn);
+
+    expect(wrapped).toBe(fn);
+    expect(wrapped).not.toBe('something that is not a function');
+  });
 });


### PR DESCRIPTION
`__sentry_wrapped__` may be overwritten by libraries, causing subsequent code to crash if the new value is not a function.