### PR TITLE
feat(browser): Attach virtual stack traces to `HttpClient` events.

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
@@ -40,6 +40,15 @@ sentryTest(
               type: 'http.client',
               handled: false,
             },
+            stacktrace: {
+              frames: expect.arrayContaining([
+                expect.objectContaining({
+                  filename: 'http://sentry-test.io/subject.bundle.js',
+                  function: '?',
+                  in_app: true,
+                }),
+              ]),
+            },
           },
         ],
       },

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
@@ -42,6 +42,15 @@ sentryTest(
               type: 'http.client',
               handled: false,
             },
+            stacktrace: {
+              frames: expect.arrayContaining([
+                expect.objectContaining({
+                  filename: 'http://sentry-test.io/subject.bundle.js',
+                  function: '?',
+                  in_app: true,
+                }),
+              ]),
+            },
           },
         ],
       },

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/test.ts
@@ -38,6 +38,15 @@ sentryTest('works with a Request passed in', async ({ getLocalTestUrl, page }) =
             type: 'http.client',
             handled: false,
           },
+          stacktrace: {
+            frames: expect.arrayContaining([
+              expect.objectContaining({
+                filename: 'http://sentry-test.io/subject.bundle.js',
+                function: '?',
+                in_app: true,
+              }),
+            ]),
+          },
         },
       ],
     },

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/test.ts
@@ -40,6 +40,15 @@ sentryTest(
               type: 'http.client',
               handled: false,
             },
+            stacktrace: {
+              frames: expect.arrayContaining([
+                expect.objectContaining({
+                  filename: 'http://sentry-test.io/subject.bundle.js',
+                  function: '?',
+                  in_app: true,
+                }),
+              ]),
+            },
           },
         ],
       },

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/test.ts
@@ -38,6 +38,15 @@ sentryTest('works with a Request (without body) & options passed in', async ({ g
             type: 'http.client',
             handled: false,
           },
+          stacktrace: {
+            frames: expect.arrayContaining([
+              expect.objectContaining({
+                filename: 'http://sentry-test.io/subject.bundle.js',
+                function: '?',
+                in_app: true,
+              }),
+            ]),
+          },
         },
       ],
     },

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/test.ts
@@ -40,6 +40,15 @@ sentryTest(
               type: 'http.client',
               handled: false,
             },
+            stacktrace: {
+              frames: expect.arrayContaining([
+                expect.objectContaining({
+                  filename: 'http://sentry-test.io/subject.bundle.js',
+                  function: '?',
+                  in_app: true,
+                }),
+              ]),
+            },
           },
         ],
       },

--- a/dev-packages/browser-integration-tests/utils/generatePlugin.ts
+++ b/dev-packages/browser-integration-tests/utils/generatePlugin.ts
@@ -176,7 +176,6 @@ class SentryScenarioGenerationPlugin {
         }
       : {};
 
