### PR TITLE
feat(core)!: Type sdkProcessingMetadata more strictly

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -5,13 +5,16 @@ import type {
   Client,
   Context,
   Contexts,
+  DynamicSamplingContext,
   Event,
   EventHint,
   EventProcessor,
   Extra,
   Extras,
+  PolymorphicRequest,
   Primitive,
   PropagationContext,
+  RequestEventData,
   Session,
   SeverityLevel,
   Span,
@@ -58,6 +61,12 @@ export interface SdkProcessingMetadata {
   requestSession?: {
     status: 'ok' | 'errored' | 'crashed';
   };
+  request?: PolymorphicRequest;
+  normalizedRequest?: RequestEventData;
+  dynamicSamplingContext?: Partial<DynamicSamplingContext>;
+  capturedSpanScope?: Scope;
+  capturedSpanIsolationScope?: Scope;
+  spanCountBeforeProcessing?: number;
 }
 
 /**
@@ -537,10 +546,8 @@ export class Scope {
 
   /**
    * Add data which will be accessible during event processing but won't get sent to Sentry.
-   *
-   * TODO(v9): We should type this stricter, so that e.g. `normalizedRequest` is strictly typed.
    */
-  public setSDKProcessingMetadata(newData: { [key: string]: unknown }): this {
+  public setSDKProcessingMetadata(newData: SdkProcessingMetadata): this {
     this._sdkProcessingMetadata = merge(this._sdkProcessingMetadata, newData, 2);
     return this;
   }

--- a/packages/core/src/types-hoist/event.ts
+++ b/packages/core/src/types-hoist/event.ts
@@ -1,15 +1,13 @@
-import type { CaptureContext, Scope } from '../scope';
+import type { CaptureContext, SdkProcessingMetadata } from '../scope';
 import type { Attachment } from './attachment';
 import type { Breadcrumb } from './breadcrumb';
 import type { Contexts } from './context';
 import type { DebugMeta } from './debugMeta';
-import type { DynamicSamplingContext } from './envelope';
 import type { Exception } from './exception';
 import type { Extras } from './extra';
 import type { Measurements } from './measurement';
 import type { Mechanism } from './mechanism';
 import type { Primitive } from './misc';
-import type { PolymorphicRequest } from './polymorphics';
 import type { RequestEventData } from './request';
 import type { SdkInfo } from './sdkinfo';
 import type { SeverityLevel } from './severity';
@@ -54,14 +52,7 @@ export interface Event {
   debug_meta?: DebugMeta;
   // A place to stash data which is needed at some point in the SDK's event processing pipeline but which shouldn't get sent to Sentry
   // Note: This is considered internal and is subject to change in minors
-  sdkProcessingMetadata?: { [key: string]: unknown } & {
-    request?: PolymorphicRequest;
-    normalizedRequest?: RequestEventData;
-    dynamicSamplingContext?: Partial<DynamicSamplingContext>;
-    capturedSpanScope?: Scope;
-    capturedSpanIsolationScope?: Scope;
-    spanCountBeforeProcessing?: number;
-  };
+  sdkProcessingMetadata?: SdkProcessingMetadata;
   transaction_info?: {
     source: TransactionSource;
   };

--- a/packages/core/src/types-hoist/request.ts
+++ b/packages/core/src/types-hoist/request.ts
@@ -4,10 +4,10 @@
 export interface RequestEventData {
   url?: string;
   method?: string;
-  data?: any;
+  data?: unknown;
   query_string?: QueryParams;
-  cookies?: { [key: string]: string };
-  env?: { [key: string]: string };
+  cookies?: Record<string, string>;
+  env?: Record<string, string>;
   headers?: { [key: string]: string };
 }
 


### PR DESCRIPTION
This ensures we use a consistent and proper type for `setSdkProcessingMetadata()` and related APIs.

Closes https://github.com/getsentry/sentry-javascript/issues/14341