### PR TITLE
feat(core): Add `raw_security` envelope types

### DIFF
--- a/packages/core/src/types-hoist/csp.ts
+++ b/packages/core/src/types-hoist/csp.ts
@@ -1,0 +1,15 @@
+export interface LegacyCSPReport {
+  readonly 'csp-report': {
+    readonly 'document-uri'?: string;
+    readonly referrer?: string;
+    readonly 'blocked-uri'?: string;
+    readonly 'effective-directive'?: string;
+    readonly 'violated-directive'?: string;
+    readonly 'original-policy'?: string;
+    readonly disposition: 'enforce' | 'report' | 'reporting';
+    readonly 'status-code'?: number;
+    readonly status?: string;
+    readonly 'script-sample'?: string;
+    readonly sample?: string;
+  };
+}

--- a/packages/core/src/types-hoist/envelope.ts
+++ b/packages/core/src/types-hoist/envelope.ts
@@ -1,6 +1,7 @@
 import type { AttachmentType } from './attachment';
 import type { SerializedCheckIn } from './checkin';
 import type { ClientReport } from './clientreport';
+import type { LegacyCSPReport } from './csp';
 import type { DsnComponents } from './dsn';
 import type { Event } from './event';
 import type { FeedbackEvent, UserFeedback } from './feedback';
@@ -41,7 +42,8 @@ export type EnvelopeItemType =
   | 'replay_recording'
   | 'check_in'
   | 'statsd'
-  | 'span';
+  | 'span'
+  | 'raw_security';
 
 export type BaseEnvelopeHeaders = {
   [key: string]: unknown;
@@ -84,6 +86,7 @@ type ProfileItemHeaders = { type: 'profile' };
 type ProfileChunkItemHeaders = { type: 'profile_chunk' };
 type StatsdItemHeaders = { type: 'statsd'; length: number };
 type SpanItemHeaders = { type: 'span' };
+type RawSecurityHeaders = { type: 'raw_security'; sentry_release?: string; sentry_environment?: string };
 
 export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event>;
 export type AttachmentItem = BaseEnvelopeItem<AttachmentItemHeaders, string | Uint8Array>;
@@ -100,6 +103,7 @@ export type FeedbackItem = BaseEnvelopeItem<FeedbackItemHeaders, FeedbackEvent>;
 export type ProfileItem = BaseEnvelopeItem<ProfileItemHeaders, Profile>;
 export type ProfileChunkItem = BaseEnvelopeItem<ProfileChunkItemHeaders, ProfileChunk>;
 export type SpanItem = BaseEnvelopeItem<SpanItemHeaders, Partial<SpanJSON>>;
+export type RawSecurityItem = BaseEnvelopeItem<RawSecurityHeaders, LegacyCSPReport>;
 
 export type EventEnvelopeHeaders = { event_id: string; sent_at: string; trace?: Partial<DynamicSamplingContext> };
 type SessionEnvelopeHeaders = { sent_at: string };
@@ -120,6 +124,7 @@ export type CheckInEnvelope = BaseEnvelope<CheckInEnvelopeHeaders, CheckInItem>;
 export type StatsdEnvelope = BaseEnvelope<StatsdEnvelopeHeaders, StatsdItem>;
 export type SpanEnvelope = BaseEnvelope<SpanEnvelopeHeaders, SpanItem>;
 export type ProfileChunkEnvelope = BaseEnvelope<BaseEnvelopeHeaders, ProfileChunkItem>;
+export type RawSecurityEnvelope = BaseEnvelope<BaseEnvelopeHeaders, RawSecurityItem>;
 
 export type Envelope =
   | EventEnvelope
@@ -129,6 +134,7 @@ export type Envelope =
   | ReplayEnvelope
   | CheckInEnvelope
   | StatsdEnvelope
-  | SpanEnvelope;
+  | SpanEnvelope
+  | RawSecurityEnvelope;
 
 export type EnvelopeItem = Envelope[1][number];

--- a/packages/core/src/types-hoist/index.ts
+++ b/packages/core/src/types-hoist/index.ts
@@ -43,6 +43,8 @@ export type {
   UserFeedbackItem,
   CheckInItem,
   CheckInEnvelope,
+  RawSecurityEnvelope,
+  RawSecurityItem,
   StatsdItem,
   StatsdEnvelope,
   ProfileItem,
@@ -179,3 +181,4 @@ export type {
 export type { ParameterizedString } from './parameterize';
 export type { ContinuousProfiler, ProfilingIntegration, Profiler } from './profiling';
 export type { ViewHierarchyData, ViewHierarchyWindow } from './view-hierarchy';
+export type { LegacyCSPReport } from './csp';

--- a/packages/core/src/utils-hoist/envelope.ts
+++ b/packages/core/src/utils-hoist/envelope.ts
@@ -224,6 +224,7 @@ const ITEM_TYPE_TO_DATA_CATEGORY_MAP: Record<EnvelopeItemType, DataCategory> = {
   feedback: 'feedback',
   span: 'span',
   statsd: 'metric_bucket',
+  raw_security: 'security',
 };
 
 /**


### PR DESCRIPTION
Adds types for the `raw_security` envelope type. These are displayed in Sentry as CSP violations.