### PR TITLE
feat(node): Do not overwrite prisma `db.system` in newer Prisma versions

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -30,7 +30,7 @@
     "@nestjs/common": "10.4.6",
     "@nestjs/core": "10.4.6",
     "@nestjs/platform-express": "10.4.6",
-    "@prisma/client": "5.9.1",
+    "@prisma/client": "5.22.0",
     "@sentry/aws-serverless": "8.45.0",
     "@sentry/core": "8.45.0",
     "@sentry/node": "8.45.0",

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/package.json
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@prisma/client": "5.9.1",
-    "prisma": "^5.9.1"
+    "@prisma/client": "5.22.0",
+    "prisma": "5.22.0"
   }
 }

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
@@ -3,103 +3,137 @@ import { createRunner } from '../../../utils/runner';
 
 conditionalTest({ min: 16 })('Prisma ORM Tests', () => {
   test('CJS - should instrument PostgreSQL queries from Prisma ORM', done => {
-    const EXPECTED_TRANSACTION = {
-      transaction: 'Test Transaction',
-      spans: expect.arrayContaining([
-        expect.objectContaining({
-          data: {
-            method: 'create',
-            model: 'User',
-            name: 'User.create',
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:client:operation',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:client:serialize',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:client:connect',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:engine',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'db.type': 'postgres',
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:engine:connection',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'db.statement': expect.stringContaining(
-              'INSERT INTO "public"."User" ("createdAt","email","name") VALUES ($1,$2,$3) RETURNING "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" /* traceparent',
-            ),
-            'sentry.origin': 'auto.db.otel.prisma',
-            'db.system': 'prisma',
-            'sentry.op': 'db',
-          },
-          description: expect.stringContaining(
-            'INSERT INTO "public"."User" ("createdAt","email","name") VALUES ($1,$2,$3) RETURNING "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" /* traceparent',
-          ),
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:engine:serialize',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:engine:response_json_serialization',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            method: 'findMany',
-            model: 'User',
-            name: 'User.findMany',
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:client:operation',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:client:serialize',
-          status: 'ok',
-        }),
-        expect.objectContaining({
-          data: {
-            'sentry.origin': 'auto.db.otel.prisma',
-          },
-          description: 'prisma:engine',
-          status: 'ok',
-        }),
-      ]),
-    };
+    createRunner(__dirname, 'scenario.js')
+      .expect({
+        transaction: transaction => {
+          expect(transaction.transaction).toBe('Test Transaction');
 
-    createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+          const spans = transaction.spans || [];
+          expect(spans.length).toBeGreaterThanOrEqual(5);
+
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                method: 'create',
+                model: 'User',
+                name: 'User.create',
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:client:operation',
+              status: 'ok',
+            }),
+          );
+
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:client:serialize',
+              status: 'ok',
+            }),
+          );
+
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:client:connect',
+              status: 'ok',
+            }),
+          );
+
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:engine',
+              status: 'ok',
+            }),
+          );
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'sentry.origin': 'auto.db.otel.prisma',
+                'sentry.op': 'db',
+                'db.system': 'postgresql',
+              },
+              description: 'prisma:engine:connection',
+              status: 'ok',
+              op: 'db',
+            }),
+          );
+
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'db.statement': expect.stringContaining(
+                  'INSERT INTO "public"."User" ("createdAt","email","name") VALUES ($1,$2,$3) RETURNING "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" /* traceparent',
+                ),
+                'sentry.origin': 'auto.db.otel.prisma',
+                'sentry.op': 'db',
+                'db.system': 'postgresql',
+                'otel.kind': 'CLIENT',
+              },
+              description: expect.stringContaining(
+                'INSERT INTO "public"."User" ("createdAt","email","name") VALUES ($1,$2,$3) RETURNING "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" /* traceparent',
+              ),
+              status: 'ok',
+              op: 'db',
+            }),
+          );
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:engine:serialize',
+              status: 'ok',
+            }),
+          );
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:engine:response_json_serialization',
+              status: 'ok',
+            }),
+          );
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                method: 'findMany',
+                model: 'User',
+                name: 'User.findMany',
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:client:operation',
+              status: 'ok',
+            }),
+          );
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:client:serialize',
+              status: 'ok',
+            }),
+          );
+          expect(spans).toContainEqual(
+            expect.objectContaining({
+              data: {
+                'sentry.origin': 'auto.db.otel.prisma',
+              },
+              description: 'prisma:engine',
+              status: 'ok',
+            }),
+          );
+        },
+      })
+      .start(done);
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/yarn.lock
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/yarn.lock
@@ -2,50 +2,57 @@
 # yarn lockfile v1
 
 
-"@prisma/client@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.9.1.tgz#d92bd2f7f006e0316cb4fda9d73f235965cf2c64"
-  integrity sha512-caSOnG4kxcSkhqC/2ShV7rEoWwd3XrftokxJqOCMVvia4NYV/TPtJlS9C2os3Igxw/Qyxumj9GBQzcStzECvtQ==
+"@prisma/client@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.22.0.tgz#da1ca9c133fbefe89e0da781c75e1c59da5f8802"
+  integrity sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==
 
