### PR TITLE
ci: Fix canary test workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,11 +14,11 @@ env:
 
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/packages/*/*.tgz
-    ${{ github.workspace }}/dev-packages/test-utils/build
     ${{ github.workspace }}/node_modules
     ${{ github.workspace }}/packages/*/node_modules
     ${{ github.workspace }}/dev-packages/*/node_modules
-    ${{ github.workspace }}/packages/utils/build
+    ${{ github.workspace }}/dev-packages/*/build
+    ${{ github.workspace }}/packages/*/build
 
 permissions:
   contents: read

--- a/dev-packages/e2e-tests/package.json
+++ b/dev-packages/e2e-tests/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf tmp node_modules pnpm-lock.yaml && yarn clean:test-applications",
     "ci:build-matrix": "ts-node ./lib/getTestMatrix.ts",
     "ci:build-matrix-optional": "ts-node ./lib/getTestMatrix.ts --optional=true",
-    "clean:test-applications": "rimraf --glob test-applications/**/{node_modules,dist,build,.next,.sveltekit,pnpm-lock.yaml} .last-run.json && pnpm store prune"
+    "clean:test-applications": "rimraf --glob test-applications/**/{node_modules,dist,build,.next,.sveltekit,pnpm-lock.yaml,.last-run.json,test-results} && pnpm store prune"
   },
   "devDependencies": {
     "@types/glob": "8.0.0",


### PR DESCRIPTION
Oops, we forgot this when moving the stuff from utils to core. The canary test workflow only kept the utils build in cache, which lead to this failing - now, we just keep all build output in cache, to be on the safe side...

see: https://github.com/getsentry/sentry-javascript/actions/runs/11971041974