### PR TITLE
feat(core)!: Remove deprecated `Request` type

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -131,6 +131,7 @@ Sentry.init({
 - The `flatten` export has been removed. There is no replacement.
 - The `urlEncode` method has been removed. There is no replacement.
 - The `getDomElement` method has been removed. There is no replacement.
+- The `Request` type has been removed. Use `RequestEventData` type instead.
 
 ### `@sentry/browser`
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -1,8 +1,6 @@
 export type {
   Breadcrumb,
   BreadcrumbHint,
-  // eslint-disable-next-line deprecation/deprecation
-  Request,
   RequestEventData,
   SdkInfo,
   Event,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -2,8 +2,6 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
-  // eslint-disable-next-line deprecation/deprecation
-  Request,
   RequestEventData,
   SdkInfo,
   Event,

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -2,8 +2,6 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
-  // eslint-disable-next-line deprecation/deprecation
-  Request,
   RequestEventData,
   SdkInfo,
   Event,

--- a/packages/core/src/types-hoist/index.ts
+++ b/packages/core/src/types-hoist/index.ts
@@ -90,8 +90,6 @@ export type {
 export type {
   QueryParams,
   RequestEventData,
-  // eslint-disable-next-line deprecation/deprecation
-  Request,
   SanitizedRequestData,
 } from './request';
 export type { Runtime } from './runtime';

--- a/packages/core/src/types-hoist/request.ts
+++ b/packages/core/src/types-hoist/request.ts
@@ -11,12 +11,6 @@ export interface RequestEventData {
   headers?: { [key: string]: string };
 }
 
-/**
- * Request data included in an event as sent to Sentry.
- * @deprecated: This type will be removed in v9. Use `RequestEventData` instead.
- */
-export type Request = RequestEventData;
-
 export type QueryParams = string | { [key: string]: string } | Array<[string, string]>;
 
 /**

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -2,8 +2,6 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
-  // eslint-disable-next-line deprecation/deprecation
-  Request,
   RequestEventData,
   SdkInfo,
   Event,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -138,8 +138,6 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
-  // eslint-disable-next-line deprecation/deprecation
-  Request,
   RequestEventData,
   SdkInfo,
   Event,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -107,7 +107,6 @@ import type {
   ReplayEvent as ReplayEvent_imported,
   ReplayRecordingData as ReplayRecordingData_imported,
   ReplayRecordingMode as ReplayRecordingMode_imported,
-  Request as Request_imported,
   RequestEventData as RequestEventData_imported,
   Runtime as Runtime_imported,
   SamplingContext as SamplingContext_imported,
@@ -378,9 +377,6 @@ export type UserFeedback = UserFeedback_imported;
 export type QueryParams = QueryParams_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type RequestEventData = RequestEventData_imported;
-/** @deprecated This type has been moved to `@sentry/core`. */
-// eslint-disable-next-line deprecation/deprecation
-export type Request = Request_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type SanitizedRequestData = SanitizedRequestData_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -2,8 +2,6 @@ export type {
   Breadcrumb,
   BreadcrumbHint,
   PolymorphicRequest,
-  // eslint-disable-next-line deprecation/deprecation
-  Request,
   RequestEventData,
   SdkInfo,
   Event,


### PR DESCRIPTION
This is named misleadingly, instead use `RequestEventData`.

Closes https://github.com/getsentry/sentry-javascript/issues/14301