### PR TITLE
feat(nuxt): Deprecate `tracingOptions` in favor of `vueIntegration`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -68,6 +68,10 @@
 
 - Deprecated `Request` in favor of `RequestEventData`.
 
+## `@sentry/nuxt`
+
+- Deprecated `tracingOptions` in `Sentry.init()` in favor of passing the `vueIntegration()` to `Sentry.init({ integrations: [...] })` and setting `tracingOptions` there.
+
 ## `@sentry/vue`
 
 - Deprecated `tracingOptions`, `trackComponents`, `timeout`, `hooks` options everywhere other than in the `tracingOptions` option of the `vueIntegration()`.

--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -8,7 +8,14 @@ import type { Options, TracingOptions } from './types';
  * Inits the Vue SDK
  */
 export function init(
-  config: Partial<Omit<Options, 'tracingOptions'> & { tracingOptions: Partial<TracingOptions> }> = {},
+  config: Partial<
+    Omit<Options, 'tracingOptions'> & {
+      /**
+       * @deprecated Add the `vueIntegration()` and pass the `tracingOptions` there instead.
+       */
+      tracingOptions: Partial<TracingOptions>;
+    }
+  > = {},
 ): Client | undefined {
   const options = {
     _metadata: {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/14265

Deprecates the `tracingOptions` in favor of the newly exposed `vueIntegration` so that we can streamline the setting of these options.