### PR TITLE
feat(node): Deprecate `nestIntegration` and `setupNestErrorHandler` in favor of using `@sentry/nestjs`

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/nestjs-errors-no-express/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/nestjs-errors-no-express/scenario.ts
@@ -48,6 +48,7 @@ class AppModule {}
 async function run(): Promise<void> {
   const app = await NestFactory.create(AppModule);
   const { httpAdapter } = app.get(HttpAdapterHost);
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.setupNestErrorHandler(app, new BaseExceptionFilter(httpAdapter));
   await app.listen(port);
   sendPortToRunner(port);

--- a/dev-packages/node-integration-tests/suites/tracing/nestjs-errors/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/nestjs-errors/scenario.ts
@@ -46,6 +46,7 @@ class AppModule {}
 async function run(): Promise<void> {
   const app = await NestFactory.create(AppModule);
   const { httpAdapter } = app.get(HttpAdapterHost);
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.setupNestErrorHandler(app, new BaseExceptionFilter(httpAdapter));
   await app.listen(port);
   sendPortToRunner(port);

--- a/dev-packages/node-integration-tests/suites/tracing/nestjs-no-express/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/nestjs-no-express/scenario.ts
@@ -48,6 +48,7 @@ class AppModule {}
 async function run(): Promise<void> {
   const app = await NestFactory.create(AppModule);
   const { httpAdapter } = app.get(HttpAdapterHost);
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.setupNestErrorHandler(app, new BaseExceptionFilter(httpAdapter));
   await app.listen(port);
   sendPortToRunner(port);

--- a/dev-packages/node-integration-tests/suites/tracing/nestjs/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/nestjs/scenario.ts
@@ -48,6 +48,7 @@ async function run(): Promise<void> {
   await app.listen(port);
 
   const { httpAdapter } = app.get(HttpAdapterHost);
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.setupNestErrorHandler(app, new BaseExceptionFilter(httpAdapter));
   sendPortToRunner(port);
 }

--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -25,3 +25,5 @@
 ## Server-side SDKs (`@sentry/node` and all dependents)
 
 - Deprecated `processThreadBreadcrumbIntegration` in favor of `childProcessIntegration`. Functionally they are the same.
+- Deprecated `nestIntegration`. Use the NestJS SDK (`@sentry/nestjs`) instead.
+- Deprecated `setupNestErrorHandler`. Use the NestJS SDK (`@sentry/nestjs`) instead.

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -84,6 +84,7 @@ export {
   mysql2Integration,
   mysqlIntegration,
   nativeNodeFetchIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   nestIntegration,
   NodeClient,
   nodeContextIntegration,
@@ -118,6 +119,7 @@ export {
   setupExpressErrorHandler,
   setupHapiErrorHandler,
   setupKoaErrorHandler,
+  // eslint-disable-next-line deprecation/deprecation
   setupNestErrorHandler,
   setUser,
   spanToBaggageHeader,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -101,7 +101,9 @@ export {
   mysql2Integration,
   redisIntegration,
   tediousIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   nestIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   setupNestErrorHandler,
   postgresIntegration,
   prismaIntegration,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -124,7 +124,9 @@ export {
   mysql2Integration,
   redisIntegration,
   tediousIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   nestIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   setupNestErrorHandler,
   postgresIntegration,
   prismaIntegration,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -101,7 +101,9 @@ export {
   mysql2Integration,
   redisIntegration,
   tediousIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   nestIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   setupNestErrorHandler,
   postgresIntegration,
   prismaIntegration,

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -1,4 +1,14 @@
+import { nestIntegration as nestIntegrationAlias } from '@sentry/node';
+
 export * from '@sentry/node';
+
+/**
+ * Integration capturing tracing data for NestJS.
+ */
+// eslint-disable-next-line deprecation/deprecation
+export const nestIntegration = nestIntegrationAlias;
+
+// TODO(v9): Export custom `getDefaultIntegrations` from this SDK that automatically registers the `nestIntegration`.
 
 export { init } from './sdk';
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -21,6 +21,7 @@ export { mongooseIntegration } from './integrations/tracing/mongoose';
 export { mysqlIntegration } from './integrations/tracing/mysql';
 export { mysql2Integration } from './integrations/tracing/mysql2';
 export { redisIntegration } from './integrations/tracing/redis';
+// eslint-disable-next-line deprecation/deprecation
 export { nestIntegration, setupNestErrorHandler } from './integrations/tracing/nest/nest';
 export { postgresIntegration } from './integrations/tracing/postgres';
 export { prismaIntegration } from './integrations/tracing/prisma';

--- a/packages/node/src/integrations/tracing/index.ts
+++ b/packages/node/src/integrations/tracing/index.ts
@@ -38,6 +38,7 @@ export function getAutoPerformanceIntegrations(): Integration[] {
     // See https://github.com/prisma/prisma/issues/23410
     // TODO v8: Figure out a better solution for this, maybe only disable in ESM mode?
     // prismaIntegration(),
+    // eslint-disable-next-line deprecation/deprecation
     nestIntegration(),
     hapiIntegration(),
     koaIntegration(),
@@ -64,6 +65,7 @@ export function getOpenTelemetryInstrumentationToPreload(): (((options?: any) =>
     instrumentKafka,
     instrumentKoa,
     instrumentLruMemoizer,
+    // eslint-disable-next-line deprecation/deprecation
     instrumentNest,
     instrumentMongo,
     instrumentMongoose,

--- a/packages/node/src/integrations/tracing/nest/nest.ts
+++ b/packages/node/src/integrations/tracing/nest/nest.ts
@@ -9,8 +9,8 @@ import {
   getIsolationScope,
   spanToJSON,
 } from '@sentry/core';
-import type { IntegrationFn, Span } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import type { Span } from '@sentry/types';
+import { consoleSandbox, logger } from '@sentry/utils';
 import { generateInstrumentOnce } from '../../../otel/instrument';
 import { SentryNestEventInstrumentation } from './sentry-nest-event-instrumentation';
 import { SentryNestInstrumentation } from './sentry-nest-instrumentation';
@@ -39,26 +39,35 @@ export const instrumentNest = Object.assign(
   { id: INTEGRATION_NAME },
 );
 
-const _nestIntegration = (() => {
+/**
+ * Integration capturing tracing data for NestJS.
+ *
+ * @deprecated The `nestIntegration` is deprecated. Instead, use the NestJS SDK directly (`@sentry/nestjs`), or use the `nestIntegration` export from `@sentry/nestjs`.
+ */
+export const nestIntegration = defineIntegration(() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
       instrumentNest();
     },
   };
-}) satisfies IntegrationFn;
-
-/**
- * Nest framework integration
- *
- * Capture tracing data for nest.
- */
-export const nestIntegration = defineIntegration(_nestIntegration);
+});
 
 /**
  * Setup an error handler for Nest.
+ *
+ * @deprecated `setupNestErrorHandler` is deprecated.
+ * Instead use the `@sentry/nestjs` package, which has more functional APIs for capturing errors.
+ * See the [`@sentry/nestjs` Setup Guide](https://docs.sentry.io/platforms/javascript/guides/nestjs/) for how to set up the Sentry NestJS SDK.
  */
 export function setupNestErrorHandler(app: MinimalNestJsApp, baseFilter: NestJsErrorFilter): void {
+  consoleSandbox(() => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[Sentry] Warning: You used the `setupNestErrorHandler()` method to set up Sentry error monitoring. This function is deprecated and will be removed in the next major version. Instead, it is recommended to use the `@sentry/nestjs` package. To set up the NestJS SDK see: https://docs.sentry.io/platforms/javascript/guides/nestjs/',
+    );
+  });
+
   // Sadly, NestInstrumentation has no requestHook, so we need to add the attributes here
   // We register this hook in this method, because if we register it in the integration `setup`,
   // it would always run even for users that are not even using Nest.js

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -84,6 +84,7 @@ export {
   mysql2Integration,
   mysqlIntegration,
   nativeNodeFetchIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   nestIntegration,
   NodeClient,
   nodeContextIntegration,
@@ -115,6 +116,7 @@ export {
   setupExpressErrorHandler,
   setupHapiErrorHandler,
   setupKoaErrorHandler,
+  // eslint-disable-next-line deprecation/deprecation
   setupNestErrorHandler,
   setUser,
   spanToBaggageHeader,

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -75,6 +75,7 @@ export {
   mysql2Integration,
   mysqlIntegration,
   nativeNodeFetchIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   nestIntegration,
   NodeClient,
   nodeContextIntegration,
@@ -106,6 +107,7 @@ export {
   setupExpressErrorHandler,
   setupHapiErrorHandler,
   setupKoaErrorHandler,
+  // eslint-disable-next-line deprecation/deprecation
   setupNestErrorHandler,
   setUser,
   spanToBaggageHeader,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -77,6 +77,7 @@ export {
   mysql2Integration,
   mysqlIntegration,
   nativeNodeFetchIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   nestIntegration,
   NodeClient,
   nodeContextIntegration,
@@ -108,6 +109,7 @@ export {
   setupExpressErrorHandler,
   setupHapiErrorHandler,
   setupKoaErrorHandler,
+  // eslint-disable-next-line deprecation/deprecation
   setupNestErrorHandler,
   setUser,
   spanToBaggageHeader,


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/14242