### PR TITLE
test(browser-integration): Add sentry DSN route handler by default

### DIFF
--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/replay/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/replay/test.ts
@@ -11,14 +11,6 @@ sentryTest('should capture a replay', async ({ getLocalTestUrl, page }) => {
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const req = waitForReplayRequest(page);
 
   const url = await getLocalTestUrl({ testDir: __dirname });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/replayError/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/replayError/test.ts
@@ -9,14 +9,6 @@ sentryTest('should capture a replay & attach an error', async ({ getLocalTestUrl
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const req = waitForReplayRequest(page);
 
   const url = await getLocalTestUrl({ testDir: __dirname });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
@@ -28,7 +28,7 @@ sentryTest('it does not download the SDK if the SDK was loaded in the meanwhile'
     });
   });
 
-  const tmpDir = await getLocalTestUrl({ testDir: __dirname, skipRouteHandler: true });
+  const tmpDir = await getLocalTestUrl({ testDir: __dirname, skipRouteHandler: true, skipDsnRouteHandler: true });
 
   await page.route(`${TEST_HOST}/*.*`, route => {
     const file = route.request().url().split('/').pop();

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/captureExceptionInOnLoad/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/captureExceptionInOnLoad/test.ts
@@ -4,14 +4,6 @@ import { sentryTest } from '../../../../utils/fixtures';
 import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../utils/helpers';
 
 sentryTest('captureException works inside of onLoad', async ({ getLocalTestUrl, page }) => {
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
   const req = await waitForErrorRequestOnUrl(page, url);
 
@@ -21,14 +13,6 @@ sentryTest('captureException works inside of onLoad', async ({ getLocalTestUrl, 
 });
 
 sentryTest('should set SENTRY_SDK_SOURCE value', async ({ getLocalTestUrl, page }) => {
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
   const req = await waitForErrorRequestOnUrl(page, url);
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customInit/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customInit/test.ts
@@ -7,14 +7,6 @@ const bundle = process.env.PW_BUNDLE || '';
 const isLazy = LOADER_CONFIGS[bundle]?.lazy;
 
 sentryTest('always calls onLoad init correctly', async ({ getLocalTestUrl, page }) => {
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrations/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrations/test.ts
@@ -8,14 +8,6 @@ sentryTest('should handle custom added integrations & default integrations', asy
   const shouldHaveReplay = !shouldSkipReplayTest();
   const shouldHaveBrowserTracing = !shouldSkipTracingTest();
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrationsFunction/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrationsFunction/test.ts
@@ -5,14 +5,6 @@ import { sentryTest } from '../../../../utils/fixtures';
 sentryTest(
   'should not add default integrations if integrations function is provided',
   async ({ getLocalTestUrl, page }) => {
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestUrl({ testDir: __dirname });
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/test.ts
@@ -8,14 +8,6 @@ sentryTest('should handle custom added Replay integration', async ({ getLocalTes
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const req = waitForReplayRequest(page);
 
   const url = await getLocalTestUrl({ testDir: __dirname });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/test.ts
@@ -4,14 +4,6 @@ import { sentryTest } from '../../../../utils/fixtures';
 import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../utils/helpers';
 
 sentryTest('keeps data on window.Sentry intact', async ({ getLocalTestUrl, page }) => {
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
   const req = await waitForErrorRequestOnUrl(page, url);
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/onLoadLate/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/onLoadLate/test.ts
@@ -4,14 +4,6 @@ import { sentryTest } from '../../../../utils/fixtures';
 import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../utils/helpers';
 
 sentryTest('late onLoad call is handled', async ({ getLocalTestUrl, page }) => {
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
   const req = await waitForErrorRequestOnUrl(page, url);
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/replay/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/replay/test.ts
@@ -8,14 +8,6 @@ sentryTest('should capture a replay', async ({ getLocalTestUrl, page }) => {
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const req = waitForReplayRequest(page);
 
   const url = await getLocalTestUrl({ testDir: __dirname });

--- a/dev-packages/browser-integration-tests/suites/feedback/attachTo/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/attachTo/test.ts
@@ -23,14 +23,6 @@ sentryTest('should capture feedback with custom button', async ({ getLocalTestUr
     }
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/test.ts
@@ -23,14 +23,6 @@ sentryTest('should capture feedback', async ({ getLocalTestUrl, page }) => {
     }
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackAndReplay/hasSampling/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackAndReplay/hasSampling/test.ts
@@ -31,14 +31,6 @@ sentryTest('should capture feedback', async ({ forceFlushReplay, getLocalTestUrl
     }
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await Promise.all([page.goto(url), page.getByText('Report a Bug').click(), reqPromise0]);

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackCsp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackCsp/test.ts
@@ -23,14 +23,6 @@ sentryTest('should capture feedback', async ({ getLocalTestUrl, page }) => {
     }
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/feedback/logger/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/logger/test.ts
@@ -19,14 +19,6 @@ sentryTest('should log error correctly', async ({ getLocalTestUrl, page }) => {
     messages.push(message.text());
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/integrations/captureConsole/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/captureConsole/test.ts
@@ -7,14 +7,6 @@ import { getMultipleSentryEnvelopeRequests } from '../../../utils/helpers';
 sentryTest('it captures console messages correctly', async ({ getLocalTestUrl, page }) => {
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const [, events] = await Promise.all([page.goto(url), getMultipleSentryEnvelopeRequests<Event>(page, 7)]);
 
   expect(events).toHaveLength(7);

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
@@ -4,14 +4,6 @@ import { sentryTest } from '../../../utils/fixtures';
 sentryTest(
   'should not initialize when inside a Firefox/Safari browser extension',
   async ({ getLocalTestUrl, page }) => {
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const errorLogs: string[] = [];
 
     page.on('console', message => {

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
@@ -2,14 +2,6 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 
 sentryTest('should not initialize when inside a Chrome browser extension', async ({ getLocalTestUrl, page }) => {
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const errorLogs: string[] = [];
 
   page.on('console', message => {

--- a/dev-packages/browser-integration-tests/suites/metrics/metricsShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/metrics/metricsShim/test.ts
@@ -22,7 +22,7 @@ sentryTest('exports shim metrics integration for non-tracing bundles', async ({ 
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
   await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/metrics/timing/test.ts
+++ b/dev-packages/browser-integration-tests/suites/metrics/timing/test.ts
@@ -13,14 +13,6 @@ sentryTest('allows to wrap sync methods with a timing metric', async ({ getLocal
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const beforeTime = Math.floor(Date.now() / 1000);
@@ -95,14 +87,6 @@ sentryTest('allows to wrap async methods with a timing metric', async ({ getLoca
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/bufferModeManual/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferModeManual/test.ts
@@ -45,7 +45,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
     await page.locator('#go-background').click();
@@ -190,7 +190,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
     await page.locator('#go-background').click();
@@ -424,7 +424,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
     // Start buffering and assert that it is enabled

--- a/dev-packages/browser-integration-tests/suites/replay/bufferModeManual/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferModeManual/test.ts
@@ -297,14 +297,6 @@ sentryTest(
 
     const reqPromise0 = waitForReplayRequest(page, 0);
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);
@@ -358,14 +350,6 @@ sentryTest(
     }
 
     const reqPromise0 = waitForReplayRequest(page, 0);
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/bufferModeReload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferModeReload/test.ts
@@ -15,14 +15,6 @@ sentryTest('continues buffer session in session mode after error & reload', asyn
 
   const reqPromise1 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/manualSnapshot/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/manualSnapshot/test.ts
@@ -13,14 +13,6 @@ sentryTest('can manually snapshot canvas', async ({ getLocalTestUrl, page, brows
   const reqPromise2 = waitForReplayRequest(page, 2);
   const reqPromise3 = waitForReplayRequest(page, 3);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/records/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/records/test.ts
@@ -12,14 +12,6 @@ sentryTest('can record canvas', async ({ getLocalTestUrl, page, browserName }) =
   const reqPromise1 = waitForReplayRequest(page, 1);
   const reqPromise2 = waitForReplayRequest(page, 2);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/test.ts
@@ -10,14 +10,6 @@ sentryTest('sets up canvas when adding ReplayCanvas integration first', async ({
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/test.ts
@@ -10,14 +10,6 @@ sentryTest('sets up canvas when adding ReplayCanvas integration after Replay', a
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/test.ts
@@ -8,14 +8,6 @@ sentryTest('does not setup up canvas without ReplayCanvas integration', async ({
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/captureComponentName/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureComponentName/test.ts
@@ -10,14 +10,6 @@ sentryTest('captures component name attribute when available', async ({ forceFlu
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);
@@ -94,14 +86,6 @@ sentryTest('sets element name to component name attribute', async ({ forceFlushR
   }
 
   const reqPromise0 = waitForReplayRequest(page, 0);
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestPath({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/captureConsoleLog/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureConsoleLog/test.ts
@@ -8,14 +8,6 @@ sentryTest('should capture console messages in replay', async ({ getLocalTestPat
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const reqPromise0 = waitForReplayRequest(page, 0);
 
   const url = await getLocalTestPath({ testDir: __dirname });
@@ -58,14 +50,6 @@ sentryTest('should capture very large console logs', async ({ getLocalTestPath, 
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -12,14 +12,6 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -12,14 +12,6 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayOffline/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayOffline/test.ts
@@ -12,14 +12,6 @@ sentryTest('should capture replays offline', async ({ getLocalTestPath, page }) 
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   // This would be the obvious way to test offline support but it doesn't appear to work!

--- a/dev-packages/browser-integration-tests/suites/replay/compressionDisabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionDisabled/test.ts
@@ -19,14 +19,6 @@ sentryTest(
 
     const reqPromise0 = waitForReplayRequest(page, 0);
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/compressionEnabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionEnabled/test.ts
@@ -17,14 +17,6 @@ sentryTest('replay recording should be compressed by default', async ({ getLocal
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/compressionWorkerUrl/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionWorkerUrl/test.ts
@@ -21,14 +21,6 @@ sentryTest(
 
     const reqPromise0 = waitForReplayRequest(page, 0);
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestUrl({ testDir: __dirname });
 
     let customCompressCalled = 0;

--- a/dev-packages/browser-integration-tests/suites/replay/customEvents/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/customEvents/test.ts
@@ -33,14 +33,6 @@ sentryTest(
     const reqPromise0 = waitForReplayRequest(page, 0);
     const reqPromise1 = waitForReplayRequest(page, 1);
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);
@@ -94,14 +86,6 @@ sentryTest(
     const reqPromise1 = waitForReplayRequest(page, 1);
     const reqPromise2 = waitForReplayRequest(page, 2);
     const reqPromise3 = waitForReplayRequest(page, 3);
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
@@ -197,14 +181,6 @@ sentryTest(
 
     const reqPromise0 = waitForReplayRequest(page, 0);
     const reqPromise1 = waitForReplayRequest(page, 1);
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
 
     const url = await getLocalTestPath({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -120,14 +120,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
     await page.goto(url);
 
@@ -181,14 +173,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
     await page.goto(url);
 
@@ -228,14 +212,6 @@ sentryTest('should add replay_id to error DSC while replay is active', async ({ 
   }
 
   const hasTracing = !shouldSkipTracingTest();
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/errorResponse/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errorResponse/test.ts
@@ -22,7 +22,7 @@ sentryTest('should stop recording after receiving an error response', async ({ g
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
   await Promise.all([page.goto(url), waitForReplayRequest(page)]);
 
   await page.locator('button').click();

--- a/dev-packages/browser-integration-tests/suites/replay/errors/beforeErrorSampling/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/beforeErrorSampling/test.ts
@@ -11,14 +11,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/errors/droppedError/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/droppedError/test.ts
@@ -28,7 +28,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
@@ -48,7 +48,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await Promise.all([
       page.goto(url),

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorNotSent/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorNotSent/test.ts
@@ -21,7 +21,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
@@ -37,7 +37,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
     const req0 = await reqPromise0;

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
@@ -94,14 +94,6 @@ sentryTest(
     const reqPromise0 = waitForReplayRequest(page, 0);
     const reqPromise1 = waitForReplayRequest(page, 1);
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/errors/immediateError/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/immediateError/test.ts
@@ -11,14 +11,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const req = waitForReplayRequest(page);
 
     const url = await getLocalTestUrl({ testDir: __dirname });

--- a/dev-packages/browser-integration-tests/suites/replay/eventBufferError/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/eventBufferError/test.ts
@@ -19,12 +19,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/test.ts
@@ -21,14 +21,6 @@ sentryTest('captures text request body', async ({ getLocalTestUrl, page, browser
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -99,14 +91,6 @@ sentryTest('captures JSON request body', async ({ getLocalTestUrl, page, browser
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -174,14 +158,6 @@ sentryTest('captures non-text request body', async ({ getLocalTestUrl, page, bro
   await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 
@@ -259,14 +235,6 @@ sentryTest('captures text request body when matching relative URL', async ({ get
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -332,14 +300,6 @@ sentryTest('does not capture request body when URL does not match', async ({ get
   await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
@@ -21,12 +21,6 @@ sentryTest('handles empty/missing request headers', async ({ getLocalTestUrl, pa
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -89,14 +83,6 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestUrl, page, b
   await page.route('http://sentry-test.io/foo', route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 
@@ -174,12 +160,6 @@ sentryTest('captures request headers on Request', async ({ getLocalTestUrl, page
   const additionalHeaders = browserName === 'webkit' ? { 'content-type': 'text/plain' } : undefined;
 
   await page.route('http://sentry-test.io/foo', route => {
-    return route.fulfill({
-      status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
     });
@@ -264,12 +244,6 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -344,14 +318,6 @@ sentryTest('does not captures request headers if URL does not match', async ({ g
   await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
@@ -19,14 +19,6 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -101,14 +93,6 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
   await page.route('**/foo', async route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/test.ts
@@ -22,14 +22,6 @@ sentryTest('captures text response body', async ({ getLocalTestUrl, page, browse
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -99,14 +91,6 @@ sentryTest('captures JSON response body', async ({ getLocalTestUrl, page, browse
     return route.fulfill({
       status: 200,
       body: JSON.stringify({ res: 'this' }),
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 
@@ -182,14 +166,6 @@ sentryTest('captures non-text response body', async ({ getLocalTestUrl, page, br
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -259,14 +235,6 @@ sentryTest.skip('does not capture response body when URL does not match', async 
     return route.fulfill({
       status: 200,
       body: 'response body',
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
@@ -21,14 +21,6 @@ sentryTest('handles empty headers', async ({ getLocalTestUrl, page, browserName 
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
@@ -94,14 +86,6 @@ sentryTest('captures response headers', async ({ getLocalTestUrl, page }) => {
         'X-Other-Header': 'test-value-2',
         'access-control-expose-headers': '*',
       },
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 
@@ -176,14 +160,6 @@ sentryTest('does not capture response headers if URL does not match', async ({ g
         'X-Other-Header': 'test-value-2',
         'access-control-expose-headers': '*',
       },
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
@@ -26,14 +26,6 @@ sentryTest('captures response size from Content-Length header if available', asy
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
 
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
@@ -116,14 +108,6 @@ sentryTest('captures response size without Content-Length header', async ({ getL
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
 
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
@@ -200,14 +184,6 @@ sentryTest('captures response size from non-text response body', async ({ getLoc
       headers: {
         'Content-Length': '',
       },
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/test.ts
@@ -34,7 +34,7 @@ sentryTest('captures correct timestamps', async ({ getLocalTestUrl, page, browse
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.fetch');
   });
 
-  const url = await getLocalTestUrl({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname, skipDsnRouteHandler: true });
   await page.goto(url);
 
   await page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/test.ts
@@ -20,14 +20,6 @@ sentryTest('captures text request body', async ({ getLocalTestUrl, page, browser
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -100,14 +92,6 @@ sentryTest('captures JSON request body', async ({ getLocalTestUrl, page, browser
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -177,14 +161,6 @@ sentryTest('captures non-text request body', async ({ getLocalTestUrl, page, bro
   await page.route('**/foo', async route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 
@@ -264,14 +240,6 @@ sentryTest('captures text request body when matching relative URL', async ({ get
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -341,14 +309,6 @@ sentryTest('does not capture request body when URL does not match', async ({ get
   await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/test.ts
@@ -20,14 +20,6 @@ sentryTest('captures request headers', async ({ getLocalTestUrl, page, browserNa
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -102,14 +94,6 @@ sentryTest('does not capture request headers if URL does not match', async ({ ge
   await page.route('http://sentry-test.io/bar', route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestSize/test.ts
@@ -20,14 +20,6 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -107,14 +99,6 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
   await page.route('**/foo', async route => {
     return route.fulfill({
       status: 200,
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/test.ts
@@ -24,14 +24,6 @@ sentryTest('captures text response body', async ({ getLocalTestUrl, page, browse
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -108,14 +100,6 @@ sentryTest('captures JSON response body', async ({ getLocalTestUrl, page, browse
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -189,14 +173,6 @@ sentryTest('captures JSON response body when responseType=json', async ({ getLoc
       headers: {
         'Content-Length': '',
       },
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 
@@ -278,14 +254,6 @@ sentryTest('captures non-text response body', async ({ getLocalTestUrl, page, br
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -359,14 +327,6 @@ sentryTest('does not capture response body when URL does not match', async ({ ge
       headers: {
         'Content-Length': '',
       },
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/test.ts
@@ -27,14 +27,6 @@ sentryTest('captures response headers', async ({ getLocalTestUrl, page, browserN
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -114,14 +106,6 @@ sentryTest(
           'X-Other-Header': 'test-value-2',
           'access-control-expose-headers': '*',
         },
-      });
-    });
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
       });
     });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseSize/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseSize/test.ts
@@ -25,14 +25,6 @@ sentryTest(
       });
     });
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const requestPromise = waitForErrorRequest(page);
     const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
       return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -120,14 +112,6 @@ sentryTest('captures response size without Content-Length header', async ({ getL
     });
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const requestPromise = waitForErrorRequest(page);
   const replayRequestPromise = collectReplayRequests(page, recordingEvents => {
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
@@ -209,14 +193,6 @@ sentryTest('captures response size for non-string bodies', async ({ getLocalTest
       headers: {
         'Content-Length': '',
       },
-    });
-  });
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
     });
   });
 

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/test.ts
@@ -34,7 +34,7 @@ sentryTest('captures correct timestamps', async ({ getLocalTestUrl, page, browse
     return getReplayPerformanceSpans(recordingEvents).some(span => span.op === 'resource.xhr');
   });
 
-  const url = await getLocalTestUrl({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname, skipDsnRouteHandler: true });
   await page.goto(url);
 
   void page.evaluate(() => {

--- a/dev-packages/browser-integration-tests/suites/replay/fileInput/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/fileInput/test.ts
@@ -26,14 +26,6 @@ sentryTest(
 
     const reqPromise0 = waitForReplayRequest(page, 0);
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/flushing/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/flushing/test.ts
@@ -21,14 +21,6 @@ sentryTest('replay events are flushed after max flush delay was reached', async 
   const reqPromise1 = waitForReplayRequest(page, 1);
   const reqPromise2 = waitForReplayRequest(page, 2);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/keyboardEvents/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/keyboardEvents/test.ts
@@ -10,14 +10,6 @@ sentryTest('captures keyboard events', async ({ forceFlushReplay, getLocalTestPa
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
@@ -10,14 +10,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     // We have to click in order to ensure the LCP is generated, leading to consistent results

--- a/dev-packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/test.ts
@@ -15,14 +15,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     // We have to click in order to ensure the LCP is generated, leading to consistent results

--- a/dev-packages/browser-integration-tests/suites/replay/logger/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/logger/test.ts
@@ -15,14 +15,6 @@ sentryTest('should output logger messages', async ({ getLocalTestPath, page }) =
     messages.push(message.text());
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const reqPromise0 = waitForReplayRequest(page, 0);
 
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/dev-packages/browser-integration-tests/suites/replay/maxReplayDuration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/maxReplayDuration/test.ts
@@ -11,14 +11,6 @@ sentryTest('keeps track of max duration across reloads', async ({ getLocalTestPa
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 

--- a/dev-packages/browser-integration-tests/suites/replay/minReplayDuration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/minReplayDuration/test.ts
@@ -17,14 +17,6 @@ sentryTest('doest not send replay before min. duration', async ({ getLocalTestPa
     return true;
   });
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -37,14 +37,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const reqPromise0 = waitForReplayRequest(page, 0);
     const reqPromise1 = waitForReplayRequest(page, 1);
     const reqPromise2 = waitForReplayRequest(page, 2);

--- a/dev-packages/browser-integration-tests/suites/replay/privacyBlock/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyBlock/test.ts
@@ -15,14 +15,6 @@ sentryTest('should allow to manually block elements', async ({ getLocalTestPath,
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/privacyDefault/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyDefault/test.ts
@@ -15,14 +15,6 @@ sentryTest('should have the correct default privacy settings', async ({ getLocal
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/privacyInput/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyInput/test.ts
@@ -54,14 +54,6 @@ sentryTest(
       return inputMutationSegmentIds.length === 2 && inputMutationSegmentIds[1] < event.segment_id;
     });
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);
@@ -137,14 +129,6 @@ sentryTest(
       }
 
       return check;
-    });
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
     });
 
     const url = await getLocalTestPath({ testDir: __dirname });

--- a/dev-packages/browser-integration-tests/suites/replay/privacyInputMaskAll/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyInputMaskAll/test.ts
@@ -46,14 +46,6 @@ sentryTest(
       );
     });
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);
@@ -108,14 +100,6 @@ sentryTest(
         firstInputMutationSegmentId < event.segment_id &&
         getIncrementalRecordingSnapshots(res).some(isInputMutation)
       );
-    });
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
     });
 
     const url = await getLocalTestPath({ testDir: __dirname });

--- a/dev-packages/browser-integration-tests/suites/replay/replayIntegrationShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/replayIntegrationShim/test.ts
@@ -24,7 +24,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/replayShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/replayShim/test.ts
@@ -24,7 +24,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
     await forceFlushReplay();

--- a/dev-packages/browser-integration-tests/suites/replay/requests/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/requests/test.ts
@@ -10,14 +10,6 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   await page.route('https://example.com', route => {
     return route.fulfill({
       status: 200,
@@ -47,14 +39,6 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
   if (shouldSkipReplayTest() || browserName === 'webkit') {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   await page.route('https://example.com', route => {
     return route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/replay/sampling/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/sampling/test.ts
@@ -19,7 +19,7 @@ sentryTest('should not send replays if both sample rates are 0', async ({ getLoc
     });
   });
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
   await page.goto(url);
 
   await page.locator('button').click();

--- a/dev-packages/browser-integration-tests/suites/replay/sessionExpiry/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionExpiry/test.ts
@@ -22,14 +22,6 @@ sentryTest('handles an expired session', async ({ browserName, forceFlushReplay,
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/sessionInactive/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionInactive/test.ts
@@ -23,14 +23,6 @@ sentryTest('handles an inactive session', async ({ getLocalTestPath, page, brows
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/sessionMaxAge/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionMaxAge/test.ts
@@ -26,14 +26,6 @@ sentryTest('handles session that exceeds max age', async ({ forceFlushReplay, ge
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/clickTargets/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/clickTargets/test.ts
@@ -35,14 +35,6 @@ import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } 
         sentryTest.skip();
       }
 
-      await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-        return route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ id: 'test-id' }),
-        });
-      });
-
       const url = await getLocalTestUrl({ testDir: __dirname });
 
       await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
@@ -90,14 +82,6 @@ import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } 
       if (shouldSkipReplayTest()) {
         sentryTest.skip();
       }
-
-      await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-        return route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ id: 'test-id' }),
-        });
-      });
 
       const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/disable/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/disable/test.ts
@@ -8,14 +8,6 @@ sentryTest('does not capture slow click when slowClickTimeout === 0', async ({ g
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/error/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/error/test.ts
@@ -13,14 +13,6 @@ sentryTest('slow click that triggers error is captured', async ({ getLocalTestUr
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
@@ -69,14 +61,6 @@ sentryTest(
     if (shouldSkipReplayTest()) {
       sentryTest.skip();
     }
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/ignore/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/ignore/test.ts
@@ -8,14 +8,6 @@ sentryTest('click is ignored on ignoreSelectors', async ({ getLocalTestUrl, page
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
@@ -57,14 +49,6 @@ sentryTest('click is ignored on div', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/multiClick/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/multiClick/test.ts
@@ -13,14 +13,6 @@ sentryTest('captures multi click when not detecting slow click', async ({ getLoc
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
@@ -104,14 +96,6 @@ sentryTest('captures multiple multi clicks', async ({ getLocalTestUrl, page, for
   if (shouldSkipReplayTest() || browserName === 'webkit') {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/mutation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/mutation/test.ts
@@ -8,14 +8,6 @@ sentryTest('mutation after threshold results in slow click', async ({ forceFlush
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const replayRequestPromise = waitForReplayRequest(page, 0);
@@ -70,14 +62,6 @@ sentryTest('multiple clicks are counted', async ({ getLocalTestUrl, page }) => {
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const replayRequestPromise = waitForReplayRequest(page, 0);
@@ -130,14 +114,6 @@ sentryTest('immediate mutation does not trigger slow click', async ({ forceFlush
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -198,14 +174,6 @@ sentryTest('inline click handler does not trigger slow click', async ({ forceFlu
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const replayRequestPromise = waitForReplayRequest(page, 0);
@@ -249,14 +217,6 @@ sentryTest('mouseDown events are considered', async ({ getLocalTestUrl, page }) 
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/scroll/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/scroll/test.ts
@@ -8,14 +8,6 @@ sentryTest('immediate scroll does not trigger slow click', async ({ getLocalTest
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
@@ -56,14 +48,6 @@ sentryTest('late scroll triggers slow click', async ({ getLocalTestUrl, page }) 
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/timeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/timeout/test.ts
@@ -8,14 +8,6 @@ sentryTest('mutation after timeout results in slow click', async ({ getLocalTest
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
@@ -62,14 +54,6 @@ sentryTest('console.log results in slow click', async ({ getLocalTestUrl, page }
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
-
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/windowOpen/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/windowOpen/test.ts
@@ -8,14 +8,6 @@ sentryTest('window.open() is considered for slow click', async ({ getLocalTestUr
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   await page.route('http://example.com/', route => {
     return route.fulfill({
       status: 200,

--- a/dev-packages/browser-integration-tests/suites/replay/throttleBreadcrumbs/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/throttleBreadcrumbs/test.ts
@@ -15,14 +15,6 @@ sentryTest(
     const reqPromise0 = waitForReplayRequest(page, 0);
     const reqPromise1 = waitForReplayRequest(page, 1);
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/unicode/compressed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/unicode/compressed/test.ts
@@ -15,14 +15,6 @@ sentryTest('replay should handle unicode characters', async ({ getLocalTestPath,
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/replay/unicode/uncompressed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/unicode/uncompressed/test.ts
@@ -15,14 +15,6 @@ sentryTest('replay should handle unicode characters', async ({ getLocalTestPath,
 
   const reqPromise0 = waitForReplayRequest(page, 0);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/sessions/initial-scope/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/initial-scope/test.ts
@@ -21,14 +21,6 @@ sentryTest('should start a new session with navigation.', async ({ getLocalTestU
 
   await page.route('**/foo', (route: Route) => route.continue({ url }));
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const initSession = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
 
   await page.click('#navigate');

--- a/dev-packages/browser-integration-tests/suites/sessions/start-session/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/start-session/test.ts
@@ -19,14 +19,6 @@ sentryTest('should start a new session with navigation.', async ({ getLocalTestU
   const url = await getLocalTestUrl({ testDir: __dirname });
   await page.route('**/foo', (route: Route) => route.continue({ url }));
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const initSession = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
 
   await page.locator('#navigate').click();

--- a/dev-packages/browser-integration-tests/suites/sessions/v7-hub-start-session/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/v7-hub-start-session/test.ts
@@ -19,14 +19,6 @@ sentryTest('should start a new session with navigation.', async ({ getLocalTestU
   const url = await getLocalTestUrl({ testDir: __dirname });
   await page.route('**/foo', (route: Route) => route.continue({ url }));
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const initSession = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
 
   await page.locator('#navigate').click();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationShim/test.ts
@@ -24,7 +24,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestPath({ testDir: __dirname, skipDsnRouteHandler: true });
 
     await page.goto(url);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/test.ts
@@ -16,14 +16,6 @@ sentryTest('should capture an INP click event span after pageload', async ({ bro
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/test.ts
@@ -18,14 +18,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/test.ts
@@ -17,14 +17,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/test.ts
@@ -18,14 +18,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.goto(url);
@@ -108,14 +100,6 @@ sentryTest(
     if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
       sentryTest.skip();
     }
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
-      });
-    });
 
     const url = await getLocalTestPath({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -74,14 +74,6 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
     sentryTest.skip();
   }
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
-    });
-  });
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   // ensure pageload transaction is finished

--- a/dev-packages/browser-integration-tests/utils/fixtures.ts
+++ b/dev-packages/browser-integration-tests/utils/fixtures.ts
@@ -68,6 +68,14 @@ const sentryTest = base.extend<TestFixtures>({
         return tmpDir;
       }
 
+      await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 'test-id' }),
+        });
+      });
+
       await page.route(`${TEST_HOST}/*.*`, route => {
         const file = route.request().url().split('/').pop();
         const filePath = path.resolve(tmpDir, `./${file}`);
@@ -96,12 +104,20 @@ const sentryTest = base.extend<TestFixtures>({
     });
   },
 
-  getLocalTestPath: ({}, use) => {
+  getLocalTestPath: ({ page }, use) => {
     return use(async ({ testDir }) => {
       const tmpDir = path.join(testDir, 'dist', crypto.randomUUID());
       const pagePath = `file:///${path.resolve(tmpDir, './index.html')}`;
 
       await build(testDir, tmpDir);
+
+      await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 'test-id' }),
+        });
+      });
 
       return pagePath;
     });


### PR DESCRIPTION
Instead of sprinkling this through tests, we can just generally handle this route, streamlining tests a bit and avoid unexpected errors/console warnings messing with things.

So this PR basically inverses this - by default, we add a "success" route handler for the Sentry DSN, and if you want to have special handling you can opt-out of this.

Supersedes https://github.com/getsentry/sentry-javascript/pull/14092/files