### PR TITLE
fix(nestjs/v8): Use correct main/module path in package.json

### DIFF
--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -14,8 +14,8 @@
     "/*.d.ts",
     "/*.d.ts.map"
   ],
-  "main": "build/cjs/nestjs/index.js",
-  "module": "build/esm/nestjs/index.js",
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/14789

backport of v9 change: https://github.com/getsentry/sentry-javascript/pull/14790