### PR TITLE
ref(nextjs): Move pages router instrumentation into separate folder

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -13,7 +13,7 @@ import { applyTunnelRouteOption } from './tunnelRoute';
 
 export * from '@sentry/react';
 
-export { captureUnderscoreErrorException } from '../common/_error';
+export { captureUnderscoreErrorException } from '../common/pages-router-instrumentation/_error';
 
 const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   __rewriteFramesAssetPrefixPath__: string;

--- a/packages/nextjs/src/common/index.ts
+++ b/packages/nextjs/src/common/index.ts
@@ -1,14 +1,14 @@
-export { wrapGetStaticPropsWithSentry } from './wrapGetStaticPropsWithSentry';
-export { wrapGetInitialPropsWithSentry } from './wrapGetInitialPropsWithSentry';
-export { wrapAppGetInitialPropsWithSentry } from './wrapAppGetInitialPropsWithSentry';
-export { wrapDocumentGetInitialPropsWithSentry } from './wrapDocumentGetInitialPropsWithSentry';
-export { wrapErrorGetInitialPropsWithSentry } from './wrapErrorGetInitialPropsWithSentry';
-export { wrapGetServerSidePropsWithSentry } from './wrapGetServerSidePropsWithSentry';
+export { wrapGetStaticPropsWithSentry } from './pages-router-instrumentation/wrapGetStaticPropsWithSentry';
+export { wrapGetInitialPropsWithSentry } from './pages-router-instrumentation/wrapGetInitialPropsWithSentry';
+export { wrapAppGetInitialPropsWithSentry } from './pages-router-instrumentation/wrapAppGetInitialPropsWithSentry';
+export { wrapDocumentGetInitialPropsWithSentry } from './pages-router-instrumentation/wrapDocumentGetInitialPropsWithSentry';
+export { wrapErrorGetInitialPropsWithSentry } from './pages-router-instrumentation/wrapErrorGetInitialPropsWithSentry';
+export { wrapGetServerSidePropsWithSentry } from './pages-router-instrumentation/wrapGetServerSidePropsWithSentry';
 export { wrapServerComponentWithSentry } from './wrapServerComponentWithSentry';
 export { wrapRouteHandlerWithSentry } from './wrapRouteHandlerWithSentry';
-export { wrapApiHandlerWithSentryVercelCrons } from './wrapApiHandlerWithSentryVercelCrons';
+export { wrapApiHandlerWithSentryVercelCrons } from './pages-router-instrumentation/wrapApiHandlerWithSentryVercelCrons';
 export { wrapMiddlewareWithSentry } from './wrapMiddlewareWithSentry';
-export { wrapPageComponentWithSentry } from './wrapPageComponentWithSentry';
+export { wrapPageComponentWithSentry } from './pages-router-instrumentation/wrapPageComponentWithSentry';
 export { wrapGenerationFunctionWithSentry } from './wrapGenerationFunctionWithSentry';
 export { withServerActionInstrumentation } from './withServerActionInstrumentation';
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/nextjs/src/common/pages-router-instrumentation/_error.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/_error.ts
@@ -1,7 +1,7 @@
 import { captureException, withScope } from '@sentry/core';
 import type { NextPageContext } from 'next';
