### PR TITLE
feat!: Bump typescript to `~5.0.0`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/create-next-app/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/package.json
@@ -19,7 +19,7 @@
     "next": "14.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/create-react-app/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-react-app/package.json
@@ -10,7 +10,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/dev-packages/e2e-tests/test-applications/default-browser/package.json
+++ b/dev-packages/e2e-tests/test-applications/default-browser/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@sentry/browser": "latest || *",
     "@types/node": "^18.19.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "start": "serve -s build",

--- a/dev-packages/e2e-tests/test-applications/nestjs-8/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-8/package.json
@@ -43,6 +43,6 @@
     "supertest": "^6.3.3",
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "~5.0.0"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic-with-graphql/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic-with-graphql/package.json
@@ -45,6 +45,6 @@
     "supertest": "^6.3.3",
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "~5.0.0"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/package.json
@@ -43,6 +43,6 @@
     "supertest": "^6.3.3",
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "~5.0.0"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/package.json
@@ -42,6 +42,6 @@
     "supertest": "^6.3.3",
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "~5.0.0"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-graphql/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-graphql/package.json
@@ -45,6 +45,6 @@
     "supertest": "^6.3.3",
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "~5.0.0"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules-decorator/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules-decorator/package.json
@@ -41,6 +41,6 @@
     "supertest": "^6.3.3",
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "~5.0.0"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/package.json
@@ -41,6 +41,6 @@
     "supertest": "^6.3.3",
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "~5.0.0"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nextjs-13/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-13/package.json
@@ -20,7 +20,7 @@
     "next": "13.5.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/package.json
@@ -20,7 +20,7 @@
     "next": "14.1.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
@@ -21,7 +21,7 @@
     "next": "15.0.0-canary.182",
     "react": "beta",
     "react-dom": "beta",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
@@ -22,7 +22,7 @@
     "next": "14.0.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/nextjs-turbo/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-turbo/package.json
@@ -20,7 +20,7 @@
     "next": "15.0.0",
     "react": "rc",
     "react-dom": "rc",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/node-connect/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-connect/package.json
@@ -16,7 +16,7 @@
     "@sentry/opentelemetry": "latest || *",
     "@types/node": "^18.19.1",
     "connect": "3.7.0",
