### PR TITLE
feat(core): Add `normalizedRequest` to `samplingContext`

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/scenario-normalizedRequest.js
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/scenario-normalizedRequest.js
@@ -1,0 +1,35 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+  tracesSampler: samplingContext => {
+    // The sampling decision is based on whether the data in `normalizedRequest` is available --> this is what we want to test for
+    return (
+      samplingContext.normalizedRequest.url.includes('/test-normalized-request?query=123') &&
+      samplingContext.normalizedRequest.method &&
+      samplingContext.normalizedRequest.query_string === 'query=123' &&
+      !!samplingContext.normalizedRequest.headers
+    );
+  },
+  debug: true,
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+const cors = require('cors');
+const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+
+const app = express();
+
+app.use(cors());
+
+app.get('/test-normalized-request', (_req, res) => {
+  res.send('Success');
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/test.ts
@@ -22,3 +22,23 @@ describe('express tracesSampler', () => {
     });
   });
 });
+
+describe('express tracesSampler includes normalizedRequest data', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  describe('CJS', () => {
+    test('correctly samples & passes data to tracesSampler', done => {
+      const runner = createRunner(__dirname, 'scenario-normalizedRequest.js')
+        .expect({
+          transaction: {
+            transaction: 'GET /test-normalized-request',
+          },
+        })
+        .start(done);
+
+      runner.makeRequest('get', '/test-normalized-request?query=123');
+    });
+  });
+});

--- a/packages/core/src/types-hoist/samplingcontext.ts
+++ b/packages/core/src/types-hoist/samplingcontext.ts
@@ -1,3 +1,4 @@
+import type { RequestEventData } from '../types-hoist/request';
 import type { ExtractedNodeRequestData, WorkerLocation } from './misc';
 import type { SpanAttributes } from './span';
 
@@ -36,8 +37,14 @@ export interface SamplingContext extends CustomSamplingContext {
 
   /**
    * Object representing the incoming request to a node server.
+   * @deprecated This attribute is currently never defined and will be removed in v9. Use `normalizedRequest` instead
    */
   request?: ExtractedNodeRequestData;
+
+  /**
+   * Object representing the incoming request to a node server in a normalized format.
+   */
+  normalizedRequest?: RequestEventData;
 
   /** The name of the span being sampled. */
   name: string;


### PR DESCRIPTION
The sampling context didn't include the `request` object anymore. By adding the `normalizedRequest`, this data is added again.