### PR TITLE
feat(nuxt): Only delete public source maps

### DIFF
--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -81,7 +81,7 @@ export function getPluginOptions(
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
       console.log(
-        '[Sentry] Setting `sentry.sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload: [".*/**/*.map"]` to delete generated source maps after they were uploaded to Sentry.',
+        '[Sentry] Setting `sentry.sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload: [".*/**/public/**/*.map"]` to delete generated source maps after they were uploaded to Sentry.',
       );
     });
   }
@@ -108,7 +108,7 @@ export function getPluginOptions(
       filesToDeleteAfterUpload: sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload
         ? sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload
         : deleteFilesAfterUpload
-          ? ['.*/**/*.map']
+          ? ['.*/**/public/**/*.map']
           : undefined,
       rewriteSources: (source: string) => normalizePath(source),
       ...moduleOptions?.unstable_sentryBundlerPluginOptions?.sourcemaps,
@@ -279,7 +279,7 @@ function warnExplicitlyDisabledSourceMap(settingKey: string): void {
   consoleSandbox(() => {
     //  eslint-disable-next-line no-console
     console.warn(
-      `[Sentry] Parts of source map generation are currently disabled in your Nuxt configuration (\`${settingKey}: false\`). This setting is either a default setting or was explicitly set in your configuration. Sentry won't override this setting. Without source maps, code snippets on the Sentry Issues page will remain minified. To show unminified code, enable source maps in \`${settingKey}\`.`,
+      `[Sentry] Parts of source map generation are currently disabled in your Nuxt configuration (\`${settingKey}: false\`). This setting is either a default setting or was explicitly set in your configuration. Sentry won't override this setting. Without source maps, code snippets on the Sentry Issues page will remain minified. To show unminified code, enable source maps in \`${settingKey}\` (e.g. by setting them to \`hidden\`).`,
     );
   });
 }


### PR DESCRIPTION
As Nuxt generates and keeps server source maps per default, only the source maps in the public folder are deleted after uploading them to Sentry.