-    "typescript": "4.9.5",
+    "typescript": "~5.0.0",
     "ts-node": "10.9.1"
   },
   "devDependencies": {

--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/package.json
@@ -21,7 +21,7 @@
     "@sentry/google-cloud-serverless": "latest || *",
     "@sentry/bun": "latest || *",
     "@types/node": "^18.19.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/node-express-incorrect-instrumentation/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-incorrect-instrumentation/package.json
@@ -18,7 +18,7 @@
     "@types/express": "4.17.17",
     "@types/node": "^18.19.1",
     "express": "4.20.0",
-    "typescript": "4.9.5",
+    "typescript": "~5.0.0",
     "zod": "~3.22.4"
   },
   "devDependencies": {

--- a/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/package.json
@@ -16,7 +16,7 @@
     "@types/express": "4.17.17",
     "@types/node": "^18.19.1",
     "express": "4.19.2",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1"

--- a/dev-packages/e2e-tests/test-applications/node-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express/package.json
@@ -18,7 +18,7 @@
     "@types/express": "4.17.17",
     "@types/node": "^18.19.1",
     "express": "4.20.0",
-    "typescript": "4.9.5",
+    "typescript": "~5.0.0",
     "zod": "~3.22.4"
   },
   "devDependencies": {

--- a/dev-packages/e2e-tests/test-applications/node-fastify/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/package.json
@@ -16,7 +16,7 @@
     "@sentry/opentelemetry": "latest || *",
     "@types/node": "^18.19.1",
     "fastify": "4.23.2",
-    "typescript": "4.9.5",
+    "typescript": "~5.0.0",
     "ts-node": "10.9.1"
   },
   "devDependencies": {

--- a/dev-packages/e2e-tests/test-applications/node-koa/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-koa/package.json
@@ -15,7 +15,7 @@
     "@sentry/node": "latest || *",
     "@types/node": "^18.19.1",
     "koa": "^2.15.2",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/node-otel-custom-sampler/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-otel-custom-sampler/package.json
@@ -18,7 +18,7 @@
     "@types/express": "4.17.17",
     "@types/node": "^18.19.1",
     "express": "4.19.2",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/node-otel-sdk-node/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-otel-sdk-node/package.json
@@ -19,7 +19,7 @@
     "@types/express": "4.17.17",
     "@types/node": "^18.19.1",
     "express": "4.19.2",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/package.json
@@ -22,7 +22,7 @@
     "@types/express": "4.17.17",
     "@types/node": "^18.19.1",
     "express": "4.19.2",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",

--- a/dev-packages/e2e-tests/test-applications/react-17/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-17/package.json
@@ -10,7 +10,7 @@
     "react-dom": "17.0.2",
     "react-router-dom": "~6.3.0",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "react-scripts build",

--- a/dev-packages/e2e-tests/test-applications/react-19/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-19/package.json
@@ -12,7 +12,7 @@
     "react": "19.0.0-rc-935180c7e0-20240524",
     "react-dom": "19.0.0-rc-935180c7e0-20240524",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "react-scripts build",

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/package.json
@@ -11,7 +11,7 @@
     "react-dom": "18.2.0",
     "react-router-dom": "^6.4.1",
     "react-scripts": "5.0.1",
-    "typescript": "4.4.2"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "react-scripts build",

--- a/dev-packages/e2e-tests/test-applications/react-router-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-5/package.json
@@ -15,7 +15,7 @@
     "react-dom": "18.2.0",
     "react-router-dom": "5.3.4",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "react-scripts build",

--- a/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/package.json
@@ -11,7 +11,7 @@
     "react-dom": "18.2.0",
     "react-router-dom": "^6.28.0",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "react-scripts build",

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/package.json
@@ -10,7 +10,7 @@
     "react-dom": "18.2.0",
     "react-router-dom": "^6.4.1",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "react-scripts build",

--- a/dev-packages/e2e-tests/test-applications/react-router-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/package.json
@@ -11,7 +11,7 @@
     "react-dom": "18.2.0",
     "react-router-dom": "^6.4.1",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "react-scripts build",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/package.json
@@ -15,7 +15,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "vite": "^6.0.1",
     "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "vite build",

--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/package.json
@@ -11,7 +11,7 @@
     "react-dom": "18.2.0",
     "react-router-dom": "6.4.1",
     "react-scripts": "5.0.1",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "build": "react-scripts build",

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -53,6 +53,8 @@ In preparation for the OpenTelemetry SDK v2, which will raise the minimum requir
 
 Additionally, like the OpenTelemetry SDK, the Sentry JavaScript SDK will follow [DefinitelyType's version support policy](https://github.com/DefinitelyTyped/DefinitelyTyped#support-window) which has a support time frame of 2 years for any released version of TypeScript.
 
+Older Typescript versions _may_ still work, but we will not test them anymore and no more guarantees apply.
+
 ## 2. Behavior Changes
 
 ### `@sentry/core` / All SDKs

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "sucrase": "^3.35.0",
     "ts-jest": "^27.1.4",
     "ts-node": "10.9.1",
-    "typescript": "4.9.5",
+    "typescript": "~5.0.0",
     "vitest": "^1.6.0",
     "yalc": "^1.0.0-pre.53"
   },

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -54,7 +54,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/npm/types/index.d.ts": [
         "build/npm/types-ts3.8/index.d.ts"
       ]

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/npm/types/index.d.ts": [
         "build/npm/types-ts3.8/index.d.ts"
       ]

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/core/test/utils-hoist/object.test.ts
+++ b/packages/core/test/utils-hoist/object.test.ts
@@ -426,7 +426,8 @@ describe('markFunctionWrapped', () => {
     const wrappedFunc = jest.fn();
     markFunctionWrapped(wrappedFunc, originalFunc);
 
-    expect((wrappedFunc as WrappedFunction).__sentry_original__).toBe(originalFunc);
+    // cannot wrap because it is frozen, but we do not error!
+    expect((wrappedFunc as WrappedFunction).__sentry_original__).toBe(undefined);
 
     wrappedFunc();
 

--- a/packages/ember/tsconfig.json
+++ b/packages/ember/tsconfig.json
@@ -7,7 +7,6 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "alwaysStrict": true,
-    "noImplicitUseStrict": false,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "noEmitOnError": false,

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/npm/types/index.d.ts": [
         "build/npm/types-ts3.8/index.d.ts"
       ]

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -35,7 +35,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -38,7 +38,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/integration-shims/package.json
+++ b/packages/integration-shims/package.json
@@ -22,7 +22,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -66,7 +66,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/npm/types/index.d.ts": [
         "build/npm/types-ts3.8/index.d.ts"
       ]

