### PR TITLE
fix(nuxt): Re-export 'default' exports with rollup plugin

### DIFF
--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -57,7 +57,7 @@ export function extractFunctionReexportQueryParameters(query: string): string[] 
   return match && match[1]
     ? match[1]
         .split(',')
-        .filter(param => param !== '' && param !== 'default')
+        .filter(param => param !== '')
         // Sanitize, as code could be injected with another rollup plugin
         .map((str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
     : [];
@@ -72,10 +72,11 @@ export function constructFunctionReExport(pathWithQuery: string, entryId: string
   return functionNames.reduce(
     (functionsCode, currFunctionName) =>
       functionsCode.concat(
-        `export async function ${currFunctionName}(...args) {\n` +
+        'async function reExport(...args) {\n' +
           `  const res = await import(${JSON.stringify(entryId)});\n` +
           `  return res.${currFunctionName}.call(this, ...args);\n` +
-          '}\n',
+          '}\n' +
+          `export { reExport as ${currFunctionName} };\n`,
       ),
     '',
   );

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -111,16 +111,34 @@ describe('constructFunctionReExport', () => {
     const result2 = constructFunctionReExport(query2, entryId);
 
     const expected = `
-export async function foo(...args) {
+async function reExport(...args) {
   const res = await import("./module");
   return res.foo.call(this, ...args);
 }
-export async function bar(...args) {
+export { reExport as foo };
+async function reExport(...args) {
   const res = await import("./module");
   return res.bar.call(this, ...args);
-}`;
+}
+export { reExport as bar };
+`;
     expect(result.trim()).toBe(expected.trim());
     expect(result2.trim()).toBe(expected.trim());
+  });
+
+  it('constructs re-export code for a "default" query parameters and entry ID', () => {
+    const query = `${SENTRY_FUNCTIONS_REEXPORT}default${QUERY_END_INDICATOR}}`;
+    const entryId = './index';
+    const result = constructFunctionReExport(query, entryId);
+
+    const expected = `
+async function reExport(...args) {
+  const res = await import("./index");
+  return res.default.call(this, ...args);
+}
+export { reExport as default };
+`;
+    expect(result.trim()).toBe(expected.trim());
   });
 
   it('returns an empty string if the query string is empty', () => {

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -88,7 +88,7 @@ describe('removeSentryQueryFromPath', () => {
 describe('extractFunctionReexportQueryParameters', () => {
   it.each([
     [`${SENTRY_FUNCTIONS_REEXPORT}foo,bar,${QUERY_END_INDICATOR}`, ['foo', 'bar']],
-    [`${SENTRY_FUNCTIONS_REEXPORT}foo,bar,default${QUERY_END_INDICATOR}`, ['foo', 'bar']],
+    [`${SENTRY_FUNCTIONS_REEXPORT}foo,bar,default${QUERY_END_INDICATOR}`, ['foo', 'bar', 'default']],
     [
       `${SENTRY_FUNCTIONS_REEXPORT}foo,a.b*c?d[e]f(g)h|i\\\\j(){hello},${QUERY_END_INDICATOR}`,
       ['foo', 'a\\.b\\*c\\?d\\[e\\]f\\(g\\)h\\|i\\\\\\\\j\\(\\)\\{hello\\}'],


### PR DESCRIPTION
While the preset for Netlify exports the serverless handler function as `export { D as default }`, the Vercel preset exports this handler as `export { D as handler };`.

This PR makes some adaptions to the code generation in the plugin to make it possible to re-export `default` functions. The previous snippet did not work as `default` is obviously not allowed as a function name.
