### PR TITLE
ref(core)!: Cleanup internal types, including `ReportDialogOptions`

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -226,6 +226,7 @@ Since v9, the types have been merged into `@sentry/core`, which removed some of 
 - The `IntegrationClass` type is no longer exported - it was not used anymore. Instead, use `Integration` or `IntegrationFn`.
 - The `samplingContext.request` attribute in the `tracesSampler` has been removed. Use `samplingContext.normalizedRequest` instead. Note that the type of `normalizedRequest` differs from `request`.
 - `Client` now always expects the `BaseClient` class - there is no more abstract `Client` that can be implemented! Any `Client` class has to extend from `BaseClient`.
+- `ReportDialogOptions` now extends `Record<string, unknown>` instead of `Record<string, any>` - this should not affect most users.
 
 # No Version Support Timeline
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "circularDepCheck": "lerna run circularDepCheck",
     "clean": "run-s clean:build clean:caches",
     "clean:build": "lerna run clean",
-    "clean:caches": "yarn rimraf eslintcache .nxcache && yarn jest --clearCache",
+    "clean:caches": "yarn rimraf eslintcache .nxcache .nx && yarn jest --clearCache",
     "clean:deps": "lerna clean --yes && rm -rf node_modules && yarn",
     "clean:tarballs": "rimraf {packages,dev-packages}/*/*.tgz",
     "clean:watchman": "watchman watch-del \".\"",

--- a/packages/browser-utils/src/metrics/inp.ts
+++ b/packages/browser-utils/src/metrics/inp.ts
@@ -127,9 +127,8 @@ function _trackINP(): () => void {
 
 /**
  * Register a listener to cache route information for INP interactions.
- * TODO(v9): `latestRoute` no longer needs to be passed in and will be removed in v9.
  */
-export function registerInpInteractionListener(_latestRoute?: unknown): void {
+export function registerInpInteractionListener(): void {
   const handleEntries = ({ entries }: { entries: PerformanceEntry[] }): void => {
     const activeSpan = getActiveSpan();
     const activeRootSpan = activeSpan && getRootSpan(activeSpan);

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -13,11 +13,10 @@ export type {
   Thread,
   User,
   Session,
+  ReportDialogOptions,
 } from '@sentry/core';
 
 export type { BrowserOptions } from './client';
-
-export type { ReportDialogOptions } from './sdk';
 
 export {
   addEventProcessor,

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -204,9 +204,7 @@ export function init(browserOptions: BrowserOptions = {}): Client | undefined {
  * All properties the report dialog supports
  */
 export interface ReportDialogOptions {
-  // TODO(v9): Change this to  [key: string]: unknkown;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: unknown;
   eventId?: string;
   dsn?: DsnLike;
   user?: {

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,4 +1,4 @@
-import type { Client, DsnLike, Integration, Options } from '@sentry/core';
+import type { Client, Integration, Options, ReportDialogOptions } from '@sentry/core';
 import {
   consoleSandbox,
   dedupeIntegration,
@@ -198,35 +198,6 @@ export function init(browserOptions: BrowserOptions = {}): Client | undefined {
   };
 
   return initAndBind(BrowserClient, clientOptions);
-}
-
-/**
- * All properties the report dialog supports
- */
-export interface ReportDialogOptions {
-  [key: string]: unknown;
-  eventId?: string;
-  dsn?: DsnLike;
-  user?: {
-    email?: string;
-    name?: string;
-  };
-  lang?: string;
-  title?: string;
-  subtitle?: string;
-  subtitle2?: string;
-  labelName?: string;
-  labelEmail?: string;
-  labelComments?: string;
-  labelClose?: string;
-  labelSubmit?: string;
-  errorGeneric?: string;
-  errorFormEntry?: string;
-  successMessage?: string;
-  /** Callback after reportDialog showed up */
-  onLoad?(this: void): void;
-  /** Callback after reportDialog closed */
-  onClose?(this: void): void;
 }
 
 /**

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1,3 +1,4 @@
+import type { ReportDialogOptions } from './report-dialog';
 import type { DsnComponents, DsnLike, SdkInfo } from './types-hoist';
 import { dsnToString, makeDsn } from './utils-hoist/dsn';
 
@@ -44,13 +45,7 @@ export function getEnvelopeEndpointWithUrlEncodedAuth(dsn: DsnComponents, tunnel
 }
 
 /** Returns the url to the report dialog endpoint. */
-export function getReportDialogEndpoint(
-  dsnLike: DsnLike,
-  dialogOptions: {
-    [key: string]: unknown;
-    user?: { name?: string; email?: string };
-  },
-): string {
+export function getReportDialogEndpoint(dsnLike: DsnLike, dialogOptions: ReportDialogOptions): string {
   const dsn = makeDsn(dsnLike);
   if (!dsn) {
     return '';

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -47,9 +47,7 @@ export function getEnvelopeEndpointWithUrlEncodedAuth(dsn: DsnComponents, tunnel
 export function getReportDialogEndpoint(
   dsnLike: DsnLike,
   dialogOptions: {
-    // TODO(v9): Change this to  [key: string]: unknown;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
+    [key: string]: unknown;
     user?: { name?: string; email?: string };
   },
 ): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,6 +111,7 @@ export {
 } from './fetch';
 export { trpcMiddleware } from './trpc';
 export { captureFeedback } from './feedback';
+export type { ReportDialogOptions } from './report-dialog';
 
 // eslint-disable-next-line deprecation/deprecation
 export { getCurrentHubShim, getCurrentHub } from './getCurrentHubShim';

--- a/packages/core/src/report-dialog.ts
+++ b/packages/core/src/report-dialog.ts
@@ -1,0 +1,29 @@
+import type { DsnLike } from './types-hoist/dsn';
+
+/**
+ * All properties the report dialog supports
+ */
+export interface ReportDialogOptions extends Record<string, unknown> {
+  eventId?: string;
+  dsn?: DsnLike;
+  user?: {
+    email?: string;
+    name?: string;
+  };
+  lang?: string;
+  title?: string;
+  subtitle?: string;
+  subtitle2?: string;
+  labelName?: string;
+  labelEmail?: string;
+  labelComments?: string;
+  labelClose?: string;
+  labelSubmit?: string;
+  errorGeneric?: string;
+  errorFormEntry?: string;
+  successMessage?: string;
+  /** Callback after reportDialog showed up */
+  onLoad?(this: void): void;
+  /** Callback after reportDialog closed */
+  onClose?(this: void): void;
+}

--- a/packages/core/src/types-hoist/wrappedfunction.ts
+++ b/packages/core/src/types-hoist/wrappedfunction.ts
@@ -3,8 +3,6 @@
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type WrappedFunction<T extends Function = Function> = T & {
-  // TODO(v9): Remove this
-  [key: string]: any;
   __sentry_wrapped__?: WrappedFunction<T>;
   __sentry_original__?: T;
 };


### PR DESCRIPTION
These are small changes, cleaning up outdated (I believe?) TODOs, and some internal type stuff.