### PR TITLE
ref(core): Streamline ACS lookups

### DIFF
--- a/packages/core/src/asyncContext/index.ts
+++ b/packages/core/src/asyncContext/index.ts
@@ -29,3 +29,14 @@ export function getAsyncContextStrategy(carrier: Carrier): AsyncContextStrategy 
   // Otherwise, use the default one (stack)
   return getStackAsyncContextStrategy();
 }
+
+/**
+ * Get the implementation of a specific async context strategy method.
+ */
+export function getAsyncContextStrategyImplementation<T extends keyof AsyncContextStrategy>(
+  prop: T,
+): AsyncContextStrategy[T] {
+  const carrier = getMainCarrier();
+  const acs = getAsyncContextStrategy(carrier);
+  return acs[prop];
+}

--- a/packages/core/src/currentScopes.ts
+++ b/packages/core/src/currentScopes.ts
@@ -17,7 +17,7 @@ export function getCurrentScope(): Scope {
  * The isolation scope is active for the current execution context.
  */
 export function getIsolationScope(): Scope {
-  return getAsyncContextStrategyImplementation('getCurrentScope')();
+  return getAsyncContextStrategyImplementation('getIsolationScope')();
 }
 
 /**

--- a/packages/core/src/currentScopes.ts
+++ b/packages/core/src/currentScopes.ts
@@ -1,6 +1,6 @@
 import type { Scope } from '@sentry/types';
 import type { Client } from '@sentry/types';
-import { getAsyncContextStrategy } from './asyncContext';
+import { getAsyncContextStrategy, getAsyncContextStrategyImplementation } from './asyncContext';
 import { getMainCarrier } from './carrier';
 import { Scope as ScopeClass } from './scope';
 import { getGlobalSingleton } from './utils-hoist/worldwide';
@@ -9,9 +9,7 @@ import { getGlobalSingleton } from './utils-hoist/worldwide';
  * Get the currently active scope.
  */
 export function getCurrentScope(): Scope {
-  const carrier = getMainCarrier();
-  const acs = getAsyncContextStrategy(carrier);
-  return acs.getCurrentScope();
+  return getAsyncContextStrategyImplementation('getCurrentScope')();
 }
 
 /**
@@ -19,9 +17,7 @@ export function getCurrentScope(): Scope {
  * The isolation scope is active for the current execution context.
  */
 export function getIsolationScope(): Scope {
-  const carrier = getMainCarrier();
-  const acs = getAsyncContextStrategy(carrier);
-  return acs.getIsolationScope();
+  return getAsyncContextStrategyImplementation('getCurrentScope')();
 }
 
 /**

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -9,8 +9,7 @@ import type {
   SpanTimeInput,
   TraceContext,
 } from '@sentry/types';
-import { getAsyncContextStrategy } from '../asyncContext';
-import { getMainCarrier } from '../carrier';
+import { getAsyncContextStrategyImplementation } from '../asyncContext';
 import { getCurrentScope } from '../currentScopes';
 import { getMetricSummaryJsonForSpan, updateMetricSummaryOnSpan } from '../metrics/metric-summary';
 import type { MetricType } from '../metrics/types';
@@ -259,10 +258,9 @@ export function getRootSpan(span: SpanWithPotentialChildren): Span {
  * Returns the currently active span.
  */
 export function getActiveSpan(): Span | undefined {
-  const carrier = getMainCarrier();
-  const acs = getAsyncContextStrategy(carrier);
-  if (acs.getActiveSpan) {
-    return acs.getActiveSpan();
+  const acsImpl = getAsyncContextStrategyImplementation('getActiveSpan');
+  if (acsImpl) {
+    return acsImpl();
   }
 
   return _getSpanForScope(getCurrentScope());

--- a/packages/core/src/utils/traceData.ts
+++ b/packages/core/src/utils/traceData.ts
@@ -1,6 +1,5 @@
 import type { SerializedTraceData } from '@sentry/types';
-import { getAsyncContextStrategy } from '../asyncContext';
-import { getMainCarrier } from '../carrier';
+import { getAsyncContextStrategyImplementation } from '../asyncContext';
 import { getClient, getCurrentScope } from '../currentScopes';
 import { isEnabled } from '../exports';
 import { getDynamicSamplingContextFromClient, getDynamicSamplingContextFromSpan } from '../tracing';
@@ -25,10 +24,9 @@ export function getTraceData(): SerializedTraceData {
     return {};
   }
 
-  const carrier = getMainCarrier();
-  const acs = getAsyncContextStrategy(carrier);
-  if (acs.getTraceData) {
-    return acs.getTraceData();
+  const acsImpl = getAsyncContextStrategyImplementation('getTraceData');
+  if (acsImpl) {
+    return acsImpl();
   }
 
   const client = getClient();


### PR DESCRIPTION
Safe a tiny amount of bytes by de-duplicating the lookup for ACS implementations.