### PR TITLE
test(astro): Fix Astro 4 e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-4/package.json
@@ -13,12 +13,12 @@
   },
   "dependencies": {
     "@astrojs/check": "0.9.2",
-    "@astrojs/node": "8.3.2",
+    "@astrojs/node": "8.3.4",
     "@playwright/test": "^1.46.0",
     "@sentry/astro": "* || latest",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@spotlightjs/astro": "2.1.6",
-    "astro": "4.13.3",
+    "astro": "4.16.18",
     "typescript": "^5.5.4"
   },
   "devDependencies": {

--- a/dev-packages/e2e-tests/test-applications/astro-4/src/env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-4/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />


### PR DESCRIPTION
In our Astro-4 E2E test app, Astro's Node adapter was pinned to a bad version that didn'T work correctly with newer Astro versions. We pinned the Astro version a while ago in https://github.com/getsentry/sentry-javascript/pull/14030 to unblock CI but looks like we just didn't follow up with investigating what caused the issue back then. 

This came up again when dependabot tried to bump the Astro version in #14781 and #14807 and as a result #14808 was opened.

This PR now 
- bumps the Node adapter version which makes newer Astro version function properly again
- updates `astro` to the latest v4 version (which is why I closed #14807)

closes #14808