### PR TITLE
feat(core): Deprecate `urlEncode`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -7,6 +7,7 @@
 - Deprecated `AddRequestDataToEventOptions.transaction`. This option effectively doesn't do anything anymore, and will
   be removed in v9.
 - Deprecated `TransactionNamingScheme` type.
+- Deprecated `urlEncode`. No replacements.
 
 ## `@sentry/core`
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1,6 +1,5 @@
 import type { DsnComponents, DsnLike, SdkInfo } from '@sentry/types';
 import { dsnToString, makeDsn } from './utils-hoist/dsn';
-import { urlEncode } from './utils-hoist/object';
 
 const SENTRY_API_VERSION = '7';
 
@@ -18,13 +17,21 @@ function _getIngestEndpoint(dsn: DsnComponents): string {
 
 /** Returns a URL-encoded string with auth config suitable for a query string. */
 function _encodedAuth(dsn: DsnComponents, sdkInfo: SdkInfo | undefined): string {
-  return urlEncode({
+  const params: Record<string, string> = {
+    sentry_version: SENTRY_API_VERSION,
+  };
+
+  if (dsn.publicKey) {
     // We send only the minimum set of required information. See
     // https://github.com/getsentry/sentry-javascript/issues/2572.
-    sentry_key: dsn.publicKey,
-    sentry_version: SENTRY_API_VERSION,
-    ...(sdkInfo && { sentry_client: `${sdkInfo.name}/${sdkInfo.version}` }),
-  });
+    params.sentry_key = dsn.publicKey;
+  }
+
+  if (sdkInfo) {
+    params.sentry_client = `${sdkInfo.name}/${sdkInfo.version}`;
+  }
+
+  return new URLSearchParams(params).toString();
 }
 
 /**

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -57,6 +57,7 @@ export {
   getOriginalFunction,
   markFunctionWrapped,
   objectify,
+  // eslint-disable-next-line deprecation/deprecation
   urlEncode,
 } from './object';
 export { basename, dirname, isAbsolute, join, normalizePath, relative, resolve } from './path';

--- a/packages/core/src/utils-hoist/object.ts
+++ b/packages/core/src/utils-hoist/object.ts
@@ -90,6 +90,8 @@ export function getOriginalFunction(func: WrappedFunction): WrappedFunction | un
  *
  * @param object An object that contains serializable values
  * @returns string Encoded
+ *
+ * @deprecated This function is deprecated and will be removed in the next major version of the SDK.
  */
 export function urlEncode(object: { [key: string]: any }): string {
   return Object.keys(object)

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -18,7 +18,7 @@ describe('API', () => {
         dsnPublicComponents,
         undefined,
         undefined,
-        'https://sentry.io:1234/subpath/api/123/envelope/?sentry_key=abc&sentry_version=7',
+        'https://sentry.io:1234/subpath/api/123/envelope/?sentry_version=7&sentry_key=abc',
       ],
       ['uses `tunnel` value when called with `tunnel` option', dsnPublicComponents, tunnel, undefined, tunnel],
       [
@@ -33,7 +33,7 @@ describe('API', () => {
         dsnPublicComponents,
         undefined,
         sdkInfo,
-        'https://sentry.io:1234/subpath/api/123/envelope/?sentry_key=abc&sentry_version=7&sentry_client=sentry.javascript.browser%2F12.31.12',
+        'https://sentry.io:1234/subpath/api/123/envelope/?sentry_version=7&sentry_key=abc&sentry_client=sentry.javascript.browser%2F12.31.12',
       ],
     ])(
       '%s',

--- a/packages/core/test/utils-hoist/object.test.ts
+++ b/packages/core/test/utils-hoist/object.test.ts
@@ -130,14 +130,17 @@ describe('fill()', () => {
 
 describe('urlEncode()', () => {
   test('returns empty string for empty object input', () => {
+    // eslint-disable-next-line deprecation/deprecation
     expect(urlEncode({})).toEqual('');
   });
 
   test('returns single key/value pair joined with = sign', () => {
+    // eslint-disable-next-line deprecation/deprecation
     expect(urlEncode({ foo: 'bar' })).toEqual('foo=bar');
   });
 
   test('returns multiple key/value pairs joined together with & sign', () => {
+    // eslint-disable-next-line deprecation/deprecation
     expect(urlEncode({ foo: 'bar', pickle: 'rick', morty: '4 2' })).toEqual('foo=bar&pickle=rick&morty=4%202');
   });
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -149,6 +149,7 @@ export {
   memoBuilder,
   arrayify,
   normalizeUrlToBase,
+  // eslint-disable-next-line deprecation/deprecation
   urlEncode,
   // eslint-disable-next-line deprecation/deprecation
   extractPathForTransaction,


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/14267

Deprecates and removes internal usages of `urlEncode`.