### PR TITLE
ref: Set `normalizedRequest` instead of `request` in various places

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
@@ -33,17 +33,12 @@ test('Sends a transaction for a request to app router', async ({ page }) => {
     trace_id: expect.any(String),
   });
 
-  expect(transactionEvent).toEqual(
-    expect.objectContaining({
-      request: {
-        cookies: {},
-        headers: expect.any(Object),
-        url: expect.any(String),
-      },
+  expect(transactionEvent.request).toEqual({
+    cookies: {},
+    headers: expect.objectContaining({
+      'user-agent': expect.any(String),
     }),
-  );
-
-  expect(Object.keys(transactionEvent.request?.headers!).length).toBeGreaterThan(0);
+  });
 
   // The transaction should not contain any spans with the same name as the transaction
   // e.g. "GET /server-component/parameter/[...parameters]"

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -221,7 +221,7 @@ describe('sentryMiddleware', () => {
       await middleware(ctx, next);
 
       expect(setSDKProcessingMetadataMock).toHaveBeenCalledWith({
-        request: {
+        normalizedRequest: {
           method: 'GET',
           url: '/users',
           headers: {
@@ -254,7 +254,7 @@ describe('sentryMiddleware', () => {
       await middleware(ctx, next);
 
       expect(setSDKProcessingMetadataMock).toHaveBeenCalledWith({
-        request: {
+        normalizedRequest: {
           method: 'GET',
           url: '/users',
         },

--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -9,8 +9,8 @@ import {
   startSpan,
   withIsolationScope,
 } from '@sentry/core';
-import type { IntegrationFn, SpanAttributes } from '@sentry/types';
-import { getSanitizedUrlString, parseUrl } from '@sentry/utils';
+import type { IntegrationFn, RequestEventData, SpanAttributes } from '@sentry/types';
+import { extractQueryParamsFromUrl, getSanitizedUrlString, parseUrl } from '@sentry/utils';
 
 const INTEGRATION_NAME = 'BunServer';
 
@@ -76,11 +76,12 @@ function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]
         const url = getSanitizedUrlString(parsedUrl);
 
         isolationScope.setSDKProcessingMetadata({
-          request: {
+          normalizedRequest: {
             url,
             method: request.method,
             headers: request.headers.toJSON(),
-          },
+            query_string: extractQueryParamsFromUrl(url),
+          } satisfies RequestEventData,
         });
 
         return continueTrace(

--- a/packages/cloudflare/src/scope-utils.ts
+++ b/packages/cloudflare/src/scope-utils.ts
@@ -25,5 +25,5 @@ export function addCultureContext(scope: Scope, cf: IncomingRequestCfProperties)
  * Set request data on scope
  */
 export function addRequest(scope: Scope, request: Request): void {
-  scope.setSDKProcessingMetadata({ request: winterCGRequestToRequestData(request) });
+  scope.setSDKProcessingMetadata({ normalizedRequest: winterCGRequestToRequestData(request) });
 }

--- a/packages/cloudflare/test/request.test.ts
+++ b/packages/cloudflare/test/request.test.ts
@@ -109,7 +109,7 @@ describe('withSentry', () => {
         },
       );
 
-      expect(sentryEvent.sdkProcessingMetadata?.request).toEqual({
+      expect(sentryEvent.sdkProcessingMetadata?.normalizedRequest).toEqual({
         headers: {},
         url: 'https://example.com/',
         method: 'GET',

--- a/packages/nextjs/src/common/captureRequestError.ts
+++ b/packages/nextjs/src/common/captureRequestError.ts
@@ -1,4 +1,6 @@
 import { captureException, withScope } from '@sentry/core';
+import type { RequestEventData } from '@sentry/types';
+import { headersToDict } from '@sentry/utils';
 
 type RequestInfo = {
   path: string;
@@ -18,10 +20,10 @@ type ErrorContext = {
 export function captureRequestError(error: unknown, request: RequestInfo, errorContext: ErrorContext): void {
   withScope(scope => {
     scope.setSDKProcessingMetadata({
-      request: {
-        headers: request.headers,
+      normalizedRequest: {
+        headers: headersToDict(request.headers),
         method: request.method,
-      },
+      } satisfies RequestEventData,
     });
 
     scope.setContext('nextjs', {

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -9,6 +9,7 @@ import {
   startSpan,
   withIsolationScope,
 } from '@sentry/core';
+import type { RequestEventData } from '@sentry/types';
 import { logger, vercelWaitUntil } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
@@ -89,9 +90,9 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
 
     isolationScope.setTransactionName(`serverAction/${serverActionName}`);
     isolationScope.setSDKProcessingMetadata({
-      request: {
+      normalizedRequest: {
         headers: fullHeadersObject,
-      },
+      } satisfies RequestEventData,
     });
 
     return continueTrace(

--- a/packages/nextjs/src/common/wrapGenerationFunctionWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGenerationFunctionWithSentry.ts
@@ -14,7 +14,7 @@ import {
   withIsolationScope,
   withScope,
 } from '@sentry/core';
-import type { WebFetchHeaders } from '@sentry/types';
+import type { RequestEventData, WebFetchHeaders } from '@sentry/types';
 import { propagationContextFromHeaders, uuid4, winterCGHeadersToDict } from '@sentry/utils';
 
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
@@ -68,9 +68,9 @@ export function wrapGenerationFunctionWithSentry<F extends (...args: any[]) => a
           scope.setTransactionName(`${componentType}.${generationFunctionIdentifier} (${componentRoute})`);
 
           isolationScope.setSDKProcessingMetadata({
-            request: {
+            normalizedRequest: {
               headers: headersDict,
-            },
+            } satisfies RequestEventData,
           });
 
           const activeSpan = getActiveSpan();

--- a/packages/nextjs/src/common/wrapMiddlewareWithSentry.ts
+++ b/packages/nextjs/src/common/wrapMiddlewareWithSentry.ts
@@ -36,7 +36,7 @@ export function wrapMiddlewareWithSentry<H extends EdgeRouteHandler>(
 
         if (req instanceof Request) {
           isolationScope.setSDKProcessingMetadata({
-            request: winterCGRequestToRequestData(req),
+            normalizedRequest: winterCGRequestToRequestData(req),
           });
           spanName = `middleware ${req.method} ${new URL(req.url).pathname}`;
           spanSource = 'url';

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -13,7 +13,7 @@ import {
   withIsolationScope,
   withScope,
 } from '@sentry/core';
-
+import type { RequestEventData } from '@sentry/types';
 import type { RouteHandlerContext } from './types';
 
 import { propagationContextFromHeaders, winterCGHeadersToDict } from '@sentry/utils';
@@ -64,10 +64,10 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
               );
               scope.setPropagationContext(incomingPropagationContext);
               scope.setSDKProcessingMetadata({
-                request: {
+                normalizedRequest: {
                   method,
                   headers: completeHeadersDict,
-                },
+                } satisfies RequestEventData,
               });
             }
 

--- a/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
+++ b/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
@@ -13,6 +13,7 @@ import {
   withIsolationScope,
   withScope,
 } from '@sentry/core';
+import type { RequestEventData } from '@sentry/types';
 import { propagationContextFromHeaders, uuid4, vercelWaitUntil, winterCGHeadersToDict } from '@sentry/utils';
 
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
@@ -49,9 +50,9 @@ export function wrapServerComponentWithSentry<F extends (...args: any[]) => any>
       const headersDict = context.headers ? winterCGHeadersToDict(context.headers) : undefined;
 
       isolationScope.setSDKProcessingMetadata({
-        request: {
+        normalizedRequest: {
           headers: headersDict,
-        },
+        } satisfies RequestEventData,
       });
 
       return withIsolationScope(isolationScope, () => {

--- a/packages/nextjs/src/edge/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/edge/wrapApiHandlerWithSentry.ts
@@ -32,7 +32,7 @@ export function wrapApiHandlerWithSentry<H extends EdgeRouteHandler>(
 
         if (req instanceof Request) {
           isolationScope.setSDKProcessingMetadata({
-            request: winterCGRequestToRequestData(req),
+            normalizedRequest: winterCGRequestToRequestData(req),
           });
           currentScope.setTransactionName(`${req.method} ${parameterizedRoute}`);
         } else {

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -131,7 +131,9 @@ export function sentryHandle(handlerOptions?: SentryHandleOptions): Handle {
     return withIsolationScope(isolationScope => {
       // We only call continueTrace in the initial top level request to avoid
       // creating a new root span for the sub request.
-      isolationScope.setSDKProcessingMetadata({ request: winterCGRequestToRequestData(input.event.request.clone()) });
+      isolationScope.setSDKProcessingMetadata({
+        normalizedRequest: winterCGRequestToRequestData(input.event.request.clone()),
+      });
       return continueTrace(getTracePropagationData(input.event), () => instrumentHandle(input, options));
     });
   };
@@ -167,7 +169,9 @@ async function instrumentHandle(
         name: routeName,
       },
       async (span?: Span) => {
-        getCurrentScope().setSDKProcessingMetadata({ request: winterCGRequestToRequestData(event.request.clone()) });
+        getCurrentScope().setSDKProcessingMetadata({
+          normalizedRequest: winterCGRequestToRequestData(event.request.clone()),
+        });
         const res = await resolve(event, {
           transformPageChunk: addSentryCodeToPage(options),
         });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -73,6 +73,8 @@ export {
   extractRequestData,
   winterCGHeadersToDict,
   winterCGRequestToRequestData,
+  extractQueryParamsFromUrl,
+  headersToDict,
 } from './requestdata';
 export type {
   AddRequestDataToEventOptions,


### PR DESCRIPTION
The request data integration prefers this over `request`, we want to get rid of `request` in v9.

Updates the following:

- [x] astro/src/server/middleware.ts
- [x] bun/src/integrations/bunserver.ts
- [x] cloudflare/src/scope-utils.ts
- [ ] google-cloud-serverless/src/gcpfunction/http.ts
- [x] nextjs/src/common/captureRequestError.ts
- [x] nextjs/src/common/withServerActionInstrumentation.ts
- [x] nextjs/src/common/wrapGenerationFunctionWithSentry.ts
- [ ] nextjs/src/common/wrapMiddlewareWithSentry.ts
- [x] nextjs/src/common/wrapRouteHandlerWithSentry.ts
- [x] nextjs/src/common/wrapServerComponentWithSentry.ts
- [ ] nextjs/src/common/pages-router-instrumentation/_error.ts
- [ ] nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentry.ts
- [ ] nextjs/src/common/utils/wrapperUtils.ts
- [x] nextjs/src/edge/wrapApiHandlerWithSentry.ts
- [ ] remix/src/utils/errors.ts
- [ ] remix/src/utils/instrumentServer.ts
- [x] sveltekit/src/server/handle.ts

Part of https://github.com/getsentry/sentry-javascript/issues/14298