### PR TITLE
feat: Deprecate `autoSessionTracking`

### DIFF
--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -19,6 +19,11 @@
   In v9, we will streamline this behavior so that passing `undefined` will result in tracing being disabled, the same as not passing the option at all.
   If you are relying on `undefined` being passed in and having tracing enabled because of this, you should update your config to set e.g. `tracesSampleRate: 0` instead, which will also enable tracing in v9.
 
+- **The `autoSessionTracking` option is deprecated.**
+
+  To enable session tracking, it is recommended to unset `autoSessionTracking` and ensure that either, in browser environments the `browserSessionIntegration` is added, or in server environments the `httpIntegration` is added.
+  To disable session tracking, it is recommended unset `autoSessionTracking` and to remove the `browserSessionIntegration` in browser environments, or configure the `httpIntegration` with the `trackIncomingRequestsAsSessions` option set to `false`.
+
 ## `@sentry/utils`
 
 - **The `@sentry/utils` package has been deprecated. Import everything from `@sentry/core` instead.**

--- a/docs/migration/draft-v9-migration-guide.md
+++ b/docs/migration/draft-v9-migration-guide.md
@@ -22,7 +22,7 @@
 - **The `autoSessionTracking` option is deprecated.**
 
   To enable session tracking, it is recommended to unset `autoSessionTracking` and ensure that either, in browser environments the `browserSessionIntegration` is added, or in server environments the `httpIntegration` is added.
-  To disable session tracking, it is recommended unset `autoSessionTracking` and to remove the `browserSessionIntegration` in browser environments, or configure the `httpIntegration` with the `trackIncomingRequestsAsSessions` option set to `false`.
+  To disable session tracking, it is recommended unset `autoSessionTracking` and to remove the `browserSessionIntegration` in browser environments, or in server environments configure the `httpIntegration` with the `trackIncomingRequestsAsSessions` option set to `false`.
 
 ## `@sentry/utils`
 

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -42,6 +42,7 @@ export function getDefaultIntegrations(options: BrowserOptions = {}): Integratio
     httpContextIntegration(),
   ];
 
+  // eslint-disable-next-line deprecation/deprecation
   if (options.autoSessionTracking !== false) {
     integrations.push(browserSessionIntegration());
   }

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -44,6 +44,7 @@ export function getDefaultIntegrations(options: Options): Integration[] {
     httpContextIntegration(),
   ];
 
+  // eslint-disable-next-line deprecation/deprecation
   if (options.autoSessionTracking !== false) {
     integrations.push(browserSessionIntegration());
   }

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -84,6 +84,7 @@ export class ServerRuntimeClient<
     // The expectation is that session aggregates are only sent when `autoSessionTracking` is enabled.
     // TODO(v9): Our goal in the future is to not have the `autoSessionTracking` option and instead rely on integrations doing the creation and sending of sessions. We will not have a central kill-switch for sessions.
     // TODO(v9): This should move into the httpIntegration.
+    // eslint-disable-next-line deprecation/deprecation
     if (this._options.autoSessionTracking && this._sessionFlusher) {
       // eslint-disable-next-line deprecation/deprecation
       const requestSession = getIsolationScope().getRequestSession();
@@ -106,6 +107,7 @@ export class ServerRuntimeClient<
     // The expectation is that session aggregates are only sent when `autoSessionTracking` is enabled.
     // TODO(v9): Our goal in the future is to not have the `autoSessionTracking` option and instead rely on integrations doing the creation and sending of sessions. We will not have a central kill-switch for sessions.
     // TODO(v9): This should move into the httpIntegration.
+    // eslint-disable-next-line deprecation/deprecation
     if (this._options.autoSessionTracking && this._sessionFlusher) {
       const eventType = event.type || 'exception';
       const isException =

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -30,7 +30,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    *
    * @deprecated Setting the `autoSessionTracking` option is deprecated.
    * To enable session tracking, it is recommended to unset `autoSessionTracking` and ensure that either, in browser environments the `browserSessionIntegration` is added, or in server environments the `httpIntegration` is added.
-   * To disable session tracking, it is recommended unset `autoSessionTracking` and to remove the `browserSessionIntegration` in browser environments, or configure the `httpIntegration` with the `trackIncomingRequestsAsSessions` option set to `false`.
+   * To disable session tracking, it is recommended unset `autoSessionTracking` and to remove the `browserSessionIntegration` in browser environments, or in server environments configure the `httpIntegration` with the `trackIncomingRequestsAsSessions` option set to `false`.
    */
   autoSessionTracking?: boolean;
 

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -26,7 +26,11 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
 
   /**
    * A flag enabling Sessions Tracking feature.
-   * By default, Sessions Tracking is enabled.
+   * By default, Session Tracking is enabled.
+   *
+   * @deprecated Setting the `autoSessionTracking` option is deprecated.
+   * To enable session tracking, it is recommended to unset `autoSessionTracking` and ensure that either, in browser environments the `browserSessionIntegration` is added, or in server environments the `httpIntegration` is added.
+   * To disable session tracking, it is recommended unset `autoSessionTracking` and to remove the `browserSessionIntegration` in browser environments, or configure the `httpIntegration` with the `trackIncomingRequestsAsSessions` option set to `false`.
    */
   autoSessionTracking?: boolean;
 

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -147,6 +147,7 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
         });
 
         const client = getClient<NodeClient>();
