### PR TITLE
fix(v7/publish): Ensure discontinued packages are published with `latest` tag

### DIFF
--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -13,7 +13,7 @@
   "module": "build/fesm2015/sentry-angular.js",
   "publishConfig": {
     "access": "public",
-    "tag": "v7"
+    "tag": "latest"
   },
   "peerDependencies": {
     "@angular/common": ">= 12.x <= 17.x",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -27,7 +27,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v7"
+    "tag": "latest"
   },
   "dependencies": {
     "@sentry/core": "7.120.2",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -27,7 +27,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v7"
+    "tag": "latest"
   },
   "dependencies": {
     "@sentry/core": "7.120.2",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -27,7 +27,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "v7"
+    "tag": "latest"
   },
   "dependencies": {
     "@sentry-internal/tracing": "7.120.2"


### PR DESCRIPTION
This PR sets the NPM publish tag of discontinued packages from `v7` back to `latest`. As pointed out in https://github.com/getsentry/sentry-javascript/issues/14923, it's a bit misleading for packages that have not received a v8 version but newer v7 versions that their `latest` tag doesn't point to the in fact latest version.

Affected packages:
- `@sentry/angular-ivy` (replaced by `@sentry/angular` in v8)
- `@sentry/hub` (discontinued)
- `@sentry/tracing` (discontinued)
- `@sentry/serverless` (replaced by `@sentry/aws-serverless`, `@sentry/google-cloud` and `@sentry/node` respectively)

fixes https://github.com/getsentry/sentry-javascript/issues/14923