### PR TITLE
perf(otel): Only calculate current timestamp once

### DIFF
--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -105,8 +105,9 @@ export class SentrySpanExporter {
    * We do this to avoid leaking memory.
    */
   private _cleanupOldSpans(spans = this._finishedSpans): void {
+    const currentTimeSeconds = Date.now() / 1000;
     this._finishedSpans = spans.filter(span => {
-      const shouldDrop = shouldCleanupSpan(span, this._timeout);
+      const shouldDrop = shouldCleanupSpan(span, currentTimeSeconds, this._timeout);
       DEBUG_BUILD &&
         shouldDrop &&
         logger.log(
@@ -174,8 +175,8 @@ function getCompletedRootNodes(nodes: SpanNode[]): SpanNodeCompleted[] {
   return nodes.filter(nodeIsCompletedRootNode);
 }
 
-function shouldCleanupSpan(span: ReadableSpan, maxStartTimeOffsetSeconds: number): boolean {
-  const cutoff = Date.now() / 1000 - maxStartTimeOffsetSeconds;
+function shouldCleanupSpan(span: ReadableSpan, currentTimeSeconds: number, maxStartTimeOffsetSeconds: number): boolean {
+  const cutoff = currentTimeSeconds - maxStartTimeOffsetSeconds;
   return spanTimeInputToSeconds(span.startTime) < cutoff;
 }
 


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/14067

Avoid calling `Date.now()` for each span in the span exporter. This should reduce blocking I/O.