### PR TITLE
ci: Ensure we check correctly for bot users

### DIFF
--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -18,7 +18,7 @@ jobs:
       && github.event.pull_request.author_association != 'COLLABORATOR'
       && github.event.pull_request.author_association != 'MEMBER'
       && github.event.pull_request.author_association != 'OWNER'
-      && endsWith(github.actor, '[bot]') == false
+      && endsWith(github.event.pull_request.user.login, '[bot]') == false
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node


### PR DESCRIPTION
It seems that `github.actor` is not necessarily the PR author, but possibly the user that merged the PR.

You can see e.g. here: https://github.com/getsentry/sentry-javascript/actions/runs/11270299315/job/31340702772 how it still ran for a dependabot PR.
