### PR TITLE
fix(nuxt): Inline nitro-utils function

### DIFF
--- a/packages/nitro-utils/package.json
+++ b/packages/nitro-utils/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/nitro-utils",
   "author": "Sentry",
   "license": "MIT",
+  "private": true,
   "engines": {
     "node": ">=16.20"
   },
@@ -34,9 +35,6 @@
         "build/types-ts3.8/index.d.ts"
       ]
     }
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "dependencies": {
     "@sentry/core": "8.44.0"

--- a/packages/nitro-utils/package.json
+++ b/packages/nitro-utils/package.json
@@ -53,7 +53,6 @@
     "build:dev:watch": "run-p build:transpile:watch build:types:watch",
     "build:transpile:watch": "rollup -c rollup.npm.config.mjs --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:tarball": "npm pack",
     "clean": "rimraf build coverage sentry-internal-nitro-utils-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",

--- a/packages/nuxt/build.config.ts
+++ b/packages/nuxt/build.config.ts
@@ -1,6 +1,4 @@
 import { defineBuildConfig } from 'unbuild';
 
 // Build Config for the Nuxt Module Builder: https://github.com/nuxt/module-builder
-export default defineBuildConfig({
-  failOnWarn: false,
-});
+export default defineBuildConfig({});

--- a/packages/nuxt/build.config.ts
+++ b/packages/nuxt/build.config.ts
@@ -2,5 +2,5 @@ import { defineBuildConfig } from 'unbuild';
 
 // Build Config for the Nuxt Module Builder: https://github.com/nuxt/module-builder
 export default defineBuildConfig({
-  failOnWarn: false
+  failOnWarn: false,
 });

--- a/packages/nuxt/build.config.ts
+++ b/packages/nuxt/build.config.ts
@@ -2,6 +2,5 @@ import { defineBuildConfig } from 'unbuild';
 
 // Build Config for the Nuxt Module Builder: https://github.com/nuxt/module-builder
 export default defineBuildConfig({
-  // The devDependency "@sentry-internal/nitro-utils" triggers "Inlined implicit external", but it's not external
-  failOnWarn: false,
+  failOnWarn: false
 });

--- a/packages/nuxt/generate-build-stubs.bash
+++ b/packages/nuxt/generate-build-stubs.bash
@@ -1,0 +1,19 @@
+# The Nuxt package is built in 2 steps and the nuxt-module-builder shows a warning if one of the files specified in the package.json is missing.
+# unbuild checks for this: https://github.com/unjs/unbuild/blob/8c647ec005a02f852e56aeef6076a35eede17df1/src/validate.ts#L81
+
+# The runtime folder (which is built with the nuxt-module-builder) is separate from the rest of the package and therefore we can ignore those warnings
+# as those files are generated in the other build step.
+
+# Create the directories if they do not exist
+mkdir -p build/cjs
+mkdir -p build/esm
+mkdir -p build/types
+
+# Write files if they do not exist
+[ ! -f build/cjs/index.server.js ] && echo "module.exports = {}" > build/cjs/index.server.js
+[ ! -f build/cjs/index.client.js ] && echo "module.exports = {}" > build/cjs/index.client.js
+[ ! -f build/esm/index.server.js ] && echo "export {}" > build/esm/index.server.js
+[ ! -f build/esm/index.client.js ] && echo "export {}" > build/esm/index.client.js
+[ ! -f build/types/index.types.d.ts ] && echo "export {}" > build/types/index.types.d.ts
+
+echo "Created build stubs for missing files"

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "build": "run-s build:types build:transpile",
     "build:dev": "yarn build",
-    "build:nuxt-module": "nuxt-module-build build --outDir build/module",
+    "build:nuxt-module": "bash ./generate-build-stubs.bash && nuxt-module-build build --outDir build/module",
     "build:transpile": "rollup -c rollup.npm.config.mjs && yarn build:nuxt-module",
     "build:types": "tsc -p tsconfig.types.json",
     "build:watch": "run-p build:transpile:watch build:types:watch",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@nuxt/module-builder": "^0.8.4",
-    "@sentry-internal/nitro-utils": "8.44.0",
     "nuxt": "^3.13.2"
   },
   "scripts": {

--- a/packages/nuxt/rollup.npm.config.mjs
+++ b/packages/nuxt/rollup.npm.config.mjs
@@ -15,9 +15,11 @@ export default [
       },
     }),
   ),
-  /*  The Nuxt module plugins are also built with the @nuxt/module-builder.
-      This rollup setup is still left here for an easier switch between the setups while
-      manually testing different built outputs (module-builder vs. rollup only) */
+
+  // The Nuxt module plugins are also built with the @nuxt/module-builder.
+  // This rollup setup is still left here for an easier switch between the setups while
+  // manually testing different built outputs (module-builder vs. rollup only)
+  /*
   ...makeNPMConfigVariants(
     makeBaseNPMConfig({
       entrypoints: ['src/runtime/plugins/sentry.client.ts', 'src/runtime/plugins/sentry.server.ts'],
@@ -31,4 +33,5 @@ export default [
       },
     }),
   ),
+ */
 ];

--- a/packages/nuxt/rollup.npm.config.mjs
+++ b/packages/nuxt/rollup.npm.config.mjs
@@ -15,23 +15,4 @@ export default [
       },
     }),
   ),
-
-  // The Nuxt module plugins are also built with the @nuxt/module-builder.
-  // This rollup setup is still left here for an easier switch between the setups while
-  // manually testing different built outputs (module-builder vs. rollup only)
-  /*
-  ...makeNPMConfigVariants(
-    makeBaseNPMConfig({
-      entrypoints: ['src/runtime/plugins/sentry.client.ts', 'src/runtime/plugins/sentry.server.ts'],
-
-      packageSpecificConfig: {
-        external: ['nuxt/app', 'nitropack/runtime', 'h3'],
-        output: {
-          // Preserve the original file structure (i.e., so that everything is still relative to `src`)
-          entryFileNames: 'runtime/[name].js',
-        },
-      },
-    }),
-  ),
- */
 ];


### PR DESCRIPTION
The package `@sentry-internal/nitro-utils` is not inlined in the build process and it's currently not possible to do this with the nuxt module builder, so I inlined the function we import from there to fix the build error people are getting.

follow-up on https://github.com/getsentry/sentry-javascript/issues/14661 
