### PR TITLE
feat(nuxt/nitro): Flush with `waitUntil` after response

### DIFF
--- a/packages/nuxt/src/runtime/plugins/sentry.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry.server.ts
@@ -38,7 +38,7 @@ export default defineNitroPlugin(nitroApp => {
     addSentryTracingMetaTags(html.head);
   });
 
-  nitroApp.hooks.hook('request', () => {
+  nitroApp.hooks.hook('afterResponse', () => {
     vercelWaitUntilAndFlush();
   });
 });

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -96,7 +96,7 @@ export async function flushSafelyWithTimeout(isDebug: boolean): Promise<void> {
 }
 
 /**
- *  Utility function for the Nuxt module runtime function as we always have to get the client instance to get
+ *  Utility function for the Nuxt module runtime as we always have to get the client instance to get
  *  the `debug` option (we cannot access BUILD_DEBUG in the module runtime).
  *
  *  This function should be called when Nitro ends a request (so Vercel can wait).


### PR DESCRIPTION
When deploying a Nuxt page to Vercel, Sentry can capture events but the server instance is closed too early. With [`waitUntil`](https://vercel.com/docs/functions/functions-api-reference#waituntil), Vercel can wait for Sentry to flush all events.
