### PR TITLE
docs(node): Remove old occurrences of tracingHandler

### DIFF
--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -51,7 +51,7 @@ export interface WrapperOptions {
   captureAllSettledReasons: boolean;
   /**
    * Automatically trace all handler invocations.
-   * You may want to disable this if you use express within Lambda (use tracingHandler instead).
+   * You may want to disable this if you use express within Lambda.
    * @default true
    */
   startTrace: boolean;

--- a/packages/core/src/types-hoist/samplingcontext.ts
+++ b/packages/core/src/types-hoist/samplingcontext.ts
@@ -35,7 +35,7 @@ export interface SamplingContext extends CustomSamplingContext {
   location?: WorkerLocation;
 
   /**
-   * Object representing the incoming request to a node server. Passed by default when using the TracingHandler.
+   * Object representing the incoming request to a node server.
    */
   request?: ExtractedNodeRequestData;
 


### PR DESCRIPTION
The `TracingHandler` is deprecated since v8, but some JSDocs still mention the usage of it which can be misleading. 