### PR TITLE
meta: Backfill v9 migration guide items

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -2,6 +2,10 @@
 
 # Deprecations
 
+## General
+
+- Returning `null` from `beforeSendSpan` span is deprecated.
+
 ## `@sentry/utils`
 
 - **The `@sentry/utils` package has been deprecated. Import everything from `@sentry/core` instead.**
@@ -17,6 +21,7 @@
 - Deprecated `memoBuilder`. No replacements.
 - Deprecated `BAGGAGE_HEADER_NAME`. No replacements.
 - Deprecated `makeFifoCache`. No replacements.
+- Deprecated `flatten`. No replacements.
 
 ## `@sentry/core`
 


### PR DESCRIPTION
Backfills items to the draft migration guide for v9 that we missed

- https://github.com/getsentry/sentry-javascript/pull/14433
- https://github.com/getsentry/sentry-javascript/pull/14454