### PR TITLE
feat(v8/core): Deprecate `getDomElement` method

### DIFF
--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -465,6 +465,7 @@ export function getMetaContent(metaName: string): string | undefined {
   // Can't specify generic to `getDomElement` because tracing can be used
   // in a variety of environments, have to disable `no-unsafe-member-access`
   // as a result.
+  // eslint-disable-next-line deprecation/deprecation
   const metaTag = getDomElement(`meta[name=${metaName}]`);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   return metaTag ? metaTag.getAttribute('content') : undefined;

--- a/packages/core/src/utils-hoist/browser.ts
+++ b/packages/core/src/utils-hoist/browser.ts
@@ -155,6 +155,8 @@ export function getLocationHref(): string {
  * `const element = getDomElement<Element>('selector');`
  *
  * @param selector the selector string passed on to document.querySelector
+ *
+ * @deprecated This method is deprecated and will be removed in the next major version.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getDomElement<E = any>(selector: string): E | null {

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -2,7 +2,13 @@ export { applyAggregateErrorsToEvent } from './aggregate-errors';
 // eslint-disable-next-line deprecation/deprecation
 export { flatten } from './array';
 export { getBreadcrumbLogLevelFromHttpStatusCode } from './breadcrumb-log-level';
-export { getComponentName, getDomElement, getLocationHref, htmlTreeAsString } from './browser';
+export {
+  getComponentName,
+  // eslint-disable-next-line deprecation/deprecation
+  getDomElement,
+  getLocationHref,
+  htmlTreeAsString,
+} from './browser';
 export { dsnFromString, dsnToString, makeDsn } from './dsn';
 export { SentryError } from './error';
 export { GLOBAL_OBJ, getGlobalSingleton } from './worldwide';

--- a/packages/core/test/utils-hoist/browser.test.ts
+++ b/packages/core/test/utils-hoist/browser.test.ts
@@ -78,6 +78,7 @@ describe('htmlTreeAsString', () => {
 describe('getDomElement', () => {
   it('returns the element for a given query selector', () => {
     document.head.innerHTML = '<div id="mydiv">Hello</div>';
+    // eslint-disable-next-line deprecation/deprecation
     const el = getDomElement('div#mydiv');
     expect(el).toBeDefined();
     expect(el?.tagName).toEqual('DIV');

--- a/packages/svelte/src/sdk.ts
+++ b/packages/svelte/src/sdk.ts
@@ -55,5 +55,6 @@ export function detectAndReportSvelteKit(): void {
  * @see https://github.com/sveltejs/kit/issues/307 for more information
  */
 export function isSvelteKitApp(): boolean {
+  // eslint-disable-next-line deprecation/deprecation
   return getDomElement('div#svelte-announcer') !== null;
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -560,6 +560,7 @@ export const resolve = resolve_imported;
 export const getComponentName = getComponentName_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */
+// eslint-disable-next-line deprecation/deprecation
 export const getDomElement = getDomElement_imported;
 
 /** @deprecated Import from `@sentry/core` instead. */


### PR DESCRIPTION
Backported deprecation of https://github.com/getsentry/sentry-javascript/pull/14797