### PR TITLE
fix(astro): Fix astro trace propagation issues

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.server.test.ts
@@ -37,7 +37,9 @@ test.describe('server-side errors', () => {
         os: expect.any(Object),
         runtime: expect.any(Object),
         trace: {
-          span_id: spanId,
+          // TODO: This is a bug, this should be spanId
+          // This is due to generateSpanContextForPropagationContext() returning '' as fallback
+          span_id: '',
           trace_id: traceId,
         },
       },

--- a/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.server.test.ts
@@ -37,9 +37,7 @@ test.describe('server-side errors', () => {
         os: expect.any(Object),
         runtime: expect.any(Object),
         trace: {
-          // TODO: This is a bug, this should be spanId
-          // This is due to generateSpanContextForPropagationContext() returning '' as fallback
-          span_id: '',
+          span_id: spanId,
           trace_id: traceId,
         },
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean:build": "lerna run clean",
     "clean:caches": "yarn rimraf eslintcache .nxcache && yarn jest --clearCache",
     "clean:deps": "lerna clean --yes && rm -rf node_modules && yarn",
-    "clean:tarballs": "rimraf -g **/*.tgz",
+    "clean:tarballs": "rimraf {packages,dev-packages}/*/*.tgz",
     "clean:all": "run-s clean:build clean:tarballs clean:caches clean:deps",
     "fix": "run-s fix:biome fix:prettier fix:lerna",
     "fix:lerna": "lerna run fix",

--- a/packages/opentelemetry/src/utils/generateSpanContextForPropagationContext.ts
+++ b/packages/opentelemetry/src/utils/generateSpanContextForPropagationContext.ts
@@ -1,6 +1,5 @@
 import type { SpanContext } from '@opentelemetry/api';
 import { TraceFlags } from '@opentelemetry/api';
-import { uuid4 } from '@sentry/core';
 import type { PropagationContext } from '@sentry/types';
 import { makeTraceState } from './makeTraceState';
 
@@ -18,8 +17,8 @@ export function generateSpanContextForPropagationContext(propagationContext: Pro
 
   const spanContext: SpanContext = {
     traceId: propagationContext.traceId,
-    // If we have no parent span ID, just generate a random one
-    spanId: propagationContext.parentSpanId || uuid4().substring(16),
+    // TODO: Do not create an invalid span context here
+    spanId: propagationContext.parentSpanId || '',
     isRemote: true,
     traceFlags: propagationContext.sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
     traceState,

--- a/packages/opentelemetry/src/utils/generateSpanContextForPropagationContext.ts
+++ b/packages/opentelemetry/src/utils/generateSpanContextForPropagationContext.ts
@@ -1,5 +1,6 @@
 import type { SpanContext } from '@opentelemetry/api';
 import { TraceFlags } from '@opentelemetry/api';
+import { uuid4 } from '@sentry/core';
 import type { PropagationContext } from '@sentry/types';
 import { makeTraceState } from './makeTraceState';
 
@@ -17,7 +18,8 @@ export function generateSpanContextForPropagationContext(propagationContext: Pro
 
   const spanContext: SpanContext = {
     traceId: propagationContext.traceId,
-    spanId: propagationContext.parentSpanId || '',
+    // If we have no parent span ID, just generate a random one
+    spanId: propagationContext.parentSpanId || uuid4().substring(16),
     isRemote: true,
     traceFlags: propagationContext.sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
     traceState,

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -1521,8 +1521,8 @@ describe('continueTrace', () => {
       const span = getActiveSpan()!;
       expect(span).toBeDefined();
       expect(spanToJSON(span)).toEqual({
-        span_id: '',
-        trace_id: expect.any(String),
+        span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
+        trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
       });
       expect(getSamplingDecision(span.spanContext())).toBe(undefined);
       expect(spanIsSampled(span)).toBe(false);

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -1521,8 +1521,8 @@ describe('continueTrace', () => {
       const span = getActiveSpan()!;
       expect(span).toBeDefined();
       expect(spanToJSON(span)).toEqual({
-        span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
-        trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
+        span_id: '',
+        trace_id: expect.any(String),
       });
       expect(getSamplingDecision(span.spanContext())).toBe(undefined);
       expect(spanIsSampled(span)).toBe(false);


### PR DESCRIPTION
Noticed this while working on https://github.com/getsentry/sentry-javascript/pull/14481.

This PR fixes a bug in our opentelemetry code that lead to invalid empty span IDs being generated in certain cases. 
Instead, we now generate valid (but random) span IDs in this case.

Additionally, I also noticed that the way we try-catched the astro server request code lead to the http.server span not being attached to servers correctly - we had a try-catch block _outside_ of the `startSpan` call, where we sent caught errors to sentry. but any error caught this way would not have an active span (because by the time the `catch` part triggers, `startSpan` is over), and thus the http.server span would not be attached to the error. By moving this try-catch inside of the `startSpan` call, we can correctly assign the span to errors. I also tried to add some tests to this - there is still a problem in there which the tests show, which I'll look at afterwards (and/or they may get fixed by https://github.com/getsentry/sentry-javascript/pull/14481)


UPDATE: Turns out part of this, the generation of an `''` span ID, has other implications - otel ignores this as it is invalid, so changing this breaks the pure otel E2E apps. I'll tackle this separately, this PR only handles better try-catching of error traces now.