### PR TITLE
fix(sveltekit): Ensure source maps deletion is called after source maps upload

### DIFF
--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -55,11 +55,13 @@ describe('sentrySvelteKit()', () => {
       // default source maps plugins:
       'sentry-telemetry-plugin',
       'sentry-vite-release-injection-plugin',
-      'sentry-debug-id-upload-plugin',
       'sentry-vite-debug-id-injection-plugin',
-      'sentry-file-deletion-plugin',
+      // custom release plugin:
+      'sentry-sveltekit-release-management-plugin',
       // custom source maps plugin:
-      'sentry-upload-sveltekit-source-maps',
+      'sentry-sveltekit-debug-id-upload-plugin',
+      // custom deletion plugin
+      'sentry-sveltekit-file-deletion-plugin',
     ]);
   });
 
@@ -76,7 +78,7 @@ describe('sentrySvelteKit()', () => {
     const instrumentPlugin = plugins[0];
 
     expect(plugins).toHaveLength(1);
-    expect(instrumentPlugin.name).toEqual('sentry-auto-instrumentation');
+    expect(instrumentPlugin?.name).toEqual('sentry-auto-instrumentation');
 
     process.env.NODE_ENV = previousEnv;
   });

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -3,8 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Plugin } from 'vite';
 import { makeCustomSentryVitePlugins } from '../../src/vite/sourceMaps';
 
