### PR TITLE
test(node): Add `--import` test to integration tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-esm/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-esm/instrument.mjs
@@ -1,0 +1,11 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  integrations: [],
+  transport: loggingTransport,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-esm/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-esm/scenario.mjs
@@ -1,0 +1,25 @@
+import * as http from 'http';
+import * as Sentry from '@sentry/node';
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+Sentry.startSpan({ name: 'test_span' }, async () => {
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v0`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v1`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v2`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v3`);
+});
+
+function makeHttpRequest(url) {
+  return new Promise(resolve => {
+    http
+      .request(url, httpRes => {
+        httpRes.on('data', () => {
+          // we don't care about data
+        });
+        httpRes.on('end', () => {
+          resolve();
+        });
+      })
+      .end();
+  });
+}

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-esm/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-esm/test.ts
@@ -1,0 +1,40 @@
+import { join } from 'path';
+import { createRunner } from '../../../../utils/runner';
+import { createTestServer } from '../../../../utils/server';
+
+test('outgoing sampled http requests are correctly instrumented in ESM', done => {
+  expect.assertions(11);
+
+  createTestServer(done)
+    .get('/api/v0', headers => {
+      expect(headers['baggage']).toEqual(expect.any(String));
+      expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})-1$/));
+      expect(headers['sentry-trace']).not.toEqual('00000000000000000000000000000000-0000000000000000-1');
+    })
+    .get('/api/v1', headers => {
+      expect(headers['baggage']).toEqual(expect.any(String));
+      expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})-1$/));
+      expect(headers['sentry-trace']).not.toEqual('00000000000000000000000000000000-0000000000000000-1');
+    })
+    .get('/api/v2', headers => {
+      expect(headers['baggage']).toBeUndefined();
+      expect(headers['sentry-trace']).toBeUndefined();
+    })
+    .get('/api/v3', headers => {
+      expect(headers['baggage']).toBeUndefined();
+      expect(headers['sentry-trace']).toBeUndefined();
+    })
+    .start()
+    .then(([SERVER_URL, closeTestServer]) => {
+      const instrumentPath = join(__dirname, 'instrument.mjs');
+      createRunner(__dirname, 'scenario.mjs')
+        .withFlags('--import', instrumentPath)
+        .withEnv({ SERVER_URL })
+        .expect({
+          transaction: {
+            // we're not too concerned with the actual transaction here since this is tested elsewhere
+          },
+        })
+        .start(closeTestServer);
+    });
+});

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -338,6 +338,8 @@ export function createRunner(...paths: string[]) {
             const output = data.toString();
             logs.push(output.trim());
 
+            if (process.env.DEBUG) log('stderr line', output);
+
             if (ensureNoErrorOutput) {
               complete(new Error(`Expected no error output but got: '${output}'`));
             }


### PR DESCRIPTION
We do test `--import=instrument.mjs` in our e2e tests but there was nothing in the Node integration tests so I added this.