### PR TITLE
chore(deno): Stop testing types

### DIFF
--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -48,8 +48,7 @@
     "lint": "eslint . --format stylish",
     "install:deno": "node ./scripts/install-deno.mjs",
     "pretest": "run-s deno-types",
-    "test": "run-s install:deno test:types test:unit",
-    "test:types": "deno check ./build/index.mjs",
+    "test": "run-s install:deno test:unit",
     "test:unit": "deno test --allow-read --allow-run",
     "test:unit:update": "deno test --allow-read --allow-write --allow-run -- --update",
     "yalc:publish": "node ./scripts/prepack.js && yalc publish build --push --sig"

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -47,8 +47,7 @@
     "prelint": "yarn deno-types",
     "lint": "eslint . --format stylish",
     "install:deno": "node ./scripts/install-deno.mjs",
-    "pretest": "run-s deno-types",
-    "test": "run-s install:deno test:unit",
+    "test": "run-s install:deno deno-types test:unit",
     "test:unit": "deno test --allow-read --allow-run",
     "test:unit:update": "deno test --allow-read --allow-write --allow-run -- --update",
     "yalc:publish": "node ./scripts/prepack.js && yalc publish build --push --sig"

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -48,7 +48,7 @@
     "lint": "eslint . --format stylish",
     "install:deno": "node ./scripts/install-deno.mjs",
     "test": "run-s install:deno deno-types test:unit",
-    "test:unit": "deno test --allow-read --allow-run",
+    "test:unit": "deno test --allow-read --allow-run --no-check",
     "test:unit:update": "deno test --allow-read --allow-write --allow-run -- --update",
     "yalc:publish": "node ./scripts/prepack.js && yalc publish build --push --sig"
   },


### PR DESCRIPTION
I noticed that after https://github.com/getsentry/sentry-javascript/pull/14729, now tests started failing 😬 

The reason:

* We run `deno check ./build/index.mjs`
* This checks the types, but we now do not inline those anymore into the generated `./build/index.d.ts` file
* Instead, we just import them from `@sentry/core`
* Now `deno check` downloads the latest version of core into a local tmp folder and uses this for checking
* But there are different exports there than locally, leading to test failures 😬 

this PR simple kills the type tests - not sure if we need them/they are needed, but I can't think of a different way to make this work, there isn't really a way (as far as I see?) to tell `deno check` to consider a dependency from a local path instead 😬 