### PR TITLE
feat(cdn): Export `getReplay` in replay CDN bundles

### DIFF
--- a/packages/browser/src/index.bundle.replay.ts
+++ b/packages/browser/src/index.bundle.replay.ts
@@ -6,7 +6,7 @@ import {
 
 export * from './index.bundle.base';
 
-export { replayIntegration } from '@sentry-internal/replay';
+export { replayIntegration, getReplay } from '@sentry-internal/replay';
 
 export {
   browserTracingIntegrationShim as browserTracingIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -29,4 +29,4 @@ import { feedbackAsyncIntegration } from './feedbackAsync';
 export { getFeedback } from '@sentry-internal/feedback';
 export { feedbackAsyncIntegration as feedbackAsyncIntegration, feedbackAsyncIntegration as feedbackIntegration };
 
-export { replayIntegration } from '@sentry-internal/replay';
+export { replayIntegration, getReplay } from '@sentry-internal/replay';

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -27,4 +27,4 @@ export {
 import { feedbackIntegrationShim } from '@sentry-internal/integration-shims';
 export { feedbackIntegrationShim as feedbackAsyncIntegration, feedbackIntegrationShim as feedbackIntegration };
 
-export { replayIntegration } from '@sentry-internal/replay';
+export { replayIntegration, getReplay } from '@sentry-internal/replay';


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/13879

I opted to not export a shim for this in non-Replay bundles, as this is already more advanced usage... We can still opt to export shims here later if needed.