### PR TITLE
fix(v7/tracing-internal): Fix case when lrp keys offset is 0

### DIFF
--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -413,10 +413,9 @@ export const extractOriginalRoute = (
   regexp?: Layer['regexp'],
   keys?: Layer['keys'],
 ): string | undefined => {
-  if (!path || !regexp || !keys || Object.keys(keys).length === 0 || !keys[0]?.offset) {
+  if (!path || !regexp || !keys || Object.keys(keys).length === 0 || keys[0]?.offset === undefined ||  keys[0]?.offset === null) {
     return undefined;
   }
-
   const orderedKeys = keys.sort((a, b) => a.offset - b.offset);
 
   // add d flag for getting indices from regexp result

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -413,7 +413,14 @@ export const extractOriginalRoute = (
   regexp?: Layer['regexp'],
   keys?: Layer['keys'],
 ): string | undefined => {
-  if (!path || !regexp || !keys || Object.keys(keys).length === 0 || keys[0]?.offset === undefined ||  keys[0]?.offset === null) {
+  if (
+    !path ||
+    !regexp ||
+    !keys ||
+    Object.keys(keys).length === 0 ||
+    keys[0]?.offset === undefined ||
+    keys[0]?.offset === null
+  ) {
     return undefined;
   }
   const orderedKeys = keys.sort((a, b) => a.offset - b.offset);

--- a/packages/tracing-internal/test/node/express.test.ts
+++ b/packages/tracing-internal/test/node/express.test.ts
@@ -87,11 +87,18 @@ if (major >= 16) {
       expect(extractOriginalRoute(path, regex, [key])).toBeUndefined();
     });
 
-    it('should return the original route path when valid inputs are provided', () => {
+    it('should return the original route path when valid inputs are provided first static value then dynamic', () => {
       const path = '/router/123';
       const regex = /^\/router\/(\d+)$/;
       const keys = [{ name: 'pathParam', offset: 8, optional: false }];
       expect(extractOriginalRoute(path, regex, keys)).toBe('/router/:pathParam');
+    });
+
+    it('should return the original route path when valid inputs are provided first dynamic value then static', () => {
+      const path = '/123/router';
+      const regex = /^(?:\/([^/]+?))\/router\/?(?=\/|$)/i;
+      const keys = [{ name: 'pathParam', offset: 0, optional: false }];
+      expect(extractOriginalRoute(path, regex, keys)).toBe('/:pathParam/router');
     });
 
     it('should handle multiple parameters in the route', () => {


### PR DESCRIPTION


This PR fix use case when lrp keys offset is calculate to 0. I discover this case after update express from v4.19.2 to v4.21.2 
For example:

api/v1/users/1/posts
Old behavior

sentry build req._reconstructedRoute as:
api/v1/users/1/posts
New behavior

sentry build req._reconstructedRoute as:
api/v1/users/:param/posts

