### PR TITLE
fix: Correctly resolve debug IDs for ANR events with custom appRoot

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/app-path.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/app-path.mjs
@@ -1,0 +1,36 @@
+import * as assert from 'assert';
+import * as crypto from 'crypto';
+import * as path from 'path';
+import * as url from 'url';
+
+import * as Sentry from '@sentry/node';
+
+global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+setTimeout(() => {
+  process.exit();
+}, 10000);
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  release: '1.0',
+  autoSessionTracking: false,
+  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100, appRootPath: __dirname })],
+});
+
+Sentry.setUser({ email: 'person@home.com' });
+Sentry.addBreadcrumb({ message: 'important message!' });
+
+function longWork() {
+  for (let i = 0; i < 20; i++) {
+    const salt = crypto.randomBytes(128).toString('base64');
+    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
+    assert.ok(hash);
+  }
+}
+
+setTimeout(() => {
+  longWork();
+}, 1000);

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -30,20 +30,20 @@ const ANR_EVENT = {
         mechanism: { type: 'ANR' },
         stacktrace: {
           frames: expect.arrayContaining([
-            {
+            expect.objectContaining({
               colno: expect.any(Number),
               lineno: expect.any(Number),
               filename: expect.any(String),
               function: '?',
               in_app: true,
-            },
-            {
+            }),
+            expect.objectContaining({
               colno: expect.any(Number),
               lineno: expect.any(Number),
               filename: expect.any(String),
               function: 'longWork',
               in_app: true,
-            },
+            }),
           ]),
         },
       },
@@ -119,6 +119,26 @@ describe('should report ANR when event loop blocked', () => {
     createRunner(__dirname, 'basic.mjs')
       .withMockSentryServer()
       .expect({ event: ANR_EVENT_WITH_DEBUG_META })
+      .start(done);
+  });
+
+  test('Custom appRootPath', done => {
+    const ANR_EVENT_WITH_SPECIFIC_DEBUG_META: Event = {
+      ...ANR_EVENT_WITH_SCOPE,
+      debug_meta: {
+        images: [
+          {
+            type: 'sourcemap',
+            debug_id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa',
+            code_file: 'app:///app-path.mjs',
+          },
+        ],
+      },
+    };
+
+    createRunner(__dirname, 'app-path.mjs')
+      .withMockSentryServer()
+      .expect({ event: ANR_EVENT_WITH_SPECIFIC_DEBUG_META })
       .start(done);
   });
 

--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -91,22 +91,27 @@ function applyDebugMeta(event: Event): void {
     return;
   }
 
+  const normalisedDebugImages = options.appRootPath ? {} : mainDebugImages;
+  if (options.appRootPath) {
+    for (const [path, debugId] of Object.entries(mainDebugImages)) {
+      normalisedDebugImages[normalizeUrlToBase(path, options.appRootPath)] = debugId;
+    }
+  }
+
   const filenameToDebugId = new Map<string, string>();
 
   for (const exception of event.exception?.values || []) {
     for (const frame of exception.stacktrace?.frames || []) {
       const filename = frame.abs_path || frame.filename;
-      if (filename && mainDebugImages[filename]) {
-        filenameToDebugId.set(filename, mainDebugImages[filename] as string);
+      if (filename && normalisedDebugImages[filename]) {
+        filenameToDebugId.set(filename, normalisedDebugImages[filename] as string);
       }
     }
   }
 
   if (filenameToDebugId.size > 0) {
     const images: DebugImage[] = [];
-    for (const [filename, debug_id] of filenameToDebugId.entries()) {
-      const code_file = options.appRootPath ? normalizeUrlToBase(filename, options.appRootPath) : filename;
-
+    for (const [code_file, debug_id] of filenameToDebugId.entries()) {
       images.push({
         type: 'sourcemap',
         code_file,


### PR DESCRIPTION
- Ref https://github.com/getsentry/sentry-electron/issues/1011

In #14709 I didn't add a test. If I had, I would have noticed that it was not working. File paths need normalising before we try and match up debug files.