### PR TITLE
ref(profiling) Fix Electron support

### DIFF
--- a/packages/profiling-node/bindings/cpu_profiler.cc
+++ b/packages/profiling-node/bindings/cpu_profiler.cc
@@ -331,11 +331,12 @@ void SentryProfile::Start(Profiler *profiler) {
   started_at = uv_hrtime();
   timestamp = timestamp_milliseconds();
 
+  v8::CpuProfilingOptions options = v8::CpuProfilingOptions(
+      v8::CpuProfilingMode::kCallerLineNumbers,
+      v8::CpuProfilingOptions::kNoSampleLimit, kSamplingInterval);
+
   // Initialize the CPU Profiler
-  profiler->cpu_profiler->StartProfiling(
-      profile_title,
-      {v8::CpuProfilingMode::kCallerLineNumbers,
-       v8::CpuProfilingOptions::kNoSampleLimit, kSamplingInterval});
+  profiler->cpu_profiler->StartProfiling(profile_title, &options);
 
   // listen for memory sample ticks
   profiler->measurements_ticker.add_cpu_listener(id, cpu_sampler_cb);


### PR DESCRIPTION
Fixes electron crash described in https://github.com/getsentry/sentry-javascript/discussions/13978#discussioncomment-11078140

I've decided not to provide any precompiled binaries yet, in part because I need more time, and also because I'm also not sure if that is something we want to do. Reading electron native module docs, it seems that the recommended approach in electron is to use electron/rebuild package to rebuild dependencies, which defeats the purpose of us providing precompiled binaries.

For now, this fixes the crash and allows users to at least use the package and we can reevaluate with time if the prebuilt binaries are something we want to add.