### PR TITLE
docs(ci): Add docs for automatic E2E test detection

### DIFF
--- a/dev-packages/e2e-tests/README.md
+++ b/dev-packages/e2e-tests/README.md
@@ -57,8 +57,14 @@ EOF
 
 Make sure to add a `test:build` and `test:assert` command to the new app's `package.json` file.
 
-Add the new test app to `test-application` matrix in `.github/workflows/build.yml` for the `job_e2e_tests` job. If you
-want to run a canary test, add it to the `canary.yml` workflow.
+Test apps in the folder `test-applications` will be automatically picked up by CI in the job `job_e2e_tests` (in `.github/workflows/build.yml`).
+The test matrix for CI is generated in `dev-packages/e2e-tests/lib/getTestMatrix.ts`.
+
+For each test app, CI checks its dependencies (and devDependencies) to see if any of them have changed in the current PR (based on nx affected projects).
+For example, if something is changed in the browser package, only E2E test apps that depend on browser will run, while others will be skipped.
+
+You can add additional information about the test (e.g. canary versions, optional in CI) by adding `sentryTest` in the `package.json`
+of a test application.
 
 **An important thing to note:** In the context of the build/test commands the fake test registry is available at
 `http://127.0.0.1:4873`. It hosts all of our packages as if they were to be published with the state of the current


### PR DESCRIPTION
Updates readme based on this PR: https://github.com/getsentry/sentry-javascript/pull/14254
