### PR TITLE
meta(nuxt): Require minimum Nuxt v3.7.0

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-3-min",
-  "description": "E2E test app for the minimum nuxt 3 version our nuxt SDK supports.",
+  "description": "E2E test app for the minimum Nuxt 3 version our Nuxt SDK supports.",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@sentry/nuxt": "latest || *",
-    "nuxt": "3.13.2"
+    "nuxt": "3.7.0"
   },
   "devDependencies": {
     "@nuxt/test-utils": "^3.14.1",
@@ -24,7 +24,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "overrides": {
-    "nitropack": "2.9.7",
-    "@vercel/nft": "^0.27.4"
+    "nitropack": "2.10.0",
+    "ofetch": "1.4.0"
   }
 }

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -39,9 +39,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "nuxt": ">=3.7.0 || 4.x",
-    "nitropack": ">=2.10.0",
-    "ofetch": ">=1.4.0"
+    "nuxt": ">=3.7.0 || 4.x"
   },
   "dependencies": {
     "@nuxt/kit": "^3.13.2",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -39,7 +39,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "nuxt": "3.x"
+    "nuxt": ">=3.7.0 || 4.x",
+    "nitropack": ">=2.10.0",
+    "ofetch": ">=1.4.0"
   },
   "dependencies": {
     "@nuxt/kit": "^3.13.2",

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -13,7 +13,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: '@sentry/nuxt/module',
     configKey: 'sentry',
     compatibility: {
-      nuxt: '^3.0.0',
+      nuxt: '>=3.7.0',
     },
   },
   defaults: {},


### PR DESCRIPTION
This PR adds a minimum required version for the Nuxt SDK. Version 3.7.0 was selected because this version adds the possibility to set client source maps to `'hidden'` ([PR here](https://github.com/nuxt/nuxt/pull/22787)).

However, as the SDK relies on other versions as well (see below, at the bottom), those packages need to be manually bumped (in case the lock-file is not updated yet). **Nuxt 3.7.0** at least supports the correct version range:
["nitropack": "^2.6.1"](https://github.com/nuxt/nuxt/blob/v3.7.0/packages/nuxt/package.json#L84)
["ofetch": "^1.3.3"](https://github.com/nuxt/nuxt/blob/v3.7.0/packages/nuxt/package.json#L87)

 Above **Nuxt v3.14.0**, everything works out of the box, as the versions are already updated:
["nitropack": "^2.10.2"](https://github.com/nuxt/nuxt/blob/v3.14.0/packages/nuxt/package.json#L97)
["ofetch": "^1.4.1"](https://github.com/nuxt/nuxt/blob/v3.14.0/packages/nuxt/package.json#L100)

#### Minimum versions, the SDK relies on:
- `nitropack` 2.10.0: for the correct peerDependency of `@vercel/nft`
- `ofetch` 1.4.0: for being able to patch `$fetch`
