### PR TITLE
fix(v8/core): Use consistent `continueTrace` implementation in core

### DIFF
--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -27,8 +27,6 @@ export declare function flush(timeout?: number | undefined): PromiseLike<boolean
 
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
-export declare const getClient: typeof clientSdk.getClient;
-export declare const continueTrace: typeof clientSdk.continueTrace;
 
 export declare const Span: clientSdk.Span;
 

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -1,6 +1,7 @@
 import type { Scope } from '../types-hoist';
 import type { getTraceData } from '../utils/traceData';
 import type {
+  continueTrace,
   startInactiveSpan,
   startSpan,
   startSpanManual,
@@ -68,4 +69,11 @@ export interface AsyncContextStrategy {
 
   /** Get trace data as serialized string values for propagation via `sentry-trace` and `baggage`. */
   getTraceData?: typeof getTraceData;
+
+  /**
+   * Continue a trace from `sentry-trace` and `baggage` values.
+   * These values can be obtained from incoming request headers, or in the browser from `<meta name="sentry-trace">`
+   * and `<meta name="baggage">` HTML tags.
+   */
+  continueTrace?: typeof continueTrace;
 }

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -191,15 +191,20 @@ export function startInactiveSpan(options: StartSpanOptions): Span {
  * be attached to the incoming trace.
  */
 export const continueTrace = <V>(
-  {
-    sentryTrace,
-    baggage,
-  }: {
+  options: {
     sentryTrace: Parameters<typeof propagationContextFromHeaders>[0];
     baggage: Parameters<typeof propagationContextFromHeaders>[1];
   },
   callback: () => V,
 ): V => {
+  const carrier = getMainCarrier();
+  const acs = getAsyncContextStrategy(carrier);
+  if (acs.continueTrace) {
+    return acs.continueTrace(options, callback);
+  }
+
+  const { sentryTrace, baggage } = options;
+
   return withScope(scope => {
     const propagationContext = propagationContextFromHeaders(sentryTrace, baggage);
     scope.setPropagationContext(propagationContext);

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentry.ts
@@ -3,6 +3,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   captureException,
   continueTrace,
+  getActiveSpan,
   httpRequestToRequestData,
   isString,
   logger,
@@ -59,7 +60,13 @@ export function wrapApiHandlerWithSentry(apiHandler: NextApiHandler, parameteriz
         req.__withSentry_applied__ = true;
 
         return withIsolationScope(isolationScope => {
-          return continueTrace(
+          // Normally, there is an active span here (from Next.js OTEL) and we just use that as parent
+          // Else, we manually continueTrace from the incoming headers
+          const continueTraceIfNoActiveSpan = getActiveSpan()
+            ? <T>(_opts: unknown, callback: () => T) => callback()
+            : continueTrace;
+
+          return continueTraceIfNoActiveSpan(
             {
               sentryTrace:
                 req.headers && isString(req.headers['sentry-trace']) ? req.headers['sentry-trace'] : undefined,

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -19,10 +19,6 @@ export declare function init(
   options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions | edgeSdk.EdgeOptions,
 ): Client | undefined;
 
-export declare const getClient: typeof clientSdk.getClient;
-export declare const getRootSpan: typeof serverSdk.getRootSpan;
-export declare const continueTrace: typeof clientSdk.continueTrace;
-
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -63,9 +63,6 @@ export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from
 export {
   // eslint-disable-next-line deprecation/deprecation
   addOpenTelemetryInstrumentation,
-  // These are custom variants that need to be used instead of the core one
-  // As they have slightly different implementations
-  continueTrace,
   // This needs exporting so the NodeClient can be used without calling init
   setOpenTelemetryContextAsyncContextStrategy as setNodeAsyncContextStrategy,
 } from '@sentry/opentelemetry';
@@ -110,6 +107,7 @@ export {
   getIsolationScope,
   getTraceData,
   getTraceMetaTags,
+  continueTrace,
   withScope,
   withIsolationScope,
   captureException,

--- a/packages/nuxt/src/index.types.ts
+++ b/packages/nuxt/src/index.types.ts
@@ -14,6 +14,5 @@ export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsInteg
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
-export declare const continueTrace: typeof clientSdk.continueTrace;
 // eslint-disable-next-line deprecation/deprecation
 export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -6,7 +6,7 @@ import {
   SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY,
   SENTRY_FORK_SET_SCOPE_CONTEXT_KEY,
 } from './constants';
-import { startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from './trace';
+import { continueTrace, startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from './trace';
 import type { CurrentScopes } from './types';
 import { getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
@@ -103,6 +103,7 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     getActiveSpan,
     suppressTracing,
     getTraceData,
+    continueTrace,
     // The types here don't fully align, because our own `Span` type is narrower
     // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
     withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -1,11 +1,17 @@
 import type { Context, Span, SpanContext, SpanOptions, Tracer } from '@opentelemetry/api';
 import { SpanStatusCode, TraceFlags, context, trace } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import type { Client, DynamicSamplingContext, Scope, Span as SentrySpan, TraceContext } from '@sentry/core';
+import type {
+  Client,
+  DynamicSamplingContext,
+  Scope,
+  Span as SentrySpan,
+  TraceContext,
+  continueTrace as baseContinueTrace,
+} from '@sentry/core';
 import {
   SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  continueTrace as baseContinueTrace,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromScope,
@@ -247,9 +253,7 @@ function getContextForScope(scope?: Scope): Context {
  * It propagates the trace as a remote span, in addition to setting it on the propagation context.
  */
 export function continueTrace<T>(options: Parameters<typeof baseContinueTrace>[0], callback: () => T): T {
-  return baseContinueTrace(options, () => {
-    return continueTraceAsRemoteSpan(context.active(), options, callback);
-  });
+  return continueTraceAsRemoteSpan(context.active(), options, callback);
 }
 
 /**

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -1574,11 +1574,8 @@ describe('continueTrace', () => {
     );
 
     expect(scope.getPropagationContext()).toEqual({
-      dsc: {}, // DSC should be an empty object (frozen), because there was an incoming trace
-      sampled: false,
-      parentSpanId: '1121201211212012',
       spanId: expect.any(String),
-      traceId: '12312012123120121231201212312012',
+      traceId: expect.any(String),
     });
 
     expect(scope.getScopeData().sdkProcessingMetadata).toEqual({});
@@ -1605,14 +1602,8 @@ describe('continueTrace', () => {
     );
 
     expect(scope.getPropagationContext()).toEqual({
-      dsc: {
-        environment: 'production',
-        version: '1.0',
-      },
-      sampled: true,
-      parentSpanId: '1121201211212012',
       spanId: expect.any(String),
-      traceId: '12312012123120121231201212312012',
+      traceId: expect.any(String),
     });
 
     expect(scope.getScopeData().sdkProcessingMetadata).toEqual({});
@@ -1639,16 +1630,9 @@ describe('continueTrace', () => {
     );
 
     expect(scope.getPropagationContext()).toEqual({
-      dsc: {
-        environment: 'production',
-        version: '1.0',
-      },
-      sampled: true,
-      parentSpanId: '1121201211212012',
       spanId: expect.any(String),
-      traceId: '12312012123120121231201212312012',
+      traceId: expect.any(String),
     });
-
     expect(scope.getScopeData().sdkProcessingMetadata).toEqual({});
   });
 

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -32,8 +32,6 @@ declare const runtime: 'client' | 'server';
 
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
-export declare const getClient: typeof clientSdk.getClient;
-export declare const continueTrace: typeof clientSdk.continueTrace;
 
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
 export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -4,6 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  continueTrace,
   fill,
   getActiveSpan,
   getClient,
@@ -19,7 +20,6 @@ import {
   winterCGRequestToRequestData,
   withIsolationScope,
 } from '@sentry/core';
-import { continueTrace } from '@sentry/opentelemetry';
 import { DEBUG_BUILD } from './debug-build';
 import { captureRemixServerException, errorHandleDataFunction, errorHandleDocumentRequestFunction } from './errors';
 import { getFutureFlagsServer, getRemixVersionFromBuild } from './futureFlags';

--- a/packages/solidstart/src/index.types.ts
+++ b/packages/solidstart/src/index.types.ts
@@ -19,13 +19,9 @@ export declare const contextLinesIntegration: typeof clientSdk.contextLinesInteg
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
-export declare const getClient: typeof clientSdk.getClient;
-
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function lastEventId(): string | undefined;
-
-export declare const continueTrace: typeof clientSdk.continueTrace;
 
 // eslint-disable-next-line deprecation/deprecation
 export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -42,15 +42,12 @@ export declare const contextLinesIntegration: typeof clientSdk.contextLinesInteg
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
-export declare const getClient: typeof clientSdk.getClient;
 // eslint-disable-next-line deprecation/deprecation
 export declare const getCurrentHub: typeof clientSdk.getCurrentHub;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function lastEventId(): string | undefined;
-
-export declare const continueTrace: typeof clientSdk.continueTrace;
 
 // eslint-disable-next-line deprecation/deprecation
 export declare const metrics: typeof clientSdk.metrics & typeof serverSdk.metrics;

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -2,6 +2,7 @@ import type { Span } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  continueTrace,
   getActiveSpan,
   getCurrentScope,
   getDefaultIsolationScope,
@@ -13,7 +14,6 @@ import {
   winterCGRequestToRequestData,
   withIsolationScope,
 } from '@sentry/core';
-import { continueTrace } from '@sentry/node';
 import type { Handle, ResolveOptions } from '@sveltejs/kit';
 
 import { DEBUG_BUILD } from '../common/debug-build';


### PR DESCRIPTION
V8 backport of https://github.com/getsentry/sentry-javascript/pull/14813

We have a different implementation of `continueTrace` for OTEL/Node. Until now we relied on actually using the import from `@sentry/node` vs `@sentry/core` to ensure this. However, this is a footgun, and actually lead to a problem in NextJS because we used the core variant there. Also, it is simply not isomorphic.

So to fix this, this PR puts `continueTrace` on the ACS so we can consistently use the core variant in all environments.

Fixes https://github.com/getsentry/sentry-javascript/issues/14787
