### PR TITLE
feat(core/utils): Deprecate `getNumberOfUrlSegments`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -15,6 +15,7 @@
 - Deprecated `extractRequestData`. Instead manually extract relevant data off request.
 - Deprecated `arrayify`. No replacements.
 - Deprecated `memoBuilder`. No replacements.
+- Deprecated `getNumberOfUrlSegments`. No replacements.
 - Deprecated `BAGGAGE_HEADER_NAME`. No replacements.
 - Deprecated `makeFifoCache`. No replacements.
 

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -159,6 +159,7 @@ export {
   parseBaggageHeader,
 } from './baggage';
 
+// eslint-disable-next-line deprecation/deprecation
 export { getNumberOfUrlSegments, getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from './url';
 // eslint-disable-next-line deprecation/deprecation
 export { makeFifoCache } from './cache';

--- a/packages/core/src/utils-hoist/url.ts
+++ b/packages/core/src/utils-hoist/url.ts
@@ -50,7 +50,10 @@ export function stripUrlQueryAndFragment(urlPath: string): string {
 
 /**
  * Returns number of URL segments of a passed string URL.
+ *
+ * @deprecated This function will be removed in the next major version.
  */
+// TODO(v9): Hoist this function into the places where we use it. (as it stands only react router v6 instrumentation)
 export function getNumberOfUrlSegments(url: string): number {
   // split at '/' or at '\/' to split regex urls correctly
   return url.split(/\\?\//).filter(s => s.length > 0 && s !== ',').length;

--- a/packages/core/test/utils-hoist/url.test.ts
+++ b/packages/core/test/utils-hoist/url.test.ts
@@ -33,6 +33,7 @@ describe('getNumberOfUrlSegments', () => {
     ['multi param parameterized path', '/stores/:storeId/products/:productId', 4],
     ['regex path', String(/\/api\/post[0-9]/), 2],
   ])('%s', (_: string, input, output) => {
+    // eslint-disable-next-line deprecation/deprecation
     expect(getNumberOfUrlSegments(input)).toEqual(output);
   });
 });

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -197,6 +197,8 @@ function getNormalizedName(
               // If the route defined on the element is something like
               // <Route path="/stores/:storeId/products/:productId" element={<div>Product</div>} />
               // We should check against the branch.pathname for the number of / separators
+              // TODO(v9): Put the implementation of `getNumberOfUrlSegments` in this file
+              // eslint-disable-next-line deprecation/deprecation
               getNumberOfUrlSegments(pathBuilder) !== getNumberOfUrlSegments(branch.pathname) &&
               // We should not count wildcard operators in the url segments calculation
               pathBuilder.slice(-2) !== '/*'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -666,6 +666,7 @@ export const _optionalChainDelete = _optionalChainDelete_imported;
 export const BAGGAGE_HEADER_NAME = BAGGAGE_HEADER_NAME_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
+// eslint-disable-next-line deprecation/deprecation
 export const getNumberOfUrlSegments = getNumberOfUrlSegments_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/14267

`getNumberOfUrlSegments` is only used in 1 place across the SDK - it doesn't need to be a util.