### PR TITLE
fix(core): Use consistent `continueTrace` implementation in core

### DIFF
--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -26,7 +26,6 @@ export declare function flush(timeout?: number | undefined): PromiseLike<boolean
 
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
-export declare const getClient: typeof clientSdk.getClient;
 
 export declare const Span: clientSdk.Span;
 

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -27,7 +27,6 @@ export declare function flush(timeout?: number | undefined): PromiseLike<boolean
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
 export declare const getClient: typeof clientSdk.getClient;
-export declare const continueTrace: typeof clientSdk.continueTrace;
 
 export declare const Span: clientSdk.Span;
 

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -1,6 +1,7 @@
 import type { Scope } from '../scope';
 import type { getTraceData } from '../utils/traceData';
 import type {
+  continueTrace,
   startInactiveSpan,
   startSpan,
   startSpanManual,
@@ -68,4 +69,11 @@ export interface AsyncContextStrategy {
 
   /** Get trace data as serialized string values for propagation via `sentry-trace` and `baggage`. */
   getTraceData?: typeof getTraceData;
+
+  /**
+   * Continue a trace from `sentry-trace` and `baggage` values.
+   * These values can be obtained from incoming request headers, or in the browser from `<meta name="sentry-trace">`
+   * and `<meta name="baggage">` HTML tags.
+   */
+  continueTrace?: typeof continueTrace;
 }

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentry.ts
@@ -62,11 +62,11 @@ export function wrapApiHandlerWithSentry(apiHandler: NextApiHandler, parameteriz
         return withIsolationScope(isolationScope => {
           // Normally, there is an active span here (from Next.js OTEL) and we just use that as parent
           // Else, we manually continueTrace from the incoming headers
-          const continueTraceOrNot = getActiveSpan()
+          const continueTraceIfNoActiveSpan = getActiveSpan()
             ? <T>(_opts: unknown, callback: () => T) => callback()
             : continueTrace;
 
-          return continueTraceOrNot(
+          return continueTraceIfNoActiveSpan(
             {
               sentryTrace:
                 req.headers && isString(req.headers['sentry-trace']) ? req.headers['sentry-trace'] : undefined,

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -1,4 +1,4 @@
-import type { RequestEventData } from '@sentry/core';
+import { RequestEventData, getActiveSpan } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SPAN_STATUS_ERROR,
@@ -95,7 +95,11 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
       } satisfies RequestEventData,
     });
 
-    return continueTrace(
+    // Normally, there is an active span here (from Next.js OTEL) and we just use that as parent
+    // Else, we manually continueTrace from the incoming headers
+    const continueTraceOrNot = getActiveSpan() ? <T>(_opts: unknown, callback: () => T) => callback() : continueTrace;
+
+    return continueTraceOrNot(
       {
         sentryTrace: sentryTraceHeader,
         baggage: baggageHeader,

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -1,4 +1,5 @@
-import { RequestEventData, getActiveSpan } from '@sentry/core';
+import type { RequestEventData } from '@sentry/core';
+import { getActiveSpan } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SPAN_STATUS_ERROR,

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -97,9 +97,11 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
 
     // Normally, there is an active span here (from Next.js OTEL) and we just use that as parent
     // Else, we manually continueTrace from the incoming headers
-    const continueTraceOrNot = getActiveSpan() ? <T>(_opts: unknown, callback: () => T) => callback() : continueTrace;
+    const continueTraceIfNoActiveSpan = getActiveSpan()
+      ? <T>(_opts: unknown, callback: () => T) => callback()
+      : continueTrace;
 
-    return continueTraceOrNot(
+    return continueTraceIfNoActiveSpan(
       {
         sentryTrace: sentryTraceHeader,
         baggage: baggageHeader,

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -19,10 +19,6 @@ export declare function init(
   options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions | edgeSdk.EdgeOptions,
 ): Client | undefined;
 
-export declare const getClient: typeof clientSdk.getClient;
-export declare const getRootSpan: typeof serverSdk.getRootSpan;
-export declare const continueTrace: typeof clientSdk.continueTrace;
-
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -58,9 +58,6 @@ export type { NodeOptions } from './types';
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from '@sentry/core';
 
 export {
-  // These are custom variants that need to be used instead of the core one
-  // As they have slightly different implementations
-  continueTrace,
   // This needs exporting so the NodeClient can be used without calling init
   setOpenTelemetryContextAsyncContextStrategy as setNodeAsyncContextStrategy,
 } from '@sentry/opentelemetry';
@@ -105,6 +102,7 @@ export {
   getIsolationScope,
   getTraceData,
   getTraceMetaTags,
+  continueTrace,
   withScope,
   withIsolationScope,
   captureException,

--- a/packages/nuxt/src/index.types.ts
+++ b/packages/nuxt/src/index.types.ts
@@ -14,4 +14,3 @@ export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsInteg
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
-export declare const continueTrace: typeof clientSdk.continueTrace;

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -6,7 +6,7 @@ import {
   SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY,
   SENTRY_FORK_SET_SCOPE_CONTEXT_KEY,
 } from './constants';
-import { startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from './trace';
+import { continueTrace, startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from './trace';
 import type { CurrentScopes } from './types';
 import { getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
@@ -103,6 +103,7 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     getActiveSpan,
     suppressTracing,
     getTraceData,
+    continueTrace,
     // The types here don't fully align, because our own `Span` type is narrower
     // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
     withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -19,10 +19,8 @@ import {
   getRootSpan,
   getTraceContextFromScope,
   handleCallbackErrors,
-  propagationContextFromHeaders,
   spanToJSON,
   spanToTraceContext,
-  withScope,
 } from '@sentry/core';
 import { continueTraceAsRemoteSpan } from './propagator';
 import type { OpenTelemetryClient, OpenTelemetrySpanContext } from './types';
@@ -255,12 +253,7 @@ function getContextForScope(scope?: Scope): Context {
  * It propagates the trace as a remote span, in addition to setting it on the propagation context.
  */
 export function continueTrace<T>(options: Parameters<typeof baseContinueTrace>[0], callback: () => T): T {
-  return withScope(scope => {
-    const { sentryTrace, baggage } = options;
-    const propagationContext = propagationContextFromHeaders(sentryTrace, baggage);
-    scope.setPropagationContext(propagationContext);
-    return continueTraceAsRemoteSpan(context.active(), options, callback);
-  });
+  return continueTraceAsRemoteSpan(context.active(), options, callback);
 }
 
 /**

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -1576,11 +1576,8 @@ describe('continueTrace', () => {
     );
 
     expect(scope.getPropagationContext()).toEqual({
-      dsc: {}, // DSC should be an empty object (frozen), because there was an incoming trace
-      sampled: false,
-      parentSpanId: '1121201211212012',
       spanId: expect.any(String),
-      traceId: '12312012123120121231201212312012',
+      traceId: expect.any(String),
     });
 
     expect(scope.getScopeData().sdkProcessingMetadata).toEqual({});
@@ -1609,14 +1606,8 @@ describe('continueTrace', () => {
     );
 
     expect(scope.getPropagationContext()).toEqual({
-      dsc: {
-        environment: 'production',
-        version: '1.0',
-      },
-      sampled: true,
-      parentSpanId: '1121201211212012',
       spanId: expect.any(String),
-      traceId: '12312012123120121231201212312012',
+      traceId: expect.any(String),
     });
 
     expect(scope.getScopeData().sdkProcessingMetadata).toEqual({});
@@ -1645,16 +1636,9 @@ describe('continueTrace', () => {
     );
 
     expect(scope.getPropagationContext()).toEqual({
-      dsc: {
-        environment: 'production',
-        version: '1.0',
-      },
-      sampled: true,
-      parentSpanId: '1121201211212012',
       spanId: expect.any(String),
-      traceId: '12312012123120121231201212312012',
+      traceId: expect.any(String),
     });
-
     expect(scope.getScopeData().sdkProcessingMetadata).toEqual({});
   });
 

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -33,7 +33,6 @@ declare const runtime: 'client' | 'server';
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
 export declare const getClient: typeof clientSdk.getClient;
-export declare const continueTrace: typeof clientSdk.continueTrace;
 
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
 export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -32,7 +32,6 @@ declare const runtime: 'client' | 'server';
 
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
-export declare const getClient: typeof clientSdk.getClient;
 
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
 export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -4,6 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  continueTrace,
   fill,
   getActiveSpan,
   getClient,
@@ -19,7 +20,6 @@ import {
   winterCGRequestToRequestData,
   withIsolationScope,
 } from '@sentry/core';
-import { continueTrace } from '@sentry/opentelemetry';
 import { DEBUG_BUILD } from './debug-build';
 import { captureRemixServerException, errorHandleDataFunction, errorHandleDocumentRequestFunction } from './errors';
 import { getFutureFlagsServer, getRemixVersionFromBuild } from './futureFlags';

--- a/packages/solidstart/src/index.types.ts
+++ b/packages/solidstart/src/index.types.ts
@@ -19,8 +19,6 @@ export declare const contextLinesIntegration: typeof clientSdk.contextLinesInteg
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
-export declare const getClient: typeof clientSdk.getClient;
-
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function lastEventId(): string | undefined;

--- a/packages/solidstart/src/index.types.ts
+++ b/packages/solidstart/src/index.types.ts
@@ -24,5 +24,3 @@ export declare const getClient: typeof clientSdk.getClient;
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function lastEventId(): string | undefined;
-
-export declare const continueTrace: typeof clientSdk.continueTrace;

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -42,7 +42,6 @@ export declare const contextLinesIntegration: typeof clientSdk.contextLinesInteg
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
-export declare const getClient: typeof clientSdk.getClient;
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
 

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -50,6 +50,4 @@ export declare function close(timeout?: number | undefined): PromiseLike<boolean
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function lastEventId(): string | undefined;
 
-export declare const continueTrace: typeof clientSdk.continueTrace;
-
 export declare function trackComponent(options: clientSdk.TrackingOptions): ReturnType<typeof clientSdk.trackComponent>;

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -2,6 +2,7 @@ import type { Span } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  continueTrace,
   getActiveSpan,
   getCurrentScope,
   getDefaultIsolationScope,
@@ -13,7 +14,6 @@ import {
   winterCGRequestToRequestData,
   withIsolationScope,
 } from '@sentry/core';
-import { continueTrace } from '@sentry/node';
 import type { Handle, ResolveOptions } from '@sveltejs/kit';
 
 import { DEBUG_BUILD } from '../common/debug-build';


### PR DESCRIPTION
We have a different implementation of `continueTrace` for OTEL/Node. Until now we relied on actually using the import from `@sentry/node` vs `@sentry/core` to ensure this. However, this is a footgun, and actually lead to a problem in NextJS because we used the core variant there. Also, it is simply not isomorphic.

So to fix this, this PR puts `continueTrace` on the ACS so we can consistently use the core variant in all environments.

Fixes https://github.com/getsentry/sentry-javascript/issues/14787