### PR TITLE
ref(google-cloud-serverless/v9): Update event functions to avoid `any`

### DIFF
--- a/packages/google-cloud-serverless/src/gcpfunction/general.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/general.ts
@@ -1,24 +1,20 @@
 import type { Request, Response } from 'express';
 
-export interface HttpFunction {
-  (req: Request, res: Response): any; // eslint-disable-line @typescript-eslint/no-explicit-any
-}
+export type HttpFunction = (req: Request, res: Response) => void;
 
-export interface EventFunction {
-  (data: Record<string, any>, context: Context): any; // eslint-disable-line @typescript-eslint/no-explicit-any
-}
+export type EventFunction = (data: Record<string, unknown>, context: Context) => void;
 
-export interface EventFunctionWithCallback {
-  (data: Record<string, any>, context: Context, callback: Function): any; // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-}
+export type EventFunctionWithCallback = (
+  data: Record<string, unknown>,
+  context: Context,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  callback: Function,
+) => void;
 
-export interface CloudEventFunction {
-  (cloudevent: CloudEventsContext): any; // eslint-disable-line @typescript-eslint/no-explicit-any
-}
+export type CloudEventFunction = (cloudevent: CloudEventsContext) => void;
 
-export interface CloudEventFunctionWithCallback {
-  (cloudevent: CloudEventsContext, callback: Function): any; // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-}
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type CloudEventFunctionWithCallback = (cloudevent: CloudEventsContext, callback: Function) => void;
 
 export interface CloudFunctionsContext {
   eventId?: string;

--- a/packages/google-cloud-serverless/src/utils.ts
+++ b/packages/google-cloud-serverless/src/utils.ts
@@ -16,14 +16,14 @@ export function domainify<A extends unknown[], R>(fn: (...args: A) => R): (...ar
  * @returns wrapped function
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function proxyFunction<A extends any[], R, F extends (...args: A) => R>(
+export function proxyFunction<F extends (...args: any[]) => unknown>(
   source: F,
   wrap: (source: F) => F,
   overrides?: Record<PropertyKey, unknown>,
 ): F {
   const wrapper = wrap(source);
   const handler: ProxyHandler<F> = {
-    apply: <T>(_target: F, thisArg: T, args: A) => {
+    apply: <T>(_target: F, thisArg: T, args: Parameters<F>) => {
       return wrapper.apply(thisArg, args);
     },
   };


### PR DESCRIPTION
This refactors google-cloud-serverless to avoid some `any` in types. Since these are kind-of public, although this is extremely unlikely to affect anybody (because we mostly replace `any` with `unknown` which should also accept anything, basically), we'll still only merge this for v9.

Extracted out of https://github.com/getsentry/sentry-javascript/pull/14463