### PR TITLE
test(nextjs): Adapt slow test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/app/very-slow-component/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/app/very-slow-component/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 
 export default async function SuperSlowPage() {
-  await new Promise(resolve => setTimeout(resolve, 10000));
+  await new Promise(resolve => setTimeout(resolve, 5000));
   return null;
 }

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
@@ -125,13 +125,14 @@ test('Should set not_found status for server actions calling notFound()', async 
 test('Will not include spans in pageload transaction with faulty timestamps for slow loading pages', async ({
   page,
 }) => {
+  test.slow();
   const pageloadTransactionEventPromise = waitForTransaction('nextjs-app-dir', transactionEvent => {
     return (
       transactionEvent?.contexts?.trace?.op === 'pageload' && transactionEvent?.transaction === '/very-slow-component'
     );
   });
 
-  await page.goto('/very-slow-component');
+  await page.goto('/very-slow-component', { timeout: 11000 });
 
   const pageLoadTransaction = await pageloadTransactionEventPromise;
 


### PR DESCRIPTION
This PR hopefully un-flakes this test by marking it as slow and adapting the timeout values.