### PR TITLE
fix(aws-serverless): Remove v8 layer as it overwrites the current layer for docs

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -142,6 +142,23 @@ targets:
     id: '@sentry-internal/eslint-config-sdk'
     includeNames: /^sentry-internal-eslint-config-sdk-\d.*\.tgz$/
 
+  # TODO(v9): Remove this target
+  # NOTE: We publish the v8 layer under its own name so people on v8 can still get patches
+  # whenever we release a new v8 version—otherwise we would overwrite the current major lambda layer.
+  - name: aws-lambda-layer
+    includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
+    layerName: SentryNodeServerlessSDKv8
+    compatibleRuntimes:
+      - name: node
+        versions:
+          - nodejs10.x
+          - nodejs12.x
+          - nodejs14.x
+          - nodejs16.x
+          - nodejs18.x
+          - nodejs20.x
+    license: MIT
+
   # AWS Lambda Layer target
   - name: aws-lambda-layer
     includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/

--- a/.craft.yml
+++ b/.craft.yml
@@ -157,24 +157,6 @@ targets:
           - nodejs20.x
     license: MIT
 
-  # NOTE: We publish the v8 layer under its own name so people on v8 can still get patches
-  # whenever we release a new v8 version—otherwise we would overwrite the current major lambda layer.
-
-  # AWS Lambda Layer target
-  - name: aws-lambda-layer
-    includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
-    layerName: SentryNodeServerlessSDKv8
-    compatibleRuntimes:
-      - name: node
-        versions:
-          - nodejs10.x
-          - nodejs12.x
-          - nodejs14.x
-          - nodejs16.x
-          - nodejs18.x
-          - nodejs20.x
-    license: MIT
-
   # CDN Bundle Target
   - name: gcs
     id: 'browser-cdn-bundles'


### PR DESCRIPTION
Unfortunately, having the v8 layer already in `.craft.yml` ends up with this layer being the default selection in the docs.

![Screenshot 2024-12-12 at 13 02 08@2x](https://github.com/user-attachments/assets/30bb83ce-79e9-41b1-887b-ec4ab7019a10)

We should add this to the `v8` branch once it exists instead.
