### PR TITLE
fix(nextjs): Don't show warning about devtool option

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -336,20 +336,11 @@ export function constructWebpackConfigFunction(
 
       if (sentryWebpackPlugin) {
         if (!userSentryOptions.sourcemaps?.disable) {
-          // TODO(v9): Remove this warning
-          if (newConfig.devtool === false) {
-            const runtimePrefix = !isServer ? 'Client' : runtime === 'edge' ? 'Edge' : 'Node.js';
-            // eslint-disable-next-line no-console
-            console.warn(
-              `[@sentry/nextjs - ${runtimePrefix}] You disabled sourcemaps with the Webpack \`devtool\` option. Currently, the Sentry SDK will override this option to generate sourcemaps. In future versions, the Sentry SDK will not override the \`devtool\` option if you explicitly disable it. If you want to generate and upload sourcemaps please set the \`devtool\` option to 'hidden-source-map' or undefined.`,
-            );
-          }
-
           // TODO(v9): Remove this warning and print warning in case source map deletion is auto configured
           if (!isServer && !userSentryOptions.sourcemaps?.deleteSourcemapsAfterUpload) {
             // eslint-disable-next-line no-console
             console.warn(
-              "[@sentry/nextjs] The Sentry SDK has enabled source map generation for your Next.js app. If you don't want to serve Source Maps to your users, either set the `deleteSourceMapsAfterUpload` option to true, or manually delete the source maps after the build. In future Sentry SDK versions `deleteSourceMapsAfterUpload` will default to `true`.",
+              "[@sentry/nextjs] The Sentry SDK has enabled source map generation for your Next.js app. If you don't want to serve Source Maps to your users, either set the `deleteSourceMapsAfterUpload` option to true, or manually delete the source maps after the build. In future Sentry SDK versions `deleteSourceMapsAfterUpload` will default to `true`. If you want do not want to generate and upload sourcemaps, set the `sourcemaps.disable` option in `withSentryConfig()`.",
             );
           }
 


### PR DESCRIPTION
I wrongfully assumend the devtool option would default to `undefined` because I missed this line in the Next.js code https://github.com/lforst/nextjs-fork/blob/36b0ff5074c441c55a862c14f0b6a45f0e789981/packages/next/src/build/webpack/config/blocks/base.ts#L61 and also stupidly had the devtool option set in my test app.

This PR makes it so we don't unnecessarily show the warning if people have not disabled source maps.