### PR TITLE
test(browser): Update tests that need changes for `getLocalTestUrl`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/subject.js
@@ -1,5 +1,1 @@
-window.addEventListener('error', function (event) {
-  Sentry.captureException(event);
-});
-
-window.thisDoesNotExist();
+Sentry.captureException(new ErrorEvent('something', { message: 'test error' }));

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/test.ts
@@ -4,15 +4,15 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture an ErrorEvent', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should capture an ErrorEvent', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.exception?.values).toHaveLength(1);
   expect(eventData.exception?.values?.[0]).toMatchObject({
     type: 'ErrorEvent',
-    value: 'Event `ErrorEvent` captured as exception with message `Script error.`',
+    value: 'Event `ErrorEvent` captured as exception with message `test error`',
     mechanism: {
       type: 'generic',
       handled: true,

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/onreadystatechange/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/onreadystatechange/subject.js
@@ -1,6 +1,6 @@
 window.calls = {};
 const xhr = new XMLHttpRequest();
-xhr.open('GET', 'test');
+xhr.open('GET', 'http://example.com');
 xhr.onreadystatechange = function wat() {
   window.calls[xhr.readyState] = window.calls[xhr.readyState] ? window.calls[xhr.readyState] + 1 : 1;
 };

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { SDK_VERSION } from '@sentry/browser';
 
-import { sentryTest } from '../../../utils/fixtures';
+import { TEST_HOST, sentryTest } from '../../../utils/fixtures';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -12,7 +12,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const replayEvent0 = getReplayEvent(await reqPromise0);
@@ -26,7 +26,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
     timestamp: expect.any(Number),
     error_ids: [],
     trace_ids: [],
-    urls: [expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/)],
+    urls: [`${TEST_HOST}/index.html`],
     replay_id: expect.stringMatching(/\w{32}/),
     replay_start_timestamp: expect.any(Number),
     segment_id: 0,
@@ -49,7 +49,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/),
+      url: `${TEST_HOST}/index.html`,
       headers: {
         'User-Agent': expect.stringContaining(''),
       },
@@ -86,7 +86,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/),
+      url: `${TEST_HOST}/index.html`,
       headers: {
         'User-Agent': expect.stringContaining(''),
       },

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { SDK_VERSION } from '@sentry/browser';
 
-import { sentryTest } from '../../../utils/fixtures';
+import { TEST_HOST, sentryTest } from '../../../utils/fixtures';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('should capture replays (@sentry-internal/replay export)', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture replays (@sentry-internal/replay export)', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
@@ -12,7 +12,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.goto(url);
   const replayEvent0 = getReplayEvent(await reqPromise0);
@@ -26,7 +26,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
     timestamp: expect.any(Number),
     error_ids: [],
     trace_ids: [],
-    urls: [expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/)],
+    urls: [`${TEST_HOST}/index.html`],
     replay_id: expect.stringMatching(/\w{32}/),
     replay_start_timestamp: expect.any(Number),
     segment_id: 0,
@@ -49,7 +49,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/),
+      url: `${TEST_HOST}/index.html`,
       headers: {
         'User-Agent': expect.stringContaining(''),
       },
