### PR TITLE
debug(replay): Remove noisy log that is causing event buffer overflow as well

### DIFF
--- a/packages/replay-internal/src/eventBuffer/EventBufferCompressionWorker.ts
+++ b/packages/replay-internal/src/eventBuffer/EventBufferCompressionWorker.ts
@@ -67,12 +67,6 @@ export class EventBufferCompressionWorker implements EventBuffer {
     this._totalSize += data.length;
 
     if (this._totalSize > REPLAY_MAX_EVENT_BUFFER_SIZE) {
-      DEBUG_BUILD &&
-        logger.info(
-          `Cannot add new event with raw size of ${data.length} to existing buffer of size ${
-            this._totalSize - data.length
-          }`,
-        );
       return Promise.reject(new EventBufferSizeExceededError());
     }
 

--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -452,7 +452,9 @@ export class ReplayContainer implements ReplayContainerInterface {
     this._isEnabled = false;
 
     try {
-      DEBUG_BUILD && logger.info(`Stopping Replay${reason ? ` triggered by ${reason}` : ''}`);
+      DEBUG_BUILD &&
+        reason !== 'addEventSizeExceeded' &&
+        logger.info(`Stopping Replay${reason ? ` triggered by ${reason}` : ''}`);
 
       resetReplayIdOnDynamicSamplingContext();
 


### PR DESCRIPTION
Removes a log statement that is output when buffer is already full (which will keep overflowing the buffer). Also noticed a log statement in `stop()` that would trigger when we stop due to event buffer being full, which would compoound the issue. This last fix should be pulled into the SDK.