### PR TITLE
test(nextjs): Test pages router API routes incoming trace propagation

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/pages/api/trace-propagation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/pages/api/trace-propagation.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type Data = {
+  name: string;
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+  res.status(200).json({ name: 'John Doe' });
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/pages-api-handler-trace-propagation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/pages-api-handler-trace-propagation.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Should create a transaction that has the same trace ID as the incoming request', async ({ request }) => {
+  const transactionPromise = waitForTransaction('nextjs-app-dir', async transactionEvent => {
+    return transactionEvent?.transaction === 'GET /api/trace-propagation';
+  });
+
+  await request.get('/api/trace-propagation', {
+    headers: {
+      'sentry-trace': '8ef4a40df2063cb023c93cbeb04d68c3-acf68e4724b58822-1',
+    },
+  });
+
+  expect((await transactionPromise).contexts?.trace).toBe(
+    expect.objectContaining({
+      trace_id: '8ef4a40df2063cb023c93cbeb04d68c3',
+      parent_span_id: 'acf68e4724b58822',
+    }),
+  );
+});


### PR DESCRIPTION
Add regression test for trace propagation in Next.js pages router api routes as fixed in https://github.com/getsentry/sentry-javascript/pull/14813.