### PR TITLE
chore: Add external contributor to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-Work in this release was contributed by  @aloisklink, @arturovt, @benjick and @maximepvrt. Thank you for your contributions!
+Work in this release was contributed by @aloisklink, @arturovt, @benjick and @maximepvrt. Thank you for your contributions!
 
 ## 8.45.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-Work in this release was contributed by @benjick. Thank you for your contribution!
-
-Work in this release was contributed by @maximepvrt, @arturovt and @aloisklink. Thank you for your contributions!
+Work in this release was contributed by  @aloisklink, @arturovt, @benjick and @maximepvrt. Thank you for your contributions!
 
 ## 8.45.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+Work in this release was contributed by @benjick. Thank you for your contribution!
+
 Work in this release was contributed by @maximepvrt, @arturovt and @aloisklink. Thank you for your contributions!
 
 ## 8.45.0


### PR DESCRIPTION
This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution. See #14766