### PR TITLE
fix(core): Fork scope if custom scope is passed to `startSpan`

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -82,6 +82,16 @@ In v9, an `undefined` value will be treated the same as if the value is not defi
 
 - The `getCurrentHub().getIntegration(IntegrationClass)` method will always return `null` in v9. This has already stopped working mostly in v8, because we stopped exposing integration classes. In v9, the fallback behavior has been removed. Note that this does not change the type signature and is thus not technically breaking, but still worth pointing out.
 
+- The `startSpan` behavior was slightly changed if you pass a custom `scope` to the span start options: While in v8, the passed scope was set active directly on the passed scope, in v9, the scope is cloned. This behavior change does not apply to `@sentry/node` where the scope was already cloned. This change was made to ensure that the span only remains active within the callback and to align behavior between `@sentry/node` and all other SDKs. As a result of the change, your span hierarchy should be more accurate. However, be aware that modifying the scope (e.g. set tags) within the `startSpan` callback behaves a bit differently now.
+
+```js
+startSpan({ name: 'example', scope: customScope }, () => {
+  getCurrentScope().setTag('tag-a', 'a'); // this tag will only remain within the callback
+  // set the tag directly on customScope in addition, if you want to to persist the tag outside of the callback
+  customScope.setTag('tag-a', 'a');
+});
+```
+
 ### `@sentry/node`
 
 - When `skipOpenTelemetrySetup: true` is configured, `httpIntegration({ spans: false })` will be configured by default. This means that you no longer have to specify this yourself in this scenario. With this change, no spans are emitted once `skipOpenTelemetrySetup: true` is configured, without any further configuration being needed.

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -16,14 +16,7 @@ import { propagationContextFromHeaders } from '../utils-hoist/tracing';
 import { handleCallbackErrors } from '../utils/handleCallbackErrors';
 import { hasTracingEnabled } from '../utils/hasTracingEnabled';
 import { _getSpanForScope, _setSpanForScope } from '../utils/spanOnScope';
