### PR TITLE
fix(replay): Remove replay id from DSC on expired sessions

### DIFF
--- a/packages/replay-internal/src/coreHandlers/handleGlobalEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleGlobalEvent.ts
@@ -7,6 +7,7 @@ import { isRrwebError } from '../util/isRrwebError';
 import { logger } from '../util/logger';
 import { addFeedbackBreadcrumb } from './util/addFeedbackBreadcrumb';
 import { shouldSampleForBufferEvent } from './util/shouldSampleForBufferEvent';
+import { resetReplayIdOnDynamicSamplingContext } from '../util/resetReplayIdOnDynamicSamplingContext';
 
 /**
  * Returns a listener to be added to `addEventProcessor(listener)`.
@@ -34,6 +35,8 @@ export function handleGlobalEventListener(replay: ReplayContainer): (event: Even
       // Ensure we do not add replay_id if the session is expired
       const isSessionActive = replay.checkAndHandleExpiredSession();
       if (!isSessionActive) {
+        // prevent exceeding replay durations by removing the expired replayId from the DSC
+        resetReplayIdOnDynamicSamplingContext();
         return event;
       }
 

--- a/packages/replay-internal/test/integration/coreHandlers/handleGlobalEvent.test.ts
+++ b/packages/replay-internal/test/integration/coreHandlers/handleGlobalEvent.test.ts
@@ -15,6 +15,7 @@ import { Error } from '../../fixtures/error';
 import { Transaction } from '../../fixtures/transaction';
 import { resetSdkMock } from '../../mocks/resetSdkMock';
 import { useFakeTimers } from '../../utils/use-fake-timers';
+import * as resetReplayIdOnDynamicSamplingContextModule from '../../../src/util/resetReplayIdOnDynamicSamplingContext';
 
 useFakeTimers();
 let replay: ReplayContainer;
@@ -415,5 +416,22 @@ describe('Integration | coreHandlers | handleGlobalEvent', () => {
         tags: expect.not.objectContaining({ replayId: expect.anything() }),
       }),
     );
+  });
+
+  it('resets replayId on DSC when session expires', () => {
+    const errorEvent = Error();
+    const txEvent = Transaction();
+
+    vi.spyOn(replay, 'checkAndHandleExpiredSession').mockReturnValue(false);
+
+    const resetReplayIdSpy = vi.spyOn(
+      resetReplayIdOnDynamicSamplingContextModule,
+      'resetReplayIdOnDynamicSamplingContext',
+    );
+
+    handleGlobalEventListener(replay)(errorEvent, {});
+    handleGlobalEventListener(replay)(txEvent, {});
+
+    expect(resetReplayIdSpy).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Since https://github.com/getsentry/sentry-javascript/pull/13893, the replayId is deleted from the DSC whenever `stop`  is called on replay.

With this PR we additionally delete the replay on the DSC whenever we encounter an expired session in the event processor.

ref https://github.com/getsentry/sentry-javascript/issues/13778#issuecomment-2474464777