### PR TITLE
ref: Add external contributor to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 This change adds a new option `trackFetchStreamPerformance` to the browser tracing integration. Only when set to `true`,
 Sentry will instrument streams via fetch.
 
-Work in this release was contributed by @ZakrepaShe. Thank you for your contribution!
+Work in this release was contributed by @ZakrepaShe and @zhiyan114. Thank you for your contributions!
 
 ## 8.34.0
 


### PR DESCRIPTION
This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution. See #13875