### PR TITLE
ref(flags): don't export FeatureFlagContext in types-hoist/context.ts

### DIFF
--- a/packages/core/src/types-hoist/context.ts
+++ b/packages/core/src/types-hoist/context.ts
@@ -133,6 +133,6 @@ export interface MissingInstrumentationContext extends Record<string, unknown> {
  * directly is not recommended. Use the functions in @sentry/browser
  * src/utils/featureFlags instead.
  */
-export interface FeatureFlagContext extends Record<string, unknown> {
+interface FeatureFlagContext extends Record<string, unknown> {
   values: FeatureFlag[];
 }


### PR DESCRIPTION
This isn't exported in types-hoist/index, but we found users can still import it from a `build/` file. Discussed with @billyvg we don't want users to accidentally import it this way. 

Note we currently use this type in sentry, until https://github.com/getsentry/sentry/pull/81954 is rolled out. 