### PR TITLE
feat(aws): Rename AWS lambda layer name to `SentryNodeServerlessSDKv9`

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -141,7 +141,7 @@ targets:
   # TODO(v9): Once stable, re-add this target to publish the AWS Lambda layer
   # - name: aws-lambda-layer
   #   includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
-  #   layerName: SentryNodeServerlessSDK
+  #   layerName: SentryNodeServerlessSDKv9
   #   compatibleRuntimes:
   #     - name: node
   #       versions:


### PR DESCRIPTION
We decided to stop publishing layers under the `SentryNodeServerlessSDK` name and instead use the version suffix even for the next major.

This will not break the docs, but will break the product as explained in https://github.com/getsentry/sentry/issues/82646. I think we can completely remove that check once we are ready to ship v9 but need to investigate further, otherwise we follow the approach outlined in that issue.