### PR TITLE
fix(browser/v7): Ensure `wrap()` only returns functions (#13838 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 7.119.1
+
+- fix(browser/v7): Ensure wrap() only returns functions (#13838 backport)
+
 ## 7.119.0
 
 - backport(tracing): Report dropped spans for transactions (#13343)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - fix(browser/v7): Ensure wrap() only returns functions (#13838 backport)
 
+Work in this release contributed by @legobeat. Thank you for your contribution!
+
 ## 7.119.0
 
 - backport(tracing): Report dropped spans for transactions (#13343)

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -66,7 +66,13 @@ export function wrap(
     // the original wrapper.
     const wrapper = fn.__sentry_wrapped__;
     if (wrapper) {
-      return wrapper;
+      if (typeof wrapper === 'function') {
+        return wrapper;
+      } else {
+        // If we find that the `__sentry_wrapped__` function is not a function at the time of accessing it, it means
+        // that something messed with it. In that case we want to return the originally passed function.
+        return fn;
+      }
     }
 
     // We don't wanna wrap it twice

--- a/packages/browser/test/unit/integrations/helpers.test.ts
+++ b/packages/browser/test/unit/integrations/helpers.test.ts
@@ -174,4 +174,17 @@ describe('internal wrap()', () => {
     expect(wrapped.__sentry_original__).toBe(fn);
     expect(fn.__sentry_wrapped__).toBe(wrapped);
   });
+
+  it('should only return __sentry_wrapped__ when it is a function', () => {
+    const fn = (() => 1337) as WrappedFunction;
+
+    wrap(fn);
+    expect(fn).toHaveProperty('__sentry_wrapped__');
+    fn.__sentry_wrapped__ = 'something that is not a function' as any;
+
+    const wrapped = wrap(fn);
+
+    expect(wrapped).toBe(fn);
+    expect(wrapped).not.toBe('something that is not a function');
+  });
 });


### PR DESCRIPTION
Backport of https://github.com/getsentry/sentry-javascript/pull/13838 targeting v7.x.

---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
