### PR TITLE
fix: Normalise ANR debug image file paths if appRoot was supplied

### DIFF
--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -104,11 +104,13 @@ function applyDebugMeta(event: Event): void {
 
   if (filenameToDebugId.size > 0) {
     const images: DebugImage[] = [];
-    for (const [filename, debugId] of filenameToDebugId.entries()) {
+    for (const [filename, debug_id] of filenameToDebugId.entries()) {
+      const code_file = options.appRootPath ? normalizeUrlToBase(filename, options.appRootPath) : filename;
+
       images.push({
         type: 'sourcemap',
-        code_file: filename,
-        debug_id: debugId,
+        code_file,
+        debug_id,
       });
     }
     event.debug_meta = { images };


### PR DESCRIPTION
We should normalise all paths in ANR events if an appRoot path is supplied. This is important for the Electron SDK where we normalise around the app path to keep usernames out of reported events.

- Ref https://github.com/getsentry/sentry-electron/issues/1011