### PR TITLE
feat: Avoid class fields all-together

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -78,6 +78,8 @@ Sentry.init({
 
 In v9, an `undefined` value will be treated the same as if the value is not defined at all. You'll need to set `tracesSampleRate: 0` if you want to enable tracing without performance.
 
+- The `getCurrentHub().getIntegration(IntegrationClass)` method will always return `null` in v9. This has already stopped working mostly in v8, because we stopped exposing integration classes. In v9, the fallback behavior has been removed. Note that this does not change the type signature and is thus not technically breaking, but still worth pointing out.
+
 ### `@sentry/node`
 
 - When `skipOpenTelemetrySetup: true` is configured, `httpIntegration({ spans: false })` will be configured by default. This means that you no longer have to specify this yourself in this scenario. With this change, no spans are emitted once `skipOpenTelemetrySetup: true` is configured, without any further configuration being needed.
@@ -208,6 +210,7 @@ This led to some duplication, where we had to keep an interface in `@sentry/type
 Since v9, the types have been merged into `@sentry/core`, which removed some of this duplication. This means that certain things that used to be a separate interface, will not expect an actual instance of the class/concrete implementation. This should not affect most users, unless you relied on passing things with a similar shape to internal methods. The following types are affected:
 
 - `Scope` now always expects the `Scope` class
+- The `IntegrationClass` type is no longer exported - it was not used anymore. Instead, use `Integration` or `IntegrationFn`.
 
 # No Version Support Timeline
 

--- a/packages/angular/.eslintrc.cjs
+++ b/packages/angular/.eslintrc.cjs
@@ -4,4 +4,8 @@ module.exports = {
   },
   extends: ['../../.eslintrc.js'],
   ignorePatterns: ['setup-test.ts', 'patch-vitest.ts'],
+  rules: {
+    // Angular transpiles this correctly/relies on this
+    '@sentry-internal/sdk/no-class-field-initializers': 'off',
+  },
 };

--- a/packages/core/src/getCurrentHubShim.ts
+++ b/packages/core/src/getCurrentHubShim.ts
@@ -11,7 +11,7 @@ import {
   setUser,
   startSession,
 } from './exports';
-import type { Client, EventHint, Hub, Integration, IntegrationClass, SeverityLevel } from './types-hoist';
+import type { Client, EventHint, Hub, Integration, SeverityLevel } from './types-hoist';
 
 /**
  * This is for legacy reasons, and returns a proxy object instead of a hub to be used.
@@ -48,9 +48,8 @@ export function getCurrentHubShim(): Hub {
     setExtras,
     setContext,
 
-    getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null {
-      const client = getClient();
-      return (client && client.getIntegrationByName<T>(integration.id)) || null;
+    getIntegration<T extends Integration>(_integration: unknown): T | null {
+      return null;
     },
 
     startSession,

--- a/packages/core/src/types-hoist/hub.ts
+++ b/packages/core/src/types-hoist/hub.ts
@@ -3,7 +3,7 @@ import type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 import type { Client } from './client';
 import type { Event, EventHint } from './event';
 import type { Extra, Extras } from './extra';
-import type { Integration, IntegrationClass } from './integration';
+import type { Integration } from './integration';
 import type { Primitive } from './misc';
 import type { Session } from './session';
 import type { SeverityLevel } from './severity';
@@ -171,9 +171,9 @@ export interface Hub {
   /**
    * Returns the integration if installed on the current client.
    *
-   * @deprecated Use `Sentry.getClient().getIntegration()` instead.
+   * @deprecated Use `Sentry.getClient().getIntegrationByName()` instead.
    */
-  getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;
+  getIntegration<T extends Integration>(integration: unknown): T | null;
 
   /**
    * Starts a new `Session`, sets on the current scope and returns it.

--- a/packages/core/src/types-hoist/index.ts
+++ b/packages/core/src/types-hoist/index.ts
@@ -58,7 +58,7 @@ export type { Exception } from './exception';
 export type { Extra, Extras } from './extra';
 // eslint-disable-next-line deprecation/deprecation
 export type { Hub } from './hub';
-export type { Integration, IntegrationClass, IntegrationFn } from './integration';
+export type { Integration, IntegrationFn } from './integration';
 export type { Mechanism } from './mechanism';
 export type { ExtractedNodeRequestData, HttpHeaderValue, Primitive, WorkerLocation } from './misc';
 export type { ClientOptions, Options } from './options';

--- a/packages/core/src/types-hoist/integration.ts
+++ b/packages/core/src/types-hoist/integration.ts
@@ -1,16 +1,6 @@
 import type { Client } from './client';
 import type { Event, EventHint } from './event';
 
-/** Integration Class Interface */
-export interface IntegrationClass<T> {
-  /**
-   * Property that holds the integration name
-   */
-  id: string;
-
-  new (...args: any[]): T;
-}
-
 /** Integration interface */
 export interface Integration {
   /**

--- a/packages/core/src/utils-hoist/syncpromise.ts
+++ b/packages/core/src/utils-hoist/syncpromise.ts
@@ -58,6 +58,8 @@ export class SyncPromise<T> implements PromiseLike<T> {
     this._state = States.PENDING;
     this._handlers = [];
 
+    // We set this functions here as class properties, to make binding them easier
+    // This way, the `this` context is easier to maintain
     this._resolve = (value?: T | PromiseLike<T> | null) => {
       this._setResult(States.RESOLVED, value);
     };

--- a/packages/eslint-plugin-sdk/src/rules/no-class-field-initializers.js
+++ b/packages/eslint-plugin-sdk/src/rules/no-class-field-initializers.js
@@ -29,14 +29,7 @@ module.exports = {
   create(context) {
     return {
       'ClassProperty, PropertyDefinition'(node) {
-        // We do allow arrow functions being initialized directly
-        if (
-          !node.static &&
-          node.value !== null &&
-          node.value.type !== 'ArrowFunctionExpression' &&
-          node.value.type !== 'FunctionExpression' &&
-          node.value.type !== 'CallExpression'
-        ) {
+        if (node.value !== null) {
           context.report({
             node,
             message: `Avoid class field initializers. Property "${node.key.name}" should be initialized in the constructor.`,

--- a/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
@@ -5,6 +5,7 @@ import {
   InstrumentationNodeModuleDefinition,
   InstrumentationNodeModuleFile,
 } from '@opentelemetry/instrumentation';
+import type { SpanAttributes } from '@sentry/core';
 import { SDK_VERSION, captureException, startSpan } from '@sentry/core';
 import { getEventSpanOptions } from './helpers';
 import type { OnEventTarget } from './types';
@@ -17,23 +18,23 @@ const supportedVersions = ['>=2.0.0'];
  * This hooks into the `OnEvent` decorator, which is applied on event handlers.
  */
 export class SentryNestEventInstrumentation extends InstrumentationBase {
-  public static readonly COMPONENT = '@nestjs/event-emitter';
-  public static readonly COMMON_ATTRIBUTES = {
-    component: SentryNestEventInstrumentation.COMPONENT,
-  };
+  public readonly COMPONENT: string;
+  public readonly COMMON_ATTRIBUTES: SpanAttributes;
 
   public constructor(config: InstrumentationConfig = {}) {
     super('sentry-nestjs-event', SDK_VERSION, config);
+
+    this.COMPONENT = '@nestjs/event-emitter';
+    this.COMMON_ATTRIBUTES = {
+      component: this.COMPONENT,
+    };
   }
 
   /**
    * Initializes the instrumentation by defining the modules to be patched.
    */
   public init(): InstrumentationNodeModuleDefinition {
-    const moduleDef = new InstrumentationNodeModuleDefinition(
-      SentryNestEventInstrumentation.COMPONENT,
-      supportedVersions,
-    );
+    const moduleDef = new InstrumentationNodeModuleDefinition(this.COMPONENT, supportedVersions);
 
     moduleDef.files.push(this._getOnEventFileInstrumentation(supportedVersions));
     return moduleDef;

--- a/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
@@ -5,12 +5,12 @@ import {
   InstrumentationNodeModuleDefinition,
   InstrumentationNodeModuleFile,
 } from '@opentelemetry/instrumentation';
-import type { SpanAttributes } from '@sentry/core';
 import { SDK_VERSION, captureException, startSpan } from '@sentry/core';
 import { getEventSpanOptions } from './helpers';
 import type { OnEventTarget } from './types';
 
 const supportedVersions = ['>=2.0.0'];
+const COMPONENT = '@nestjs/event-emitter';
 
 /**
  * Custom instrumentation for nestjs event-emitter
@@ -18,23 +18,15 @@ const supportedVersions = ['>=2.0.0'];
  * This hooks into the `OnEvent` decorator, which is applied on event handlers.
  */
 export class SentryNestEventInstrumentation extends InstrumentationBase {
-  public readonly COMPONENT: string;
-  public readonly COMMON_ATTRIBUTES: SpanAttributes;
-
   public constructor(config: InstrumentationConfig = {}) {
     super('sentry-nestjs-event', SDK_VERSION, config);
-
-    this.COMPONENT = '@nestjs/event-emitter';
-    this.COMMON_ATTRIBUTES = {
-      component: this.COMPONENT,
-    };
   }
 
   /**
    * Initializes the instrumentation by defining the modules to be patched.
    */
   public init(): InstrumentationNodeModuleDefinition {
-    const moduleDef = new InstrumentationNodeModuleDefinition(this.COMPONENT, supportedVersions);
+    const moduleDef = new InstrumentationNodeModuleDefinition(COMPONENT, supportedVersions);
 
     moduleDef.files.push(this._getOnEventFileInstrumentation(supportedVersions));
     return moduleDef;

--- a/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
@@ -5,7 +5,7 @@ import {
   InstrumentationNodeModuleDefinition,
   InstrumentationNodeModuleFile,
 } from '@opentelemetry/instrumentation';
-import type { Span, SpanAttributes } from '@sentry/core';
+import type { Span } from '@sentry/core';
 import {
   SDK_VERSION,
   addNonEnumerableProperty,
@@ -20,6 +20,7 @@ import { getMiddlewareSpanOptions, getNextProxy, instrumentObservable, isPatched
 import type { CallHandler, CatchTarget, InjectableTarget, MinimalNestJsExecutionContext, Observable } from './types';
 
 const supportedVersions = ['>=8.0.0 <11'];
+const COMPONENT = '@nestjs/common';
 
 /**
  * Custom instrumentation for nestjs.
@@ -29,23 +30,15 @@ const supportedVersions = ['>=8.0.0 <11'];
  * 2. @Catch decorator, which is applied on exception filters.
  */
 export class SentryNestInstrumentation extends InstrumentationBase {
-  public readonly COMPONENT: string;
-  public readonly COMMON_ATTRIBUTES: SpanAttributes;
-
   public constructor(config: InstrumentationConfig = {}) {
     super('sentry-nestjs', SDK_VERSION, config);
-
-    this.COMPONENT = '@nestjs/common';
-    this.COMMON_ATTRIBUTES = {
-      component: this.COMPONENT,
-    };
   }
 
   /**
    * Initializes the instrumentation by defining the modules to be patched.
    */
   public init(): InstrumentationNodeModuleDefinition {
-    const moduleDef = new InstrumentationNodeModuleDefinition(this.COMPONENT, supportedVersions);
+    const moduleDef = new InstrumentationNodeModuleDefinition(COMPONENT, supportedVersions);
 
     moduleDef.files.push(
       this._getInjectableFileInstrumentation(supportedVersions),

--- a/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
@@ -5,7 +5,7 @@ import {
   InstrumentationNodeModuleDefinition,
   InstrumentationNodeModuleFile,
 } from '@opentelemetry/instrumentation';
-import type { Span } from '@sentry/core';
+import type { Span, SpanAttributes } from '@sentry/core';
 import {
   SDK_VERSION,
   addNonEnumerableProperty,
@@ -29,20 +29,23 @@ const supportedVersions = ['>=8.0.0 <11'];
  * 2. @Catch decorator, which is applied on exception filters.
  */
 export class SentryNestInstrumentation extends InstrumentationBase {
-  public static readonly COMPONENT = '@nestjs/common';
-  public static readonly COMMON_ATTRIBUTES = {
-    component: SentryNestInstrumentation.COMPONENT,
-  };
+  public readonly COMPONENT: string;
+  public readonly COMMON_ATTRIBUTES: SpanAttributes;
 
   public constructor(config: InstrumentationConfig = {}) {
     super('sentry-nestjs', SDK_VERSION, config);
+
+    this.COMPONENT = '@nestjs/common';
+    this.COMMON_ATTRIBUTES = {
+      component: this.COMPONENT,
+    };
   }
 
   /**
    * Initializes the instrumentation by defining the modules to be patched.
    */
   public init(): InstrumentationNodeModuleDefinition {
-    const moduleDef = new InstrumentationNodeModuleDefinition(SentryNestInstrumentation.COMPONENT, supportedVersions);
+    const moduleDef = new InstrumentationNodeModuleDefinition(this.COMPONENT, supportedVersions);
 
     moduleDef.files.push(
       this._getInjectableFileInstrumentation(supportedVersions),

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -145,14 +145,14 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     }
   }
 
-  public resetErrorBoundary: () => void = () => {
+  public resetErrorBoundary(): void {
     const { onReset } = this.props;
     const { error, componentStack, eventId } = this.state;
     if (onReset) {
       onReset(error, componentStack, eventId);
     }
     this.setState(INITIAL_STATE);
-  };
+  }
 
   public render(): React.ReactNode {
     const { fallback, children } = this.props;
@@ -164,7 +164,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
         element = React.createElement(fallback, {
           error: state.error,
           componentStack: state.componentStack as string,
-          resetError: this.resetErrorBoundary,
+          resetError: this.resetErrorBoundary.bind(this),
           eventId: state.eventId as string,
         });
       } else {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -134,6 +134,7 @@ class Profiler extends React.Component<ProfilerProps> {
   }
 }
 
+// React.Component default props are defined as static property on the class
 Object.assign(Profiler, {
   defaultProps: {
     disabled: false,

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -39,13 +39,6 @@ class Profiler extends React.Component<ProfilerProps> {
    */
   protected _updateSpan: Span | undefined;
 
-  // eslint-disable-next-line @typescript-eslint/member-ordering
-  public static defaultProps: Partial<ProfilerProps> = {
-    disabled: false,
-    includeRender: true,
-    includeUpdates: true,
-  };
-
   public constructor(props: ProfilerProps) {
     super(props);
     const { name, disabled = false } = this.props;
@@ -140,6 +133,14 @@ class Profiler extends React.Component<ProfilerProps> {
     return this.props.children;
   }
 }
+
+Object.assign(Profiler, {
+  defaultProps: {
+    disabled: false,
+    includeRender: true,
+    includeUpdates: true,
+  },
+});
 
 /**
  * withProfiler is a higher order component that wraps a

--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -46,16 +46,8 @@ export const replayIntegration = ((options?: ReplayConfiguration) => {
 
 /**
  * Replay integration
- *
- * TODO: Rewrite this to be functional integration
- * Exported for tests.
  */
 export class Replay implements Integration {
-  /**
-   * @inheritDoc
-   */
-  public static id: string = 'Replay';
-
   /**
    * @inheritDoc
    */
@@ -114,7 +106,7 @@ export class Replay implements Integration {
     beforeErrorSampling,
     onError,
   }: ReplayConfiguration = {}) {
-    this.name = Replay.id;
+    this.name = 'Replay';
 
     const privacyOptions = getPrivacyOptions({
       mask,

--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -147,6 +147,27 @@ export class ReplayContainer implements ReplayContainerInterface {
    */
   private _canvas: ReplayCanvasIntegrationOptions | undefined;
 
+  /**
+   * Handle when visibility of the page content changes. Opening a new tab will
+   * cause the state to change to hidden because of content of current page will
+   * be hidden. Likewise, moving a different window to cover the contents of the
+   * page will also trigger a change to a hidden state.
+   */
+  private _handleVisibilityChange: () => void;
+
+  /**
+   * Handle when page is blurred
+   */
+  private _handleWindowBlur: () => void;
+
+  /**
+   * Handle when page is focused
+   */
+  private _handleWindowFocus: () => void;
+
+  /** Ensure page remains active when a key is pressed. */
+  private _handleKeyboardEvent: (event: KeyboardEvent) => void;
+
   public constructor({
     options,
     recordingOptions,
@@ -213,6 +234,42 @@ export class ReplayContainer implements ReplayContainerInterface {
         traceInternals: !!experiments.traceInternals,
       });
     }
+
+    this._handleVisibilityChange = () => {
+      if (WINDOW.document.visibilityState === 'visible') {
+        this._doChangeToForegroundTasks();
+      } else {
+        this._doChangeToBackgroundTasks();
+      }
+    };
+
+    /**
+     * Handle when page is blurred
+     */
+    this._handleWindowBlur = () => {
+      const breadcrumb = createBreadcrumb({
+        category: 'ui.blur',
+      });
+
+      // Do not count blur as a user action -- it's part of the process of them
+      // leaving the page
+      this._doChangeToBackgroundTasks(breadcrumb);
+    };
+
+    this._handleWindowFocus = () => {
+      const breadcrumb = createBreadcrumb({
+        category: 'ui.focus',
+      });
+
+      // Do not count focus as a user action -- instead wait until they focus and
+      // interactive with page
+      this._doChangeToForegroundTasks(breadcrumb);
+    };
+
+    /** Ensure page remains active when a key is pressed. */
+    this._handleKeyboardEvent = (event: KeyboardEvent) => {
+      handleKeyboardEvent(this, event);
+    };
   }
 
   /** Get the event context. */
@@ -394,7 +451,7 @@ export class ReplayContainer implements ReplayContainerInterface {
               checkoutEveryNms: Math.max(360_000, this._options._experiments.continuousCheckout),
             }),
         emit: getHandleRecordingEmit(this),
-        onMutation: this._onMutationHandler,
+        onMutation: this._onMutationHandler.bind(this),
         ...(canvasOptions
           ? {
               recordCanvas: canvasOptions.recordCanvas,
@@ -908,51 +965,6 @@ export class ReplayContainer implements ReplayContainerInterface {
   }
 
   /**
-   * Handle when visibility of the page content changes. Opening a new tab will
-   * cause the state to change to hidden because of content of current page will
-   * be hidden. Likewise, moving a different window to cover the contents of the
-   * page will also trigger a change to a hidden state.
-   */
-  private _handleVisibilityChange: () => void = () => {
-    if (WINDOW.document.visibilityState === 'visible') {
-      this._doChangeToForegroundTasks();
-    } else {
-      this._doChangeToBackgroundTasks();
-    }
-  };
-
-  /**
-   * Handle when page is blurred
-   */
-  private _handleWindowBlur: () => void = () => {
-    const breadcrumb = createBreadcrumb({
-      category: 'ui.blur',
-    });
-
-    // Do not count blur as a user action -- it's part of the process of them
-    // leaving the page
-    this._doChangeToBackgroundTasks(breadcrumb);
-  };
-
-  /**
-   * Handle when page is focused
-   */
-  private _handleWindowFocus: () => void = () => {
-    const breadcrumb = createBreadcrumb({
-      category: 'ui.focus',
-    });
-
-    // Do not count focus as a user action -- instead wait until they focus and
-    // interactive with page
-    this._doChangeToForegroundTasks(breadcrumb);
-  };
-
-  /** Ensure page remains active when a key is pressed. */
-  private _handleKeyboardEvent: (event: KeyboardEvent) => void = (event: KeyboardEvent) => {
-    handleKeyboardEvent(this, event);
-  };
-
-  /**
    * Tasks to run when we consider a page to be hidden (via blurring and/or visibility)
    */
   private _doChangeToBackgroundTasks(breadcrumb?: ReplayBreadcrumbFrame): void {
@@ -1199,7 +1211,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    * Flush recording data to Sentry. Creates a lock so that only a single flush
    * can be active at a time. Do not call this directly.
    */
-  private _flush = async ({
+  private async _flush({
     force = false,
   }: {
     /**
@@ -1208,7 +1220,7 @@ export class ReplayContainer implements ReplayContainerInterface {
      * is stopped).
      */
     force?: boolean;
-  } = {}): Promise<void> => {
+  } = {}): Promise<void> {
     if (!this._isEnabled && !force) {
       // This can happen if e.g. the replay was stopped because of exceeding the retry limit
       return;
@@ -1279,7 +1291,7 @@ export class ReplayContainer implements ReplayContainerInterface {
         this._debouncedFlush();
       }
     }
-  };
+  }
 
   /** Save the session, if it is sticky */
   private _maybeSaveSession(): void {
@@ -1289,7 +1301,7 @@ export class ReplayContainer implements ReplayContainerInterface {
   }
 
   /** Handler for rrweb.record.onMutation */
-  private _onMutationHandler = (mutations: unknown[]): boolean => {
+  private _onMutationHandler(mutations: unknown[]): boolean {
     const count = mutations.length;
 
     const mutationLimit = this._options.mutationLimit;
@@ -1319,5 +1331,5 @@ export class ReplayContainer implements ReplayContainerInterface {
 
     // `true` means we use the regular mutation handling by rrweb
     return true;
-  };
+  }
 }

--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -235,6 +235,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       });
     }
 
+    // We set these handler properties as class properties, to make binding/unbinding them easier
     this._handleVisibilityChange = () => {
       if (WINDOW.document.visibilityState === 'visible') {
         this._doChangeToForegroundTasks();

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -77,7 +77,6 @@ import type {
   InProgressCheckIn as InProgressCheckIn_imported,
   InformationUnit as InformationUnit_imported,
   Integration as Integration_imported,
-  IntegrationClass as IntegrationClass_imported,
   IntegrationFn as IntegrationFn_imported,
   InternalBaseTransportOptions as InternalBaseTransportOptions_imported,
   MeasurementUnit as MeasurementUnit_imported,
@@ -304,8 +303,6 @@ export type Extras = Extras_imported;
 export type Hub = Hub_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type Integration = Integration_imported;
-/** @deprecated This type has been moved to `@sentry/core`. */
-export type IntegrationClass<T> = IntegrationClass_imported<T>;
 /** @deprecated This type has been moved to `@sentry/core`. */
 // eslint-disable-next-line deprecation/deprecation
 export type IntegrationFn<IntegrationType = Integration> = IntegrationFn_imported<IntegrationType>;


### PR DESCRIPTION
We already have an eslint rule to avoid class fields, but had exceptions for static fields as well as for arrow functions.

This also leads to bundle size increases, so removing the exceptions and handling the (few) exceptions we have there should save some bytes.

Additionally, this has additional challenges if we want to avoid/reduce polyfills, as class fields need to be polyfilled for ES2020, sadly.

Found as part of https://github.com/getsentry/sentry-javascript/pull/14882