### PR TITLE
fix(node): Ensure `ignoreOutgoingRequests` of `httpIntegration` applies to breadcrumbs

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
@@ -11,7 +11,6 @@ Sentry.init({
   integrations: [
     Sentry.httpIntegration({
       ignoreOutgoingRequests: (url, request) => {
-        console.log('ignoreOutgoingRequests', url, request);
         if (url === 'http://example.com/blockUrl') {
           return true;
         }

--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -20,7 +20,7 @@ const INSTRUMENTATION_NAME = '@opentelemetry_sentry-patched/instrumentation-http
 
 interface HttpOptions {
   /**
-   * Whether breadcrumbs should be recorded for requests.
+   * Whether breadcrumbs should be recorded for outgoing requests.
    * Defaults to true
    */
   breadcrumbs?: boolean;
@@ -45,8 +45,8 @@ interface HttpOptions {
   ignoreOutgoingRequests?: (url: string, request: RequestOptions) => boolean;
 
   /**
-   * Do not capture spans or breadcrumbs for incoming HTTP requests to URLs where the given callback returns `true`.
-   * This controls both span & breadcrumb creation - spans will be non recording if tracing is disabled.
+   * Do not capture spans for incoming HTTP requests to URLs where the given callback returns `true`.
+   * Spans will be non recording if tracing is disabled.
    *
    * The `urlPath` param consists of the URL path and query string (if any) of the incoming request.
    * For example: `'/users/details?id=123'`
@@ -82,12 +82,15 @@ interface HttpOptions {
   };
 }
 
-export const instrumentSentryHttp = generateInstrumentOnce<{ breadcrumbs?: boolean }>(
-  `${INTEGRATION_NAME}.sentry`,
-  options => {
-    return new SentryHttpInstrumentation({ breadcrumbs: options?.breadcrumbs });
-  },
-);
+export const instrumentSentryHttp = generateInstrumentOnce<{
+  breadcrumbs?: HttpOptions['breadcrumbs'];
+  ignoreOutgoingRequests?: HttpOptions['ignoreOutgoingRequests'];
+}>(`${INTEGRATION_NAME}.sentry`, options => {
+  return new SentryHttpInstrumentation({
+    breadcrumbs: options?.breadcrumbs,
+    ignoreOutgoingRequests: options?.ignoreOutgoingRequests,
+  });
+});
 
 export const instrumentOtelHttp = generateInstrumentOnce<HttpInstrumentationConfig>(INTEGRATION_NAME, config => {
   const instrumentation = new HttpInstrumentation(config);


### PR DESCRIPTION
This PR fixes a bug, initially reported in [Discord](https://discord.com/channels/621778831602221064/1293560604816179201/1293560604816179201), which caused the `httpIntegration`'s `ignoreOutgoingRequests` option to not be applied to breadcrumb creation for outgoing requests. The result was that despite spans being correctly filtered by the option, breadcrumbs would still be created which contradicts the function'S JSDoc and [our docs](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/http/#ignoreoutgoingrequests).

It seems like this was already a bug prior to #13763. However, the behaviour seems to have been carried over to #13763. 

This PR fixes the bug by:
- correctly passing in `ignoreOutgoingRequests` to `SentryHttpIntegration` (same signature as `httpIntegration`)
- reconstructing the `url` and `request` parameter like in the [OpenTelemetry instrumentation](https://github.com/open-telemetry/opentelemetry-js/blob/7293e69c1e55ca62e15d0724d22605e61bd58952/experimental/packages/opentelemetry-instrumentation-http/src/http.ts#L756-L789)
- adding/adjusting a regression test so that we properly test agains `ignoreOutgoingRequests` with both params. Now not just for filtered spans but also for breadcrumbs.