### PR TITLE
feat(nuxt): Log server instrumentation might not work in dev

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -78,7 +78,7 @@ export default defineNuxtModule<ModuleOptions>({
           consoleSandbox(() => {
             // eslint-disable-next-line no-console
             console.log(
-              '[Sentry] Your application is running in development mode. Note: @sentry/nuxt is in beta and may not work as expected on the server-side (Nitro).',
+              '[Sentry] Your application is running in development mode. Note: @sentry/nuxt is in beta and may not work as expected on the server-side (Nitro). Errors are reported, but tracing does not work.',
             );
           });
         }

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -74,6 +74,15 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.hooks.hook('nitro:init', nitro => {
       if (serverConfigFile && serverConfigFile.includes('.server.config')) {
+        if (nitro.options.dev) {
+          consoleSandbox(() => {
+            // eslint-disable-next-line no-console
+            console.log(
+              '[Sentry] Your application is running in development mode. Note: @sentry/nuxt is in beta and may not work as expected on the server-side (Nitro).',
+            );
+          });
+        }
+
         if (moduleOptions.dynamicImportForServerEntry === false) {
           addServerConfigToBuild(moduleOptions, nuxt, nitro, serverConfigFile);
 


### PR DESCRIPTION
Sentry is initialized too late in development mode and tracing does not work. This is a note to inform users about that. Will be fixed in the stable version.