### PR TITLE
ref(core): Store `ipAddress` as SDKProcessingMetadata

### DIFF
--- a/packages/core/src/integrations/requestdata.ts
+++ b/packages/core/src/integrations/requestdata.ts
@@ -79,14 +79,13 @@ const _requestDataIntegration = ((options: RequestDataIntegrationOptions = {}) =
       // that's happened, it will be easier to add this logic in without worrying about unexpected side effects.)
 
       const { sdkProcessingMetadata = {} } = event;
-      const { request, normalizedRequest } = sdkProcessingMetadata;
+      const { request, normalizedRequest, ipAddress } = sdkProcessingMetadata;
 
       const addRequestDataOptions = convertReqDataIntegrationOptsToAddReqDataOpts(_options);
 
       // If this is set, it takes precedence over the plain request object
       if (normalizedRequest) {
         // Some other data is not available in standard HTTP requests, but can sometimes be augmented by e.g. Express or Next.js
-        const ipAddress = request ? request.ip || (request.socket && request.socket.remoteAddress) : undefined;
         const user = request ? request.user : undefined;
 
         addNormalizedRequestDataToEvent(event, normalizedRequest, { ipAddress, user }, addRequestDataOptions);

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -67,6 +67,7 @@ export interface SdkProcessingMetadata {
   capturedSpanScope?: Scope;
   capturedSpanIsolationScope?: Scope;
   spanCountBeforeProcessing?: number;
+  ipAddress?: string;
 }
 
 /**

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -155,6 +155,9 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
 
         const normalizedRequest = httpRequestToRequestData(request);
 
+        // request.ip is non-standard but some frameworks set this
+        const ipAddress = (request as { ip?: string }).ip || request.socket?.remoteAddress;
+
         patchRequestToCaptureBody(request, isolationScope);
 
         // Update the isolation scope, isolate this request
@@ -162,6 +165,7 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
         isolationScope.setSDKProcessingMetadata({
           request,
           normalizedRequest,
+          ipAddress,
         });
 
         // attempt to update the scope's `transactionName` based on the request URL


### PR DESCRIPTION
Instead of picking this from the plain `request` in `requestDartaIntegration`.

Extracted from https://github.com/getsentry/sentry-javascript/pull/14806