### PR TITLE
feat(replay): Clear fallback buffer when switching buffers

### DIFF
--- a/packages/replay-internal/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay-internal/src/eventBuffer/EventBufferProxy.ts
@@ -115,6 +115,9 @@ export class EventBufferProxy implements EventBuffer {
     // Wait for original events to be re-added before resolving
     try {
       await Promise.all(addEventPromises);
+
+      // Can now clear fallback buffer as it's no longer necessary
+      this._fallback.clear();
     } catch (error) {
       DEBUG_BUILD && logger.exception(error, 'Failed to add events when switching buffers.');
     }


### PR DESCRIPTION
Saw this while debugging, this should not have a big effect since the fallback buffer should be relatively small.
