### PR TITLE
feat(core)!: Remove validSeverityLevels export

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -104,7 +104,8 @@ It will be removed in a future major version.
 
 ### `@sentry/core`
 
-- The `getNumberOfUrlSegments` method has been removed. There are no replacements.
+- The `getNumberOfUrlSegments` method has been removed. There is no replacement.
+- The `validSeverityLevels` export has been removed. There is no replacement.
 
 ### `@sentry/nestjs`
 

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -90,8 +90,7 @@ export type {
   TransactionNamingScheme,
 } from './requestdata';
 
-// eslint-disable-next-line deprecation/deprecation
-export { severityLevelFromString, validSeverityLevels } from './severity';
+export { severityLevelFromString } from './severity';
 export {
   UNKNOWN_FUNCTION,
   createStackParser,

--- a/packages/core/src/utils-hoist/severity.ts
+++ b/packages/core/src/utils-hoist/severity.ts
@@ -1,11 +1,6 @@
 import type { SeverityLevel } from '../types-hoist';
 
 /**
- * @deprecated This variable has been deprecated and will be removed in the next major version.
- */
-export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug'];
-
-/**
  * Converts a string-based level into a `SeverityLevel`, normalizing it along the way.
  *
  * @param level String representation of desired `SeverityLevel`.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -155,7 +155,6 @@ import {
   updateRateLimits as updateRateLimits_imported,
   urlEncode as urlEncode_imported,
   uuid4 as uuid4_imported,
-  validSeverityLevels as validSeverityLevels_imported,
   vercelWaitUntil as vercelWaitUntil_imported,
   watchdogTimer as watchdogTimer_imported,
   winterCGHeadersToDict as winterCGHeadersToDict_imported,
@@ -339,10 +338,6 @@ export const winterCGRequestToRequestData = winterCGRequestToRequestData_importe
 
 /** @deprecated Import from `@sentry/core` instead. */
 export const severityLevelFromString = severityLevelFromString_imported;
-
-/** @deprecated Import from `@sentry/core` instead. */
-// eslint-disable-next-line deprecation/deprecation
-export const validSeverityLevels = validSeverityLevels_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
 export const UNKNOWN_FUNCTION = UNKNOWN_FUNCTION_imported;


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/14268

Deprecation PR: https://github.com/getsentry/sentry-javascript/pull/14407

Removes `validSeverityLevels`. This has no replacement.