### PR TITLE
feat(node): Add alias `childProcessIntegration` for `processThreadBreadcrumbIntegration` and deprecate it

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -52,6 +52,7 @@ const DEPENDENTS: Dependent[] = [
       'NodeClient',
       // Bun doesn't emit the required diagnostics_channel events
       'processThreadBreadcrumbIntegration',
+      'childProcessIntegration',
     ],
   },
   {

--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -12,6 +12,10 @@
 
 - Deprecated `transactionNamingScheme` option in `requestDataIntegration`.
 
-## `@sentry/types``
+## `@sentry/types`
 
 - Deprecated `Request` in favor of `RequestEventData`.
+
+## Server-side SDKs (`@sentry/node` and all dependents)
+
+- Deprecated `processThreadBreadcrumbIntegration` in favor of `childProcessIntegration`. Functionally they are the same.

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -92,6 +92,7 @@ export {
   postgresIntegration,
   prismaIntegration,
   processThreadBreadcrumbIntegration,
+  childProcessIntegration,
   redisIntegration,
   requestDataIntegration,
   rewriteFramesIntegration,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -106,6 +106,7 @@ export {
   postgresIntegration,
   prismaIntegration,
   processThreadBreadcrumbIntegration,
+  childProcessIntegration,
   hapiIntegration,
   setupHapiErrorHandler,
   spotlightIntegration,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -118,6 +118,7 @@ export {
   profiler,
   amqplibIntegration,
   processThreadBreadcrumbIntegration,
+  childProcessIntegration,
 } from '@sentry/node';
 
 export {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -33,7 +33,8 @@ export { tediousIntegration } from './integrations/tracing/tedious';
 export { genericPoolIntegration } from './integrations/tracing/genericPool';
 export { dataloaderIntegration } from './integrations/tracing/dataloader';
 export { amqplibIntegration } from './integrations/tracing/amqplib';
-export { processThreadBreadcrumbIntegration } from './integrations/processThread';
+// eslint-disable-next-line deprecation/deprecation
+export { processThreadBreadcrumbIntegration, childProcessIntegration } from './integrations/processThread';
 
 export { SentryContextManager } from './otel/contextManager';
 export { generateInstrumentOnce } from './otel/instrument';

--- a/packages/node/src/integrations/processThread.ts
+++ b/packages/node/src/integrations/processThread.ts
@@ -2,7 +2,6 @@ import type { ChildProcess } from 'node:child_process';
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { Worker } from 'node:worker_threads';
 import { addBreadcrumb, defineIntegration } from '@sentry/core';
-import type { IntegrationFn } from '@sentry/types';
 
 interface Options {
   /**
@@ -15,7 +14,10 @@ interface Options {
 
 const INTEGRATION_NAME = 'ProcessAndThreadBreadcrumbs';
 
-const _processThreadBreadcrumbIntegration = ((options: Options = {}) => {
+/**
+ * Capture breadcrumbs for child processes and worker threads.
+ */
+export const childProcessIntegration = defineIntegration((options: Options = {}) => {
   return {
     name: INTEGRATION_NAME,
     setup(_client) {
@@ -34,12 +36,14 @@ const _processThreadBreadcrumbIntegration = ((options: Options = {}) => {
       });
     },
   };
-}) satisfies IntegrationFn;
+});
 
 /**
  * Capture breadcrumbs for child processes and worker threads.
+ *
+ * @deprecated Use `childProcessIntegration` integration instead. Functionally they are the same. `processThreadBreadcrumbIntegration` will be removed in the next major version.
  */
-export const processThreadBreadcrumbIntegration = defineIntegration(_processThreadBreadcrumbIntegration);
+export const processThreadBreadcrumbIntegration = childProcessIntegration;
 
 function captureChildProcessEvents(child: ChildProcess, options: Options): void {
   let hasExited = false;

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -36,7 +36,7 @@ import { modulesIntegration } from '../integrations/modules';
 import { nativeNodeFetchIntegration } from '../integrations/node-fetch';
 import { onUncaughtExceptionIntegration } from '../integrations/onuncaughtexception';
 import { onUnhandledRejectionIntegration } from '../integrations/onunhandledrejection';
-import { processThreadBreadcrumbIntegration } from '../integrations/processThread';
+import { childProcessIntegration } from '../integrations/processThread';
 import { INTEGRATION_NAME as SPOTLIGHT_INTEGRATION_NAME, spotlightIntegration } from '../integrations/spotlight';
 import { getAutoPerformanceIntegrations } from '../integrations/tracing';
 import { makeNodeTransport } from '../transports';
@@ -72,7 +72,7 @@ export function getDefaultIntegrationsWithoutPerformance(): Integration[] {
     contextLinesIntegration(),
     localVariablesIntegration(),
     nodeContextIntegration(),
-    processThreadBreadcrumbIntegration(),
+    childProcessIntegration(),
     ...getCjsOnlyIntegrations(),
   ];
 }


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-javascript/issues/14276