### PR TITLE
feat(nuxt): Respect user-provided source map generation settings

### DIFF
--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -1,27 +1,39 @@
 import type { Nuxt } from '@nuxt/schema';
 import { type SentryRollupPluginOptions, sentryRollupPlugin } from '@sentry/rollup-plugin';
+import { consoleSandbox } from '@sentry/utils';
 import { type SentryVitePluginOptions, sentryVitePlugin } from '@sentry/vite-plugin';
 import type { NitroConfig } from 'nitropack';
+import type { OutputOptions } from 'rollup';
 import type { SentryNuxtModuleOptions } from '../common/types';
 
 /**
- *  Setup source maps for Sentry inside the Nuxt module during build time (in Vite for Nuxt and Rollup for Nitro).
+ * Whether the user enabled (true, 'hidden', 'inline') or disabled (false) sourcemaps
+ */
+export type UserSourcemapSetting = 'enabled' | 'disabled' | 'unset' | undefined;
+
+/**
+ *  Setup source maps for Sentry inside the Nuxt module during build time (in Vite for Nuxt and Rollup for N itr/**
+ *
  */
 export function setupSourceMaps(moduleOptions: SentryNuxtModuleOptions, nuxt: Nuxt): void {
   const sourceMapsUploadOptions = moduleOptions.sourceMapsUploadOptions || {};
   const sourceMapsEnabled = sourceMapsUploadOptions.enabled ?? true;
 
-  nuxt.hook('vite:extendConfig', async (viteInlineConfig, _env) => {
-    if (sourceMapsEnabled && viteInlineConfig.mode !== 'development') {
-      // Add Sentry plugin
-      viteInlineConfig.plugins = viteInlineConfig.plugins || [];
-      viteInlineConfig.plugins.push(sentryVitePlugin(getPluginOptions(moduleOptions)));
+  nuxt.hook('modules:done', () => {
+    if (sourceMapsEnabled && !nuxt.options.dev) {
+      changeNuxtSourcemapSettings(nuxt, moduleOptions);
+    }
+  });
 
-      // Enable source maps
-      viteInlineConfig.build = viteInlineConfig.build || {};
-      viteInlineConfig.build.sourcemap = true;
+  nuxt.hook('vite:extendConfig', async (viteConfig, _env) => {
+    if (sourceMapsEnabled && viteConfig.mode !== 'development') {
+      const previousUserSourcemapSetting = changeViteSourcemapSettings(viteConfig, moduleOptions);
 
-      logDebugInfo(moduleOptions, viteInlineConfig.build?.sourcemap);
+      //  Add Sentry plugin
+      viteConfig.plugins = viteConfig.plugins || [];
+      viteConfig.plugins.push(
+        sentryVitePlugin(getPluginOptions(moduleOptions, previousUserSourcemapSetting === 'unset')),
+      );
     }
   });
 
@@ -38,15 +50,12 @@ export function setupSourceMaps(moduleOptions: SentryNuxtModuleOptions, nuxt: Nu
         nitroConfig.rollupConfig.plugins = [nitroConfig.rollupConfig.plugins];
       }
 
+      const previousUserSourcemapSetting = changeRollupSourcemapSettings(nitroConfig, moduleOptions);
+
       // Add Sentry plugin
-      nitroConfig.rollupConfig.plugins.push(sentryRollupPlugin(getPluginOptions(moduleOptions)));
-
-      // Enable source maps
-      nitroConfig.rollupConfig.output = nitroConfig?.rollupConfig?.output || {};
-      nitroConfig.rollupConfig.output.sourcemap = true;
-      nitroConfig.rollupConfig.output.sourcemapExcludeSources = false; // Adding "sourcesContent" to the source map (Nitro sets this eto `true`)
-
-      logDebugInfo(moduleOptions, nitroConfig.rollupConfig.output?.sourcemap);
+      nitroConfig.rollupConfig.plugins.push(
+        sentryRollupPlugin(getPluginOptions(moduleOptions, previousUserSourcemapSetting === 'unset')),
+      );
     }
   });
 }
