### PR TITLE
chore(craft): Remove aws v8 layer from .craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -142,23 +142,6 @@ targets:
     id: '@sentry-internal/eslint-config-sdk'
     includeNames: /^sentry-internal-eslint-config-sdk-\d.*\.tgz$/
 
-  # TODO(v9): Remove this target
-  # NOTE: We publish the v8 layer under its own name so people on v8 can still get patches
-  # whenever we release a new v8 version—otherwise we would overwrite the current major lambda layer.
-  - name: aws-lambda-layer
-    includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
-    layerName: SentryNodeServerlessSDKv8
-    compatibleRuntimes:
-      - name: node
-        versions:
-          - nodejs10.x
-          - nodejs12.x
-          - nodejs14.x
-          - nodejs16.x
-          - nodejs18.x
-          - nodejs20.x
-    license: MIT
-
   # AWS Lambda Layer target
   - name: aws-lambda-layer
     includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/


### PR DESCRIPTION
The v9 branch should not push to the v8 layer.