### PR TITLE
ref(browser): Ensure start time of interaction root and child span is aligned

### DIFF
--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -192,7 +192,8 @@ export function startTrackingLongAnimationFrames(): void {
  */
 export function startTrackingInteractions(): void {
   addPerformanceInstrumentationHandler('event', ({ entries }) => {
-    if (!getActiveSpan()) {
+    const parent = getActiveSpan();
+    if (!parent) {
       return;
     }
     for (const entry of entries) {
@@ -218,6 +219,8 @@ export function startTrackingInteractions(): void {
         if (span) {
           span.end(startTime + duration);
         }
+
+        startAndEndSpan(parent, startTime, startTime + duration, spanOptions);
       }
     }
   });

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -215,11 +215,6 @@ export function startTrackingInteractions(): void {
           spanOptions.attributes['ui.component_name'] = componentName;
         }
 
-        const span = startInactiveSpan(spanOptions);
-        if (span) {
-          span.end(startTime + duration);
-        }
-
         startAndEndSpan(parent, startTime, startTime + duration, spanOptions);
       }
     }


### PR DESCRIPTION
This PR replaces the manual start and end calls for interaction child spans with our `startAndEndSpan` helper.
Using `startAndEndSpan` also will adjust the root span's start time stamp if the (in this case interaction-) child span starts earlier than the parent span. I think in this particular case, this is fine or even desireable because my testing so far has shown that the performance entry we use for the child spans starts a couple of ms earlier than the surrounding idle interaction transaction. We can add a similar check as in #14183 or #14186 if this becomes a problem.

Further context: If users enable `experiments.enableInteractions`, for every click, we create:
1. A root idle span whose name is the name of the current route (unless there's an ongoing pageload/navigation span)
2. A child span whose name is the computed selector of the clicked element. 

EDIT: Initially, I did this to reduce bundle size but it looks like this actually isn't happening. On the plus side, I think the behaviour change is still worth to merge in and the size increase is negligible. Maybe, it's even within the usual margin of error of our size check. Anyway, the code change is the same, I just re-purposed the PR a bit 😅 