### PR TITLE
fix(core): Do not throw when trying to fill readonly properties

### DIFF
--- a/packages/core/src/utils-hoist/object.ts
+++ b/packages/core/src/utils-hoist/object.ts
@@ -32,7 +32,11 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
     markFunctionWrapped(wrapped, original);
   }
 
-  source[name] = wrapped;
+  try {
+    source[name] = wrapped;
+  } catch {
+    DEBUG_BUILD && logger.log(`Failed to replace method "${name}" in object`, source);
+  }
 }
 
 /**

--- a/packages/core/test/utils-hoist/object.test.ts
+++ b/packages/core/test/utils-hoist/object.test.ts
@@ -31,6 +31,29 @@ describe('fill()', () => {
     expect(replacement).toBeCalled();
   });
 
+  test('does not throw on readonly properties', () => {
+    const originalFn = () => 41;
+    const source = {
+      get prop() {
+        return originalFn;
+      },
+      set prop(_fn: () => number) {
+        throw new Error('OH NO, this is not writeable...');
+      },
+    };
+
+    expect(source.prop()).toEqual(41);
+
+    const replacement = jest.fn().mockImplementation(() => {
+      return () => 42;
+    });
+    fill(source, 'prop', replacement);
+    expect(replacement).toBeCalled();
+
+    expect(source.prop).toBe(originalFn);
+    expect(source.prop()).toEqual(41);
+  });
+
   test('can do anything inside replacement function', () => {
     const source = {
       foo: (): number => 42,


### PR DESCRIPTION
This PR adds a guard to avoid us throwing if we try to fill a readonly property on an object.

Generally speaking this should not work, but it does not hurt us to be defensive here and try-catch this to avoid breaking users apps.

Fixes https://github.com/getsentry/sentry-javascript/issues/14368