### PR TITLE
chore(nuxt): Remove nft override to ensure we are testing with latest nitro

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
@@ -21,8 +21,5 @@
     "@nuxt/test-utils": "^3.14.1",
     "@playwright/test": "^1.44.1",
     "@sentry-internal/test-utils": "link:../../../test-utils"
-  },
-  "overrides": {
-    "@vercel/nft": "0.27.4"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@sentry/nuxt": "latest || *",
-    "nuxt": "^3.13.1"
+    "nuxt": "^3.14.0"
   },
   "devDependencies": {
     "@nuxt/test-utils": "^3.14.1",


### PR DESCRIPTION
Noticed that our e2e tests are not actually using nitro 2.10 despite being on the latest nuxt version: https://github.com/getsentry/sentry-javascript/actions/runs/12028119465/job/33531969920#step:13:196

This fixes it.