### PR TITLE
test(e2e): Pin react-router-dom dep in `react-send-to-sentry` Test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/package.json
@@ -9,7 +9,7 @@
     "@types/react-dom": "18.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.4.1",
+    "react-router-dom": "6.4.1",
     "react-scripts": "5.0.1",
     "typescript": "4.9.5"
   },


### PR DESCRIPTION
Causes failures on develop