### PR TITLE
fix(node): Ensure express requests are properly handled

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/requestUser/server.js
+++ b/dev-packages/node-integration-tests/suites/express/requestUser/server.js
@@ -1,0 +1,49 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+  debug: true,
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+const cors = require('cors');
+const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+
+const app = express();
+
+app.use(cors());
+
+app.use((req, _res, next) => {
+  // We simulate this, which would in other cases be done by some middleware
+  req.user = {
+    id: '1',
+    email: 'test@sentry.io',
+  };
+
+  next();
+});
+
+app.get('/test1', (_req, _res) => {
+  throw new Error('error_1');
+});
+
+app.use((_req, _res, next) => {
+  Sentry.setUser({
+    id: '2',
+    email: 'test2@sentry.io',
+  });
+
+  next();
+});
+
+app.get('/test2', (_req, _res) => {
+  throw new Error('error_2');
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/requestUser/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/requestUser/test.ts
@@ -1,0 +1,49 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+describe('express user handling', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  test('picks user from request', done => {
+    createRunner(__dirname, 'server.js')
+      .expect({
+        event: {
+          user: {
+            id: '1',
+            email: 'test@sentry.io',
+          },
+          exception: {
+            values: [
+              {
+                value: 'error_1',
+              },
+            ],
+          },
+        },
+      })
+      .start(done)
+      .makeRequest('get', '/test1', { expectError: true });
+  });
+
+  test('setUser overwrites user from request', done => {
+    createRunner(__dirname, 'server.js')
+      .expect({
+        event: {
+          user: {
+            id: '2',
+            email: 'test2@sentry.io',
+          },
+          exception: {
+            values: [
+              {
+                value: 'error_2',
+              },
+            ],
+          },
+        },
+      })
+      .start(done)
+      .makeRequest('get', '/test2', { expectError: true });
+  });
+});

--- a/packages/core/src/utils-hoist/requestdata.ts
+++ b/packages/core/src/utils-hoist/requestdata.ts
@@ -295,8 +295,8 @@ export function addNormalizedRequestDataToEvent(
 
     if (Object.keys(extractedUser).length) {
       event.user = {
-        ...event.user,
         ...extractedUser,
+        ...event.user,
       };
     }
   }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/14847

After some digging, I figured out that the `req.user` handling on express is not working anymore, because apparently express does not mutate the actual http `request` object, but clones/forkes it (??) somehow. So since we now set the request in the SentryHttpInstrumentation generally, it would not pick up express-specific things anymore.

IMHO this is not great and we do not want this anymore in v9 anyhow, but it was the behavior before. This PR fixes this by setting the express request again on the isolation scope in an express middleware, which is registered by `Sentry.setupExpressErrorHandler(app)`. 

Note that we plan to change this behavior here: https://github.com/getsentry/sentry-javascript/pull/14806 but I figured it still makes sense to fix this on develop first, so we have a proper history/tests for this. I will backport this to v8 too. Then, in PR #14806 I will remove the middleware again.