### PR TITLE
ref(node): Avoid using propagator for node-fetch TWP instrumentation

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -93,6 +93,10 @@
 
 - Deprecated `autoInstrumentRemix: false`. The next major version will default to behaving as if this option were `true` and the option itself will be removed.
 
+## `@sentry/opentelemetry`
+
+- Deprecated `generateSpanContextForPropagationContext` in favor of doing this manually - we do not need this export anymore.
+
 ## Server-side SDKs (`@sentry/node` and all dependents)
 
 - Deprecated `processThreadBreadcrumbIntegration` in favor of `childProcessIntegration`. Functionally they are the same.

--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -1,6 +1,6 @@
 import type { UndiciRequest, UndiciResponse } from '@opentelemetry/instrumentation-undici';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
-import { getClient, getTraceData, LRUMap } from '@sentry/core';
+import { LRUMap, getClient, getTraceData } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, addBreadcrumb, defineIntegration, hasTracingEnabled } from '@sentry/core';
 import { getBreadcrumbLogLevelFromHttpStatusCode, getSanitizedUrlString, parseUrl } from '@sentry/core';
 import { addOpenTelemetryInstrumentation, shouldPropagateTraceForUrl } from '@sentry/opentelemetry';

--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -1,19 +1,9 @@
-import { context, propagation, trace } from '@opentelemetry/api';
 import type { UndiciRequest, UndiciResponse } from '@opentelemetry/instrumentation-undici';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  addBreadcrumb,
-  defineIntegration,
-  getCurrentScope,
-  hasTracingEnabled,
-} from '@sentry/core';
+import { getTraceData } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, addBreadcrumb, defineIntegration, hasTracingEnabled } from '@sentry/core';
 import { getBreadcrumbLogLevelFromHttpStatusCode, getSanitizedUrlString, parseUrl } from '@sentry/core';
-import {
-  addOpenTelemetryInstrumentation,
-  generateSpanContextForPropagationContext,
-  getPropagationContextFromSpan,
-} from '@sentry/opentelemetry';
+import { addOpenTelemetryInstrumentation } from '@sentry/opentelemetry';
 import type { IntegrationFn, SanitizedRequestData } from '@sentry/types';
 
 interface NodeFetchOptions {
@@ -50,23 +40,7 @@ const _nativeNodeFetchIntegration = ((options: NodeFetchOptions = {}) => {
           // If tracing is disabled, we still want to propagate traces
           // So we do that manually here, matching what the instrumentation does otherwise
           if (!hasTracingEnabled()) {
-            const ctx = context.active();
-            const addedHeaders: Record<string, string> = {};
-
-            // We generate a virtual span context from the active one,
-            // Where we attach the URL to the trace state, so the propagator can pick it up
-            const activeSpan = trace.getSpan(ctx);
-            const propagationContext = activeSpan
-              ? getPropagationContextFromSpan(activeSpan)
-              : getCurrentScope().getPropagationContext();
-
-            const spanContext = generateSpanContextForPropagationContext(propagationContext);
-            // We know that in practice we'll _always_ haven a traceState here
-            spanContext.traceState = spanContext.traceState?.set('sentry.url', url);
-            const ctxWithUrlTraceState = trace.setSpanContext(ctx, spanContext);
-
-            propagation.inject(ctxWithUrlTraceState, addedHeaders);
-
+            const addedHeaders = getTraceData();
             const requestHeaders = request.headers;
             if (Array.isArray(requestHeaders)) {
               Object.entries(addedHeaders).forEach(headers => requestHeaders.push(...headers));

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -45,7 +45,11 @@ export { setupEventContextTrace } from './setupEventContextTrace';
 
 export { setOpenTelemetryContextAsyncContextStrategy } from './asyncContextStrategy';
 export { wrapContextManagerClass } from './contextManager';
-export { SentryPropagator, getPropagationContextFromSpan } from './propagator';
+export {
+  SentryPropagator,
+  getPropagationContextFromSpan,
+  shouldPropagateTraceForUrl,
+} from './propagator';
 export { SentrySpanProcessor } from './spanProcessor';
 export {
   SentrySampler,

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -24,6 +24,7 @@ export { getDynamicSamplingContextFromSpan } from '@sentry/core';
 export { isSentryRequestSpan } from './utils/isSentryRequest';
 
 export { enhanceDscWithOpenTelemetryRootSpanName } from './utils/enhanceDscWithOpenTelemetryRootSpanName';
+// eslint-disable-next-line deprecation/deprecation
 export { generateSpanContextForPropagationContext } from './utils/generateSpanContextForPropagationContext';
 
 export { getActiveSpan } from './utils/getActiveSpan';

--- a/packages/opentelemetry/src/utils/generateSpanContextForPropagationContext.ts
+++ b/packages/opentelemetry/src/utils/generateSpanContextForPropagationContext.ts
@@ -6,6 +6,8 @@ import { makeTraceState } from './makeTraceState';
 /**
  * Generates a SpanContext that represents a PropagationContext.
  * This can be set on a `context` to make this a (virtual) active span.
+ *
+ * @deprecated This function is deprecated and will be removed in the next major version.
  */
 export function generateSpanContextForPropagationContext(propagationContext: PropagationContext): SpanContext {
   // We store the DSC as OTEL trace state on the span context


### PR DESCRIPTION
Instead, use the new and improved `getTraceData` directly, which avoids URL issues etc. and just gets the trace data.

This also deprecates `generateSpanContextForPropagationContext` and inlines it to the one place we still use this for, I'll probably adapt this in a follow up PR.