### PR TITLE
fix(replay): Try/catch `sendBufferedReplayOrFlush` to prevent cycles

### DIFF
--- a/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
@@ -68,10 +68,14 @@ function handleErrorEvent(replay: ReplayContainer, event: ErrorEvent): void {
     return;
   }
 
-  setTimeout(() => {
-    // Capture current event buffer as new replay
-    // This should never reject
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    replay.sendBufferedReplayOrFlush();
+  setTimeout(async () => {
+    try {
+      // Capture current event buffer as new replay
+      // This should never reject
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      await replay.sendBufferedReplayOrFlush();
+    } catch (err) {
+      replay.handleException(err);
+    }
   });
 }

--- a/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
@@ -71,8 +71,6 @@ function handleErrorEvent(replay: ReplayContainer, event: ErrorEvent): void {
   setTimeout(async () => {
     try {
       // Capture current event buffer as new replay
-      // This should never reject
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       await replay.sendBufferedReplayOrFlush();
     } catch (err) {
       replay.handleException(err);


### PR DESCRIPTION
It is possible that an error gets thrown outside
of flushing (we should be catching exceptions in
flush and do no re-throw), which our core SDK
error handler would catch due to global rejection
handler and trigger replay SDK to flush again.
