### PR TITLE
feat(core/utils): Deprecate `_browserPerformanceTimeOriginMode`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -36,6 +36,7 @@
 - Deprecated `BAGGAGE_HEADER_NAME`. No replacements.
 - Deprecated `makeFifoCache`. No replacements.
 - Deprecated `flatten`. No replacements.
+- Deprecated `_browserPerformanceTimeOriginMode`. No replacements.
 
 ## `@sentry/core`
 

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -113,6 +113,7 @@ export {
 } from './supports';
 export { SyncPromise, rejectedSyncPromise, resolvedSyncPromise } from './syncpromise';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   _browserPerformanceTimeOriginMode,
   browserPerformanceTimeOrigin,
   dateTimestampInSeconds,

--- a/packages/core/src/utils-hoist/time.ts
+++ b/packages/core/src/utils-hoist/time.ts
@@ -70,6 +70,8 @@ export const timestampInSeconds = createUnixTimestampInSecondsFunc();
 
 /**
  * Internal helper to store what is the source of browserPerformanceTimeOrigin below. For debugging only.
+ *
+ * @deprecated This variable will be removed in the next major version.
  */
 export let _browserPerformanceTimeOriginMode: string;
 
@@ -84,6 +86,7 @@ export const browserPerformanceTimeOrigin = ((): number | undefined => {
 
   const { performance } = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
   if (!performance || !performance.now) {
+    // eslint-disable-next-line deprecation/deprecation
     _browserPerformanceTimeOriginMode = 'none';
     return undefined;
   }
@@ -113,15 +116,18 @@ export const browserPerformanceTimeOrigin = ((): number | undefined => {
   if (timeOriginIsReliable || navigationStartIsReliable) {
     // Use the more reliable time origin
     if (timeOriginDelta <= navigationStartDelta) {
+      // eslint-disable-next-line deprecation/deprecation
       _browserPerformanceTimeOriginMode = 'timeOrigin';
       return performance.timeOrigin;
     } else {
+      // eslint-disable-next-line deprecation/deprecation
       _browserPerformanceTimeOriginMode = 'navigationStart';
       return navigationStart;
     }
   }
 
   // Either both timeOrigin and navigationStart are skewed or neither is available, fallback to Date.
+  // eslint-disable-next-line deprecation/deprecation
   _browserPerformanceTimeOriginMode = 'dateNow';
   return dateNow;
 })();

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -593,6 +593,7 @@ export const supportsReferrerPolicy = supportsReferrerPolicy_imported;
 export const supportsReportingObserver = supportsReportingObserver_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
+// eslint-disable-next-line deprecation/deprecation
 export const _browserPerformanceTimeOriginMode = _browserPerformanceTimeOriginMode_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */


### PR DESCRIPTION
This export is completely internal and should not be exposed.