### PR TITLE
feat: Allow capture of more than 1 ANR event

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
@@ -13,7 +13,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   autoSessionTracking: false,
-  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100, maxAnrEvents: 2 })],
 });
 
 Sentry.setUser({ email: 'person@home.com' });
@@ -31,7 +31,6 @@ setTimeout(() => {
   longWork();
 }, 1000);
 
-// Ensure we only send one event even with multiple blocking events
 setTimeout(() => {
   longWork();
 }, 4000);

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -72,7 +72,7 @@ const ANR_EVENT_WITH_DEBUG_META: Event = {
       {
         type: 'sourcemap',
         debug_id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa',
-        code_file: expect.stringContaining('basic.'),
+        code_file: expect.stringContaining('basic'),
       },
     ],
   },
@@ -90,6 +90,14 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
   test('ESM', done => {
     createRunner(__dirname, 'basic.mjs')
       .withMockSentryServer()
+      .expect({ event: ANR_EVENT_WITH_DEBUG_META })
+      .start(done);
+  });
+
+  test('multiple events via maxAnrEvents', done => {
+    createRunner(__dirname, 'basic-multiple.mjs')
+      .withMockSentryServer()
+      .expect({ event: ANR_EVENT_WITH_DEBUG_META })
       .expect({ event: ANR_EVENT_WITH_DEBUG_META })
       .start(done);
   });

--- a/packages/node/src/integrations/anr/common.ts
+++ b/packages/node/src/integrations/anr/common.ts
@@ -22,6 +22,12 @@ export interface AnrIntegrationOptions {
    */
   captureStackTrace: boolean;
   /**
+   * Maximum number of ANR events to send.
+   *
+   * Defaults to 1.
+   */
+  maxAnrEvents: number;
+  /**
    * Tags to include with ANR events.
    */
   staticTags: { [key: string]: Primitive };

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -154,6 +154,7 @@ async function _startWorker(
     pollInterval: integrationOptions.pollInterval || DEFAULT_INTERVAL,
     anrThreshold: integrationOptions.anrThreshold || DEFAULT_HANG_THRESHOLD,
     captureStackTrace: !!integrationOptions.captureStackTrace,
+    maxAnrEvents: integrationOptions.maxAnrEvents || 1,
     staticTags: integrationOptions.staticTags || {},
     contexts,
   };


### PR DESCRIPTION
- Closes #11160 
- Ref https://github.com/getsentry/sentry-electron/issues/876

Adds a `maxAnrEvents` option to the ANR integration which allows you to capture more than one event.
