### PR TITLE
feat(core): Deprecate `parseUrl`

### DIFF
--- a/packages/browser-utils/src/instrument/xhr.ts
+++ b/packages/browser-utils/src/instrument/xhr.ts
@@ -37,7 +37,7 @@ export function instrumentXHR(): void {
       // open() should always be called with two or more arguments
       // But to be on the safe side, we actually validate this and bail out if we don't have a method & url
       const method = isString(xhrOpenArgArray[0]) ? xhrOpenArgArray[0].toUpperCase() : undefined;
-      const url = parseUrl(xhrOpenArgArray[1]);
+      const url = ensureUrlIsString(xhrOpenArgArray[1]);
 
       if (!method || !url) {
         return originalOpen.apply(xhrOpenThisArg, xhrOpenArgArray);
@@ -140,7 +140,7 @@ export function instrumentXHR(): void {
   });
 }
 
-function parseUrl(url: string | unknown): string | undefined {
+function ensureUrlIsString(url: string | unknown): string | undefined {
   if (isString(url)) {
     return url;
   }

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -151,6 +151,7 @@ export {
   parseBaggageHeader,
 } from './baggage';
 
+// eslint-disable-next-line deprecation/deprecation
 export { getNumberOfUrlSegments, getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from './url';
 export { makeFifoCache } from './cache';
 export { eventFromMessage, eventFromUnknownInput, exceptionFromError, parseStackFrames } from './eventbuilder';

--- a/packages/core/src/utils-hoist/url.ts
+++ b/packages/core/src/utils-hoist/url.ts
@@ -1,6 +1,7 @@
 type PartialURL = {
   host?: string;
   path?: string;
+  pathname?: string;
   protocol?: string;
   relative?: string;
   search?: string;
@@ -13,6 +14,8 @@ type PartialURL = {
  * // intentionally using regex and not <a/> href parsing trick because React Native and other
  * // environments where DOM might not be available
  * @returns parsed URL object
+ *
+ * @deprecated This function is deprecated and will be removed in the next major version. Use `new URL()` instead.
  */
 export function parseUrl(url: string): PartialURL {
   if (!url) {
@@ -61,7 +64,10 @@ export function getNumberOfUrlSegments(url: string): number {
  * see: https://develop.sentry.dev/sdk/data-handling/#structuring-data
  */
 export function getSanitizedUrlString(url: PartialURL): string {
-  const { protocol, host, path } = url;
+  const { protocol, host, path, pathname } = url;
+
+  // This is the compatibility layer between PartialURL and URL
+  const prioritizedPathArg = pathname || path;
 
   const filteredHost =
     (host &&
@@ -74,5 +80,5 @@ export function getSanitizedUrlString(url: PartialURL): string {
         .replace(/(:443)$/, '')) ||
     '';
 
-  return `${protocol ? `${protocol}://` : ''}${filteredHost}${path}`;
+  return `${protocol ? `${protocol}://` : ''}${filteredHost}${prioritizedPathArg}`;
 }

--- a/packages/core/test/utils-hoist/url.test.ts
+++ b/packages/core/test/utils-hoist/url.test.ts
@@ -84,6 +84,7 @@ describe('getSanitizedUrlString', () => {
     ['url with port 443', 'http://172.31.12.144:443/test', 'http://172.31.12.144/test'],
     ['url with IP and port 80', 'http://172.31.12.144:80/test', 'http://172.31.12.144/test'],
   ])('returns a sanitized URL for a %s', (_, rawUrl: string, sanitizedURL: string) => {
+    // eslint-disable-next-line deprecation/deprecation
     const urlObject = parseUrl(rawUrl);
     expect(getSanitizedUrlString(urlObject)).toEqual(sanitizedURL);
   });

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -13,7 +13,6 @@ import {
   getSanitizedUrlString,
   httpRequestToRequestData,
   logger,
-  parseUrl,
   stripUrlQueryAndFragment,
   withIsolationScope,
 } from '@sentry/core';
@@ -311,20 +310,20 @@ function addRequestBreadcrumb(request: http.ClientRequest, response: http.Incomi
 function getBreadcrumbData(request: http.ClientRequest): Partial<SanitizedRequestData> {
   try {
     // `request.host` does not contain the port, but the host header does
-    const host = request.getHeader('host') || request.host;
+    const hostHeader = request.getHeader('host');
+    const host = typeof hostHeader === 'string' ? hostHeader : request.host;
     const url = new URL(request.path, `${request.protocol}//${host}`);
-    const parsedUrl = parseUrl(url.toString());
 
     const data: Partial<SanitizedRequestData> = {
-      url: getSanitizedUrlString(parsedUrl),
+      url: getSanitizedUrlString(url),
       'http.method': request.method || 'GET',
     };
 
-    if (parsedUrl.search) {
-      data['http.query'] = parsedUrl.search;
+    if (url.search) {
+      data['http.query'] = url.search;
     }
-    if (parsedUrl.hash) {
-      data['http.fragment'] = parsedUrl.hash;
+    if (url.hash) {
+      data['http.fragment'] = url.hash;
     }
 
     return data;

--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -8,7 +8,7 @@ import {
   getCurrentScope,
   hasTracingEnabled,
 } from '@sentry/core';
-import { getBreadcrumbLogLevelFromHttpStatusCode, getSanitizedUrlString, parseUrl } from '@sentry/core';
+import { getBreadcrumbLogLevelFromHttpStatusCode, getSanitizedUrlString } from '@sentry/core';
 import {
   addOpenTelemetryInstrumentation,
   generateSpanContextForPropagationContext,
@@ -128,18 +128,17 @@ function addRequestBreadcrumb(request: UndiciRequest, response: UndiciResponse):
 function getBreadcrumbData(request: UndiciRequest): Partial<SanitizedRequestData> {
   try {
     const url = new URL(request.path, request.origin);
-    const parsedUrl = parseUrl(url.toString());
 
     const data: Partial<SanitizedRequestData> = {
-      url: getSanitizedUrlString(parsedUrl),
+      url: getSanitizedUrlString(url),
       'http.method': request.method || 'GET',
     };
 
-    if (parsedUrl.search) {
-      data['http.query'] = parsedUrl.search;
+    if (url.search) {
+      data['http.query'] = url.search;
     }
-    if (parsedUrl.hash) {
-      data['http.fragment'] = parsedUrl.hash;
+    if (url.hash) {
+      data['http.fragment'] = url.hash;
     }
 
     return data;

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -13,7 +13,7 @@ import {
   SEMATTRS_MESSAGING_SYSTEM,
   SEMATTRS_RPC_SERVICE,
 } from '@opentelemetry/semantic-conventions';
-import { getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from '@sentry/core';
+import { getSanitizedUrlString, stripUrlQueryAndFragment } from '@sentry/core';
 import type { SpanAttributes, TransactionSource } from '@sentry/types';
 
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
@@ -196,6 +196,9 @@ function getGraphqlOperationNamesFromAttribute(attr: AttributeValue): string {
   return `${attr}`;
 }
 
+// Just a dummy url base for the `URL` constructor.
+const DUMMY_URL_BASE = 'dummy://';
+
 /** Exported for tests only */
 export function getSanitizedUrl(
   attributes: Attributes,
@@ -216,8 +219,8 @@ export function getSanitizedUrl(
   // This is the normalized route name - may not always be available!
   const httpRoute = attributes[ATTR_HTTP_ROUTE];
 
-  const parsedUrl = typeof httpUrl === 'string' ? parseUrl(httpUrl) : undefined;
-  const url = parsedUrl ? getSanitizedUrlString(parsedUrl) : undefined;
+  const parsedUrl = typeof httpUrl === 'string' ? new URL(httpUrl, DUMMY_URL_BASE) : undefined;
+  const url = parsedUrl && parsedUrl.protocol !== 'dummy:' ? getSanitizedUrlString(parsedUrl) : undefined;
   const query = parsedUrl && parsedUrl.search ? parsedUrl.search : undefined;
   const fragment = parsedUrl && parsedUrl.hash ? parsedUrl.hash : undefined;
 


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/14267

Deprecates and removes usages of `parseUrl` which can be replaced with the URL constructor with our current version support.