### PR TITLE
meta(changelog): Update changelog for v7.120.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 7.120.0
+
+- feat(v7/browser): Add moduleMetadataIntegration lazy loading support (#13822)
+
+Work in this release contributed by @gilisho. Thank you for your contribution!
+
 ## 7.119.2
 
 - chore(nextjs/v7): Bump rollup to 2.79.2


### PR DESCRIPTION
Small backport release to publish the module metadata integration to the CDN for lazy loading.