### PR TITLE
ci: Use `list` reporter for playwright on CI instead of `line`

### DIFF
--- a/dev-packages/browser-integration-tests/playwright.config.ts
+++ b/dev-packages/browser-integration-tests/playwright.config.ts
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig = {
     },
   ],
 
-  reporter: process.env.CI ? [['line'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
+  reporter: process.env.CI ? [['list'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
 
   globalSetup: require.resolve('./playwright.setup.ts'),
   globalTeardown: require.resolve('./playwright.teardown.ts'),

--- a/dev-packages/e2e-tests/test-applications/ember-classic/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/playwright.config.ts
@@ -35,7 +35,7 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['line'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
+  reporter: process.env.CI ? [['list'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/playwright.config.ts
@@ -35,7 +35,7 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['line'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
+  reporter: process.env.CI ? [['list'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/playwright.config.mjs
@@ -23,7 +23,7 @@ const config = {
   /* Retry on CI only */
   retries: 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['line'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
+  reporter: process.env.CI ? [['list'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/playwright.config.mjs
@@ -23,7 +23,7 @@ const config = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['line'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
+  reporter: process.env.CI ? [['list'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/packages/remix/playwright.config.ts
+++ b/packages/remix/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   },
   // Run tests inside of a single file in parallel
   fullyParallel: true,
-  reporter: process.env.CI ? [['line'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
+  reporter: process.env.CI ? [['list'], ['junit', { outputFile: 'results.junit.xml' }]] : 'list',
   // Use 3 workers on CI, else use defaults (based on available CPU cores)
   // Note that 3 is a random number selected to work well with our CI setup
   workers: process.env.CI ? 3 : undefined,


### PR DESCRIPTION
This does not work properly anyhow (e.g. it shows all the tests because of how CI logs are rendered, see https://github.com/getsentry/sentry-javascript/actions/runs/11557223813/job/32202778369), so we may as well also have the added detail of per-test runtime etc. in there.