### PR TITLE
feat(remix): Deprecate `autoInstrumentRemix: false`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -87,6 +87,10 @@
   });
   ```
 
+## `@sentry/remix`
+
+- Deprecated `autoInstrumentRemix: false`. The next major version will default to behaving as if this option were `true` and the option itself will be removed.
+
 ## Server-side SDKs (`@sentry/node` and all dependents)
 
 - Deprecated `processThreadBreadcrumbIntegration` in favor of `childProcessIntegration`. Functionally they are the same.

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -168,6 +168,7 @@ export function getRemixDefaultIntegrations(options: RemixOptions): Integration[
   return [
     ...getDefaultNodeIntegrations(options as NodeOptions).filter(integration => integration.name !== 'Http'),
     httpIntegration(),
+    // eslint-disable-next-line deprecation/deprecation
     options.autoInstrumentRemix ? remixIntegration() : undefined,
   ].filter(int => int) as Integration[];
 }

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -399,6 +399,7 @@ export function instrumentBuild(
   build: ServerBuild | (() => ServerBuild | Promise<ServerBuild>),
   options: RemixOptions,
 ): ServerBuild | (() => ServerBuild | Promise<ServerBuild>) {
+  // eslint-disable-next-line deprecation/deprecation
   const autoInstrumentRemix = options?.autoInstrumentRemix || false;
 
   if (typeof build === 'function') {
@@ -434,6 +435,7 @@ const makeWrappedCreateRequestHandler = (options: RemixOptions) =>
       const newBuild = instrumentBuild(build, options);
       const requestHandler = origCreateRequestHandler.call(this, newBuild, ...args);
 
+      // eslint-disable-next-line deprecation/deprecation
       return wrapRequestHandler(requestHandler, newBuild, options.autoInstrumentRemix || false);
     };
   };

--- a/packages/remix/src/utils/remixOptions.ts
+++ b/packages/remix/src/utils/remixOptions.ts
@@ -4,5 +4,21 @@ import type { Options } from '@sentry/types';
 
 export type RemixOptions = (Options | BrowserOptions | NodeOptions) & {
   captureActionFormDataKeys?: Record<string, string | boolean>;
-  autoInstrumentRemix?: boolean;
-};
+} & (
+    | {
+        /**
+         * Enables OpenTelemetry Remix instrumentation.
+         *
+         * Note: This option will be the default behavior and will be removed in the next major version.
+         */
+        autoInstrumentRemix?: true;
+      }
+    | {
+        /**
+         * Enables OpenTelemetry Remix instrumentation
+         *
+         * @deprecated Setting this option to `false` is deprecated as the next major version will default to behaving as if this option were `true` and the option itself will be removed.
+         */
+        autoInstrumentRemix?: false;
+      }
+  );

--- a/packages/remix/src/utils/remixOptions.ts
+++ b/packages/remix/src/utils/remixOptions.ts
@@ -18,6 +18,7 @@ export type RemixOptions = (Options | BrowserOptions | NodeOptions) & {
          * Enables OpenTelemetry Remix instrumentation
          *
          * @deprecated Setting this option to `false` is deprecated as the next major version will default to behaving as if this option were `true` and the option itself will be removed.
+         * It is recommended to set this option to `true`.
          */
         autoInstrumentRemix?: false;
       }


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/14507

`autoInstrumentRemix` will be removed in v9 in favor of a coherent unified instrumentation experience OOTB.