### PR TITLE
fix(nextjs): Drop `_not-found` spans for all HTTP methods

### DIFF
--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -238,8 +238,7 @@ export function init(options: NodeOptions): NodeClient | undefined {
             // Pages router
             event.transaction === '/404' ||
             // App router (could be "GET /404", "POST /404", ...)
-            event.transaction?.match(/^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH) \/404$/) ||
-            event.transaction === 'GET /_not-found'
+            event.transaction?.match(/^(GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH) \/(404|_not-found)$/)
           ) {
             return null;
           }


### PR DESCRIPTION
POST requests and such can also emit `_not-found` transactions. We want to drop those.