### PR TITLE
ci: Fix CodeQL workflow config

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    # Skip for pushes from dependabot, which is not supported
+    if: github.event_name == 'pull_request' || github.actor != 'dependabot[bot]'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,6 @@ name: 'CI: CodeQL'
 on:
   push:
     branches: [develop]
-    branches-ignore:
-      # Ignore dependabot branches
-      - "dependabot/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [develop]


### PR DESCRIPTION
Reverts https://github.com/getsentry/sentry-javascript/pull/14109 and re-implements this differently.

Actually, the problem was dependabot merging to develop (so the fix would not have caught that anyhow), + this was incorrect syntax (oops) as we had ignore-branches _and_ branches, which does not work.

Now, instead we just run this always but check if this is a push from dependabot, which hopefully works better.

See https://github.com/getsentry/sentry-javascript/actions/runs/11570166519