### PR TITLE
fix(react): Match routes with `parseSearch` option in TanStack Router instrumentation

### DIFF
--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -7,7 +7,11 @@ import {
 
 import { browserTracingIntegration as originalBrowserTracingIntegration } from '@sentry/browser';
 import type { Integration } from '@sentry/types';
-import type { VendoredTanstackRouter, VendoredTanstackRouterRouteMatch } from './vendor/tanstackrouter-types';
+import type {
+  VendoredTanstackRouter,
+  VendoredTanstackRouterLocation,
+  VendoredTanstackRouterRouteMatch,
+} from './vendor/tanstackrouter-types';
 
 /**
  * A custom browser tracing integration for TanStack Router.
@@ -40,8 +44,10 @@ export function tanstackRouterBrowserTracingIntegration(
       const initialWindowLocation = WINDOW.location;
       if (instrumentPageLoad && initialWindowLocation) {
         const matchedRoutes = castRouterInstance.matchRoutes(
-          initialWindowLocation.pathname,
-          initialWindowLocation.search,
+          {
+            pathname: initialWindowLocation.pathname,
+            search: castRouterInstance.options.parseSearch(initialWindowLocation.search),
+          } as VendoredTanstackRouterLocation,
           { preload: false, throwOnError: false },
         );
 
@@ -66,11 +72,10 @@ export function tanstackRouterBrowserTracingIntegration(
             return;
           }
 
-          const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(
-            onBeforeNavigateArgs.toLocation.pathname,
-            onBeforeNavigateArgs.toLocation.search,
-            { preload: false, throwOnError: false },
-          );
+          const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(onBeforeNavigateArgs.toLocation, {
+            preload: false,
+            throwOnError: false,
+          });
 
           const onBeforeNavigateLastMatch = onResolvedMatchedRoutes[onResolvedMatchedRoutes.length - 1];
 
@@ -88,11 +93,10 @@ export function tanstackRouterBrowserTracingIntegration(
           const unsubscribeOnResolved = castRouterInstance.subscribe('onResolved', onResolvedArgs => {
             unsubscribeOnResolved();
             if (navigationSpan) {
-              const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(
-                onResolvedArgs.toLocation.pathname,
-                onResolvedArgs.toLocation.search,
-                { preload: false, throwOnError: false },
-              );
+              const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(onResolvedArgs.toLocation, {
+                preload: false,
+                throwOnError: false,
+              });
 
               const onResolvedLastMatch = onResolvedMatchedRoutes[onResolvedMatchedRoutes.length - 1];
 

--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -7,11 +7,7 @@ import {
 
 import { browserTracingIntegration as originalBrowserTracingIntegration } from '@sentry/browser';
 import type { Integration } from '@sentry/types';
-import type {
-  VendoredTanstackRouter,
-  VendoredTanstackRouterLocation,
-  VendoredTanstackRouterRouteMatch,
-} from './vendor/tanstackrouter-types';
+import type { VendoredTanstackRouter, VendoredTanstackRouterRouteMatch } from './vendor/tanstackrouter-types';
 
 /**
  * A custom browser tracing integration for TanStack Router.
@@ -44,10 +40,8 @@ export function tanstackRouterBrowserTracingIntegration(
       const initialWindowLocation = WINDOW.location;
       if (instrumentPageLoad && initialWindowLocation) {
         const matchedRoutes = castRouterInstance.matchRoutes(
-          {
-            pathname: initialWindowLocation.pathname,
-            search: castRouterInstance.options.parseSearch(initialWindowLocation.search),
-          } as VendoredTanstackRouterLocation,
+          initialWindowLocation.pathname,
+          castRouterInstance.options.parseSearch(initialWindowLocation.search),
           { preload: false, throwOnError: false },
         );
 
@@ -72,10 +66,11 @@ export function tanstackRouterBrowserTracingIntegration(
             return;
           }
 
-          const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(onBeforeNavigateArgs.toLocation, {
-            preload: false,
-            throwOnError: false,
-          });
+          const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(
+            onBeforeNavigateArgs.toLocation.pathname,
+            onBeforeNavigateArgs.toLocation.search,
+            { preload: false, throwOnError: false },
+          );
 
           const onBeforeNavigateLastMatch = onResolvedMatchedRoutes[onResolvedMatchedRoutes.length - 1];
 
@@ -93,10 +88,11 @@ export function tanstackRouterBrowserTracingIntegration(
           const unsubscribeOnResolved = castRouterInstance.subscribe('onResolved', onResolvedArgs => {
             unsubscribeOnResolved();
             if (navigationSpan) {
-              const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(onResolvedArgs.toLocation, {
-                preload: false,
-                throwOnError: false,
-              });
+              const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(
+                onResolvedArgs.toLocation.pathname,
+                onResolvedArgs.toLocation.search,
+                { preload: false, throwOnError: false },
+              );
 
               const onResolvedLastMatch = onResolvedMatchedRoutes[onResolvedMatchedRoutes.length - 1];
 

--- a/packages/react/src/vendor/tanstackrouter-types.ts
+++ b/packages/react/src/vendor/tanstackrouter-types.ts
@@ -34,8 +34,13 @@ export interface VendoredTanstackRouter {
     parseSearch: (search: string) => Record<string, any>;
   };
   matchRoutes: (
-    location: VendoredTanstackRouterLocation,
-    opts?: { preload?: boolean; throwOnError?: boolean },
+    pathname: string,
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    locationSearch: {},
+    opts?: {
+      preload?: boolean;
+      throwOnError?: boolean;
+    },
   ) => Array<VendoredTanstackRouterRouteMatch>;
   subscribe(
     eventType: 'onResolved' | 'onBeforeNavigate',
@@ -46,7 +51,7 @@ export interface VendoredTanstackRouter {
   ): () => void;
 }
 
-export interface VendoredTanstackRouterLocation {
+interface VendoredTanstackRouterLocation {
   pathname: string;
   // eslint-disable-next-line @typescript-eslint/ban-types
   search: {};

--- a/packages/react/src/vendor/tanstackrouter-types.ts
+++ b/packages/react/src/vendor/tanstackrouter-types.ts
@@ -29,14 +29,13 @@ SOFTWARE.
 export interface VendoredTanstackRouter {
   history: VendoredTanstackRouterHistory;
   state: VendoredTanstackRouterState;
+  options: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parseSearch: (search: string) => Record<string, any>;
+  };
   matchRoutes: (
-    pathname: string,
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    locationSearch: {},
-    opts?: {
-      preload?: boolean;
-      throwOnError?: boolean;
-    },
+    location: VendoredTanstackRouterLocation,
+    opts?: { preload?: boolean; throwOnError?: boolean },
   ) => Array<VendoredTanstackRouterRouteMatch>;
   subscribe(
     eventType: 'onResolved' | 'onBeforeNavigate',
@@ -47,7 +46,7 @@ export interface VendoredTanstackRouter {
   ): () => void;
 }
 
-interface VendoredTanstackRouterLocation {
+export interface VendoredTanstackRouterLocation {
   pathname: string;
   // eslint-disable-next-line @typescript-eslint/ban-types
   search: {};


### PR DESCRIPTION
The current sentry implementation was breaking in my application because we use [custom search param serialization](https://tanstack.com/router/latest/docs/framework/react/guide/custom-search-param-serialization).

The default tanstack implementation uses `this.options.parseSearch` to parse the search string into a parsed location

https://github.com/TanStack/router/blob/55891518fcfa7c308e1db4149d357cf38700c882/packages/react-router/src/router.ts#L1015-L1016

The `matchRoutes` signature that sentry was using has been deprecated.

https://github.com/TanStack/router/blob/55891518fcfa7c308e1db4149d357cf38700c882/packages/react-router/src/router.ts#L1063-L1098

The signature only exists to support sentry as far as I can tell

https://github.com/TanStack/router/issues/2164
https://github.com/TanStack/router/pull/2165

This PR implements two fixes

1. use the new `matchRoutes` signature instead of the deprecated signature
2. use `parseSearch` to support applications that use custom search param serialization.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
