### PR TITLE
ref(types): Deprecate `Request` type in favor of `RequestEventData`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -11,3 +11,7 @@
 ## `@sentry/core`
 
 - Deprecated `transactionNamingScheme` option in `requestDataIntegration`.
+
+## `@sentry/types``
+
+- Deprecated `Request` in favor of `RequestEventData`.

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -1,7 +1,9 @@
 export type {
   Breadcrumb,
   BreadcrumbHint,
+  // eslint-disable-next-line deprecation/deprecation
   Request,
+  RequestEventData,
   SdkInfo,
   Event,
   EventHint,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -2,7 +2,9 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
+  // eslint-disable-next-line deprecation/deprecation
   Request,
+  RequestEventData,
   SdkInfo,
   Event,
   EventHint,

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -2,7 +2,9 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
+  // eslint-disable-next-line deprecation/deprecation
   Request,
+  RequestEventData,
   SdkInfo,
   Event,
   EventHint,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -2,7 +2,9 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
+  // eslint-disable-next-line deprecation/deprecation
   Request,
+  RequestEventData,
   SdkInfo,
   Event,
   EventHint,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -144,7 +144,9 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
+  // eslint-disable-next-line deprecation/deprecation
   Request,
+  RequestEventData,
   SdkInfo,
   Event,
   EventHint,

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -6,7 +6,7 @@ import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
 import { getRequestInfo } from '@opentelemetry/instrumentation-http';
 import { addBreadcrumb, getClient, getIsolationScope, withIsolationScope } from '@sentry/core';
-import type { PolymorphicRequest, Request, SanitizedRequestData } from '@sentry/types';
+import type { PolymorphicRequest, RequestEventData, SanitizedRequestData } from '@sentry/types';
 import {
   getBreadcrumbLogLevelFromHttpStatusCode,
   getSanitizedUrlString,
@@ -142,7 +142,7 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
         // This is non-standard, but may be set on e.g. Next.js or Express requests
         const cookies = (request as PolymorphicRequest).cookies;
 
-        const normalizedRequest: Request = {
+        const normalizedRequest: RequestEventData = {
           url: absoluteUrl,
           method: request.method,
           query_string: extractQueryParams(request),
@@ -347,7 +347,7 @@ function getBreadcrumbData(request: http.ClientRequest): Partial<SanitizedReques
  * we monkey patch `req.on('data')` to intercept the body chunks.
  * This way, we only read the body if the user also consumes the body, ensuring we do not change any behavior in unexpected ways.
  */
-function patchRequestToCaptureBody(req: IncomingMessage, normalizedRequest: Request): void {
+function patchRequestToCaptureBody(req: IncomingMessage, normalizedRequest: RequestEventData): void {
   const chunks: Buffer[] = [];
 
   function getChunksSize(): number {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -9,7 +9,7 @@ import type { Measurements } from './measurement';
 import type { Mechanism } from './mechanism';
 import type { Primitive } from './misc';
 import type { PolymorphicRequest } from './polymorphics';
-import type { Request } from './request';
+import type { RequestEventData } from './request';
 import type { CaptureContext, Scope } from './scope';
 import type { SdkInfo } from './sdkinfo';
 import type { SeverityLevel } from './severity';
@@ -36,7 +36,7 @@ export interface Event {
   dist?: string;
   environment?: string;
   sdk?: SdkInfo;
-  request?: Request;
+  request?: RequestEventData;
   transaction?: string;
   modules?: { [key: string]: string };
   fingerprint?: string[];
@@ -56,7 +56,7 @@ export interface Event {
   // Note: This is considered internal and is subject to change in minors
   sdkProcessingMetadata?: { [key: string]: unknown } & {
     request?: PolymorphicRequest;
-    normalizedRequest?: Request;
+    normalizedRequest?: RequestEventData;
     dynamicSamplingContext?: Partial<DynamicSamplingContext>;
     capturedSpanScope?: Scope;
     capturedSpanIsolationScope?: Scope;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -87,7 +87,13 @@ export type {
   SendFeedbackParams,
   UserFeedback,
 } from './feedback';
-export type { QueryParams, Request, SanitizedRequestData } from './request';
+export type {
+  QueryParams,
+  RequestEventData,
+  // eslint-disable-next-line deprecation/deprecation
+  Request,
+  SanitizedRequestData,
+} from './request';
 export type { Runtime } from './runtime';
 export type { CaptureContext, Scope, ScopeContext, ScopeData } from './scope';
 export type { SdkInfo } from './sdkinfo';

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -1,8 +1,7 @@
 /**
  * Request data included in an event as sent to Sentry.
- * TODO(v9): Rename this to avoid confusion, because Request is also a native type.
  */
-export interface Request {
+export interface RequestEventData {
   url?: string;
   method?: string;
   data?: any;
@@ -11,6 +10,12 @@ export interface Request {
   env?: { [key: string]: string };
   headers?: { [key: string]: string };
 }
+
+/**
+ * Request data included in an event as sent to Sentry.
+ * @deprecated: This type will be removed in v9. Use `RequestEventData` instead.
+ */
+export type Request = RequestEventData;
 
 export type QueryParams = string | { [key: string]: string } | Array<[string, string]>;
 

--- a/packages/utils/src/requestdata.ts
+++ b/packages/utils/src/requestdata.ts
@@ -3,7 +3,7 @@ import type {
   Event,
   ExtractedNodeRequestData,
   PolymorphicRequest,
-  Request,
+  RequestEventData,
   TransactionSource,
   WebFetchHeaders,
   WebFetchRequest,
@@ -260,7 +260,7 @@ export function extractRequestData(
  */
 export function addNormalizedRequestDataToEvent(
   event: Event,
-  req: Request,
+  req: RequestEventData,
   // This is non-standard data that is not part of the regular HTTP request
   additionalData: { ipAddress?: string; user?: Record<string, unknown> },
   options: AddRequestDataToEventOptions,
@@ -428,10 +428,13 @@ export function winterCGRequestToRequestData(req: WebFetchRequest): PolymorphicR
   };
 }
 
-function extractNormalizedRequestData(normalizedRequest: Request, { include }: { include: string[] }): Request {
+function extractNormalizedRequestData(
+  normalizedRequest: RequestEventData,
+  { include }: { include: string[] },
+): RequestEventData {
   const includeKeys = include ? (Array.isArray(include) ? include : DEFAULT_REQUEST_INCLUDES) : [];
 
-  const requestData: Request = {};
+  const requestData: RequestEventData = {};
   const headers = { ...normalizedRequest.headers };
 
   if (includeKeys.includes('headers')) {

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -2,7 +2,9 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
+  // eslint-disable-next-line deprecation/deprecation
   Request,
+  RequestEventData,
   SdkInfo,
   Event,
   EventHint,


### PR DESCRIPTION
The type `Request` is very misleading and overloaded, so let's rename it to something clearer.

I opted with `RequestEventData`, but happy to hear other ideas as well.

Closes https://github.com/getsentry/sentry-javascript/issues/14300