### PR TITLE
fix(nextjs): Only apply tracing metadata to data fetcher data when data is an object

### DIFF
--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapAppGetInitialPropsWithSentry.ts
@@ -41,32 +41,29 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
           sentryTrace,
           baggage,
         }: {
-          data: {
-            pageProps: {
-              _sentryTraceData?: string;
-              _sentryBaggage?: string;
-            };
-          };
+          data?: unknown;
           sentryTrace?: string;
           baggage?: string;
         } = await tracedGetInitialProps.apply(thisArg, args);
 
-        // Per definition, `pageProps` is not optional, however an increased amount of users doesn't seem to call
-        // `App.getInitialProps(appContext)` in their custom `_app` pages which is required as per
-        // https://nextjs.org/docs/advanced-features/custom-app - resulting in missing `pageProps`.
-        // For this reason, we just handle the case where `pageProps` doesn't exist explicitly.
-        if (!appGetInitialProps.pageProps) {
-          appGetInitialProps.pageProps = {};
-        }
+        if (typeof appGetInitialProps === 'object' && appGetInitialProps !== null) {
+          // Per definition, `pageProps` is not optional, however an increased amount of users doesn't seem to call
+          // `App.getInitialProps(appContext)` in their custom `_app` pages which is required as per
+          // https://nextjs.org/docs/advanced-features/custom-app - resulting in missing `pageProps`.
+          // For this reason, we just handle the case where `pageProps` doesn't exist explicitly.
+          if (!(appGetInitialProps as Record<string, unknown>).pageProps) {
+            (appGetInitialProps as Record<string, unknown>).pageProps = {};
+          }
 
-        // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
-        if (sentryTrace) {
-          appGetInitialProps.pageProps._sentryTraceData = sentryTrace;
-        }
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (sentryTrace) {
+            (appGetInitialProps as { pageProps: Record<string, unknown> }).pageProps._sentryTraceData = sentryTrace;
+          }
 
-        // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
-        if (baggage) {
-          appGetInitialProps.pageProps._sentryBaggage = baggage;
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (baggage) {
+            (appGetInitialProps as { pageProps: Record<string, unknown> }).pageProps._sentryBaggage = baggage;
+          }
         }
 
         return appGetInitialProps;

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapErrorGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapErrorGetInitialPropsWithSentry.ts
@@ -43,22 +43,19 @@ export function wrapErrorGetInitialPropsWithSentry(
           baggage,
           sentryTrace,
         }: {
-          data: ErrorProps & {
-            _sentryTraceData?: string;
-            _sentryBaggage?: string;
-          };
+          data?: unknown;
           baggage?: string;
           sentryTrace?: string;
         } = await tracedGetInitialProps.apply(thisArg, args);
 
         // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
         if (sentryTrace) {
-          errorGetInitialProps._sentryTraceData = sentryTrace;
+          (errorGetInitialProps as Record<string, unknown>)._sentryTraceData = sentryTrace;
         }
 
         // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
         if (baggage) {
-          errorGetInitialProps._sentryBaggage = baggage;
+          (errorGetInitialProps as Record<string, unknown>)._sentryBaggage = baggage;
         }
 
         return errorGetInitialProps;

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapGetInitialPropsWithSentry.ts
@@ -39,22 +39,21 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
           baggage,
           sentryTrace,
         }: {
-          data: {
-            _sentryTraceData?: string;
-            _sentryBaggage?: string;
-          };
+          data?: unknown;
           baggage?: string;
           sentryTrace?: string;
         } = (await tracedGetInitialProps.apply(thisArg, args)) ?? {}; // Next.js allows undefined to be returned from a getInitialPropsFunction.
 
-        // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
-        if (sentryTrace) {
-          initialProps._sentryTraceData = sentryTrace;
-        }
+        if (typeof initialProps === 'object' && initialProps !== null) {
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (sentryTrace) {
+            (initialProps as Record<string, unknown>)._sentryTraceData = sentryTrace;
+          }
 
-        // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
-        if (baggage) {
-          initialProps._sentryBaggage = baggage;
+          // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
+          if (baggage) {
+            (initialProps as Record<string, unknown>)._sentryBaggage = baggage;
+          }
         }
 
         return initialProps;

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapGetServerSidePropsWithSentry.ts
@@ -36,7 +36,7 @@ export function wrapGetServerSidePropsWithSentry(
         sentryTrace,
       } = await (tracedGetServerSideProps.apply(thisArg, args) as ReturnType<typeof tracedGetServerSideProps>);
 
-      if (serverSideProps && 'props' in serverSideProps) {
+      if (typeof serverSideProps === 'object' && 'props' in serverSideProps) {
         // The Next.js serializer throws on undefined values so we need to guard for it (#12102)
         if (sentryTrace) {
           (serverSideProps.props as Record<string, unknown>)._sentryTraceData = sentryTrace;


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/14571

Technically this is unnecessary because Next.js requires data fetchers to return an object but still we don't want people thinking Sentry is the problem.