### PR TITLE
fix(core): Fork scope if custom scope is passed to `startSpanManual`

### DIFF
--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -840,7 +840,7 @@ describe('startSpanManual', () => {
       const initialScope = getCurrentScope();
       const manualScope = initialScope.clone();
 
-      startSpanManual({ name: 'GET users/[id]', scope: manualScope }, (span, finish) => {
+      startSpanManual({ name: 'GET users/[id]', scope: manualScope }, span => {
         // current scope is forked from the customScope
         expect(getCurrentScope()).not.toBe(initialScope);
         expect(getCurrentScope()).not.toBe(manualScope);


### PR DESCRIPTION
This PR follows up on #14900 and analogously forks an optionally passed custom `scope` to ensure the active span is only active inside the callback. 