### PR TITLE
debug(replay): Add debugging statements around event buffer

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -79,7 +79,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'replayCanvasIntegration'),
     gzip: true,
-    limit: '78 KB',
+    limit: '80 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback)',

--- a/packages/replay-internal/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay-internal/src/eventBuffer/EventBufferProxy.ts
@@ -115,6 +115,7 @@ export class EventBufferProxy implements EventBuffer {
     // Wait for original events to be re-added before resolving
     try {
       await Promise.all(addEventPromises);
+      DEBUG_BUILD && logger.info('Finished switching to compression worker');
 
       // Can now clear fallback buffer as it's no longer necessary
       this._fallback.clear();

--- a/packages/replay-internal/src/util/handleRecordingEmit.ts
+++ b/packages/replay-internal/src/util/handleRecordingEmit.ts
@@ -74,12 +74,11 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
 
       // When in buffer mode, make sure we adjust the session started date to the current earliest event of the buffer
       // this should usually be the timestamp of the checkout event, but to be safe...
-      if (replay.recordingMode === 'buffer' && session) {
+      if (replay.recordingMode === 'buffer' && session && replay.eventBuffer) {
         DEBUG_BUILD &&
-          replay.eventBuffer &&
           logger.info('Attempting to fetch earliest event from event buffer type: ', replay.eventBuffer.type);
 
-        const earliestEvent = replay.eventBuffer && replay.eventBuffer.getEarliestTimestamp();
+        const earliestEvent = replay.eventBuffer.getEarliestTimestamp();
 
         if (earliestEvent) {
           DEBUG_BUILD &&

--- a/packages/replay-internal/src/util/handleRecordingEmit.ts
+++ b/packages/replay-internal/src/util/handleRecordingEmit.ts
@@ -43,6 +43,7 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
       // dependent on this reset.
       if (replay.recordingMode === 'buffer' && isCheckout) {
         replay.setInitialState();
+        DEBUG_BUILD && logger.info(`Adding checkout event while in buffer mode (${JSON.stringify(event).length})`);
       }
 
       // If the event is not added (e.g. due to being paused, disabled, or out of the max replay duration),
@@ -73,8 +74,13 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
 
       // When in buffer mode, make sure we adjust the session started date to the current earliest event of the buffer
       // this should usually be the timestamp of the checkout event, but to be safe...
-      if (replay.recordingMode === 'buffer' && session && replay.eventBuffer) {
-        const earliestEvent = replay.eventBuffer.getEarliestTimestamp();
+      if (replay.recordingMode === 'buffer' && session) {
+        DEBUG_BUILD &&
+          replay.eventBuffer &&
+          logger.info('Attempting to fetch earliest event from event buffer type: ', replay.eventBuffer.type);
+
+        const earliestEvent = replay.eventBuffer && replay.eventBuffer.getEarliestTimestamp();
+
         if (earliestEvent) {
           DEBUG_BUILD &&
             logger.info(`Updating session start time to earliest event in buffer to ${new Date(earliestEvent)}`);
@@ -84,6 +90,9 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
           if (replay.getOptions().stickySession) {
             saveSession(session);
           }
+        } else {
+          // XXX(billy): debugging
+          DEBUG_BUILD && logger.warn('Unable to find earliest event in event buffer');
         }
       }
 


### PR DESCRIPTION
This is not intended to be merged to prod, I would like to debug how/why
we keep hitting EventBuffer limits on Sentry SaaS. Aside from debugging
statements, there should be no other behavioral changes.
