### PR TITLE
feat(core): Add `serverRequestSessionIntegration`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,7 @@ export { inboundFiltersIntegration } from './integrations/inboundfilters';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
 export { moduleMetadataIntegration } from './integrations/metadata';
 export { requestDataIntegration } from './integrations/requestdata';
+export { serverRequestSessionIntegration } from './integrations/serverrequestsession';
 export { captureConsoleIntegration } from './integrations/captureconsole';
 // eslint-disable-next-line deprecation/deprecation
 export { debugIntegration } from './integrations/debug';

--- a/packages/core/src/integrations/serverrequestsession.ts
+++ b/packages/core/src/integrations/serverrequestsession.ts
@@ -1,5 +1,5 @@
-import { startSession } from '..';
 import { getIsolationScope } from '../currentScopes';
+import { startSession } from '../exports';
 import { defineIntegration } from '../integration';
 
 export const serverRequestSessionIntegration = defineIntegration(() => {

--- a/packages/core/src/integrations/serverrequestsession.ts
+++ b/packages/core/src/integrations/serverrequestsession.ts
@@ -1,0 +1,29 @@
+import { startSession } from '..';
+import { getIsolationScope } from '../currentScopes';
+import { defineIntegration } from '../integration';
+
+export const serverRequestSessionIntegration = defineIntegration(() => {
+  return {
+    name: 'ServerRequestSession',
+    setup(client) {
+      client.on('preprocessEvent', event => {
+        const isException =
+          event.type === undefined && event.exception && event.exception.values && event.exception.values.length > 0;
+
+        // If the event is of type Exception, then a request session should be captured
+        if (isException) {
+          const requestSession = getIsolationScope().getRequestSession();
+
+          // Ensure that this is happening within the bounds of a request, and make sure not to override
+          // Session Status if Errored / Crashed
+          if (requestSession && requestSession.status === 'ok') {
+            requestSession.status = 'errored';
+          }
+        }
+      });
+
+      // TODO(v9): Remove this start session call
+      startSession();
+    },
+  };
+});

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -134,11 +134,11 @@ export class ServerRuntimeClient<
     return super.close(timeout);
   }
 
-  /** Method that initialises an instance of SessionFlusher on Client */
+  /** Method that initializes an instance of SessionFlusher on Client */
   public initSessionFlusher(): void {
     const { release, environment } = this._options;
     if (!release) {
-      DEBUG_BUILD && logger.warn('Cannot initialise an instance of SessionFlusher if no release is provided!');
+      DEBUG_BUILD && logger.warn('Cannot initialize an instance of SessionFlusher if no release is provided!');
     } else {
       this._sessionFlusher = new SessionFlusher(this, {
         release,


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/14550

Pulls out the logic for turning request-response cycles into sessions into an integration.

As a next step we will deprecate the `autoSessionTracking` option.