### PR TITLE
feat(nextjs)!: Don't rely on Next.js Build ID for release names

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -394,7 +394,6 @@ The Sentry metrics beta has ended and the metrics API has been removed from the 
 ## `@sentry/nextjs`
 
 - Deprecated `hideSourceMaps`. No replacements. The SDK emits hidden sourcemaps by default.
--
 
 ## `@sentry/opentelemetry`
 

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -90,6 +90,12 @@ In v9, an `undefined` value will be treated the same as if the value is not defi
 
 - The `captureUserFeedback` method has been removed. Use `captureFeedback` instead and update the `comments` field to `message`.
 
+### `@sentry/nextjs`
+
+- The Sentry Next.js SDK will no longer use the Next.js Build ID as fallback identifier for releases. The SDK will continue to attempt to read CI-provider-specific environment variables and the current git SHA to automatically determine a release name. If you examine that you no longer see releases created in Sentry, it is recommended to manually provide a release name to `withSentryConfig` via the `release.name` option.
+
+  This behavior was changed because the Next.js Build ID is non-deterministic and the release name is injected into client bundles, causing build artifacts to be non-deterministic. This caused issues for some users. Additionally, because it is uncertain whether it will be possible to rely on a Build ID when Turbopack becomes stable, we decided to pull the plug now instead of introducing confusing behavior in the future.
+
 ### Uncategorized (TODO)
 
 TODO
@@ -388,6 +394,7 @@ The Sentry metrics beta has ended and the metrics API has been removed from the 
 ## `@sentry/nextjs`
 
 - Deprecated `hideSourceMaps`. No replacements. The SDK emits hidden sourcemaps by default.
+-
 
 ## `@sentry/opentelemetry`
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -22,7 +22,6 @@ let showedExportModeTunnelWarning = false;
  * @param sentryBuildOptions Additional options to configure instrumentation and
  * @returns The modified config to be exported
  */
