### PR TITLE
ref(v8/nextjs): Fix typo in source maps deletion warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-Work in this release was contributed by @aloisklink. Thank you for your contribution!
+Work in this release was contributed by @aloisklink and @benjick. Thank you for your contributions!
 
 ## 8.46.0
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -340,7 +340,7 @@ export function constructWebpackConfigFunction(
           if (!isServer && !userSentryOptions.sourcemaps?.deleteSourcemapsAfterUpload) {
             // eslint-disable-next-line no-console
             console.warn(
-              "[@sentry/nextjs] The Sentry SDK has enabled source map generation for your Next.js app. If you don't want to serve Source Maps to your users, either set the `deleteSourceMapsAfterUpload` option to true, or manually delete the source maps after the build. In future Sentry SDK versions `deleteSourceMapsAfterUpload` will default to `true`. If you do not want to generate and upload sourcemaps, set the `sourcemaps.disable` option in `withSentryConfig()`.",
+              "[@sentry/nextjs] The Sentry SDK has enabled source map generation for your Next.js app. If you don't want to serve Source Maps to your users, either set the `sourcemaps.deleteSourcemapsAfterUpload` option to true, or manually delete the source maps after the build. In future Sentry SDK versions `sourcemaps.deleteSourcemapsAfterUpload` will default to `true`. If you do not want to generate and upload sourcemaps, set the `sourcemaps.disable` option in `withSentryConfig()`.",
             );
           }
 


### PR DESCRIPTION

backport of #14766 to v8. Nothing major just figured we might as well get this out with the next v8 release
