### PR TITLE
fix(node): Ensure `NODE_OPTIONS` is not passed to worker threads [v8]

### DIFF
--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -176,6 +176,7 @@ async function _startWorker(
     workerData: options,
     // We don't want any Node args to be passed to the worker
     execArgv: [],
+    env: { ...process.env, NODE_OPTIONS: undefined },
   });
 
   process.on('exit', () => {

--- a/packages/node/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-async.ts
@@ -81,6 +81,7 @@ export const localVariablesAsyncIntegration = defineIntegration(((
       workerData: options,
       // We don't want any Node args to be passed to the worker
       execArgv: [],
+      env: { ...process.env, NODE_OPTIONS: undefined },
     });
 
     process.on('exit', () => {


### PR DESCRIPTION
Backport of #14824
