### PR TITLE
fix(nextjs): Respect directives in value injection loader

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-13/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-13/sentry.client.config.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/sentry.client.config.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.client.config.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/sentry.client.config.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({

--- a/dev-packages/e2e-tests/test-applications/nextjs-t3/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-t3/sentry.client.config.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({

--- a/dev-packages/e2e-tests/test-applications/nextjs-turbo/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-turbo/sentry.client.config.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({

--- a/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
+++ b/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
@@ -4,6 +4,15 @@ type LoaderOptions = {
   values: Record<string, unknown>;
 };
 
+// We need to be careful not to inject anything before any `"use strict";`s or "use client"s or really any other directive.
+// As an additional complication directives may come after any number of comments.
+// This regex is shamelessly stolen from: https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/7f984482c73e4284e8b12a08dfedf23b5a82f0af/packages/bundler-plugin-core/src/index.ts#L535-L539
+const SKIP_COMMENT_AND_DIRECTIVE_REGEX =
+  // Note: CodeQL complains that this regex potentially has n^2 runtime. This likely won't affect realistic files.
+  // Rollup doesn't like if we put this regex as a literal (?). No idea why.
+  // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor
+  new RegExp('^(?:\\s*|/\\*(?:.|\\r|\\n)*?\\*/|//.*[\\n\\r])*(?:"[^"]*";|\'[^\']*\';)?');
+
 /**
  * Set values on the global/window object at the start of a module.
  *
@@ -22,5 +31,7 @@ export default function valueInjectionLoader(this: LoaderThis<LoaderOptions>, us
     .map(([key, value]) => `globalThis["${key}"] = ${JSON.stringify(value)};`)
     .join('\n');
 
-  return `${injectedCode}\n${userCode}`;
+  return userCode.replace(SKIP_COMMENT_AND_DIRECTIVE_REGEX, match => {
+    return match + injectedCode;
+  });
 }


### PR DESCRIPTION
This PR is in preparateion for turbopack.

In the future, `sentry.client.config.ts` will likely need to be configured with a `"use client"` directive so that turbopack knows it needs to be treated as a file on the client.

Our value injection loader currently always prepends the `sentry.client.config.ts` file with statements, rendering any directives in the file useless and crashing turbopack when the file is attempted to be imported somewhere.

This PR detects any comments and directives on top of a file to only inject values after.