### PR TITLE
feat(core): Deprecate `flatten`

### DIFF
--- a/packages/core/src/utils-hoist/array.ts
+++ b/packages/core/src/utils-hoist/array.ts
@@ -1,6 +1,9 @@
 export type NestedArray<T> = Array<NestedArray<T> | T>;
 
-/** Flattens a multi-dimensional array */
+/** Flattens a multi-dimensional array
+ *
+ * @deprecated This function is deprecated and will be removed in the next major version.
+ */
 export function flatten<T>(input: NestedArray<T>): T[] {
   const result: T[] = [];
 

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -1,4 +1,5 @@
 export { applyAggregateErrorsToEvent } from './aggregate-errors';
+// eslint-disable-next-line deprecation/deprecation
 export { flatten } from './array';
 export { getBreadcrumbLogLevelFromHttpStatusCode } from './breadcrumb-log-level';
 export { getComponentName, getDomElement, getLocationHref, htmlTreeAsString } from './browser';

--- a/packages/core/test/utils-hoist/array.test.ts
+++ b/packages/core/test/utils-hoist/array.test.ts
@@ -1,16 +1,19 @@
 import type { NestedArray } from '../../src/utils-hoist/array';
+// eslint-disable-next-line deprecation/deprecation
 import { flatten } from '../../src/utils-hoist/array';
 
 describe('flatten', () => {
   it('should return the same array when input is a flat array', () => {
     const input = [1, 2, 3, 4];
     const expected = [1, 2, 3, 4];
+    // eslint-disable-next-line deprecation/deprecation
     expect(flatten(input)).toEqual(expected);
   });
 
   it('should flatten a nested array of numbers', () => {
     const input = [[1, 2, [3]], 4];
     const expected = [1, 2, 3, 4];
+    // eslint-disable-next-line deprecation/deprecation
     expect(flatten(input)).toEqual(expected);
   });
 
@@ -20,6 +23,7 @@ describe('flatten', () => {
       ['How', 'Are', 'You'],
     ];
     const expected = ['Hello', 'World', 'How', 'Are', 'You'];
+    // eslint-disable-next-line deprecation/deprecation
     expect(flatten(input)).toEqual(expected);
   });
 
@@ -29,30 +33,35 @@ describe('flatten', () => {
       [{ a: 3 }, { b: 4 }],
     ];
     const expected = [{ a: 1 }, { b: 2 }, { a: 3 }, { b: 4 }];
+    // eslint-disable-next-line deprecation/deprecation
     expect(flatten(input)).toEqual(expected);
   });
 
   it('should flatten a mixed type array', () => {
     const input: NestedArray<string | { b: number }> = [['a', { b: 2 }, 'c'], 'd'];
     const expected = ['a', { b: 2 }, 'c', 'd'];
+    // eslint-disable-next-line deprecation/deprecation
     expect(flatten(input)).toEqual(expected);
   });
 
   it('should flatten a deeply nested array', () => {
     const input = [1, [2, [3, [4, [5]]]]];
     const expected = [1, 2, 3, 4, 5];
+    // eslint-disable-next-line deprecation/deprecation
     expect(flatten(input)).toEqual(expected);
   });
 
   it('should return an empty array when input is empty', () => {
     const input: any[] = [];
     const expected: any[] = [];
+    // eslint-disable-next-line deprecation/deprecation
     expect(flatten(input)).toEqual(expected);
   });
 
   it('should return the same array when input is a flat array', () => {
     const input = [1, 'a', { b: 2 }, 'c', 3];
     const expected = [1, 'a', { b: 2 }, 'c', 3];
+    // eslint-disable-next-line deprecation/deprecation
     expect(flatten(input)).toEqual(expected);
   });
 });

--- a/packages/node/src/utils/redisCache.ts
+++ b/packages/node/src/utils/redisCache.ts
@@ -1,5 +1,4 @@
 import type { CommandArgs as IORedisCommandArgs } from '@opentelemetry/instrumentation-ioredis';
-import { flatten } from '@sentry/core';
 
 const SINGLE_ARG_COMMANDS = ['get', 'set', 'setex'];
 
@@ -94,4 +93,24 @@ export function calculateCacheItemSize(response: unknown): number | undefined {
         return typeof size === 'number' ? (acc !== undefined ? acc + size : size) : acc;
       }, 0)
     : getSize(response);
+}
+
+// TODO(v9): This is inlined from core so we can deprecate `flatten`.
+//           It's usage can be replaced with `Array.flat` in v9.
+type NestedArray<T> = Array<NestedArray<T> | T>;
+function flatten<T>(input: NestedArray<T>): T[] {
+  const result: T[] = [];
+
+  const flattenHelper = (input: NestedArray<T>): void => {
+    input.forEach((el: T | NestedArray<T>) => {
+      if (Array.isArray(el)) {
+        flattenHelper(el as NestedArray<T>);
+      } else {
+        result.push(el as T);
+      }
+    });
+  };
+
+  flattenHelper(input);
+  return result;
 }

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { consoleSandbox, flatten } from '@sentry/core';
+import { consoleSandbox } from '@sentry/core';
 
 /**
  *  Find the default SDK init file for the given type (client or server).
@@ -92,18 +92,21 @@ export function constructWrappedFunctionExportQuery(
   entrypointWrappedFunctions: string[],
   debug?: boolean,
 ): string {
+  const functionsToExport: { wrap: string[]; reexport: string[] } = {
+    wrap: [],
+    reexport: [],
+  };
+
   // `exportedBindings` can look like this:  `{ '.': [ 'handler' ] }` or `{ '.': [], './firebase-gen-1.mjs': [ 'server' ] }`
   // The key `.` refers to exports within the current file, while other keys show from where exports were imported first.
-  const functionsToExport = flatten(Object.values(exportedBindings || {})).reduce(
-    (functions, currFunctionName) => {
-      if (entrypointWrappedFunctions.includes(currFunctionName)) {
-        functions.wrap.push(currFunctionName);
+  Object.values(exportedBindings || {}).forEach(functions =>
+    functions.forEach(fn => {
+      if (entrypointWrappedFunctions.includes(fn)) {
+        functionsToExport.wrap.push(fn);
       } else {
-        functions.reexport.push(currFunctionName);
+        functionsToExport.reexport.push(fn);
       }
-      return functions;
-    },
-    { wrap: [], reexport: [] } as { wrap: string[]; reexport: string[] },
+    }),
   );
 
   if (debug && functionsToExport.wrap.length === 0) {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -610,6 +610,7 @@ export const isNodeEnv = isNodeEnv_imported;
 export const loadModule = loadModule_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
+// eslint-disable-next-line deprecation/deprecation
 export const flatten = flatten_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/14267

From my investigation, redis does not actually support arrays/nested arrays for keys and ioredis is wrapping thinly over redis functions, but otel has `any[]` as one of their possible values for command line arguments so I opted for inlining the implementation and adding a note to use `Array.flat` in v9.