### PR TITLE
docs: Improve docstrings for node otel integrations

### DIFF
--- a/packages/node/src/integrations/tracing/amqplib.ts
+++ b/packages/node/src/integrations/tracing/amqplib.ts
@@ -27,4 +27,18 @@ const _amqplibIntegration = (() => {
   };
 }) satisfies IntegrationFn;
 
+/**
+ * Adds Sentry tracing instrumentation for the [amqplib](https://www.npmjs.com/package/amqplib) library.
+ *
+ * For more information, see the [`amqplibIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/amqplib/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.amqplibIntegration()],
+ * });
+ * ```
+ */
 export const amqplibIntegration = defineIntegration(_amqplibIntegration);

--- a/packages/node/src/integrations/tracing/connect.ts
+++ b/packages/node/src/integrations/tracing/connect.ts
@@ -29,6 +29,22 @@ const _connectIntegration = (() => {
   };
 }) satisfies IntegrationFn;
 
+/**
+ * Adds Sentry tracing instrumentation for [Connect](https://github.com/senchalabs/connect/).
+ *
+ * If you also want to capture errors, you need to call `setupConnectErrorHandler(app)` after you initialize your connect app.
+ *
+ * For more information, see the [connect documentation](https://docs.sentry.io/platforms/javascript/guides/connect/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *   integrations: [Sentry.connectIntegration()],
+ * })
+ * ```
+ */
 export const connectIntegration = defineIntegration(_connectIntegration);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,6 +53,25 @@ function connectErrorMiddleware(err: any, req: any, res: any, next: any): void {
   next(err);
 }
 
