### PR TITLE
fix(node): Include `debug_meta` with ANR events

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 
 const Sentry = require('@sentry/node');
 
+global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
+
 setTimeout(() => {
   process.exit();
 }, 10000);

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -3,6 +3,8 @@ import * as crypto from 'crypto';
 
 import * as Sentry from '@sentry/node';
 
+global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
+
 setTimeout(() => {
   process.exit();
 }, 10000);

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -1,3 +1,4 @@
+import type { Event } from '@sentry/types';
 import { conditionalTest } from '../../utils';
 import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
@@ -64,17 +65,33 @@ const ANR_EVENT_WITH_SCOPE = {
   ]),
 };
 
+const ANR_EVENT_WITH_DEBUG_META: Event = {
+  ...ANR_EVENT_WITH_SCOPE,
+  debug_meta: {
+    images: [
+      {
+        type: 'sourcemap',
+        debug_id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa',
+        code_file: expect.stringContaining('basic.'),
+      },
+    ],
+  },
+};
+
 conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
   test('CJS', done => {
-    createRunner(__dirname, 'basic.js').withMockSentryServer().expect({ event: ANR_EVENT_WITH_SCOPE }).start(done);
+    createRunner(__dirname, 'basic.js').withMockSentryServer().expect({ event: ANR_EVENT_WITH_DEBUG_META }).start(done);
   });
 
   test('ESM', done => {
-    createRunner(__dirname, 'basic.mjs').withMockSentryServer().expect({ event: ANR_EVENT_WITH_SCOPE }).start(done);
+    createRunner(__dirname, 'basic.mjs')
+      .withMockSentryServer()
+      .expect({ event: ANR_EVENT_WITH_DEBUG_META })
+      .start(done);
   });
 
   test('blocked indefinitely', done => {

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -1,11 +1,11 @@
+import * as diagnosticsChannel from 'node:diagnostics_channel';
 import { Worker } from 'node:worker_threads';
 import { defineIntegration, getCurrentScope, getGlobalScope, getIsolationScope, mergeScopeData } from '@sentry/core';
 import type { Contexts, Event, EventHint, Integration, IntegrationFn, ScopeData } from '@sentry/types';
-import { getFilenameToDebugIdMap, GLOBAL_OBJ, logger } from '@sentry/utils';
+import { GLOBAL_OBJ, getFilenameToDebugIdMap, logger } from '@sentry/utils';
 import { NODE_VERSION } from '../../nodeVersion';
 import type { NodeClient } from '../../sdk/client';
 import type { AnrIntegrationOptions, WorkerStartData } from './common';
-import * as diagnosticsChannel from 'node:diagnostics_channel';
 
 // This string is a placeholder that gets overwritten with the worker code.
 export const base64WorkerScript = '###AnrWorkerScript###';


### PR DESCRIPTION
 - Ref: https://github.com/getsentry/sentry-electron/issues/1011

Sends a map of filename -> debug ids to the ANR worker thread and sends an updated list every time more modules are loaded. These are then used and included with events so they can be symbolicated 

