### PR TITLE
fix(spotlight): Export spotlightBrowserIntegration from the main browser package

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -74,3 +74,4 @@ export {
 export type { Span } from '@sentry/types';
 export { makeBrowserOfflineTransport } from './transports/offline';
 export { browserProfilingIntegration } from './profiling/integration';
+export { spotlightBrowserIntegration } from './integrations/spotlight';


### PR DESCRIPTION
Follow up to #13263 where we forgot to export it from the main package :facepalm:
