### PR TITLE
ref(nextjs): Swith to pure OTEL performance instrumentation instead of build-time instrumentation for pages router pages

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -115,6 +115,7 @@ export function constructWebpackConfigFunction(
         projectDir,
         rawNewConfig.resolve?.modules,
       ),
+      runtime,
     };
 
     const normalizeLoaderResourcePath = (resourcePath: string): string => {


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/13737

- Stuff to figure out:
  - Can we completely disable build-time instrumentation or will error monitoring stop working?
  - We need to propagate trace data to the frontend somehow.