### PR TITLE
feat(core/utils): Deprecate `dynamicRequire`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -35,6 +35,7 @@
 - Deprecated `getNumberOfUrlSegments`. No replacements.
 - Deprecated `BAGGAGE_HEADER_NAME`. No replacements.
 - Deprecated `makeFifoCache`. No replacements.
+- Deprecated `dynamicRequire`. No replacements.
 - Deprecated `flatten`. No replacements.
 
 ## `@sentry/core`

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -49,6 +49,7 @@ export {
   parseSemver,
   uuid4,
 } from './misc';
+// eslint-disable-next-line deprecation/deprecation
 export { dynamicRequire, isNodeEnv, loadModule } from './node';
 export { normalize, normalizeToSize, normalizeUrlToBase } from './normalize';
 export {

--- a/packages/core/src/utils-hoist/node.ts
+++ b/packages/core/src/utils-hoist/node.ts
@@ -23,6 +23,7 @@ export function isNodeEnv(): boolean {
  * Requires a module which is protected against bundler minification.
  *
  * @param request The module path to resolve
+ * @deprecated This function will be removed in the next major version.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function dynamicRequire(mod: any, request: string): any {
@@ -47,6 +48,7 @@ export function loadModule<T>(moduleName: string): T | undefined {
   let mod: T | undefined;
 
   try {
+    // eslint-disable-next-line deprecation/deprecation
     mod = dynamicRequire(module, moduleName);
   } catch (e) {
     // no-empty
@@ -54,7 +56,9 @@ export function loadModule<T>(moduleName: string): T | undefined {
 
   if (!mod) {
     try {
+      // eslint-disable-next-line deprecation/deprecation
       const { cwd } = dynamicRequire(module, 'process');
+      // eslint-disable-next-line deprecation/deprecation
       mod = dynamicRequire(module, `${cwd()}/node_modules/${moduleName}`) as T;
     } catch (e) {
       // no-empty

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -602,6 +602,7 @@ export const browserPerformanceTimeOrigin = browserPerformanceTimeOrigin_importe
 export const supportsHistory = supportsHistory_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
+// eslint-disable-next-line deprecation/deprecation
 export const dynamicRequire = dynamicRequire_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */


### PR DESCRIPTION
The function is purely internal and should not be exposed.