### PR TITLE
ref(flags): remove FeatureFlagContext type export

### DIFF
--- a/packages/core/src/types-hoist/index.ts
+++ b/packages/core/src/types-hoist/index.ts
@@ -19,6 +19,7 @@ export type {
   TraceContext,
   CloudResourceContext,
   MissingInstrumentationContext,
+  FeatureFlagContext,
 } from './context';
 export type { DataCategory } from './datacategory';
 export type { DsnComponents, DsnLike, DsnProtocol } from './dsn';


### PR DESCRIPTION
Follow-up from https://github.com/getsentry/sentry/pull/81925#discussion_r1878864173. Like the other context types this should be exported here. We're using it in sentry right now, but importing from /build.