### PR TITLE
fix(replay): Fix onError sampling when loading an expired buffered session

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -86,7 +86,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'feedbackIntegration'),
     gzip: true,
-    limit: '91 KB',
+    limit: '95 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback, metrics)',

--- a/packages/replay-internal/src/util/handleRecordingEmit.ts
+++ b/packages/replay-internal/src/util/handleRecordingEmit.ts
@@ -71,16 +71,6 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
       // only be added for checkouts
       addSettingsEvent(replay, isCheckout);
 
-      // If there is a previousSessionId after a full snapshot occurs, then
-      // the replay session was started due to session expiration. The new session
-      // is started before triggering a new checkout and contains the id
-      // of the previous session. Do not immediately flush in this case
-      // to avoid capturing only the checkout and instead the replay will
-      // be captured if they perform any follow-up actions.
-      if (session && session.previousSessionId) {
-        return true;
-      }
-
       // When in buffer mode, make sure we adjust the session started date to the current earliest event of the buffer
       // this should usually be the timestamp of the checkout event, but to be safe...
       if (replay.recordingMode === 'buffer' && session && replay.eventBuffer) {
@@ -95,6 +85,16 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
             saveSession(session);
           }
         }
+      }
+
+      // If there is a previousSessionId after a full snapshot occurs, then
+      // the replay session was started due to session expiration. The new session
+      // is started before triggering a new checkout and contains the id
+      // of the previous session. Do not immediately flush in this case
+      // to avoid capturing only the checkout and instead the replay will
+      // be captured if they perform any follow-up actions.
+      if (session && session.previousSessionId) {
+        return true;
       }
 
       if (replay.recordingMode === 'session') {

--- a/packages/replay-internal/test/integration/errorSampleRate.test.ts
+++ b/packages/replay-internal/test/integration/errorSampleRate.test.ts
@@ -228,7 +228,7 @@ describe('Integration | errorSampleRate', () => {
           },
         ]),
       });
-      vi.clearAllMocks();
+      vi.unmock('../../src/session/fetchSession');
       await waitForFlush();
     });
 


### PR DESCRIPTION
This fixes a bug where an older, saved session (that has a `previousSessionId`, i.e. session was recorded and expired) would cause buffered replays to not send when an error happens. This is because the session start timestamp would never update, causing our flush logic to skip sending the replay due to incorrect replay duration calculation.
