### PR TITLE
feat(react): Add support for React Router `createMemoryRouter`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/.gitignore
@@ -1,0 +1,29 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
+!*.d.ts

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/.npmrc
@@ -1,0 +1,2 @@
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "react-create-browser-router-test",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@sentry/react": "latest || *",
+    "@types/node": "^18.19.1",
+    "@types/react": "18.0.0",
+    "@types/react-dom": "18.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-router-dom": "^6.4.1",
+    "react-scripts": "5.0.1",
+    "typescript": "~5.0.0"
+  },
+  "scripts": {
+    "build": "react-scripts build",
+    "start": "serve -s build",
+    "test": "playwright test",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "test:build": "pnpm install && pnpm build",
+    "test:build-canary": "pnpm install && pnpm add react@canary react-dom@canary && pnpm build",
+    "test:assert": "pnpm test"
+  },
+  "eslintConfig": {
+    "extends": ["react-app", "react-app/jest"]
+  },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.44.1",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "serve": "14.0.1"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/playwright.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm start`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/public/index.html
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Web site created using create-react-app" />
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/globals.d.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/globals.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  recordedTransactions?: string[];
+  capturedExceptionId?: string;
+  sentryReplayId?: string;
+}

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/index.tsx
@@ -1,0 +1,66 @@
+import * as Sentry from '@sentry/react';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import {
+  RouterProvider,
+  createBrowserRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom';
+import Index from './pages/Index';
+import User from './pages/User';
+
+const replay = Sentry.replayIntegration();
+
+Sentry.init({
+  // environment: 'qa', // dynamic sampling bias to keep transactions
+  dsn: process.env.REACT_APP_E2E_TEST_DSN,
+  integrations: [
+    Sentry.reactRouterV6BrowserTracingIntegration({
+      useEffect: React.useEffect,
+      useLocation,
+      useNavigationType,
+      createRoutesFromChildren,
+      matchRoutes,
+    }),
+    replay,
+  ],
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+  release: 'e2e-test',
+
+  tunnel: 'http://localhost:3031',
+
+  // Always capture replays, so we can test this properly
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+
+  debug: !!process.env.DEBUG,
+});
+
+const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV6(createBrowserRouter);
+
+const router = sentryCreateBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <Index />,
+    },
+    {
+      path: '/user/:id',
+      element: <User />,
+    },
+  ],
+  {
+    // We're testing whether this option is avoided in the integration
+    // We expect this to be ignored
+    initialEntries: ['/user/1'],
+  },
+);
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+
+root.render(<RouterProvider router={router} />);

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/Index.tsx
@@ -1,0 +1,23 @@
+// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+const Index = () => {
+  return (
+    <>
+      <input
+        type="button"
+        value="Capture Exception"
+        id="exception-button"
+        onClick={() => {
+          throw new Error('I am an error!');
+        }}
+      />
+      <Link to="/user/5" id="navigation">
+        navigate
+      </Link>
+    </>
+  );
+};
+
+export default Index;

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/User.tsx
@@ -1,0 +1,8 @@
+// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
+import * as React from 'react';
+
+const User = () => {
+  return <p>I am a blank page :)</p>;
+};
+
+export default User;

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/react-app-env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'react-create-browser-router',
+});

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/tests/errors.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test('Captures exception correctly', async ({ page }) => {
+  const errorEventPromise = waitForError('react-create-browser-router', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'I am an error!';
+  });
+
+  await page.goto('/');
+
+  const exceptionButton = page.locator('id=exception-button');
+  await exceptionButton.click();
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('I am an error!');
+
+  expect(errorEvent.request).toEqual({
+    headers: expect.any(Object),
+    url: 'http://localhost:3030/',
+  });
+
+  expect(errorEvent.transaction).toEqual('/');
+
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/tests/transactions.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Captures a pageload transaction', async ({ page }) => {
+  const transactionEventPromise = waitForTransaction('react-create-browser-router', event => {
+    return event.contexts?.trace?.op === 'pageload';
+  });
+
+  await page.goto('/');
+
+  const transactionEvent = await transactionEventPromise;
+  expect(transactionEvent.contexts?.trace).toEqual({
+    data: {
+      deviceMemory: expect.any(String),
+      effectiveConnectionType: expect.any(String),
+      hardwareConcurrency: expect.any(String),
+      'lcp.element': 'body > div#root > input#exception-button[type="button"]',
+      'lcp.id': 'exception-button',
+      'lcp.size': 1650,
+      'sentry.idle_span_finish_reason': 'idleTimeout',
+      'sentry.op': 'pageload',
+      'sentry.origin': 'auto.pageload.react.reactrouter_v6',
+      'sentry.sample_rate': 1,
+      'sentry.source': 'route',
+      'performance.timeOrigin': expect.any(Number),
+      'performance.activationStart': expect.any(Number),
+      'lcp.renderTime': expect.any(Number),
+      'lcp.loadTime': expect.any(Number),
+    },
+    op: 'pageload',
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.pageload.react.reactrouter_v6',
+  });
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      transaction: '/',
+      type: 'transaction',
+      transaction_info: {
+        source: 'route',
+      },
+    }),
+  );
+
+  expect(transactionEvent.spans).toContainEqual({
+    data: {
+      'sentry.origin': 'auto.ui.browser.metrics',
+      'sentry.op': 'browser.domContentLoadedEvent',
+    },
+    description: page.url(),
+    op: 'browser.domContentLoadedEvent',
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.ui.browser.metrics',
+  });
+  expect(transactionEvent.spans).toContainEqual({
+    data: {
+      'sentry.origin': 'auto.ui.browser.metrics',
+      'sentry.op': 'browser.connect',
+    },
+    description: page.url(),
+    op: 'browser.connect',
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.ui.browser.metrics',
+  });
+  expect(transactionEvent.spans).toContainEqual({
+    data: {
+      'sentry.origin': 'auto.ui.browser.metrics',
+      'sentry.op': 'browser.request',
+    },
+    description: page.url(),
+    op: 'browser.request',
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.ui.browser.metrics',
+  });
+  expect(transactionEvent.spans).toContainEqual({
+    data: {
+      'sentry.origin': 'auto.ui.browser.metrics',
+      'sentry.op': 'browser.response',
+    },
+    description: page.url(),
+    op: 'browser.response',
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.ui.browser.metrics',
+  });
+});
+
+test('Captures a navigation transaction', async ({ page }) => {
+  const transactionEventPromise = waitForTransaction('react-create-browser-router', event => {
+    return event.contexts?.trace?.op === 'navigation';
+  });
+
+  await page.goto('/');
+  const linkElement = page.locator('id=navigation');
+  await linkElement.click();
+
+  const transactionEvent = await transactionEventPromise;
+  expect(transactionEvent.contexts?.trace).toEqual({
+    data: expect.objectContaining({
+      deviceMemory: expect.any(String),
+      effectiveConnectionType: expect.any(String),
+      hardwareConcurrency: expect.any(String),
+      'sentry.idle_span_finish_reason': 'idleTimeout',
+      'sentry.op': 'navigation',
+      'sentry.origin': 'auto.navigation.react.reactrouter_v6',
+      'sentry.sample_rate': 1,
+      'sentry.source': 'route',
+    }),
+    op: 'navigation',
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.navigation.react.reactrouter_v6',
+  });
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      transaction: '/user/:id',
+      type: 'transaction',
+      transaction_info: {
+        source: 'route',
+      },
+    }),
+  );
+
+  expect(transactionEvent.spans).toEqual([]);
+});

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/tests/transactions.test.ts
@@ -9,29 +9,6 @@ test('Captures a pageload transaction', async ({ page }) => {
   await page.goto('/');
 
   const transactionEvent = await transactionEventPromise;
-  expect(transactionEvent.contexts?.trace).toEqual({
-    data: {
-      deviceMemory: expect.any(String),
-      effectiveConnectionType: expect.any(String),
-      hardwareConcurrency: expect.any(String),
-      'lcp.element': 'body > div#root > input#exception-button[type="button"]',
-      'lcp.id': 'exception-button',
-      'lcp.size': 1650,
-      'sentry.idle_span_finish_reason': 'idleTimeout',
-      'sentry.op': 'pageload',
-      'sentry.origin': 'auto.pageload.react.reactrouter_v6',
-      'sentry.sample_rate': 1,
-      'sentry.source': 'route',
-      'performance.timeOrigin': expect.any(Number),
-      'performance.activationStart': expect.any(Number),
-      'lcp.renderTime': expect.any(Number),
-      'lcp.loadTime': expect.any(Number),
-    },
-    op: 'pageload',
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.pageload.react.reactrouter_v6',
-  });
 
   expect(transactionEvent).toEqual(
     expect.objectContaining({
@@ -43,62 +20,24 @@ test('Captures a pageload transaction', async ({ page }) => {
     }),
   );
 
-  expect(transactionEvent.spans).toContainEqual({
-    data: {
-      'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.domContentLoadedEvent',
-    },
-    description: page.url(),
-    op: 'browser.domContentLoadedEvent',
-    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.browser.metrics',
-  });
-  expect(transactionEvent.spans).toContainEqual({
-    data: {
-      'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.connect',
-    },
-    description: page.url(),
-    op: 'browser.connect',
-    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.browser.metrics',
-  });
-  expect(transactionEvent.spans).toContainEqual({
-    data: {
-      'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.request',
-    },
-    description: page.url(),
-    op: 'browser.request',
-    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.browser.metrics',
-  });
-  expect(transactionEvent.spans).toContainEqual({
-    data: {
-      'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.response',
-    },
-    description: page.url(),
-    op: 'browser.response',
-    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.browser.metrics',
-  });
+  expect(transactionEvent.contexts?.trace).toEqual(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        deviceMemory: expect.any(String),
+        effectiveConnectionType: expect.any(String),
+        hardwareConcurrency: expect.any(String),
+        'sentry.idle_span_finish_reason': 'idleTimeout',
+        'sentry.op': 'pageload',
+        'sentry.origin': 'auto.pageload.react.reactrouter_v6',
+        'sentry.sample_rate': 1,
+        'sentry.source': 'route',
+      }),
+      op: 'pageload',
+      span_id: expect.stringMatching(/[a-f0-9]{16}/),
+      trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      origin: 'auto.pageload.react.reactrouter_v6',
+    }),
+  );
 });
 
 test('Captures a navigation transaction', async ({ page }) => {
@@ -113,9 +52,6 @@ test('Captures a navigation transaction', async ({ page }) => {
   const transactionEvent = await transactionEventPromise;
   expect(transactionEvent.contexts?.trace).toEqual({
     data: expect.objectContaining({
-      deviceMemory: expect.any(String),
-      effectiveConnectionType: expect.any(String),
-      hardwareConcurrency: expect.any(String),
       'sentry.idle_span_finish_reason': 'idleTimeout',
       'sentry.op': 'navigation',
       'sentry.origin': 'auto.navigation.react.reactrouter_v6',

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": ["src", "tests"]
+}

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/.gitignore
@@ -1,0 +1,29 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
+!*.d.ts

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/.npmrc
@@ -1,0 +1,2 @@
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "react-create-memory-router-test",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@sentry/react": "latest || *",
+    "@types/node": "^18.19.1",
+    "@types/react": "18.0.0",
+    "@types/react-dom": "18.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-router-dom": "^6.4.1",
+    "react-scripts": "5.0.1",
+    "typescript": "~5.0.0"
+  },
+  "scripts": {
+    "build": "react-scripts build",
+    "start": "serve -s build",
+    "test": "playwright test",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "test:build": "pnpm install && pnpm build",
+    "test:build-canary": "pnpm install && pnpm add react@canary react-dom@canary && pnpm build",
+    "test:assert": "pnpm test"
+  },
+  "eslintConfig": {
+    "extends": ["react-app", "react-app/jest"]
+  },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.44.1",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "serve": "14.0.1"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/playwright.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm start`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/public/index.html
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Web site created using create-react-app" />
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/globals.d.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/globals.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  recordedTransactions?: string[];
+  capturedExceptionId?: string;
+  sentryReplayId?: string;
+}

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/index.tsx
@@ -1,0 +1,65 @@
+import * as Sentry from '@sentry/react';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import {
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom';
+import Index from './pages/Index';
+import User from './pages/User';
+
+const replay = Sentry.replayIntegration();
+
+Sentry.init({
+  // environment: 'qa', // dynamic sampling bias to keep transactions
+  dsn: process.env.REACT_APP_E2E_TEST_DSN,
+  integrations: [
+    Sentry.reactRouterV6BrowserTracingIntegration({
+      useEffect: React.useEffect,
+      useLocation,
+      useNavigationType,
+      createRoutesFromChildren,
+      matchRoutes,
+    }),
+    replay,
+  ],
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+  release: 'e2e-test',
+
+  tunnel: 'http://localhost:3031',
+
+  // Always capture replays, so we can test this properly
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+
+  debug: !!process.env.DEBUG,
+});
+
+const sentryCreateMemoryRouter = Sentry.wrapCreateMemoryRouterV6(createMemoryRouter);
+
+const router = sentryCreateMemoryRouter(
+  [
+    {
+      path: '/',
+      element: <Index />,
+    },
+    {
+      path: '/user/:id',
+      element: <User />,
+    },
+  ],
+  {
+    initialEntries: ['/', '/user/1', '/user/2'],
+    initialIndex: 2,
+  },
+);
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+
+root.render(<RouterProvider router={router} />);

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/Index.tsx
@@ -1,6 +1,5 @@
 // biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 
 const Index = () => {
   return (

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/Index.tsx
@@ -1,0 +1,20 @@
+// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+const Index = () => {
+  return (
+    <>
+      <input
+        type="button"
+        value="Capture Exception"
+        id="exception-button"
+        onClick={() => {
+          throw new Error('I am an error!');
+        }}
+      />
+    </>
+  );
+};
+
+export default Index;

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/User.tsx
@@ -1,0 +1,19 @@
+// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+const User = () => {
+  return (
+    <div>
+      <Link to="/" id="home-button">
+        Home
+      </Link>
+      <Link to="/user/5" id="navigation-button">
+        navigate
+      </Link>
+      <p>I am a blank page :)</p>;
+    </div>
+  );
+};
+
+export default User;

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/react-app-env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'react-create-memory-router',
+});

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/tests/errors.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test('Captures exception correctly', async ({ page }) => {
+  const errorEventPromise = waitForError('react-create-memory-router', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'I am an error!';
+  });
+
+  await page.goto('/');
+
+  // We're on the user page, navigate back to the home page
+  const homeButton = page.locator('id=home-button');
+  await homeButton.click();
+
+  const exceptionButton = page.locator('id=exception-button');
+  await exceptionButton.click();
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('I am an error!');
+
+  expect(errorEvent.request).toEqual({
+    headers: expect.any(Object),
+    url: 'http://localhost:3030/',
+  });
+
+  expect(errorEvent.transaction).toEqual('/');
+
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/tests/transactions.test.ts
@@ -9,28 +9,6 @@ test('Captures a pageload transaction', async ({ page }) => {
   await page.goto('/');
 
   const transactionEvent = await transactionEventPromise;
-  expect(transactionEvent.contexts?.trace).toEqual({
-    data: {
-      deviceMemory: expect.any(String),
-      effectiveConnectionType: expect.any(String),
-      hardwareConcurrency: expect.any(String),
-      'lcp.element': 'body > div#root > div',
-      'lcp.size': expect.any(Number),
-      'sentry.idle_span_finish_reason': 'idleTimeout',
-      'sentry.op': 'pageload',
-      'sentry.origin': 'auto.pageload.react.reactrouter_v6',
-      'sentry.sample_rate': 1,
-      'sentry.source': 'route',
-      'performance.timeOrigin': expect.any(Number),
-      'performance.activationStart': expect.any(Number),
-      'lcp.renderTime': expect.any(Number),
-      'lcp.loadTime': expect.any(Number),
-    },
-    op: 'pageload',
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.pageload.react.reactrouter_v6',
-  });
 
   expect(transactionEvent).toEqual(
     expect.objectContaining({
@@ -42,62 +20,21 @@ test('Captures a pageload transaction', async ({ page }) => {
     }),
   );
 
-  expect(transactionEvent.spans).toContainEqual({
-    data: {
-      'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.domContentLoadedEvent',
-    },
-    description: page.url(),
-    op: 'browser.domContentLoadedEvent',
-    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.browser.metrics',
-  });
-  expect(transactionEvent.spans).toContainEqual({
-    data: {
-      'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.connect',
-    },
-    description: page.url(),
-    op: 'browser.connect',
-    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.browser.metrics',
-  });
-  expect(transactionEvent.spans).toContainEqual({
-    data: {
-      'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.request',
-    },
-    description: page.url(),
-    op: 'browser.request',
-    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.browser.metrics',
-  });
-  expect(transactionEvent.spans).toContainEqual({
-    data: {
-      'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.response',
-    },
-    description: page.url(),
-    op: 'browser.response',
-    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.browser.metrics',
-  });
+  expect(transactionEvent.contexts?.trace).toEqual(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        'sentry.idle_span_finish_reason': 'idleTimeout',
+        'sentry.op': 'pageload',
+        'sentry.origin': 'auto.pageload.react.reactrouter_v6',
+        'sentry.sample_rate': 1,
+        'sentry.source': 'route',
+      }),
+      op: 'pageload',
+      span_id: expect.stringMatching(/[a-f0-9]{16}/),
+      trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      origin: 'auto.pageload.react.reactrouter_v6',
+    }),
+  );
 });
 
 test('Captures a navigation transaction', async ({ page }) => {
@@ -112,9 +49,6 @@ test('Captures a navigation transaction', async ({ page }) => {
   const transactionEvent = await transactionEventPromise;
   expect(transactionEvent.contexts?.trace).toEqual({
     data: expect.objectContaining({
-      deviceMemory: expect.any(String),
-      effectiveConnectionType: expect.any(String),
-      hardwareConcurrency: expect.any(String),
       'sentry.idle_span_finish_reason': 'idleTimeout',
       'sentry.op': 'navigation',
       'sentry.origin': 'auto.navigation.react.reactrouter_v6',

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/tests/transactions.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Captures a pageload transaction', async ({ page }) => {
+  const transactionEventPromise = waitForTransaction('react-create-memory-router', event => {
+    return event.contexts?.trace?.op === 'pageload';
+  });
+
+  await page.goto('/');
+
+  const transactionEvent = await transactionEventPromise;
+  expect(transactionEvent.contexts?.trace).toEqual({
+    data: {
+      deviceMemory: expect.any(String),
+      effectiveConnectionType: expect.any(String),
+      hardwareConcurrency: expect.any(String),
+      'lcp.element': 'body > div#root > div',
+      'lcp.size': 8084,
+      'sentry.idle_span_finish_reason': 'idleTimeout',
+      'sentry.op': 'pageload',
+      'sentry.origin': 'auto.pageload.react.reactrouter_v6',
+      'sentry.sample_rate': 1,
+      'sentry.source': 'route',
+      'performance.timeOrigin': expect.any(Number),
+      'performance.activationStart': expect.any(Number),
+      'lcp.renderTime': expect.any(Number),
+      'lcp.loadTime': expect.any(Number),
+    },
+    op: 'pageload',
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.pageload.react.reactrouter_v6',
+  });
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      transaction: '/user/:id',
+      type: 'transaction',
+      transaction_info: {
+        source: 'route',
+      },
+    }),
+  );
+
+  expect(transactionEvent.spans).toContainEqual({
+    data: {
+      'sentry.origin': 'auto.ui.browser.metrics',
+      'sentry.op': 'browser.domContentLoadedEvent',
+    },
+    description: page.url(),
+    op: 'browser.domContentLoadedEvent',
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.ui.browser.metrics',
+  });
+  expect(transactionEvent.spans).toContainEqual({
+    data: {
+      'sentry.origin': 'auto.ui.browser.metrics',
+      'sentry.op': 'browser.connect',
+    },
+    description: page.url(),
+    op: 'browser.connect',
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.ui.browser.metrics',
+  });
+  expect(transactionEvent.spans).toContainEqual({
+    data: {
+      'sentry.origin': 'auto.ui.browser.metrics',
+      'sentry.op': 'browser.request',
+    },
+    description: page.url(),
+    op: 'browser.request',
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.ui.browser.metrics',
+  });
+  expect(transactionEvent.spans).toContainEqual({
+    data: {
+      'sentry.origin': 'auto.ui.browser.metrics',
+      'sentry.op': 'browser.response',
+    },
+    description: page.url(),
+    op: 'browser.response',
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.ui.browser.metrics',
+  });
+});
+
+test('Captures a navigation transaction', async ({ page }) => {
+  const transactionEventPromise = waitForTransaction('react-create-memory-router', event => {
+    return event.contexts?.trace?.op === 'navigation';
+  });
+
+  await page.goto('/');
+  const linkElement = page.locator('id=navigation-button');
+  await linkElement.click();
+
+  const transactionEvent = await transactionEventPromise;
+  expect(transactionEvent.contexts?.trace).toEqual({
+    data: expect.objectContaining({
+      deviceMemory: expect.any(String),
+      effectiveConnectionType: expect.any(String),
+      hardwareConcurrency: expect.any(String),
+      'sentry.idle_span_finish_reason': 'idleTimeout',
+      'sentry.op': 'navigation',
+      'sentry.origin': 'auto.navigation.react.reactrouter_v6',
+      'sentry.sample_rate': 1,
+      'sentry.source': 'route',
+    }),
+    op: 'navigation',
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.navigation.react.reactrouter_v6',
+  });
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      transaction: '/user/:id',
+      type: 'transaction',
+      transaction_info: {
+        source: 'route',
+      },
+    }),
+  );
+
+  expect(transactionEvent.spans).toEqual([]);
+});

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/tests/transactions.test.ts
@@ -15,7 +15,7 @@ test('Captures a pageload transaction', async ({ page }) => {
       effectiveConnectionType: expect.any(String),
       hardwareConcurrency: expect.any(String),
       'lcp.element': 'body > div#root > div',
-      'lcp.size': 8084,
+      'lcp.size': expect.any(Number),
       'sentry.idle_span_finish_reason': 'idleTimeout',
       'sentry.op': 'pageload',
       'sentry.origin': 'auto.pageload.react.reactrouter_v6',

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -18,10 +18,12 @@ export {
   withSentryReactRouterV6Routing,
   wrapUseRoutesV6,
   wrapCreateBrowserRouterV6,
+  wrapCreateMemoryRouterV6,
 } from './reactrouterv6';
 export {
   reactRouterV7BrowserTracingIntegration,
   withSentryReactRouterV7Routing,
   wrapCreateBrowserRouterV7,
+  wrapCreateMemoryRouterV7,
   wrapUseRoutesV7,
 } from './reactrouterv7';

--- a/packages/react/src/reactrouterv6-compat-utils.tsx
+++ b/packages/react/src/reactrouterv6-compat-utils.tsx
@@ -70,6 +70,7 @@ export function createV6CompatibleWrapCreateBrowserRouter<
 >(
   createRouterFunction: CreateRouterFunction<TState, TRouter>,
   version: V6CompatibleVersion,
+  isMemoryRouter = false,
 ): CreateRouterFunction<TState, TRouter> {
   if (!_useEffect || !_useLocation || !_useNavigationType || !_matchRoutes) {
     DEBUG_BUILD &&
@@ -82,9 +83,9 @@ export function createV6CompatibleWrapCreateBrowserRouter<
 
   // `opts` for createBrowserHistory and createMemoryHistory are different, but also not relevant for us at the moment.
   // `basename` is the only option that is relevant for us, and it is the same for all.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (
     routes: RouteObject[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     opts?: Record<string, any> & {
       basename?: string;
       initialEntries?: (string | { pathname: string })[];
@@ -95,18 +96,21 @@ export function createV6CompatibleWrapCreateBrowserRouter<
     const basename = opts?.basename;
 
     const activeRootSpan = getActiveRootSpan();
+    let initialEntry = undefined;
 
-    const initialEntries = opts && opts.initialEntries;
-    const initialIndex = opts && opts.initialIndex;
+    if (isMemoryRouter) {
+      const initialEntries = opts && opts.initialEntries;
+      const initialIndex = opts && opts.initialIndex;
 
-    const hasOnlyOneInitialEntry = initialEntries && initialEntries.length === 1;
-    const hasIndexedEntry = initialIndex !== undefined && initialEntries && initialEntries[initialIndex];
+      const hasOnlyOneInitialEntry = initialEntries && initialEntries.length === 1;
+      const hasIndexedEntry = initialIndex !== undefined && initialEntries && initialEntries[initialIndex];
 
-    const initialEntry = hasOnlyOneInitialEntry
-      ? initialEntries[0]
-      : hasIndexedEntry
-        ? initialEntries[initialIndex]
-        : undefined;
+      initialEntry = hasOnlyOneInitialEntry
+        ? initialEntries[0]
+        : hasIndexedEntry
+          ? initialEntries[initialIndex]
+          : undefined;
+    }
 
     const location = initialEntry
       ? typeof initialEntry === 'string'

--- a/packages/react/src/reactrouterv6-compat-utils.tsx
+++ b/packages/react/src/reactrouterv6-compat-utils.tsx
@@ -143,8 +143,8 @@ export function createV6CompatibleWrapCreateMemoryRouter<
     const activeRootSpan = getActiveRootSpan();
     let initialEntry = undefined;
 
-    const initialEntries = opts && opts.initialEntries;
-    const initialIndex = opts && opts.initialIndex;
+    const initialEntries = opts?.initialEntries;
+    const initialIndex = opts?.initialIndex;
 
     const hasOnlyOneInitialEntry = initialEntries && initialEntries.length === 1;
     const hasIndexedEntry = initialIndex !== undefined && initialEntries && initialEntries[initialIndex];

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -5,6 +5,7 @@ import {
   createReactRouterV6CompatibleTracingIntegration,
   createV6CompatibleWithSentryReactRouterRouting,
   createV6CompatibleWrapCreateBrowserRouter,
+  createV6CompatibleWrapCreateMemoryRouter,
   createV6CompatibleWrapUseRoutes,
 } from './reactrouterv6-compat-utils';
 import type { CreateRouterFunction, Router, RouterState, UseRoutes } from './types';
@@ -48,7 +49,7 @@ export function wrapCreateMemoryRouterV6<
   TState extends RouterState = RouterState,
   TRouter extends Router<TState> = Router<TState>,
 >(createMemoryRouterFunction: CreateRouterFunction<TState, TRouter>): CreateRouterFunction<TState, TRouter> {
-  return createV6CompatibleWrapCreateBrowserRouter(createMemoryRouterFunction, '6', true);
+  return createV6CompatibleWrapCreateMemoryRouter(createMemoryRouterFunction, '6');
 }
 
 /**

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -39,6 +39,19 @@ export function wrapCreateBrowserRouterV6<
 }
 
 /**
+ * A wrapper function that adds Sentry routing instrumentation to a React Router v6 createMemoryRouter function.
+ * This is used to automatically capture route changes as transactions when using the createMemoryRouter API.
+ * The difference between createBrowserRouter and createMemoryRouter is that with createMemoryRouter,
+ * optional `initialEntries` are also taken into account.
+ */
+export function wrapCreateMemoryRouterV6<
+  TState extends RouterState = RouterState,
+  TRouter extends Router<TState> = Router<TState>,
+>(createMemoryRouterFunction: CreateRouterFunction<TState, TRouter>): CreateRouterFunction<TState, TRouter> {
+  return createV6CompatibleWrapCreateBrowserRouter(createMemoryRouterFunction, '6', true);
+}
+
+/**
  * A higher-order component that adds Sentry routing instrumentation to a React Router v6 Route component.
  * This is used to automatically capture route changes as transactions.
  */

--- a/packages/react/src/reactrouterv7.tsx
+++ b/packages/react/src/reactrouterv7.tsx
@@ -6,6 +6,7 @@ import {
   createReactRouterV6CompatibleTracingIntegration,
   createV6CompatibleWithSentryReactRouterRouting,
   createV6CompatibleWrapCreateBrowserRouter,
+  createV6CompatibleWrapCreateMemoryRouter,
   createV6CompatibleWrapUseRoutes,
 } from './reactrouterv6-compat-utils';
 import type { CreateRouterFunction, Router, RouterState, UseRoutes } from './types';
@@ -50,7 +51,7 @@ export function wrapCreateMemoryRouterV7<
   TState extends RouterState = RouterState,
   TRouter extends Router<TState> = Router<TState>,
 >(createMemoryRouterFunction: CreateRouterFunction<TState, TRouter>): CreateRouterFunction<TState, TRouter> {
-  return createV6CompatibleWrapCreateBrowserRouter(createMemoryRouterFunction, '7', true);
+  return createV6CompatibleWrapCreateMemoryRouter(createMemoryRouterFunction, '7');
 }
 
 /**

--- a/packages/react/src/reactrouterv7.tsx
+++ b/packages/react/src/reactrouterv7.tsx
@@ -41,6 +41,19 @@ export function wrapCreateBrowserRouterV7<
 }
 
 /**
+ * A wrapper function that adds Sentry routing instrumentation to a React Router v7 createMemoryRouter function.
+ * This is used to automatically capture route changes as transactions when using the createMemoryRouter API.
+ * The difference between createBrowserRouter and createMemoryRouter is that with createMemoryRouter,
+ * optional `initialEntries` are also taken into account.
+ */
+export function wrapCreateMemoryRouterV7<
+  TState extends RouterState = RouterState,
+  TRouter extends Router<TState> = Router<TState>,
+>(createMemoryRouterFunction: CreateRouterFunction<TState, TRouter>): CreateRouterFunction<TState, TRouter> {
+  return createV6CompatibleWrapCreateBrowserRouter(createMemoryRouterFunction, '7', true);
+}
+
+/**
  * A wrapper function that adds Sentry routing instrumentation to a React Router v7 useRoutes hook.
  * This is used to automatically capture route changes as transactions when using the useRoutes hook.
  */

--- a/packages/react/test/reactrouterv6.test.tsx
+++ b/packages/react/test/reactrouterv6.test.tsx
@@ -30,6 +30,7 @@ import {
   reactRouterV6BrowserTracingIntegration,
   withSentryReactRouterV6Routing,
   wrapCreateBrowserRouterV6,
+  wrapCreateMemoryRouterV6,
   wrapUseRoutesV6,
 } from '../src/reactrouterv6';
 
@@ -84,88 +85,97 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
     getCurrentScope().setClient(undefined);
   });
 
-  describe('wrapCreateBrowserRouterV6 - createMemoryRouter', () => {
-    it('starts a pageload transaction', () => {
-      const client = createMockBrowserClient();
-      setCurrentClient(client);
+  it('wrapCreateMemoryRouterV6 starts and updates a pageload transaction - single initialEntry', () => {
+    const client = createMockBrowserClient();
+    setCurrentClient(client);
 
-      client.addIntegration(
-        reactRouterV6BrowserTracingIntegration({
-          useEffect: React.useEffect,
-          useLocation,
-          useNavigationType,
-          createRoutesFromChildren,
-          matchRoutes,
-        }),
-      );
+    client.addIntegration(
+      reactRouterV6BrowserTracingIntegration({
+        useEffect: React.useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
+    );
 
-      const routes: RouteObject[] = [
-        {
-          path: '/',
-          element: <div>Home</div>,
-        },
-        {
-          path: '/about',
-          element: <div>About</div>,
-        },
-      ];
+    const routes: RouteObject[] = [
+      {
+        path: '/',
+        element: <div>Home</div>,
+      },
+      {
+        path: '/about',
+        element: <div>About</div>,
+      },
+    ];
 
-      const wrappedCreateMemoryRouter = wrapCreateBrowserRouterV6(createMemoryRouter);
+    const wrappedCreateMemoryRouter = wrapCreateMemoryRouterV6(createMemoryRouter);
 
-      const router = wrappedCreateMemoryRouter(routes, {
-        initialEntries: ['/', '/about'],
-        initialIndex: 1,
-      });
-
-      render(<RouterProvider router={router} />);
-
-      expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
-      expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
-        name: '/',
-        attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v6',
-        },
-      });
+    const router = wrappedCreateMemoryRouter(routes, {
+      initialEntries: ['/about'],
     });
 
-    it('updates the transaction name on a pageload', () => {
-      const client = createMockBrowserClient();
-      setCurrentClient(client);
+    render(<RouterProvider router={router} />);
 
-      client.addIntegration(
-        reactRouterV6BrowserTracingIntegration({
-          useEffect: React.useEffect,
-          useLocation,
-          useNavigationType,
-          createRoutesFromChildren,
-          matchRoutes,
-        }),
-      );
-
-      const routes: RouteObject[] = [
-        {
-          path: '/',
-          element: <div>Home</div>,
-        },
-        {
-          path: '/about',
-          element: <div>About</div>,
-        },
-      ];
-
-      const wrappedCreateMemoryRouter = wrapCreateBrowserRouterV6(createMemoryRouter);
-
-      const router = wrappedCreateMemoryRouter(routes, {
-        initialEntries: ['/', '/about'],
-        initialIndex: 2,
-      });
-
-      render(<RouterProvider router={router} />);
-
-      expect(mockRootSpan.updateName).toHaveBeenLastCalledWith('/about');
+    expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
+    expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
+      name: '/',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v6',
+      },
     });
+
+    expect(mockRootSpan.updateName).toHaveBeenLastCalledWith('/about');
+  });
+
+  it('wrapCreateMemoryRouterV6 starts and updates a pageload transaction - multiple initialEntries', () => {
+    const client = createMockBrowserClient();
+    setCurrentClient(client);
+
+    client.addIntegration(
+      reactRouterV6BrowserTracingIntegration({
+        useEffect: React.useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
+    );
+
+    const routes: RouteObject[] = [
+      {
+        path: '/',
+        element: <div>Home</div>,
+      },
+      {
+        path: '/about',
+        element: <div>About</div>,
+      },
+    ];
+
+    const wrappedCreateMemoryRouter = wrapCreateMemoryRouterV6(createMemoryRouter);
+
+    const router = wrappedCreateMemoryRouter(routes, {
+      initialEntries: ['/', '/about'],
+      initialIndex: 1,
+    });
+
+    render(<RouterProvider router={router} />);
+
+    expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
+    expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
+      name: '/',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v6',
+      },
+    });
+
+    expect(mockRootSpan.updateName).toHaveBeenLastCalledWith('/about');
   });
 
   describe('withSentryReactRouterV6Routing', () => {

--- a/packages/react/test/reactrouterv6.test.tsx
+++ b/packages/react/test/reactrouterv6.test.tsx
@@ -29,7 +29,6 @@ import { BrowserClient } from '../src';
 import {
   reactRouterV6BrowserTracingIntegration,
   withSentryReactRouterV6Routing,
-  wrapCreateBrowserRouterV6,
   wrapCreateMemoryRouterV6,
   wrapUseRoutesV6,
 } from '../src/reactrouterv6';


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/14814

I was not able to properly distinguish between the instances of `BrowserRouter` and `MemoryRouter`. However, using `initialEntries` with `BrowserRouter` should break TypeScript where it's available. We can alternatively export a wrapper specific to `MemoryRouter` if that makes better sense.