### PR TITLE
fix(nextjs): Don't report `NEXT_REDIRECT` from browser

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -6,6 +6,7 @@ import type { Client, EventProcessor, Integration } from '@sentry/types';
 
 import { devErrorSymbolicationEventProcessor } from '../common/devErrorSymbolicationEventProcessor';
 import { getVercelEnv } from '../common/getVercelEnv';
+import { isRedirectNavigationError } from '../common/nextNavigationErrorUtils';
 import { browserTracingIntegration } from './browserTracingIntegration';
 import { nextjsClientStackFrameNormalizationIntegration } from './clientNormalizationIntegration';
 import { INCOMPLETE_APP_ROUTER_INSTRUMENTATION_TRANSACTION_NAME } from './routing/appRouterRoutingInstrumentation';
@@ -46,6 +47,11 @@ export function init(options: BrowserOptions): Client | undefined {
       : event;
   filterIncompleteNavigationTransactions.id = 'IncompleteTransactionFilter';
   addEventProcessor(filterIncompleteNavigationTransactions);
+
+  const filterNextRedirectError: EventProcessor = (event, hint) =>
+    isRedirectNavigationError(hint?.originalException) ? null : event;
+  filterNextRedirectError.id = 'NextRedirectErrorFilter';
+  addEventProcessor(filterNextRedirectError);
 
   if (process.env.NODE_ENV === 'development') {
     addEventProcessor(devErrorSymbolicationEventProcessor);


### PR DESCRIPTION
Fixes #14436

Reduces error spam by not reporting `NEXT_NOT_FOUND` error which get thrown when use the `redirect()` functions.

From ServerComponents were addressed in #7642 and ServerAction in #10474, but this PR addresses what is reported from the Client (Browser).


- https://github.com/vercel/next.js/blob/2161d8c012dcd98eb8690814bd275d56c45bf00a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts#L384-L397
- https://github.com/vercel/next.js/blob/2161d8c012dcd98eb8690814bd275d56c45bf00a/packages/next/src/client/components/redirect.ts#L10-L18