### PR TITLE
feat(node): Add `trackIncomingRequestsAsSessions` option to http integration

### DIFF
--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -2,7 +2,7 @@ import type { ClientRequest, IncomingMessage, RequestOptions, ServerResponse } f
 import { diag } from '@opentelemetry/api';
 import type { HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import type { IntegrationFn, Span } from '@sentry/core';
+import type { Span } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { getClient } from '@sentry/opentelemetry';
 import { generateInstrumentOnce } from '../../otel/instrument';
@@ -29,6 +29,16 @@ interface HttpOptions {
    * only the Sentry-specific instrumentation for request isolation is applied.
    */
   spans?: boolean;
+
+  /**
+   * Whether the integration should create [Sessions](https://docs.sentry.io/product/releases/health/#sessions) for incoming requests to track the health and crash-free rate of your releases in Sentry.
+   * Read more about Release Health: https://docs.sentry.io/product/releases/health/
+   *
+   * Defaults to `true`.
+   *
+   * Note: If `autoSessionTracking` is set to `false` in `Sentry.init()` or the Client owning this integration, this option will also default to `false`.
+   */
+  trackIncomingRequestsAsSessions?: boolean;
 
   /**
    * Do not capture spans or breadcrumbs for outgoing HTTP requests to URLs where the given callback returns `true`.
@@ -123,20 +133,18 @@ const instrumentHttp = (options: HttpOptions = {}): void => {
   instrumentSentryHttp(options);
 };
 
-const _httpIntegration = ((options: HttpOptions = {}) => {
+/**
+ * The http integration instruments Node's internal http and https modules.
+ * It creates breadcrumbs and spans for outgoing HTTP requests which will be attached to the currently active span.
+ */
+export const httpIntegration = defineIntegration((options: HttpOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
       instrumentHttp(options);
     },
   };
-}) satisfies IntegrationFn;
-
-/**
- * The http integration instruments Node's internal http and https modules.
- * It creates breadcrumbs and spans for outgoing HTTP requests which will be attached to the currently active span.
- */
-export const httpIntegration = defineIntegration(_httpIntegration);
+});
 
 /**
  * Determines if @param req is a ClientRequest, meaning the request was created within the express app
@@ -207,7 +215,12 @@ function getConfigWithDefaults(options: Partial<HttpOptions> = {}): HttpInstrume
     },
     responseHook: (span, res) => {
       const client = getClient<NodeClient>();
-      if (client && client.getOptions().autoSessionTracking) {
+
+      if (
+        client &&
+        client.getOptions().autoSessionTracking !== false &&
+        options.trackIncomingRequestsAsSessions !== false
+      ) {
         setImmediate(() => {
           client['_captureRequestSession']();
         });

--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -36,7 +36,7 @@ interface HttpOptions {
    *
    * Defaults to `true`.
    *
-   * Note: If `autoSessionTracking` is set to `false` in `Sentry.init()` or the Client owning this integration, this option will also default to `false`.
+   * Note: If `autoSessionTracking` is set to `false` in `Sentry.init()` or the Client owning this integration, this option will be ignored.
    */
   trackIncomingRequestsAsSessions?: boolean;
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/14550

This is the option we can migrate to as part of removing `autoSessionTracking.`