### PR TITLE
fix(aws-serverless): Remove possible prototype pollution source

### DIFF
--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -168,6 +168,12 @@ export function tryPatchHandler(taskRoot: string, handlerPath: string): void {
     return;
   }
 
+  // Check for prototype pollution
+  if (functionName === '__proto__' || functionName === 'constructor' || functionName === 'prototype') {
+    DEBUG_BUILD && logger.error(`Invalid handler name: ${functionName}`);
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   (mod as HandlerModule)[functionName!] = wrapHandler(obj);
 }


### PR DESCRIPTION
Fixes [https://github.com/getsentry/sentry-javascript/security/code-scanning/307](https://github.com/getsentry/sentry-javascript/security/code-scanning/307)

To fix the prototype pollution issue, we need to ensure that the `handlerName` does not include any special properties like `__proto__`, `constructor`, or `prototype`. We can achieve this by adding a check to filter out these properties before performing the assignment.

1. Add a check to ensure `handlerName` does not include `__proto__`, `constructor`, or `prototype`.
2. If `handlerName` includes any of these properties, log an error and return without making the assignment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