-import { flushSafelyWithTimeout } from './utils/responseEnd';
-import { vercelWaitUntil } from './utils/vercelWaitUntil';
+import { flushSafelyWithTimeout } from '../utils/responseEnd';
+import { vercelWaitUntil } from '../utils/vercelWaitUntil';
 
 type ContextOrProps = {
   req?: NextPageContext['req'];

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentry.ts
@@ -9,10 +9,10 @@ import {
 import { consoleSandbox, isString, logger, objectify } from '@sentry/utils';
 
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
-import type { AugmentedNextApiRequest, AugmentedNextApiResponse, NextApiHandler } from './types';
-import { flushSafelyWithTimeout } from './utils/responseEnd';
-import { escapeNextjsTracing } from './utils/tracingUtils';
-import { vercelWaitUntil } from './utils/vercelWaitUntil';
+import type { AugmentedNextApiRequest, AugmentedNextApiResponse, NextApiHandler } from '../types';
+import { flushSafelyWithTimeout } from '../utils/responseEnd';
+import { escapeNextjsTracing } from '../utils/tracingUtils';
+import { vercelWaitUntil } from '../utils/vercelWaitUntil';
 
 /**
  * Wrap the given API route handler for tracing and error capturing. Thin wrapper around `withSentry`, which only

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentryVercelCrons.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentryVercelCrons.ts
@@ -1,7 +1,7 @@
 import { captureCheckIn } from '@sentry/core';
 import type { NextApiRequest } from 'next';
 
-import type { VercelCronsConfig } from './types';
+import type { VercelCronsConfig } from '../types';
 
 type EdgeRequest = {
   nextUrl: URL;

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapAppGetInitialPropsWithSentry.ts
@@ -1,7 +1,7 @@
 import type App from 'next/app';
 
-import { isBuild } from './utils/isBuild';
-import { withErrorInstrumentation, withTracedServerSideDataFetcher } from './utils/wrapperUtils';
+import { isBuild } from '../utils/isBuild';
+import { withErrorInstrumentation, withTracedServerSideDataFetcher } from '../utils/wrapperUtils';
 
 type AppGetInitialProps = (typeof App)['getInitialProps'];
 

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapDocumentGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapDocumentGetInitialPropsWithSentry.ts
@@ -1,7 +1,7 @@
 import type Document from 'next/document';
 
-import { isBuild } from './utils/isBuild';
-import { withErrorInstrumentation, withTracedServerSideDataFetcher } from './utils/wrapperUtils';
+import { isBuild } from '../utils/isBuild';
+import { withErrorInstrumentation, withTracedServerSideDataFetcher } from '../utils/wrapperUtils';
 
 type DocumentGetInitialProps = typeof Document.getInitialProps;
 

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapGetServerSidePropsWithSentry.ts
@@ -1,7 +1,7 @@
 import type { GetServerSideProps } from 'next';
 
-import { isBuild } from './utils/isBuild';
-import { withErrorInstrumentation, withTracedServerSideDataFetcher } from './utils/wrapperUtils';
+import { isBuild } from '../utils/isBuild';
+import { withErrorInstrumentation, withTracedServerSideDataFetcher } from '../utils/wrapperUtils';
 
 /**
  * Create a wrapped version of the user's exported `getServerSideProps` function

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapGetStaticPropsWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapGetStaticPropsWithSentry.ts
@@ -1,7 +1,7 @@
 import type { GetStaticProps } from 'next';
 
-import { isBuild } from './utils/isBuild';
-import { callDataFetcherTraced, withErrorInstrumentation } from './utils/wrapperUtils';
+import { isBuild } from '../utils/isBuild';
+import { callDataFetcherTraced, withErrorInstrumentation } from '../utils/wrapperUtils';
 
 type Props = { [key: string]: unknown };
 

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapPageComponentWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapPageComponentWithSentry.ts
@@ -1,6 +1,6 @@
 import { captureException, getCurrentScope, withIsolationScope } from '@sentry/core';
 import { extractTraceparentData } from '@sentry/utils';
-import { escapeNextjsTracing } from './utils/tracingUtils';
+import { escapeNextjsTracing } from '../utils/tracingUtils';
 
 interface FunctionComponent {
   (...args: unknown[]): unknown;

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -6,7 +6,7 @@ import { getDefaultIntegrations, init as vercelEdgeInit } from '@sentry/vercel-e
 import { isBuild } from '../common/utils/isBuild';
 import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegration';
 
-export { captureUnderscoreErrorException } from '../common/_error';
+export { captureUnderscoreErrorException } from '../common/pages-router-instrumentation/_error';
 
 export type EdgeOptions = VercelEdgeOptions;
 

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -26,7 +26,7 @@ import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegrati
 
 export * from '@sentry/node';
 
-export { captureUnderscoreErrorException } from '../common/_error';
+export { captureUnderscoreErrorException } from '../common/pages-router-instrumentation/_error';
 
 const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   __rewriteFramesDistDir__?: string;
@@ -325,4 +325,4 @@ function sdkAlreadyInitialized(): boolean {
 
 export * from '../common';
 
-export { wrapApiHandlerWithSentry } from '../common/wrapApiHandlerWithSentry';
+export { wrapApiHandlerWithSentry } from '../common/pages-router-instrumentation/wrapApiHandlerWithSentry';


### PR DESCRIPTION
Simply moves all runtime agnostic instrumentation related to the pages router into its own folder.