### PR TITLE
chore(publish): Temporarily stop publishing lambda layer for v9 peview versions

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -143,19 +143,20 @@ targets:
     includeNames: /^sentry-internal-eslint-config-sdk-\d.*\.tgz$/
 
   # AWS Lambda Layer target
-  - name: aws-lambda-layer
-    includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
-    layerName: SentryNodeServerlessSDK
-    compatibleRuntimes:
-      - name: node
-        versions:
-          - nodejs10.x
-          - nodejs12.x
-          - nodejs14.x
-          - nodejs16.x
-          - nodejs18.x
-          - nodejs20.x
-    license: MIT
+  # TODO(v9): Once stable, re-add this target to publish the AWS Lambda layer
+  # - name: aws-lambda-layer
+  #   includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
+  #   layerName: SentryNodeServerlessSDK
+  #   compatibleRuntimes:
+  #     - name: node
+  #       versions:
+  #         - nodejs10.x
+  #         - nodejs12.x
+  #         - nodejs14.x
+  #         - nodejs16.x
+  #         - nodejs18.x
+  #         - nodejs20.x
+  #   license: MIT
 
   # CDN Bundle Target
   - name: gcs


### PR DESCRIPTION
This PR temporarily disables publishing a lambda layer while `develop` is the branch where we cut v9 pre releases from. We shouldn't publish prerelease layer versions since we can't mark these layers as pre-release. They'd appear simply as stable new layer versions (with incremented ARN number)