### PR TITLE
ci: Use PAT for external contributor PR

### DIFF
--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
+          # This token is scoped to Daniel Griesser
+          # If we used the default GITHUB_TOKEN, the resulting PR would not trigger CI :(
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
           commit-message: "ref: Add external contributor to CHANGELOG.md"
           title: "ref: Add external contributor to CHANGELOG.md"
           branch: 'external-contributor/patch-${{ github.event.pull_request.user.login }}'


### PR DESCRIPTION
I noticed multiple times, e.g. https://github.com/getsentry/sentry-javascript/pull/13883, that the external contributor PRs do not trigger CI automatically. 

I think this is because stuff that is triggered by GITHUB_TOKEN does not trigger CI. So I am updating this to use the repo scoped token instead, let's see if that works.