-import {
-  addChildSpanToSpan,
-  getActiveSpan,
-  getRootSpan,
-  spanIsSampled,
-  spanTimeInputToSeconds,
-  spanToJSON,
-} from '../utils/spanUtils';
+import { addChildSpanToSpan, getRootSpan, spanIsSampled, spanTimeInputToSeconds, spanToJSON } from '../utils/spanUtils';
 import { freezeDscOnSpan, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { logSpanStart } from './logSpans';
 import { sampleSpan } from './sampling';

--- a/packages/core/src/types-hoist/startSpanOptions.ts
+++ b/packages/core/src/types-hoist/startSpanOptions.ts
@@ -9,11 +9,12 @@ export interface StartSpanOptions {
    * If set, start the span on a fork of this scope instead of on the current scope.
    * To ensure proper span cleanup, the passed scope is cloned for the duration of the span.
    *
-   * If you want to modify the passed scope inside the callback, be aware that:
-   * - calling `getCurrentScope()` will return the cloned scope, meaning all modifications
-   *   will be reset once the callback finishes
-   * - if you want to modify the passed scope and have the changes persist after the callback
-   *   ends, modify the scope directly and don't use `getCurrentScope()`
+   * If you want to modify the passed scope inside the callback, calling `getCurrentScope()`
+   * will return the cloned scope, meaning all scope modifications will be reset once the
+   * callback finishes
+   *
+   * If you want to modify the passed scope and have the changes persist after the callback ends,
+   * modify the scope directly instead of using `getCurrentScope()`
    */
   scope?: Scope;
 

--- a/packages/core/src/types-hoist/startSpanOptions.ts
+++ b/packages/core/src/types-hoist/startSpanOptions.ts
@@ -5,7 +5,16 @@ export interface StartSpanOptions {
   /** A manually specified start time for the created `Span` object. */
   startTime?: SpanTimeInput;
 
-  /** If defined, start this span off this scope instead off the current scope. */
+  /**
+   * If set, start the span on a fork of this scope instead of on the current scope.
+   * To ensure proper span cleanup, the passed scope is cloned for the duration of the span.
+   *
+   * If you want to modify the passed scope inside the callback, be aware that:
+   * - calling `getCurrentScope()` will return the cloned scope, meaning all modifications
+   *   will be reset once the callback finishes
+   * - if you want to modify the passed scope and have the changes persist after the callback
+   *   ends, modify the scope directly and don't use `getCurrentScope()`
+   */
   scope?: Scope;
 
   /** The name of the span. */

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -25,7 +25,7 @@ import {
 import { SentryNonRecordingSpan } from '../../../src/tracing/sentryNonRecordingSpan';
 import { startNewTrace } from '../../../src/tracing/trace';
 import type { Event, Span, StartSpanOptions } from '../../../src/types-hoist';
-import { _getSpanForScope, _setSpanForScope } from '../../../src/utils/spanOnScope';
+import { _setSpanForScope } from '../../../src/utils/spanOnScope';
 import { getActiveSpan, getRootSpan, getSpanDescendants, spanIsSampled } from '../../../src/utils/spanUtils';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -290,24 +290,46 @@ describe('trace', () => {
       let manualScope: Scope;
       let parentSpan: Span;
 
+      // "hack" to create a manual scope with a parent span
       startSpanManual({ name: 'detached' }, span => {
         parentSpan = span;
         manualScope = getCurrentScope();
         manualScope.setTag('manual', 'tag');
       });
 
+      expect(manualScope!.getScopeData().tags).toEqual({ manual: 'tag' });
+      expect(getCurrentScope()).not.toBe(manualScope!);
+
       getCurrentScope().setTag('outer', 'tag');
 
       startSpan({ name: 'GET users/[id]', scope: manualScope! }, span => {
+        // the current scope in the callback is a fork of the manual scope
         expect(getCurrentScope()).not.toBe(initialScope);
+        expect(getCurrentScope()).not.toBe(manualScope);
+        expect(getCurrentScope().getScopeData().tags).toEqual({ manual: 'tag' });
 
-        expect(getCurrentScope()).toEqual(manualScope);
+        // getActiveSpan returns the correct span
         expect(getActiveSpan()).toBe(span);
 
+        // span hierarchy is correct
         expect(getSpanParentSpanId(span)).toBe(parentSpan.spanContext().spanId);
+
+        // scope data modifications are isolated between original and forked manual scope
+        getCurrentScope().setTag('inner', 'tag');
+        manualScope!.setTag('manual-scope-inner', 'tag');
+
+        expect(getCurrentScope().getScopeData().tags).toEqual({ manual: 'tag', inner: 'tag' });
+        expect(manualScope!.getScopeData().tags).toEqual({ manual: 'tag', 'manual-scope-inner': 'tag' });
       });
 
+      // manualScope modifications remain set outside the callback
+      expect(manualScope!.getScopeData().tags).toEqual({ manual: 'tag', 'manual-scope-inner': 'tag' });
+
+      // current scope is reset back to initial scope
       expect(getCurrentScope()).toBe(initialScope);
+      expect(getCurrentScope().getScopeData().tags).toEqual({ outer: 'tag' });
+
+      // although the manual span is still running, it's no longer active due to being outside of the callback
       expect(getActiveSpan()).toBe(undefined);
     });
 


### PR DESCRIPTION
This PR fixes unexpected behaviour that would emerge when starting multiple spans in sequence with `startSpan` when passing on the same scope. Prior to this change, the second span would be started as the child span of the first one, because the span set active on the custom scope was not re-set to the parent span of the first span. The reason is that we didn't clean up or restore the previously active span because the custom scope is not forked in contrast to the current scope. 

In very niche scenarios, this could furthermore lead to only the first span being sent and subsequent spans being discarded because they were being incorrectly considered a child span. Examples for this are the Sentry and CodeCov bundler plugins where we solely rely on `@sentry/core` and a custom client setup. In more conventional setups, using the Node (POTEL) or browser SDKs this probably would have gone unnoticed.

This PR fixes this edge case by also forking the custom scope if it is passed into `startSpan`. Since this has implications on the lifetime of other span modifications like setting tags, we consider this a behaviourally breaking change and will not backport it to v8. I adjusted tests to reflect the scope data lifetime. It's worth noting though, that in POTEL SDKs we already forked custom scope, so this PR further aligns behaviour.

This came up while reviewing https://github.com/codecov/codecov-javascript-bundler-plugins/pull/224