### PR TITLE
feat(replay): Do not log "timeout while trying to read resp body" as exception

### DIFF
--- a/packages/replay-internal/src/coreHandlers/util/fetchUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/fetchUtils.ts
@@ -209,6 +209,11 @@ async function _parseFetchResponseBody(response: Response): Promise<[string | un
     const text = await _tryGetResponseText(res);
     return [text];
   } catch (error) {
+    if (error instanceof Error && error.message.indexOf('Timeout') > -1) {
+      DEBUG_BUILD && logger.warn('Parsing text body from response timed out');
+      return [undefined, 'BODY_PARSE_TIMEOUT'];
+    }
+
     DEBUG_BUILD && logger.exception(error, 'Failed to get text body from response');
     return [undefined, 'BODY_PARSE_ERROR'];
   }
@@ -299,8 +304,6 @@ function _tryGetResponseText(response: Response): Promise<string | undefined> {
       )
       .finally(() => clearTimeout(timeout));
   });
-
-  return _getResponseText(response);
 }
 
 async function _getResponseText(response: Response): Promise<string> {

--- a/packages/replay-internal/src/types/request.ts
+++ b/packages/replay-internal/src/types/request.ts
@@ -8,6 +8,7 @@ export type NetworkMetaWarning =
   | 'TEXT_TRUNCATED'
   | 'URL_SKIPPED'
   | 'BODY_PARSE_ERROR'
+  | 'BODY_PARSE_TIMEOUT'
   | 'UNPARSEABLE_BODY_TYPE';
 
 interface NetworkMeta {

--- a/packages/replay-internal/test/unit/coreHandlers/util/fetchUtils.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/util/fetchUtils.test.ts
@@ -132,7 +132,7 @@ describe('Unit | coreHandlers | util | fetchUtils', () => {
       ]);
 
       expect(res).toEqual({
-        _meta: { warnings: ['BODY_PARSE_ERROR'] },
+        _meta: { warnings: ['BODY_PARSE_TIMEOUT'] },
         headers: {},
         size: undefined,
       });


### PR DESCRIPTION
Change this to be a warn level log instead of an exception (which gets captured to Sentry). Since this is an error we are throwing ourselves and it is to be expected, no need to treat as an exception.

This also adds a new meta string to differentiate from an error while parsing. This means we can show a more specific error message on the frontend.
