### PR TITLE
ci: Ensure release comments are not added for prereleases

### DIFF
--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -24,6 +24,7 @@ jobs:
           steps.get_version.outputs.version != ''
           && !contains(steps.get_version.outputs.version, '-beta.')
           && !contains(steps.get_version.outputs.version, '-alpha.')
+          && !contains(steps.get_version.outputs.version, '-rc.')
 
         uses: getsentry/release-comment-issues-gh-action@v1
         with:

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -20,7 +20,11 @@ jobs:
         run: echo "version=${{ github.event.inputs.version || github.event.release.tag_name }}" >> $GITHUB_OUTPUT
 
       - name: Comment on linked issues that are mentioned in release
-        if: steps.get_version.outputs.version != ''
+        if: |
+          steps.get_version.outputs.version != ''
+          && !contains(steps.get_version.outputs.version, '-beta.')
+          && !contains(steps.get_version.outputs.version, '-alpha.')
+
         uses: getsentry/release-comment-issues-gh-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Noticed here: https://github.com/getsentry/sentry-javascript/issues/13932#issuecomment-2414900079 we should not add comments for prereleases 😅 