### PR TITLE
test(ember): Skip ember-embroider E2E test for now

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-classic/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/package.json
@@ -18,7 +18,7 @@
     "test:build": "pnpm install && npx playwright install && pnpm build",
     "test:build-latest": "pnpm install && pnpm add ember-source@latest && npx playwright install && pnpm build",
     "test:assert": "playwright test",
-    "clean": "npx rimraf node_modules,pnpm-lock.yaml,dist"
+    "clean": "npx rimraf node_modules pnpm-lock.yaml dist"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -18,7 +18,7 @@
     "test:build": "pnpm install && npx playwright install && pnpm build",
     "test:build-latest": "pnpm install && pnpm add ember-source@latest && npx playwright install && pnpm build",
     "test:assert": "playwright test",
-    "clean": "npx rimraf node_modules,pnpm-lock.yaml,dist"
+    "clean": "npx rimraf node_modules pnpm-lock.yaml dist"
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -70,6 +70,6 @@
     "extends": "../../package.json"
   },
   "sentryTest": {
-    "ignore": true
+    "skip": true
   }
 }

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -68,5 +68,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "sentryTest": {
+    "ignore": true
   }
 }


### PR DESCRIPTION
This is failing due to some dependency shenanigans, so skipping this for now until we can figure this out.