### PR TITLE
feat(browser): Add `http.response_delivery_type` attribute to resource spans

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/attributes/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/attributes/subject.js
@@ -1,0 +1,11 @@
+async function run() {
+  Sentry.startSpan({ name: 'parent_span' }, () => {
+    Sentry.startSpan({ name: 'child_span', attributes: { someAttribute: '' } }, () => {
+      // whatever a user would do here
+    });
+  });
+}
+
+(async () => {
+  await run();
+})();

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/attributes/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/attributes/test.ts
@@ -1,0 +1,21 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import {
+  envelopeRequestParser,
+  shouldSkipTracingTest,
+  waitForTransactionRequestOnUrl,
+} from '../../../../utils/helpers';
+
+sentryTest('sends an empty string attribute', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+  const req = await waitForTransactionRequestOnUrl(page, url);
+  const transaction = envelopeRequestParser(req);
+
+  const childSpan = transaction.spans?.[0];
+  expect(childSpan?.data?.someAttribute).toBe('');
+});

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -541,10 +541,7 @@ export function _addResourceSpans(
   setResourceEntrySizeData(attributes, entry, 'decodedBodySize', 'http.decoded_response_content_length');
 
   if (entry.deliveryType != null) {
-    // Falling back to 'default' as attributes with empty string are dropped by our backend.
-    // The empty string is the default value for the deliveryType attribute, indicating that
-    // the browser actually sent a request (as opposed to retrieved the response from its cache).
-    attributes['http.response_delivery_type'] = entry.deliveryType || 'default';
+    attributes['http.response_delivery_type'] = entry.deliveryType;
   }
 
   if ('renderBlockingStatus' in entry) {

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -513,6 +513,7 @@ export interface ResourceEntry extends Record<string, unknown> {
   encodedBodySize?: number;
   decodedBodySize?: number;
   renderBlockingStatus?: string;
+  deliveryType?: string;
 }
 
 /** Create resource-related spans */
@@ -538,6 +539,10 @@ export function _addResourceSpans(
   setResourceEntrySizeData(attributes, entry, 'transferSize', 'http.response_transfer_size');
   setResourceEntrySizeData(attributes, entry, 'encodedBodySize', 'http.response_content_length');
   setResourceEntrySizeData(attributes, entry, 'decodedBodySize', 'http.decoded_response_content_length');
+
+  if (entry.deliveryType != null) {
+    attributes['http.response_delivery_type'] = entry.deliveryType || 'default';
+  }
 
   if ('renderBlockingStatus' in entry) {
     attributes['resource.render_blocking_status'] = entry.renderBlockingStatus;

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -541,6 +541,9 @@ export function _addResourceSpans(
   setResourceEntrySizeData(attributes, entry, 'decodedBodySize', 'http.decoded_response_content_length');
 
   if (entry.deliveryType != null) {
+    // Falling back to 'default' as attributes with empty string are dropped by our backend.
+    // The empty string is the default value for the deliveryType attribute, indicating that
+    // the browser actually sent a request (as opposed to retrieved the response from its cache).
     attributes['http.response_delivery_type'] = entry.deliveryType || 'default';
   }
 

--- a/packages/browser-utils/test/browser/browserMetrics.test.ts
+++ b/packages/browser-utils/test/browser/browserMetrics.test.ts
@@ -340,6 +340,32 @@ describe('_addResourceSpans', () => {
   });
 });
 
+// resource delivery types: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
+// i.e. better but not yet widely supported way to check for browser cache hit
+it.each(['', 'cache', 'navigational-prefetch'])(
+  'attaches delivery type to resource spans if available',
+  deliveryType => {
+    const spans: Span[] = [];
+
+    getClient()?.on('spanEnd', span => {
+      spans.push(span);
+    });
+
+    const entry: ResourceEntry = {
+      initiatorType: 'css',
+      transferSize: 0,
+      encodedBodySize: 0,
+      decodedBodySize: 0,
+      deliveryType,
+    };
+
+    _addResourceSpans(span, entry, resourceEntryName, 100, 23, 345);
+
+    expect(spans).toHaveLength(1);
+    expect(spanToJSON(spans[0]!)).toEqual(expect.objectContaining({ 'http.response_delivery_type': deliveryType }));
+  },
+);
+
 const setGlobalLocation = (location: Location) => {
   // @ts-expect-error need to delete this in order to set to new value
   delete WINDOW.location;

--- a/packages/browser-utils/test/browser/browserMetrics.test.ts
+++ b/packages/browser-utils/test/browser/browserMetrics.test.ts
@@ -341,7 +341,7 @@ describe('_addResourceSpans', () => {
 
   // resource delivery types: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
   // i.e. better but not yet widely supported way to check for browser cache hit
-  it.each(['cache', 'navigational-prefetch'])(
+  it.each(['cache', 'navigational-prefetch', ''])(
     'attaches delivery type ("%s") to resource spans if available',
     deliveryType => {
       const spans: Span[] = [];
@@ -364,27 +364,6 @@ describe('_addResourceSpans', () => {
       expect(spanToJSON(spans[0]!).data).toMatchObject({ 'http.response_delivery_type': deliveryType });
     },
   );
-
-  it('attaches "default" as delivery if the empty string ("") default value is set', () => {
-    const spans: Span[] = [];
-
-    getClient()?.on('spanEnd', span => {
-      spans.push(span);
-    });
-
-    const entry: ResourceEntry = {
-      initiatorType: 'css',
-      transferSize: 0,
-      encodedBodySize: 0,
-      decodedBodySize: 0,
-      deliveryType: '',
-    };
-
-    _addResourceSpans(span, entry, resourceEntryName, 100, 23, 345);
-
-    expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!).data).toMatchObject({ 'http.response_delivery_type': 'default' });
-  });
 });
 
 const setGlobalLocation = (location: Location) => {


### PR DESCRIPTION
This PR adds the `deliveryType` field of a `ResourcePeformanceEntry` to our `resource` spans. This [attribute](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType) can give a definitive answer if a resource was retrieved from the browser cache or if the request was actually made to the resource src. 

Unfortunately, `deliveryType` is not yet supported in all browsers but where it is, it should give us more reliable indicators of browser cache hits/misses. 

The [alternative way](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize#checking_if_a_cache_was_hit) of checking for cache hits/misses (which is to check for transfer and decoded body sizes of a response) has a flaw: It only works for requests to 3rd party origins if that origin returns the `Allow-Resource-Timing` http header with a matching value. Otherwise, we can't determine the cache hit/miss status for 3rd party requests for certain.

One important thing: The `deliveryType` value indicating that a request was actually made (i.e. cache miss) is the empty string `""`. We adjusted Relay to forward empty string values (https://github.com/getsentry/relay/pull/4174) to ensure this value is ingested correctly.

### Idea for Product Improvement

Extracted to https://github.com/getsentry/sentry/issues/79651