+/**
+ * Add a Connect middleware to capture errors to Sentry.
+ *
+ * @param app The Connect app to attach the error handler to
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ * const connect = require("connect");
+ *
+ * const app = connect();
+ *
+ * Sentry.setupConnectErrorHandler(app);
+ *
+ * // Add you connect routes here
+ *
+ * app.listen(3000);
+ * ```
+ */
 export const setupConnectErrorHandler = (app: ConnectApp): void => {
   app.use(connectErrorMiddleware);
 

--- a/packages/node/src/integrations/tracing/dataloader.ts
+++ b/packages/node/src/integrations/tracing/dataloader.ts
@@ -50,8 +50,17 @@ const _dataloaderIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Dataloader integration
+ * Adds Sentry tracing instrumentation for the [dataloader](https://www.npmjs.com/package/dataloader) library.
  *
- * Capture tracing data for Dataloader.
+ * For more information, see the [`dataloaderIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/dataloader/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.dataloaderIntegration()],
+ * });
+ * ```
  */
 export const dataloaderIntegration = defineIntegration(_dataloaderIntegration);

--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -60,10 +60,20 @@ const _expressIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Express integration
+ * Adds Sentry tracing instrumentation for [Express](https://expressjs.com/).
  *
- * Capture tracing data for express.
- * In order to capture exceptions, you have to call `setupExpressErrorHandler(app)` before any other middleware and after all controllers.
+ * If you also want to capture errors, you need to call `setupExpressErrorHandler(app)` after you set up your Express server.
+ *
+ * For more information, see the [express documentation](https://docs.sentry.io/platforms/javascript/guides/express/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *   integrations: [Sentry.expressIntegration()],
+ * })
+ * ```
  */
 export const expressIntegration = defineIntegration(_expressIntegration);
 
@@ -134,8 +144,28 @@ export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressMid
 }
 
 /**
- * Setup an error handler for Express.
+ * Add an Express error handler to capture errors to Sentry.
+ *
  * The error handler must be before any other middleware and after all controllers.
+ *
+ * @param app The Express instances
+ * @param options {ExpressHandlerOptions} Configuration options for the handler
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ * const express = require("express");
+ *
+ * const app = express();
+ *
+ * // Add your routes, etc.
+ *
+ * // Add this after all routes,
+ * // but before any and other error-handling middlewares are defined
+ * Sentry.setupExpressErrorHandler(app);
+ *
+ * app.listen(3000);
+ * ```
  */
 export function setupExpressErrorHandler(
   app: { use: (middleware: ExpressMiddleware) => unknown },

--- a/packages/node/src/integrations/tracing/fastify.ts
+++ b/packages/node/src/integrations/tracing/fastify.ts
@@ -55,14 +55,41 @@ const _fastifyIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Express integration
+ * Adds Sentry tracing instrumentation for [Fastify](https://fastify.dev/).
  *
- * Capture tracing data for fastify.
+ * If you also want to capture errors, you need to call `setupFastifyErrorHandler(app)` after you set up your Fastify server.
+ *
+ * For more information, see the [fastify documentation](https://docs.sentry.io/platforms/javascript/guides/fastify/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *   integrations: [Sentry.fastifyIntegration()],
+ * })
+ * ```
  */
 export const fastifyIntegration = defineIntegration(_fastifyIntegration);
 
 /**
- * Setup an error handler for Fastify.
+ * Add an Fastify error handler to capture errors to Sentry.
+ *
+ * @param fastify The Fastify instance to which to add the error handler
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ * const Fastify = require("fastify");
+ *
+ * const app = Fastify();
+ *
+ * Sentry.setupFastifyErrorHandler(app);
+ *
+ * // Add your routes, etc.
+ *
+ * app.listen({ port: 3000 });
+ * ```
  */
 export function setupFastifyErrorHandler(fastify: Fastify): void {
   const plugin = Object.assign(

--- a/packages/node/src/integrations/tracing/genericPool.ts
+++ b/packages/node/src/integrations/tracing/genericPool.ts
@@ -33,8 +33,17 @@ const _genericPoolIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * GenericPool integration
+ * Adds Sentry tracing instrumentation for the [generic-pool](https://www.npmjs.com/package/generic-pool) library.
  *
- * Capture tracing data for GenericPool.
+ * For more information, see the [`genericPoolIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/genericpool/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.genericPoolIntegration()],
+ * });
+ * ```
  */
 export const genericPoolIntegration = defineIntegration(_genericPoolIntegration);

--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -93,9 +93,19 @@ const _graphqlIntegration = ((options: GraphqlOptions = {}) => {
 }) satisfies IntegrationFn;
 
 /**
- * GraphQL integration
+ * Adds Sentry tracing instrumentation for the [graphql](https://www.npmjs.com/package/graphql) library.
  *
- * Capture tracing data for GraphQL.
+ * For more information, see the [`graphqlIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/graphql/).
+ *
+ * @param {GraphqlOptions} options Configuration options for the GraphQL integration.
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.graphqlIntegration()],
+ * });
  */
 export const graphqlIntegration = defineIntegration(_graphqlIntegration);
 

--- a/packages/node/src/integrations/tracing/hapi/index.ts
+++ b/packages/node/src/integrations/tracing/hapi/index.ts
@@ -31,10 +31,20 @@ const _hapiIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Hapi integration
+ * Adds Sentry tracing instrumentation for [Hapi](https://hapi.dev/).
  *
- * Capture tracing data for Hapi.
  * If you also want to capture errors, you need to call `setupHapiErrorHandler(server)` after you set up your server.
+ *
+ * For more information, see the [hapi documentation](https://docs.sentry.io/platforms/javascript/guides/hapi/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *   integrations: [Sentry.hapiIntegration()],
+ * })
+ * ```
  */
 export const hapiIntegration = defineIntegration(_hapiIntegration);
 
@@ -81,6 +91,24 @@ export const hapiErrorPlugin = {
 
 /**
  * Add a Hapi plugin to capture errors to Sentry.
+ *
+ * @param server The Hapi server to attach the error handler to
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ * const Hapi = require('@hapi/hapi');
+ *
+ * const init = async () => {
+ *   const server = Hapi.server();
+ *
+ *   // all your routes here
+ *
+ *   await Sentry.setupHapiErrorHandler(server);
+ *
+ *   await server.start();
+ * };
+ * ```
  */
 export async function setupHapiErrorHandler(server: Server): Promise<void> {
   await server.register(hapiErrorPlugin);

--- a/packages/node/src/integrations/tracing/kafka.ts
+++ b/packages/node/src/integrations/tracing/kafka.ts
@@ -30,8 +30,16 @@ const _kafkaIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * KafkaJs integration
+ * Adds Sentry tracing instrumentation for the [kafkajs](https://www.npmjs.com/package/kafkajs) library.
  *
- * Capture tracing data for KafkaJs.
+ * For more information, see the [`kafkaIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/kafka/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.kafkaIntegration()],
+ * });
  */
 export const kafkaIntegration = defineIntegration(_kafkaIntegration);

--- a/packages/node/src/integrations/tracing/koa.ts
+++ b/packages/node/src/integrations/tracing/koa.ts
@@ -48,8 +48,46 @@ const _koaIntegration = (() => {
   };
 }) satisfies IntegrationFn;
 
+/**
+ * Adds Sentry tracing instrumentation for [Koa](https://koajs.com/).
+ *
+ * If you also want to capture errors, you need to call `setupKoaErrorHandler(app)` after you set up your Koa server.
+ *
+ * For more information, see the [koa documentation](https://docs.sentry.io/platforms/javascript/guides/koa/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *   integrations: [Sentry.koaIntegration()],
+ * })
+ * ```
+ */
 export const koaIntegration = defineIntegration(_koaIntegration);
 
+/**
+ * Add an Koa error handler to capture errors to Sentry.
+ *
+ * The error handler must be before any other middleware and after all controllers.
+ *
+ * @param app The Express instances
+ * @param options {ExpressHandlerOptions} Configuration options for the handler
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ * const Koa = require("koa");
+ *
+ * const app = new Koa();
+ *
+ * Sentry.setupKoaErrorHandler(app);
+ *
+ * // Add your routes, etc.
+ *
+ * app.listen(3000);
+ * ```
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const setupKoaErrorHandler = (app: { use: (arg0: (ctx: any, next: any) => Promise<void>) => void }): void => {
   app.use(async (ctx, next) => {

--- a/packages/node/src/integrations/tracing/lrumemoizer.ts
+++ b/packages/node/src/integrations/tracing/lrumemoizer.ts
@@ -18,8 +18,16 @@ const _lruMemoizerIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * LruMemoizer integration
+ * Adds Sentry tracing instrumentation for the [lru-memoizer](https://www.npmjs.com/package/lru-memoizer) library.
  *
- * Propagate traces through LruMemoizer.
+ * For more information, see the [`lruMemoizerIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/lrumemoizer/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.lruMemoizerIntegration()],
+ * });
  */
 export const lruMemoizerIntegration = defineIntegration(_lruMemoizerIntegration);

--- a/packages/node/src/integrations/tracing/mongo.ts
+++ b/packages/node/src/integrations/tracing/mongo.ts
@@ -27,8 +27,17 @@ const _mongoIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * MongoDB integration
+ * Adds Sentry tracing instrumentation for the [mongodb](https://www.npmjs.com/package/mongodb) library.
  *
- * Capture tracing data for MongoDB.
+ * For more information, see the [`mongoIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/mongo/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.mongoIntegration()],
+ * });
+ * ```
  */
 export const mongoIntegration = defineIntegration(_mongoIntegration);

--- a/packages/node/src/integrations/tracing/mongoose.ts
+++ b/packages/node/src/integrations/tracing/mongoose.ts
@@ -27,8 +27,17 @@ const _mongooseIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Mongoose integration
+ * Adds Sentry tracing instrumentation for the [mongoose](https://www.npmjs.com/package/mongoose) library.
  *
- * Capture tracing data for Mongoose.
+ * For more information, see the [`mongooseIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/mongoose/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.mongooseIntegration()],
+ * });
+ * ```
  */
 export const mongooseIntegration = defineIntegration(_mongooseIntegration);

--- a/packages/node/src/integrations/tracing/mysql.ts
+++ b/packages/node/src/integrations/tracing/mysql.ts
@@ -17,8 +17,17 @@ const _mysqlIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * MySQL integration
+ * Adds Sentry tracing instrumentation for the [mysql](https://www.npmjs.com/package/mysql) library.
  *
- * Capture tracing data for mysql.
+ * For more information, see the [`mysqlIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/mysql/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.mysqlIntegration()],
+ * });
+ * ```
  */
 export const mysqlIntegration = defineIntegration(_mysqlIntegration);

--- a/packages/node/src/integrations/tracing/mysql2.ts
+++ b/packages/node/src/integrations/tracing/mysql2.ts
@@ -27,8 +27,17 @@ const _mysql2Integration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * MySQL2 integration
+ * Adds Sentry tracing instrumentation for the [mysql2](https://www.npmjs.com/package/mysql2) library.
  *
- * Capture tracing data for mysql2
+ * For more information, see the [`mysql2Integration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/mysql2/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.mysqlIntegration()],
+ * });
+ * ```
  */
 export const mysql2Integration = defineIntegration(_mysql2Integration);

--- a/packages/node/src/integrations/tracing/postgres.ts
+++ b/packages/node/src/integrations/tracing/postgres.ts
@@ -28,8 +28,17 @@ const _postgresIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Postgres integration
+ * Adds Sentry tracing instrumentation for the [pg](https://www.npmjs.com/package/pg) library.
  *
- * Capture tracing data for pg.
+ * For more information, see the [`postgresIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/postgres/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.postgresIntegration()],
+ * });
+ * ```
  */
 export const postgresIntegration = defineIntegration(_postgresIntegration);

--- a/packages/node/src/integrations/tracing/prisma.ts
+++ b/packages/node/src/integrations/tracing/prisma.ts
@@ -38,12 +38,30 @@ const _prismaIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Prisma integration
+ * Adds Sentry tracing instrumentation for the [prisma](https://www.npmjs.com/package/prisma) library.
  *
- * Capture tracing data for prisma.
- * Note: This requires to set:
- * previewFeatures = ["tracing"]
- * For the prisma client.
- * See https://www.prisma.io/docs/concepts/components/prisma-client/opentelemetry-tracing for more details.
+ * For more information, see the [`prismaIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/prisma/).
+ *
+ * @example
+ *
+ * Make sure `previewFeatures = ["tracing"]` is set in the prisma client generator block. See the
+ * [prisma docs](https://www.prisma.io/docs/concepts/components/prisma-client/opentelemetry-tracing) for more details.
+ *
+ * ```prisma
+ * generator client {
+ *  provider = "prisma-client-js"
+ *  previewFeatures = ["tracing"]
+ * }
+ * ```
+ *
+ * Then you can use the integration like this:
+ *
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.prismaIntegration()],
+ * });
+ * ```
  */
 export const prismaIntegration = defineIntegration(_prismaIntegration);

--- a/packages/node/src/integrations/tracing/redis.ts
+++ b/packages/node/src/integrations/tracing/redis.ts
@@ -110,8 +110,18 @@ const _redisIntegration = ((options: RedisOptions = {}) => {
 }) satisfies IntegrationFn;
 
 /**
- * Redis integration for "ioredis"
+ * Adds Sentry tracing instrumentation for the [redis](https://www.npmjs.com/package/redis) and
+ * [ioredis](https://www.npmjs.com/package/ioredis) libraries.
  *
- * Capture tracing data for redis and ioredis.
+ * For more information, see the [`redisIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/redis/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.redisIntegration()],
+ * });
+ * ```
  */
 export const redisIntegration = defineIntegration(_redisIntegration);

--- a/packages/node/src/integrations/tracing/tedious.ts
+++ b/packages/node/src/integrations/tracing/tedious.ts
@@ -41,8 +41,17 @@ const _tediousIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Tedious integration
+ * Adds Sentry tracing instrumentation for the [tedious](https://www.npmjs.com/package/tedious) library.
  *
- * Capture tracing data for tedious.
+ * For more information, see the [`tediousIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/tedious/).
+ *
+ * @example
+ * ```javascript
+ * const Sentry = require('@sentry/node');
+ *
+ * Sentry.init({
+ *  integrations: [Sentry.tediousIntegration()],
+ * });
+ * ```
  */
 export const tediousIntegration = defineIntegration(_tediousIntegration);


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-javascript/issues/13317

Improve the docstrings and link to documentation pages as appropriate (as they contain information about opentelemetry and supported versions).