### PR TITLE
fix(browser): Avoid recording long task spans starting before their parent span

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -40,7 +40,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration'),
     gzip: true,
-    limit: '36 KB',
+    limit: '36.5 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay)',
@@ -124,7 +124,7 @@ module.exports = [
     import: createImport('init', 'ErrorBoundary', 'reactRouterV6BrowserTracingIntegration'),
     ignore: ['react/jsx-runtime'],
     gzip: true,
-    limit: '39.05 KB',
+    limit: '39.5 KB',
   },
   // Vue SDK (ESM)
   {

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/init.js
@@ -1,0 +1,19 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    Sentry.browserTracingIntegration({
+      idleTimeout: 9000,
+      enableLongAnimationFrame: false,
+      instrumentPageLoad: false,
+      instrumentNavigation: true,
+      enableInp: false,
+      enableLongTask: true,
+    }),
+  ],
+  tracesSampleRate: 1,
+  debug: true,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/subject.js
@@ -1,0 +1,17 @@
+const longTaskButton = document.getElementById('myButton');
+
+longTaskButton?.addEventListener('click', () => {
+  const startTime = Date.now();
+
+  function getElapsed() {
+    const time = Date.now();
+    return time - startTime;
+  }
+
+  while (getElapsed() < 500) {
+    //
+  }
+
+  // trigger a navigation in the same event loop tick
+  window.history.pushState({}, '', '/#myHeading');
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/template.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <div>Rendered Before Long Task</div>
+    <script src="https://example.com/path/to/script.js"></script>
+
+    <button id="myButton">Start long task</button>
+    <h1 id="myHeading">Heading</h1>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/test.ts
@@ -1,0 +1,27 @@
+import type { Event } from '@sentry/types';
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
+
+sentryTest(
+  "doesn't capture long task spans starting before a navigation in the navigation transaction",
+  async ({ browserName, getLocalTestPath, page }) => {
+    // Long tasks only work on chrome
+    if (shouldSkipTracingTest() || browserName !== 'chromium') {
+      sentryTest.skip();
+    }
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    await page.goto(url);
+
+    await page.locator('#myButton').click();
+
+    const navigationTransactionEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+    expect(navigationTransactionEvent.contexts?.trace?.op).toBe('navigation');
+
+    const longTaskSpans = navigationTransactionEvent?.spans?.filter(span => span.op === 'ui.long-task');
+    expect(longTaskSpans).toHaveLength(0);
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/test.ts
@@ -1,5 +1,5 @@
-import type { Event } from '@sentry/types';
 import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -9,9 +9,7 @@
   "engines": {
     "node": ">=14.18"
   },
-  "files": [
-    "/build/npm"
-  ],
+  "files": ["/build/npm"],
   "main": "build/npm/cjs/index.js",
   "module": "build/npm/esm/index.js",
   "types": "build/npm/types/index.d.ts",
@@ -30,9 +28,7 @@
   },
   "typesVersions": {
     "<4.9": {
-      "build/npm/types/index.d.ts": [
-        "build/npm/types-ts3.8/index.d.ts"
-      ]
+      "build/npm/types/index.d.ts": ["build/npm/types-ts3.8/index.d.ts"]
     }
   },
   "publishConfig": {
@@ -53,7 +49,7 @@
   },
   "scripts": {
     "build": "run-p build:transpile build:bundle build:types",
-    "build:dev": "yarn build",
+    "build:dev": "run-p build:transpile build:types",
     "build:bundle": "rollup -c rollup.bundle.config.mjs",
     "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "run-s build:types:core build:types:downlevel",


### PR DESCRIPTION
This PR fixes inconsistent behaviour in our browserTracingIntegration, where we'd previously add `ui.long-task` spans to an ongoing (navigation) transaction, even if the long task started before the navigation transaction started. 

Most other browserTracingIntegration spans (resource, timing, measure/mark spans) are already dropped/not started if their start time stamp is earlier than the navigation start time stamp. This happens in [one central location](https://github.com/getsentry/sentry-javascript/blob/c2bae3ed9cd4a79fc634b1b7f2baa1d2fad246ef/packages/browser-utils/src/metrics/browserMetrics.ts#L312-L314) but it does not apply to long-task spans because they have to be handled separately. 

This PR specifically:
- not checks for the start time stamp and drops long task spans starting before a _navigation_ spans started. 
- refactors the start and end logic a bit to compensate for bundle size increase (see comment)
- adds a regression test that previously would fail

Note: We have similar behaviour for long animation frame spans. I'll probably open another PR to adjust the logic there as well.