### PR TITLE
feat(react)!: Remove deprecated `getNumberOfUrlSegments` method

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -97,6 +97,10 @@ It will be removed in a future major version.
 - The `wrapUseRoutes` method has been removed. Use `wrapUseRoutesV6` or `wrapUseRoutesV7` instead depending on what version of react router you are using.
 - The `wrapCreateBrowserRouter` method has been removed. Use `wrapCreateBrowserRouterV6` or `wrapCreateBrowserRouterV7` depending on what version of react router you are using.
 
+### `@sentry/core`
+
+- The `getNumberOfUrlSegments` method has been removed. There are no replacements.
+
 ## 5. Build Changes
 
 Previously the CJS versions of the SDK code (wrongfully) contained compatibility statements for default exports in ESM:

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -162,8 +162,7 @@ export {
   parseBaggageHeader,
 } from './baggage';
 
-// eslint-disable-next-line deprecation/deprecation
-export { getNumberOfUrlSegments, getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from './url';
+export { getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from './url';
 // eslint-disable-next-line deprecation/deprecation
 export { makeFifoCache } from './cache';
 export { eventFromMessage, eventFromUnknownInput, exceptionFromError, parseStackFrames } from './eventbuilder';

--- a/packages/core/src/utils-hoist/url.ts
+++ b/packages/core/src/utils-hoist/url.ts
@@ -49,17 +49,6 @@ export function stripUrlQueryAndFragment(urlPath: string): string {
 }
 
 /**
- * Returns number of URL segments of a passed string URL.
- *
- * @deprecated This function will be removed in the next major version.
- */
-// TODO(v9): Hoist this function into the places where we use it. (as it stands only react router v6 instrumentation)
-export function getNumberOfUrlSegments(url: string): number {
-  // split at '/' or at '\/' to split regex urls correctly
-  return url.split(/\\?\//).filter(s => s.length > 0 && s !== ',').length;
-}
-
-/**
  * Takes a URL object and returns a sanitized string which is safe to use as span name
  * see: https://develop.sentry.dev/sdk/data-handling/#structuring-data
  */

--- a/packages/core/test/utils-hoist/url.test.ts
+++ b/packages/core/test/utils-hoist/url.test.ts
@@ -1,9 +1,4 @@
-import {
-  getNumberOfUrlSegments,
-  getSanitizedUrlString,
-  parseUrl,
-  stripUrlQueryAndFragment,
-} from '../../src/utils-hoist/url';
+import { getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from '../../src/utils-hoist/url';
 
 describe('stripQueryStringAndFragment', () => {
   const urlString = 'http://dogs.are.great:1231/yay/';
@@ -23,18 +18,6 @@ describe('stripQueryStringAndFragment', () => {
   it('strips query string and fragment from url', () => {
     const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
     expect(stripUrlQueryAndFragment(urlWithQueryStringAndFragment)).toBe(urlString);
-  });
-});
-
-describe('getNumberOfUrlSegments', () => {
-  test.each([
-    ['regular path', '/projects/123/views/234', 4],
-    ['single param parameterized path', '/users/:id/details', 3],
-    ['multi param parameterized path', '/stores/:storeId/products/:productId', 4],
-    ['regex path', String(/\/api\/post[0-9]/), 2],
-  ])('%s', (_: string, input, output) => {
-    // eslint-disable-next-line deprecation/deprecation
-    expect(getNumberOfUrlSegments(input)).toEqual(output);
   });
 });
 

--- a/packages/react/src/reactrouterv6-compat-utils.tsx
+++ b/packages/react/src/reactrouterv6-compat-utils.tsx
@@ -16,7 +16,6 @@ import {
   getActiveSpan,
   getClient,
   getCurrentScope,
-  getNumberOfUrlSegments,
   getRootSpan,
   logger,
   spanToJSON,
@@ -436,8 +435,6 @@ function getNormalizedName(
               // If the route defined on the element is something like
               // <Route path="/stores/:storeId/products/:productId" element={<div>Product</div>} />
               // We should check against the branch.pathname for the number of / separators
-              // TODO(v9): Put the implementation of `getNumberOfUrlSegments` in this file
-              // eslint-disable-next-line deprecation/deprecation
               getNumberOfUrlSegments(pathBuilder) !== getNumberOfUrlSegments(branch.pathname) &&
               // We should not count wildcard operators in the url segments calculation
               !pathEndsWithWildcard(pathBuilder)
@@ -571,4 +568,12 @@ function getActiveRootSpan(): Span | undefined {
 
   // Only use this root span if it is a pageload or navigation span
   return op === 'navigation' || op === 'pageload' ? rootSpan : undefined;
+}
+
+/**
+ * Returns number of URL segments of a passed string URL.
+ */
+export function getNumberOfUrlSegments(url: string): number {
+  // split at '/' or at '\/' to split regex urls correctly
+  return url.split(/\\?\//).filter(s => s.length > 0 && s !== ',').length;
 }

--- a/packages/react/test/reactrouterv6-compat-utils.test.tsx
+++ b/packages/react/test/reactrouterv6-compat-utils.test.tsx
@@ -1,0 +1,12 @@
+import { getNumberOfUrlSegments } from '../src/reactrouterv6-compat-utils';
+
+describe('getNumberOfUrlSegments', () => {
+  test.each([
+    ['regular path', '/projects/123/views/234', 4],
+    ['single param parameterized path', '/users/:id/details', 3],
+    ['multi param parameterized path', '/stores/:storeId/products/:productId', 4],
+    ['regex path', String(/\/api\/post[0-9]/), 2],
+  ])('%s', (_: string, input, output) => {
+    expect(getNumberOfUrlSegments(input)).toEqual(output);
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -77,7 +77,6 @@ import {
   getFunctionName as getFunctionName_imported,
   getGlobalSingleton as getGlobalSingleton_imported,
   getLocationHref as getLocationHref_imported,
-  getNumberOfUrlSegments as getNumberOfUrlSegments_imported,
   getOriginalFunction as getOriginalFunction_imported,
   getSDKSource as getSDKSource_imported,
   getSanitizedUrlString as getSanitizedUrlString_imported,
@@ -643,10 +642,6 @@ export const addRequestDataToEvent = addRequestDataToEvent_imported;
 /** @deprecated Import from `@sentry/core` instead. */
 // eslint-disable-next-line deprecation/deprecation
 export const BAGGAGE_HEADER_NAME = BAGGAGE_HEADER_NAME_imported;
-
-/** @deprecated Import from `@sentry/core` instead. */
-// eslint-disable-next-line deprecation/deprecation
-export const getNumberOfUrlSegments = getNumberOfUrlSegments_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
 export const getSanitizedUrlString = getSanitizedUrlString_imported;


### PR DESCRIPTION
Removes code deprecated in https://github.com/getsentry/sentry-javascript/pull/14458

Removes `getNumberOfUrlSegments` as a public export from `@sentry/core`.

This method is still used, so we extract it into a helper in `@sentry/react` (and port the tests accordingly).