### PR TITLE
ref(vue): Reduce bundle size for starting application render span

### DIFF
--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -81,18 +81,16 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
         const isRoot = this.$root === this;
 
         if (isRoot) {
-          const activeSpan = getActiveSpan();
-          if (activeSpan) {
-            this.$_sentryRootSpan =
-              this.$_sentryRootSpan ||
-              startInactiveSpan({
-                name: 'Application Render',
-                op: `${VUE_OP}.render`,
-                attributes: {
-                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.vue',
-                },
-              });
-          }
+          this.$_sentryRootSpan =
+            this.$_sentryRootSpan ||
+            startInactiveSpan({
+              name: 'Application Render',
+              op: `${VUE_OP}.render`,
+              attributes: {
+                [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.vue',
+              },
+              onlyIfParent: true,
+            });
         }
 
         // Skip components that we don't want to track to minimize the noise and give a more granular control to the user


### PR DESCRIPTION
Just a smal bundle size reduction PR for the Vue SDK: I discovered while working on #14251 that we can simplify the check here and just use the `onlyIfParent` flag instead of querying the active span. This should behave identically.