### PR TITLE
feat(utils): Deprecate `memoBuilder`, `BAGGAGE_HEADER_NAME`, and `makeFifoCache`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -14,6 +14,9 @@
 - Deprecated `addRequestDataToEvent`. Use `addNormalizedRequestDataToEvent` instead.
 - Deprecated `extractRequestData`. Instead manually extract relevant data off request.
 - Deprecated `arrayify`. No replacements.
+- Deprecated `memoBuilder`. No replacements.
+- Deprecated `BAGGAGE_HEADER_NAME`. No replacements.
+- Deprecated `makeFifoCache`. No replacements.
 
 ## `@sentry/core`
 

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -22,7 +22,6 @@ import {
   startInactiveSpan,
 } from '@sentry/core';
 import {
-  BAGGAGE_HEADER_NAME,
   addFetchEndInstrumentationHandler,
   addFetchInstrumentationHandler,
   browserPerformanceTimeOrigin,
@@ -449,7 +448,7 @@ function setHeaderOnXhr(
       // We can therefore simply set a baggage header without checking what was there before
       // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      xhr.setRequestHeader!(BAGGAGE_HEADER_NAME, sentryBaggageHeader);
+      xhr.setRequestHeader!('baggage', sentryBaggageHeader);
     }
   } catch (_) {
     // Error: InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -9,11 +9,7 @@ import {
   startInactiveSpan,
 } from './tracing';
 import { SentryNonRecordingSpan } from './tracing/sentryNonRecordingSpan';
-import {
-  BAGGAGE_HEADER_NAME,
-  SENTRY_BAGGAGE_KEY_PREFIX,
-  dynamicSamplingContextToSentryBaggageHeader,
-} from './utils-hoist/baggage';
+import { SENTRY_BAGGAGE_KEY_PREFIX, dynamicSamplingContextToSentryBaggageHeader } from './utils-hoist/baggage';
 import { isInstanceOf } from './utils-hoist/is';
 import { generateSentryTraceHeader } from './utils-hoist/tracing';
 import { parseUrl } from './utils-hoist/url';
