### PR TITLE
fix(nuxt): Avoid sending resource request transactions

### DIFF
--- a/packages/nuxt/src/server/sdk.ts
+++ b/packages/nuxt/src/server/sdk.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { applySdkMetadata, flush, getGlobalScope } from '@sentry/core';
 import { logger, vercelWaitUntil } from '@sentry/core';
 import {
@@ -9,7 +10,6 @@ import {
 import type { Client, EventProcessor, Integration } from '@sentry/types';
 import { DEBUG_BUILD } from '../common/debug-build';
 import type { SentryNuxtServerOptions } from '../common/types';
-import * as path from 'node:path';
 
 /**
  * Initializes the server-side of the Nuxt SDK

--- a/packages/nuxt/src/server/sdk.ts
+++ b/packages/nuxt/src/server/sdk.ts
@@ -9,6 +9,7 @@ import {
 import type { Client, EventProcessor, Integration } from '@sentry/types';
 import { DEBUG_BUILD } from '../common/debug-build';
 import type { SentryNuxtServerOptions } from '../common/types';
+import * as path from 'node:path';
 
 /**
  * Initializes the server-side of the Nuxt SDK
@@ -33,23 +34,26 @@ export function init(options: SentryNuxtServerOptions): Client | undefined {
 }
 
 /**
- * Filter out transactions for Nuxt build assets
- * This regex matches the default path to the nuxt-generated build assets (`_nuxt`).
+ * Filter out transactions for resource requests which we don't want to send to Sentry
+ * for quota reasons.
  *
  * Only exported for testing
  */
 export function lowQualityTransactionsFilter(options: SentryNuxtServerOptions): EventProcessor {
   return Object.assign(
     (event => {
-      if (event.type === 'transaction' && event.transaction?.match(/^GET \/_nuxt\//)) {
-        // todo: the buildAssetDir could be changed in the nuxt config - change this to a more generic solution
+      if (event.type !== 'transaction' || !event.transaction) {
+        return event;
+      }
+      // We don't want to send transaction for file requests, so everything ending with a *.someExtension should be filtered out
+      // path.extname will return an empty string for normal page requests
+      if (path.extname(event.transaction)) {
         options.debug &&
           DEBUG_BUILD &&
           logger.log('NuxtLowQualityTransactionsFilter filtered transaction: ', event.transaction);
         return null;
-      } else {
-        return event;
       }
+      return event;
     }) satisfies EventProcessor,
     { id: 'NuxtLowQualityTransactionsFilter' },
   );


### PR DESCRIPTION
This PR refactors the low quality transaction filter in the Nuxt SDK to filter out all resource requests. Unless I'm missing something, our SDKs should generally not send dedicated transactions for resource requests as they would deplete transaction quota fairly quickly, compared to only tracking page requests. 

The heuristic I chose is pretty simple. Using `path.extname` we get a falsy value if the transaction name does not end in a file extension. Which should be enough but it's almost too good to be true 🤔 

Let's see what our e2e tests have to say... welp turns out they're happy 😅 