### PR TITLE
chore(node): Bump otel instrumentation to `^0.56.0`

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -68,7 +68,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^1.29.0",
     "@opentelemetry/core": "^1.29.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/instrumentation-amqplib": "^0.45.0",
     "@opentelemetry/instrumentation-connect": "0.42.0",
     "@opentelemetry/instrumentation-dataloader": "0.15.0",


### PR DESCRIPTION
Noticed in e2e tests that we had unmet peer dep warnings.