### PR TITLE
fix(nestjs): Use correct main/module path in package.json

### DIFF
--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -14,8 +14,8 @@
     "/*.d.ts",
     "/*.d.ts.map"
   ],
-  "main": "build/cjs/nestjs/index.js",
-  "module": "build/esm/nestjs/index.js",
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/14789

`build/cjs/nestjs/index.js` and `build/esm/nestjs/index.js` doesn't exist, this fixes that.