### PR TITLE
fix(react): align Error Boundary componentStack typing with React.Err…

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -99,7 +99,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
   public componentDidCatch(error: unknown, errorInfo: React.ErrorInfo): void {
     const { componentStack } = errorInfo;
     // TODO(v9): Remove this check and type `componentStack` to be React.ErrorInfo['componentStack'].
-    const passedInComponentStack: string | undefined = componentStack == null ? undefined : componentStack;
+    const passedInComponentStack: React.ErrorInfo['componentStack'] = componentStack || undefined;
 
     const { beforeCapture, onError, showDialog, dialogOptions } = this.props;
     withScope(scope => {


### PR DESCRIPTION
…orInfo

Fixed ErrorBoundary componentStack type in @sentry/react to use React.ErrorInfo['componentStack']

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
