### PR TITLE
feat(core)!: Remove `BAGGAGE_HEADER_NAME` export

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -106,6 +106,7 @@ It will be removed in a future major version.
 
 - The `getNumberOfUrlSegments` method has been removed. There is no replacement.
 - The `validSeverityLevels` export has been removed. There is no replacement.
+- The `BAGGAGE_HEADER_NAME` export has been removed. There is no replacement.
 
 ### `@sentry/nestjs`
 

--- a/packages/core/src/utils-hoist/baggage.ts
+++ b/packages/core/src/utils-hoist/baggage.ts
@@ -4,11 +4,6 @@ import { DEBUG_BUILD } from './debug-build';
 import { isString } from './is';
 import { logger } from './logger';
 
-/**
- * @deprecated Use a `"baggage"` string directly
- */
-export const BAGGAGE_HEADER_NAME = 'baggage';
-
 export const SENTRY_BAGGAGE_KEY_PREFIX = 'sentry-';
 
 export const SENTRY_BAGGAGE_KEY_PREFIX_REGEX = /^sentry-/;

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -151,8 +151,6 @@ export {
 } from './ratelimit';
 export type { RateLimits } from './ratelimit';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  BAGGAGE_HEADER_NAME,
   MAX_BAGGAGE_STRING_LENGTH,
   SENTRY_BAGGAGE_KEY_PREFIX,
   SENTRY_BAGGAGE_KEY_PREFIX_REGEX,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines */
 import {
-  BAGGAGE_HEADER_NAME as BAGGAGE_HEADER_NAME_imported,
   CONSOLE_LEVELS as CONSOLE_LEVELS_imported,
   DEFAULT_RETRY_AFTER as DEFAULT_RETRY_AFTER_imported,
   DEFAULT_USER_INCLUDES as DEFAULT_USER_INCLUDES_imported,
@@ -633,10 +632,6 @@ export const extractRequestData = extractRequestData_imported;
 /** @deprecated Import from `@sentry/core` instead. */
 // eslint-disable-next-line deprecation/deprecation
 export const addRequestDataToEvent = addRequestDataToEvent_imported;
-
-/** @deprecated Import from `@sentry/core` instead. */
-// eslint-disable-next-line deprecation/deprecation
-export const BAGGAGE_HEADER_NAME = BAGGAGE_HEADER_NAME_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
 export const getSanitizedUrlString = getSanitizedUrlString_imported;


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/14268

Deprecation PR: https://github.com/getsentry/sentry-javascript/pull/14434

Removes `BAGGAGE_HEADER_NAME`. This has no replacement.