### PR TITLE
fix(aws-lambda): Remove version suffix from lambda layer

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -146,7 +146,8 @@ targets:
   # whenever we release a new v8 version—otherwise we would overwrite the current major lambda layer.
   - name: aws-lambda-layer
     includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
-    layerName: SentryNodeServerlessSDKv8
+    # TODO(v9): change to `SentryNodeServerlessSDKv8` once v9 is released
+    layerName: SentryNodeServerlessSDK
     compatibleRuntimes:
       - name: node
         versions:


### PR DESCRIPTION
The v8 suffixed layer lands in the release-registry every time we publish a release from the v8 branch which not only breaks https://github.com/getsentry/sentry/blob/c11f4c099257b2388d150f71fb39516e3d3f2328/src/sentry/integrations/aws_lambda/utils.py#L236-L253 but also ends up in the docs as the current version: when using the ARN dropdown https://docs.sentry.io/platforms/javascript/guides/aws-lambda/install/cjs-layer/.

This removes the suffix so we get the current major published under the non-suffixed name.

Follow-up task: https://github.com/getsentry/sentry-javascript/issues/14842