### PR TITLE
fix(core): Ensure standalone spans are not sent if SDK is disabled

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-sdk-disabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-sdk-disabled/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+window.fetchCallCount = 0;
+window.spanEnded = false;
+
+const originalWindowFetch = window.fetch;
+window.fetch = (...args) => {
+  window.fetchCallCount++;
+  return originalWindowFetch(...args);
+};
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  tracesSampleRate: 1.0,
+  enabled: false,
+});

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-sdk-disabled/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-sdk-disabled/subject.js
@@ -1,0 +1,3 @@
+Sentry.startSpan({ name: 'standalone_segment_span', experimental: { standalone: true } }, () => {});
+
+window.spanEnded = true;

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-sdk-disabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-sdk-disabled/test.ts
@@ -1,0 +1,22 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
+
+sentryTest("doesn't send a standalone span envelope if SDK is disabled", async ({ getLocalTestPath, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+  await page.goto(url);
+
+  // @ts-expect-error this exists in the test init/subject
+  await page.waitForFunction(() => !!window.spanEnded);
+  await page.waitForTimeout(2000);
+
+  // @ts-expect-error this exists in the test init
+  const fetchCallCount = await page.evaluate(() => window.fetchCallCount);
+  // We expect no fetch calls because the SDK is disabled
+  expect(fetchCallCount).toBe(0);
+});

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -565,7 +565,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
     if (this._isEnabled() && this._transport) {
       return this._transport.send(envelope).then(null, reason => {
-        DEBUG_BUILD && logger.error('Error while sending event:', reason);
+        DEBUG_BUILD && logger.error('Error while sending envelope:', reason);
         return reason;
       });
     }

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -429,10 +429,7 @@ function sendSpanEnvelope(envelope: SpanEnvelope): void {
     return;
   }
 
-  const transport = client.getTransport();
-  if (transport) {
-    transport.send(envelope).then(null, reason => {
-      DEBUG_BUILD && logger.error('Error while sending span:', reason);
-    });
-  }
+  // sendEnvelope should not throw
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  client.sendEnvelope(envelope);
 }


### PR DESCRIPTION
Previously, when standalone (most prominently INP) spans would `.end()`, they'd always be sent to Sentry, even if the SDK was disabled (via `Sentry.init({enabled: false})` for example). This was caused by us directly calling `transport.send` and not checking for the enabled option, instead of using the client to send the span envelope. 

This PR now changes the sending logic to use the client's `sendEnvelope` method which we generally use to send envelopes (sessions, client reports, checkins, metrics (RIP), and also events). This has a minor implication: We will now also emit a `beforeEnvelope` client hook event for sending standalone spans. I think this is actually more correct than before but could potentially break someone. IMO this is worth the "risk" as it's easily revertible and client hooks are primarily meant for internal use. Happy to adjust the PR though if reviewers have different opinions. 

fixes #14082 