### PR TITLE
fix(google-cloud-serverless): Update homepage link in package.json

### DIFF
--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -3,7 +3,7 @@
   "version": "8.39.0",
   "description": "Official Sentry SDK for Google Cloud Functions",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
-  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/google-cloud",
+  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/google-cloud-serverless",
   "author": "Sentry",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
The link to the homepage results in a 404.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
