### PR TITLE
feat(deps): Bump @opentelemetry/instrumentation from 0.53.0 to 0.54.0 for @sentry/opentelemetry

### DIFF
--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.25.1",
-    "@opentelemetry/instrumentation": "^0.53.0",
+    "@opentelemetry/instrumentation": "^0.54.0",
     "@opentelemetry/sdk-trace-base": "^1.26.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },


### PR DESCRIPTION
Sadly, https://github.com/getsentry/sentry-javascript/pull/14174 didn't bump the dep in `@sentry/opentelemetry`.