### PR TITLE
fix(feedback): Avoid lazy loading code for `syncFeedbackIntegration`

### DIFF
--- a/packages/browser/src/feedbackSync.ts
+++ b/packages/browser/src/feedbackSync.ts
@@ -3,11 +3,9 @@ import {
   feedbackModalIntegration,
   feedbackScreenshotIntegration,
 } from '@sentry-internal/feedback';
-import { lazyLoadIntegration } from './utils/lazyLoadIntegration';
 
 /** Add a widget to capture user feedback to your application. */
 export const feedbackSyncIntegration = buildFeedbackIntegration({
-  lazyLoadIntegration,
   getModalIntegration: () => feedbackModalIntegration,
   getScreenshotIntegration: () => feedbackScreenshotIntegration,
 });

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -5,7 +5,7 @@ import type {
   Integration,
   IntegrationFn,
 } from '@sentry/core';
-import { getClient, isBrowser, logger } from '@sentry/core';
+import { addIntegration, isBrowser, logger } from '@sentry/core';
 import {
   ADD_SCREENSHOT_LABEL,
   CANCEL_BUTTON_LABEL,
@@ -39,16 +39,22 @@ type Unsubscribe = () => void;
  * Allow users to capture user feedback and send it to Sentry.
  */
 
-interface BuilderOptions {
-  // The type here should be `keyof typeof LazyLoadableIntegrations`, but that'll cause a cicrular
-  // dependency with @sentry/core
-  lazyLoadIntegration: (
-    name: 'feedbackModalIntegration' | 'feedbackScreenshotIntegration',
-    scriptNonce?: string,
-  ) => Promise<IntegrationFn>;
-  getModalIntegration?: null | (() => IntegrationFn);
-  getScreenshotIntegration?: null | (() => IntegrationFn);
-}
+type BuilderOptions =
+  | {
+      lazyLoadIntegration?: never;
+      getModalIntegration: () => IntegrationFn;
+      getScreenshotIntegration: () => IntegrationFn;
+    }
+  | {
+      // The type here should be `keyof typeof LazyLoadableIntegrations`, but that'll cause a cicrular
+      // dependency with @sentry/core
+      lazyLoadIntegration: (
+        name: 'feedbackModalIntegration' | 'feedbackScreenshotIntegration',
+        scriptNonce?: string,
+      ) => Promise<IntegrationFn>;
+      getModalIntegration?: never;
+      getScreenshotIntegration?: never;
+    };
 
 export const buildFeedbackIntegration = ({
   lazyLoadIntegration,
@@ -172,36 +178,30 @@ export const buildFeedbackIntegration = ({
       return _shadow as ShadowRoot;
     };
 
-    const _findIntegration = async <I extends Integration>(
-      integrationName: string,
-      getter: undefined | null | (() => IntegrationFn),
-      functionMethodName: 'feedbackModalIntegration' | 'feedbackScreenshotIntegration',
-    ): Promise<I> => {
-      const client = getClient();
-      const existing = client && client.getIntegrationByName(integrationName);
-      if (existing) {
-        return existing as I;
-      }
-      const integrationFn = (getter && getter()) || (await lazyLoadIntegration(functionMethodName, scriptNonce));
-      const integration = integrationFn();
-      client && client.addIntegration(integration);
-      return integration as I;
-    };
-
     const _loadAndRenderDialog = async (
       options: FeedbackInternalOptions,
     ): Promise<ReturnType<FeedbackModalIntegration['createDialog']>> => {
       const screenshotRequired = options.enableScreenshot && isScreenshotSupported();
-      const [modalIntegration, screenshotIntegration] = await Promise.all([
-        _findIntegration<FeedbackModalIntegration>('FeedbackModal', getModalIntegration, 'feedbackModalIntegration'),
+
+      const [modalIntegrationFn, screenshotIntegrationFn] = await Promise.all([
+        getModalIntegration ? getModalIntegration() : lazyLoadIntegration('feedbackModalIntegration', scriptNonce),
         screenshotRequired
-          ? _findIntegration<FeedbackScreenshotIntegration>(
-              'FeedbackScreenshot',
-              getScreenshotIntegration,
-              'feedbackScreenshotIntegration',
-            )
+          ? getScreenshotIntegration
+            ? getScreenshotIntegration()
+            : lazyLoadIntegration('feedbackScreenshotIntegration', scriptNonce)
           : undefined,
       ]);
+
+      const modalIntegration = modalIntegrationFn() as FeedbackModalIntegration;
+      const screenshotIntegration = screenshotIntegrationFn
+        ? (screenshotIntegrationFn() as FeedbackScreenshotIntegration)
+        : undefined;
+
+      addIntegration(modalIntegration);
+      if (screenshotIntegration) {
+        addIntegration(screenshotIntegration);
+      }
+
       if (!modalIntegration) {
         // TODO: Let the end-user retry async loading
         DEBUG_BUILD &&


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/14891

This PR updates the sync feedback integration to avoid it pulling in the `lazyLoadIntegration` code. This is not really needed and leads to some problems (and also bundle size increase).

For this I updated the type signature of `buildFeedbackIntegration` to ensure that _either_ `lazyLoadIntegration` _or_ the getter functions are provided, so we can type-safely use this.

We probably also want to backport this to v8 then.