### PR TITLE
chore(e2e): Pin react types for nextjs-t3 app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-t3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-t3/package.json
@@ -33,7 +33,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/eslint": "^8.56.10",
     "@types/node": "^20.14.10",
-    "@types/react": "^18.3.3",
+    "@types/react": "18.3.1",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.1.0",
     "@typescript-eslint/parser": "^8.1.0",


### PR DESCRIPTION
Types for react cache are incompatible so we pin it for now.