### PR TITLE
feat(core): Add `handled` option to `captureConsoleIntegration`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/captureConsole/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/captureConsole/test.ts
@@ -30,6 +30,7 @@ sentryTest('it captures console messages correctly', async ({ getLocalTestUrl, p
       extra: {
         arguments: ['console log'],
       },
+      message: 'console log',
     }),
   );
   expect(logEvent?.exception).toBeUndefined();
@@ -40,6 +41,7 @@ sentryTest('it captures console messages correctly', async ({ getLocalTestUrl, p
       extra: {
         arguments: ['console warn'],
       },
+      message: 'console warn',
     }),
   );
   expect(warnEvent?.exception).toBeUndefined();
@@ -50,6 +52,7 @@ sentryTest('it captures console messages correctly', async ({ getLocalTestUrl, p
       extra: {
         arguments: ['console info'],
       },
+      message: 'console info',
     }),
   );
   expect(infoEvent?.exception).toBeUndefined();
@@ -60,6 +63,7 @@ sentryTest('it captures console messages correctly', async ({ getLocalTestUrl, p
       extra: {
         arguments: ['console error'],
       },
+      message: 'console error',
     }),
   );
   expect(errorEvent?.exception).toBeUndefined();
@@ -70,6 +74,7 @@ sentryTest('it captures console messages correctly', async ({ getLocalTestUrl, p
       extra: {
         arguments: ['console trace'],
       },
+      message: 'console trace',
     }),
   );
   expect(traceEvent?.exception).toBeUndefined();

--- a/dev-packages/browser-integration-tests/suites/integrations/captureConsole/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/captureConsole/test.ts
@@ -90,6 +90,11 @@ sentryTest('it captures console messages correctly', async ({ getLocalTestUrl, p
     }),
   );
   expect(errorWithErrorEvent?.exception?.values?.[0].value).toBe('console error with error object');
+  expect(errorWithErrorEvent?.exception?.values?.[0].mechanism).toEqual({
+    // TODO (v9): Adjust to true after changing the integration's default value
+    handled: false,
+    type: 'console',
+  });
   expect(traceWithErrorEvent).toEqual(
     expect.objectContaining({
       level: 'log',

--- a/packages/core/src/integrations/captureconsole.ts
+++ b/packages/core/src/integrations/captureconsole.ts
@@ -28,7 +28,7 @@ const INTEGRATION_NAME = 'CaptureConsole';
 const _captureConsoleIntegration = ((options: CaptureConsoleOptions = {}) => {
   const levels = options.levels || CONSOLE_LEVELS;
   // TODO(v9): Flip default value to `true`
-  const handled = options.handled != null ? options.handled : false;
+  const handled = !!options.handled;
 
   return {
     name: INTEGRATION_NAME,

--- a/packages/core/src/integrations/captureconsole.ts
+++ b/packages/core/src/integrations/captureconsole.ts
@@ -11,12 +11,24 @@ import { GLOBAL_OBJ } from '../utils-hoist/worldwide';
 
 interface CaptureConsoleOptions {
   levels?: string[];
+
+  // TODO(v9): Flip default value to `true` and adjust JSDoc!
+  /**
+   * By default, Sentry will mark captured console messages as unhandled.
+   * Set this to `true` if you want to mark them as handled instead.
+   *
+   * Note: in v9 of the SDK, this option will default to `true`, meaning the default behavior will change to mark console messages as handled.
+   * @default false
+   */
+  handled?: boolean;
 }
 
 const INTEGRATION_NAME = 'CaptureConsole';
 
 const _captureConsoleIntegration = ((options: CaptureConsoleOptions = {}) => {
   const levels = options.levels || CONSOLE_LEVELS;
+  // TODO(v9): Flip default value to `true`
+  const handled = options.handled != null ? options.handled : false;
 
   return {
     name: INTEGRATION_NAME,
@@ -30,7 +42,7 @@ const _captureConsoleIntegration = ((options: CaptureConsoleOptions = {}) => {
           return;
         }
 
-        consoleHandler(args, level);
+        consoleHandler(args, level, handled);
       });
     },
   };
@@ -41,7 +53,7 @@ const _captureConsoleIntegration = ((options: CaptureConsoleOptions = {}) => {
  */
 export const captureConsoleIntegration = defineIntegration(_captureConsoleIntegration);
 
-function consoleHandler(args: unknown[], level: string): void {
+function consoleHandler(args: unknown[], level: string, handled: boolean): void {
   const captureContext: CaptureContext = {
     level: severityLevelFromString(level),
     extra: {
@@ -54,7 +66,7 @@ function consoleHandler(args: unknown[], level: string): void {
       event.logger = 'console';
 
       addExceptionMechanism(event, {
-        handled: false,
+        handled,
         type: 'console',
       });
 


### PR DESCRIPTION
This PR adds a `handled` option to the `captureConsoleIntegration`. Right now, for v8, it will default to `false` as previously but it gives users the option to override the handled value. In v9, we will flip the default value to `true` after discussing this offline with the team. In this integration we can never be sure about the `handled` state at all. But flipping it to handled by default seems reasonable. 

closes #14659 

I will add an integration test once #14668 is merged and we can properly assert on exceptions from captureConsole. Might do it as a follow-up, depending on what gets reviewed and merged first.