### PR TITLE
ref(browser): Reduce bundle size of GlobalHandlers integration

### DIFF
--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -155,11 +155,11 @@ function _eventFromRejectionWithPrimitive(reason: Primitive): Event {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _enhanceEventWithInitialFrame(event: Event, url: any, line: any, column: any): Event {
-  const frames: StackFrame[] = [];
+  let frames: StackFrame[] = [];
   try {
     // @ts-expect-error - this is fine and done to reduce bundle size
     // we're catching the error if any of the properties in the chain is undefined
-    frames.push(event.exception.values[0].stacktrace.frames);
+    frames = event.exception.values[0].stacktrace.frames;
   } catch {
     // ignored
   }


### PR DESCRIPTION
Just a slight reduction but while reviewing https://github.com/getsentry/sentry-javascript/pull/14546 I figured this might shave off a couple of bytes. Let's see...