### PR TITLE
test(node): Add integration test to demonstrate sample rate propagation of incoming trace

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/server.js
@@ -1,0 +1,32 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  // disable attaching headers to /test/* endpoints
+  tracePropagationTargets: [/^(?!.*test).*$/],
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+
+const app = express();
+
+app.use(cors());
+app.use(bodyParser.json());
+app.use(bodyParser.text());
+app.use(bodyParser.raw());
+
+app.get('/test', (req, res) => {
+  res.send({ headers: req.headers });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/test.ts
@@ -1,0 +1,30 @@
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
+
+describe('tracesSampleRate propagation', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  const traceId = '12345678123456781234567812345678';
+
+  test('uses sample rate from incoming baggage header in trace envelope item', done => {
+    createRunner(__dirname, 'server.js')
+      .expectHeader({
+        transaction: {
+          trace: {
+            sample_rate: '0.05',
+            sampled: 'true',
+            trace_id: traceId,
+            transaction: 'myTransaction',
+          },
+        },
+      })
+      .start(done)
+      .makeRequest('get', '/test', {
+        headers: {
+          'sentry-trace': `${traceId}-1234567812345678-1`,
+          baggage: `sentry-sample_rate=0.05,sentry-trace_id=${traceId},sentry-sampled=true,sentry-transaction=myTransaction`,
+        },
+      });
+  });
+});


### PR DESCRIPTION
While investigating an internally reported SDK issue, I had the suspicion that our Node SDK might handle the sample rate from an incoming `baggage` header incorrectly. Turns out that's not the case and things work correctly. I couldn't find a test though, where we specifically cover a non `1.0` `sentry-sample_rate` baggage value, so I figured there's value in adding this test. 