### PR TITLE
docs(nuxt): Remove beta notice

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -4,16 +4,13 @@
   </a>
 </p>
 
-# Official Sentry SDK for Nuxt (BETA)
+# Official Sentry SDK for Nuxt
 
 [![npm version](https://img.shields.io/npm/v/@sentry/nuxt.svg)](https://www.npmjs.com/package/@sentry/nuxt)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/nuxt.svg)](https://www.npmjs.com/package/@sentry/nuxt)
 [![npm dt](https://img.shields.io/npm/dt/@sentry/nuxt.svg)](https://www.npmjs.com/package/@sentry/nuxt)
 
-This SDK is in **Beta**. The API is stable but updates may include minor changes in behavior. Please reach out on
-[GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. This
-SDK is for [Nuxt](https://nuxt.com/). If you're using [Vue](https://vuejs.org/) see our
-[Vue SDK here](https://github.com/getsentry/sentry-javascript/tree/develop/packages/vue).
+This SDK is for [Nuxt](https://nuxt.com/). If you're using [Vue](https://vuejs.org/) see our [Vue SDK here](https://github.com/getsentry/sentry-javascript/tree/develop/packages/vue).
 
 ## Links
 
@@ -30,7 +27,7 @@ functionality related to Nuxt.
 
 **Limitations:**
 
-- Server monitoring is not available during development mode (`nuxt dev`)
+- Server-side (Nitro) tracing is not available during development mode (`nuxt dev`)
 
 ## Manual Setup
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -79,7 +79,8 @@ export default defineNuxtModule<ModuleOptions>({
           consoleSandbox(() => {
             // eslint-disable-next-line no-console
             console.log(
-              '[Sentry] Your application is running in development mode. Note: @sentry/nuxt is in beta and may not work as expected on the server-side (Nitro). Errors are reported, but tracing does not work.',
+              '%c [Sentry] Your application is running in development mode. @sentry/nuxt will only report errors and will not add performance tracing on the server-side (Nitro) in development mode.',
+              'color:#fe69c0',
             );
           });
         }


### PR DESCRIPTION
Removes the beta notice from the Nuxt SDK.
