### PR TITLE
ref(browser): Refactor type casts of browser metrics

### DIFF
--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -300,7 +300,7 @@ interface AddPerformanceEntriesOptions {
 /** Add performance related spans to a transaction */
 export function addPerformanceEntries(span: Span, options: AddPerformanceEntriesOptions): void {
   const performance = getBrowserPerformanceAPI();
-  if (!performance || !WINDOW.performance.getEntries || !browserPerformanceTimeOrigin) {
+  if (!performance || !performance.getEntries || !browserPerformanceTimeOrigin) {
     // Gatekeeper if performance API not available
     return;
   }
@@ -352,7 +352,6 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
         _addResourceSpans(span, entry as PerformanceResourceTiming, entry.name, startTime, duration, timeOrigin);
         break;
       }
-      default:
       // Ignore other entry types.
     }
   });

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -488,7 +488,7 @@ function _addPerformanceNavigationTiming(
   entry: PerformanceNavigationTiming,
   event: StartEventName,
   timeOrigin: number,
-  name?: string,
+  name: string = event,
 ): void {
   const eventEnd = _getEndPropertyNameForNavigationTiming(event) satisfies keyof PerformanceNavigationTiming;
   const end = entry[eventEnd];
@@ -497,7 +497,7 @@ function _addPerformanceNavigationTiming(
     return;
   }
   startAndEndSpan(span, timeOrigin + msToSec(start), timeOrigin + msToSec(end), {
-    op: `browser.${name || event}`,
+    op: `browser.${name}`,
     name: entry.name,
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -462,23 +462,35 @@ function _addNavigationSpans(span: Span, entry: PerformanceNavigationTiming, tim
   _addRequest(span, entry, timeOrigin);
 }
 
+type StartEventName =
+  | 'secureConnection'
+  | 'fetch'
+  | 'domainLookup'
+  | 'unloadEvent'
+  | 'redirect'
+  | 'connect'
+  | 'domContentLoadedEvent'
+  | 'loadEvent';
+
+type EndEventName =
+  | 'connectEnd'
+  | 'domainLookupStart'
+  | 'domainLookupEnd'
+  | 'unloadEventEnd'
+  | 'redirectEnd'
+  | 'connectEnd'
+  | 'domContentLoadedEventEnd'
+  | 'loadEventEnd';
+
 /** Create performance navigation related spans */
 function _addPerformanceNavigationTiming(
   span: Span,
   entry: PerformanceNavigationTiming,
-  event:
-    | 'secureConnection'
-    | 'fetch'
-    | 'domainLookup'
-    | 'unloadEvent'
-    | 'redirect'
-    | 'connect'
-    | 'domContentLoadedEvent'
-    | 'loadEvent',
+  event: StartEventName,
   timeOrigin: number,
   name?: string,
 ): void {
-  const eventEnd = getEndPropertyNameForNavigationTiming(event) satisfies keyof PerformanceNavigationTiming;
+  const eventEnd = _getEndPropertyNameForNavigationTiming(event) satisfies keyof PerformanceNavigationTiming;
   const end = entry[eventEnd];
   const start = entry[`${event}Start`];
   if (!start || !end) {
@@ -493,25 +505,7 @@ function _addPerformanceNavigationTiming(
   });
 }
 
-function getEndPropertyNameForNavigationTiming(
-  event:
-    | 'secureConnection'
-    | 'fetch'
-    | 'domainLookup'
-    | 'unloadEvent'
-    | 'redirect'
-    | 'connect'
-    | 'domContentLoadedEvent'
-    | 'loadEvent',
-):
-  | 'connectEnd'
-  | 'domainLookupStart'
-  | 'domainLookupEnd'
-  | 'unloadEventEnd'
-  | 'redirectEnd'
-  | 'connectEnd'
-  | 'domContentLoadedEventEnd'
-  | 'loadEventEnd' {
+function _getEndPropertyNameForNavigationTiming(event: StartEventName): EndEventName {
   if (event === 'secureConnection') {
     return 'connectEnd';
   }

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -479,10 +479,10 @@ function _addPerformanceNavigationTiming(
   timeOrigin: number,
   name?: string,
 ): void {
-  const eventEnd = getEndPropertyNameForNavigationTiming(event);
+  const eventEnd = getEndPropertyNameForNavigationTiming(event) satisfies keyof PerformanceNavigationTiming;
   const end = entry[eventEnd];
   const start = entry[`${event}Start`];
-  if (typeof start !== 'number' || typeof end !== 'number') {
+  if (!start || !end) {
     return;
   }
   startAndEndSpan(span, timeOrigin + msToSec(start), timeOrigin + msToSec(end), {
@@ -504,7 +504,15 @@ function getEndPropertyNameForNavigationTiming(
     | 'connect'
     | 'domContentLoadedEvent'
     | 'loadEvent',
-): keyof PerformanceNavigationTiming {
+):
+  | 'connectEnd'
+  | 'domainLookupStart'
+  | 'domainLookupEnd'
+  | 'unloadEventEnd'
+  | 'redirectEnd'
+  | 'connectEnd'
+  | 'domContentLoadedEventEnd'
+  | 'loadEventEnd' {
   if (event === 'secureConnection') {
     return 'connectEnd';
   }

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -409,7 +409,10 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
   _measurements = {};
 }
 
-/** Create measure related spans */
+/**
+ * Create measure related spans.
+ * Exported only for tests.
+ */
 export function _addMeasureSpans(
   span: Span,
   entry: PerformanceEntry,
@@ -543,8 +546,11 @@ function _addRequest(span: Span, entry: PerformanceNavigationTiming, timeOrigin:
   }
 }
 
-/** Create resource-related spans */
-function _addResourceSpans(
+/**
+ * Create resource-related spans.
+ * Exported only for tests.
+ */
+export function _addResourceSpans(
   span: Span,
   entry: PerformanceResourceTiming,
   resourceUrl: string,


### PR DESCRIPTION
Get rid of some type casts around browser timing events/metrics capture.