### PR TITLE
fix(core): Set `sentry.source` attribute to `custom` when calling `span.updateName` on `SentrySpan`

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -139,7 +139,7 @@ module.exports = [
     path: 'packages/vue/build/esm/index.js',
     import: createImport('init', 'browserTracingIntegration'),
     gzip: true,
-    limit: '38 KB',
+    limit: '38.5 KB',
   },
   // Svelte SDK (ESM)
   {

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/basic/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/basic/test.ts
@@ -6,19 +6,36 @@ import {
   shouldSkipTracingTest,
   waitForTransactionRequestOnUrl,
 } from '../../../../utils/helpers';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+} from '@sentry/browser';
 
-sentryTest('should send a transaction in an envelope', async ({ getLocalTestPath, page }) => {
-  if (shouldSkipTracingTest()) {
-    sentryTest.skip();
-  }
+sentryTest(
+  'sends a transaction in an envelope with manual origin and custom source',
+  async ({ getLocalTestPath, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
 
-  const url = await getLocalTestPath({ testDir: __dirname });
-  const req = await waitForTransactionRequestOnUrl(page, url);
-  const transaction = envelopeRequestParser(req);
+    const url = await getLocalTestPath({ testDir: __dirname });
+    const req = await waitForTransactionRequestOnUrl(page, url);
+    const transaction = envelopeRequestParser(req);
 
-  expect(transaction.transaction).toBe('parent_span');
-  expect(transaction.spans).toBeDefined();
-});
+    const attributes = transaction.contexts?.trace?.data;
+    expect(attributes).toEqual({
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
+      [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
+      [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
+    });
+
+    expect(transaction.transaction_info?.source).toBe('custom');
+
+    expect(transaction.transaction).toBe('parent_span');
+    expect(transaction.spans).toBeDefined();
+  },
+);
 
 sentryTest('should report finished spans as children of the root transaction', async ({ getLocalTestPath, page }) => {
   if (shouldSkipTracingTest()) {

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/basic/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/basic/test.ts
@@ -1,16 +1,16 @@
 import { expect } from '@playwright/test';
 
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+} from '@sentry/browser';
 import { sentryTest } from '../../../../utils/fixtures';
 import {
   envelopeRequestParser,
   shouldSkipTracingTest,
   waitForTransactionRequestOnUrl,
 } from '../../../../utils/helpers';
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
-  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-} from '@sentry/browser';
 
 sentryTest(
   'sends a transaction in an envelope with manual origin and custom source',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/init.js
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window._testBaseTimestamp = performance.timeOrigin / 1000;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/subject.js
@@ -1,0 +1,3 @@
+const activeSpan = Sentry.getActiveSpan();
+const rootSpan = activeSpan && Sentry.getRootSpan(activeSpan);
+rootSpan?.updateName('new name');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/test.ts
@@ -1,14 +1,14 @@
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/types';
 
-import { sentryTest } from '../../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/browser';
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
 sentryTest('sets the source to custom when updating the transaction name', async ({ getLocalTestPath, page }) => {
   if (shouldSkipTracingTest()) {

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/test.ts
@@ -10,7 +10,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/browser';
 
-sentryTest('creates a pageload transaction with url as source', async ({ getLocalTestPath, page }) => {
+sentryTest('sets the source to custom when updating the transaction name', async ({ getLocalTestPath, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
@@ -18,22 +18,19 @@ sentryTest('creates a pageload transaction with url as source', async ({ getLoca
   const url = await getLocalTestPath({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
-  const timeOrigin = await page.evaluate<number>('window._testBaseTimestamp');
-
-  const { start_timestamp: startTimestamp } = eventData;
 
   const traceContextData = eventData.contexts?.trace?.data;
-
-  expect(startTimestamp).toBeCloseTo(timeOrigin, 1);
 
   expect(traceContextData).toMatchObject({
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
     [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
-    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
   });
 
+  expect(eventData.transaction).toBe('new name');
+
   expect(eventData.contexts?.trace?.op).toBe('pageload');
   expect(eventData.spans?.length).toBeGreaterThan(0);
-  expect(eventData.transaction_info?.source).toEqual('url');
+  expect(eventData.transaction_info?.source).toEqual('custom');
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload/test.ts
@@ -1,14 +1,14 @@
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/types';
 
-import { sentryTest } from '../../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/browser';
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
 sentryTest('creates a pageload transaction with url as source', async ({ getLocalTestPath, page }) => {
   if (shouldSkipTracingTest()) {

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -193,6 +193,7 @@ export class SentrySpan implements Span {
    */
   public updateName(name: string): this {
     this._name = name;
+    this.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'custom');
     return this;
   }
 

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -1,5 +1,5 @@
 import { timestampInSeconds } from '@sentry/utils';
-import { setCurrentClient } from '../../../src';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, setCurrentClient } from '../../../src';
 import { SentrySpan } from '../../../src/tracing/sentrySpan';
 import { SPAN_STATUS_ERROR } from '../../../src/tracing/spanstatus';
 import { TRACE_FLAG_NONE, TRACE_FLAG_SAMPLED, spanToJSON } from '../../../src/utils/spanUtils';
@@ -19,6 +19,19 @@ describe('SentrySpan', () => {
       span.updateName('new name');
 
       expect(spanToJSON(span).description).toEqual('new name');
+    });
+
+    it('sets the source to custom when calling updateName', () => {
+      const span = new SentrySpan({
+        name: 'original name',
+        attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url' },
+      });
+
+      span.updateName('new name');
+
+      const spanJson = spanToJSON(span);
+      expect(spanJson.description).toEqual('new name');
+      expect(spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
     });
   });
 

--- a/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
@@ -61,6 +61,7 @@ export function appRouterInstrumentNavigation(client: Client): void {
   WINDOW.addEventListener('popstate', () => {
     if (currentNavigationSpan && currentNavigationSpan.isRecording()) {
       currentNavigationSpan.updateName(WINDOW.location.pathname);
+      currentNavigationSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'url');
     } else {
       currentNavigationSpan = startBrowserTracingNavigationSpan(client, {
         name: WINDOW.location.pathname,
@@ -105,9 +106,11 @@ export function appRouterInstrumentNavigation(client: Client): void {
 
               if (routerFunctionName === 'push') {
                 span?.updateName(transactionNameifyRouterArgument(argArray[0]));
+                span?.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'url');
                 span?.setAttribute('navigation.type', 'router.push');
               } else if (routerFunctionName === 'replace') {
                 span?.updateName(transactionNameifyRouterArgument(argArray[0]));
+                span?.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'url');
                 span?.setAttribute('navigation.type', 'router.replace');
               } else if (routerFunctionName === 'back') {
                 span?.setAttribute('navigation.type', 'router.back');

--- a/packages/solid/src/solidrouter.ts
+++ b/packages/solid/src/solidrouter.ts
@@ -82,14 +82,14 @@ function withSentryRouterRoot(Root: Component<RouteSectionProps>): Component<Rou
       const rootSpan = getActiveRootSpan();
 
       if (rootSpan) {
-        const { op, description, data } = spanToJSON(rootSpan);
+        const { op, description } = spanToJSON(rootSpan);
 
         // We only need to update navigation spans that have been created by
         // a browser back-button navigation (stored as `-1` by solid router)
         // everything else was already instrumented correctly in `useBeforeLeave`
         if (op === 'navigation' && description === '-1') {
           rootSpan.updateName(name);
-          rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, data && data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]);
+          rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'url');
         }
       }
     });

--- a/packages/solid/src/solidrouter.ts
+++ b/packages/solid/src/solidrouter.ts
@@ -82,13 +82,14 @@ function withSentryRouterRoot(Root: Component<RouteSectionProps>): Component<Rou
       const rootSpan = getActiveRootSpan();
 
       if (rootSpan) {
-        const { op, description } = spanToJSON(rootSpan);
+        const { op, description, data } = spanToJSON(rootSpan);
 
         // We only need to update navigation spans that have been created by
         // a browser back-button navigation (stored as `-1` by solid router)
         // everything else was already instrumented correctly in `useBeforeLeave`
         if (op === 'navigation' && description === '-1') {
           rootSpan.updateName(name);
+          rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, data && data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]);
         }
       }
     });


### PR DESCRIPTION
This PR fixes a "regression" introduced in v8 where we no longer updated the source of the span when calling `span.updateName`. We had this behaviour in our v7 `Transaction` class (IIRC via `transaction.setName(name, source)` but most likely forgot to port it to the `Span` class as the `event.transaction_info.source` field is only relevant for transactions (i.e. root spans in today's SDK lingo).

The PR also adds and improves some unit and browser integration tests so that we check against the default source as well as that updating the name updates the source. 

Important: While this is a fix in the core package it has **no effect** on spans created in the Node SDK, since these are created from OpenTelemetry. I'll open a second PR for Node, as the changes there are more involved. This fix only addresses the behaviour of our `SentrySpan` class, which is used in browser SDKs (and none-Otel SDKs if any others use tracing)

The issue addressed in this PR shouldn't be a major issue because it does not concern manually created root spans. Probably the only relevant scenario where this behaviour had user impact is something like:
1. SDK starts pageload/navigation span with source `url` (likely via `browserTracingIntegration` from `@sentry/browser`)
2. User updates the span name but doesn't set source explicitly
3. SDK sends transaction envelope with `transaction_info.source: "url"`
4. Relay applies clustering because the `"url"` source is low quality
5. Custom name is lost or modified by clustering.

Which again is unlikely an issue in framework SDKs because most of our routing instrumentations update the span name _and_ set the source to `"route"`. The described example would for example happen in `@sentry/browser` with the default `browserTracingIntegration` enabled and users running their own enhancement for e.g. a yet unsupported router.