### PR TITLE
fix(nuxt): Create declaration files for Nuxt module

### DIFF
--- a/packages/nuxt/src/tsconfig.json
+++ b/packages/nuxt/src/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+
+  "compilerOptions": {
+    // nuxt-module-build uses the closest `tsconfig.json` to build the Nuxt module declarations
+    "declaration": true,
+  }
+}


### PR DESCRIPTION
[Nuxt module builder](https://github.com/nuxt/module-builder) uses the closest `tsconfig.json` and this had `"declaration": false`. I added another `tsconfig.json` closer to the module to generate those declarations.

fixes https://github.com/getsentry/sentry-javascript/issues/13899
