### PR TITLE
chore(tests): Add esbuild overrides for vite 6 tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-5/package.json
@@ -17,5 +17,10 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "^8.42.0",
     "astro": "^5.0.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "esbuild": "0.24.0"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/package.json
@@ -56,5 +56,10 @@
         "label": "react-router-7-spa (TS 3.8)"
       }
     ]
+  },
+  "pnpm": {
+    "overrides": {
+      "esbuild": "0.24.0"
+    }
   }
 }


### PR DESCRIPTION
Adds an override for esbuild for tests that use vite6.

ref https://github.com/evanw/esbuild/issues/4010