### PR TITLE
fix(node): Make sure modulesIntegration does not crash esm apps

### DIFF
--- a/dev-packages/node-integration-tests/suites/esm/modules-integration/app.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/modules-integration/app.mjs
@@ -1,0 +1,10 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  autoSessionTracking: false,
+  integrations: [Sentry.modulesIntegration()],
+  transport: loggingTransport,
+});

--- a/dev-packages/node-integration-tests/suites/esm/modules-integration/test.ts
+++ b/dev-packages/node-integration-tests/suites/esm/modules-integration/test.ts
@@ -1,0 +1,12 @@
+import { conditionalTest } from '../../../utils';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+conditionalTest({ min: 18 })('modulesIntegration', () => {
+  test('does not crash ESM setups', done => {
+    createRunner(__dirname, 'app.mjs').ensureNoErrorOutput().start(done);
+  });
+});

--- a/packages/node/src/integrations/modules.ts
+++ b/packages/node/src/integrations/modules.ts
@@ -2,12 +2,26 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { defineIntegration } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/types';
+import { logger } from '@sentry/utils';
+import { DEBUG_BUILD } from '../debug-build';
+import { isCjs } from '../utils/commonjs';
 
 let moduleCache: { [key: string]: string };
 
 const INTEGRATION_NAME = 'Modules';
 
 const _modulesIntegration = (() => {
+  // This integration only works in CJS contexts
+  if (!isCjs()) {
+    DEBUG_BUILD &&
+      logger.warn(
+        'modulesIntegration only works in CommonJS (CJS) environments. Remove this integration if you are using ESM.',
+      );
+    return {
+      name: INTEGRATION_NAME,
+    };
+  }
+
   return {
     name: INTEGRATION_NAME,
     processEvent(event) {
@@ -23,6 +37,8 @@ const _modulesIntegration = (() => {
 
 /**
  * Add node modules / packages to the event.
+ *
+ * Only works in CommonJS (CJS) environments.
  */
 export const modulesIntegration = defineIntegration(_modulesIntegration);
 


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/12500
resolves https://github.com/getsentry/sentry-javascript/issues/14165

`modulesIntegration` uses top-level require which will crash ESM apps if you explicitly import and use the integration.

```mjs
// index.mjs
Sentry.init({
    dsn: '__DSN__',
    integrations: [
        Sentry.modulesIntegration(),
    ]
});
```

This fixes that by adding a boolean check for cjs apps, and logging out a warning as a result.