-const mockedSentryVitePlugin = {
+const mockedViteDebugIdUploadPlugin = {
   name: 'sentry-vite-debug-id-upload-plugin',
+  writeBundle: vi.fn(),
+};
+
+const mockedViteReleaseManagementPlugin = {
+  name: 'sentry-release-management-plugin',
+  writeBundle: vi.fn(),
+};
+
+const mockedFileDeletionPlugin = {
+  name: 'sentry-file-deletion-plugin',
   writeBundle: vi.fn(),
 };
 
@@ -13,7 +23,11 @@ vi.mock('@sentry/vite-plugin', async () => {
 
   return {
     ...original,
-    sentryVitePlugin: () => [mockedSentryVitePlugin],
+    sentryVitePlugin: () => [
+      mockedViteReleaseManagementPlugin,
+      mockedViteDebugIdUploadPlugin,
+      mockedFileDeletionPlugin,
+    ],
   };
 });
 
@@ -30,20 +44,22 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-async function getCustomSentryViteUploadSourcemapsPlugin(): Promise<Plugin | undefined> {
+async function getSentryViteSubPlugin(name: string): Promise<Plugin | undefined> {
   const plugins = await makeCustomSentryVitePlugins({
     authToken: 'token',
     org: 'org',
     project: 'project',
     adapter: 'other',
   });
-  return plugins.find(plugin => plugin.name === 'sentry-upload-sveltekit-source-maps');
+
+  return plugins.find(plugin => plugin.name === name);
 }
 
 describe('makeCustomSentryVitePlugin()', () => {
   it('returns the custom sentry source maps plugin', async () => {
-    const plugin = await getCustomSentryViteUploadSourcemapsPlugin();
-    expect(plugin?.name).toEqual('sentry-upload-sveltekit-source-maps');
+    const plugin = await getSentryViteSubPlugin('sentry-sveltekit-debug-id-upload-plugin');
+
+    expect(plugin?.name).toEqual('sentry-sveltekit-debug-id-upload-plugin');
     expect(plugin?.apply).toEqual('build');
     expect(plugin?.enforce).toEqual('post');
 
@@ -58,9 +74,9 @@ describe('makeCustomSentryVitePlugin()', () => {
     expect(plugin?.writeBundle).toBeUndefined();
   });
 
-  describe('Custom sentry vite plugin', () => {
+  describe('Custom debug id source maps plugin plugin', () => {
     it('enables source map generation', async () => {
-      const plugin = await getCustomSentryViteUploadSourcemapsPlugin();
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-debug-id-upload-plugin');
       // @ts-expect-error this function exists!
       const sentrifiedConfig = plugin.config({ build: { foo: {} }, test: {} });
       expect(sentrifiedConfig).toEqual({
@@ -73,7 +89,7 @@ describe('makeCustomSentryVitePlugin()', () => {
     });
 
     it('injects the output dir into the server hooks file', async () => {
-      const plugin = await getCustomSentryViteUploadSourcemapsPlugin();
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-debug-id-upload-plugin');
       // @ts-expect-error this function exists!
       const transformOutput = await plugin.transform('foo', '/src/hooks.server.ts');
       const transformedCode = transformOutput.code;
@@ -84,34 +100,34 @@ describe('makeCustomSentryVitePlugin()', () => {
     });
 
     it('uploads source maps during the SSR build', async () => {
-      const plugin = await getCustomSentryViteUploadSourcemapsPlugin();
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-debug-id-upload-plugin');
       // @ts-expect-error this function exists!
       plugin.configResolved({ build: { ssr: true } });
       // @ts-expect-error this function exists!
       await plugin.closeBundle();
-      expect(mockedSentryVitePlugin.writeBundle).toHaveBeenCalledTimes(1);
+      expect(mockedViteDebugIdUploadPlugin.writeBundle).toHaveBeenCalledTimes(1);
     });
 
     it("doesn't upload source maps during the non-SSR builds", async () => {
-      const plugin = await getCustomSentryViteUploadSourcemapsPlugin();
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-debug-id-upload-plugin');
 
       // @ts-expect-error this function exists!
       plugin.configResolved({ build: { ssr: false } });
       // @ts-expect-error this function exists!
       await plugin.closeBundle();
-      expect(mockedSentryVitePlugin.writeBundle).not.toHaveBeenCalled();
+      expect(mockedViteDebugIdUploadPlugin.writeBundle).not.toHaveBeenCalled();
     });
   });
 
   it('catches errors while uploading source maps', async () => {
-    mockedSentryVitePlugin.writeBundle.mockImplementationOnce(() => {
+    mockedViteDebugIdUploadPlugin.writeBundle.mockImplementationOnce(() => {
       throw new Error('test error');
     });
 
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementationOnce(() => {});
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementationOnce(() => {});
 
-    const plugin = await getCustomSentryViteUploadSourcemapsPlugin();
+    const plugin = await getSentryViteSubPlugin('sentry-sveltekit-debug-id-upload-plugin');
 
     // @ts-expect-error this function exists!
     expect(plugin.closeBundle).not.toThrow();
@@ -123,5 +139,101 @@ describe('makeCustomSentryVitePlugin()', () => {
 
     expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to upload source maps'));
     expect(consoleLogSpy).toHaveBeenCalled();
+  });
+
+  describe('Custom release management plugin', () => {
+    it('has the expected hooks and properties', async () => {
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-release-management-plugin');
+
+      expect(plugin).toEqual({
+        name: 'sentry-sveltekit-release-management-plugin',
+        apply: 'build',
+        enforce: 'post',
+        closeBundle: expect.any(Function),
+      });
+    });
+
+    it('calls the original release management plugin to start the release creation pipeline', async () => {
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-release-management-plugin');
+      // @ts-expect-error this function exists!
+      await plugin.closeBundle();
+      expect(mockedViteReleaseManagementPlugin.writeBundle).toHaveBeenCalledTimes(1);
+    });
+
+    it('catches errors during release creation', async () => {
+      mockedViteReleaseManagementPlugin.writeBundle.mockImplementationOnce(() => {
+        throw new Error('test error');
+      });
+
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementationOnce(() => {});
+
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-release-management-plugin');
+
+      // @ts-expect-error this function exists!
+      expect(plugin.closeBundle).not.toThrow();
+
+      // @ts-expect-error this function exists!
+      await plugin.closeBundle();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to upload release data'),
+        expect.any(Error),
+      );
+    });
+
+    it('also works correctly if the original release management plugin has its old name', async () => {
+      const currentName = mockedViteReleaseManagementPlugin.name;
+      mockedViteReleaseManagementPlugin.name = 'sentry-debug-id-upload-plugin';
+
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-release-management-plugin');
+
+      // @ts-expect-error this function exists!
+      await plugin.closeBundle();
+
+      expect(mockedViteReleaseManagementPlugin.writeBundle).toHaveBeenCalledTimes(1);
+
+      mockedViteReleaseManagementPlugin.name = currentName;
+    });
+  });
+
+  describe('Custom file deletion plugin', () => {
+    it('has the expected hooks and properties', async () => {
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-file-deletion-plugin');
+
+      expect(plugin).toEqual({
+        name: 'sentry-sveltekit-file-deletion-plugin',
+        apply: 'build',
+        enforce: 'post',
+        closeBundle: expect.any(Function),
+      });
+    });
+
+    it('calls the original file deletion plugin to delete files', async () => {
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-file-deletion-plugin');
+      // @ts-expect-error this function exists!
+      await plugin.closeBundle();
+      expect(mockedFileDeletionPlugin.writeBundle).toHaveBeenCalledTimes(1);
+    });
+
+    it('catches errors during file deletion', async () => {
+      mockedFileDeletionPlugin.writeBundle.mockImplementationOnce(() => {
+        throw new Error('test error');
+      });
+
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementationOnce(() => {});
+
+      const plugin = await getSentryViteSubPlugin('sentry-sveltekit-file-deletion-plugin');
+
+      // @ts-expect-error this function exists!
+      expect(plugin.closeBundle).not.toThrow();
+
+      // @ts-expect-error this function exists!
+      await plugin.closeBundle();
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to delete source maps'),
+        expect.any(Error),
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR fixes a source maps deletion bug in the Sentry SvelteKit SDK reported in https://github.com/getsentry/sentry-javascript/issues/14131. 

After debugging this extensively, the root cause turned out to be a timing issue. For SvelteKit, we have to move all invocations of the `writeBundle` hook in the sub-plugins of the original Sentry Vite plugin to the `closeBundle` hook, to ensure that the second build made when the SvelteKit adapter is invoked is also awaited correctly. We did this correctly for the debug id source maps upload plugin but did not do it for the release management and file deletion plugins. 

The changed order of things caused a deadlock situations due to our deletion plugin waiting on upload and release plugins to finish. Since the deletion plugin was started earlier than the upload plugin, it was awaiting something that wasn't even started yet.

This PR now:
- replaces the original release management plugin with a custom one where we start release creation on `closeBundle`
- replaces the original file deletion plugin with a custom one where we start deletion on `closeBundle`
- in both cases, further ensures that the plugin is only invoked for build and as late as possible (`enforce: 'post'`). All of these three things ensure now that the deadlock situation is resolved.
- searches for the release management plugin by its old and new name introduced in https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/647
- slightly renames the custom source maps uploading plugin for better convention; as well as some variables for better readability
- adds unit tests for the new custom sub plugins

closes https://github.com/getsentry/sentry-javascript/issues/14131