### PR TITLE
feat(react)!: Remove deprecated react router methods

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
@@ -41,7 +41,7 @@ Sentry.init({
   debug: !!process.env.DEBUG,
 });
 
-const sentryCreateHashRouter = Sentry.wrapCreateBrowserRouter(createHashRouter);
+const sentryCreateHashRouter = Sentry.wrapCreateBrowserRouterV6(createHashRouter);
 
 const router = sentryCreateHashRouter([
   {

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
@@ -39,7 +39,7 @@ Sentry.init({
   tunnel: 'http://localhost:3031', // proxy server
 });
 
-const useSentryRoutes = Sentry.wrapUseRoutes(useRoutes);
+const useSentryRoutes = Sentry.wrapUseRoutesV6(useRoutes);
 
 function App() {
   return useSentryRoutes([

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -92,7 +92,10 @@ It will be removed in a future major version.
 
 ## 4. Removal of Deprecated APIs (TODO)
 
-TODO
+### `@sentry/react`
+
+- The `wrapUseRoutes` method has been removed. Use `wrapUseRoutesV6` or `wrapUseRoutesV7` instead depending on what version of react router you are using.
+- The `wrapCreateBrowserRouter` method has been removed. Use `wrapCreateBrowserRouterV6` or `wrapCreateBrowserRouterV7` depending on what version of react router you are using.
 
 ## 5. Build Changes
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -16,11 +16,7 @@ export {
 export {
   reactRouterV6BrowserTracingIntegration,
   withSentryReactRouterV6Routing,
-  // eslint-disable-next-line deprecation/deprecation
-  wrapUseRoutes,
   wrapUseRoutesV6,
-  // eslint-disable-next-line deprecation/deprecation
-  wrapCreateBrowserRouter,
   wrapCreateBrowserRouterV6,
 } from './reactrouterv6';
 export {

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -28,12 +28,6 @@ export function wrapUseRoutesV6(origUseRoutes: UseRoutes): UseRoutes {
 }
 
 /**
- * Alias for backwards compatibility
- * @deprecated Use `wrapUseRoutesV6` or `wrapUseRoutesV7` instead.
- */
-export const wrapUseRoutes = wrapUseRoutesV6;
-
-/**
  * A wrapper function that adds Sentry routing instrumentation to a React Router v6 createBrowserRouter function.
  * This is used to automatically capture route changes as transactions when using the createBrowserRouter API.
  */
@@ -43,12 +37,6 @@ export function wrapCreateBrowserRouterV6<
 >(createRouterFunction: CreateRouterFunction<TState, TRouter>): CreateRouterFunction<TState, TRouter> {
   return createV6CompatibleWrapCreateBrowserRouter(createRouterFunction, '6');
 }
-
-/**
- * Alias for backwards compatibility
- * @deprecated Use `wrapCreateBrowserRouterV6` or `wrapCreateBrowserRouterV7` instead.
- */
-export const wrapCreateBrowserRouter = wrapCreateBrowserRouterV6;
 
 /**
  * A higher-order component that adds Sentry routing instrumentation to a React Router v6 Route component.


### PR DESCRIPTION
Removes code deprecated in https://github.com/getsentry/sentry-javascript/pull/14513 and adds changelog entry as appropriate:

Removed methods:
1. The `wrapUseRoutes` method has been removed. Use `wrapUseRoutesV6` or `wrapUseRoutesV7` instead depending on what version of react router you are using.
2. The `wrapCreateBrowserRouter` method has been removed. Use `wrapCreateBrowserRouterV6` or `wrapCreateBrowserRouterV7` depending on what version of react router you are using.