### PR TITLE
chore: Don't run dependabot on CodeQL PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ name: 'CI: CodeQL'
 on:
   push:
     branches: [develop]
+    branches-ignore:
+      # Ignore dependabot branches
+      - "dependabot/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [develop]


### PR DESCRIPTION
We get failures when running dependabot on CodeQL PRs: https://github.com/getsentry/sentry-javascript/actions/runs/11561736812/job/32181414647

```
  Warning: Resource not accessible by integration
  Error: Resource not accessible by integration
  Warning: Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#scanning-on-push for more information on how to configure these events.
```

Given dependabot is not going to change any code (just deps), I think we are safe to remove CodeQL scanning.