### PR TITLE
chore(replay): Use `vitest run` for replay test run

### DIFF
--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -52,7 +52,7 @@
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:biome": "biome check --apply .",
     "lint": "eslint . --format stylish",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"
   },


### PR DESCRIPTION
When running tests for the monorepo locally, replay tests can hang/may not resolve because we run them in watch mode by default. You can still use `yarn test:watch` if you want watch mode anyhow. We use `vitest run` everywhere else we have vitest already.