+        // eslint-disable-next-line deprecation/deprecation
         if (client && client.getOptions().autoSessionTracking) {
           // eslint-disable-next-line deprecation/deprecation
           isolationScope.setRequestSession({ status: 'ok' });

--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -38,6 +38,7 @@ interface HttpOptions {
    *
    * Note: If `autoSessionTracking` is set to `false` in `Sentry.init()` or the Client owning this integration, this option will be ignored.
    */
+  // TODO(v9): Remove the note above.
   trackIncomingRequestsAsSessions?: boolean;
 
   /**
@@ -218,6 +219,7 @@ function getConfigWithDefaults(options: Partial<HttpOptions> = {}): HttpInstrume
 
       if (
         client &&
+        // eslint-disable-next-line deprecation/deprecation
         client.getOptions().autoSessionTracking !== false &&
         options.trackIncomingRequestsAsSessions !== false
       ) {

--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -122,6 +122,7 @@ export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressMid
 
     if (shouldHandleError(error)) {
       const client = getClient<NodeClient>();
+      // eslint-disable-next-line deprecation/deprecation
       if (client && client.getOptions().autoSessionTracking) {
         // Check if the `SessionFlusher` is instantiated on the client to go into this branch that marks the
         // `requestSession.status` as `Crashed`, and this check is necessary because the `SessionFlusher` is only

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -157,6 +157,7 @@ function _init(
   logger.log(`Running in ${isCjs() ? 'CommonJS' : 'ESM'} mode.`);
 
   // TODO(V9): Remove this code since all of the logic should be in an integration
+  // eslint-disable-next-line deprecation/deprecation
   if (options.autoSessionTracking) {
     startSessionTracking();
   }
@@ -218,9 +219,11 @@ function getClientOptions(
   const autoSessionTracking =
     typeof release !== 'string'
       ? false
-      : options.autoSessionTracking === undefined
+      : // eslint-disable-next-line deprecation/deprecation
+        options.autoSessionTracking === undefined
         ? true
-        : options.autoSessionTracking;
+        : // eslint-disable-next-line deprecation/deprecation
+          options.autoSessionTracking;
 
   if (options.spotlight == null) {
     const spotlightEnv = envToBool(process.env.SENTRY_SPOTLIGHT, { strict: true });
@@ -315,6 +318,7 @@ function updateScopeFromEnvVariables(): void {
  */
 function startSessionTracking(): void {
   const client = getClient<NodeClient>();
+  // eslint-disable-next-line deprecation/deprecation
   if (client && client.getOptions().autoSessionTracking) {
     client.initSessionFlusher();
   }

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -87,6 +87,7 @@ export function init(options: VercelEdgeOptions = {}): Client | undefined {
       options.release = detectedRelease;
     } else {
       // If release is not provided, then we should disable autoSessionTracking
+      // eslint-disable-next-line deprecation/deprecation
       options.autoSessionTracking = false;
     }
   }
@@ -94,7 +95,9 @@ export function init(options: VercelEdgeOptions = {}): Client | undefined {
   options.environment =
     options.environment || process.env.SENTRY_ENVIRONMENT || getVercelEnv(false) || process.env.NODE_ENV;
 
+  // eslint-disable-next-line deprecation/deprecation
   if (options.autoSessionTracking === undefined && options.dsn !== undefined) {
+    // eslint-disable-next-line deprecation/deprecation
     options.autoSessionTracking = true;
   }
 


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/14550

Deprecates `autoSessionTracking`. Instead, the `browserSessionIntegration` and `httpIntegration({ trackIncomingRequestsAsSessions: ... })` should be used.