### PR TITLE
fix(v7/cdn): Ensure `_sentryModuleMetadata` is not mangled

### DIFF
--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -139,6 +139,8 @@ export function makeTerserPlugin() {
           // For v7 backwards-compatibility we need to access txn._frozenDynamicSamplingContext
           // TODO (v8): Remove this reserved word
           '_frozenDynamicSamplingContext',
+          // This is used in metadata integration
+          '_sentryModuleMetadata',
         ],
       },
     },


### PR DESCRIPTION
Creating a corresponding PR to v7 for this fix: https://github.com/getsentry/sentry-javascript/pull/14344
This should solve https://github.com/getsentry/sentry-javascript/issues/14343 in v7.