### PR TITLE
feat(core)!: Always use session from isolation scope

### DIFF
--- a/dev-packages/browser-integration-tests/suites/sessions/update-session/test.ts
+++ b/dev-packages/browser-integration-tests/suites/sessions/update-session/test.ts
@@ -2,14 +2,16 @@ import { expect } from '@playwright/test';
 import type { SessionContext } from '@sentry/core';
 
 import { sentryTest } from '../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest, waitForSession } from '../../../utils/helpers';
 
 sentryTest('should update session when an error is thrown.', async ({ getLocalTestUrl, page }) => {
   const url = await getLocalTestUrl({ testDir: __dirname });
+
   const pageloadSession = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
-  const updatedSession = (
-    await Promise.all([page.locator('#throw-error').click(), getFirstSentryEnvelopeRequest<SessionContext>(page)])
-  )[1];
+
+  const updatedSessionPromise = waitForSession(page);
+  await page.locator('#throw-error').click();
+  const updatedSession = await updatedSessionPromise;
 
   expect(pageloadSession).toBeDefined();
   expect(pageloadSession.init).toBe(true);
@@ -25,9 +27,10 @@ sentryTest('should update session when an exception is captured.', async ({ getL
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const pageloadSession = await getFirstSentryEnvelopeRequest<SessionContext>(page, url);
-  const updatedSession = (
-    await Promise.all([page.locator('#capture-exception').click(), getFirstSentryEnvelopeRequest<SessionContext>(page)])
-  )[1];
+
+  const updatedSessionPromise = waitForSession(page);
+  await page.locator('#capture-exception').click();
+  const updatedSession = await updatedSessionPromise;
 
   expect(pageloadSession).toBeDefined();
   expect(pageloadSession.init).toBe(true);

--- a/dev-packages/browser-integration-tests/utils/helpers.ts
+++ b/dev-packages/browser-integration-tests/utils/helpers.ts
@@ -7,6 +7,7 @@ import type {
   Event,
   EventEnvelope,
   EventEnvelopeHeaders,
+  SessionContext,
   TransactionEvent,
 } from '@sentry/core';
 
@@ -157,7 +158,7 @@ export const countEnvelopes = async (
  * @param {{ path?: string; content?: string }} impl
  * @return {*}  {Promise<void>}
  */
-async function runScriptInSandbox(
+export async function runScriptInSandbox(
   page: Page,
   impl: {
     path?: string;
@@ -178,7 +179,7 @@ async function runScriptInSandbox(
  * @param {string} [url]
  * @return {*}  {Promise<Array<Event>>}
  */
-async function getSentryEvents(page: Page, url?: string): Promise<Array<Event>> {
+export async function getSentryEvents(page: Page, url?: string): Promise<Array<Event>> {
   if (url) {
     await page.goto(url);
   }
@@ -248,6 +249,25 @@ export function waitForTransactionRequest(
       return false;
     }
   });
+}
+
+export async function waitForSession(page: Page): Promise<SessionContext> {
+  const req = await page.waitForRequest(req => {
+    const postData = req.postData();
+    if (!postData) {
+      return false;
+    }
+
+    try {
+      const event = envelopeRequestParser<SessionContext>(req);
+
+      return typeof event.init === 'boolean' && event.started !== undefined;
+    } catch {
+      return false;
+    }
+  });
+
+  return envelopeRequestParser<SessionContext>(req);
 }
 
 /**
@@ -353,7 +373,7 @@ async function getMultipleRequests<T>(
 /**
  * Wait and get multiple envelope requests at the given URL, or the current page
  */
-async function getMultipleSentryEnvelopeRequests<T>(
+export async function getMultipleSentryEnvelopeRequests<T>(
   page: Page,
   count: number,
   options?: {
@@ -374,7 +394,7 @@ async function getMultipleSentryEnvelopeRequests<T>(
  * @param {string} [url]
  * @return {*}  {Promise<T>}
  */
-async function getFirstSentryEnvelopeRequest<T>(
+export async function getFirstSentryEnvelopeRequest<T>(
   page: Page,
   url?: string,
   requestParser: (req: Request) => T = envelopeRequestParser as (req: Request) => T,
@@ -388,5 +408,3 @@ async function getFirstSentryEnvelopeRequest<T>(
 
   return req;
 }
-
-export { runScriptInSandbox, getMultipleSentryEnvelopeRequests, getFirstSentryEnvelopeRequest, getSentryEvents };

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -150,7 +150,6 @@ Sentry.init({
 The following changes are unlikely to affect users of the SDK. They are listed here only for completion sake, and to alert users that may be relying on internal behavior.
 
 - `client._prepareEvent()` now requires a currentScope & isolationScope to be passed as last arugments
-- `client._processEvent()` is now private (was protected)
 
 ### `@sentry/browser`
 

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -143,9 +143,14 @@ Sentry.init({
 - The `flatten` export has been removed. There is no replacement.
 - The `urlEncode` method has been removed. There is no replacement.
 - The `getDomElement` method has been removed. There is no replacement.
-- The `Request` type has been removed. Use `RequestEventData` type instead.
-- The `TransactionNamingScheme` type has been removed. There is no replacement.
 - The `memoBuilder` method has been removed. There is no replacement.
+
+#### Other/Internal Changes
+
+The following changes are unlikely to affect users of the SDK. They are listed here only for completion sake, and to alert users that may be relying on internal behavior.
+
+- `client._prepareEvent()` now requires a currentScope & isolationScope to be passed as last arugments
+- `client._processEvent()` is now private (was protected)
 
 ### `@sentry/browser`
 
@@ -210,6 +215,8 @@ This led to some duplication, where we had to keep an interface in `@sentry/type
 Since v9, the types have been merged into `@sentry/core`, which removed some of this duplication. This means that certain things that used to be a separate interface, will not expect an actual instance of the class/concrete implementation. This should not affect most users, unless you relied on passing things with a similar shape to internal methods. The following types are affected:
 
 - `Scope` now always expects the `Scope` class
+- The `TransactionNamingScheme` type has been removed. There is no replacement.
+- The `Request` type has been removed. Use `RequestEventData` type instead.
 - The `IntegrationClass` type is no longer exported - it was not used anymore. Instead, use `Integration` or `IntegrationFn`.
 
 # No Version Support Timeline

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -105,8 +105,13 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
   /**
    * @inheritDoc
    */
-  protected _prepareEvent(event: Event, hint: EventHint, scope?: Scope): PromiseLike<Event | null> {
+  protected _prepareEvent(
+    event: Event,
+    hint: EventHint,
+    currentScope: Scope,
+    isolationScope: Scope,
+  ): PromiseLike<Event | null> {
     event.platform = event.platform || 'javascript';
-    return super._prepareEvent(event, hint, scope);
+    return super._prepareEvent(event, hint, currentScope, isolationScope);
   }
 }

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -764,7 +764,12 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @param currentScope A scope containing event metadata.
    * @returns A SyncPromise that resolves with the event or rejects in case event was/will not be send.
    */
-  private _processEvent(event: Event, hint: EventHint, currentScope: Scope, isolationScope: Scope): PromiseLike<Event> {
+  protected _processEvent(
+    event: Event,
+    hint: EventHint,
+    currentScope: Scope,
+    isolationScope: Scope,
+  ): PromiseLike<Event> {
     const options = this.getOptions();
     const { sampleRate } = options;
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -822,7 +822,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
         }
 
         const session = currentScope.getSession() || isolationScope.getSession();
-        if (!isTransaction && session) {
+        if (!isError && session) {
           this._updateSessionFromEvent(session, processedEvent);
         }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -822,7 +822,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
         }
 
         const session = currentScope.getSession() || isolationScope.getSession();
-        if (!isError && session) {
+        if (isError && session) {
           this._updateSessionFromEvent(session, processedEvent);
         }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -764,7 +764,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @param currentScope A scope containing event metadata.
    * @returns A SyncPromise that resolves with the event or rejects in case event was/will not be send.
    */
-  protected _processEvent(
+  private _processEvent(
     event: Event,
     hint: EventHint,
     currentScope: Scope,

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -764,12 +764,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @param currentScope A scope containing event metadata.
    * @returns A SyncPromise that resolves with the event or rejects in case event was/will not be send.
    */
-  private _processEvent(
-    event: Event,
-    hint: EventHint,
-    currentScope: Scope,
-    isolationScope: Scope,
-  ): PromiseLike<Event> {
+  private _processEvent(event: Event, hint: EventHint, currentScope: Scope, isolationScope: Scope): PromiseLike<Event> {
     const options = this.getOptions();
     const { sampleRate } = options;
 

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -287,10 +287,6 @@ export function startSession(context?: SessionContext): Session {
   // Afterwards we set the new session on the scope
   isolationScope.setSession(session);
 
-  // TODO (v8): Remove this and only use the isolation scope(?).
-  // For v7 though, we can't "soft-break" people using getCurrentHub().getScope().setSession()
-  currentScope.setSession(session);
-
   return session;
 }
 
@@ -309,10 +305,6 @@ export function endSession(): void {
 
   // the session is over; take it off of the scope
   isolationScope.setSession();
-
-  // TODO (v8): Remove this and only use the isolation scope(?).
-  // For v7 though, we can't "soft-break" people using getCurrentHub().getScope().setSession()
-  currentScope.setSession();
 }
 
 /**
@@ -320,11 +312,8 @@ export function endSession(): void {
  */
 function _sendSessionUpdate(): void {
   const isolationScope = getIsolationScope();
-  const currentScope = getCurrentScope();
   const client = getClient();
-  // TODO (v8): Remove currentScope and only use the isolation scope(?).
-  // For v7 though, we can't "soft-break" people using getCurrentHub().getScope().setSession()
-  const session = currentScope.getSession() || isolationScope.getSession();
+  const session = isolationScope.getSession();
   if (session && client) {
     client.captureSession(session);
   }

--- a/packages/core/src/getCurrentHubShim.ts
+++ b/packages/core/src/getCurrentHubShim.ts
@@ -2,6 +2,7 @@ import { addBreadcrumb } from './breadcrumbs';
 import { getClient, getCurrentScope, getIsolationScope, withScope } from './currentScopes';
 import {
   captureEvent,
+  captureSession,
   endSession,
   setContext,
   setExtra,
@@ -54,15 +55,7 @@ export function getCurrentHubShim(): Hub {
 
     startSession,
     endSession,
-    captureSession(end?: boolean): void {
-      // both send the update and pull the session from the scope
-      if (end) {
-        return endSession();
-      }
-
-      // only send the update
-      _sendSessionUpdate();
-    },
+    captureSession,
   };
 }
 
@@ -77,16 +70,3 @@ export function getCurrentHubShim(): Hub {
  */
 // eslint-disable-next-line deprecation/deprecation
 export const getCurrentHub = getCurrentHubShim;
-
-/**
- * Sends the current Session on the scope
- */
-function _sendSessionUpdate(): void {
-  const scope = getIsolationScope();
-  const client = getClient();
-
-  const session = scope.getSession();
-  if (client && session) {
-    client.captureSession(session);
-  }
-}

--- a/packages/core/src/getCurrentHubShim.ts
+++ b/packages/core/src/getCurrentHubShim.ts
@@ -82,7 +82,7 @@ export const getCurrentHub = getCurrentHubShim;
  * Sends the current Session on the scope
  */
 function _sendSessionUpdate(): void {
-  const scope = getCurrentScope();
+  const scope = getIsolationScope();
   const client = getClient();
 
   const session = scope.getSession();

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -166,8 +166,8 @@ export class ServerRuntimeClient<
   protected _prepareEvent(
     event: Event,
     hint: EventHint,
-    scope?: Scope,
-    isolationScope?: Scope,
+    currentScope: Scope,
+    isolationScope: Scope,
   ): PromiseLike<Event | null> {
     if (this._options.platform) {
       event.platform = event.platform || this._options.platform;
@@ -184,7 +184,7 @@ export class ServerRuntimeClient<
       event.server_name = event.server_name || this._options.serverName;
     }
 
-    return super._prepareEvent(event, hint, scope, isolationScope);
+    return super._prepareEvent(event, hint, currentScope, isolationScope);
   }
 
   /** Extract trace information from scope */

--- a/packages/core/test/lib/server-runtime-client.test.ts
+++ b/packages/core/test/lib/server-runtime-client.test.ts
@@ -1,6 +1,6 @@
 import type { Event, EventHint } from '../../src/types-hoist';
 
-import { createTransport } from '../../src';
+import { Scope, createTransport } from '../../src';
 import type { ServerRuntimeClientOptions } from '../../src/server-runtime-client';
 import { ServerRuntimeClient } from '../../src/server-runtime-client';
 
@@ -18,6 +18,9 @@ function getDefaultClientOptions(options: Partial<ServerRuntimeClientOptions> = 
 describe('ServerRuntimeClient', () => {
   let client: ServerRuntimeClient;
 
+  const currentScope = new Scope();
+  const isolationScope = new Scope();
+
   describe('_prepareEvent', () => {
     test('adds platform to event', () => {
       const options = getDefaultClientOptions({ dsn: PUBLIC_DSN });
@@ -25,7 +28,7 @@ describe('ServerRuntimeClient', () => {
 
       const event: Event = {};
       const hint: EventHint = {};
-      (client as any)._prepareEvent(event, hint);
+      client['_prepareEvent'](event, hint, currentScope, isolationScope);
 
       expect(event.platform).toEqual('blargh');
     });
@@ -36,7 +39,7 @@ describe('ServerRuntimeClient', () => {
 
       const event: Event = {};
       const hint: EventHint = {};
-      (client as any)._prepareEvent(event, hint);
+      client['_prepareEvent'](event, hint, currentScope, isolationScope);
 
       expect(event.server_name).toEqual('server');
     });
@@ -47,7 +50,7 @@ describe('ServerRuntimeClient', () => {
 
       const event: Event = {};
       const hint: EventHint = {};
-      (client as any)._prepareEvent(event, hint);
+      client['_prepareEvent'](event, hint, currentScope, isolationScope);
 
       expect(event.contexts?.runtime).toEqual({
         name: 'edge',
@@ -60,7 +63,7 @@ describe('ServerRuntimeClient', () => {
 
       const event: Event = { contexts: { runtime: { name: 'foo', version: '1.2.3' } } };
       const hint: EventHint = {};
-      (client as any)._prepareEvent(event, hint);
+      client['_prepareEvent'](event, hint, currentScope, isolationScope);
 
       expect(event.contexts?.runtime).toEqual({ name: 'foo', version: '1.2.3' });
       expect(event.contexts?.runtime).not.toEqual({ name: 'edge' });

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -186,7 +186,7 @@ async function _startWorker(
 
   const timer = setInterval(() => {
     try {
-      const currentSession = getCurrentScope().getSession();
+      const currentSession = getIsolationScope().getSession();
       // We need to copy the session object and remove the toJSON method so it can be sent to the worker
       // serialized without making it a SerializedSession
       const session = currentSession ? { ...currentSession, toJSON: undefined } : undefined;
@@ -202,7 +202,7 @@ async function _startWorker(
   worker.on('message', (msg: string) => {
     if (msg === 'session-ended') {
       log('ANR event sent from ANR worker. Clearing session in this thread.');
-      getCurrentScope().setSession(undefined);
+      getIsolationScope().setSession(undefined);
     }
   });
 


### PR DESCRIPTION
This PR ensures that we always take the session from the isolation scope, never from the current scope.

This has the implication that we need to be sure to pass the isolation scope to `_processEvent`, as this is where the session may be marked as errored. For this, I updated the internal method `_processEvent` to take the isolation scope as last argument, as well as streamlining this slightly.

I opted to update the signature of the protected `_prepareEvent` method too, and make currentScope/isolationScope required there. We already always pass this in now, so it safes a few bytes to avoid the fallback everywhere. This should not really affect users unless they overwrite the `_processEvent` method, which is internal/private anyhow, so IMHO this should be fine. I added a small note to the migration guide anyhow!