### PR TITLE
meta(ci): Don't fail CI run when codecov fails to upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -611,6 +611,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: cancelled() == false
+        continue-on-error: true
         uses: codecov/test-results-action@v1
         with:
           directory: dev-packages/browser-integration-tests
@@ -671,6 +672,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: cancelled() == false
+        continue-on-error: true
         uses: codecov/test-results-action@v1
         with:
           directory: dev-packages/browser-integration-tests
@@ -1034,6 +1036,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: cancelled() == false
+        continue-on-error: true
         uses: codecov/test-results-action@v1
         with:
           directory: dev-packages/e2e-tests


### PR DESCRIPTION
Ref: https://github.com/codecov/test-results-action/issues/91

The job randomly fails and causes CI failure.