### PR TITLE
fix: Ensure type for `init` is correct in meta frameworks

### DIFF
--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -7,14 +7,14 @@ export * from '@sentry/node';
 
 import type { NodeOptions } from '@sentry/node';
 
-import type { Integration, Options, StackParser } from '@sentry/types';
+import type { Client, Integration, Options, StackParser } from '@sentry/types';
 
 import type * as clientSdk from './index.client';
 import type * as serverSdk from './index.server';
 import sentryAstro from './index.server';
 
 /** Initializes Sentry Astro SDK */
-export declare function init(options: Options | clientSdk.BrowserOptions | NodeOptions): void;
+export declare function init(options: Options | clientSdk.BrowserOptions | NodeOptions): Client | undefined;
 
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -7,7 +7,7 @@ export * from './client';
 export * from './server';
 export * from './edge';
 
-import type { Integration, Options, StackParser } from '@sentry/types';
+import type { Client, Integration, Options, StackParser } from '@sentry/types';
 
 import type * as clientSdk from './client';
 import type { ServerComponentContext, VercelCronsConfig } from './common/types';
@@ -17,7 +17,7 @@ import type * as serverSdk from './server';
 /** Initializes Sentry Next.js SDK */
 export declare function init(
   options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions | edgeSdk.EdgeOptions,
-): void;
+): Client | undefined;
 
 export declare const getClient: typeof clientSdk.getClient;
 export declare const getRootSpan: typeof serverSdk.getRootSpan;

--- a/packages/nuxt/src/index.types.ts
+++ b/packages/nuxt/src/index.types.ts
@@ -1,4 +1,4 @@
-import type { Integration, Options, StackParser } from '@sentry/types';
+import type { Client, Integration, Options, StackParser } from '@sentry/types';
 import type { SentryNuxtClientOptions } from './common/types';
 import type * as clientSdk from './index.client';
 import type * as serverSdk from './index.server';
@@ -9,7 +9,7 @@ export * from './index.client';
 export * from './index.server';
 
 // re-export colliding types
-export declare function init(options: Options | SentryNuxtClientOptions | serverSdk.NodeOptions): void;
+export declare function init(options: Options | SentryNuxtClientOptions | serverSdk.NodeOptions): Client | undefined;
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -3,14 +3,14 @@
 export * from './index.client';
 export * from './index.server';
 
-import type { Integration, Options, StackParser } from '@sentry/types';
+import type { Client, Integration, Options, StackParser } from '@sentry/types';
 
 import * as clientSdk from './index.client';
 import * as serverSdk from './index.server';
 import type { RemixOptions } from './utils/remixOptions';
 
 /** Initializes Sentry Remix SDK */
-export declare function init(options: RemixOptions): void;
+export declare function init(options: RemixOptions): Client | undefined;
 
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;

--- a/packages/solidstart/src/index.types.ts
+++ b/packages/solidstart/src/index.types.ts
@@ -5,13 +5,13 @@ export * from './client';
 export * from './server';
 export * from './vite';
 
-import type { Integration, Options, StackParser } from '@sentry/types';
+import type { Client, Integration, Options, StackParser } from '@sentry/types';
 
 import type * as clientSdk from './client';
 import type * as serverSdk from './server';
 
 /** Initializes Sentry Solid Start SDK */
-export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): void;
+export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): Client | undefined;
 
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -5,14 +5,14 @@ export * from './client';
 export * from './vite';
 export * from './server';
 
-import type { Integration, Options, StackParser } from '@sentry/types';
+import type { Client, Integration, Options, StackParser } from '@sentry/types';
 import type { HandleClientError, HandleServerError } from '@sveltejs/kit';
 
 import type * as clientSdk from './client';
 import type * as serverSdk from './server';
 
 /** Initializes Sentry SvelteKit SDK */
-export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): void;
+export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): Client | undefined;
 
 export declare function handleErrorWithSentry<T extends HandleClientError | HandleServerError>(handleError?: T): T;
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/13932

We have defined the type for the shared client/server types in meta-frameworks incorrectly, `init` now returns `Client | undefined` and not `void` anymore.