### PR TITLE
fix(feeback): Handle css correctly in screenshot mode

### DIFF
--- a/packages/feedback/src/modal/components/Dialog.css.ts
+++ b/packages/feedback/src/modal/components/Dialog.css.ts
@@ -60,7 +60,7 @@ const DIALOG = `
   gap: 16px;
   padding: var(--dialog-padding, 24px);
   max-width: 100%;
-  width: var(--form-width, 272px);
+  width: 100%;
   max-height: 100%;
   overflow: auto;
 
@@ -70,12 +70,6 @@ const DIALOG = `
   box-shadow: var(--dialog-box-shadow, var(--box-shadow));
   transform: translate(0, 0) scale(1);
   transition: transform 0.2s ease-in-out;
-}
-
-@media (max-width: 600px) {
-  .dialog__content {
-    width: var(--form-width, 100%);
-  }
 }
 
 `;
@@ -90,7 +84,20 @@ const DIALOG_HEADER = `
 }
 .dialog__title {
   align-self: center;
+  width: var(--form-width, 272px);
 }
+
+@media (max-width: 600px) {
+  .dialog__title {
+    width: auto;
+  }
+}
+
+.dialog__position:has(.editor) .dialog__title {
+  width: auto;
+}
+
+
 .brand-link {
   display: inline-flex;
 }
@@ -115,7 +122,11 @@ const FORM = `
   flex-direction: column;
   justify-content: space-between;
   gap: 20px;
-  width: 100%;
+  width: var(--form-width, 100%);
+}
+
+.dialog__position:has(.editor) .form__right {
+  width: var(--form-width, 272px);
 }
 
 .form__top {


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/14517

related to https://github.com/getsentry/sentry-javascript/pull/14355

Updated version:

<img width="1213" alt="Screenshot 2024-11-29 at 21 20 35" src="https://github.com/user-attachments/assets/3446fa11-719a-4bf6-b97e-2caa9616ce0f">

<img width="522" alt="Screenshot 2024-11-29 at 21 20 48" src="https://github.com/user-attachments/assets/39569594-b132-4ba6-8e0e-802918cc2edf">

<img width="1728" alt="Screenshot 2024-11-29 at 21 21 16" src="https://github.com/user-attachments/assets/7bf817e7-b847-4c4b-b8e7-400b715e33e5">
