### PR TITLE
test(node-integration-tests): Look for specific error message in iitm test

### DIFF
--- a/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/test.ts
+++ b/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/test.ts
@@ -1,17 +1,15 @@
+import { spawnSync } from 'child_process';
+import { join } from 'path';
 import { conditionalTest } from '../../../utils';
-import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+import { cleanupChildProcesses } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
 conditionalTest({ min: 18 })('import-in-the-middle', () => {
-  test('onlyIncludeInstrumentedModules', done => {
-    const runner = createRunner(__dirname, 'app.mjs').start(() => {
-      runner.getLogs().forEach(logMsg => {
-        expect(logMsg).not.toContain('should be the only hooked modules but we just hooked');
-      });
-      done();
-    });
+  test('onlyIncludeInstrumentedModules', () => {
+    const result = spawnSync('node', [join(__dirname, 'app.mjs')], { encoding: 'utf-8' });
+    expect(result.stderr).not.toMatch('should be the only hooked modules but we just hooked');
   });
 });


### PR DESCRIPTION
Node 22 emits a deprecation warning for this test so we cannot just assert that there are no outputs.

Example: https://github.com/getsentry/sentry-javascript/actions/runs/12276373376/job/34253754090?pr=14636