### PR TITLE
fix(nextjs): Adjust path to `requestAsynStorageShim.js` template file

### DIFF
--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -174,7 +174,7 @@ export default function wrappingLoader(
       }
       templateCode = templateCode.replace(
         /__SENTRY_NEXTJS_REQUEST_ASYNC_STORAGE_SHIM__/g,
-        '@sentry/nextjs/esm/config/templates/requestAsyncStorageShim.js',
+        '@sentry/nextjs/build/esm/config/templates/requestAsyncStorageShim.js',
       );
     }
 


### PR DESCRIPTION
Looks like we missed adding the `build` dir to the template path of `requestAsyncStorageShim` in the NextJS SDK when we changed the package-internal directory structure a while ago (IIRC this was pre-v8 but not sure actually)

I'm a bit surprised that this works at all, given we use `exports` conditions and this is a path to a specific file not covered by any `exports` entry. But I guess webpack can handle this still.

EDIT: Well turns out, this doesn't work. We'll need to add the `exports` entries.

fixes https://github.com/getsentry/sentry-javascript/issues/13925

closes https://github.com/getsentry/sentry-javascript/issues/13926
closes https://github.com/getsentry/sentry-javascript/issues/13927