@@ -65,8 +74,18 @@ function normalizePath(path: string): string {
  */
 export function getPluginOptions(
   moduleOptions: SentryNuxtModuleOptions,
+  deleteFilesAfterUpload: boolean,
 ): SentryVitePluginOptions | SentryRollupPluginOptions {
   const sourceMapsUploadOptions = moduleOptions.sourceMapsUploadOptions || {};
+
+  if (typeof sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload === 'undefined' && deleteFilesAfterUpload) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.log(
+        '[Sentry] Setting `sentry.sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload: [".*/**/*.map"]` to delete generated source maps after they were uploaded to Sentry.',
+      );
+    });
+  }
 
   return {
     org: sourceMapsUploadOptions.org ?? process.env.SENTRY_ORG,
@@ -87,25 +106,189 @@ export function getPluginOptions(
       // If we could know where the server/client assets are located, we could do something like this (based on the Nitro preset): isNitro ? ['./.output/server/**/*'] : ['./.output/public/**/*'],
       assets: sourceMapsUploadOptions.sourcemaps?.assets ?? undefined,
       ignore: sourceMapsUploadOptions.sourcemaps?.ignore ?? undefined,
-      filesToDeleteAfterUpload: sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload ?? undefined,
+      filesToDeleteAfterUpload: sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload
+        ? sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload
+        : deleteFilesAfterUpload
+          ? ['.*/**/*.map']
+          : undefined,
       rewriteSources: (source: string) => normalizePath(source),
       ...moduleOptions?.unstable_sentryBundlerPluginOptions?.sourcemaps,
     },
   };
 }
 
