### PR TITLE
meta(types): Remove Feature Flag APIs from deprecated package

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -54,7 +54,6 @@ import type {
   Extra as Extra_imported,
   ExtractedNodeRequestData as ExtractedNodeRequestData_imported,
   Extras as Extras_imported,
-  FeatureFlag as FeatureFlag_imported,
   FeedbackEvent as FeedbackEvent_imported,
   FeedbackFormData as FeedbackFormData_imported,
   FeedbackInternalOptions as FeedbackInternalOptions_imported,
@@ -574,5 +573,3 @@ export type Profiler = Profiler_imported;
 export type ViewHierarchyData = ViewHierarchyData_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type ViewHierarchyWindow = ViewHierarchyWindow_imported;
-/** @deprecated This type has been moved to `@sentry/core`. */
-export type FeatureFlag = FeatureFlag_imported;


### PR DESCRIPTION
Removes an export that was added to the deprecated types package in https://github.com/getsentry/sentry-javascript/pull/14207.

Should be fine since we never released that change.