### PR TITLE
feat(opentelemetry): Set `response` context for http.server spans

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-8/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-8/tests/transactions.test.ts
@@ -46,6 +46,10 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     origin: 'auto.http.otel.http',
   });
 
+  expect(transactionEvent.contexts?.response).toEqual({
+    status_code: 200,
+  });
+
   expect(transactionEvent).toEqual(
     expect.objectContaining({
       spans: expect.arrayContaining([

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/transactions.test.ts
@@ -46,6 +46,10 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     origin: 'auto.http.otel.http',
   });
 
+  expect(transactionEvent.contexts?.response).toEqual({
+    status_code: 200,
+  });
+
   expect(transactionEvent).toEqual(
     expect.objectContaining({
       transaction: 'GET /test-transaction',

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -1,8 +1,16 @@
+/* eslint-disable max-lines */
 import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { ATTR_HTTP_RESPONSE_STATUS_CODE, SEMATTRS_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions';
-import type { SpanJSON, SpanOrigin, TraceContext, TransactionEvent, TransactionSource } from '@sentry/core';
+import type {
+  SpanAttributes,
+  SpanJSON,
+  SpanOrigin,
+  TraceContext,
+  TransactionEvent,
+  TransactionSource,
+} from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -221,13 +229,14 @@ function parseSpan(span: ReadableSpan): { op?: string; origin?: SpanOrigin; sour
   return { origin, op, source };
 }
 
-function createTransactionForOtelSpan(span: ReadableSpan): TransactionEvent {
+/** Exported only for tests. */
+export function createTransactionForOtelSpan(span: ReadableSpan): TransactionEvent {
   const { op, description, data, origin = 'manual', source } = getSpanData(span);
   const capturedSpanScopes = getCapturedScopesOnSpan(span as unknown as Span);
 
   const sampleRate = span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] as number | undefined;
 
-  const attributes = dropUndefinedKeys({
+  const attributes: SpanAttributes = dropUndefinedKeys({
     [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
     [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: sampleRate,
     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
@@ -257,12 +266,16 @@ function createTransactionForOtelSpan(span: ReadableSpan): TransactionEvent {
     status: getStatusMessage(status), // As per protocol, span status is allowed to be undefined
   });
 
-  const transactionEvent: TransactionEvent = {
+  const statusCode = attributes[ATTR_HTTP_RESPONSE_STATUS_CODE];
+  const responseContext = typeof statusCode === 'number' ? { response: { status_code: statusCode } } : undefined;
+
+  const transactionEvent: TransactionEvent = dropUndefinedKeys({
     contexts: {
       trace: traceContext,
       otel: {
         resource: span.resource.attributes,
       },
+      ...responseContext,
     },
     spans: [],
     start_timestamp: spanTimeInputToSeconds(span.startTime),
@@ -283,7 +296,7 @@ function createTransactionForOtelSpan(span: ReadableSpan): TransactionEvent {
       },
     }),
     _metrics_summary: getMetricSummaryJsonForSpan(span as unknown as Span),
-  };
+  });
 
   return transactionEvent;
 }

--- a/packages/opentelemetry/test/spanExporter.test.ts
+++ b/packages/opentelemetry/test/spanExporter.test.ts
@@ -1,4 +1,4 @@
-import { ATTR_HTTP_RESPONSE_STATUS_CODE } from '@opentelemetry/semantic-conventions/*';
+import { ATTR_HTTP_RESPONSE_STATUS_CODE } from '@opentelemetry/semantic-conventions';
 import { SDK_VERSION, SEMANTIC_ATTRIBUTE_SENTRY_OP, startInactiveSpan } from '@sentry/core';
 import { createTransactionForOtelSpan } from '../src/spanExporter';
 import { cleanupOtel, mockSdkInit } from './helpers/mockSdkInit';

--- a/packages/opentelemetry/test/spanExporter.test.ts
+++ b/packages/opentelemetry/test/spanExporter.test.ts
@@ -1,0 +1,111 @@
+import { ATTR_HTTP_RESPONSE_STATUS_CODE } from '@opentelemetry/semantic-conventions/*';
+import { SDK_VERSION, SEMANTIC_ATTRIBUTE_SENTRY_OP, startInactiveSpan } from '@sentry/core';
+import { createTransactionForOtelSpan } from '../src/spanExporter';
+import { cleanupOtel, mockSdkInit } from './helpers/mockSdkInit';
+
+describe('createTransactionForOtelSpan', () => {
+  beforeEach(() => {
+    mockSdkInit({
+      enableTracing: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanupOtel();
+  });
+
+  it('works with a basic span', () => {
+    const span = startInactiveSpan({ name: 'test', startTime: 1733821670000 });
+    span.end(1733821672000);
+
+    const event = createTransactionForOtelSpan(span as any);
+    // we do not care about this here
+    delete event.sdkProcessingMetadata;
+
+    expect(event).toEqual({
+      contexts: {
+        trace: {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.source': 'custom',
+            'sentry.sample_rate': 1,
+            'sentry.origin': 'manual',
+          },
+          origin: 'manual',
+          status: 'ok',
+        },
+        otel: {
+          resource: {
+            'service.name': 'opentelemetry-test',
+            'telemetry.sdk.language': 'nodejs',
+            'telemetry.sdk.name': 'opentelemetry',
+            'telemetry.sdk.version': expect.any(String),
+            'service.namespace': 'sentry',
+            'service.version': SDK_VERSION,
+          },
+        },
+      },
+      spans: [],
+      start_timestamp: 1733821670,
+      timestamp: 1733821672,
+      transaction: 'test',
+      type: 'transaction',
+      transaction_info: { source: 'custom' },
+    });
+  });
+
+  it('works with a http.server span', () => {
+    const span = startInactiveSpan({
+      name: 'test',
+      startTime: 1733821670000,
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 200,
+      },
+    });
+    span.end(1733821672000);
+
+    const event = createTransactionForOtelSpan(span as any);
+    // we do not care about this here
+    delete event.sdkProcessingMetadata;
+
+    expect(event).toEqual({
+      contexts: {
+        trace: {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.source': 'custom',
+            'sentry.sample_rate': 1,
+            'sentry.origin': 'manual',
+            'sentry.op': 'http.server',
+            'http.response.status_code': 200,
+          },
+          origin: 'manual',
+          status: 'ok',
+          op: 'http.server',
+        },
+        otel: {
+          resource: {
+            'service.name': 'opentelemetry-test',
+            'telemetry.sdk.language': 'nodejs',
+            'telemetry.sdk.name': 'opentelemetry',
+            'telemetry.sdk.version': expect.any(String),
+            'service.namespace': 'sentry',
+            'service.version': SDK_VERSION,
+          },
+        },
+        response: {
+          status_code: 200,
+        },
+      },
+      spans: [],
+      start_timestamp: 1733821670,
+      timestamp: 1733821672,
+      transaction: 'test',
+      type: 'transaction',
+      transaction_info: { source: 'custom' },
+    });
+  });
+});


### PR DESCRIPTION
This implements the `response` context for http.server spans (https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#response-context).

I opted to not implement this for the browser, as we do not really expect server spans there. I added a test there anyhow to show the shape of the transaction event, so we can adjust this easier if we want in the future.

Closes https://github.com/getsentry/sentry-javascript/issues/14619
Closes https://github.com/getsentry/sentry-javascript/pull/14634