### PR TITLE
feat(vue/nuxt)!: No longer create `"update"` spans for component tracking by default

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -102,6 +102,28 @@
   });
   ```
 
+## `@sentry/nuxt` and `@sentry/vue`
+
+- When component tracking is enabled, "update" spans are no longer created by default.
+  Add an `"update"` item to the `tracingOptions.hooks` option via the `vueIntegration()` to restore this behavior.
+
+  ```ts
+  Sentry.init({
+    integrations: [
+      Sentry.vueIntegration({
+        tracingOptions: {
+          trackComponents: true,
+          hooks: [
+            'mount',
+            'update', // <--
+            'unmount',
+          ],
+        },
+      }),
+    ],
+  });
+  ```
+
 ## `@sentry/astro`
 
 - Deprecated passing `dsn`, `release`, `environment`, `sampleRate`, `tracesSampleRate`, `replaysSessionSampleRate` to the integration. Use the runtime-specific `Sentry.init()` calls for passing these options instead.

--- a/packages/vue/src/constants.ts
+++ b/packages/vue/src/constants.ts
@@ -1,3 +1,3 @@
 import type { Operation } from './types';
 
-export const DEFAULT_HOOKS: Operation[] = ['activate', 'mount', 'update'];
+export const DEFAULT_HOOKS: Operation[] = ['activate', 'mount'];


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/12851