### PR TITLE
test(remix): Stop relying on node-integration-tests in remix

### DIFF
--- a/packages/remix/test/integration/test/server/utils/helpers.ts
+++ b/packages/remix/test/integration/test/server/utils/helpers.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { createRequestHandler } from '@remix-run/express';
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import * as Sentry from '@sentry/node';
-import type { EnvelopeItemType, TransactionEvent, Event } from '@sentry/types';
+import type { EnvelopeItemType, Event, TransactionEvent } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
@@ -282,7 +282,6 @@ export class RemixTestEnv extends TestEnv {
 const parseEnvelope = (body: string): Array<Record<string, unknown>> => {
   return body.split('\n').map(e => JSON.parse(e));
 };
-
 
 /**
  * Asserts against a Sentry Event ignoring non-deterministic properties

--- a/packages/remix/test/integration/test/server/utils/helpers.ts
+++ b/packages/remix/test/integration/test/server/utils/helpers.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { createRequestHandler } from '@remix-run/express';
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import * as Sentry from '@sentry/node';
-import type { EnvelopeItemType } from '@sentry/types';
+import type { EnvelopeItemType, TransactionEvent, Event } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
@@ -13,8 +13,6 @@ import type { Express } from 'express';
 import type { HttpTerminator } from 'http-terminator';
 import { createHttpTerminator } from 'http-terminator';
 import nock from 'nock';
-
-export * from '../../../../../../../dev-packages/node-integration-tests/utils';
 
 type DataCollectorOptions = {
   // Optional custom URL
@@ -283,4 +281,35 @@ export class RemixTestEnv extends TestEnv {
 
 const parseEnvelope = (body: string): Array<Record<string, unknown>> => {
   return body.split('\n').map(e => JSON.parse(e));
+};
+
+
+/**
+ * Asserts against a Sentry Event ignoring non-deterministic properties
+ *
+ * @param {Record<string, unknown>} actual
+ * @param {Record<string, unknown>} expected
+ */
+export const assertSentryEvent = (actual: Event, expected: Record<string, unknown>): void => {
+  expect(actual).toMatchObject({
+    event_id: expect.any(String),
+    ...expected,
+  });
+};
+
+/**
+ * Asserts against a Sentry Transaction ignoring non-deterministic properties
+ *
+ * @param {Record<string, unknown>} actual
+ * @param {Record<string, unknown>} expected
+ */
+export const assertSentryTransaction = (actual: TransactionEvent, expected: Record<string, unknown>): void => {
+  expect(actual).toMatchObject({
+    event_id: expect.any(String),
+    timestamp: expect.anything(),
+    start_timestamp: expect.anything(),
+    spans: expect.any(Array),
+    type: 'transaction',
+    ...expected,
+  });
 };


### PR DESCRIPTION
Oops, https://github.com/getsentry/sentry-javascript/pull/14245 broke our remix integration tests.

Instead of re-exporting this from a path (which is not resolved nicely etc. and not reflected by our dependency graph) we can just inline the two methods we need here, they are not too complicated.