-// TODO(v9): Always return an async function here to allow us to do async things like grabbing a deterministic build ID.
 export function withSentryConfig<C>(nextConfig?: C, sentryBuildOptions: SentryBuildOptions = {}): C {
   const castNextConfig = (nextConfig as NextConfig) || {};
   if (typeof castNextConfig === 'function') {

--- a/packages/nextjs/test/config/testUtils.ts
+++ b/packages/nextjs/test/config/testUtils.ts
@@ -69,6 +69,7 @@ export async function materializeFinalWebpackConfig(options: {
   const webpackConfigFunction = constructWebpackConfigFunction(
     materializedUserNextConfig,
     options.sentryBuildTimeOptions,
+    undefined,
   );
 
   // call it to get concrete values for comparison

--- a/packages/nextjs/test/config/webpack/webpackPluginOptions.test.ts
+++ b/packages/nextjs/test/config/webpack/webpackPluginOptions.test.ts
@@ -24,36 +24,40 @@ function generateBuildContext(overrides: {
 describe('getWebpackPluginOptions()', () => {
   it('forwards relevant options', () => {
     const buildContext = generateBuildContext({ isServer: false });
-    const generatedPluginOptions = getWebpackPluginOptions(buildContext, {
-      authToken: 'my-auth-token',
-      headers: { 'my-test-header': 'test' },
-      org: 'my-org',
-      project: 'my-project',
-      telemetry: false,
-      reactComponentAnnotation: {
-        enabled: true,
-      },
-      silent: false,
-      debug: true,
-      sentryUrl: 'my-url',
-      sourcemaps: {
-        assets: ['my-asset'],
-        ignore: ['my-ignore'],
-      },
-      release: {
-        name: 'my-release',
-        create: false,
-        finalize: false,
-        dist: 'my-dist',
-        vcsRemote: 'my-origin',
-        setCommits: {
-          auto: true,
+    const generatedPluginOptions = getWebpackPluginOptions(
+      buildContext,
+      {
+        authToken: 'my-auth-token',
+        headers: { 'my-test-header': 'test' },
+        org: 'my-org',
+        project: 'my-project',
+        telemetry: false,
+        reactComponentAnnotation: {
+          enabled: true,
         },
-        deploy: {
-          env: 'my-env',
+        silent: false,
+        debug: true,
+        sentryUrl: 'my-url',
+        sourcemaps: {
+          assets: ['my-asset'],
+          ignore: ['my-ignore'],
+        },
+        release: {
+          name: 'my-release',
+          create: false,
+          finalize: false,
+          dist: 'my-dist',
+          vcsRemote: 'my-origin',
+          setCommits: {
+            auto: true,
+          },
+          deploy: {
+            env: 'my-env',
+          },
         },
       },
-    });
+      'my-release',
+    );
 
     expect(generatedPluginOptions.authToken).toBe('my-auth-token');
     expect(generatedPluginOptions.debug).toBe(true);
@@ -111,12 +115,16 @@ describe('getWebpackPluginOptions()', () => {
 
   it('forwards bundleSizeOptimization options', () => {
     const buildContext = generateBuildContext({ isServer: false });
-    const generatedPluginOptions = getWebpackPluginOptions(buildContext, {
-      bundleSizeOptimizations: {
-        excludeTracing: true,
-        excludeReplayShadowDom: false,
+    const generatedPluginOptions = getWebpackPluginOptions(
+      buildContext,
+      {
+        bundleSizeOptimizations: {
+          excludeTracing: true,
+          excludeReplayShadowDom: false,
+        },
       },
-    });
+      undefined,
+    );
 
     expect(generatedPluginOptions).toMatchObject({
       bundleSizeOptimizations: {
@@ -128,7 +136,7 @@ describe('getWebpackPluginOptions()', () => {
 
   it('returns the right `assets` and `ignore` values during the server build', () => {
     const buildContext = generateBuildContext({ isServer: true });
-    const generatedPluginOptions = getWebpackPluginOptions(buildContext, {});
+    const generatedPluginOptions = getWebpackPluginOptions(buildContext, {}, undefined);
     expect(generatedPluginOptions.sourcemaps).toMatchObject({
       assets: ['/my/project/dir/.next/server/**', '/my/project/dir/.next/serverless/**'],
       ignore: [],
@@ -137,7 +145,7 @@ describe('getWebpackPluginOptions()', () => {
 
   it('returns the right `assets` and `ignore` values during the client build', () => {
     const buildContext = generateBuildContext({ isServer: false });
-    const generatedPluginOptions = getWebpackPluginOptions(buildContext, {});
+    const generatedPluginOptions = getWebpackPluginOptions(buildContext, {}, undefined);
     expect(generatedPluginOptions.sourcemaps).toMatchObject({
       assets: ['/my/project/dir/.next/static/chunks/pages/**', '/my/project/dir/.next/static/chunks/app/**'],
       ignore: [
@@ -152,7 +160,7 @@ describe('getWebpackPluginOptions()', () => {
 
   it('returns the right `assets` and `ignore` values during the client build with `widenClientFileUpload`', () => {
     const buildContext = generateBuildContext({ isServer: false });
-    const generatedPluginOptions = getWebpackPluginOptions(buildContext, { widenClientFileUpload: true });
+    const generatedPluginOptions = getWebpackPluginOptions(buildContext, { widenClientFileUpload: true }, undefined);
     expect(generatedPluginOptions.sourcemaps).toMatchObject({
       assets: ['/my/project/dir/.next/static/chunks/**'],
       ignore: [
@@ -167,7 +175,7 @@ describe('getWebpackPluginOptions()', () => {
 
   it('sets `sourcemaps.assets` to an empty array when `sourcemaps.disable` is true', () => {
     const buildContext = generateBuildContext({ isServer: false });
-    const generatedPluginOptions = getWebpackPluginOptions(buildContext, { sourcemaps: { disable: true } });
+    const generatedPluginOptions = getWebpackPluginOptions(buildContext, { sourcemaps: { disable: true } }, undefined);
     expect(generatedPluginOptions.sourcemaps).toMatchObject({
       assets: [],
     });
@@ -179,7 +187,7 @@ describe('getWebpackPluginOptions()', () => {
       nextjsConfig: { distDir: '.dist\\v1' },
       isServer: false,
     });
-    const generatedPluginOptions = getWebpackPluginOptions(buildContext, { widenClientFileUpload: true });
+    const generatedPluginOptions = getWebpackPluginOptions(buildContext, { widenClientFileUpload: true }, undefined);
     expect(generatedPluginOptions.sourcemaps).toMatchObject({
       assets: ['C:/my/windows/project/dir/.dist/v1/static/chunks/**'],
       ignore: [
@@ -189,6 +197,19 @@ describe('getWebpackPluginOptions()', () => {
         'C:/my/windows/project/dir/.dist/v1/static/chunks/polyfills-*',
         'C:/my/windows/project/dir/.dist/v1/static/chunks/webpack-*',
       ],
+    });
+  });
+
+  it('sets options to not create a release or do any release operations when releaseName is undefined', () => {
+    const buildContext = generateBuildContext({ isServer: false });
+    const generatedPluginOptions = getWebpackPluginOptions(buildContext, {}, undefined);
+
+    expect(generatedPluginOptions).toMatchObject({
+      release: {
+        inject: false,
+        create: false,
+        finalize: false,
+      },
     });
   });
 });


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/14940