### PR TITLE
feat(nextjs): Deprecate typedef for `hideSourceMaps`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -108,6 +108,10 @@
 - Deprecated `wrapUseRoutes`. Use `wrapUseRoutesV6` or `wrapUseRoutesV7` instead.
 - Deprecated `wrapCreateBrowserRouter`. Use `wrapCreateBrowserRouterV6` or `wrapCreateBrowserRouterV7` instead.
 
+## `@sentry/nextjs`
+
+- Deprecated `hideSourceMaps`. No replacements. The SDK emits hidden sourcemaps by default.
+
 ## `@sentry/opentelemetry`
 
 - Deprecated `generateSpanContextForPropagationContext` in favor of doing this manually - we do not need this export anymore.

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -379,6 +379,7 @@ export type SentryBuildOptions = {
    *
    * @deprecated This is deprecated. The SDK emits chunks without `sourceMappingURL` for client bundles by default.
    */
+  // TODO(v9): Remove option
   hideSourceMaps?: boolean;
 
   /**

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -376,6 +376,8 @@ export type SentryBuildOptions = {
   /**
    * Use `hidden-source-map` for webpack `devtool` option, which strips the `sourceMappingURL` from the bottom of built
    * JS files.
+   *
+   * @deprecated This is deprecated. The SDK emits chunks without `sourceMappingURL` for client bundles by default.
    */
   hideSourceMaps?: boolean;
 

--- a/packages/nextjs/test/config/webpack/constructWebpackConfig.test.ts
+++ b/packages/nextjs/test/config/webpack/constructWebpackConfig.test.ts
@@ -68,19 +68,19 @@ describe('constructWebpackConfigFunction()', () => {
     expect(finalWebpackConfig?.devtool).not.toEqual('source-map');
   });
 
-  it('allows for the use of `hidden-source-map` as `devtool` value for client-side builds', async () => {
+  it('uses `hidden-source-map` as `devtool` value for client-side builds', async () => {
     const finalClientWebpackConfig = await materializeFinalWebpackConfig({
       exportedNextConfig: exportedNextConfig,
       incomingWebpackConfig: clientWebpackConfig,
       incomingWebpackBuildContext: clientBuildContext,
-      sentryBuildTimeOptions: { hideSourceMaps: true },
+      sentryBuildTimeOptions: {},
     });
 
     const finalServerWebpackConfig = await materializeFinalWebpackConfig({
       exportedNextConfig: exportedNextConfig,
       incomingWebpackConfig: serverWebpackConfig,
       incomingWebpackBuildContext: serverBuildContext,
-      sentryBuildTimeOptions: { hideSourceMaps: true },
+      sentryBuildTimeOptions: {},
     });
 
     expect(finalClientWebpackConfig.devtool).toEqual('hidden-source-map');

--- a/packages/nextjs/test/types/next.config.ts
+++ b/packages/nextjs/test/types/next.config.ts
@@ -3,7 +3,6 @@ import type { NextConfig } from 'next';
 import { withSentryConfig } from '../../src/config/withSentryConfig';
 
 const config: NextConfig = {
-  hideSourceMaps: true,
   webpack: config => ({
     ...config,
     module: {


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/13618#issuecomment-2520598510

Seems like I forgot to remove the typedefs for the `hideSourceMaps` option in v8. The option no longer does anything so we should deprecate it and remove it in v9.

I am not just removing it in this PR because I don't want to crash builds.