-    // Checking if the current scenario has imported `@sentry/integrations`.
     compiler.hooks.normalModuleFactory.tap(this._name, factory => {
       factory.hooks.parser.for('javascript/auto').tap(this._name, parser => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/packages/browser-utils/src/instrument/xhr.ts
+++ b/packages/browser-utils/src/instrument/xhr.ts
@@ -15,17 +15,14 @@ type WindowWithXhr = Window & { XMLHttpRequest?: typeof XMLHttpRequest };
  * Use at your own risk, this might break without changelog notice, only used internally.
  * @hidden
  */
-export function addXhrInstrumentationHandler(
-  handler: (data: HandlerDataXhr) => void,
-  httpClientInstrumented?: boolean,
-): void {
+export function addXhrInstrumentationHandler(handler: (data: HandlerDataXhr) => void): void {
   const type = 'xhr';
   addHandler(type, handler);
-  maybeInstrument(type, () => instrumentXHR(httpClientInstrumented));
+  maybeInstrument(type, instrumentXHR);
 }
 
 /** Exported only for tests. */
-export function instrumentXHR(httpClientInstrumented: boolean = false): void {
+export function instrumentXHR(): void {
   if (!(WINDOW as WindowWithXhr).XMLHttpRequest) {
     return;
   }
@@ -85,7 +82,7 @@ export function instrumentXHR(httpClientInstrumented: boolean = false): void {
             endTimestamp: timestampInSeconds() * 1000,
             startTimestamp,
             xhr: xhrOpenThisArg,
-            error: httpClientInstrumented ? virtualError : undefined,
+            stack: virtualError.stack,
           };
           triggerHandlers('xhr', handlerData);
         }

--- a/packages/browser-utils/src/instrument/xhr.ts
+++ b/packages/browser-utils/src/instrument/xhr.ts
@@ -82,7 +82,7 @@ export function instrumentXHR(): void {
             endTimestamp: timestampInSeconds() * 1000,
             startTimestamp,
             xhr: xhrOpenThisArg,
-            stack: virtualError.stack,
+            virtualError,
           };
           triggerHandlers('xhr', handlerData);
         }

--- a/packages/browser/src/integrations/httpclient.ts
+++ b/packages/browser/src/integrations/httpclient.ts
@@ -46,7 +46,7 @@ const _httpClientIntegration = ((options: Partial<HttpClientOptions> = {}) => {
 
   return {
     name: INTEGRATION_NAME,
-    setup(client: Client): void {
+    setup(client): void {
       _wrapFetch(client, _options);
       _wrapXHR(client, _options);
     },
@@ -93,10 +93,7 @@ function _fetchResponseHandler(
       stacktrace: error instanceof Error ? error.stack : undefined,
     });
 
-    // withScope(scope => {
-    //   scope.setFingerprint([request.url, request.method, response.status.toString()]);
     captureEvent(event);
-    // });
   }
 }
 

--- a/packages/core/src/types-hoist/instrument.ts
+++ b/packages/core/src/types-hoist/instrument.ts
@@ -32,7 +32,7 @@ export interface HandlerDataXhr {
   xhr: SentryWrappedXMLHttpRequest;
   startTimestamp?: number;
   endTimestamp?: number;
-  error?: unknown;
+  stack?: string;
 }
 
 interface SentryFetchData {
@@ -57,6 +57,7 @@ export interface HandlerDataFetch {
     headers: WebFetchHeaders;
   };
   error?: unknown;
+  stack?: string;
 }
 
 export interface HandlerDataDom {

--- a/packages/core/src/types-hoist/instrument.ts
+++ b/packages/core/src/types-hoist/instrument.ts
@@ -32,6 +32,7 @@ export interface HandlerDataXhr {
   xhr: SentryWrappedXMLHttpRequest;
   startTimestamp?: number;
   endTimestamp?: number;
+  error?: unknown;
 }
 
 interface SentryFetchData {

--- a/packages/core/src/types-hoist/instrument.ts
+++ b/packages/core/src/types-hoist/instrument.ts
@@ -32,7 +32,9 @@ export interface HandlerDataXhr {
   xhr: SentryWrappedXMLHttpRequest;
   startTimestamp?: number;
   endTimestamp?: number;
-  stack?: string;
+  error?: unknown;
+  // This is to be consumed by the HttpClient integration
+  virtualError?: unknown;
 }
 
 interface SentryFetchData {
@@ -57,7 +59,8 @@ export interface HandlerDataFetch {
     headers: WebFetchHeaders;
   };
   error?: unknown;
-  stack?: string;
+  // This is to be consumed by the HttpClient integration
+  virtualError?: unknown;
 }
 
 export interface HandlerDataDom {

--- a/packages/core/src/utils-hoist/instrument/fetch.ts
+++ b/packages/core/src/utils-hoist/instrument/fetch.ts
@@ -48,7 +48,7 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
 
   fill(GLOBAL_OBJ, 'fetch', function (originalFetch: () => void): () => void {
     return function (...args: any[]): void {
-      // We capture the stack right here and not in the Promise error callback because Safari (and probably other
+      // We capture the error right here and not in the Promise error callback because Safari (and probably other
       // browsers too) will wipe the stack trace up to this point, only leaving us with this file which is useless.
 
       // NOTE: If you are a Sentry user, and you are seeing this stack frame,
@@ -56,7 +56,6 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
       //       have a stack trace, so the SDK backfilled the stack trace so
       //       you can see which fetch call failed.
       const virtualError = new Error();
-      const virtualStackTrace = virtualError.stack;
 
       const { method, url } = parseFetchArgs(args);
       const handlerData: HandlerDataFetch = {
@@ -66,7 +65,8 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
           url,
         },
         startTimestamp: timestampInSeconds() * 1000,
-        stack: virtualStackTrace,
+        // // Adding the error to be able to fingerprint the failed fetch event in HttpClient instrumentation
+        virtualError,
       };
 
       // if there is no callback, fetch is instrumented directly
@@ -82,7 +82,6 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
           if (onFetchResolved) {
             onFetchResolved(response);
           } else {
-            // Adding the stacktrace to be able to fingerprint the failed fetch event in HttpClient instrumentation
             triggerHandlers('fetch', {
               ...handlerData,
               endTimestamp: timestampInSeconds() * 1000,
@@ -104,7 +103,7 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
             //       it means the error, that was caused by your fetch call did not
             //       have a stack trace, so the SDK backfilled the stack trace so
             //       you can see which fetch call failed.
-            error.stack = virtualStackTrace;
+            error.stack = virtualError.stack;
             addNonEnumerableProperty(error, 'framesToPop', 1);
           }
 


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-javascript/issues/8353

Updated `fetch` and `xhr` wrappers to pass virtual errors to the `HttpClient` integration so we can group the events with the stack traces. 

It seems we can't create the virtual errors inside the `HttpClient` integration, as we're losing the non-Sentry frames.

Sampled fetch event - [Link](https://sentry-sdks.sentry.io/issues/6094873721/?project=5659328&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=1m&stream_index=0)
Sampled XHR event - [Link](https://sentry-sdks.sentry.io/issues/6094938511/?project=5659328&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1m&stream_index=0)
