### PR TITLE
fix(opentelemetry): Prevent span name update overwrites and ensure `sentry.source` is set correctly

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage/test.ts
@@ -1,11 +1,24 @@
+import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/node';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should send a manually started root span', done => {
+test('sends a manually started root span with source set to custom', done => {
   createRunner(__dirname, 'scenario.ts')
-    .expect({ transaction: { transaction: 'test_span' } })
+    .expect({
+      transaction: {
+        transaction: 'test_span',
+        transaction_info: { source: 'custom' },
+        contexts: {
+          trace: {
+            span_id: expect.any(String),
+            trace_id: expect.any(String),
+            data: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom' },
+          },
+        },
+      },
+    })
     .start(done);
 });

--- a/packages/nestjs/src/decorators/sentry-traced.ts
+++ b/packages/nestjs/src/decorators/sentry-traced.ts
@@ -1,4 +1,4 @@
-import { startSpan } from '@sentry/node';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, startSpan } from '@sentry/node';
 
 /**
  * A decorator usable to wrap arbitrary functions with spans.
@@ -14,6 +14,10 @@ export function SentryTraced(op: string = 'function') {
         {
           op: op,
           name: propertyKey,
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.nestjs',
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
+          },
         },
         () => {
           return originalMethod.apply(this, args);

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -173,6 +173,8 @@ export function init(options: NodeOptions): NodeClient | undefined {
       ) {
         const route = spanAttributes['next.route'].replace(/\/route$/, '');
         rootSpan.updateName(route);
+        // set the source of the root span to what it was before cleaning up the name
+        rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]);
         rootSpan.setAttribute(ATTR_HTTP_ROUTE, route);
       }
     }

--- a/packages/node/src/integrations/fs.ts
+++ b/packages/node/src/integrations/fs.ts
@@ -1,5 +1,10 @@
 import { FsInstrumentation } from '@opentelemetry/instrumentation-fs';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  defineIntegration,
+} from '@sentry/core';
 import { generateInstrumentOnce } from '../otel/instrument';
 
 const INTEGRATION_NAME = 'FileSystem';
@@ -45,6 +50,7 @@ export const fsIntegration = defineIntegration(
                 span.setAttributes({
                   [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'file',
                   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.file.fs',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
                 });
 
                 if (options.recordErrorMessagesAsSpanAttributes) {

--- a/packages/node/src/integrations/tracing/connect.ts
+++ b/packages/node/src/integrations/tracing/connect.ts
@@ -2,6 +2,7 @@ import { ConnectInstrumentation } from '@opentelemetry/instrumentation-connect';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   captureException,
   defineIntegration,
   getClient,
@@ -108,5 +109,7 @@ function addConnectSpanAttributes(span: Span): void {
   const name = attributes['connect.name'];
   if (typeof name === 'string') {
     span.updateName(name);
+    // set the source of the span to what it was before (likely undefined)
+    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]);
   }
 }

--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -1,6 +1,12 @@
 import type * as http from 'node:http';
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, defineIntegration, getDefaultIsolationScope, spanToJSON } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  defineIntegration,
+  getDefaultIsolationScope,
+  spanToJSON,
+} from '@sentry/core';
 import { captureException, getClient, getIsolationScope } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/types';
 import { logger } from '@sentry/utils';
@@ -31,6 +37,8 @@ export const instrumentExpress = generateInstrumentOnce(
         const name = attributes['express.name'];
         if (typeof name === 'string') {
           span.updateName(name);
+          // set the source of the span to what it was before (likely undefined)
+          span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]);
         }
       },
       spanNameHook(info, defaultName) {

--- a/packages/node/src/integrations/tracing/fastify.ts
+++ b/packages/node/src/integrations/tracing/fastify.ts
@@ -2,6 +2,7 @@ import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   captureException,
   defineIntegration,
   getClient,
@@ -156,5 +157,7 @@ function addFastifySpanAttributes(span: Span): void {
   if (typeof name === 'string') {
     // Also remove `fastify -> ` prefix
     span.updateName(name.replace(/^fastify -> /, ''));
+    // set the source of the span to what it was before (likely undefined)
+    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]);
   }
 }

--- a/packages/node/src/integrations/tracing/koa.ts
+++ b/packages/node/src/integrations/tracing/koa.ts
@@ -3,6 +3,7 @@ import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   captureException,
   defineIntegration,
   getDefaultIsolationScope,
@@ -120,5 +121,7 @@ function addKoaSpanAttributes(span: Span): void {
     // Somehow, name is sometimes `''` for middleware spans
     // See: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2220
     span.updateName(name || '< unknown >');
+    // set the source of the span to what it was before (likely undefined)
+    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]);
   }
 }

--- a/packages/node/src/integrations/tracing/nest/helpers.ts
+++ b/packages/node/src/integrations/tracing/nest/helpers.ts
@@ -1,4 +1,9 @@
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, withActiveSpan } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  withActiveSpan,
+} from '@sentry/core';
 import type { Span } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
 import type { CatchTarget, InjectableTarget, NextFunction, Observable, Subscription } from './types';
@@ -32,6 +37,7 @@ export function getMiddlewareSpanOptions(target: InjectableTarget | CatchTarget,
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'middleware.nestjs',
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.middleware.nestjs',
+      [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
     },
   };
 }

--- a/packages/node/src/integrations/tracing/nest/helpers.ts
+++ b/packages/node/src/integrations/tracing/nest/helpers.ts
@@ -4,7 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   withActiveSpan,
 } from '@sentry/core';
-import type { Span } from '@sentry/types';
+import type { Span, StartSpanOptions } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
 import type { CatchTarget, InjectableTarget, NextFunction, Observable, Subscription } from './types';
 
@@ -28,8 +28,10 @@ export function isPatched(target: InjectableTarget | CatchTarget): boolean {
 /**
  * Returns span options for nest middleware spans.
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function getMiddlewareSpanOptions(target: InjectableTarget | CatchTarget, name: string | undefined = undefined) {
+export function getMiddlewareSpanOptions(
+  target: InjectableTarget | CatchTarget,
+  name: string | undefined = undefined,
+): StartSpanOptions {
   const span_name = name ?? target.name; // fallback to class name if no name is provided
 
   return {

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -135,6 +135,7 @@ function makeWrappedDocumentRequestFunction(autoInstrumentRemix?: boolean, remix
               url: request.url,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.remix',
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function.remix.document_request',
+              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
             },
           },
           () => {
@@ -175,6 +176,7 @@ function makeWrappedDataFunction(
           name: id,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.remix',
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
             name,
           },
         },

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -234,6 +234,13 @@ export interface Span {
 
   /**
    * Update the name of the span.
+   *
+   * Calling this method will also override or set the `SEMANTIC_ATTRIBUTE_SENTRY_SOURCE` attribute to `custom`.
+   * This indicates to the Sentry backend that the span name was set manually to skip potential post processing of the name.
+   * This is very likely what you want to achieve when calling this method!
+   *
+   * If you still need to change the source attribute (for instance for custom router instrumentation),
+   * you can do so by calling `span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, sourceValue)`.
    */
   updateName(name: string): this;
 


### PR DESCRIPTION
heavy WIP; tests will fail a lot still

