### PR TITLE
fix(solidstart): Use production server for e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solidstart/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart/package.json
@@ -3,20 +3,9 @@
   "version": "0.0.0",
   "scripts": {
     "clean": "pnpx rimraf node_modules pnpm-lock.yaml .vinxi .output",
-    "clean:build": "pnpx rimraf .vinxi .output",
     "dev": "NODE_OPTIONS='--import ./src/instrument.server.mjs' vinxi dev",
-    "build": "vinxi build",
-    "//": [
-      "We are using `vinxi dev` to start the server because `vinxi start` is experimental and ",
-      "doesn't correctly resolve modules for @sentry/solidstart/solidrouter.",
-      "This is currently not an issue outside of our repo. See: https://github.com/nksaraf/vinxi/issues/177",
-      "We run the build command to ensure building succeeds. However, keeping",
-      "build output around slows down the vite dev server when using `@sentry/vite-plugin` so we clear it out",
-      "before actually running the tests.",
-      "Cleaning the build output should be removed once we can use `vinxi start`."
-    ],
-    "preview": "pnpm clean:build && HOST=localhost PORT=3030 NODE_OPTIONS='--import ./src/instrument.server.mjs' vinxi dev",
-    "start": "HOST=localhost PORT=3030 NODE_OPTIONS='--import ./src/instrument.server.mjs' vinxi start",
+    "build": "vinxi build && sh ./post_build.sh",
+    "preview": "HOST=localhost PORT=3030 NODE_OPTIONS='--import ./src/instrument.server.mjs' vinxi start",
     "test:prod": "TEST_ENV=production playwright test",
     "test:build": "pnpm install && npx playwright install && pnpm build",
     "test:assert": "pnpm test:prod"
@@ -41,5 +30,8 @@
     "vite": "^5.2.8",
     "vite-plugin-solid": "^2.10.2",
     "vitest": "^1.5.0"
+  },
+  "overrides": {
+    "@vercel/nft": "0.27.4"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart/post_build.sh
+++ b/dev-packages/e2e-tests/test-applications/solidstart/post_build.sh
@@ -1,0 +1,8 @@
+# TODO: Investigate the need for this script periodically and remove once these modules are correctly resolved.
+
+# This script copies `import-in-the-middle` and `@sentry/solidstart` from the E2E test project root `node_modules`
+# to the nitro server build output `node_modules` as these are not properly resolved in our yarn workspace/pnpm
+# e2e structure. Some files like `hook.mjs` and `@sentry/solidstart/solidrouter.server.js` are missing. This is
+# not reproducible in an external project (when pinning `@vercel/nft` to `v0.27.0` and higher).
+cp -r node_modules/.pnpm/import-in-the-middle@1.*/node_modules/import-in-the-middle .output/server/node_modules
+cp -rL node_modules/@sentry/solidstart .output/server/node_modules/@sentry

--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/errorboundary.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/errorboundary.test.ts
@@ -11,7 +11,6 @@ test('captures an exception', async ({ page }) => {
   });
 
   await page.goto('/error-boundary');
-  await page.goto('/error-boundary');
   await page.locator('#caughtErrorBtn').click();
   const errorEvent = await errorEventPromise;
 
@@ -41,7 +40,6 @@ test('captures a second exception after resetting the boundary', async ({ page }
     );
   });
 
-  await page.goto('/error-boundary');
   await page.goto('/error-boundary');
   await page.locator('#caughtErrorBtn').click();
   const firstErrorEvent = await firstErrorEventPromise;


### PR DESCRIPTION
Adds a small post-build script to copy over deps that are not correctly resolved in our yarn workspace/pnpm e2e test applications (but do work correctly in standalone projects). This allows us to finally use the vinxi production server to run e2e tests and is similar to what the Nuxt SDK has to do.

Also allows us to get rid of the double page loads for the first test to avoid hydration errors that were caused by the dev server previously.