-function logDebugInfo(moduleOptions: SentryNuxtModuleOptions, sourceMapsPreviouslyEnabled: boolean): void {
-  if (moduleOptions.debug && !sourceMapsPreviouslyEnabled) {
-    // eslint-disable-next-line no-console
-    console.log('[Sentry]: Enabled source maps generation in the Vite build options.');
+/*  There are 3 ways to set up sourcemaps (https://github.com/getsentry/sentry-javascript/issues/13993)
+    1. User explicitly disabled sourcemaps
+      - keep this setting (emit a warning that errors won't be unminified in Sentry)
+      - We will not upload anything
+    2. users enabled source map generation (true, hidden, inline).
+      - keep this setting this and
+      - don't do anything (i.e. deletion) besides uploading.
+    3. users did not set source maps generation
+      - we enable 'hidden' source maps generation
+      - configure `filesToDeleteAfterUpload` to delete all .map files (we emit a log about this)
 
-    const sourceMapsUploadOptions = moduleOptions.sourceMapsUploadOptions || {};
+    Nuxt has 3 places to set sourcemaps: vite options, rollup options, nuxt itself
+    Ideally, all 3 are enabled to get all sourcemaps.
+ */
 
-    if (!sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[Sentry] We recommend setting the `sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload` option to clean up source maps after uploading. Otherwise, source maps might be deployed to production, depending on your configuration',
-      );
+/** only exported for testing */
+export function changeNuxtSourcemapSettings(
+  nuxt: Nuxt,
+  sentryModuleOptions: SentryNuxtModuleOptions,
+): { client: UserSourcemapSetting; server: UserSourcemapSetting } {
+  nuxt.options = nuxt.options || {};
+  nuxt.options.sourcemap = nuxt.options.sourcemap ?? { server: undefined, client: undefined };
+
+  let previousUserSourceMapSetting: { client: UserSourcemapSetting; server: UserSourcemapSetting } = {
+    client: undefined,
+    server: undefined,
+  };
+
+  const nuxtSourcemap = nuxt.options.sourcemap;
+
+  if (typeof nuxtSourcemap === 'string' || typeof nuxtSourcemap === 'boolean' || typeof nuxtSourcemap === 'undefined') {
+    switch (nuxtSourcemap) {
+      case false:
+        warnExplicitlyDisabledSourcemap('sourcemap');
+        previousUserSourceMapSetting = { client: 'disabled', server: 'disabled' };
+        break;
+
+      case 'hidden':
+      case true:
+        logKeepSourcemapSetting(sentryModuleOptions, 'sourcemap', (nuxtSourcemap as true).toString());
+        previousUserSourceMapSetting = { client: 'enabled', server: 'enabled' };
+        break;
+      case undefined:
+        nuxt.options.sourcemap = { server: 'hidden', client: 'hidden' };
+        logSentryEnablesSourcemap('sourcemap.client', 'hidden');
+        logSentryEnablesSourcemap('sourcemap.server', 'hidden');
+        previousUserSourceMapSetting = { client: 'unset', server: 'unset' };
+        break;
+    }
+  } else {
+    if (nuxtSourcemap.client === false) {
+      warnExplicitlyDisabledSourcemap('sourcemap.client');
+      previousUserSourceMapSetting.client = 'disabled';
+    } else if (['hidden', true].includes(nuxtSourcemap.client)) {
+      logKeepSourcemapSetting(sentryModuleOptions, 'sourcemap.client', nuxtSourcemap.client.toString());
+      previousUserSourceMapSetting.client = 'enabled';
+    } else {
+      nuxt.options.sourcemap.client = 'hidden';
+      logSentryEnablesSourcemap('sourcemap.client', 'hidden');
+      previousUserSourceMapSetting.client = 'unset';
+    }
+
+    if (nuxtSourcemap.server === false) {
+      warnExplicitlyDisabledSourcemap('sourcemap.server');
+      previousUserSourceMapSetting.server = 'disabled';
+    } else if (['hidden', true].includes(nuxtSourcemap.server)) {
+      logKeepSourcemapSetting(sentryModuleOptions, 'sourcemap.server', nuxtSourcemap.server.toString());
+      previousUserSourceMapSetting.server = 'enabled';
+    } else {
+      nuxt.options.sourcemap.server = 'hidden';
+      logSentryEnablesSourcemap('sourcemap.server', 'hidden');
+      previousUserSourceMapSetting.server = 'unset';
     }
   }
+
+  return previousUserSourceMapSetting;
+}
+
+/** only exported for testing */
+export function changeViteSourcemapSettings(
+  viteConfig: { build?: { sourcemap?: boolean | 'inline' | 'hidden' } },
+  sentryModuleOptions: SentryNuxtModuleOptions,
+): UserSourcemapSetting {
+  viteConfig.build = viteConfig.build || {};
+  const viteSourcemap = viteConfig.build.sourcemap;
+
+  let previousUserSourceMapSetting: UserSourcemapSetting;
+
+  if (viteSourcemap === false) {
+    warnExplicitlyDisabledSourcemap('vite.build.sourcemap');
+    previousUserSourceMapSetting = 'disabled';
+  } else if (viteSourcemap && ['hidden', 'inline', true].includes(viteSourcemap)) {
+    logKeepSourcemapSetting(sentryModuleOptions, 'vite.build.sourcemap', viteSourcemap.toString());
+    previousUserSourceMapSetting = 'enabled';
+  } else {
+    viteConfig.build.sourcemap = 'hidden';
+    logSentryEnablesSourcemap('vite.build.sourcemap', 'hidden');
+    previousUserSourceMapSetting = 'unset';
+  }
+
+  return previousUserSourceMapSetting;
+}
+
+/** only exported for testing */
+export function changeRollupSourcemapSettings(
+  nitroConfig: {
+    rollupConfig?: {
+      output?: {
+        sourcemap?: OutputOptions['sourcemap'];
+        sourcemapExcludeSources?: OutputOptions['sourcemapExcludeSources'];
+      };
+    };
+  },
+  sentryModuleOptions: SentryNuxtModuleOptions,
+): UserSourcemapSetting {
+  nitroConfig.rollupConfig = nitroConfig.rollupConfig || {};
+  nitroConfig.rollupConfig.output = nitroConfig.rollupConfig.output || { sourcemap: undefined };
+
+  let previousUserSourceMapSetting: UserSourcemapSetting;
+
+  const nitroSourcemap = nitroConfig.rollupConfig.output.sourcemap;
+
+  if (nitroSourcemap === false) {
+    warnExplicitlyDisabledSourcemap('nitro.rollupConfig.output.sourcemap');
+    previousUserSourceMapSetting = 'disabled';
+  } else if (nitroSourcemap && ['hidden', 'inline', true].includes(nitroSourcemap)) {
+    logKeepSourcemapSetting(sentryModuleOptions, 'nitro.rollupConfig.output.sourcemap', nitroSourcemap.toString());
+    previousUserSourceMapSetting = 'enabled';
+  } else {
+    nitroConfig.rollupConfig.output.sourcemap = 'hidden';
+    logSentryEnablesSourcemap('nitro.rollupConfig.output.sourcemap', 'hidden');
+    previousUserSourceMapSetting = 'unset';
+  }
+
+  nitroConfig.rollupConfig.output.sourcemapExcludeSources = false;
+  consoleSandbox(() => {
+    // eslint-disable-next-line no-console
+    console.log(
+      '[Sentry] Disabled sourcemap setting in the Nuxt config: `nitro.rollupConfig.output.sourcemapExcludeSources`. Source maps will include the actual code to be able to un-minify code snippets in Sentry.',
+    );
+  });
+
+  return previousUserSourceMapSetting;
+}
+
+function logKeepSourcemapSetting(
+  sentryNuxtModuleOptions: SentryNuxtModuleOptions,
+  settingKey: string,
+  settingValue: string,
+): void {
+  if (sentryNuxtModuleOptions.debug) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[Sentry] We discovered \`${settingKey}\` is set to \`${settingValue}\`. Sentry will keep this sourcemap setting. This will un-minify the code snippet on the Sentry Issue page.`,
+      );
+    });
+  }
+}
+
+function warnExplicitlyDisabledSourcemap(settingKey: string): void {
+  consoleSandbox(() => {
+    //  eslint-disable-next-line no-console
+    console.warn(
+      `[Sentry] Parts of sourcemap generation are currently disabled in your Nuxt configuration (\`${settingKey}: false\`). This setting is either a default setting or was explicitly set in your configuration. Sentry won't override this setting. Without sourcemaps, code snippets on the Sentry Issues page will remain minified. To show unminified code, enable sourcemaps in \`${settingKey}\`.`,
+    );
+  });
+}
+
+function logSentryEnablesSourcemap(settingKey: string, settingValue: string): void {
+  consoleSandbox(() => {
+    //  eslint-disable-next-line no-console
+    console.log(`[Sentry] Enabled sourcemap generation in the build options with \`${settingKey}: ${settingValue}\`.`);
+  });
 }