--- a/packages/nitro-utils/package.json
+++ b/packages/nitro-utils/package.json
@@ -30,7 +30,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -55,7 +55,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -22,7 +22,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "lib/types/index.d.ts": [
         "lib/types-ts3.8/index.d.ts"
       ]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -42,7 +42,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -20,7 +20,7 @@
     "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.17",
     "nock": "^13.5.5",
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "resolutions": {
     "@sentry/browser": "file:../../../browser",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -19,7 +19,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/npm/types/index.d.ts": [
         "build/npm/types-ts3.8/index.d.ts"
       ]

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -19,7 +19,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/npm/types/index.d.ts": [
         "build/npm/types-ts3.8/index.d.ts"
       ]

--- a/packages/replay-worker/package.json
+++ b/packages/replay-worker/package.json
@@ -6,7 +6,7 @@
   "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -14,7 +14,7 @@
     "tsconfig.json"
   ],
   "peerDependencies": {
-    "typescript": "4.9.5"
+    "typescript": "~5.0.0"
   },
   "scripts": {
     "clean": "yarn rimraf sentry-internal-typescript-*.tgz",

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -12,7 +12,6 @@
     "noErrorTruncation": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
-    "noImplicitUseStrict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "preserveWatchOutput": true,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
       ]

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -29,7 +29,7 @@
     }
   },
   "typesVersions": {
-    "<4.9": {
+    "<5.0": {
       "build/npm/types/index.d.ts": [
         "build/npm/types-ts3.8/index.d.ts"
       ]

--- a/scripts/verify-packages-versions.js
+++ b/scripts/verify-packages-versions.js
@@ -1,6 +1,6 @@
 const pkg = require('../package.json');
 
-const TYPESCRIPT_VERSION = '4.9.5';
+const TYPESCRIPT_VERSION = '~5.0.0';
 
 if (pkg.devDependencies.typescript !== TYPESCRIPT_VERSION) {
   console.error(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -32607,30 +32607,25 @@ typescript@4.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
-typescript@4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-"typescript@>=3 < 6":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+"typescript@>=3 < 6", typescript@^5.0.4, typescript@^5.4.4:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 typescript@^3.9:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^5.0.4, typescript@^5.4.4:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
-
 typescript@next:
   version "5.2.0-dev.20230530"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.0-dev.20230530.tgz#4251ade97a9d8a86850c4d5c3c4f3e1cb2ccf52c"
   integrity sha512-bIoMajCZWzLB+pWwncaba/hZc6dRnw7x8T/fenOnP9gYQB/gc4xdm48AXp5SH5I/PvvSeZ/dXkUMtc8s8BiDZw==
+
+typescript@~5.0.0:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.39"


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/14757

For now we keep downleveling to 3.8, as long as that works without problems... we can still remove that in a follow up step.