### PR TITLE
ref(flags): copy empty flags to event for CTA

### DIFF
--- a/packages/browser/src/utils/featureFlags.ts
+++ b/packages/browser/src/utils/featureFlags.ts
@@ -22,9 +22,8 @@ export function copyFlagsFromScopeToEvent(event: Event): Event {
   const flagContext = scope.getScopeData().contexts.flags;
   const flagBuffer = flagContext ? flagContext.values : [];
 
-  if (!flagBuffer.length) {
-    return event;
-  }
+  // Note we still copy empty buffers to the event, as way to signal whether
+  // a FF integration has been set up.
 
   if (event.contexts === undefined) {
     event.contexts = {};


### PR DESCRIPTION
Closes https://github.com/getsentry/team-replay/issues/527

If `flags` is never initialized in the event context, sentry FE interprets this as not having set up a flag integration, and misleadingly shows a CTA.
