### PR TITLE
ref(core): Streamline global handlers & add comments

### DIFF
--- a/packages/core/src/utils-hoist/instrument/globalError.ts
+++ b/packages/core/src/utils-hoist/instrument/globalError.ts
@@ -20,6 +20,8 @@ export function addGlobalErrorInstrumentationHandler(handler: (data: HandlerData
 function instrumentError(): void {
   _oldOnErrorHandler = GLOBAL_OBJ.onerror;
 
+  // Note: The reason we are doing window.onerror instead of window.addEventListener('error') is
+  // is that we are using this handler in the Loader Script, to handle buffered errors consistently
   GLOBAL_OBJ.onerror = function (
     msg: string | object,
     url?: string,
@@ -36,7 +38,7 @@ function instrumentError(): void {
     };
     triggerHandlers('error', handlerData);
 
-    if (_oldOnErrorHandler && !_oldOnErrorHandler.__SENTRY_LOADER__) {
+    if (_oldOnErrorHandler) {
       // eslint-disable-next-line prefer-rest-params
       return _oldOnErrorHandler.apply(this, arguments);
     }

--- a/packages/core/src/utils-hoist/instrument/globalUnhandledRejection.ts
+++ b/packages/core/src/utils-hoist/instrument/globalUnhandledRejection.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { HandlerDataUnhandledRejection } from '../../types-hoist';
 
 import { GLOBAL_OBJ } from '../worldwide';
@@ -24,11 +22,13 @@ export function addGlobalUnhandledRejectionInstrumentationHandler(
 function instrumentUnhandledRejection(): void {
   _oldOnUnhandledRejectionHandler = GLOBAL_OBJ.onunhandledrejection;
 
-  GLOBAL_OBJ.onunhandledrejection = function (e: any): boolean {
+  // Note: The reason we are doing window.onerror instead of window.addEventListener('unhandledrejection') is
+  // is that we are using this handler in the Loader Script, to handle buffered rejections consistently
+  GLOBAL_OBJ.onunhandledrejection = function (e: unknown): boolean {
     const handlerData: HandlerDataUnhandledRejection = e;
     triggerHandlers('unhandledrejection', handlerData);
 
-    if (_oldOnUnhandledRejectionHandler && !_oldOnUnhandledRejectionHandler.__SENTRY_LOADER__) {
+    if (_oldOnUnhandledRejectionHandler) {
       // eslint-disable-next-line prefer-rest-params
       return _oldOnUnhandledRejectionHandler.apply(this, arguments);
     }

--- a/packages/core/src/utils-hoist/worldwide.ts
+++ b/packages/core/src/utils-hoist/worldwide.ts
@@ -56,12 +56,10 @@ export type InternalGlobal = {
   onerror?: {
     (event: object | string, source?: string, lineno?: number, colno?: number, error?: Error): any;
     __SENTRY_INSTRUMENTED__?: true;
-    __SENTRY_LOADER__?: true;
   };
   onunhandledrejection?: {
     (event: unknown): boolean;
     __SENTRY_INSTRUMENTED__?: true;
-    __SENTRY_LOADER__?: true;
   };
   SENTRY_ENVIRONMENT?: string;
   SENTRY_DSN?: string;


### PR DESCRIPTION
This adds a comment explaining why we are using `window.onerror` instead of `window.addEventListener('error')`, for future reference.

It also removes the check for `__SENTRY_LOADER__` check, which we removed quite some time ago in the Loader.