### PR TITLE
feat(replay): Upgrade rrweb packages to 2.30.0

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.44.1",
-    "@sentry-internal/rrweb": "2.29.0",
+    "@sentry-internal/rrweb": "2.30.0",
     "@sentry/browser": "8.42.0",
     "axios": "1.7.7",
     "babel-loader": "^8.2.2",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@sentry-internal/rrweb": "2.29.0"
+    "@sentry-internal/rrweb": "2.30.0"
   },
   "dependencies": {
     "@sentry-internal/replay": "8.42.0",

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -69,8 +69,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "8.42.0",
-    "@sentry-internal/rrweb": "2.29.0",
-    "@sentry-internal/rrweb-snapshot": "2.29.0",
+    "@sentry-internal/rrweb": "2.30.0",
+    "@sentry-internal/rrweb-snapshot": "2.30.0",
     "fflate": "^0.8.1",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8616,34 +8616,34 @@
     "@angular-devkit/schematics" "14.2.13"
     jsonc-parser "3.1.0"
 
-"@sentry-internal/rrdom@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.29.0.tgz#df60564466718ae7ada376cf1bd483b8ee07831a"
-  integrity sha512-TXhujPMt0Iq4l/sjm+rdU/CI6yR8K9+NheKPbCrs3UBzQHbu2VglrlEmhyx57mJY2GwRBrvLcCr5NokX7v1eBA==
+"@sentry-internal/rrdom@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.30.0.tgz#b0d0455be62db08a196d22c3f99e063489634223"
+  integrity sha512-u5f38j3y7esGSoJfblgQETX2sWC2+jM3nkzhqPP0nOEKoIb0GPA+m1fa2D949BXrk20e98qEUPzW32dpF4ka/w==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.29.0"
+    "@sentry-internal/rrweb-snapshot" "2.30.0"
 
-"@sentry-internal/rrweb-snapshot@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.29.0.tgz#b0bb64ccffbd486bb739c87d481aa8cdcd7d5c05"
-  integrity sha512-nIf593YObUzdmEilT3LEXBTpcVGXRYlYTgxiESeJgXrEmNoeB1BolKh4OJa5KpEmwmHcfe3zl15GdzhjxOIwAA==
+"@sentry-internal/rrweb-snapshot@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.30.0.tgz#d4e1974e32e068db0bd3e3cfd5f0d700f5c4d414"
+  integrity sha512-rR6KRcE0UZfrh1taBO1KLVzfDaQ2iWW879LBMa94HEH/xUUSG3vRF7t55rmKpxIam1v2Ib6iiCMMTAZoZxzE0Q==
 
-"@sentry-internal/rrweb-types@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.29.0.tgz#71b20e6dd452f005ff37f059df2dacad98f6e0ea"
-  integrity sha512-0x1aT+ifDjX3JKd4kmGzbofkI6qWYAOZmd5tPX07OmVnT3aIoecBqBCUagx15ewm0kMRv5Pl53is0EWzHIDvlA==
+"@sentry-internal/rrweb-types@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.30.0.tgz#50ab65034fab3d8243b601ff9925fe45ad141f48"
+  integrity sha512-Wb6RM5SnnWdCpHB6nxEGFV4bqQwMMDOGryMj8QyZf7fK6lkxtEBXOWiEhxUgAUPjMBqQDZm/2DzKO+bW4NHLZg==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.29.0"
+    "@sentry-internal/rrweb-snapshot" "2.30.0"
     "@types/css-font-loading-module" "0.0.7"
 
-"@sentry-internal/rrweb@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.29.0.tgz#1019bee52be0ed4bd3112a3e1a1c50adfb6bab78"
-  integrity sha512-UmEtyfo3yCdJsIdt0m7OLLmg9CeNmGlkmGSa91nResZVIC1+rd4RA+PmmqkwAV/WOljCXHZHs7ezlW1Mjjm2vQ==
+"@sentry-internal/rrweb@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.30.0.tgz#9af028b80a0081c75ff410817fe2fcda010f9cf6"
+  integrity sha512-ZOf4RmxX29LgQDW5sy9D/JfwmQbgMzF6DfA00rlFTtQYht56gbgtmWfqeWMDxG9tas71BnMTOz6eF28t7MoykQ==
   dependencies:
-    "@sentry-internal/rrdom" "2.29.0"
-    "@sentry-internal/rrweb-snapshot" "2.29.0"
-    "@sentry-internal/rrweb-types" "2.29.0"
+    "@sentry-internal/rrdom" "2.30.0"
+    "@sentry-internal/rrweb-snapshot" "2.30.0"
+    "@sentry-internal/rrweb-types" "2.30.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
Includes the following fixes:

- fix: Catch calls to iframe content document ([#222](https://github.com/getsentry/rrweb/pull/222))
- fix(snapshot): Fix CSS expansion of add CSS property ([#223](https://github.com/getsentry/rrweb/pull/223))
