### PR TITLE
fix(core): Silently fail maybeInstrument

### DIFF
--- a/packages/utils/src/instrument/handlers.ts
+++ b/packages/utils/src/instrument/handlers.ts
@@ -37,8 +37,12 @@ export function resetInstrumentationHandlers(): void {
 /** Maybe run an instrumentation function, unless it was already called. */
 export function maybeInstrument(type: InstrumentHandlerType, instrumentFn: () => void): void {
   if (!instrumented[type]) {
-    instrumentFn();
-    instrumented[type] = true;
+    try {
+      instrumentFn();
+      instrumented[type] = true;
+    } catch (e) {
+      DEBUG_BUILD && logger.error('Error while instrumenting', e);
+    }
   }
 }
 

--- a/packages/utils/test/instrument.test.ts
+++ b/packages/utils/test/instrument.test.ts
@@ -1,0 +1,13 @@
+import { maybeInstrument } from '../src';
+
+describe('maybeInstrument', () => {
+  test('does not throw when instrumenting fails', () => {
+    maybeInstrument('xhr', () => {
+      throw new Error('test');
+    });
+  });
+
+  test('does not throw when instrumenting fn is not a function', () => {
+    maybeInstrument('xhr', undefined as any);
+  });
+});


### PR DESCRIPTION
We have some cases where certain instrumentations fails while patching (e.g. xhr).
This PR wraps the patching of these functions in a try catch to fail silently and log an error so we don't break user's apps.

relates to https://github.com/getsentry/sentry-javascript/issues/14077