--- a/packages/nuxt/test/vite/sourceMaps.test.ts
+++ b/packages/nuxt/test/vite/sourceMaps.test.ts
@@ -1,11 +1,11 @@
 import type { Nuxt } from '@nuxt/schema';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SentryNuxtModuleOptions } from '../../src/common/types';
-import type { UserSourcemapSetting } from '../../src/vite/sourceMaps';
+import type { UserSourceMapSetting } from '../../src/vite/sourceMaps';
 import {
-  changeNuxtSourcemapSettings,
-  changeRollupSourcemapSettings,
-  changeViteSourcemapSettings,
+  changeNuxtSourceMapSettings,
+  changeRollupSourceMapSettings,
+  changeViteSourceMapSettings,
   getPluginOptions,
 } from '../../src/vite/sourceMaps';
 
@@ -159,7 +159,7 @@ describe('change sourcemap settings', () => {
       const cases: {
         sourcemap?: boolean | 'hidden' | 'inline';
         expectedSourcemap: boolean | string;
-        expectedReturn: UserSourcemapSetting;
+        expectedReturn: UserSourceMapSetting;
       }[] = [
         { sourcemap: false, expectedSourcemap: false, expectedReturn: 'disabled' },
         { sourcemap: 'hidden', expectedSourcemap: 'hidden', expectedReturn: 'enabled' },
@@ -170,7 +170,7 @@ describe('change sourcemap settings', () => {
 
       cases.forEach(({ sourcemap, expectedSourcemap, expectedReturn }) => {
         viteConfig.build = { sourcemap };
-        const previousUserSourcemapSetting = changeViteSourcemapSettings(viteConfig, sentryModuleOptions);
+        const previousUserSourcemapSetting = changeViteSourceMapSettings(viteConfig, sentryModuleOptions);
         expect(viteConfig.build.sourcemap).toBe(expectedSourcemap);
         expect(previousUserSourcemapSetting).toBe(expectedReturn);
       });
@@ -192,7 +192,7 @@ describe('change sourcemap settings', () => {
       const cases: {
         output?: { sourcemap?: boolean | 'hidden' | 'inline' };
         expectedSourcemap: boolean | string;
-        expectedReturn: UserSourcemapSetting;
+        expectedReturn: UserSourceMapSetting;
       }[] = [
         { output: { sourcemap: false }, expectedSourcemap: false, expectedReturn: 'disabled' },
         { output: { sourcemap: 'hidden' }, expectedSourcemap: 'hidden', expectedReturn: 'enabled' },
@@ -204,7 +204,7 @@ describe('change sourcemap settings', () => {
 
       cases.forEach(({ output, expectedSourcemap, expectedReturn }) => {
         nitroConfig.rollupConfig = { output };
-        const previousUserSourceMapSetting = changeRollupSourcemapSettings(nitroConfig, sentryModuleOptions);
+        const previousUserSourceMapSetting = changeRollupSourceMapSettings(nitroConfig, sentryModuleOptions);
         expect(nitroConfig.rollupConfig?.output?.sourcemap).toBe(expectedSourcemap);
         expect(previousUserSourceMapSetting).toBe(expectedReturn);
         expect(nitroConfig.rollupConfig?.output?.sourcemapExcludeSources).toBe(false);
@@ -233,7 +233,7 @@ describe('change sourcemap settings', () => {
       cases.forEach(({ clientSourcemap, expectedSourcemap, expectedReturn }) => {
         // @ts-expect-error - Nuxt types don't accept `undefined` but we want to test this case
         nuxt.options.sourcemap.client = clientSourcemap;
-        const previousUserSourcemapSetting = changeNuxtSourcemapSettings(nuxt as Nuxt, sentryModuleOptions);
+        const previousUserSourcemapSetting = changeNuxtSourceMapSettings(nuxt as Nuxt, sentryModuleOptions);
         expect(nuxt.options.sourcemap.client).toBe(expectedSourcemap);
         expect(previousUserSourcemapSetting.client).toBe(expectedReturn);
       });
@@ -250,7 +250,7 @@ describe('change sourcemap settings', () => {
       cases.forEach(({ serverSourcemap, expectedSourcemap, expectedReturn }) => {
         // @ts-expect-error server available
         nuxt.options.sourcemap.server = serverSourcemap;
-        const previousUserSourcemapSetting = changeNuxtSourcemapSettings(nuxt as Nuxt, sentryModuleOptions);
+        const previousUserSourcemapSetting = changeNuxtSourceMapSettings(nuxt as Nuxt, sentryModuleOptions);
         expect(nuxt.options.sourcemap.server).toBe(expectedSourcemap);
         expect(previousUserSourcemapSetting.server).toBe(expectedReturn);
       });
@@ -267,7 +267,7 @@ describe('change sourcemap settings', () => {
         cases.forEach(({ sourcemap, expectedSourcemap, expectedReturn }) => {
           // @ts-expect-error string type is possible in Nuxt (but type says differently)
           nuxt.options.sourcemap = sourcemap;
-          const previousUserSourcemapSetting = changeNuxtSourcemapSettings(nuxt as Nuxt, sentryModuleOptions);
+          const previousUserSourcemapSetting = changeNuxtSourceMapSettings(nuxt as Nuxt, sentryModuleOptions);
           expect(nuxt.options.sourcemap).toBe(expectedSourcemap);
           expect(previousUserSourcemapSetting.client).toBe(expectedReturn);
           expect(previousUserSourcemapSetting.server).toBe(expectedReturn);
@@ -277,7 +277,7 @@ describe('change sourcemap settings', () => {
       it("sets client and server to 'hidden' if nuxt.options.sourcemap not set", () => {
         // @ts-expect-error - Nuxt types don't accept `undefined` but we want to test this case
         nuxt.options.sourcemap = undefined;
-        const previousUserSourcemapSetting = changeNuxtSourcemapSettings(nuxt as Nuxt, sentryModuleOptions);
+        const previousUserSourcemapSetting = changeNuxtSourceMapSettings(nuxt as Nuxt, sentryModuleOptions);
         expect(nuxt.options.sourcemap.client).toBe('hidden');
         expect(nuxt.options.sourcemap.server).toBe('hidden');
         expect(previousUserSourcemapSetting.client).toBe('unset');


### PR DESCRIPTION
Nuxt implementation for: https://github.com/getsentry/sentry-javascript/issues/13993
Fixes: https://github.com/getsentry/sentry-javascript/issues/13997

In Nuxt, there are 3 places to set source maps (and all need to be enabled):
- `sourcemap`
- `nitro.rollupConfig.output.sourcemap`
- `vite.build.sourcemap`

As Nuxt sets `sourcemap.client: false` ([docs here](https://nuxt.com/docs/api/nuxt-config#sourcemap)), it's not possible to determine whether this setting was set by the user or the framework. Users have to set this manually like this:
```js
export default defineNuxtConfig({
  sourcemap: {
    client: true,
  },
})
```

With this PR, all source maps are set to `'hidden'` if they were undefined before and keep the setting otherwise. This is done in 3 separate functions (one for vite, rollup and nuxt) to better distinguish between the settings.
