### PR TITLE
build: Drop comments from npm build output

### DIFF
--- a/dev-packages/rollup-utils/plugins/npmPlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/npmPlugins.mjs
@@ -97,9 +97,8 @@ export function makeDebuggerPlugin(hookName) {
  */
 export function makeCleanupPlugin() {
   return cleanup({
-    // line endings are unix-ized by default
-    comments: 'all', // comments to keep
-    compactComments: 'false', // don't remove blank lines in multi-line comments
+    // Keep comments containing `Copyright` and `@license`
+    comments: ['license', /Copyright/],
     maxEmptyLines: 1,
     extensions: ['js', 'jsx', 'ts', 'tsx'],
   });


### PR DESCRIPTION
Let's see how that impacts bundle size...