### PR TITLE
feat(opentelemetry): Ignore propagation context when not continuing trace

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/scenario.ts
@@ -14,17 +14,5 @@ Sentry.getCurrentScope().setPropagationContext({
   traceId: '12345678901234567890123456789012',
 });
 
-const spanIdTraceId = Sentry.startSpan(
-  {
-    name: 'test_span_1',
-  },
-  span1 => span1.spanContext().traceId,
-);
-
-Sentry.startSpan(
-  {
-    name: 'test_span_2',
-    attributes: { spanIdTraceId },
-  },
-  () => undefined,
-);
+Sentry.startSpan({ name: 'test_span_1' }, () => undefined);
+Sentry.startSpan({ name: 'test_span_2' }, () => undefined);

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/test.ts
@@ -5,24 +5,29 @@ afterAll(() => {
 });
 
 test('should send manually started parallel root spans in root context', done => {
-  expect.assertions(7);
-
   createRunner(__dirname, 'scenario.ts')
-    .expect({ transaction: { transaction: 'test_span_1' } })
     .expect({
-      transaction: transaction => {
-        expect(transaction).toBeDefined();
-        const traceId = transaction.contexts?.trace?.trace_id;
-        expect(traceId).toBeDefined();
-
-        // It ignores propagation context of the root context
-        expect(traceId).not.toBe('12345678901234567890123456789012');
-        expect(transaction.contexts?.trace?.parent_span_id).toBeUndefined();
-
-        // Different trace ID than the first span
-        const trace1Id = transaction.contexts?.trace?.data?.spanIdTraceId;
-        expect(trace1Id).toBeDefined();
-        expect(trace1Id).not.toBe(traceId);
+      transaction: {
+        transaction: 'test_span_1',
+        contexts: {
+          trace: {
+            span_id: expect.any(String),
+            parent_span_id: '1234567890123456',
+            trace_id: '12345678901234567890123456789012',
+          },
+        },
+      },
+    })
+    .expect({
+      transaction: {
+        transaction: 'test_span_2',
+        contexts: {
+          trace: {
+            span_id: expect.any(String),
+            parent_span_id: '1234567890123456',
+            trace_id: '12345678901234567890123456789012',
+          },
+        },
       },
     })
     .start(done);

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope/test.ts
@@ -19,8 +19,7 @@ test('should send manually started parallel root spans outside of root context',
         const trace1Id = transaction.contexts?.trace?.data?.spanIdTraceId;
         expect(trace1Id).toBeDefined();
 
-        // Same trace ID as the first span
-        expect(trace1Id).toBe(traceId);
+        expect(trace1Id).not.toBe(traceId);
       },
     })
     .start(done);


### PR DESCRIPTION
Let's see how that would even work...

Implements changes on top of https://github.com/getsentry/sentry-javascript/pull/14426