### PR TITLE
fix(profiling-node): Ensure profileId is added to transaction event

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -85,7 +85,7 @@ function setupAutomatedSpanProfiling(client: NodeClient): void {
       // Unref timeout so it doesn't keep the process alive.
       timeout.unref();
 
-      getCurrentScope().setContext('profile', { profile_id });
+      getIsolationScope().setContext('profile', { profile_id });
       spanToProfileIdMap.set(span, profile_id);
     }
   });


### PR DESCRIPTION
This PR changes how we store the profile id on the SDK while the the profile is recording. Previously, we'd add the profile id to the current scope. It seems like in some cases, the current scope active at root span start is not applied to the transaction event in an express request transaction. Meaning that when we send the transaction envelope, the transaction event does not contain a profileId. 

This PR puts the profile id onto the isolation scope instead, which at least in server applications (like express) should correspond to the lifetime of a request. 

This doesn't fix all the weird behaviour I discovered in https://github.com/getsentry/sentry-javascript/issues/14655#issuecomment-2538609260 but in my local debugging, profiles were sent after making this change. 

fixes https://github.com/getsentry/sentry-javascript/issues/14655