### PR TITLE
feat(sveltekit): Respect user-provided source map generation settings

### DIFF
--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -18,7 +18,7 @@ export function makeAddSentryVitePlugin(options: SentrySolidStartPluginOptions, 
     // Only if source maps were previously not set, we update the "filesToDeleteAfterUpload" (as we override the setting with "hidden")
     typeof viteConfig.build?.sourcemap === 'undefined'
   ) {
-    // This also works for adapters, as the source maps are also copied to e.g. the .vercel folder
+    // For .output, .vercel, .netlify etc.
     updatedFilesToDeleteAfterUpload = ['.*/**/*.map'];
 
     consoleSandbox(() => {

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -85,7 +85,7 @@ export async function makeCustomSentryVitePlugins(options?: CustomSentryVitePlug
         consoleSandbox(() => {
           // eslint-disable-next-line no-console
           console.warn(
-            '[Source Maps Plugin] Could not load Vite config with Vite "production" mode. This is needed for Sentry to automatically update source map settings.',
+            '[Sentry] Could not load Vite config with Vite "production" mode. This is needed for Sentry to automatically update source map settings.',
           );
         });
       }
@@ -95,7 +95,7 @@ export async function makeCustomSentryVitePlugins(options?: CustomSentryVitePlug
       consoleSandbox(() => {
         // eslint-disable-next-line no-console
         console.warn(
-          `[Source Maps Plugin] Automatically setting \`sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload: ["${filesToDeleteGlob}"]\` to delete generated source maps after they were uploaded to Sentry.`,
+          `[Sentry] Automatically setting \`sourceMapsUploadOptions.sourcemaps.filesToDeleteAfterUpload: ["${filesToDeleteGlob}"]\` to delete generated source maps after they were uploaded to Sentry.`,
         );
       });
     }

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -55,7 +55,6 @@ export async function makeCustomSentryVitePlugins(options?: CustomSentryVitePlug
   const svelteConfig = await loadSvelteConfig();
 
   const usedAdapter = options?.adapter || 'other';
-  const sveltekitOutputDir = svelteConfig.kit?.outDir || '.svelte-kit';
   const adapterOutputDir = await getAdapterOutputDir(svelteConfig, usedAdapter);
 
   const globalWithSourceMapSetting = globalThis as GlobalWithSourceMapSetting;

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -71,7 +71,10 @@ export async function makeCustomSentryVitePlugins(options?: CustomSentryVitePlug
     },
   };
 
-  const defaultFileDeletionGlob = [`./${sveltekitOutputDir}/**/*.map`, `./${adapterOutputDir}/**/*.map`];
+  // Including all hidden (`.*`) directories by default so that folders like .vercel,
+  // .netlify, etc are also cleaned up. Additionally, we include the adapter output
+  // dir which could be a non-hidden directory, like `build` for the Node adapter.
+  const defaultFileDeletionGlob = ['./.*/**/*.map', `./${adapterOutputDir}/**/*.map`];
 
   if (!globalWithSourceMapSetting._sentry_sourceMapSetting) {
     const configFile = await loadConfigFromFile({ command: 'build', mode: 'production' });
@@ -115,7 +118,7 @@ export async function makeCustomSentryVitePlugins(options?: CustomSentryVitePlug
     sourcemaps: {
       ...options?.sourcemaps,
       filesToDeleteAfterUpload: shouldDeleteDefaultSourceMaps
-        ? [`./${sveltekitOutputDir}/**/*.map`, `./${adapterOutputDir}/**/*.map`]
+        ? defaultFileDeletionGlob
         : options?.sourcemaps?.filesToDeleteAfterUpload,
     },
   };

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -43,7 +43,7 @@ describe('sentrySvelteKit()', () => {
 
     expect(plugins).toBeInstanceOf(Array);
     // 1 auto instrument plugin + 5 source maps plugins
-    expect(plugins).toHaveLength(7);
+    expect(plugins).toHaveLength(8);
   });
 
   it('returns the custom sentry source maps upload plugin, unmodified sourcemaps plugins and the auto-instrument plugin by default', async () => {
@@ -56,6 +56,7 @@ describe('sentrySvelteKit()', () => {
       'sentry-telemetry-plugin',
       'sentry-vite-release-injection-plugin',
       'sentry-vite-debug-id-injection-plugin',
+      'sentry-sveltekit-update-source-map-setting-plugin',
       // custom release plugin:
       'sentry-sveltekit-release-management-plugin',
       // custom source maps plugin:
@@ -86,7 +87,7 @@ describe('sentrySvelteKit()', () => {
   it("doesn't return the auto instrument plugin if autoInstrument is `false`", async () => {
     const plugins = await getSentrySvelteKitPlugins({ autoInstrument: false });
     const pluginNames = plugins.map(plugin => plugin.name);
-    expect(plugins).toHaveLength(6);
+    expect(plugins).toHaveLength(7);
     expect(pluginNames).not.toContain('sentry-upload-source-maps');
   });
 

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getUpdatedSourceMapSetting, makeCustomSentryVitePlugins } from '../../src/vite/sourceMaps';
+import { makeCustomSentryVitePlugins } from '../../src/vite/sourceMaps';
 
 import type { Plugin } from 'vite';
 


### PR DESCRIPTION
Enables `hidden` source maps if source maps are unset. In case they are explicitly disabled or enabled the setting is kept as is.

Still need to figure out how to set `filesToDeleteAfterUpload` as this setting needs to be passed when "calling" the sentry Vite plugin. However, `filesToDeleteAfterUpload` is dependent on the Vite options and we only have access to the Vite options when creating the custom plugin.

I thought about moving this parts of this logic to the `sentryVitePlugin` in general.

closes https://github.com/getsentry/sentry-javascript/issues/14885
