### PR TITLE
feat(utils): Single implementation to fetch debug ids

### DIFF
--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -1,21 +1,11 @@
 /* eslint-disable max-lines */
 
 import { DEFAULT_ENVIRONMENT, getClient, spanToJSON } from '@sentry/core';
-import type {
-  DebugImage,
-  Envelope,
-  Event,
-  EventEnvelope,
-  Profile,
-  Span,
-  StackFrame,
-  StackParser,
-  ThreadCpuProfile,
-} from '@sentry/types';
+import type { DebugImage, Envelope, Event, EventEnvelope, Profile, Span, ThreadCpuProfile } from '@sentry/types';
 import {
-  GLOBAL_OBJ,
   browserPerformanceTimeOrigin,
   forEachEnvelopeItem,
+  getFilenameToDebugIdMap,
   logger,
   timestampInSeconds,
   uuid4,
@@ -352,17 +342,10 @@ export function findProfiledTransactionsFromEnvelope(envelope: Envelope): Event[
   return events;
 }
 
-const debugIdStackParserCache = new WeakMap<StackParser, Map<string, StackFrame[]>>();
 /**
  * Applies debug meta data to an event from a list of paths to resources (sourcemaps)
  */
 export function applyDebugMetadata(resource_paths: ReadonlyArray<string>): DebugImage[] {
-  const debugIdMap = GLOBAL_OBJ._sentryDebugIds;
-
-  if (!debugIdMap) {
-    return [];
-  }
-
   const client = getClient();
   const options = client && client.getOptions();
   const stackParser = options && options.stackParser;
@@ -371,38 +354,8 @@ export function applyDebugMetadata(resource_paths: ReadonlyArray<string>): Debug
     return [];
   }
 
-  let debugIdStackFramesCache: Map<string, StackFrame[]>;
-  const cachedDebugIdStackFrameCache = debugIdStackParserCache.get(stackParser);
-  if (cachedDebugIdStackFrameCache) {
-    debugIdStackFramesCache = cachedDebugIdStackFrameCache;
-  } else {
-    debugIdStackFramesCache = new Map<string, StackFrame[]>();
-    debugIdStackParserCache.set(stackParser, debugIdStackFramesCache);
-  }
-
   // Build a map of filename -> debug_id
-  const filenameDebugIdMap = Object.keys(debugIdMap).reduce<Record<string, string>>((acc, debugIdStackTrace) => {
-    let parsedStack: StackFrame[];
-
-    const cachedParsedStack = debugIdStackFramesCache.get(debugIdStackTrace);
-    if (cachedParsedStack) {
-      parsedStack = cachedParsedStack;
-    } else {
-      parsedStack = stackParser(debugIdStackTrace);
-      debugIdStackFramesCache.set(debugIdStackTrace, parsedStack);
-    }
-
-    for (let i = parsedStack.length - 1; i >= 0; i--) {
-      const stackFrame = parsedStack[i];
-      const file = stackFrame && stackFrame.filename;
-
-      if (stackFrame && file) {
-        acc[file] = debugIdMap[debugIdStackTrace] as string;
-        break;
-      }
-    }
-    return acc;
-  }, {});
+  const filenameDebugIdMap = getFilenameToDebugIdMap(stackParser);
 
   const images: DebugImage[] = [];
   for (const path of resource_paths) {

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -5,7 +5,7 @@ import type { DebugImage, Envelope, Event, EventEnvelope, Profile, Span, ThreadC
 import {
   browserPerformanceTimeOrigin,
   forEachEnvelopeItem,
-  getFilenameToDebugIdMap,
+  getDebugImagesForResources,
   logger,
   timestampInSeconds,
   uuid4,
@@ -354,21 +354,7 @@ export function applyDebugMetadata(resource_paths: ReadonlyArray<string>): Debug
     return [];
   }
 
-  // Build a map of filename -> debug_id
-  const filenameDebugIdMap = getFilenameToDebugIdMap(stackParser);
-
-  const images: DebugImage[] = [];
-  for (const path of resource_paths) {
-    if (path && filenameDebugIdMap[path]) {
-      images.push({
-        type: 'sourcemap',
-        code_file: path,
-        debug_id: filenameDebugIdMap[path] as string,
-      });
-    }
-  }
-
-  return images;
+  return getDebugImagesForResources(stackParser, resource_paths);
 }
 
 /**

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -20,7 +20,7 @@ import {
   createEnvelope,
   dsnToString,
   forEachEnvelopeItem,
-  getFilenameToDebugIdMap,
+  getDebugImagesForResources,
   logger,
   uuid4,
 } from '@sentry/utils';
@@ -432,20 +432,5 @@ export function applyDebugMetadata(client: Client, resource_paths: ReadonlyArray
     return [];
   }
 
-  // Build a map of filename -> debug_id.
-  const filenameDebugIdMap = getFilenameToDebugIdMap(options.stackParser);
-
-  const images: DebugImage[] = [];
-
-  for (const resource of resource_paths) {
-    if (resource && filenameDebugIdMap[resource]) {
-      images.push({
-        type: 'sourcemap',
-        code_file: resource,
-        debug_id: filenameDebugIdMap[resource] as string,
-      });
-    }
-  }
-
-  return images;
+  return getDebugImagesForResources(options.stackParser, resource_paths);
 }

--- a/packages/utils/src/debug-ids.ts
+++ b/packages/utils/src/debug-ids.ts
@@ -1,4 +1,4 @@
-import type { StackFrame, StackParser } from '@sentry/types';
+import type { DebugImage, StackFrame, StackParser } from '@sentry/types';
 import { GLOBAL_OBJ } from './worldwide';
 
 const debugIdStackParserCache = new WeakMap<StackParser, Map<string, StackFrame[]>>();
@@ -44,4 +44,27 @@ export function getFilenameToDebugIdMap(stackParser: StackParser): Record<string
     }
     return acc;
   }, {});
+}
+
+/**
+ * Returns a list of debug images for the given resources.
+ */
+export function getDebugImagesForResources(
+  stackParser: StackParser,
+  resource_paths: ReadonlyArray<string>,
+): DebugImage[] {
+  const filenameDebugIdMap = getFilenameToDebugIdMap(stackParser);
+
+  const images: DebugImage[] = [];
+  for (const path of resource_paths) {
+    if (path && filenameDebugIdMap[path]) {
+      images.push({
+        type: 'sourcemap',
+        code_file: path,
+        debug_id: filenameDebugIdMap[path] as string,
+      });
+    }
+  }
+
+  return images;
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -40,3 +40,4 @@ export * from './buildPolyfills';
 export * from './propagationContext';
 export * from './vercelWaitUntil';
 export * from './version';
+export * from './debug-ids';


### PR DESCRIPTION
In the process of fixing https://github.com/getsentry/sentry-electron/issues/1011 I was looking for a way to get a `Map<Filename, DebugId>`.  I found that there was already some code duplication for parsing and caching of debug ids from the polyfilled globals.

This PR moves the common code to `@sentry/utils` which will be useful for fixing the above.
