### PR TITLE
test(nextjs): Adjust test for origin

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
@@ -16,7 +16,7 @@ test('Sends a transaction for a request to app router', async ({ page }) => {
   expect(transactionEvent.contexts?.trace).toEqual({
     data: expect.objectContaining({
       'sentry.op': 'http.server',
-      'sentry.origin': 'auto',
+      'sentry.origin': expect.stringMatching(/^(auto|auto\.http\.otel\.http)$/),
       'sentry.sample_rate': 1,
       'sentry.source': 'route',
       'http.method': 'GET',
@@ -27,7 +27,7 @@ test('Sends a transaction for a request to app router', async ({ page }) => {
       'otel.kind': 'SERVER',
     }),
     op: 'http.server',
-    origin: 'auto',
+    origin: expect.stringMatching(/^(auto|auto\.http\.otel\.http)$/),
     span_id: expect.any(String),
     status: 'ok',
     trace_id: expect.any(String),


### PR DESCRIPTION
I assume this is due ot https://github.com/getsentry/sentry-javascript/pull/13763