### PR TITLE
chore: Add GHSA entry for nuxt e2e test

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,7 +1,9 @@
 fail-on-severity: 'high'
 allow-ghsas:
   # dependency review does not allow specific file exclusions
-  # we use an older version of NextJS in our tests and thus need to 
+  # we use an older version of NextJS in our tests and thus need to
   # exclude this
   # once our minimum supported version is over 14.1.1 this can be removed
   - GHSA-fr5h-rqp8-mj6g
+  # we need this for an E2E test for the minimum required version of Nuxt 3.7.0
+  - GHSA-v784-fjjh-f8r4


### PR DESCRIPTION
Updates dependency review allow list for a vulnerable version that we need to test in an e2e test.