### PR TITLE
feat: Warn about source-map generation

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -35,6 +35,15 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
 
         // We don't need to check for AUTH_TOKEN here, because the plugin will pick it up from the env
         if (shouldUploadSourcemaps && command !== 'dev') {
+          // TODO(v9): Remove this warning
+          if (config.vite.build?.sourcemap === false) {
+            logger.warn(
+              "You disabled sourcemaps with the `vite.build.sourcemap` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the `vite.build.sourcemap` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the `vite.build.sourcemap` option to 'hidden' or undefined.",
+            );
+          }
+
+          // TODO: Add deleteSourcemapsAfterUpload option and warn if it isn't set.
+
           updateConfig({
             vite: {
               build: {

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -36,7 +36,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
         // We don't need to check for AUTH_TOKEN here, because the plugin will pick it up from the env
         if (shouldUploadSourcemaps && command !== 'dev') {
           // TODO(v9): Remove this warning
-          if (config.vite.build?.sourcemap === false) {
+          if (config?.vite?.build?.sourcemap === false) {
             logger.warn(
               "You disabled sourcemaps with the `vite.build.sourcemap` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the `vite.build.sourcemap` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the `vite.build.sourcemap` option to 'hidden' or undefined.",
             );

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -470,7 +470,7 @@ export type IgnoreWarningsOption = (
 // The two possible formats for providing custom webpack config in `next.config.js`
 export type WebpackConfigFunction = (config: WebpackConfigObject, options: BuildContext) => WebpackConfigObject;
 export type WebpackConfigObject = {
-  devtool?: string;
+  devtool?: string | boolean;
   plugins?: Array<WebpackPluginInstance>;
   entry: WebpackEntryProperty;
   output: { filename: string; path: string };

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -341,7 +341,7 @@ export function constructWebpackConfigFunction(
             const runtimePrefix = !isServer ? 'Client' : runtime === 'edge' ? 'Edge' : 'Node.js';
             // eslint-disable-next-line no-console
             console.warn(
-              `[@sentry/nextjs - ${runtimePrefix}] You disabled sourcemaps with the Webpack \`devtool\` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the \`devtool\` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the \`devtool\` option to true or undefined.`,
+              `[@sentry/nextjs - ${runtimePrefix}] You disabled sourcemaps with the Webpack \`devtool\` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the \`devtool\` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the \`devtool\` option to 'hidden-source-map' or undefined.`,
             );
           }
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -336,13 +336,33 @@ export function constructWebpackConfigFunction(
 
       if (sentryWebpackPlugin) {
         if (!userSentryOptions.sourcemaps?.disable) {
+          // TODO(v9): Remove this warning
+          if (newConfig.devtool === false) {
+            const runtimePrefix = !isServer ? 'Client' : runtime === 'edge' ? 'Edge' : 'Node.js';
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[@sentry/nextjs - ${runtimePrefix}] You disabled sourcemaps with the Webpack \`devtool\` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the \`devtool\` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the \`devtool\` option to true or undefined.`,
+            );
+          }
+
+          // TODO(v9): Remove this warning and print warning in case source map deletion is auto configured
+          if (!isServer && !userSentryOptions.sourcemaps?.deleteSourcemapsAfterUpload) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              "[@sentry/nextjs] The Sentry SDK has enabled source map generation for your Next.js app. If you don't want to serve Source Maps to your users, either set the `deleteSourceMapsAfterUpload` option to true, or manually delete the source maps after the build. In future Sentry SDK versions `deleteSourceMapsAfterUpload` will default to `true`.",
+            );
+          }
+
           // `hidden-source-map` produces the same sourcemaps as `source-map`, but doesn't include the `sourceMappingURL`
           // comment at the bottom. For folks who aren't publicly hosting their sourcemaps, this is helpful because then
           // the browser won't look for them and throw errors into the console when it can't find them. Because this is a
           // front-end-only problem, and because `sentry-cli` handles sourcemaps more reliably with the comment than
           // without, the option to use `hidden-source-map` only applies to the client-side build.
-          newConfig.devtool =
-            isServer || userNextConfig.productionBrowserSourceMaps ? 'source-map' : 'hidden-source-map';
+          if (isServer || userNextConfig.productionBrowserSourceMaps) {
+            newConfig.devtool = 'source-map';
+          } else {
+            newConfig.devtool = 'hidden-source-map';
+          }
         }
 
         newConfig.plugins = newConfig.plugins || [];

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -22,8 +22,7 @@ export function makeSourceMapsVitePlugin(options: SentrySolidStartPluginOptions)
           if (!sourceMapsUploadOptions?.filesToDeleteAfterUpload) {
             // eslint-disable-next-line no-console
             console.warn(
-              `[Sentry SolidStart PLugin] We recommend setting the \`sourceMapsUploadOptions.filesToDeleteAfterUpload\` option to clean up source maps after uploading.
-[Sentry SolidStart Plugin] Otherwise, source maps might be deployed to production, depending on your configuration`,
+              '[Sentry SolidStart PLugin] We recommend setting the `sourceMapsUploadOptions.filesToDeleteAfterUpload` option to clean up source maps after uploading. Otherwise, source maps might be deployed to production, depending on your configuration. In future versions the SDK will default to deleting sourcemaps after uploading them.',
             );
           }
         }

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -19,7 +19,7 @@ export function makeSourceMapsVitePlugin(options: SentrySolidStartPluginOptions)
         if (config.build?.sourcemap === false) {
           // eslint-disable-next-line no-console
           console.warn(
-            "[Sentry SolidStart PLugin] You disabled sourcemaps with the `build.sourcemap` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the `build.sourcemap` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the `build.sourcemap` option to 'hidden' or undefined.",
+            "[Sentry SolidStart Plugin] You disabled sourcemaps with the `build.sourcemap` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the `build.sourcemap` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the `build.sourcemap` option to 'hidden' or undefined.",
           );
         }
 
@@ -27,7 +27,7 @@ export function makeSourceMapsVitePlugin(options: SentrySolidStartPluginOptions)
         if (!sourceMapsUploadOptions?.filesToDeleteAfterUpload) {
           // eslint-disable-next-line no-console
           console.warn(
-            "[Sentry SolidStart PLugin] The Sentry SDK has enabled source map generation for your SolidStart app. If you don't want to serve Source Maps to your users, either configure the `filesToDeleteAfterUpload` option with a glob to remove source maps after uploading them, or manually delete the source maps after the build. In future Sentry SDK versions source maps will be deleted automatically after uploading them.",
+            "[Sentry SolidStart Plugin] The Sentry SDK has enabled source map generation for your SolidStart app. If you don't want to serve Source Maps to your users, either configure the `filesToDeleteAfterUpload` option with a glob to remove source maps after uploading them, or manually delete the source maps after the build. In future Sentry SDK versions source maps will be deleted automatically after uploading them.",
           );
         }
 

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -15,17 +15,22 @@ export function makeSourceMapsVitePlugin(options: SentrySolidStartPluginOptions)
       apply: 'build',
       enforce: 'post',
       config(config) {
-        const sourceMapsPreviouslyNotEnabled = !config.build?.sourcemap;
-        if (debug && sourceMapsPreviouslyNotEnabled) {
+        // TODO(v9): Remove this warning
+        if (config.build?.sourcemap === false) {
           // eslint-disable-next-line no-console
-          console.log('[Sentry SolidStart Plugin] Enabling source map generation');
-          if (!sourceMapsUploadOptions?.filesToDeleteAfterUpload) {
-            // eslint-disable-next-line no-console
-            console.warn(
-              '[Sentry SolidStart PLugin] We recommend setting the `sourceMapsUploadOptions.filesToDeleteAfterUpload` option to clean up source maps after uploading. Otherwise, source maps might be deployed to production, depending on your configuration. In future versions the SDK will default to deleting sourcemaps after uploading them.',
-            );
-          }
+          console.warn(
+            "[Sentry SolidStart PLugin] You disabled sourcemaps with the `build.sourcemap` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the `build.sourcemap` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the `build.sourcemap` option to 'hidden' or undefined.",
+          );
         }
+
+        // TODO(v9): Remove this warning and print warning in case source map deletion is auto configured
+        if (!sourceMapsUploadOptions?.filesToDeleteAfterUpload) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[Sentry SolidStart PLugin] The Sentry SDK has enabled source map generation for your SolidStart app. If you don't want to serve Source Maps to your users, either configure the `filesToDeleteAfterUpload` option with a glob to remove source maps after uploading them, or manually delete the source maps after the build. In future Sentry SDK versions source maps will be deleted automatically after uploading them.",
+          );
+        }
+
         return {
           ...config,
           build: {


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/14286

The goal for the future is to a) not stomp user settings if they explicitly disable source maps b) warn users that they should delete their sourcemaps before uploading c) warn users that the SDK will delete by default in the future.