### PR TITLE
ref: add test-results/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ jest/transformers/*.js
 # node tarballs
 packages/*/sentry-*.tgz
 .nxcache
+# test results
+test-results/
 
 # logs
 yarn-error.log


### PR DESCRIPTION
Noticed running browser-integration-tests locally generates this folder, can we exclude it from git?