### PR TITLE
fix(node): Remove `dataloader` instrumentation from default integrations

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/dataloader/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing/dataloader/scenario.js
@@ -6,6 +6,7 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
+  integrations: [Sentry.dataloaderIntegration()],
 });
 
 const PORT = 8008;

--- a/packages/node/src/integrations/tracing/index.ts
+++ b/packages/node/src/integrations/tracing/index.ts
@@ -3,7 +3,6 @@ import { instrumentHttp } from '../http';
 
 import { amqplibIntegration, instrumentAmqplib } from './amqplib';
 import { connectIntegration, instrumentConnect } from './connect';
-import { dataloaderIntegration, instrumentDataloader } from './dataloader';
 import { expressIntegration, instrumentExpress } from './express';
 import { fastifyIntegration, instrumentFastify } from './fastify';
 import { genericPoolIntegration, instrumentGenericPool } from './genericPool';
@@ -44,7 +43,6 @@ export function getAutoPerformanceIntegrations(): Integration[] {
     connectIntegration(),
     genericPoolIntegration(),
     kafkaIntegration(),
-    dataloaderIntegration(),
     amqplibIntegration(),
     lruMemoizerIntegration(),
   ];
@@ -74,7 +72,6 @@ export function getOpenTelemetryInstrumentationToPreload(): (((options?: any) =>
     instrumentGraphql,
     instrumentRedis,
     instrumentGenericPool,
-    instrumentDataloader,
     instrumentAmqplib,
   ];
 }


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/13869

Removing `dataloader` instrumentation from default integrations until we patch this upstream.