### PR TITLE
fix(replay): Fix `onError` callback

### DIFF
--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -114,6 +114,7 @@ export class Replay implements Integration {
 
     beforeAddRecordingEvent,
     beforeErrorSampling,
+    onError,
   }: ReplayConfiguration = {}) {
     this.name = Replay.id;
 
@@ -183,6 +184,7 @@ export class Replay implements Integration {
       networkResponseHeaders: _getMergedNetworkHeaders(networkResponseHeaders),
       beforeAddRecordingEvent,
       beforeErrorSampling,
+      onError,
 
       _experiments,
     };


### PR DESCRIPTION
This fixes the `onError` callback added in https://github.com/getsentry/sentry-javascript/pull/13721 -- the option itself was not being propagated to the replay options.
