### PR TITLE
feat(vue): Deprecate configuring Vue tracing options anywhere else other than through the `vueIntegration`'s `tracingOptions` option

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -34,6 +34,27 @@
 
 - Deprecated `Request` in favor of `RequestEventData`.
 
+## `@sentry/vue`
+
+- Deprecated `tracingOptions`, `trackComponents`, `timeout`, `hooks` options everywhere other than in the `tracingOptions` option of the `vueIntegration()`.
+  These options should now be set as follows:
+
+  ```ts
+  import * as Sentry from '@sentry/vue';
+
+  Sentry.init({
+    integrations: [
+      Sentry.vueIntegration({
+        tracingOptions: {
+          trackComponents: true,
+          timeout: 1000,
+          hooks: ['mount', 'update', 'unmount'],
+        },
+      }),
+    ],
+  });
+  ```
+
 ## Server-side SDKs (`@sentry/node` and all dependents)
 
 - Deprecated `processThreadBreadcrumbIntegration` in favor of `childProcessIntegration`. Functionally they are the same.

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -26,7 +26,7 @@ export type ViewModel = {
   };
 };
 
-export interface VueOptions extends TracingOptions {
+export interface VueOptions {
   /** Vue constructor to be used inside the integration (as imported by `import Vue from 'vue'` in Vue2) */
   Vue?: Vue;
 
@@ -60,9 +60,64 @@ export interface VueOptions extends TracingOptions {
 
   /** {@link TracingOptions} */
   tracingOptions?: Partial<TracingOptions>;
+
+  /**
+   * Decides whether to track components by hooking into its lifecycle methods.
+   * Can be either set to `boolean` to enable/disable tracking for all of them.
+   * Or to an array of specific component names (case-sensitive).
+   *
+   * @deprecated Use tracingOptions
+   */
+  trackComponents: boolean | string[];
+
+  /**
+   * How long to wait until the tracked root activity is marked as finished and sent of to Sentry
+   *
+   * @deprecated Use tracingOptions
+   */
+  timeout: number;
+
+  /**
+   * List of hooks to keep track of during component lifecycle.
+   * Available hooks: 'activate' | 'create' | 'destroy' | 'mount' | 'unmount' | 'update'
+   * Based on https://vuejs.org/v2/api/#Options-Lifecycle-Hooks
+   *
+   * @deprecated Use tracingOptions
+   */
+  hooks: Operation[];
 }
 
-export interface Options extends BrowserOptions, VueOptions {}
+export interface Options extends BrowserOptions, VueOptions {
+  /**
+   * @deprecated Use `vueIntegration` tracingOptions
+   */
+  tracingOptions?: Partial<TracingOptions>;
+
+  /**
+   * Decides whether to track components by hooking into its lifecycle methods.
+   * Can be either set to `boolean` to enable/disable tracking for all of them.
+   * Or to an array of specific component names (case-sensitive).
+   *
+   * @deprecated Use `vueIntegration` tracingOptions
+   */
+  trackComponents: boolean | string[];
+
+  /**
+   * How long to wait until the tracked root activity is marked as finished and sent of to Sentry
+   *
+   * @deprecated Use `vueIntegration` tracingOptions
+   */
+  timeout: number;
+
+  /**
+   * List of hooks to keep track of during component lifecycle.
+   * Available hooks: 'activate' | 'create' | 'destroy' | 'mount' | 'unmount' | 'update'
+   * Based on https://vuejs.org/v2/api/#Options-Lifecycle-Hooks
+   *
+   * @deprecated Use `vueIntegration` tracingOptions
+   */
+  hooks: Operation[];
+}
 
 /** Vue specific configuration for Tracing Integration  */
 export interface TracingOptions {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/14265

Currently there are 4 ways of configuring the `tracingOptions`:

- flat in Sentry.init()
- inside `tracingOptions` in Sentry.init()
- flat in the `vueIntegration()` options
- inside `tracingOptions` in the `vueIntegration()` options

Because that is may to many ways of configuration, we decided that the only way should be inside `tracingOptions` in the `vueIntegration()` options.