### PR TITLE
feat(browser): Send additional LCP timing info

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/template.html
@@ -6,6 +6,5 @@
   <body>
     <div id="content"></div>
     <img src="https://example.com/my/image.png" />
-    <button type="button">Test button</button>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -5,7 +5,14 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should capture a LCP vital with element details.', async ({ browserName, getLocalTestUrl, page }) => {
+/*
+  Because we "serve" the html test page as a static file, all requests for the image
+  are considered 3rd party requests. So the LCP value we obtain for the image is also
+  considered a 3rd party LCP value, meaning `renderTime` is only set if we also
+  return the `Timing-Allow-Origin` header.
+*/
+
+sentryTest('captures LCP vitals with element details.', async ({ browserName, getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
@@ -25,8 +32,6 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.lcp?.value).toBeDefined();
 
-  // XXX: This should be body > img, but it can be flakey as sometimes it will report
-  // the button as LCP.
   expect(eventData.contexts?.trace?.data?.['lcp.element'].startsWith('body >')).toBe(true);
   expect(eventData.contexts?.trace?.data?.['lcp.size']).toBeGreaterThan(0);
   expect(eventData.contexts?.trace?.data?.['lcp.loadTime']).toBeGreaterThan(0);
@@ -34,11 +39,14 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   // renderTime is not set because we do not return the `Timing-Allow-Origin` header
   // and the image is loaded from a 3rd party origin
   expect(eventData.contexts?.trace?.data?.['lcp.renderTime']).toBeUndefined();
+
+  // The LCP value should be the loadTime because the renderTime is not set
+  expect(eventData.measurements?.lcp?.value).toBeCloseTo(eventData.contexts?.trace?.data?.['lcp.loadTime']);
 });
 
 sentryTest(
   'captures LCP renderTime when returning Timing-Allow-Origin header.',
-  async ({ browserName, getLocalTestPath, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest() || browserName !== 'chromium') {
       sentryTest.skip();
     }
@@ -51,7 +59,7 @@ sentryTest(
       });
     });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+    const url = await getLocalTestUrl({ testDir: __dirname });
     const [eventData] = await Promise.all([
       getFirstSentryEnvelopeRequest<Event>(page),
       page.goto(url),
@@ -61,14 +69,12 @@ sentryTest(
     expect(eventData.measurements).toBeDefined();
     expect(eventData.measurements?.lcp?.value).toBeDefined();
 
-    // XXX: This should be body > img, but it can be flakey as sometimes it will report
-    // the button as LCP.
     expect(eventData.contexts?.trace?.data?.['lcp.element'].startsWith('body >')).toBe(true);
     expect(eventData.contexts?.trace?.data?.['lcp.size']).toBeGreaterThan(0);
     expect(eventData.contexts?.trace?.data?.['lcp.loadTime']).toBeGreaterThan(0);
-
-    // renderTime is not set because we do not return the `Timing-Allow-Origin` header
-    // and the image is loaded from a 3rd party origin
     expect(eventData.contexts?.trace?.data?.['lcp.renderTime']).toBeGreaterThan(0);
+
+    // The LCP value should be the renderTime because the renderTime is set
+    expect(eventData.measurements?.lcp?.value).toBeCloseTo(eventData.contexts?.trace?.data?.['lcp.renderTime']);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -23,11 +23,7 @@ sentryTest('captures LCP vitals with element details.', async ({ browserName, ge
   });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
-  const [eventData] = await Promise.all([
-    getFirstSentryEnvelopeRequest<Event>(page),
-    page.goto(url),
-    page.locator('button').click(),
-  ]);
+  const [eventData] = await Promise.all([getFirstSentryEnvelopeRequest<Event>(page), page.goto(url)]);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.lcp?.value).toBeDefined();
@@ -60,11 +56,7 @@ sentryTest(
     });
 
     const url = await getLocalTestUrl({ testDir: __dirname });
-    const [eventData] = await Promise.all([
-      getFirstSentryEnvelopeRequest<Event>(page),
-      page.goto(url),
-      page.locator('button').click(),
-    ]);
+    const [eventData] = await Promise.all([getFirstSentryEnvelopeRequest<Event>(page), page.goto(url)]);
 
     expect(eventData.measurements).toBeDefined();
     expect(eventData.measurements?.lcp?.value).toBeDefined();

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -36,9 +36,9 @@ sentryTest('captures LCP vitals with element details.', async ({ browserName, ge
   expect(eventData.contexts?.trace?.data?.['lcp.size']).toBeGreaterThan(0);
   expect(eventData.contexts?.trace?.data?.['lcp.loadTime']).toBeGreaterThan(0);
 
-  // renderTime is not set because we do not return the `Timing-Allow-Origin` header
+  // renderTime is 0 because we don't return the `Timing-Allow-Origin` header
   // and the image is loaded from a 3rd party origin
-  expect(eventData.contexts?.trace?.data?.['lcp.renderTime']).toBeUndefined();
+  expect(eventData.contexts?.trace?.data?.['lcp.renderTime']).toBe(0);
 
   // The LCP value should be the loadTime because the renderTime is not set
   expect(eventData.measurements?.lcp?.value).toBeCloseTo(eventData.contexts?.trace?.data?.['lcp.loadTime']);

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -29,4 +29,6 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   // the button as LCP.
   expect(eventData.contexts?.trace?.data?.['lcp.element'].startsWith('body >')).toBe(true);
   expect(eventData.contexts?.trace?.data?.['lcp.size']).toBeGreaterThan(0);
+  expect(eventData.contexts?.trace?.data?.['lcp.renderTime']).toBeGreaterThan(0);
+  expect(eventData.contexts?.trace?.data?.['lcp.loadTime']).toBeGreaterThan(0);
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -29,6 +29,46 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   // the button as LCP.
   expect(eventData.contexts?.trace?.data?.['lcp.element'].startsWith('body >')).toBe(true);
   expect(eventData.contexts?.trace?.data?.['lcp.size']).toBeGreaterThan(0);
-  expect(eventData.contexts?.trace?.data?.['lcp.renderTime']).toBeGreaterThan(0);
   expect(eventData.contexts?.trace?.data?.['lcp.loadTime']).toBeGreaterThan(0);
+
+  // renderTime is not set because we do not return the `Timing-Allow-Origin` header
+  // and the image is loaded from a 3rd party origin
+  expect(eventData.contexts?.trace?.data?.['lcp.renderTime']).toBeUndefined();
 });
+
+sentryTest(
+  'captures LCP renderTime when returning Timing-Allow-Origin header.',
+  async ({ browserName, getLocalTestPath, page }) => {
+    if (shouldSkipTracingTest() || browserName !== 'chromium') {
+      sentryTest.skip();
+    }
+
+    page.route('**', route => route.continue());
+    page.route('**/my/image.png', async (route: Route) => {
+      return route.fulfill({
+        path: `${__dirname}/assets/sentry-logo-600x179.png`,
+        headers: { 'Timing-Allow-Origin': '*' },
+      });
+    });
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+    const [eventData] = await Promise.all([
+      getFirstSentryEnvelopeRequest<Event>(page),
+      page.goto(url),
+      page.locator('button').click(),
+    ]);
+
+    expect(eventData.measurements).toBeDefined();
+    expect(eventData.measurements?.lcp?.value).toBeDefined();
+
+    // XXX: This should be body > img, but it can be flakey as sometimes it will report
+    // the button as LCP.
+    expect(eventData.contexts?.trace?.data?.['lcp.element'].startsWith('body >')).toBe(true);
+    expect(eventData.contexts?.trace?.data?.['lcp.size']).toBeGreaterThan(0);
+    expect(eventData.contexts?.trace?.data?.['lcp.loadTime']).toBeGreaterThan(0);
+
+    // renderTime is not set because we do not return the `Timing-Allow-Origin` header
+    // and the image is loaded from a 3rd party origin
+    expect(eventData.contexts?.trace?.data?.['lcp.renderTime']).toBeGreaterThan(0);
+  },
+);

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/tests/transactions.test.ts
@@ -24,6 +24,8 @@ test('Captures a pageload transaction', async ({ page }) => {
       'sentry.source': 'route',
       'performance.timeOrigin': expect.any(Number),
       'performance.activationStart': expect.any(Number),
+      'lcp.renderTime': expect.any(Number),
+      'lcp.loadTime': expect.any(Number),
     },
     op: 'pageload',
     span_id: expect.any(String),

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -635,16 +635,16 @@ function _setWebVitalAttributes(span: Span): void {
       span.setAttribute('lcp.url', _lcpEntry.url.trim().slice(0, 200));
     }
 
-    if (_lcpEntry.renderTime) {
-      // renderTime is the time portion of LCP that's related to rendering the LCP element.
+    if (_lcpEntry.loadTime != null) {
+      // loadTime is the time of LCP that's related to receiving the LCP element response..
+      span.setAttribute('lcp.loadTime', _lcpEntry.loadTime);
+    }
+
+    if (_lcpEntry.renderTime != null) {
+      // renderTime is loadTime + rendering time
       // it's 0 if the LCP element is loaded from a 3rd party origin that doesn't send the
       // `Timing-Allow-Origin` header.
       span.setAttribute('lcp.renderTime', _lcpEntry.renderTime);
-    }
-
-    if (_lcpEntry.loadTime) {
-      // loadTime is the time portion of LCP that's related to loading the LCP element.
-      span.setAttribute('lcp.loadTime', _lcpEntry.loadTime);
     }
 
     span.setAttribute('lcp.size', _lcpEntry.size);

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -635,6 +635,18 @@ function _setWebVitalAttributes(span: Span): void {
       span.setAttribute('lcp.url', _lcpEntry.url.trim().slice(0, 200));
     }
 
+    if (_lcpEntry.renderTime) {
+      // renderTime is the time portion of LCP that's related to rendering the LCP element.
+      // it's 0 if the LCP element is loaded from a 3rd party origin that doesn't send the
+      // `Timing-Allow-Origin` header.
+      span.setAttribute('lcp.renderTime', _lcpEntry.renderTime);
+    }
+
+    if (_lcpEntry.loadTime) {
+      // loadTime is the time portion of LCP that's related to loading the LCP element.
+      span.setAttribute('lcp.loadTime', _lcpEntry.loadTime);
+    }
+
     span.setAttribute('lcp.size', _lcpEntry.size);
   }
 


### PR DESCRIPTION
This PR adds `loadTime` and `renderTime` attributes from the [LCP performance entry](https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint#instance_properties) to the `pageload` span. Besides being valuable information for users, this also helps us detect if LCP is potentially unreliable:

* if the LCP element was from a 3rd party origin and the `Timing-Allow-Origin` header was not sent in the resource response, the `renderTime` will be `0`.

Background information: The `web-vitals` library takes the `startTime` attribute of the LCP entry as the LCP value. `startTime` is set to:
* `renderTime` if `renderTime > 0`
* `loadTime` otherwise