@@ -86,7 +86,7 @@ sentryTest('should capture replays (@sentry-internal/replay export)', async ({ g
       name: 'sentry.javascript.browser',
     },
     request: {
-      url: expect.stringMatching(/\/dist\/([\w-]+)\/index\.html$/),
+      url: `${TEST_HOST}/index.html`,
       headers: {
         'User-Agent': expect.stringContaining(''),
       },

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import { sentryTest } from '../../../utils/fixtures';
+import { TEST_HOST, sentryTest } from '../../../utils/fixtures';
 import {
   expectedCLSPerformanceSpan,
   expectedClickBreadcrumb,
@@ -30,7 +30,7 @@ well as the correct DOM snapshots and updates are recorded and sent.
 */
 sentryTest(
   'record page navigations and performance entries across multiple pages',
-  async ({ getLocalTestPath, page, browserName }) => {
+  async ({ getLocalTestUrl, page, browserName }) => {
     // We only test this against the NPM package and replay bundles
     // and only on chromium as most performance entries are only available in chromium
     if (shouldSkipReplayTest() || browserName !== 'chromium') {
@@ -48,7 +48,7 @@ sentryTest(
     const reqPromise8 = waitForReplayRequest(page, 8);
     const reqPromise9 = waitForReplayRequest(page, 9);
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const [req0] = await Promise.all([reqPromise0, page.goto(url)]);
     const replayEvent0 = getReplayEvent(req0);
@@ -72,7 +72,7 @@ sentryTest(
     const collectedPerformanceSpans = [...recording0.performanceSpans, ...recording1.performanceSpans];
     const collectedBreadcrumbs = [...recording0.breadcrumbs, ...recording1.breadcrumbs];
 
-    expect(collectedPerformanceSpans.length).toEqual(8);
+    expect(collectedPerformanceSpans.length).toBeGreaterThanOrEqual(6);
     expect(collectedPerformanceSpans).toEqual(
       expect.arrayContaining([
         expectedNavigationPerformanceSpan,
@@ -112,7 +112,7 @@ sentryTest(
     const collectedPerformanceSpansAfterReload = [...recording2.performanceSpans, ...recording3.performanceSpans];
     const collectedBreadcrumbsAdterReload = [...recording2.breadcrumbs, ...recording3.breadcrumbs];
 
-    expect(collectedPerformanceSpansAfterReload.length).toEqual(8);
+    expect(collectedPerformanceSpansAfterReload.length).toBeGreaterThanOrEqual(6);
     expect(collectedPerformanceSpansAfterReload).toEqual(
       expect.arrayContaining([
         expectedReloadPerformanceSpan,
@@ -146,7 +146,8 @@ sentryTest(
           url: expect.stringContaining('page-0.html'),
           headers: {
             // @ts-expect-error this is fine
-            'User-Agent': expect.stringContaining(''),
+            'User-Agent': expect.any(String),
+            Referer: `${TEST_HOST}/index.html`,
           },
         },
       }),
@@ -168,7 +169,8 @@ sentryTest(
           url: expect.stringContaining('page-0.html'),
           headers: {
             // @ts-expect-error this is fine
-            'User-Agent': expect.stringContaining(''),
+            'User-Agent': expect.any(String),
+            Referer: `${TEST_HOST}/index.html`,
           },
         },
       }),
@@ -210,13 +212,12 @@ sentryTest(
       getExpectedReplayEvent({
         segment_id: 6,
         urls: ['/spa'],
-
         request: {
-          // @ts-expect-error this is fine
-          url: expect.stringContaining('page-0.html'),
+          url: `${TEST_HOST}/spa`,
           headers: {
             // @ts-expect-error this is fine
-            'User-Agent': expect.stringContaining(''),
+            'User-Agent': expect.any(String),
+            Referer: `${TEST_HOST}/index.html`,
           },
         },
       }),
@@ -235,11 +236,11 @@ sentryTest(
         urls: [],
 
         request: {
-          // @ts-expect-error this is fine
-          url: expect.stringContaining('page-0.html'),
+          url: `${TEST_HOST}/spa`,
           headers: {
             // @ts-expect-error this is fine
-            'User-Agent': expect.stringContaining(''),
+            'User-Agent': expect.any(String),
+            Referer: `${TEST_HOST}/index.html`,
           },
         },
       }),
@@ -279,6 +280,14 @@ sentryTest(
     expect(replayEvent8).toEqual(
       getExpectedReplayEvent({
         segment_id: 8,
+        request: {
+          url: `${TEST_HOST}/index.html`,
+          headers: {
+            // @ts-expect-error this is fine
+            'User-Agent': expect.any(String),
+            Referer: `${TEST_HOST}/spa`,
+          },
+        },
       }),
     );
     expect(normalize(recording8.fullSnapshots)).toMatchSnapshot('seg-8-snap-full');
@@ -293,6 +302,14 @@ sentryTest(
       getExpectedReplayEvent({
         segment_id: 9,
         urls: [],
+        request: {
+          url: `${TEST_HOST}/index.html`,
+          headers: {
+            // @ts-expect-error this is fine
+            'User-Agent': expect.any(String),
+            Referer: `${TEST_HOST}/spa`,
+          },
+        },
       }),
     );
     expect(recording9.fullSnapshots.length).toEqual(0);
@@ -304,7 +321,7 @@ sentryTest(
     ];
     const collectedBreadcrumbsAfterIndexNavigation = [...recording8.breadcrumbs, ...recording9.breadcrumbs];
 
-    expect(collectedPerformanceSpansAfterIndexNavigation.length).toEqual(8);
+    expect(collectedPerformanceSpansAfterIndexNavigation.length).toBeGreaterThanOrEqual(6);
     expect(collectedPerformanceSpansAfterIndexNavigation).toEqual(
       expect.arrayContaining([
         expectedNavigationPerformanceSpan,

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full-chromium
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full-chromium
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full-chromium
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full-chromium
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-4-snap-full
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-4-snap-full
@@ -116,7 +116,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/index.html"
+                      "href": "http://sentry-test.io/index.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-4-snap-full-chromium
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-4-snap-full-chromium
@@ -116,7 +116,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/index.html"
+                      "href": "http://sentry-test.io/index.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full-chromium
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full-chromium
@@ -73,7 +73,7 @@
                     "type": 2,
                     "tagName": "a",
                     "attributes": {
-                      "href": "/page-0.html"
+                      "href": "http://sentry-test.io/page-0.html"
                     },
                     "childNodes": [
                       {

--- a/dev-packages/browser-integration-tests/suites/stacktraces/protocol_containing_fn_identifiers/test.ts
+++ b/dev-packages/browser-integration-tests/suites/stacktraces/protocol_containing_fn_identifiers/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
 sentryTest(
   'should parse function identifiers that contain protocol names correctly @firefox',
-  async ({ getLocalTestPath, page, runInChromium, runInFirefox, runInWebkit }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page, runInChromium, runInFirefox, runInWebkit }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const frames = eventData.exception?.values?.[0].stacktrace?.frames;
@@ -52,14 +52,14 @@ sentryTest(
 
 sentryTest(
   'should not add any part of the function identifier to beginning of filename',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     expect(eventData.exception?.values?.[0].stacktrace?.frames).toMatchObject(
       // specifically, we're trying to avoid values like `Blob@file://path/to/file` in frames with function names like `makeBlob`
-      Array(7).fill({ filename: expect.stringMatching(/^file:\/?/) }),
+      Array(7).fill({ filename: expect.stringMatching(/^http:\/?/) }),
     );
   },
 );

--- a/dev-packages/browser-integration-tests/suites/stacktraces/protocol_fn_identifiers/test.ts
+++ b/dev-packages/browser-integration-tests/suites/stacktraces/protocol_fn_identifiers/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
 sentryTest(
   'should parse function identifiers that are protocol names correctly @firefox',
-  async ({ getLocalTestPath, page, runInChromium, runInFirefox, runInWebkit }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page, runInChromium, runInFirefox, runInWebkit }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const frames = eventData.exception?.values?.[0].stacktrace?.frames;
@@ -56,8 +56,8 @@ sentryTest(
 
 sentryTest(
   'should not add any part of the function identifier to beginning of filename',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
@@ -65,7 +65,7 @@ sentryTest(
     expect(eventData.exception?.values).toBeDefined();
     expect(eventData.exception?.values?.[0].stacktrace).toBeDefined();
     expect(eventData.exception?.values?.[0].stacktrace?.frames).toMatchObject(
-      Array(7).fill({ filename: expect.stringMatching(/^file:\/?/) }),
+      Array(7).fill({ filename: expect.stringMatching(/^http:\/?/) }),
     );
   },
 );

--- a/dev-packages/browser-integration-tests/suites/stacktraces/regular_fn_identifiers/test.ts
+++ b/dev-packages/browser-integration-tests/suites/stacktraces/regular_fn_identifiers/test.ts
@@ -6,8 +6,8 @@ import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
 sentryTest(
   'should parse function identifiers correctly @firefox',
-  async ({ getLocalTestPath, page, runInChromium, runInFirefox, runInWebkit }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page, runInChromium, runInFirefox, runInWebkit }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
     const frames = eventData.exception?.values?.[0].stacktrace?.frames;
@@ -56,14 +56,14 @@ sentryTest(
 
 sentryTest(
   'should not add any part of the function identifier to beginning of filename',
-  async ({ getLocalTestPath, page }) => {
-    const url = await getLocalTestPath({ testDir: __dirname });
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
 
     const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     expect(eventData.exception?.values?.[0].stacktrace?.frames).toMatchObject(
       // specifically, we're trying to avoid values like `Blob@file://path/to/file` in frames with function names like `makeBlob`
-      Array(8).fill({ filename: expect.stringMatching(/^file:\/?/) }),
+      Array(8).fill({ filename: expect.stringMatching(/^http:\/?/) }),
     );
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/test.ts
@@ -170,7 +170,7 @@ async function makeRequestAndGetBaggageItems(page: Page): Promise<string[]> {
   return baggage?.split(',').sort() ?? [];
 }
 
-async function captureErrorAndGetEnvelopeTraceHeader(page: Page): Promise<DynamicSamplingContext | undefined> {
+async function captureErrorAndGetEnvelopeTraceHeader(page: Page): Promise<Partial<DynamicSamplingContext> | undefined> {
   const errorEventPromise = getMultipleSentryEnvelopeRequests<EventAndTraceHeader>(
     page,
     1,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
@@ -5,35 +5,47 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should add resource spans to pageload transaction', async ({ getLocalTestPath, page, browser }) => {
+sentryTest('should add resource spans to pageload transaction', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 
   // Intercepting asset requests to avoid network-related flakiness and random retries (on Firefox).
-  await page.route('**/path/to/image.svg', (route: Route) => route.fulfill({ path: `${__dirname}/assets/image.svg` }));
-  await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
-  await page.route('**/path/to/style.css', (route: Route) => route.fulfill({ path: `${__dirname}/assets/style.css` }));
+  await page.route('https://example.com/path/to/image.svg', (route: Route) =>
+    route.fulfill({ path: `${__dirname}/assets/image.svg` }),
+  );
+  await page.route('https://example.com/path/to/script.js', (route: Route) =>
+    route.fulfill({ path: `${__dirname}/assets/script.js` }),
+  );
+  await page.route('https://example.com/path/to/style.css', (route: Route) =>
+    route.fulfill({ path: `${__dirname}/assets/style.css` }),
+  );
 
-  const url = await getLocalTestPath({ testDir: __dirname });
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const resourceSpans = eventData.spans?.filter(({ op }) => op?.startsWith('resource'));
 
-  // Webkit 16.0 (which is linked to Playwright 1.27.1) consistently creates 2 consecutive spans for `css`,
-  // so we need to check for 3 or 4 spans.
-  if (browser.browserType().name() === 'webkit') {
-    expect(resourceSpans?.length).toBeGreaterThanOrEqual(3);
-  } else {
-    expect(resourceSpans?.length).toBe(3);
+  const scriptSpans = resourceSpans?.filter(({ op }) => op === 'resource.script');
+  const linkSpans = resourceSpans?.filter(({ op }) => op === 'resource.link');
+  const imgSpans = resourceSpans?.filter(({ op }) => op === 'resource.img');
+
+  expect(imgSpans).toHaveLength(1);
+  expect(linkSpans).toHaveLength(1);
+
+  const hasCdnBundle = (process.env.PW_BUNDLE || '').startsWith('bundle');
+
+  const expectedScripts = ['/init.bundle.js', '/subject.bundle.js', 'https://example.com/path/to/script.js'];
+  if (hasCdnBundle) {
+    expectedScripts.unshift('/cdn.bundle.js');
   }
 
-  ['resource.img', 'resource.script', 'resource.link'].forEach(op =>
-    expect(resourceSpans).toContainEqual(
-      expect.objectContaining({
-        op: op,
-        parent_span_id: eventData.contexts?.trace?.span_id,
-      }),
-    ),
-  );
+  expect(scriptSpans?.map(({ description }) => description).sort()).toEqual(expectedScripts);
+
+  const spanId = eventData.contexts?.trace?.span_id;
+
+  expect(spanId).toBeDefined();
+  expect(imgSpans?.[0].parent_span_id).toBe(spanId);
+  expect(linkSpans?.[0].parent_span_id).toBe(spanId);
+  expect(scriptSpans?.map(({ parent_span_id }) => parent_span_id)).toEqual(expectedScripts.map(() => spanId));
 });

--- a/dev-packages/browser-integration-tests/utils/replayEventTemplates.ts
+++ b/dev-packages/browser-integration-tests/utils/replayEventTemplates.ts
@@ -33,7 +33,7 @@ const DEFAULT_REPLAY_EVENT = {
   request: {
     url: expect.stringContaining('/index.html'),
     headers: {
-      'User-Agent': expect.stringContaining(''),
+      'User-Agent': expect.any(String),
     },
   },
   platform: 'javascript',


### PR DESCRIPTION
Extracted these out of https://github.com/getsentry/sentry-javascript/pull/11904 - these are all the tests that required changing any (test) code for them to pass with `getLocalTestUrl` vs `getLocalTestPath`.