### PR TITLE
feat(nuxt): Add `entrypointWrappedFunctions` to define async wrapped server functions

### DIFF
--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -118,11 +118,12 @@ export type SentryNuxtModuleOptions = {
   dynamicImportForServerEntry?: boolean;
 
   /**
-   * The `asyncFunctionReExports` option is only relevant when `dynamicImportForServerEntry: true` (default value).
+   * By default—unless you configure `dynamicImportForServerEntry: false`—the SDK will try to wrap your application entrypoint
+   * with a dynamic `import()` to ensure all dependencies can be properly instrumented.
    *
-   * As the server entry file is wrapped with a dynamic `import()`, previous async function exports need to be re-exported.
-   * The SDK detects and re-exports those exports (mostly serverless functions). This is why they are re-exported as async functions.
-   * In case you have a custom setup and your server exports other async functions, you can override the default array with this option.
+   * By default, the SDK will wrap the default export as well as a `handler` or `server` export from the entrypoint.
+   * If your application has a different main export that is used to run the application, you can overwrite this by providing an array of export names to wrap.
+   * Any wrapped export is expected to be an async function.
    *
    * @default ['default', 'handler', 'server']
    */

--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -119,7 +119,8 @@ export type SentryNuxtModuleOptions = {
 
   /**
    * By default—unless you configure `dynamicImportForServerEntry: false`—the SDK will try to wrap your application entrypoint
-   * with a dynamic `import()` to ensure all dependencies can be properly instrumented.
+   * with a dynamic `import()` to ensure all dependencies can be properly instrumented. Any previous exports from the entrypoint are still exported.
+   * Most exports of the server entrypoint are serverless functions and those are wrapped by Sentry. Other exports stay as-is.
    *
    * By default, the SDK will wrap the default export as well as a `handler` or `server` export from the entrypoint.
    * If your application has a different main export that is used to run the application, you can overwrite this by providing an array of export names to wrap.
@@ -127,7 +128,7 @@ export type SentryNuxtModuleOptions = {
    *
    * @default ['default', 'handler', 'server']
    */
-  asyncFunctionReExports?: string[];
+  entrypointWrappedFunctions?: string[];
 
   /**
    * Options to be passed directly to the Sentry Rollup Plugin (`@sentry/rollup-plugin`) and Sentry Vite Plugin (`@sentry/vite-plugin`) that ship with the Sentry Nuxt SDK.

--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -118,6 +118,17 @@ export type SentryNuxtModuleOptions = {
   dynamicImportForServerEntry?: boolean;
 
   /**
+   * The `asyncFunctionReExports` option is only relevant when `dynamicImportForServerEntry: true` (default value).
+   *
+   * As the server entry file is wrapped with a dynamic `import()`, previous async function exports need to be re-exported.
+   * The SDK detects and re-exports those exports (mostly serverless functions). This is why they are re-exported as async functions.
+   * In case you have a custom setup and your server exports other async functions, you can override the default array with this option.
+   *
+   * @default ['default', 'handler', 'server']
+   */
+  asyncFunctionReExports?: string[];
+
+  /**
    * Options to be passed directly to the Sentry Rollup Plugin (`@sentry/rollup-plugin`) and Sentry Vite Plugin (`@sentry/vite-plugin`) that ship with the Sentry Nuxt SDK.
    * You can use this option to override any options the SDK passes to the Vite (for Nuxt) and Rollup (for Nitro) plugin.
    *

--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -118,12 +118,12 @@ export type SentryNuxtModuleOptions = {
   dynamicImportForServerEntry?: boolean;
 
   /**
-   * By default—unless you configure `dynamicImportForServerEntry: false`—the SDK will try to wrap your application entrypoint
+   * By default—unless you configure `dynamicImportForServerEntry: false`—the SDK will try to wrap your Nitro server entrypoint
    * with a dynamic `import()` to ensure all dependencies can be properly instrumented. Any previous exports from the entrypoint are still exported.
    * Most exports of the server entrypoint are serverless functions and those are wrapped by Sentry. Other exports stay as-is.
    *
    * By default, the SDK will wrap the default export as well as a `handler` or `server` export from the entrypoint.
-   * If your application has a different main export that is used to run the application, you can overwrite this by providing an array of export names to wrap.
+   * If your server has a different main export that is used to run the server, you can overwrite this by providing an array of export names to wrap.
    * Any wrapped export is expected to be an async function.
    *
    * @default ['default', 'handler', 'server']

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -21,9 +21,7 @@ export default defineNuxtModule<ModuleOptions>({
     const moduleOptions = {
       ...moduleOptionsParam,
       dynamicImportForServerEntry: moduleOptionsParam.dynamicImportForServerEntry !== false, // default: true
-      asyncFunctionReExports: moduleOptionsParam.asyncFunctionReExports
-        ? moduleOptionsParam.asyncFunctionReExports
-        : ['default', 'handler', 'server'],
+      asyncFunctionReExports: moduleOptionsParam.asyncFunctionReExports || ['default', 'handler', 'server'],
     };
 
     const moduleDirResolver = createResolver(import.meta.url);

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -21,7 +21,7 @@ export default defineNuxtModule<ModuleOptions>({
     const moduleOptions = {
       ...moduleOptionsParam,
       dynamicImportForServerEntry: moduleOptionsParam.dynamicImportForServerEntry !== false, // default: true
-      asyncFunctionReExports: moduleOptionsParam.asyncFunctionReExports || ['default', 'handler', 'server'],
+      entrypointWrappedFunctions: moduleOptionsParam.entrypointWrappedFunctions || ['default', 'handler', 'server'],
     };
 
     const moduleDirResolver = createResolver(import.meta.url);

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -21,6 +21,9 @@ export default defineNuxtModule<ModuleOptions>({
     const moduleOptions = {
       ...moduleOptionsParam,
       dynamicImportForServerEntry: moduleOptionsParam.dynamicImportForServerEntry !== false, // default: true
+      asyncFunctionReExports: moduleOptionsParam.asyncFunctionReExports
+        ? moduleOptionsParam.asyncFunctionReExports
+        : ['default', 'handler', 'server'],
     };
 
     const moduleDirResolver = createResolver(import.meta.url);
@@ -101,7 +104,7 @@ export default defineNuxtModule<ModuleOptions>({
             });
           }
         } else {
-          addDynamicImportEntryFileWrapper(nitro, serverConfigFile);
+          addDynamicImportEntryFileWrapper(nitro, serverConfigFile, moduleOptions);
 
           if (moduleOptions.debug) {
             consoleSandbox(() => {

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -27,7 +27,8 @@ export function findDefaultSdkInitFile(type: 'server' | 'client'): string | unde
 }
 
 export const SENTRY_WRAPPED_ENTRY = '?sentry-query-wrapped-entry';
-export const SENTRY_FUNCTIONS_REEXPORT = '?sentry-query-functions-reexport=';
+export const SENTRY_WRAPPED_FUNCTIONS = '?sentry-query-wrapped-functions=';
+export const SENTRY_REEXPORTED_FUNCTIONS = '?sentry-query-reexported-functions=';
 export const QUERY_END_INDICATOR = 'SENTRY-QUERY-END';
 
 /**
@@ -49,63 +50,102 @@ export function removeSentryQueryFromPath(url: string): string {
  *
  * Only exported for testing.
  */
-export function extractFunctionReexportQueryParameters(query: string): string[] {
+export function extractFunctionReexportQueryParameters(query: string): { wrap: string[]; reexport: string[] } {
   // Regex matches the comma-separated params between the functions query
   // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor
-  const regex = new RegExp(`\\${SENTRY_FUNCTIONS_REEXPORT}(.*?)\\${QUERY_END_INDICATOR}`);
-  const match = query.match(regex);
+  const wrapRegex = new RegExp(
+    `\\${SENTRY_WRAPPED_FUNCTIONS}(.*?)(\\${QUERY_END_INDICATOR}|\\${SENTRY_REEXPORTED_FUNCTIONS})`,
+  );
+  // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor
+  const reexportRegex = new RegExp(`\\${SENTRY_REEXPORTED_FUNCTIONS}(.*?)(\\${QUERY_END_INDICATOR})`);
 
-  return match && match[1]
-    ? match[1]
-        .split(',')
-        .filter(param => param !== '')
-        // Sanitize, as code could be injected with another rollup plugin
-        .map((str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-    : [];
+  const wrapMatch = query.match(wrapRegex);
+  const reexportMatch = query.match(reexportRegex);
+
+  const wrap =
+    wrapMatch && wrapMatch[1]
+      ? wrapMatch[1]
+          .split(',')
+          .filter(param => param !== '')
+          .map((str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      : [];
+
+  const reexport =
+    reexportMatch && reexportMatch[1]
+      ? reexportMatch[1]
+          .split(',')
+          .filter(param => param !== '' && param !== 'default')
+          .map((str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      : [];
+
+  return { wrap, reexport };
 }
 
 /**
  *  Constructs a comma-separated string with all functions that need to be re-exported later from the server entry.
  *  It uses Rollup's `exportedBindings` to determine the functions to re-export
  */
-export function constructFunctionsReExportQuery(
+export function constructWrappedFunctionExportQuery(
   exportedBindings: Record<string, string[]> | null,
-  asyncFunctionReExports: string[],
+  entrypointWrappedFunctions: string[],
   debug?: boolean,
 ): string {
   // `exportedBindings` can look like this:  `{ '.': [ 'handler' ] }` or `{ '.': [], './firebase-gen-1.mjs': [ 'server' ] }`
   // The key `.` refers to exports within the current file, while other keys show from where exports were imported first.
-  const functionsToExport = flatten(Object.values(exportedBindings || {})).filter(functionName =>
-    asyncFunctionReExports.includes(functionName),
+  const functionsToExport = flatten(Object.values(exportedBindings || {})).reduce(
+    (functions, currFunctionName) => {
+      if (entrypointWrappedFunctions.includes(currFunctionName)) {
+        functions.wrap.push(currFunctionName);
+      } else {
+        functions.reexport.push(currFunctionName);
+      }
+      return functions;
+    },
+    { wrap: [], reexport: [] } as { wrap: string[]; reexport: string[] },
   );
 
-  if (debug && functionsToExport.length === 0) {
+  if (debug && functionsToExport.wrap.length === 0) {
     consoleSandbox(() =>
       // eslint-disable-next-line no-console
       console.warn(
-        "[Sentry] No functions found for re-export. In case your server needs to export async functions other than `handler` or  `server`, consider adding the name(s) to Sentry's build options `sentry.asyncFunctionReExports` in your `nuxt.config.ts`.",
+        "[Sentry] No functions found to wrap. In case your server needs to export async functions other than `handler` or  `server`, consider adding the name(s) to Sentry's build options `sentry.entrypointWrappedFunctions` in your `nuxt.config.ts`.",
       ),
     );
   }
 
-  return functionsToExport?.length ? SENTRY_FUNCTIONS_REEXPORT.concat(functionsToExport.join(',')) : '';
+  const wrapQuery = functionsToExport.wrap.length
+    ? `${SENTRY_WRAPPED_FUNCTIONS}${functionsToExport.wrap.join(',')}`
+    : '';
+  const reexportQuery = functionsToExport.reexport.length
+    ? `${SENTRY_REEXPORTED_FUNCTIONS}${functionsToExport.reexport.join(',')}`
+    : '';
+
+  return [wrapQuery, reexportQuery].filter(Boolean).join('');
 }
 
 /**
- * Constructs a code snippet with function reexports (can be used in Rollup plugins)
+ * Constructs a code snippet with function reexports (can be used in Rollup plugins as a return value for `load()`)
  */
 export function constructFunctionReExport(pathWithQuery: string, entryId: string): string {
-  const functionNames = extractFunctionReexportQueryParameters(pathWithQuery);
+  const { wrap: wrapFunctions, reexport: reexportFunctions } = extractFunctionReexportQueryParameters(pathWithQuery);
 
-  return functionNames.reduce(
-    (functionsCode, currFunctionName) =>
-      functionsCode.concat(
-        `async function reExport${currFunctionName.toUpperCase()}(...args) {\n` +
-          `  const res = await import(${JSON.stringify(entryId)});\n` +
-          `  return res.${currFunctionName}.call(this, ...args);\n` +
-          '}\n' +
-          `export { reExport${currFunctionName.toUpperCase()} as ${currFunctionName} };\n`,
+  return wrapFunctions
+    .reduce(
+      (functionsCode, currFunctionName) =>
+        functionsCode.concat(
+          `async function ${currFunctionName}_sentryWrapped(...args) {\n` +
+            `  const res = await import(${JSON.stringify(entryId)});\n` +
+            `  return res.${currFunctionName}.call(this, ...args);\n` +
+            '}\n' +
+            `export { ${currFunctionName}_sentryWrapped as ${currFunctionName} };\n`,
+        ),
+      '',
+    )
+    .concat(
+      reexportFunctions.reduce(
+        (functionsCode, currFunctionName) =>
+          functionsCode.concat(`export { ${currFunctionName} } from ${JSON.stringify(entryId)};`),
+        '',
       ),
-    '',
-  );
+    );
 }

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -44,9 +44,8 @@ export function removeSentryQueryFromPath(url: string): string {
 }
 
 /**
- * Extracts and sanitizes function re-export query parameters from a query string.
- * If it is a default export, it is not considered for re-exporting. This function is mostly relevant for re-exporting
- * serverless `handler` functions.
+ * Extracts and sanitizes function re-export and function wrap query parameters from a query string.
+ * If it is a default export, it is not considered for re-exporting.
  *
  * Only exported for testing.
  */
@@ -83,7 +82,8 @@ export function extractFunctionReexportQueryParameters(query: string): { wrap: s
 
 /**
  *  Constructs a comma-separated string with all functions that need to be re-exported later from the server entry.
- *  It uses Rollup's `exportedBindings` to determine the functions to re-export
+ *  It uses Rollup's `exportedBindings` to determine the functions to re-export. Functions which should be wrapped
+ *  (e.g. serverless handlers) are wrapped by Sentry.
  */
 export function constructWrappedFunctionExportQuery(
   exportedBindings: Record<string, string[]> | null,

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -70,13 +70,13 @@ export function constructFunctionReExport(pathWithQuery: string, entryId: string
   const functionNames = extractFunctionReexportQueryParameters(pathWithQuery);
 
   return functionNames.reduce(
-    (functionsCode, currFunctionName) =>
+    (functionsCode, currFunctionName, idx) =>
       functionsCode.concat(
-        'async function reExport(...args) {\n' +
+        `async function reExport${idx}(...args) {\n` +
           `  const res = await import(${JSON.stringify(entryId)});\n` +
           `  return res.${currFunctionName}.call(this, ...args);\n` +
           '}\n' +
-          `export { reExport as ${currFunctionName} };\n`,
+          `export { reExport${idx} as ${currFunctionName} };\n`,
       ),
     '',
   );

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -66,6 +66,7 @@ export function extractFunctionReexportQueryParameters(query: string): { wrap: s
       ? wrapMatch[1]
           .split(',')
           .filter(param => param !== '')
+          // Sanitize, as code could be injected with another rollup plugin
           .map((str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
       : [];
 
@@ -74,6 +75,7 @@ export function extractFunctionReexportQueryParameters(query: string): { wrap: s
       ? reexportMatch[1]
           .split(',')
           .filter(param => param !== '' && param !== 'default')
+          // Sanitize, as code could be injected with another rollup plugin
           .map((str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
       : [];
 
@@ -108,7 +110,7 @@ export function constructWrappedFunctionExportQuery(
     consoleSandbox(() =>
       // eslint-disable-next-line no-console
       console.warn(
-        "[Sentry] No functions found to wrap. In case your server needs to export async functions other than `handler` or  `server`, consider adding the name(s) to Sentry's build options `sentry.entrypointWrappedFunctions` in your `nuxt.config.ts`.",
+        "[Sentry] No functions found to wrap. In case the server needs to export async functions other than `handler` or  `server`, consider adding the name(s) to Sentry's build options `sentry.entrypointWrappedFunctions` in `nuxt.config.ts`.",
       ),
     );
   }
@@ -120,7 +122,7 @@ export function constructWrappedFunctionExportQuery(
     ? `${SENTRY_REEXPORTED_FUNCTIONS}${functionsToExport.reexport.join(',')}`
     : '';
 
-  return [wrapQuery, reexportQuery].filter(Boolean).join('');
+  return [wrapQuery, reexportQuery].join('');
 }
 
 /**

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -111,16 +111,16 @@ describe('constructFunctionReExport', () => {
     const result2 = constructFunctionReExport(query2, entryId);
 
     const expected = `
-async function reExport(...args) {
+async function reExport0(...args) {
   const res = await import("./module");
   return res.foo.call(this, ...args);
 }
-export { reExport as foo };
-async function reExport(...args) {
+export { reExport0 as foo };
+async function reExport1(...args) {
   const res = await import("./module");
   return res.bar.call(this, ...args);
 }
-export { reExport as bar };
+export { reExport1 as bar };
 `;
     expect(result.trim()).toBe(expected.trim());
     expect(result2.trim()).toBe(expected.trim());
@@ -132,11 +132,11 @@ export { reExport as bar };
     const result = constructFunctionReExport(query, entryId);
 
     const expected = `
-async function reExport(...args) {
+async function reExport0(...args) {
   const res = await import("./index");
   return res.default.call(this, ...args);
 }
-export { reExport as default };
+export { reExport0 as default };
 `;
     expect(result.trim()).toBe(expected.trim());
   });

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -152,7 +152,7 @@ describe('constructWrappedFunctionExportQuery', () => {
     const result = constructWrappedFunctionExportQuery(exportedBindings, entrypointWrappedFunctions, debug);
     expect(result).toBe('?sentry-query-reexported-functions=handler');
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      "[Sentry] No functions found to wrap. In case your server needs to export async functions other than `handler` or  `server`, consider adding the name(s) to Sentry's build options `sentry.entrypointWrappedFunctions` in your `nuxt.config.ts`.",
+      "[Sentry] No functions found to wrap. In case the server needs to export async functions other than `handler` or  `server`, consider adding the name(s) to Sentry's build options `sentry.entrypointWrappedFunctions` in `nuxt.config.ts`.",
     );
 
     consoleWarnSpy.mockRestore();

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -2,10 +2,11 @@ import * as fs from 'fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   QUERY_END_INDICATOR,
-  SENTRY_FUNCTIONS_REEXPORT,
+  SENTRY_REEXPORTED_FUNCTIONS,
   SENTRY_WRAPPED_ENTRY,
+  SENTRY_WRAPPED_FUNCTIONS,
   constructFunctionReExport,
-  constructFunctionsReExportQuery,
+  constructWrappedFunctionExportQuery,
   extractFunctionReexportQueryParameters,
   findDefaultSdkInitFile,
   removeSentryQueryFromPath,
@@ -71,7 +72,7 @@ describe('findDefaultSdkInitFile', () => {
 
 describe('removeSentryQueryFromPath', () => {
   it('strips the Sentry query part from the path', () => {
-    const url = `/example/path${SENTRY_WRAPPED_ENTRY}${SENTRY_FUNCTIONS_REEXPORT}foo,${QUERY_END_INDICATOR}`;
+    const url = `/example/path${SENTRY_WRAPPED_ENTRY}${SENTRY_WRAPPED_FUNCTIONS}foo,${QUERY_END_INDICATOR}`;
     const url2 = `/example/path${SENTRY_WRAPPED_ENTRY}${QUERY_END_INDICATOR}`;
     const result = removeSentryQueryFromPath(url);
     const result2 = removeSentryQueryFromPath(url2);
@@ -88,33 +89,56 @@ describe('removeSentryQueryFromPath', () => {
 
 describe('extractFunctionReexportQueryParameters', () => {
   it.each([
-    [`${SENTRY_FUNCTIONS_REEXPORT}foo,bar,${QUERY_END_INDICATOR}`, ['foo', 'bar']],
-    [`${SENTRY_FUNCTIONS_REEXPORT}foo,bar,default${QUERY_END_INDICATOR}`, ['foo', 'bar', 'default']],
+    [`${SENTRY_WRAPPED_FUNCTIONS}foo,bar,${QUERY_END_INDICATOR}`, { wrap: ['foo', 'bar'], reexport: [] }],
     [
-      `${SENTRY_FUNCTIONS_REEXPORT}foo,a.b*c?d[e]f(g)h|i\\\\j(){hello},${QUERY_END_INDICATOR}`,
-      ['foo', 'a\\.b\\*c\\?d\\[e\\]f\\(g\\)h\\|i\\\\\\\\j\\(\\)\\{hello\\}'],
+      `${SENTRY_WRAPPED_FUNCTIONS}foo,bar,default${QUERY_END_INDICATOR}`,
+      { wrap: ['foo', 'bar', 'default'], reexport: [] },
     ],
-    [`/example/path/${SENTRY_FUNCTIONS_REEXPORT}foo,bar${QUERY_END_INDICATOR}`, ['foo', 'bar']],
-    [`${SENTRY_FUNCTIONS_REEXPORT}${QUERY_END_INDICATOR}`, []],
-    ['?other-query=param', []],
+    [
+      `${SENTRY_WRAPPED_FUNCTIONS}foo,a.b*c?d[e]f(g)h|i\\\\j(){hello},${QUERY_END_INDICATOR}`,
+      { wrap: ['foo', 'a\\.b\\*c\\?d\\[e\\]f\\(g\\)h\\|i\\\\\\\\j\\(\\)\\{hello\\}'], reexport: [] },
+    ],
+    [`/example/path/${SENTRY_WRAPPED_FUNCTIONS}foo,bar${QUERY_END_INDICATOR}`, { wrap: ['foo', 'bar'], reexport: [] }],
+    [
+      `${SENTRY_WRAPPED_FUNCTIONS}foo,bar,${SENTRY_REEXPORTED_FUNCTIONS}${QUERY_END_INDICATOR}`,
+      { wrap: ['foo', 'bar'], reexport: [] },
+    ],
+    [`${SENTRY_REEXPORTED_FUNCTIONS}${QUERY_END_INDICATOR}`, { wrap: [], reexport: [] }],
+    [
+      `/path${SENTRY_WRAPPED_FUNCTIONS}foo,bar${SENTRY_REEXPORTED_FUNCTIONS}bar${QUERY_END_INDICATOR}`,
+      { wrap: ['foo', 'bar'], reexport: ['bar'] },
+    ],
+    ['?other-query=param', { wrap: [], reexport: [] }],
   ])('extracts parameters from the query string: %s', (query, expected) => {
     const result = extractFunctionReexportQueryParameters(query);
     expect(result).toEqual(expected);
   });
 });
 
-describe('constructFunctionsReExportQuery', () => {
+describe('constructWrappedFunctionExportQuery', () => {
   it.each([
-    [{ '.': ['handler'] }, ['handler'], '?sentry-query-functions-reexport=handler'],
-    [{ '.': ['handler'], './module': ['server'] }, [], ''],
-    [{ '.': ['handler'], './module': ['server'] }, ['server'], '?sentry-query-functions-reexport=server'],
-    [{ '.': ['handler', 'otherFunction'] }, ['handler'], '?sentry-query-functions-reexport=handler'],
-    [{ '.': ['handler', 'otherFn'] }, ['handler', 'otherFn'], '?sentry-query-functions-reexport=handler,otherFn'],
-    [{ '.': ['bar'], './module': ['foo'] }, ['bar', 'foo'], '?sentry-query-functions-reexport=bar,foo'],
+    [{ '.': ['handler'] }, ['handler'], `${SENTRY_WRAPPED_FUNCTIONS}handler`],
+    [{ '.': ['handler'], './module': ['server'] }, [], `${SENTRY_REEXPORTED_FUNCTIONS}handler,server`],
+    [
+      { '.': ['handler'], './module': ['server'] },
+      ['server'],
+      `${SENTRY_WRAPPED_FUNCTIONS}server${SENTRY_REEXPORTED_FUNCTIONS}handler`,
+    ],
+    [
+      { '.': ['handler', 'otherFunction'] },
+      ['handler'],
+      `${SENTRY_WRAPPED_FUNCTIONS}handler${SENTRY_REEXPORTED_FUNCTIONS}otherFunction`,
+    ],
+    [{ '.': ['handler', 'otherFn'] }, ['handler', 'otherFn'], `${SENTRY_WRAPPED_FUNCTIONS}handler,otherFn`],
+    [{ '.': ['bar'], './module': ['foo'] }, ['bar', 'foo'], `${SENTRY_WRAPPED_FUNCTIONS}bar,foo`],
+    [{ '.': ['foo', 'bar'] }, ['foo'], `${SENTRY_WRAPPED_FUNCTIONS}foo${SENTRY_REEXPORTED_FUNCTIONS}bar`],
+    [{ '.': ['foo', 'bar'] }, ['bar'], `${SENTRY_WRAPPED_FUNCTIONS}bar${SENTRY_REEXPORTED_FUNCTIONS}foo`],
+    [{ '.': ['foo', 'bar'] }, ['foo', 'bar'], `${SENTRY_WRAPPED_FUNCTIONS}foo,bar`],
+    [{ '.': ['foo', 'bar'] }, [], `${SENTRY_REEXPORTED_FUNCTIONS}foo,bar`],
   ])(
-    'constructs re-export query for exportedBindings: %j and asyncFunctionReExports: %j',
-    (exportedBindings, asyncFunctionReExports, expected) => {
-      const result = constructFunctionsReExportQuery(exportedBindings, asyncFunctionReExports);
+    'constructs re-export query for exportedBindings: %j and entrypointWrappedFunctions: %j',
+    (exportedBindings, entrypointWrappedFunctions, expected) => {
+      const result = constructWrappedFunctionExportQuery(exportedBindings, entrypointWrappedFunctions);
       expect(result).toBe(expected);
     },
   );
@@ -122,13 +146,13 @@ describe('constructFunctionsReExportQuery', () => {
   it('logs a warning if no functions are found for re-export and debug is true', () => {
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const exportedBindings = { '.': ['handler'] };
-    const asyncFunctionReExports = ['nonExistentFunction'];
+    const entrypointWrappedFunctions = ['nonExistentFunction'];
     const debug = true;
 
-    const result = constructFunctionsReExportQuery(exportedBindings, asyncFunctionReExports, debug);
-    expect(result).toBe('');
+    const result = constructWrappedFunctionExportQuery(exportedBindings, entrypointWrappedFunctions, debug);
+    expect(result).toBe('?sentry-query-reexported-functions=handler');
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      "[Sentry] No functions found for re-export. In case your server needs to export async functions other than `handler` or  `server`, consider adding the name(s) to Sentry's build options `sentry.asyncFunctionReExports` in your `nuxt.config.ts`.",
+      "[Sentry] No functions found to wrap. In case your server needs to export async functions other than `handler` or  `server`, consider adding the name(s) to Sentry's build options `sentry.entrypointWrappedFunctions` in your `nuxt.config.ts`.",
     );
 
     consoleWarnSpy.mockRestore();
@@ -137,54 +161,85 @@ describe('constructFunctionsReExportQuery', () => {
 
 describe('constructFunctionReExport', () => {
   it('constructs re-export code for given query parameters and entry ID', () => {
-    const query = `${SENTRY_FUNCTIONS_REEXPORT}foo,bar,${QUERY_END_INDICATOR}}`;
-    const query2 = `${SENTRY_FUNCTIONS_REEXPORT}foo,bar${QUERY_END_INDICATOR}}`;
+    const query = `${SENTRY_WRAPPED_FUNCTIONS}foo,bar,${QUERY_END_INDICATOR}}`;
+    const query2 = `${SENTRY_WRAPPED_FUNCTIONS}foo,bar${QUERY_END_INDICATOR}}`;
     const entryId = './module';
     const result = constructFunctionReExport(query, entryId);
     const result2 = constructFunctionReExport(query2, entryId);
 
     const expected = `
-async function reExportFOO(...args) {
+async function foo_sentryWrapped(...args) {
   const res = await import("./module");
   return res.foo.call(this, ...args);
 }
-export { reExportFOO as foo };
-async function reExportBAR(...args) {
+export { foo_sentryWrapped as foo };
+async function bar_sentryWrapped(...args) {
   const res = await import("./module");
   return res.bar.call(this, ...args);
 }
-export { reExportBAR as bar };
+export { bar_sentryWrapped as bar };
 `;
     expect(result.trim()).toBe(expected.trim());
     expect(result2.trim()).toBe(expected.trim());
   });
 
   it('constructs re-export code for a "default" query parameters and entry ID', () => {
-    const query = `${SENTRY_FUNCTIONS_REEXPORT}default${QUERY_END_INDICATOR}}`;
+    const query = `${SENTRY_WRAPPED_FUNCTIONS}default${QUERY_END_INDICATOR}}`;
     const entryId = './index';
     const result = constructFunctionReExport(query, entryId);
 
     const expected = `
-async function reExportDEFAULT(...args) {
+async function default_sentryWrapped(...args) {
   const res = await import("./index");
   return res.default.call(this, ...args);
 }
-export { reExportDEFAULT as default };
+export { default_sentryWrapped as default };
 `;
     expect(result.trim()).toBe(expected.trim());
   });
 
   it('constructs re-export code for a "default" query parameters and entry ID', () => {
-    const query = `${SENTRY_FUNCTIONS_REEXPORT}default${QUERY_END_INDICATOR}}`;
+    const query = `${SENTRY_WRAPPED_FUNCTIONS}default${QUERY_END_INDICATOR}}`;
     const entryId = './index';
     const result = constructFunctionReExport(query, entryId);
 
     const expected = `
-async function reExportDEFAULT(...args) {
+async function default_sentryWrapped(...args) {
   const res = await import("./index");
   return res.default.call(this, ...args);
 }
-export { reExportDEFAULT as default };
+export { default_sentryWrapped as default };
+`;
+    expect(result.trim()).toBe(expected.trim());
+  });
+
+  it('constructs re-export code for a mix of wrapped and re-exported functions', () => {
+    const query = `${SENTRY_WRAPPED_FUNCTIONS}foo,${SENTRY_REEXPORTED_FUNCTIONS}bar${QUERY_END_INDICATOR}`;
+    const entryId = './module';
+    const result = constructFunctionReExport(query, entryId);
+
+    const expected = `
+async function foo_sentryWrapped(...args) {
+  const res = await import("./module");
+  return res.foo.call(this, ...args);
+}
+export { foo_sentryWrapped as foo };
+export { bar } from "./module";
+`;
+    expect(result.trim()).toBe(expected.trim());
+  });
+
+  it('does not re-export a default export for regular re-exported functions', () => {
+    const query = `${SENTRY_WRAPPED_FUNCTIONS}foo${SENTRY_REEXPORTED_FUNCTIONS}default${QUERY_END_INDICATOR}`;
+    const entryId = './module';
+    const result = constructFunctionReExport(query, entryId);
+
+    const expected = `
+async function foo_sentryWrapped(...args) {
+  const res = await import("./module");
+  return res.foo.call(this, ...args);
+}
+export { foo_sentryWrapped as foo };
 `;
     expect(result.trim()).toBe(expected.trim());
   });


### PR DESCRIPTION
Based on this PR: https://github.com/getsentry/sentry-javascript/pull/14086

We get the names of the exports with Rollup's `exportedBindings`, but we cannot know whether this is a function or something else. As we need to re-export serverless functions for Netlify, Vercel and so on, an educated guess is made that `'default', 'handler', 'server'` are potential serverless functions that need to be wrapped by Sentry and re-exported. 

In case users experience issues, this can be changed with `entrypointWrappedFunctions`.

All other exports are exported as they were before.