### PR TITLE
fix(node): Don't leak `__span` property into breadcrumbs

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/middleware.test.ts
@@ -95,7 +95,7 @@ test('Should trace outgoing fetch requests inside middleware and create breadcru
     expect.arrayContaining([
       {
         category: 'fetch',
-        data: { __span: expect.any(String), method: 'GET', status_code: 200, url: 'http://localhost:3030/' },
+        data: { method: 'GET', status_code: 200, url: 'http://localhost:3030/' },
         timestamp: expect.any(Number),
         type: 'http',
       },

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -286,8 +286,12 @@ function _getFetchBreadcrumbHandler(client: Client): (handlerData: HandlerDataFe
       return;
     }
 
+    const breadcrumbData: FetchBreadcrumbData = {
+      method: handlerData.fetchData.method,
+      url: handlerData.fetchData.url,
+    };
+
     if (handlerData.error) {
-      const data: FetchBreadcrumbData = handlerData.fetchData;
       const hint: FetchBreadcrumbHint = {
         data: handlerData.error,
         input: handlerData.args,
@@ -298,7 +302,7 @@ function _getFetchBreadcrumbHandler(client: Client): (handlerData: HandlerDataFe
       addBreadcrumb(
         {
           category: 'fetch',
-          data,
+          data: breadcrumbData,
           level: 'error',
           type: 'http',
         },
@@ -306,22 +310,23 @@ function _getFetchBreadcrumbHandler(client: Client): (handlerData: HandlerDataFe
       );
     } else {
       const response = handlerData.response as Response | undefined;
-      const data: FetchBreadcrumbData = {
-        ...handlerData.fetchData,
-        status_code: response && response.status,
-      };
+
+      breadcrumbData.request_body_size = handlerData.fetchData.request_body_size;
+      breadcrumbData.response_body_size = handlerData.fetchData.response_body_size;
+      breadcrumbData.status_code = response && response.status;
+
       const hint: FetchBreadcrumbHint = {
         input: handlerData.args,
         response,
         startTimestamp,
         endTimestamp,
       };
-      const level = getBreadcrumbLogLevelFromHttpStatusCode(data.status_code);
+      const level = getBreadcrumbLogLevelFromHttpStatusCode(breadcrumbData.status_code);
 
       addBreadcrumb(
         {
           category: 'fetch',
-          data,
+          data: breadcrumbData,
           type: 'http',
           level,
         },

--- a/packages/cloudflare/src/integrations/fetch.ts
+++ b/packages/cloudflare/src/integrations/fetch.ts
@@ -124,8 +124,12 @@ function createBreadcrumb(handlerData: HandlerDataFetch): void {
     return;
   }
 
+  const breadcrumbData: FetchBreadcrumbData = {
+    method: handlerData.fetchData.method,
+    url: handlerData.fetchData.url,
+  };
+
   if (handlerData.error) {
-    const data = handlerData.fetchData;
     const hint: FetchBreadcrumbHint = {
       data: handlerData.error,
       input: handlerData.args,
@@ -136,29 +140,31 @@ function createBreadcrumb(handlerData: HandlerDataFetch): void {
     addBreadcrumb(
       {
         category: 'fetch',
-        data,
+        data: breadcrumbData,
         level: 'error',
         type: 'http',
       },
       hint,
     );
   } else {
-    const data: FetchBreadcrumbData = {
-      ...handlerData.fetchData,
-      status_code: handlerData.response && handlerData.response.status,
-    };
+    const response = handlerData.response as Response | undefined;
+
+    breadcrumbData.request_body_size = handlerData.fetchData.request_body_size;
+    breadcrumbData.response_body_size = handlerData.fetchData.response_body_size;
+    breadcrumbData.status_code = response && response.status;
+
     const hint: FetchBreadcrumbHint = {
       input: handlerData.args,
-      response: handlerData.response,
+      response,
       startTimestamp,
       endTimestamp,
     };
-    const level = getBreadcrumbLogLevelFromHttpStatusCode(data.status_code);
+    const level = getBreadcrumbLogLevelFromHttpStatusCode(breadcrumbData.status_code);
 
     addBreadcrumb(
       {
         category: 'fetch',
-        data,
+        data: breadcrumbData,
         type: 'http',
         level,
       },

--- a/packages/cloudflare/test/integrations/fetch.test.ts
+++ b/packages/cloudflare/test/integrations/fetch.test.ts
@@ -171,7 +171,6 @@ describe('WinterCGFetch instrumentation', () => {
           method: 'POST',
           status_code: 201,
           url: 'http://my-website.com/',
-          __span: expect.any(String),
         },
         type: 'http',
       },

--- a/packages/deno/src/integrations/breadcrumbs.ts
+++ b/packages/deno/src/integrations/breadcrumbs.ts
@@ -151,8 +151,12 @@ function _getFetchBreadcrumbHandler(client: Client): (handlerData: HandlerDataFe
       return;
     }
 
+    const breadcrumbData: FetchBreadcrumbData = {
+      method: handlerData.fetchData.method,
+      url: handlerData.fetchData.url,
+    };
+
     if (handlerData.error) {
-      const data: FetchBreadcrumbData = handlerData.fetchData;
       const hint: FetchBreadcrumbHint = {
         data: handlerData.error,
         input: handlerData.args,
@@ -163,7 +167,7 @@ function _getFetchBreadcrumbHandler(client: Client): (handlerData: HandlerDataFe
       addBreadcrumb(
         {
           category: 'fetch',
-          data,
+          data: breadcrumbData,
           level: 'error',
           type: 'http',
         },
@@ -171,22 +175,23 @@ function _getFetchBreadcrumbHandler(client: Client): (handlerData: HandlerDataFe
       );
     } else {
       const response = handlerData.response as Response | undefined;
-      const data: FetchBreadcrumbData = {
-        ...handlerData.fetchData,
-        status_code: response && response.status,
-      };
+
+      breadcrumbData.request_body_size = handlerData.fetchData.request_body_size;
+      breadcrumbData.response_body_size = handlerData.fetchData.response_body_size;
+      breadcrumbData.status_code = response && response.status;
+
       const hint: FetchBreadcrumbHint = {
         input: handlerData.args,
         response,
         startTimestamp,
         endTimestamp,
       };
-      const level = getBreadcrumbLogLevelFromHttpStatusCode(data.status_code);
+      const level = getBreadcrumbLogLevelFromHttpStatusCode(breadcrumbData.status_code);
 
       addBreadcrumb(
         {
           category: 'fetch',
-          data,
+          data: breadcrumbData,
           type: 'http',
           level,
         },

--- a/packages/vercel-edge/src/integrations/wintercg-fetch.ts
+++ b/packages/vercel-edge/src/integrations/wintercg-fetch.ts
@@ -130,8 +130,12 @@ function createBreadcrumb(handlerData: HandlerDataFetch): void {
     return;
   }
 
+  const breadcrumbData: FetchBreadcrumbData = {
+    method: handlerData.fetchData.method,
+    url: handlerData.fetchData.url,
+  };
+
   if (handlerData.error) {
-    const data = handlerData.fetchData;
     const hint: FetchBreadcrumbHint = {
       data: handlerData.error,
       input: handlerData.args,
@@ -142,29 +146,31 @@ function createBreadcrumb(handlerData: HandlerDataFetch): void {
     addBreadcrumb(
       {
         category: 'fetch',
-        data,
+        data: breadcrumbData,
         level: 'error',
         type: 'http',
       },
       hint,
     );
   } else {
-    const data: FetchBreadcrumbData = {
-      ...handlerData.fetchData,
-      status_code: handlerData.response && handlerData.response.status,
-    };
+    const response = handlerData.response as Response | undefined;
+
+    breadcrumbData.request_body_size = handlerData.fetchData.request_body_size;
+    breadcrumbData.response_body_size = handlerData.fetchData.response_body_size;
+    breadcrumbData.status_code = response && response.status;
+
     const hint: FetchBreadcrumbHint = {
       input: handlerData.args,
-      response: handlerData.response,
+      response,
       startTimestamp,
       endTimestamp,
     };
-    const level = getBreadcrumbLogLevelFromHttpStatusCode(data.status_code);
+    const level = getBreadcrumbLogLevelFromHttpStatusCode(breadcrumbData.status_code);
 
     addBreadcrumb(
       {
         category: 'fetch',
-        data,
+        data: breadcrumbData,
         type: 'http',
         level,
       },

--- a/packages/vercel-edge/test/wintercg-fetch.test.ts
+++ b/packages/vercel-edge/test/wintercg-fetch.test.ts
@@ -171,7 +171,6 @@ describe('WinterCGFetch instrumentation', () => {
           method: 'POST',
           status_code: 201,
           url: 'http://my-website.com/',
-          __span: expect.any(String),
         },
         type: 'http',
       },


### PR DESCRIPTION
It seems like the fact that fetch breadcrumbs had the `__span` property was an accident since like forever. This PR makes it more explicit what we put in the breadcrumb data.