### PR TITLE
ref(nextjs): Make Pages Router API Routes instrumentation OTEL ready

### DIFF
--- a/packages/nextjs/src/common/span-attributes-with-logic-attached.ts
+++ b/packages/nextjs/src/common/span-attributes-with-logic-attached.ts
@@ -1,0 +1,4 @@
+/**
+ * If this attribute is attached to a transaction, the Next.js SDK will drop that transaction.
+ */
+export const TRANSACTION_ATTR_SHOULD_DROP_TRANSACTION = 'sentry.drop_transaction';

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -21,6 +21,7 @@ import type { EventProcessor } from '@sentry/types';
 import { DEBUG_BUILD } from '../common/debug-build';
 import { devErrorSymbolicationEventProcessor } from '../common/devErrorSymbolicationEventProcessor';
 import { getVercelEnv } from '../common/getVercelEnv';
+import { TRANSACTION_ATTR_SHOULD_DROP_TRANSACTION } from '../common/span-attributes-with-logic-attached';
 import { isBuild } from '../common/utils/isBuild';
 import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegration';
 
@@ -241,6 +242,11 @@ export function init(options: NodeOptions): NodeClient | undefined {
             event.transaction?.match(/^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH) \/404$/) ||
             event.transaction === 'GET /_not-found'
           ) {
+            return null;
+          }
+
+          // Filter transactions that we explicitly want to drop.
+          if (event.contexts?.trace?.data?.[TRANSACTION_ATTR_SHOULD_DROP_TRANSACTION]) {
             return null;
           }
 


### PR DESCRIPTION
Drop all spans/transactions emitted by Next.js for pages router API routes because they are currently super buggy with wrong timestamps. Fix pending: https://github.com/vercel/next.js/pull/70908

This is just a bit of prep-work so we can at some point disable the logic where we turn on all Next.js spans and still have high quality data.