@@ -157,11 +153,11 @@ export function addTracingHeadersToFetchRequest(
     newHeaders.set('sentry-trace', sentryTraceHeader);
 
     if (sentryBaggageHeader) {
-      const prevBaggageHeader = newHeaders.get(BAGGAGE_HEADER_NAME);
+      const prevBaggageHeader = newHeaders.get('baggage');
       if (prevBaggageHeader) {
         const prevHeaderStrippedFromSentryBaggage = stripBaggageHeaderOfSentryBaggageValues(prevBaggageHeader);
         newHeaders.set(
-          BAGGAGE_HEADER_NAME,
+          'baggage',
           // If there are non-sentry entries (i.e. if the stripped string is non-empty/truthy) combine the stripped header and sentry baggage header
           // otherwise just set the sentry baggage header
           prevHeaderStrippedFromSentryBaggage
@@ -169,7 +165,7 @@ export function addTracingHeadersToFetchRequest(
             : sentryBaggageHeader,
         );
       } else {
-        newHeaders.set(BAGGAGE_HEADER_NAME, sentryBaggageHeader);
+        newHeaders.set('baggage', sentryBaggageHeader);
       }
     }
 
@@ -183,7 +179,7 @@ export function addTracingHeadersToFetchRequest(
         })
         // Get rid of previous sentry baggage values in baggage header
         .map(header => {
-          if (Array.isArray(header) && header[0] === BAGGAGE_HEADER_NAME && typeof header[1] === 'string') {
+          if (Array.isArray(header) && header[0] === 'baggage' && typeof header[1] === 'string') {
             const [headerName, headerValue, ...rest] = header;
             return [headerName, stripBaggageHeaderOfSentryBaggageValues(headerValue), ...rest];
           } else {
@@ -197,7 +193,7 @@ export function addTracingHeadersToFetchRequest(
     if (sentryBaggageHeader) {
       // If there are multiple entries with the same key, the browser will merge the values into a single request header.
       // Its therefore safe to simply push a "baggage" entry, even though there might already be another baggage header.
-      newHeaders.push([BAGGAGE_HEADER_NAME, sentryBaggageHeader]);
+      newHeaders.push(['baggage', sentryBaggageHeader]);
     }
 
     return newHeaders as PolymorphicRequestHeaders;

--- a/packages/core/src/utils-hoist/baggage.ts
+++ b/packages/core/src/utils-hoist/baggage.ts
@@ -4,6 +4,9 @@ import { DEBUG_BUILD } from './debug-build';
 import { isString } from './is';
 import { logger } from './logger';
 
+/**
+ * @deprecated Use a `"baggage"` string directly
+ */
 export const BAGGAGE_HEADER_NAME = 'baggage';
 
 export const SENTRY_BAGGAGE_KEY_PREFIX = 'sentry-';

--- a/packages/core/src/utils-hoist/cache.ts
+++ b/packages/core/src/utils-hoist/cache.ts
@@ -1,6 +1,8 @@
 /**
  * Creates a cache that evicts keys in fifo order
  * @param size {Number}
+ *
+ * @deprecated This function is deprecated and will be removed in the next major version.
  */
 export function makeFifoCache<Key extends string, Value>(
   size: number,

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -35,6 +35,7 @@ export {
 } from './is';
 export { isBrowser } from './isBrowser';
 export { CONSOLE_LEVELS, consoleSandbox, logger, originalConsoleMethods } from './logger';
+// eslint-disable-next-line deprecation/deprecation
 export { memoBuilder } from './memo';
 export {
   addContextToFrame,
@@ -147,6 +148,7 @@ export {
 } from './ratelimit';
 export type { RateLimits } from './ratelimit';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   BAGGAGE_HEADER_NAME,
   MAX_BAGGAGE_STRING_LENGTH,
   SENTRY_BAGGAGE_KEY_PREFIX,
@@ -157,6 +159,7 @@ export {
 } from './baggage';
 
 export { getNumberOfUrlSegments, getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from './url';
+// eslint-disable-next-line deprecation/deprecation
 export { makeFifoCache } from './cache';
 export { eventFromMessage, eventFromUnknownInput, exceptionFromError, parseStackFrames } from './eventbuilder';
 export { callFrameToStackFrame, watchdogTimer } from './anr';

--- a/packages/core/src/utils-hoist/memo.ts
+++ b/packages/core/src/utils-hoist/memo.ts
@@ -10,7 +10,10 @@ export type MemoFunc = [
 
 /**
  * Helper to decycle json objects
+ *
+ * @deprecated This function is deprecated and will be removed in the next major version.
  */
+// TODO(v9): Move this function into normalize() directly
 export function memoBuilder(): MemoFunc {
   const hasWeakSet = typeof WeakSet === 'function';
   const inner: any = hasWeakSet ? new WeakSet() : [];

--- a/packages/core/src/utils-hoist/normalize.ts
+++ b/packages/core/src/utils-hoist/normalize.ts
@@ -74,6 +74,7 @@ function visit(
   value: unknown,
   depth: number = +Infinity,
   maxProperties: number = +Infinity,
+  // eslint-disable-next-line deprecation/deprecation
   memo: MemoFunc = memoBuilder(),
 ): Primitive | ObjOrArray<unknown> {
   const [memoize, unmemoize] = memo;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -613,6 +613,7 @@ export const loadModule = loadModule_imported;
 export const flatten = flatten_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
+// eslint-disable-next-line deprecation/deprecation
 export const memoBuilder = memoBuilder_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
@@ -660,6 +661,7 @@ export const _optionalChain = _optionalChain_imported;
 export const _optionalChainDelete = _optionalChainDelete_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
+// eslint-disable-next-line deprecation/deprecation
 export const BAGGAGE_HEADER_NAME = BAGGAGE_HEADER_NAME_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
@@ -675,6 +677,7 @@ export const parseUrl = parseUrl_imported;
 export const stripUrlQueryAndFragment = stripUrlQueryAndFragment_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
+// eslint-disable-next-line deprecation/deprecation
 export const makeFifoCache = makeFifoCache_imported;
 
 import type {


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/14267

Deprecates a few unused/unnecessary exports from the utils package.