### PR TITLE
fix(core): Filter out unactionable CEFSharp promise rejection error by default

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -17,6 +17,7 @@ const DEFAULT_IGNORE_ERRORS = [
   'can\'t redefine non-configurable property "solana"', // Probably a browser extension or custom browser (Brave) throwing this error
   "vv().getRestrictions is not a function. (In 'vv().getRestrictions(1,a)', 'vv().getRestrictions' is undefined)", // Error thrown by GTM, seemingly not affecting end-users
   "Can't find variable: _AutofillCallbackHandler", // Unactionable error in instagram webview https://developers.facebook.com/community/threads/320013549791141/
+  /^Non-Error promise rejection captured with value: Object Not Found Matching Id:\d+, MethodName:simulateEvent, ParamCount:\d+$/, // unactionable error from CEFSharp, a .NET library that embeds chromium in .NET apps
 ];
 
 /** Options for the InboundFilters integration */

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -269,6 +269,18 @@ const GOOGLETAG_EVENT: Event = {
   },
 };
 
+const CEFSHARP_EVENT: Event = {
+  exception: {
+    values: [
+      {
+        type: 'TypeError',
+        value:
+          'Non-Error promise rejection captured with value: Object Not Found Matching Id:3, MethodName:simulateEvent, ParamCount:1',
+      },
+    ],
+  },
+};
+
 const MALFORMED_EVENT: Event = {
   exception: {
     values: [
@@ -383,6 +395,11 @@ describe('InboundFilters', () => {
     it('uses default filters (googletag)', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(GOOGLETAG_EVENT, {})).toBe(null);
+    });
+
+    it('uses default filters (CEFSharp)', () => {
+      const eventProcessor = createInboundFiltersEventProcessor();
+      expect(eventProcessor(CEFSHARP_EVENT, {})).toBe(null);
     });
 
     it('filters on last exception when multiple present', () => {


### PR DESCRIPTION
We have internal [user reports](https://sentry.slack.com/archives/CTZCE4WBZ/p1733360320054299) about an uncaught promise rejection being thrown by a .NET library called CEFSharp. This lib can embed chromium in a .NET app, which I guess means, a web page can be displayed within a .NET app. Apparently there's some problem that spams this error to some of our users.

This error seems to happen quite frequently and it's not the first time we're hearing about it:
  - https://github.com/getsentry/sentry-javascript/issues/3440#issuecomment-864140452
  - https://github.com/getsentry/sentry-javascript/issues/3796
- Stackoverflow: https://stackoverflow.com/questions/75536442/troubleshooting-non-error-promise-rejection-captured-with-value-object-not-fou
- Issue in  DDog browser SDK repo: https://github.com/DataDog/browser-sdk/issues/2715#issuecomment-2359950290
- A blog post suggesting this is related to a crawler: https://trackjs.com/javascript-errors/object-not-found-matching-id-methodname-paramcount/

This was also already reported in the [CEFSharp repo](https://github.com/cefsharp/CefSharp/discussions/3633)

IMHO we can just filter this error by default, so this PR adds the error to be ignored by our default `inboundFiltersIntegration` (which I still think has a completely misleading name by the way 😅)