### PR TITLE
fix(nextjs): Don't leak webpack types into exports

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -100,13 +100,7 @@
     "next": "13.2.0"
   },
   "peerDependencies": {
-    "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0",
-    "webpack": ">=5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "webpack": {
-      "optional": true
-    }
+    "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -1,12 +1,5 @@
 import type { GLOBAL_OBJ } from '@sentry/utils';
 import type { SentryWebpackPluginOptions } from '@sentry/webpack-plugin';
-import type { DefinePlugin, WebpackPluginInstance } from 'webpack';
-
-// Export this from here because importing something from Webpack (the library) in `webpack.ts` confuses the heck out of
-// madge, which we use for circular dependency checking. We've manually excluded this file from the check (which is
-// safe, since it only includes types), so we can import it here without causing madge to fail. See
-// https://github.com/pahen/madge/issues/306.
-export type { WebpackPluginInstance };
 
 // The first argument to `withSentryConfig` (which is the user's next config).
 export type ExportedNextConfig = NextConfigObject | NextConfigFunction;
@@ -16,6 +9,11 @@ type NextRewrite = {
   source: string;
   destination: string;
 };
+
+interface WebpackPluginInstance {
+  [index: string]: any;
+  apply: (compiler: any) => void;
+}
 
 export type NextConfigObject = {
   // Custom webpack options
@@ -502,7 +500,7 @@ export type BuildContext = {
   config: any;
   webpack: {
     version: string;
-    DefinePlugin: typeof DefinePlugin;
+    DefinePlugin: WebpackPluginInstance;
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   defaultLoaders: any; // needed for type tests (test:types)

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -500,7 +500,7 @@ export type BuildContext = {
   config: any;
   webpack: {
     version: string;
-    DefinePlugin: WebpackPluginInstance;
+    DefinePlugin: new (values: Record<string, string | boolean>) => WebpackPluginInstance;
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   defaultLoaders: any; // needed for type tests (test:types)


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/14066

We're just vendoring the types. The chance that anyone is depending on the specifics is lim x -> 0.