### PR TITLE
feat(core)!: Remove `arrayify` method

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -106,6 +106,7 @@ It will be removed in a future major version.
 
 - The `getNumberOfUrlSegments` method has been removed. There is no replacement.
 - The `validSeverityLevels` export has been removed. There is no replacement.
+- The `arrayify` export has been removed. There is no replacement.
 
 ### `@sentry/nestjs`
 

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -42,8 +42,6 @@ export {
   addContextToFrame,
   addExceptionMechanism,
   addExceptionTypeValue,
-  // eslint-disable-next-line deprecation/deprecation
-  arrayify,
   checkOrSetAlreadyCaught,
   getEventDescription,
   parseSemver,

--- a/packages/core/src/utils-hoist/misc.ts
+++ b/packages/core/src/utils-hoist/misc.ts
@@ -230,15 +230,3 @@ function isAlreadyCaptured(exception: unknown): boolean | void {
     return (exception as { __sentry_captured__?: boolean }).__sentry_captured__;
   } catch {} // eslint-disable-line no-empty
 }
-
-/**
- * Checks whether the given input is already an array, and if it isn't, wraps it in one.
- *
- * @param maybeArray Input to turn into an array, if necessary
- * @returns The input, if already an array, or an array with the input as the only element, if not
- *
- * @deprecated This function has been deprecated and will not be replaced.
- */
-export function arrayify<T = unknown>(maybeArray: T | T[]): T[] {
-  return Array.isArray(maybeArray) ? maybeArray : [maybeArray];
-}

--- a/packages/core/test/utils-hoist/misc.test.ts
+++ b/packages/core/test/utils-hoist/misc.test.ts
@@ -3,7 +3,6 @@ import type { Event, Mechanism, StackFrame } from '../../src/types-hoist';
 import {
   addContextToFrame,
   addExceptionMechanism,
-  arrayify,
   checkOrSetAlreadyCaught,
   getEventDescription,
   uuid4,
@@ -361,29 +360,5 @@ describe('uuid4 generation', () => {
     for (let index = 0; index < 1_000; index++) {
       expect(uuid4()).toMatch(uuid4Regex);
     }
-  });
-});
-
-describe('arrayify()', () => {
-  it('returns arrays untouched', () => {
-    // eslint-disable-next-line deprecation/deprecation
-    expect(arrayify([])).toEqual([]);
-    // eslint-disable-next-line deprecation/deprecation
-    expect(arrayify(['dogs', 'are', 'great'])).toEqual(['dogs', 'are', 'great']);
-  });
-
-  it('wraps non-arrays with an array', () => {
-    // eslint-disable-next-line deprecation/deprecation
-    expect(arrayify(1231)).toEqual([1231]);
-    // eslint-disable-next-line deprecation/deprecation
-    expect(arrayify('dogs are great')).toEqual(['dogs are great']);
-    // eslint-disable-next-line deprecation/deprecation
-    expect(arrayify(true)).toEqual([true]);
-    // eslint-disable-next-line deprecation/deprecation
-    expect(arrayify({})).toEqual([{}]);
-    // eslint-disable-next-line deprecation/deprecation
-    expect(arrayify(null)).toEqual([null]);
-    // eslint-disable-next-line deprecation/deprecation
-    expect(arrayify(undefined)).toEqual([undefined]);
   });
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -29,7 +29,6 @@ import {
   addNormalizedRequestDataToEvent as addNormalizedRequestDataToEvent_imported,
   addRequestDataToEvent as addRequestDataToEvent_imported,
   applyAggregateErrorsToEvent as applyAggregateErrorsToEvent_imported,
-  arrayify as arrayify_imported,
   baggageHeaderToDynamicSamplingContext as baggageHeaderToDynamicSamplingContext_imported,
   basename as basename_imported,
   browserPerformanceTimeOrigin as browserPerformanceTimeOrigin_imported,
@@ -607,10 +606,6 @@ export const flatten = flatten_imported;
 /** @deprecated Import from `@sentry/core` instead. */
 // eslint-disable-next-line deprecation/deprecation
 export const memoBuilder = memoBuilder_imported;
-
-/** @deprecated Import from `@sentry/core` instead. */
-// eslint-disable-next-line deprecation/deprecation
-export const arrayify = arrayify_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
 export const normalizeUrlToBase = normalizeUrlToBase_imported;


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/14268

Deprecation PR: https://github.com/getsentry/sentry-javascript/pull/14405

Removes `arrayify`. This has no replacement.