### PR TITLE
fix(node): Guard against invalid `maxSpanWaitDuration` values

### DIFF
--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -142,7 +142,7 @@ export function setupOtel(client: NodeClient): BasicTracerProvider {
     forceFlushTimeoutMillis: 500,
     spanProcessors: [
       new SentrySpanProcessor({
-        timeout: _getSpanProcessorTimeout(client.getOptions().maxSpanWaitDuration),
+        timeout: _clampSpanProcessorTimeout(client.getOptions().maxSpanWaitDuration),
       }),
     ],
   });
@@ -157,7 +157,7 @@ export function setupOtel(client: NodeClient): BasicTracerProvider {
 }
 
 /** Just exported for tests. */
-export function _getSpanProcessorTimeout(maxSpanWaitDuration: number | undefined): number | undefined {
+export function _clampSpanProcessorTimeout(maxSpanWaitDuration: number | undefined): number | undefined {
   if (maxSpanWaitDuration == null) {
     return undefined;
   }

--- a/packages/node/test/sdk/initOtel.test.ts
+++ b/packages/node/test/sdk/initOtel.test.ts
@@ -1,28 +1,28 @@
 import { logger } from '@sentry/core';
-import { _getSpanProcessorTimeout } from '../../src/sdk/initOtel';
+import { _clampSpanProcessorTimeout } from '../../src/sdk/initOtel';
 
-describe('_getSpanProcessorTimeout', () => {
+describe('_clampSpanProcessorTimeout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('works with undefined', () => {
     const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
-    const timeout = _getSpanProcessorTimeout(undefined);
+    const timeout = _clampSpanProcessorTimeout(undefined);
     expect(timeout).toBe(undefined);
     expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
 
   it('works with positive number', () => {
     const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
-    const timeout = _getSpanProcessorTimeout(10);
+    const timeout = _clampSpanProcessorTimeout(10);
     expect(timeout).toBe(10);
     expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
 
   it('works with 0', () => {
     const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
-    const timeout = _getSpanProcessorTimeout(0);
+    const timeout = _clampSpanProcessorTimeout(0);
     expect(timeout).toBe(undefined);
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
     expect(loggerWarnSpy).toHaveBeenCalledWith(
@@ -32,7 +32,7 @@ describe('_getSpanProcessorTimeout', () => {
 
   it('works with negative number', () => {
     const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
-    const timeout = _getSpanProcessorTimeout(-10);
+    const timeout = _clampSpanProcessorTimeout(-10);
     expect(timeout).toBe(undefined);
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
     expect(loggerWarnSpy).toHaveBeenCalledWith(
@@ -42,7 +42,7 @@ describe('_getSpanProcessorTimeout', () => {
 
   it('works with -Infinity', () => {
     const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
-    const timeout = _getSpanProcessorTimeout(-Infinity);
+    const timeout = _clampSpanProcessorTimeout(-Infinity);
     expect(timeout).toBe(undefined);
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
     expect(loggerWarnSpy).toHaveBeenCalledWith(
@@ -52,7 +52,7 @@ describe('_getSpanProcessorTimeout', () => {
 
   it('works with Infinity', () => {
     const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
-    const timeout = _getSpanProcessorTimeout(Infinity);
+    const timeout = _clampSpanProcessorTimeout(Infinity);
     expect(timeout).toBe(1_000_000);
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
     expect(loggerWarnSpy).toHaveBeenCalledWith('`maxSpanWaitDuration` is too high, using the maximum value of 1000000');
@@ -60,7 +60,7 @@ describe('_getSpanProcessorTimeout', () => {
 
   it('works with large number', () => {
     const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
-    const timeout = _getSpanProcessorTimeout(1_000_000_000);
+    const timeout = _clampSpanProcessorTimeout(1_000_000_000);
     expect(timeout).toBe(1_000_000);
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
     expect(loggerWarnSpy).toHaveBeenCalledWith('`maxSpanWaitDuration` is too high, using the maximum value of 1000000');
@@ -68,7 +68,7 @@ describe('_getSpanProcessorTimeout', () => {
 
   it('works with NaN', () => {
     const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
-    const timeout = _getSpanProcessorTimeout(NaN);
+    const timeout = _clampSpanProcessorTimeout(NaN);
     expect(timeout).toBe(undefined);
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
     expect(loggerWarnSpy).toHaveBeenCalledWith(

--- a/packages/node/test/sdk/initOtel.test.ts
+++ b/packages/node/test/sdk/initOtel.test.ts
@@ -1,0 +1,78 @@
+import { logger } from '@sentry/core';
+import { _getSpanProcessorTimeout } from '../../src/sdk/initOtel';
+
+describe('_getSpanProcessorTimeout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('works with undefined', () => {
+    const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const timeout = _getSpanProcessorTimeout(undefined);
+    expect(timeout).toBe(undefined);
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('works with positive number', () => {
+    const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const timeout = _getSpanProcessorTimeout(10);
+    expect(timeout).toBe(10);
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('works with 0', () => {
+    const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const timeout = _getSpanProcessorTimeout(0);
+    expect(timeout).toBe(undefined);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      '`maxSpanWaitDuration` must be a positive number, using default value instead.',
+    );
+  });
+
+  it('works with negative number', () => {
+    const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const timeout = _getSpanProcessorTimeout(-10);
+    expect(timeout).toBe(undefined);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      '`maxSpanWaitDuration` must be a positive number, using default value instead.',
+    );
+  });
+
+  it('works with -Infinity', () => {
+    const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const timeout = _getSpanProcessorTimeout(-Infinity);
+    expect(timeout).toBe(undefined);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      '`maxSpanWaitDuration` must be a positive number, using default value instead.',
+    );
+  });
+
+  it('works with Infinity', () => {
+    const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const timeout = _getSpanProcessorTimeout(Infinity);
+    expect(timeout).toBe(1_000_000);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).toHaveBeenCalledWith('`maxSpanWaitDuration` is too high, using the maximum value of 1000000');
+  });
+
+  it('works with large number', () => {
+    const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const timeout = _getSpanProcessorTimeout(1_000_000_000);
+    expect(timeout).toBe(1_000_000);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).toHaveBeenCalledWith('`maxSpanWaitDuration` is too high, using the maximum value of 1000000');
+  });
+
+  it('works with NaN', () => {
+    const loggerWarnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const timeout = _getSpanProcessorTimeout(NaN);
+    expect(timeout).toBe(undefined);
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      '`maxSpanWaitDuration` must be a positive number, using default value instead.',
+    );
+  });
+});


### PR DESCRIPTION
Today, if you pass e.g. `Infinity` or another large number to `maxSpanWaitDuration`, the SDK will error out because we try to do `new Array(maxSpanWaitDuration)`, which is impossible.

Ideally, we can properly allow an infinite wait time, but for now this adds checks to ensure only valid values are passed in there, and we do not explode.

See https://github.com/getsentry/sentry-javascript/pull/14154#issuecomment-2527984250