-"@prisma/debug@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.9.1.tgz#906274e73d3267f88b69459199fa3c51cd9511a3"
-  integrity sha512-yAHFSFCg8KVoL0oRUno3m60GAjsUKYUDkQ+9BA2X2JfVR3kRVSJFc/GpQ2fSORi4pSHZR9orfM4UC9OVXIFFTA==
+"@prisma/debug@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.22.0.tgz#58af56ed7f6f313df9fb1042b6224d3174bbf412"
+  integrity sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==
 
-"@prisma/engines-version@5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64":
-  version "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64.tgz#54d2164f28d23e09d41cf9eb0bddbbe7f3aaa660"
-  integrity sha512-HFl7275yF0FWbdcNvcSRbbu9JCBSLMcurYwvWc8WGDnpu7APxQo2ONtZrUggU3WxLxUJ2uBX+0GOFIcJeVeOOQ==
+"@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2":
+  version "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz#d534dd7235c1ba5a23bacd5b92cc0ca3894c28f4"
+  integrity sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==
 
-"@prisma/engines@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.9.1.tgz#767539afc6f193a182d0495b30b027f61f279073"
-  integrity sha512-gkdXmjxQ5jktxWNdDA5aZZ6R8rH74JkoKq6LD5mACSvxd2vbqWeWIOV0Py5wFC8vofOYShbt6XUeCIUmrOzOnQ==
+"@prisma/engines@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.22.0.tgz#28f3f52a2812c990a8b66eb93a0987816a5b6d84"
+  integrity sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==
   dependencies:
-    "@prisma/debug" "5.9.1"
-    "@prisma/engines-version" "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64"
-    "@prisma/fetch-engine" "5.9.1"
-    "@prisma/get-platform" "5.9.1"
+    "@prisma/debug" "5.22.0"
+    "@prisma/engines-version" "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
+    "@prisma/fetch-engine" "5.22.0"
+    "@prisma/get-platform" "5.22.0"
 
-"@prisma/fetch-engine@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.9.1.tgz#5d3b2c9af54a242e37b3f9561b59ab72f8e92818"
-  integrity sha512-l0goQOMcNVOJs1kAcwqpKq3ylvkD9F04Ioe1oJoCqmz05mw22bNAKKGWuDd3zTUoUZr97va0c/UfLNru+PDmNA==
+"@prisma/fetch-engine@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz#4fb691b483a450c5548aac2f837b267dd50ef52e"
+  integrity sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==
   dependencies:
-    "@prisma/debug" "5.9.1"
-    "@prisma/engines-version" "5.9.0-32.23fdc5965b1e05fc54e5f26ed3de66776b93de64"
-    "@prisma/get-platform" "5.9.1"
+    "@prisma/debug" "5.22.0"
+    "@prisma/engines-version" "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
+    "@prisma/get-platform" "5.22.0"
 
-"@prisma/get-platform@5.9.1":
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.9.1.tgz#a66bb46ab4d30db786c84150ef074ab0aad4549e"
-  integrity sha512-6OQsNxTyhvG+T2Ksr8FPFpuPeL4r9u0JF0OZHUBI/Uy9SS43sPyAIutt4ZEAyqWQt104ERh70EZedkHZKsnNbg==
+"@prisma/get-platform@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.22.0.tgz#fc675bc9d12614ca2dade0506c9c4a77e7dddacd"
+  integrity sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==
   dependencies:
-    "@prisma/debug" "5.9.1"
+    "@prisma/debug" "5.22.0"
 
-prisma@^5.9.1:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.9.1.tgz#baa3dd635fbf71504980978f10f55ea11068f6aa"
-  integrity sha512-Hy/8KJZz0ELtkw4FnG9MS9rNWlXcJhf98Z2QMqi0QiVMoS8PzsBkpla0/Y5hTlob8F3HeECYphBjqmBxrluUrQ==
+fsevents@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+prisma@5.22.0:
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.22.0.tgz#1f6717ff487cdef5f5799cc1010459920e2e6197"
+  integrity sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==
   dependencies:
-    "@prisma/engines" "5.9.1"
+    "@prisma/engines" "5.22.0"
+  optionalDependencies:
+    fsevents "2.3.3"

--- a/packages/node/src/integrations/tracing/prisma.ts
+++ b/packages/node/src/integrations/tracing/prisma.ts
@@ -29,7 +29,9 @@ const _prismaIntegration = (() => {
           span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.prisma');
         }
 
-        if (spanJSON.description === 'prisma:engine:db_query') {
+        // In Prisma v5.22+, the `db.system` attribute is automatically set
+        // On older versions, this is missing, so we add it here
+        if (spanJSON.description === 'prisma:engine:db_query' && !spanJSON.data['db.system']) {
           span.setAttribute('db.system', 'prisma');
         }
       });


### PR DESCRIPTION
Since v5.22, Prisma properly adds the `db.system` to it's OTEL spans. 
This PR fixes the behavior so we do not overwrite it. For now, I left the fallback behavior in, that would add it if `db.system` is missing - as otherwise this would "break" on older prisma versions. 

This also needs to be backported to v8.