### PR TITLE
feat(core): Deprecate `debugIntegration` and `sessionTimingIntegration`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -11,6 +11,8 @@
 ## `@sentry/core`
 
 - Deprecated `transactionNamingScheme` option in `requestDataIntegration`.
+- Deprecated `debugIntegration`. To log outgoing events, use [Hook Options](https://docs.sentry.io/platforms/javascript/configuration/options/#hooks) (`beforeSend`, `beforeSendTransaction`, ...).
+- Deprecated `sessionTimingIntegration`. To capture session durations alongside events, use [Context](https://docs.sentry.io/platforms/javascript/enriching-events/context/) (`Sentry.setContext()`).
 
 ## `@sentry/types`
 

--- a/package.json
+++ b/package.json
@@ -152,11 +152,13 @@
     "proseWrap": "always",
     "singleQuote": true,
     "trailingComma": "all",
-    "overrides": [{
-      "files": "CHANGELOG.md",
-      "options": {
-        "proseWrap": "preserve"
+    "overrides": [
+      {
+        "files": "*.md",
+        "options": {
+          "proseWrap": "preserve"
+        }
       }
-    }]
+    ]
   }
 }

--- a/packages/core/src/integrations/debug.ts
+++ b/packages/core/src/integrations/debug.ts
@@ -11,10 +11,6 @@ interface DebugOptions {
   debugger?: boolean;
 }
 
-/**
- * Integration to debug sent Sentry events.
- * This integration should not be used in production.
- */
 const _debugIntegration = ((options: DebugOptions = {}) => {
   const _options = {
     debugger: false,
@@ -51,4 +47,11 @@ const _debugIntegration = ((options: DebugOptions = {}) => {
   };
 }) satisfies IntegrationFn;
 
+/**
+ * Integration to debug sent Sentry events.
+ * This integration should not be used in production.
+ *
+ * @deprecated This integration is deprecated and will be removed in the next major version of the SDK.
+ * To log outgoing events, use [Hook Options](https://docs.sentry.io/platforms/javascript/configuration/options/#hooks) (`beforeSend`, `beforeSendTransaction`, ...).
+ */
 export const debugIntegration = defineIntegration(_debugIntegration);

--- a/packages/core/src/integrations/sessiontiming.ts
+++ b/packages/core/src/integrations/sessiontiming.ts
@@ -28,5 +28,8 @@ const _sessionTimingIntegration = (() => {
 /**
  * This function adds duration since the sessionTimingIntegration was initialized
  * till the time event was sent.
+ *
+ * @deprecated This integration is deprecated and will be removed in the next major version of the SDK.
+ * To capture session durations alongside events, use [Context](https://docs.sentry.io/platforms/javascript/enriching-events/context/) (`Sentry.setContext()`).
  */
 export const sessionTimingIntegration = defineIntegration(_sessionTimingIntegration);


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/14272