### PR TITLE
ref: Use optional chaining where possible

### DIFF
--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/customOnErrorHandler/subject.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/customOnErrorHandler/subject.js
@@ -2,7 +2,7 @@ const oldOnError = window.onerror;
 
 window.onerror = function () {
   console.log('custom error');
-  oldOnError && oldOnError.apply(this, arguments);
+  oldOnError?.apply(this, arguments);
 };
 
 window.doSomethingWrong();

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/launchdarkly/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/launchdarkly/init.js
@@ -13,7 +13,7 @@ Sentry.init({
 // Also, no SDK has mock utils for FlagUsedHandler's.
 const MockLaunchDarkly = {
   initialize(_clientId, context, options) {
-    const flagUsedHandler = options && options.inspectors ? options.inspectors[0].method : undefined;
+    const flagUsedHandler = options.inspectors ? options.inspectors[0].method : undefined;
 
     return {
       variation(key, defaultValue) {

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/acs/getCurrentScope/subject.js
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/acs/getCurrentScope/subject.js
@@ -1,4 +1,4 @@
-const sentryCarrier = window && window.__SENTRY__;
+const sentryCarrier = window?.__SENTRY__;
 
 /**
  * Simulate an old pre v8 SDK obtaining the hub from the global sentry carrier

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/isOlderThan/subject.js
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/isOlderThan/subject.js
@@ -1,4 +1,4 @@
-const sentryCarrier = window && window.__SENTRY__;
+const sentryCarrier = window?.__SENTRY__;
 
 /**
  * Simulate an old pre v8 SDK obtaining the hub from the global sentry carrier

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-legacy/app/routes/navigate.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-legacy/app/routes/navigate.tsx
@@ -14,7 +14,7 @@ export default function LoaderError() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/app/routes/navigate.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/app/routes/navigate.tsx
@@ -14,7 +14,7 @@ export default function LoaderError() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/app/routes/navigate.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/app/routes/navigate.tsx
@@ -14,7 +14,7 @@ export default function LoaderError() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-legacy/app/routes/navigate.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-legacy/app/routes/navigate.tsx
@@ -14,7 +14,7 @@ export default function LoaderError() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-legacy/app/routes/navigate.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-legacy/app/routes/navigate.tsx
@@ -14,7 +14,7 @@ export default function LoaderError() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/routes/navigate.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/routes/navigate.tsx
@@ -14,7 +14,7 @@ export default function LoaderError() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/app/routes/navigate.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/app/routes/navigate.tsx
@@ -14,7 +14,7 @@ export default function LoaderError() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/dev-packages/e2e-tests/test-applications/ember-classic/app/initializers/deprecation.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/app/initializers/deprecation.ts
@@ -2,7 +2,7 @@ import { registerDeprecationHandler } from '@ember/debug';
 
 export function initialize(): void {
   registerDeprecationHandler((message, options, next) => {
-    if (options && options.until && options.until !== '3.0.0') {
+    if (options?.until && options.until !== '3.0.0') {
       return;
     } else {
       next(message, options);

--- a/packages/angular/patch-vitest.ts
+++ b/packages/angular/patch-vitest.ts
@@ -182,22 +182,20 @@ function isAngularFixture(val: any): boolean {
  */
 function fixtureVitestSerializer(fixture: any) {
   // * Get Component meta data
-  const componentType = (
-    fixture && fixture.componentType ? fixture.componentType : fixture.componentRef.componentType
-  ) as any;
+  const componentType = (fixture?.componentType ? fixture.componentType : fixture.componentRef.componentType) as any;
 
   let inputsData: string = '';
 
   const selector = Reflect.getOwnPropertyDescriptor(componentType, '__annotations__')?.value[0].selector;
 
-  if (componentType && componentType.propDecorators) {
+  if (componentType?.propDecorators) {
     inputsData = Object.entries(componentType.propDecorators)
       .map(([key, value]) => `${key}="${value}"`)
       .join('');
   }
 
   // * Get DOM Elements
-  const divElement = fixture && fixture.nativeElement ? fixture.nativeElement : fixture.location.nativeElement;
+  const divElement = fixture?.nativeElement ? fixture.nativeElement : fixture.location.nativeElement;
 
   // * Convert string data to HTML data
   const doc = new DOMParser().parseFromString(

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -62,7 +62,7 @@ export function init(options: BrowserOptions): Client | undefined {
 function checkAndSetAngularVersion(): void {
   const ANGULAR_MINIMUM_VERSION = 14;
 
-  const angularVersion = VERSION && VERSION.major ? parseInt(VERSION.major, 10) : undefined;
+  const angularVersion = VERSION?.major ? parseInt(VERSION.major, 10) : undefined;
 
   if (angularVersion) {
     if (angularVersion < ANGULAR_MINIMUM_VERSION) {

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -62,7 +62,7 @@ export function init(options: BrowserOptions): Client | undefined {
 function checkAndSetAngularVersion(): void {
   const ANGULAR_MINIMUM_VERSION = 14;
 
-  const angularVersion = VERSION?.major ? parseInt(VERSION.major, 10) : undefined;
+  const angularVersion = VERSION?.major && parseInt(VERSION.major, 10);
 
   if (angularVersion) {
     if (angularVersion < ANGULAR_MINIMUM_VERSION) {

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -322,7 +322,7 @@ export function TraceClass(options?: TraceClassOptions): ClassDecorator {
       tracingSpan = runOutsideAngular(() =>
         startInactiveSpan({
           onlyIfParent: true,
-          name: `<${options?.name ? options.name : 'unnamed'}>`,
+          name: `<${options?.name || 'unnamed'}>`,
           op: ANGULAR_INIT_OP,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -322,7 +322,7 @@ export function TraceClass(options?: TraceClassOptions): ClassDecorator {
       tracingSpan = runOutsideAngular(() =>
         startInactiveSpan({
           onlyIfParent: true,
-          name: `<${options && options.name ? options.name : 'unnamed'}>`,
+          name: `<${options?.name ? options.name : 'unnamed'}>`,
           op: ANGULAR_INIT_OP,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',
@@ -367,7 +367,7 @@ export function TraceMethod(options?: TraceMethodOptions): MethodDecorator {
       runOutsideAngular(() => {
         startInactiveSpan({
           onlyIfParent: true,
-          name: `<${options && options.name ? options.name : 'unnamed'}>`,
+          name: `<${options?.name ? options.name : 'unnamed'}>`,
           op: `${ANGULAR_OP}.${String(propertyKey)}`,
           startTime: now,
           attributes: {
@@ -397,9 +397,9 @@ export function TraceMethod(options?: TraceMethodOptions): MethodDecorator {
 export function getParameterizedRouteFromSnapshot(route?: ActivatedRouteSnapshot | null): string {
   const parts: string[] = [];
 
-  let currentRoute = route && route.firstChild;
+  let currentRoute = route?.firstChild;
   while (currentRoute) {
-    const path = currentRoute && currentRoute.routeConfig && currentRoute.routeConfig.path;
+    const path = currentRoute?.routeConfig && currentRoute.routeConfig.path;
     if (path === null || path === undefined) {
       break;
     }

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -88,10 +88,12 @@ async function instrumentRequest(
 ): Promise<Response> {
   // Make sure we don't accidentally double wrap (e.g. user added middleware and integration auto added it)
   const locals = ctx.locals as AstroLocalsWithSentry | undefined;
-  if (!locals || locals.__sentry_wrapped__) {
+  if (locals?.__sentry_wrapped__) {
     return next();
   }
-  addNonEnumerableProperty(locals, '__sentry_wrapped__', true);
+  if (locals) {
+    addNonEnumerableProperty(locals, '__sentry_wrapped__', true);
+  }
 
   const isDynamicPageRequest = checkIsDynamicPageRequest(ctx);
 

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -87,8 +87,8 @@ async function instrumentRequest(
   isolationScope?: Scope,
 ): Promise<Response> {
   // Make sure we don't accidentally double wrap (e.g. user added middleware and integration auto added it)
-  const locals = ctx.locals as AstroLocalsWithSentry;
-  if (locals && locals.__sentry_wrapped__) {
+  const locals = ctx.locals as AstroLocalsWithSentry | undefined;
+  if (!locals || locals.__sentry_wrapped__) {
     return next();
   }
   addNonEnumerableProperty(locals, '__sentry_wrapped__', true);
@@ -164,7 +164,7 @@ async function instrumentRequest(
               const client = getClient();
               const contentType = originalResponse.headers.get('content-type');
 
-              const isPageloadRequest = contentType && contentType.startsWith('text/html');
+              const isPageloadRequest = contentType?.startsWith('text/html');
               if (!isPageloadRequest || !client) {
                 return originalResponse;
               }

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -323,7 +323,7 @@ export function wrapHandler<TEvent, TResult>(
         throw e;
       } finally {
         clearTimeout(timeoutWarningTimer);
-        if (span && span.isRecording()) {
+        if (span?.isRecording()) {
           span.end();
         }
         await flush(options.flushTimeout).catch(e => {

--- a/packages/aws-serverless/src/utils.ts
+++ b/packages/aws-serverless/src/utils.ts
@@ -53,7 +53,7 @@ export function getAwsTraceData(event: HandlerEvent, context?: HandlerContext): 
     baggage: headers.baggage,
   };
 
-  if (context && context.clientContext && context.clientContext.Custom) {
+  if (context?.clientContext?.Custom) {
     const customContext: Record<string, unknown> = context.clientContext.Custom;
     const sentryTrace = isString(customContext['sentry-trace']) ? customContext['sentry-trace'] : undefined;
 

--- a/packages/browser-utils/src/instrument/dom.ts
+++ b/packages/browser-utils/src/instrument/dom.ts
@@ -64,8 +64,7 @@ export function instrumentDOM(): void {
   // guaranteed to fire at least once.)
   ['EventTarget', 'Node'].forEach((target: string) => {
     const globalObject = WINDOW as unknown as Record<string, { prototype?: object }>;
-    const targetObj = globalObject[target];
-    const proto = targetObj && targetObj.prototype;
+    const proto = globalObject[target]?.prototype;
 
     // eslint-disable-next-line no-prototype-builtins
     if (!proto || !proto.hasOwnProperty || !proto.hasOwnProperty('addEventListener')) {

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -674,7 +674,7 @@ function _setWebVitalAttributes(span: Span): void {
   }
 
   // See: https://developer.mozilla.org/en-US/docs/Web/API/LayoutShift
-  if (_clsEntry && _clsEntry.sources) {
+  if (_clsEntry?.sources) {
     _clsEntry.sources.forEach((source, index) =>
       span.setAttribute(`cls.source.${index + 1}`, htmlTreeAsString(source.node)),
     );

--- a/packages/browser-utils/src/metrics/cls.ts
+++ b/packages/browser-utils/src/metrics/cls.ts
@@ -77,10 +77,12 @@ export function trackClsAsStandaloneSpan(): void {
     });
 
     const activeSpan = getActiveSpan();
-    const rootSpan = activeSpan && getRootSpan(activeSpan);
-    const spanJSON = rootSpan && spanToJSON(rootSpan);
-    if (spanJSON && spanJSON.op === 'pageload') {
-      pageloadSpanId = rootSpan.spanContext().spanId;
+    if (activeSpan) {
+      const rootSpan = getRootSpan(activeSpan);
+      const spanJSON = spanToJSON(rootSpan);
+      if (spanJSON.op === 'pageload') {
+        pageloadSpanId = rootSpan.spanContext().spanId;
+      }
     }
   }, 0);
 }
@@ -88,7 +90,7 @@ export function trackClsAsStandaloneSpan(): void {
 function sendStandaloneClsSpan(clsValue: number, entry: LayoutShift | undefined, pageloadSpanId: string) {
   DEBUG_BUILD && logger.log(`Sending CLS span (${clsValue})`);
 
-  const startTime = msToSec((browserPerformanceTimeOrigin || 0) + ((entry && entry.startTime) || 0));
+  const startTime = msToSec((browserPerformanceTimeOrigin || 0) + (entry?.startTime || 0));
   const routeName = getCurrentScope().getScopeData().transactionName;
 
   const name = entry ? htmlTreeAsString(entry.sources[0] && entry.sources[0].node) : 'Layout shift';
@@ -96,7 +98,7 @@ function sendStandaloneClsSpan(clsValue: number, entry: LayoutShift | undefined,
   const attributes: SpanAttributes = dropUndefinedKeys({
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser.cls',
     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.webvital.cls',
-    [SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME]: (entry && entry.duration) || 0,
+    [SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME]: entry?.duration || 0,
     // attach the pageload span id to the CLS span so that we can link them in the UI
     'sentry.pageload.span_id': pageloadSpanId,
   });

--- a/packages/browser-utils/src/metrics/utils.ts
+++ b/packages/browser-utils/src/metrics/utils.ts
@@ -78,7 +78,7 @@ export function startStandaloneWebVitalSpan(options: StandaloneWebVitalSpanOptio
   // We need to get the replay, user, and activeTransaction from the current scope
   // so that we can associate replay id, profile id, and a user display to the span
   const replay = client.getIntegrationByName<Integration & { getReplayId: () => string }>('Replay');
-  const replayId = replay && replay.getReplayId();
+  const replayId = replay?.getReplayId();
 
   const scope = getCurrentScope();
 
@@ -124,7 +124,7 @@ export function startStandaloneWebVitalSpan(options: StandaloneWebVitalSpanOptio
 /** Get the browser performance API. */
 export function getBrowserPerformanceAPI(): Performance | undefined {
   // @ts-expect-error we want to make sure all of these are available, even if TS is sure they are
-  return WINDOW && WINDOW.addEventListener && WINDOW.performance;
+  return WINDOW.addEventListener && WINDOW.performance;
 }
 
 /**

--- a/packages/browser-utils/src/metrics/web-vitals/lib/getActivationStart.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/lib/getActivationStart.ts
@@ -18,5 +18,5 @@ import { getNavigationEntry } from './getNavigationEntry';
 
 export const getActivationStart = (): number => {
   const navEntry = getNavigationEntry();
-  return (navEntry && navEntry.activationStart) || 0;
+  return navEntry?.activationStart || 0;
 };

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -55,7 +55,7 @@ function eventFromPlainObject(
   isUnhandledRejection?: boolean,
 ): Event {
   const client = getClient();
-  const normalizeDepth = client && client.getOptions().normalizeDepth;
+  const normalizeDepth = client?.getOptions().normalizeDepth;
 
   // If we can, we extract an exception from the object properties
   const errorFromProp = getErrorPropertyFromObject(exception);
@@ -178,7 +178,7 @@ function isWebAssemblyException(exception: unknown): exception is WebAssembly.Ex
  * Usually, this is the `name` property on Error objects but WASM errors need to be treated differently.
  */
 export function extractType(ex: Error & { message: { error?: Error } }): string | undefined {
-  const name = ex && ex.name;
+  const name = ex?.name;
 
   // The name for WebAssembly.Exception Errors needs to be extracted differently.
   // Context: https://github.com/getsentry/sentry-javascript/issues/13787
@@ -197,7 +197,7 @@ export function extractType(ex: Error & { message: { error?: Error } }): string 
  * In this specific case we try to extract stacktrace.message.error.message
  */
 export function extractMessage(ex: Error & { message: { error?: Error } }): string {
-  const message = ex && ex.message;
+  const message = ex?.message;
 
   if (!message) {
     return 'No error message';
@@ -225,11 +225,11 @@ export function eventFromException(
   hint?: EventHint,
   attachStacktrace?: boolean,
 ): PromiseLike<Event> {
-  const syntheticException = (hint && hint.syntheticException) || undefined;
+  const syntheticException = hint?.syntheticException || undefined;
   const event = eventFromUnknownInput(stackParser, exception, syntheticException, attachStacktrace);
   addExceptionMechanism(event); // defaults to { type: 'generic', handled: true }
   event.level = 'error';
-  if (hint && hint.event_id) {
+  if (hint?.event_id) {
     event.event_id = hint.event_id;
   }
   return resolvedSyncPromise(event);
@@ -246,10 +246,10 @@ export function eventFromMessage(
   hint?: EventHint,
   attachStacktrace?: boolean,
 ): PromiseLike<Event> {
-  const syntheticException = (hint && hint.syntheticException) || undefined;
+  const syntheticException = hint?.syntheticException || undefined;
   const event = eventFromString(stackParser, message, syntheticException, attachStacktrace);
   event.level = level;
-  if (hint && hint.event_id) {
+  if (hint?.event_id) {
     event.event_id = hint.event_id;
   }
   return resolvedSyncPromise(event);

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -313,7 +313,7 @@ function _getFetchBreadcrumbHandler(client: Client): (handlerData: HandlerDataFe
 
       breadcrumbData.request_body_size = handlerData.fetchData.request_body_size;
       breadcrumbData.response_body_size = handlerData.fetchData.response_body_size;
-      breadcrumbData.status_code = response && response.status;
+      breadcrumbData.status_code = response?.status;
 
       const hint: FetchBreadcrumbHint = {
         input: handlerData.args,

--- a/packages/browser/src/integrations/browserapierrors.ts
+++ b/packages/browser/src/integrations/browserapierrors.ts
@@ -163,8 +163,7 @@ function _wrapXHR(originalSend: () => void): () => void {
 
 function _wrapEventTarget(target: string): void {
   const globalObject = WINDOW as unknown as Record<string, { prototype?: object }>;
-  const targetObj = globalObject[target];
-  const proto = targetObj && targetObj.prototype;
+  const proto = globalObject[target]?.prototype;
 
   // eslint-disable-next-line no-prototype-builtins
   if (!proto || !proto.hasOwnProperty || !proto.hasOwnProperty('addEventListener')) {

--- a/packages/browser/src/integrations/contextlines.ts
+++ b/packages/browser/src/integrations/contextlines.ts
@@ -65,7 +65,7 @@ function addSourceContext(event: Event, contextLines: number): Event {
 
   exceptions.forEach(exception => {
     const stacktrace = exception.stacktrace;
-    if (stacktrace && stacktrace.frames) {
+    if (stacktrace?.frames) {
       stacktrace.frames = stacktrace.frames.map(frame =>
         applySourceContextToFrame(frame, htmlLines, htmlFilename, contextLines),
       );

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -194,7 +194,7 @@ function globalHandlerLog(type: string): void {
 
 function getOptions(): { stackParser: StackParser; attachStacktrace?: boolean } {
   const client = getClient<BrowserClient>();
-  const options = (client && client.getOptions()) || {
+  const options = client?.getOptions() || {
     stackParser: () => [],
     attachStacktrace: false,
   };

--- a/packages/browser/src/integrations/spotlight.ts
+++ b/packages/browser/src/integrations/spotlight.ts
@@ -84,6 +84,6 @@ export function isSpotlightInteraction(event: Event): boolean {
       event.contexts &&
       event.contexts.trace &&
       event.contexts.trace.op === 'ui.action.click' &&
-      event.spans.some(({ description }) => description && description.includes('#sentry-spotlight')),
+      event.spans.some(({ description }) => description?.includes('#sentry-spotlight')),
   );
 }

--- a/packages/browser/src/profiling/integration.ts
+++ b/packages/browser/src/profiling/integration.ts
@@ -49,7 +49,7 @@ const _browserProfilingIntegration = (() => {
         const profilesToAddToEnvelope: Profile[] = [];
 
         for (const profiledTransaction of profiledTransactionEvents) {
-          const context = profiledTransaction && profiledTransaction.contexts;
+          const context = profiledTransaction?.contexts;
           const profile_id = context && context['profile'] && context['profile']['profile_id'];
           const start_timestamp = context && context['profile'] && context['profile']['start_timestamp'];
 

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -98,7 +98,7 @@ export interface ProfiledEvent extends Event {
 }
 
 function getTraceId(event: Event): string {
-  const traceId: unknown = event && event.contexts && event.contexts['trace'] && event.contexts['trace']['trace_id'];
+  const traceId: unknown = event.contexts?.trace?.['trace_id'];
   // Log a warning if the profile has an invalid traceId (should be uuidv4).
   // All profiles and transactions are rejected if this is the case and we want to
   // warn users that this is happening if they enable debug flag
@@ -333,7 +333,7 @@ export function findProfiledTransactionsFromEnvelope(envelope: Envelope): Event[
     for (let j = 1; j < item.length; j++) {
       const event = item[j] as Event;
 
-      if (event && event.contexts && event.contexts['profile'] && event.contexts['profile']['profile_id']) {
+      if (event?.contexts && event.contexts['profile'] && event.contexts['profile']['profile_id']) {
         events.push(item[j] as Event);
       }
     }
@@ -347,8 +347,8 @@ export function findProfiledTransactionsFromEnvelope(envelope: Envelope): Event[
  */
 export function applyDebugMetadata(resource_paths: ReadonlyArray<string>): DebugImage[] {
   const client = getClient();
-  const options = client && client.getOptions();
-  const stackParser = options && options.stackParser;
+  const options = client?.getOptions();
+  const stackParser = options?.stackParser;
 
   if (!stackParser) {
     return [];
@@ -478,7 +478,7 @@ export function shouldProfileSpan(span: Span): boolean {
   }
 
   const client = getClient();
-  const options = client && client.getOptions();
+  const options = client?.getOptions();
   if (!options) {
     DEBUG_BUILD && logger.log('[Profiling] Profiling disabled, no options found.');
     return false;

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -5,6 +5,7 @@ import {
   functionToStringIntegration,
   getCurrentScope,
   getIntegrationsToSetup,
+  getLocationHref,
   getReportDialogEndpoint,
   inboundFiltersIntegration,
   initAndBind,
@@ -103,8 +104,8 @@ function shouldShowBrowserExtensionError(): boolean {
   const extensionKey = windowWithMaybeExtension.chrome ? 'chrome' : 'browser';
   const extensionObject = windowWithMaybeExtension[extensionKey];
 
-  const runtimeId = extensionObject && extensionObject.runtime && extensionObject.runtime.id;
-  const href = (WINDOW.location && WINDOW.location.href) || '';
+  const runtimeId = extensionObject?.runtime?.id;
+  const href = getLocationHref() || '';
 
   const extensionProtocols = ['chrome-extension:', 'moz-extension:', 'ms-browser-extension:', 'safari-web-extension:'];
 
@@ -214,7 +215,7 @@ export function showReportDialog(options: ReportDialogOptions = {}): void {
 
   const scope = getCurrentScope();
   const client = scope.getClient();
-  const dsn = client && client.getDsn();
+  const dsn = client?.getDsn();
 
   if (!dsn) {
     DEBUG_BUILD && logger.error('DSN not configured for showReportDialog call');

--- a/packages/browser/src/tracing/backgroundtab.ts
+++ b/packages/browser/src/tracing/backgroundtab.ts
@@ -7,7 +7,7 @@ import { WINDOW } from '../helpers';
  * document is hidden.
  */
 export function registerBackgroundTabDetection(): void {
-  if (WINDOW && WINDOW.document) {
+  if (WINDOW.document) {
     WINDOW.document.addEventListener('visibilitychange', () => {
       const activeSpan = getActiveSpan();
       if (!activeSpan) {

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -23,6 +23,7 @@ import {
   getCurrentScope,
   getDynamicSamplingContextFromSpan,
   getIsolationScope,
+  getLocationHref,
   getRootSpan,
   logger,
   propagationContextFromHeaders,
@@ -298,7 +299,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
     name: BROWSER_TRACING_INTEGRATION_ID,
     afterAllSetup(client) {
       let activeSpan: Span | undefined;
-      let startingUrl: string | undefined = WINDOW.location && WINDOW.location.href;
+      let startingUrl: string | undefined = getLocationHref();
 
       function maybeEndActiveSpan(): void {
         if (activeSpan && !spanToJSON(activeSpan).timestamp) {
@@ -384,7 +385,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
              * only be caused in certain development environments where the usage of a hot module reloader is causing
              * errors.
              */
-            if (from === undefined && startingUrl && startingUrl.indexOf(to) !== -1) {
+            if (from === undefined && startingUrl?.indexOf(to) !== -1) {
               startingUrl = undefined;
               return;
             }
@@ -473,8 +474,8 @@ export function getMetaContent(metaName: string): string | undefined {
    */
   const optionalWindowDocument = WINDOW.document as (typeof WINDOW)['document'] | undefined;
 
-  const metaTag = optionalWindowDocument && optionalWindowDocument.querySelector(`meta[name=${metaName}]`);
-  return (metaTag && metaTag.getAttribute('content')) || undefined;
+  const metaTag = optionalWindowDocument?.querySelector(`meta[name=${metaName}]`);
+  return metaTag?.getAttribute('content') || undefined;
 }
 
 /** Start listener for interaction transactions */

--- a/packages/browser/src/utils/lazyLoadIntegration.ts
+++ b/packages/browser/src/utils/lazyLoadIntegration.ts
@@ -68,7 +68,7 @@ export async function lazyLoadIntegration(
   });
 
   const currentScript = WINDOW.document.currentScript;
-  const parent = WINDOW.document.body || WINDOW.document.head || (currentScript && currentScript.parentElement);
+  const parent = WINDOW.document.body || WINDOW.document.head || currentScript?.parentElement;
 
   if (parent) {
     parent.appendChild(script);
@@ -93,8 +93,7 @@ export async function lazyLoadIntegration(
 
 function getScriptURL(bundle: string): string {
   const client = getClient<BrowserClient>();
-  const options = client && client.getOptions();
-  const baseURL = (options && options.cdnBaseUrl) || 'https://browser.sentry-cdn.com';
+  const baseURL = client?.getOptions()?.cdnBaseUrl || 'https://browser.sentry-cdn.com';
 
   return new URL(`/${SDK_VERSION}/${bundle}.min.js`, baseURL).toString();
 }

--- a/packages/browser/test/sdk.test.ts
+++ b/packages/browser/test/sdk.test.ts
@@ -154,8 +154,6 @@ describe('init', () => {
       new MockIntegration('MockIntegration 0.2'),
     ];
 
-    const originalLocation = WINDOW.location || {};
-
     const options = getDefaultBrowserOptions({ dsn: PUBLIC_DSN, defaultIntegrations: DEFAULT_INTEGRATIONS });
 
     afterEach(() => {
@@ -204,12 +202,9 @@ describe('init', () => {
       extensionProtocol => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-        // @ts-expect-error - this is a hack to simulate a dedicated page in a browser extension
-        delete WINDOW.location;
-        // @ts-expect-error - this is a hack to simulate a dedicated page in a browser extension
-        WINDOW.location = {
-          href: `${extensionProtocol}://mock-extension-id/dedicated-page.html`,
-        };
+        const locationHrefSpy = vi
+          .spyOn(SentryCore, 'getLocationHref')
+          .mockImplementation(() => `${extensionProtocol}://mock-extension-id/dedicated-page.html`);
 
         Object.defineProperty(WINDOW, 'browser', { value: { runtime: { id: 'mock-extension-id' } }, writable: true });
 
@@ -218,7 +213,7 @@ describe('init', () => {
         expect(consoleErrorSpy).toBeCalledTimes(0);
 
         consoleErrorSpy.mockRestore();
-        WINDOW.location = originalLocation;
+        locationHrefSpy.mockRestore();
       },
     );
 

--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -100,7 +100,7 @@ function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]
                   const response = await (fetchTarget.apply(fetchThisArg, fetchArgs) as ReturnType<
                     typeof serveOptions.fetch
                   >);
-                  if (response && response.status) {
+                  if (response?.status) {
                     setHttpStatus(span, response.status);
                     isolationScope.setContext('response', {
                       headers: response.headers.toJSON(),

--- a/packages/cloudflare/src/integrations/fetch.ts
+++ b/packages/cloudflare/src/integrations/fetch.ts
@@ -151,7 +151,7 @@ function createBreadcrumb(handlerData: HandlerDataFetch): void {
 
     breadcrumbData.request_body_size = handlerData.fetchData.request_body_size;
     breadcrumbData.response_body_size = handlerData.fetchData.response_body_size;
-    breadcrumbData.status_code = response && response.status;
+    breadcrumbData.status_code = response?.status;
 
     const hint: FetchBreadcrumbHint = {
       input: handlerData.args,

--- a/packages/core/src/checkin.ts
+++ b/packages/core/src/checkin.ts
@@ -24,7 +24,7 @@ export function createCheckInEnvelope(
     sent_at: new Date().toISOString(),
   };
 
-  if (metadata && metadata.sdk) {
+  if (metadata?.sdk) {
     headers.sdk = {
       name: metadata.sdk.name,
       version: metadata.sdk.version,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -207,7 +207,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     const eventId = uuid4();
 
     // ensure we haven't captured this very object before
-    if (hint && hint.originalException && checkOrSetAlreadyCaught(hint.originalException)) {
+    if (hint?.originalException && checkOrSetAlreadyCaught(hint.originalException)) {
       DEBUG_BUILD && logger.log(ALREADY_SEEN_ERROR);
       return eventId;
     }
@@ -619,7 +619,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
       for (const ex of exceptions) {
         const mechanism = ex.mechanism;
-        if (mechanism && mechanism.handled === false) {
+        if (mechanism?.handled === false) {
           crashed = true;
           break;
         }
@@ -698,7 +698,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   ): PromiseLike<Event | null> {
     const options = this.getOptions();
     const integrations = Object.keys(this._integrations);
-    if (!hint.integrations && integrations.length > 0) {
+    if (!hint.integrations && integrations?.length) {
       hint.integrations = integrations;
     }
 

--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -85,7 +85,7 @@ export function createEventEnvelope(
   */
   const eventType = event.type && event.type !== 'replay_event' ? event.type : 'event';
 
-  enhanceEventWithSdkInfo(event, metadata && metadata.sdk);
+  enhanceEventWithSdkInfo(event, metadata?.sdk);
 
   const envelopeHeaders = createEventEnvelopeHeaders(event, sdkInfo, tunnel, dsn);
 
@@ -114,8 +114,8 @@ export function createSpanEnvelope(spans: [SentrySpan, ...SentrySpan[]], client?
   // different segments in one envelope
   const dsc = getDynamicSamplingContextFromSpan(spans[0]);
 
-  const dsn = client && client.getDsn();
-  const tunnel = client && client.getOptions().tunnel;
+  const dsn = client?.getDsn();
+  const tunnel = client?.getOptions().tunnel;
 
   const headers: SpanEnvelope[0] = {
     sent_at: new Date().toISOString(),
@@ -123,7 +123,7 @@ export function createSpanEnvelope(spans: [SentrySpan, ...SentrySpan[]], client?
     ...(!!tunnel && dsn && { dsn: dsnToString(dsn) }),
   };
 
-  const beforeSendSpan = client && client.getOptions().beforeSendSpan;
+  const beforeSendSpan = client?.getOptions().beforeSendSpan;
   const convertToSpanJSON = beforeSendSpan
     ? (span: SentrySpan) => {
         const spanJson = spanToJSON(span);

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -28,7 +28,7 @@ export function captureFeedback(
     tags,
   };
 
-  const client = (scope && scope.getClient()) || getClient();
+  const client = scope?.getClient() || getClient();
 
   if (client) {
     client.emit('beforeSendFeedback', feedbackEvent, hint);

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -84,7 +84,7 @@ export function getIntegrationsToSetup(options: Pick<Options, 'defaultIntegratio
 export function setupIntegrations(client: Client, integrations: Integration[]): IntegrationIndex {
   const integrationIndex: IntegrationIndex = {};
 
-  integrations.forEach(integration => {
+  integrations.forEach((integration: Integration | undefined) => {
     // guard against empty provided integrations
     if (integration) {
       setupIntegration(client, integration, integrationIndex);
@@ -100,7 +100,7 @@ export function setupIntegrations(client: Client, integrations: Integration[]): 
 export function afterSetupIntegrations(client: Client, integrations: Integration[]): void {
   for (const integration of integrations) {
     // guard against empty provided integrations
-    if (integration && integration.afterAllSetup) {
+    if (integration?.afterAllSetup) {
       integration.afterAllSetup(client);
     }
   }

--- a/packages/core/src/integrations/rewriteframes.ts
+++ b/packages/core/src/integrations/rewriteframes.ts
@@ -82,7 +82,7 @@ export const rewriteFramesIntegration = defineIntegration((options: RewriteFrame
   function _processStacktrace(stacktrace?: Stacktrace): Stacktrace {
     return {
       ...stacktrace,
-      frames: stacktrace && stacktrace.frames && stacktrace.frames.map(f => iteratee(f)),
+      frames: stacktrace?.frames && stacktrace.frames.map(f => iteratee(f)),
     };
   }
 

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -572,7 +572,7 @@ export class Scope {
    * @returns {string} The id of the captured Sentry event.
    */
   public captureException(exception: unknown, hint?: EventHint): string {
-    const eventId = hint && hint.event_id ? hint.event_id : uuid4();
+    const eventId = hint?.event_id || uuid4();
 
     if (!this._client) {
       logger.warn('No client configured on scope - will not capture exception!');
@@ -601,7 +601,7 @@ export class Scope {
    * @returns {string} The id of the captured message.
    */
   public captureMessage(message: string, level?: SeverityLevel, hint?: EventHint): string {
-    const eventId = hint && hint.event_id ? hint.event_id : uuid4();
+    const eventId = hint?.event_id || uuid4();
 
     if (!this._client) {
       logger.warn('No client configured on scope - will not capture message!');
@@ -631,7 +631,7 @@ export class Scope {
    * @returns {string} The id of the captured event.
    */
   public captureEvent(event: Event, hint?: EventHint): string {
-    const eventId = hint && hint.event_id ? hint.event_id : uuid4();
+    const eventId = hint?.event_id || uuid4();
 
     if (!this._client) {
       logger.warn('No client configured on scope - will not capture event!');

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -83,7 +83,7 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
 
   // For OpenTelemetry, we freeze the DSC on the trace state
   const traceState = rootSpan.spanContext().traceState;
-  const traceStateDsc = traceState && traceState.get('sentry.dsc');
+  const traceStateDsc = traceState?.get('sentry.dsc');
 
   // If the span has a DSC, we want it to take precedence
   const dscOnTraceState = traceStateDsc && baggageHeaderToDynamicSamplingContext(traceStateDsc);

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -372,7 +372,7 @@ function getAcs(): AsyncContextStrategy {
 
 function _startRootSpan(spanArguments: SentrySpanArguments, scope: Scope, parentSampled?: boolean): SentrySpan {
   const client = getClient();
-  const options: Partial<ClientOptions> = (client && client.getOptions()) || {};
+  const options: Partial<ClientOptions> = client?.getOptions() || {};
 
   const { name = '', attributes } = spanArguments;
   const [sampled, sampleRate] = scope.getScopeData().sdkProcessingMetadata[SUPPRESS_TRACING_KEY]

--- a/packages/core/src/transports/multiplexed.ts
+++ b/packages/core/src/transports/multiplexed.ts
@@ -121,7 +121,7 @@ export function makeMultiplexedTransport<TO extends BaseTransportOptions>(
 
     async function send(envelope: Envelope): Promise<TransportMakeRequestResponse> {
       function getEvent(types?: EnvelopeItemType[]): Event | undefined {
-        const eventTypes: EnvelopeItemType[] = types && types.length ? types : ['event'];
+        const eventTypes: EnvelopeItemType[] = types?.length ? types : ['event'];
         return eventFromEnvelope(envelope, eventTypes);
       }
 

--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -44,14 +44,14 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
     const { path, type, next, rawInput, getRawInput } = opts;
 
     const client = getClient();
-    const clientOptions = client && client.getOptions();
+    const clientOptions = client?.getOptions();
 
     const trpcContext: Record<string, unknown> = {
       procedure_path: path,
       procedure_type: type,
     };
 
-    if (options.attachRpcInput !== undefined ? options.attachRpcInput : clientOptions && clientOptions.sendDefaultPii) {
+    if (options.attachRpcInput !== undefined ? options.attachRpcInput : clientOptions?.sendDefaultPii) {
       if (rawInput !== undefined) {
         trpcContext.input = normalize(rawInput);
       }

--- a/packages/core/src/utils-hoist/browser.ts
+++ b/packages/core/src/utils-hoist/browser.ts
@@ -96,12 +96,11 @@ function _htmlElementAsString(el: unknown, keyAttrs?: string[]): string {
   out.push(elem.tagName.toLowerCase());
 
   // Pairs of attribute keys defined in `serializeAttribute` and their values on element.
-  const keyAttrPairs =
-    keyAttrs && keyAttrs.length
-      ? keyAttrs.filter(keyAttr => elem.getAttribute(keyAttr)).map(keyAttr => [keyAttr, elem.getAttribute(keyAttr)])
-      : null;
+  const keyAttrPairs = keyAttrs?.length
+    ? keyAttrs.filter(keyAttr => elem.getAttribute(keyAttr)).map(keyAttr => [keyAttr, elem.getAttribute(keyAttr)])
+    : null;
 
-  if (keyAttrPairs && keyAttrPairs.length) {
+  if (keyAttrPairs?.length) {
     keyAttrPairs.forEach(keyAttrPair => {
       out.push(`[${keyAttrPair[0]}="${keyAttrPair[1]}"]`);
     });

--- a/packages/core/src/utils-hoist/debug-ids.ts
+++ b/packages/core/src/utils-hoist/debug-ids.ts
@@ -42,7 +42,7 @@ export function getFilenameToDebugIdMap(stackParser: StackParser): Record<string
 
       for (let i = parsedStack.length - 1; i >= 0; i--) {
         const stackFrame = parsedStack[i];
-        const filename = stackFrame && stackFrame.filename;
+        const filename = stackFrame?.filename;
         const debugId = debugIdMap[stackKey];
 
         if (filename && debugId) {

--- a/packages/core/src/utils-hoist/eventbuilder.ts
+++ b/packages/core/src/utils-hoist/eventbuilder.ts
@@ -104,7 +104,7 @@ function getException(
   mechanism.synthetic = true;
 
   if (isPlainObject(exception)) {
-    const normalizeDepth = client && client.getOptions().normalizeDepth;
+    const normalizeDepth = client?.getOptions().normalizeDepth;
     const extras = { ['__serialized__']: normalizeToSize(exception as Record<string, unknown>, normalizeDepth) };
 
     const errorFromProp = getErrorPropertyFromObject(exception);
@@ -113,7 +113,7 @@ function getException(
     }
 
     const message = getMessageForObject(exception);
-    const ex = (hint && hint.syntheticException) || new Error(message);
+    const ex = hint?.syntheticException || new Error(message);
     ex.message = message;
 
     return [ex, extras];
@@ -121,7 +121,7 @@ function getException(
 
   // This handles when someone does: `throw "something awesome";`
   // We use synthesized Error here so we can extract a (rough) stack trace.
-  const ex = (hint && hint.syntheticException) || new Error(exception as string);
+  const ex = hint?.syntheticException || new Error(exception as string);
   ex.message = `${exception}`;
 
   return [ex, undefined];
@@ -137,8 +137,7 @@ export function eventFromUnknownInput(
   exception: unknown,
   hint?: EventHint,
 ): Event {
-  const providedMechanism: Mechanism | undefined =
-    hint && hint.data && (hint.data as { mechanism: Mechanism }).mechanism;
+  const providedMechanism: Mechanism | undefined = hint?.data && (hint.data as { mechanism: Mechanism }).mechanism;
   const mechanism: Mechanism = providedMechanism || {
     handled: true,
     type: 'generic',
@@ -161,7 +160,7 @@ export function eventFromUnknownInput(
 
   return {
     ...event,
-    event_id: hint && hint.event_id,
+    event_id: hint?.event_id,
   };
 }
 
@@ -177,11 +176,11 @@ export function eventFromMessage(
   attachStacktrace?: boolean,
 ): Event {
   const event: Event = {
-    event_id: hint && hint.event_id,
+    event_id: hint?.event_id,
     level,
   };
 
-  if (attachStacktrace && hint && hint.syntheticException) {
+  if (attachStacktrace && hint?.syntheticException) {
     const frames = parseStackFrames(stackParser, hint.syntheticException);
     if (frames.length) {
       event.exception = {

--- a/packages/core/src/utils-hoist/instrument/console.ts
+++ b/packages/core/src/utils-hoist/instrument/console.ts
@@ -37,7 +37,7 @@ function instrumentConsole(): void {
         triggerHandlers('console', handlerData);
 
         const log = originalConsoleMethods[level];
-        log && log.apply(GLOBAL_OBJ.console, args);
+        log?.apply(GLOBAL_OBJ.console, args);
       };
     });
   });

--- a/packages/core/src/utils-hoist/instrument/fetch.ts
+++ b/packages/core/src/utils-hoist/instrument/fetch.ts
@@ -118,7 +118,7 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
 }
 
 async function resolveResponse(res: Response | undefined, onFinishedResolving: () => void): Promise<void> {
-  if (res && res.body) {
+  if (res?.body) {
     const body = res.body;
     const responseReader = body.getReader();
 

--- a/packages/core/src/utils-hoist/is.ts
+++ b/packages/core/src/utils-hoist/is.ts
@@ -155,7 +155,7 @@ export function isRegExp(wat: unknown): wat is RegExp {
  */
 export function isThenable(wat: any): wat is PromiseLike<any> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  return Boolean(wat && wat.then && typeof wat.then === 'function');
+  return Boolean(wat?.then && typeof wat.then === 'function');
 }
 
 /**

--- a/packages/core/src/utils-hoist/isBrowser.ts
+++ b/packages/core/src/utils-hoist/isBrowser.ts
@@ -14,5 +14,5 @@ type ElectronProcess = { type?: string };
 // Electron renderers with nodeIntegration enabled are detected as Node.js so we specifically test for them
 function isElectronNodeRenderer(): boolean {
   const process = (GLOBAL_OBJ as typeof GLOBAL_OBJ & { process?: ElectronProcess }).process;
-  return !!process && process.type === 'renderer';
+  return process?.type === 'renderer';
 }

--- a/packages/core/src/utils-hoist/misc.ts
+++ b/packages/core/src/utils-hoist/misc.ts
@@ -26,10 +26,10 @@ export function uuid4(): string {
 
   let getRandomByte = (): number => Math.random() * 16;
   try {
-    if (crypto && crypto.randomUUID) {
+    if (crypto?.randomUUID) {
       return crypto.randomUUID().replace(/-/g, '');
     }
-    if (crypto && crypto.getRandomValues) {
+    if (crypto?.getRandomValues) {
       getRandomByte = () => {
         // crypto.getRandomValues might return undefined instead of the typed array
         // in old Chromium versions (e.g. 23.0.1235.0 (151422))
@@ -115,7 +115,7 @@ export function addExceptionMechanism(event: Event, newMechanism?: Partial<Mecha
   firstException.mechanism = { ...defaultMechanism, ...currentMechanism, ...newMechanism };
 
   if (newMechanism && 'data' in newMechanism) {
-    const mergedData = { ...(currentMechanism && currentMechanism.data), ...newMechanism.data };
+    const mergedData = { ...currentMechanism?.data, ...newMechanism.data };
     firstException.mechanism.data = mergedData;
   }
 }

--- a/packages/core/src/utils-hoist/node-stack-trace.ts
+++ b/packages/core/src/utils-hoist/node-stack-trace.ts
@@ -104,7 +104,7 @@ export function node(getModule?: GetModuleFn): StackLineParserFn {
       const isNative = lineMatch[5] === 'native';
 
       // If it's a Windows path, trim the leading slash so that `/C:/foo` becomes `C:/foo`
-      if (filename && filename.match(/\/[A-Z]:/)) {
+      if (filename?.match(/\/[A-Z]:/)) {
         filename = filename.slice(1);
       }
 

--- a/packages/core/src/utils-hoist/requestdata.ts
+++ b/packages/core/src/utils-hoist/requestdata.ts
@@ -48,7 +48,7 @@ export function addNormalizedRequestDataToEvent(
 ): void {
   const include = {
     ...DEFAULT_INCLUDES,
-    ...(options && options.include),
+    ...options?.include,
   };
 
   if (include.request) {
@@ -222,7 +222,7 @@ function extractNormalizedRequestData(
   }
 
   if (includeKeys.includes('cookies')) {
-    const cookies = normalizedRequest.cookies || (headers && headers.cookie ? parseCookie(headers.cookie) : undefined);
+    const cookies = normalizedRequest.cookies || (headers?.cookie ? parseCookie(headers.cookie) : undefined);
     requestData.cookies = cookies || {};
   }
 

--- a/packages/core/src/utils-hoist/vendor/getIpAddress.ts
+++ b/packages/core/src/utils-hoist/vendor/getIpAddress.ts
@@ -62,7 +62,7 @@ export function getClientIPAddress(headers: { [key: string]: string | string[] |
       return parseForwardedHeader(value);
     }
 
-    return value && value.split(',').map((v: string) => v.trim());
+    return value?.split(',').map((v: string) => v.trim());
   });
 
   // Flatten the array and filter out any falsy entries

--- a/packages/core/src/utils-hoist/vercelWaitUntil.ts
+++ b/packages/core/src/utils-hoist/vercelWaitUntil.ts
@@ -19,11 +19,9 @@ export function vercelWaitUntil(task: Promise<unknown>): void {
     GLOBAL_OBJ[Symbol.for('@vercel/request-context')];
 
   const ctx =
-    vercelRequestContextGlobal && vercelRequestContextGlobal.get && vercelRequestContextGlobal.get()
-      ? vercelRequestContextGlobal.get()
-      : {};
+    vercelRequestContextGlobal?.get && vercelRequestContextGlobal.get() ? vercelRequestContextGlobal.get() : {};
 
-  if (ctx && ctx.waitUntil) {
+  if (ctx?.waitUntil) {
     ctx.waitUntil(task);
   }
 }

--- a/packages/core/src/utils/eventUtils.ts
+++ b/packages/core/src/utils/eventUtils.ts
@@ -13,7 +13,7 @@ export function getPossibleEventMessages(event: Event): string[] {
   try {
     // @ts-expect-error Try catching to save bundle size
     const lastException = event.exception.values[event.exception.values.length - 1];
-    if (lastException && lastException.value) {
+    if (lastException?.value) {
       possibleMessages.push(lastException.value);
       if (lastException.type) {
         possibleMessages.push(`${lastException.type}: ${lastException.value}`);

--- a/packages/core/src/utils/hasTracingEnabled.ts
+++ b/packages/core/src/utils/hasTracingEnabled.ts
@@ -17,7 +17,7 @@ export function hasTracingEnabled(
   }
 
   const client = getClient();
-  const options = maybeOptions || (client && client.getOptions());
+  const options = maybeOptions || client?.getOptions();
   // eslint-disable-next-line deprecation/deprecation
   return !!options && (options.enableTracing || options.tracesSampleRate != null || !!options.tracesSampler);
 }

--- a/packages/core/src/utils/isSentryRequestUrl.ts
+++ b/packages/core/src/utils/isSentryRequestUrl.ts
@@ -7,8 +7,8 @@ import type { DsnComponents } from '../types-hoist';
  * @param url url to verify
  */
 export function isSentryRequestUrl(url: string, client: Client | undefined): boolean {
-  const dsn = client && client.getDsn();
-  const tunnel = client && client.getOptions().tunnel;
+  const dsn = client?.getDsn();
+  const tunnel = client?.getOptions().tunnel;
   return checkDsn(url, dsn) || checkTunnel(url, tunnel);
 }
 

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -149,12 +149,12 @@ export function applyClientOptions(event: Event, options: ClientOptions): void {
   }
 
   const exception = event.exception && event.exception.values && event.exception.values[0];
-  if (exception && exception.value) {
+  if (exception?.value) {
     exception.value = truncate(exception.value, maxValueLength);
   }
 
   const request = event.request;
-  if (request && request.url) {
+  if (request?.url) {
     request.url = truncate(request.url, maxValueLength);
   }
 }

--- a/packages/deno/src/integrations/breadcrumbs.ts
+++ b/packages/deno/src/integrations/breadcrumbs.ts
@@ -178,7 +178,7 @@ function _getFetchBreadcrumbHandler(client: Client): (handlerData: HandlerDataFe
 
       breadcrumbData.request_body_size = handlerData.fetchData.request_body_size;
       breadcrumbData.response_body_size = handlerData.fetchData.response_body_size;
-      breadcrumbData.status_code = response && response.status;
+      breadcrumbData.status_code = response?.status;
 
       const hint: FetchBreadcrumbHint = {
         input: handlerData.args,

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -18,7 +18,7 @@ import {
   getClient,
   startInactiveSpan,
 } from '@sentry/browser';
-import { GLOBAL_OBJ, browserPerformanceTimeOrigin, timestampInSeconds } from '@sentry/core';
+import { GLOBAL_OBJ, addIntegration, browserPerformanceTimeOrigin, timestampInSeconds } from '@sentry/core';
 import type { Span } from '@sentry/core';
 import type { ExtendedBackburner } from '@sentry/ember/runloop';
 import type { EmberRouterMain, EmberSentryConfig, GlobalConfig, OwnConfig } from '../types';
@@ -410,7 +410,7 @@ function _hasPerformanceSupport(): { HAS_PERFORMANCE: boolean; HAS_PERFORMANCE_T
     measure?: Performance['measure'];
     getEntriesByName?: Performance['getEntriesByName'];
   };
-  const HAS_PERFORMANCE = Boolean(_performance && _performance.clearMarks && _performance.clearMeasures);
+  const HAS_PERFORMANCE = Boolean(_performance?.clearMarks && _performance.clearMeasures);
   const HAS_PERFORMANCE_TIMING = Boolean(
     _performance.measure && _performance.getEntriesByName && browserPerformanceTimeOrigin !== undefined,
   );
@@ -439,12 +439,8 @@ export async function instrumentForPerformance(appInstance: ApplicationInstance)
   });
 
   const client = getClient<BrowserClient>();
-
   const isAlreadyInitialized = macroCondition(isTesting()) ? !!client?.getIntegrationByName('BrowserTracing') : false;
-
-  if (client && client.addIntegration) {
-    client.addIntegration(browserTracing);
-  }
+  addIntegration(browserTracing);
 
   // We _always_ call this, as it triggers the page load & navigation spans
   _instrumentNavigation(appInstance, config, startBrowserTracingPageLoadSpan, startBrowserTracingNavigationSpan);

--- a/packages/feedback/src/core/getFeedback.ts
+++ b/packages/feedback/src/core/getFeedback.ts
@@ -8,5 +8,5 @@ type FeedbackIntegration = ReturnType<typeof buildFeedbackIntegration>;
  */
 export function getFeedback(): ReturnType<FeedbackIntegration> | undefined {
   const client = getClient();
-  return client && client.getIntegrationByName<ReturnType<FeedbackIntegration>>('Feedback');
+  return client?.getIntegrationByName<ReturnType<FeedbackIntegration>>('Feedback');
 }

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -220,12 +220,12 @@ export const buildFeedbackIntegration = ({
         options: {
           ...options,
           onFormClose: () => {
-            dialog && dialog.close();
-            options.onFormClose && options.onFormClose();
+            dialog?.close();
+            options.onFormClose?.();
           },
           onFormSubmitted: () => {
-            dialog && dialog.close();
-            options.onFormSubmitted && options.onFormSubmitted();
+            dialog?.close();
+            options.onFormSubmitted?.();
           },
         },
         screenshotIntegration,
@@ -253,8 +253,8 @@ export const buildFeedbackIntegration = ({
           dialog = await _loadAndRenderDialog({
             ...mergedOptions,
             onFormSubmitted: () => {
-              dialog && dialog.removeFromDom();
-              mergedOptions.onFormSubmitted && mergedOptions.onFormSubmitted();
+              dialog?.removeFromDom();
+              mergedOptions.onFormSubmitted?.();
             },
           });
         }
@@ -264,7 +264,7 @@ export const buildFeedbackIntegration = ({
       targetEl.addEventListener('click', handleClick);
       const unsubscribe = (): void => {
         _subscriptions = _subscriptions.filter(sub => sub !== unsubscribe);
-        dialog && dialog.removeFromDom();
+        dialog?.removeFromDom();
         dialog = null;
         targetEl.removeEventListener('click', handleClick);
       };
@@ -342,7 +342,7 @@ export const buildFeedbackIntegration = ({
        */
       remove(): void {
         if (_shadow) {
-          _shadow.parentElement && _shadow.parentElement.remove();
+          _shadow.parentElement?.remove();
           _shadow = null;
         }
         // Remove any lingering subscriptions

--- a/packages/feedback/src/modal/components/Form.tsx
+++ b/packages/feedback/src/modal/components/Form.tsx
@@ -66,7 +66,7 @@ export function Form({
 
   const [showScreenshotInput, setShowScreenshotInput] = useState(false);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const ScreenshotInputComponent: any = screenshotInput && screenshotInput.input;
+  const ScreenshotInputComponent: any = screenshotInput?.input;
 
   const [screenshotError, setScreenshotError] = useState<null | Error>(null);
   const onScreenshotError = useCallback((error: Error) => {

--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -60,7 +60,7 @@ export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
         },
       };
 
-      const screenshotInput = screenshotIntegration && screenshotIntegration.createInput({ h, hooks, dialog, options });
+      const screenshotInput = screenshotIntegration?.createInput({ h, hooks, dialog, options });
 
       const renderContent = (open: boolean): void => {
         render(

--- a/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
+++ b/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
@@ -302,7 +302,7 @@ export function ScreenshotEditorFactory({
       onAfterScreenshot: hooks.useCallback(() => {
         (dialog.el as HTMLElement).style.display = 'block';
         const container = canvasContainerRef.current;
-        container && container.appendChild(imageBuffer);
+        container?.appendChild(imageBuffer);
         resizeCropper();
       }, []),
       onError: hooks.useCallback(error => {

--- a/packages/nestjs/src/setup.ts
+++ b/packages/nestjs/src/setup.ts
@@ -55,12 +55,12 @@ class SentryTracingInterceptor implements NestInterceptor {
 
     if (context.getType() === 'http') {
       const req = context.switchToHttp().getRequest() as FastifyRequest | ExpressRequest;
-      if ('routeOptions' in req && req.routeOptions && req.routeOptions.url) {
+      if ('routeOptions' in req && req.routeOptions?.url) {
         // fastify case
         getIsolationScope().setTransactionName(
           `${(req.routeOptions.method || 'GET').toUpperCase()} ${req.routeOptions.url}`,
         );
-      } else if ('route' in req && req.route && req.route.path) {
+      } else if ('route' in req && req.route?.path) {
         // express case
         getIsolationScope().setTransactionName(`${(req.method || 'GET').toUpperCase()} ${req.route.path}`);
       }

--- a/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
@@ -59,7 +59,7 @@ export function appRouterInstrumentNavigation(client: Client): void {
   let currentNavigationSpan: Span | undefined = undefined;
 
   WINDOW.addEventListener('popstate', () => {
-    if (currentNavigationSpan && currentNavigationSpan.isRecording()) {
+    if (currentNavigationSpan?.isRecording()) {
       currentNavigationSpan.updateName(WINDOW.location.pathname);
       currentNavigationSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'url');
     } else {

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -67,7 +67,7 @@ function extractNextDataTagInformation(): NextDataTagInfo {
   // Let's be on the safe side and actually check first if there is really a __NEXT_DATA__ script tag on the page.
   // Theoretically this should always be the case though.
   const nextDataTag = globalObject.document.getElementById('__NEXT_DATA__');
-  if (nextDataTag && nextDataTag.innerHTML) {
+  if (nextDataTag?.innerHTML) {
     try {
       nextData = JSON.parse(nextDataTag.innerHTML);
     } catch (e) {
@@ -91,7 +91,7 @@ function extractNextDataTagInformation(): NextDataTagInfo {
   nextDataTagInfo.route = page;
   nextDataTagInfo.params = query;
 
-  if (props && props.pageProps) {
+  if (props?.pageProps) {
     nextDataTagInfo.sentryTrace = props.pageProps._sentryTraceData;
     nextDataTagInfo.baggage = props.pageProps._sentryBaggage;
   }

--- a/packages/nextjs/src/common/pages-router-instrumentation/_error.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/_error.ts
@@ -19,7 +19,7 @@ export async function captureUnderscoreErrorException(contextOrProps: ContextOrP
   const { req, res, err } = contextOrProps;
 
   // 404s (and other 400-y friends) can trigger `_error`, but we don't want to send them to Sentry
-  const statusCode = (res && res.statusCode) || contextOrProps.statusCode;
+  const statusCode = res?.statusCode || contextOrProps.statusCode;
   if (statusCode && statusCode < 500) {
     return Promise.resolve();
   }

--- a/packages/nitro-utils/src/rollupPlugins/wrapServerEntryWithDynamicImport.ts
+++ b/packages/nitro-utils/src/rollupPlugins/wrapServerEntryWithDynamicImport.ts
@@ -50,7 +50,7 @@ export function wrapServerEntryWithDynamicImport(config: WrapServerEntryPluginOp
         return { id: source, moduleSideEffects: true };
       }
 
-      if (additionalImports && additionalImports.includes(source)) {
+      if (additionalImports?.includes(source)) {
         // When importing additional imports like "import-in-the-middle/hook.mjs" in the returned code of the `load()` function below:
         // By setting `moduleSideEffects` to `true`, the import is added to the bundle, although nothing is imported from it
         // By importing "import-in-the-middle/hook.mjs", we can make sure this file is included, as not all node builders are including files imported with `module.register()`.
@@ -67,7 +67,7 @@ export function wrapServerEntryWithDynamicImport(config: WrapServerEntryPluginOp
         const resolution = await this.resolve(source, importer, options);
 
         // If it cannot be resolved or is external, just return it so that Rollup can display an error
-        if (!resolution || (resolution && resolution.external)) return resolution;
+        if (!resolution || resolution?.external) return resolution;
 
         const moduleInfo = await this.load(resolution);
 

--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -253,7 +253,7 @@ if (options.captureStackTrace) {
 
           clearTimeout(getScopeTimeout);
 
-          const scopes = param && param.result ? (param.result.value as ScopeData) : undefined;
+          const scopes = param?.result ? (param.result.value as ScopeData) : undefined;
 
           session.post('Debugger.resume');
           session.post('Debugger.disable');

--- a/packages/node/src/utils/envToBool.ts
+++ b/packages/node/src/utils/envToBool.ts
@@ -34,5 +34,5 @@ export function envToBool(value: unknown, options?: BoolCastOptions): boolean | 
     return true;
   }
 
-  return options && options.strict ? null : Boolean(value);
+  return options?.strict ? null : Boolean(value);
 }

--- a/packages/node/src/utils/errorhandling.ts
+++ b/packages/node/src/utils/errorhandling.ts
@@ -23,8 +23,7 @@ export function logAndExitProcess(error: unknown): void {
 
   const options = client.getOptions();
   const timeout =
-    (options && options.shutdownTimeout && options.shutdownTimeout > 0 && options.shutdownTimeout) ||
-    DEFAULT_SHUTDOWN_TIMEOUT;
+    options?.shutdownTimeout && options.shutdownTimeout > 0 ? options.shutdownTimeout : DEFAULT_SHUTDOWN_TIMEOUT;
   client.close(timeout).then(
     (result: boolean) => {
       if (!result) {

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -83,7 +83,7 @@ const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 afterEach(done => {
   jest.clearAllMocks();
 
-  if (testServer && testServer.listening) {
+  if (testServer?.listening) {
     testServer.close(done);
   } else {
     done();

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -85,7 +85,7 @@ const defaultOptions = {
 afterEach(done => {
   jest.clearAllMocks();
 
-  if (testServer && testServer.listening) {
+  if (testServer?.listening) {
     testServer.close(done);
   } else {
     done();

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -78,7 +78,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     nuxt.hooks.hook('nitro:init', nitro => {
-      if (serverConfigFile && serverConfigFile.includes('.server.config')) {
+      if (serverConfigFile?.includes('.server.config')) {
         if (nitro.options.dev) {
           consoleSandbox(() => {
             // eslint-disable-next-line no-console

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -66,7 +66,7 @@ export function reportNuxtError(options: {
     const sentryOptions = sentryClient ? (sentryClient.getOptions() as ClientOptions & VueOptions) : null;
 
     // `attachProps` is enabled by default and props should only not be attached if explicitly disabled (see DEFAULT_CONFIG in `vueIntegration`).
-    if (sentryOptions && sentryOptions.attachProps && instance.$props !== false) {
+    if (sentryOptions?.attachProps && instance.$props !== false) {
       metadata.propsData = instance.$props;
     }
   }

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -198,7 +198,7 @@ export function getInjectionData(context: Context): {
 
   // If we have a remote span, the spanId should be considered as the parentSpanId, not spanId itself
   // Instead, we use a virtual (generated) spanId for propagation
-  if (span && span.spanContext().isRemote) {
+  if (span?.spanContext().isRemote) {
     const spanContext = span.spanContext();
     const dynamicSamplingContext = getDynamicSamplingContextFromSpan(span);
 

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -27,7 +27,7 @@ function onSpanStart(span: Span, parentContext: Context): void {
   }
 
   // We need this in the span exporter
-  if (parentSpan && parentSpan.spanContext().isRemote) {
+  if (parentSpan?.spanContext().isRemote) {
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_PARENT_IS_REMOTE, true);
   }
 

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -156,7 +156,7 @@ export function withActiveSpan<T>(span: Span | null, callback: (scope: Scope) =>
 
 function getTracer(): Tracer {
   const client = getClient<Client & OpenTelemetryClient>();
-  return (client && client.tracer) || trace.getTracer('@sentry/opentelemetry', SDK_VERSION);
+  return client?.tracer || trace.getTracer('@sentry/opentelemetry', SDK_VERSION);
 }
 
 function getSpanOptions(options: OpenTelemetrySpanContext): SpanOptions {

--- a/packages/opentelemetry/src/utils/groupSpansWithParents.ts
+++ b/packages/opentelemetry/src/utils/groupSpansWithParents.ts
@@ -66,7 +66,7 @@ function createOrUpdateNode(nodeMap: SpanMap, spanNode: SpanNode): SpanNode {
   const existing = nodeMap.get(spanNode.id);
 
   // If span is already set, nothing to do here
-  if (existing && existing.span) {
+  if (existing?.span) {
     return existing;
   }
 

--- a/packages/opentelemetry/src/utils/mapStatus.ts
+++ b/packages/opentelemetry/src/utils/mapStatus.ts
@@ -70,7 +70,7 @@ export function mapStatus(span: AbstractSpan): SpanStatus {
   }
 
   // We default to setting the spans status to ok.
-  if (status && status.code === SpanStatusCode.UNSET) {
+  if (status?.code === SpanStatusCode.UNSET) {
     return { code: SPAN_STATUS_OK };
   } else {
     return { code: SPAN_STATUS_ERROR, message: 'unknown_error' };

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -255,8 +255,8 @@ export function getSanitizedUrl(
 
   const parsedUrl = typeof httpUrl === 'string' ? parseUrl(httpUrl) : undefined;
   const url = parsedUrl ? getSanitizedUrlString(parsedUrl) : undefined;
-  const query = parsedUrl && parsedUrl.search ? parsedUrl.search : undefined;
-  const fragment = parsedUrl && parsedUrl.hash ? parsedUrl.hash : undefined;
+  const query = parsedUrl?.search || undefined;
+  const fragment = parsedUrl?.hash || undefined;
 
   if (typeof httpRoute === 'string') {
     return { urlPath: httpRoute, url, query, fragment, hasRoute: true };

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -158,7 +158,7 @@ function withProfiler<P extends Record<string, any>>(
   options?: Pick<Partial<ProfilerProps>, Exclude<keyof ProfilerProps, 'updateProps' | 'children'>>,
 ): React.FC<P> {
   const componentDisplayName =
-    (options && options.name) || WrappedComponent.displayName || WrappedComponent.name || UNKNOWN_COMPONENT;
+    options?.name || WrappedComponent.displayName || WrappedComponent.name || UNKNOWN_COMPONENT;
 
   const Wrapped: React.FC<P> = (props: P) => (
     <Profiler {...options} name={componentDisplayName} updateProps={props}>
@@ -189,7 +189,7 @@ function useProfiler(
   },
 ): void {
   const [mountSpan] = React.useState(() => {
-    if (options && options.disabled) {
+    if (options?.disabled) {
       return undefined;
     }
 

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -121,11 +121,11 @@ function instrumentReactRouter(
   matchPath?: MatchPath,
 ): void {
   function getInitPathName(): string | undefined {
-    if (history && history.location) {
+    if (history.location) {
       return history.location.pathname;
     }
 
-    if (WINDOW && WINDOW.location) {
+    if (WINDOW.location) {
       return WINDOW.location.pathname;
     }
 
@@ -226,7 +226,7 @@ export function withSentryRouting<P extends Record<string, any>, R extends React
   const componentDisplayName = Route.displayName || Route.name;
 
   const WrappedRoute: React.FC<P> = (props: P) => {
-    if (props && props.computedMatch && props.computedMatch.isExact) {
+    if (props?.computedMatch?.isExact) {
       const route = props.computedMatch.path;
       const activeRootSpan = getActiveRootSpan();
 

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -57,7 +57,7 @@ export function reactRouterV3BrowserTracingIntegration(
     afterAllSetup(client) {
       integration.afterAllSetup(client);
 
-      if (instrumentPageLoad && WINDOW && WINDOW.location) {
+      if (instrumentPageLoad && WINDOW.location) {
         normalizeTransactionName(
           routes,
           WINDOW.location as unknown as Location,

--- a/packages/react/src/reactrouterv6-compat-utils.tsx
+++ b/packages/react/src/reactrouterv6-compat-utils.tsx
@@ -85,7 +85,7 @@ export function createV6CompatibleWrapCreateBrowserRouter<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (routes: RouteObject[], opts?: Record<string, any> & { basename?: string }): TRouter {
     const router = createRouterFunction(routes, opts);
-    const basename = opts && opts.basename;
+    const basename = opts?.basename;
 
     const activeRootSpan = getActiveRootSpan();
 
@@ -150,7 +150,7 @@ export function createReactRouterV6CompatibleTracingIntegration(
     afterAllSetup(client) {
       integration.afterAllSetup(client);
 
-      const initPathName = WINDOW && WINDOW.location && WINDOW.location.pathname;
+      const initPathName = WINDOW.location?.pathname;
       if (instrumentPageLoad && initPathName) {
         startBrowserTracingPageLoadSpan(client, {
           name: initPathName,
@@ -196,9 +196,7 @@ export function createV6CompatibleWrapUseRoutes(origUseRoutes: UseRoutes, versio
 
     // A value with stable identity to either pick `locationArg` if available or `location` if not
     const stableLocationParam =
-      typeof locationArg === 'string' || (locationArg && locationArg.pathname)
-        ? (locationArg as { pathname: string })
-        : location;
+      typeof locationArg === 'string' || locationArg?.pathname ? (locationArg as { pathname: string }) : location;
 
     _useEffect(() => {
       const normalizedLocation =

--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -131,8 +131,8 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
         const transformedState = options.stateTransformer(newState);
         if (typeof transformedState !== 'undefined' && transformedState !== null) {
           const client = getClient();
-          const options = client && client.getOptions();
-          const normalizationDepth = (options && options.normalizeDepth) || 3; // default state normalization depth to 3
+          const options = client?.getOptions();
+          const normalizationDepth = options?.normalizeDepth || 3; // default state normalization depth to 3
 
           // Set the normalization depth of the redux state to the configured `normalizeDepth` option or a sane number as a fallback
           const newStateContext = { state: { type: 'redux', value: transformedState } };

--- a/packages/remix/src/client/performance.tsx
+++ b/packages/remix/src/client/performance.tsx
@@ -59,7 +59,7 @@ let _useMatches: UseMatches | undefined;
 let _instrumentNavigation: boolean | undefined;
 
 function getInitPathName(): string | undefined {
-  if (WINDOW && WINDOW.location) {
+  if (WINDOW.location) {
     return WINDOW.location.pathname;
   }
 
@@ -177,7 +177,7 @@ export function withSentry<P extends Record<string, unknown>, R extends React.Co
         return;
       }
 
-      if (_instrumentNavigation && matches && matches.length) {
+      if (_instrumentNavigation && matches?.length) {
         if (activeRootSpan) {
           activeRootSpan.end();
         }

--- a/packages/remix/test/integration/common/routes/action-json-response.$id.tsx
+++ b/packages/remix/test/integration/common/routes/action-json-response.$id.tsx
@@ -43,7 +43,7 @@ export default function ActionJSONResponse() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/packages/remix/test/integration/common/routes/loader-defer-response.$id.tsx
+++ b/packages/remix/test/integration/common/routes/loader-defer-response.$id.tsx
@@ -14,7 +14,7 @@ export default function LoaderJSONResponse() {
 
   return (
     <div>
-      <h1 id="data-render">{data && data.id ? data.id : 'Not Found'}</h1>
+      <h1 id="data-render">{data?.id ? data.id : 'Not Found'}</h1>
     </div>
   );
 }

--- a/packages/remix/test/integration/common/routes/loader-json-response.$id.tsx
+++ b/packages/remix/test/integration/common/routes/loader-json-response.$id.tsx
@@ -22,7 +22,7 @@ export default function LoaderJSONResponse() {
 
   return (
     <div>
-      <h1>{data && data.id ? data.id : 'Not Found'}</h1>
+      <h1>{data?.id ? data.id : 'Not Found'}</h1>
     </div>
   );
 }

--- a/packages/remix/test/integration/common/routes/server-side-unexpected-errors.$id.tsx
+++ b/packages/remix/test/integration/common/routes/server-side-unexpected-errors.$id.tsx
@@ -21,7 +21,7 @@ export default function ActionJSONResponse() {
 
   return (
     <div>
-      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
     </div>
   );
 }

--- a/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
@@ -15,7 +15,7 @@ export function handleAfterSendEvent(replay: ReplayContainer): AfterSendEventCal
       return;
     }
 
-    const statusCode = sendResponse && sendResponse.statusCode;
+    const statusCode = sendResponse?.statusCode;
 
     // We only want to do stuff on successful error sending, otherwise you get error replays without errors attached
     // If not using the base transport, we allow `undefined` response (as a custom transport may not implement this correctly yet)

--- a/packages/replay-internal/src/coreHandlers/handleNetworkBreadcrumbs.ts
+++ b/packages/replay-internal/src/coreHandlers/handleNetworkBreadcrumbs.ts
@@ -92,9 +92,9 @@ function _isFetchBreadcrumb(breadcrumb: Breadcrumb): breadcrumb is Breadcrumb & 
 }
 
 function _isXhrHint(hint?: BreadcrumbHint): hint is XhrHint {
-  return hint && hint.xhr;
+  return hint?.xhr;
 }
 
 function _isFetchHint(hint?: BreadcrumbHint): hint is FetchHint {
-  return hint && hint.response;
+  return hint?.response;
 }

--- a/packages/replay-internal/src/coreHandlers/util/fetchUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/fetchUtils.ts
@@ -179,8 +179,7 @@ function getResponseData(
   },
 ): ReplayNetworkRequestOrResponse | undefined {
   try {
-    const size =
-      bodyText && bodyText.length && responseBodySize === undefined ? getBodySize(bodyText) : responseBodySize;
+    const size = bodyText?.length && responseBodySize === undefined ? getBodySize(bodyText) : responseBodySize;
 
     if (!captureDetails) {
       return buildSkippedNetworkRequestOrResponse(size);

--- a/packages/replay-internal/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/networkUtils.ts
@@ -179,7 +179,7 @@ export function buildNetworkRequestOrResponse(
 
   const { body: normalizedBody, warnings } = normalizeNetworkBody(body);
   info.body = normalizedBody;
-  if (warnings && warnings.length > 0) {
+  if (warnings?.length) {
     info._meta = {
       warnings,
     };

--- a/packages/replay-internal/src/util/addGlobalListeners.ts
+++ b/packages/replay-internal/src/util/addGlobalListeners.ts
@@ -60,7 +60,7 @@ export function addGlobalListeners(replay: ReplayContainer): void {
     // We want to flush replay
     client.on('beforeSendFeedback', (feedbackEvent, options) => {
       const replayId = replay.getSessionId();
-      if (options && options.includeReplay && replay.isEnabled() && replayId) {
+      if (options?.includeReplay && replay.isEnabled() && replayId) {
         // This should never reject
         if (feedbackEvent.contexts && feedbackEvent.contexts.feedback) {
           feedbackEvent.contexts.feedback.replay_id = replayId;

--- a/packages/replay-internal/src/util/createPerformanceEntries.ts
+++ b/packages/replay-internal/src/util/createPerformanceEntries.ts
@@ -189,7 +189,7 @@ function createResourceEntry(
  */
 export function getLargestContentfulPaint(metric: Metric): ReplayPerformanceEntry<WebVitalData> {
   const lastEntry = metric.entries[metric.entries.length - 1] as (PerformanceEntry & { element?: Node }) | undefined;
-  const node = lastEntry && lastEntry.element ? [lastEntry.element] : undefined;
+  const node = lastEntry?.element ? [lastEntry.element] : undefined;
   return getWebVital(metric, 'largest-contentful-paint', node);
 }
 
@@ -227,7 +227,7 @@ export function getCumulativeLayoutShift(metric: Metric): ReplayPerformanceEntry
  */
 export function getFirstInputDelay(metric: Metric): ReplayPerformanceEntry<WebVitalData> {
   const lastEntry = metric.entries[metric.entries.length - 1] as (PerformanceEntry & { target?: Node }) | undefined;
-  const node = lastEntry && lastEntry.target ? [lastEntry.target] : undefined;
+  const node = lastEntry?.target ? [lastEntry.target] : undefined;
   return getWebVital(metric, 'first-input-delay', node);
 }
 
@@ -236,7 +236,7 @@ export function getFirstInputDelay(metric: Metric): ReplayPerformanceEntry<WebVi
  */
 export function getInteractionToNextPaint(metric: Metric): ReplayPerformanceEntry<WebVitalData> {
   const lastEntry = metric.entries[metric.entries.length - 1] as (PerformanceEntry & { target?: Node }) | undefined;
-  const node = lastEntry && lastEntry.target ? [lastEntry.target] : undefined;
+  const node = lastEntry?.target ? [lastEntry.target] : undefined;
   return getWebVital(metric, 'interaction-to-next-paint', node);
 }
 

--- a/packages/replay-internal/src/util/debounce.ts
+++ b/packages/replay-internal/src/util/debounce.ts
@@ -32,7 +32,7 @@ export function debounce(func: CallbackFunction, wait: number, options?: Debounc
   let timerId: ReturnType<typeof setTimeout> | undefined;
   let maxTimerId: ReturnType<typeof setTimeout> | undefined;
 
-  const maxWait = options && options.maxWait ? Math.max(options.maxWait, wait) : 0;
+  const maxWait = options?.maxWait ? Math.max(options.maxWait, wait) : 0;
 
   function invokeFunc(): unknown {
     cancelTimers();

--- a/packages/replay-internal/src/util/getReplay.ts
+++ b/packages/replay-internal/src/util/getReplay.ts
@@ -6,5 +6,5 @@ import type { replayIntegration } from '../integration';
  */
 export function getReplay(): ReturnType<typeof replayIntegration> | undefined {
   const client = getClient();
-  return client && client.getIntegrationByName<ReturnType<typeof replayIntegration>>('Replay');
+  return client?.getIntegrationByName<ReturnType<typeof replayIntegration>>('Replay');
 }

--- a/packages/replay-internal/src/util/handleRecordingEmit.ts
+++ b/packages/replay-internal/src/util/handleRecordingEmit.ts
@@ -93,7 +93,7 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
       // of the previous session. Do not immediately flush in this case
       // to avoid capturing only the checkout and instead the replay will
       // be captured if they perform any follow-up actions.
-      if (session && session.previousSessionId) {
+      if (session?.previousSessionId) {
         return true;
       }
 

--- a/packages/replay-internal/src/util/prepareReplayEvent.ts
+++ b/packages/replay-internal/src/util/prepareReplayEvent.ts
@@ -47,7 +47,7 @@ export async function prepareReplayEvent({
 
   // extract the SDK name because `client._prepareEvent` doesn't add it to the event
   const metadata = client.getSdkMetadata();
-  const { name, version } = (metadata && metadata.sdk) || {};
+  const { name, version } = metadata?.sdk || {};
 
   preparedEvent.sdk = {
     ...preparedEvent.sdk,

--- a/packages/replay-internal/src/util/sendReplayRequest.ts
+++ b/packages/replay-internal/src/util/sendReplayRequest.ts
@@ -30,8 +30,8 @@ export async function sendReplayRequest({
 
   const client = getClient();
   const scope = getCurrentScope();
-  const transport = client && client.getTransport();
-  const dsn = client && client.getDsn();
+  const transport = client?.getTransport();
+  const dsn = client?.getDsn();
 
   if (!client || !transport || !dsn || !session.sampled) {
     return resolvedSyncPromise({});

--- a/packages/replay-internal/test/integration/beforeAddRecordingEvent.test.ts
+++ b/packages/replay-internal/test/integration/beforeAddRecordingEvent.test.ts
@@ -99,7 +99,7 @@ describe('Integration | beforeAddRecordingEvent', () => {
   });
 
   afterAll(() => {
-    integration && integration.stop();
+    integration?.stop();
   });
 
   it('changes click breadcrumbs message', async () => {

--- a/packages/replay-internal/test/integration/flush.test.ts
+++ b/packages/replay-internal/test/integration/flush.test.ts
@@ -113,7 +113,7 @@ describe('Integration | flush', () => {
   });
 
   afterAll(() => {
-    replay && replay.stop();
+    replay?.stop();
   });
 
   it('flushes twice after multiple flush() calls)', async () => {

--- a/packages/replay-internal/test/integration/rateLimiting.test.ts
+++ b/packages/replay-internal/test/integration/rateLimiting.test.ts
@@ -44,7 +44,7 @@ describe('Integration | rate-limiting behaviour', () => {
     clearSession(replay);
     vi.clearAllMocks();
 
-    replay && replay.stop();
+    replay?.stop();
   });
 
   it.each([

--- a/packages/replay-internal/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay-internal/test/integration/sendReplayEvent.test.ts
@@ -78,7 +78,7 @@ describe('Integration | sendReplayEvent', () => {
   });
 
   afterAll(() => {
-    replay && replay.stop();
+    replay?.stop();
   });
 
   it('uploads a replay event when document becomes hidden', async () => {

--- a/packages/solid/src/solidrouter.ts
+++ b/packages/solid/src/solidrouter.ts
@@ -37,8 +37,8 @@ function handleNavigation(location: string): void {
   // To avoid increasing the api surface with internal properties, we look at
   // the sdk metadata.
   const metaData = client.getSdkMetadata();
-  const { name } = (metaData && metaData.sdk) || {};
-  const framework = name && name.includes('solidstart') ? 'solidstart' : 'solid';
+  const { name } = metaData?.sdk || {};
+  const framework = name?.includes('solidstart') ? 'solidstart' : 'solid';
 
   startBrowserTracingNavigationSpan(client, {
     name: location,

--- a/packages/solidstart/src/server/middleware.ts
+++ b/packages/solidstart/src/server/middleware.ts
@@ -33,7 +33,7 @@ export function sentryBeforeResponseMiddleware() {
     addNonEnumerableProperty(response, '__sentry_wrapped__', true);
 
     const contentType = event.response.headers.get('content-type');
-    const isPageloadRequest = contentType && contentType.startsWith('text/html');
+    const isPageloadRequest = contentType?.startsWith('text/html');
 
     if (!isPageloadRequest) {
       return;

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -41,7 +41,7 @@ export function browserTracingIntegration(
 }
 
 function _instrumentPageload(client: Client): void {
-  const initialPath = WINDOW && WINDOW.location && WINDOW.location.pathname;
+  const initialPath = WINDOW.location?.pathname;
 
   const pageloadSpan = startBrowserTracingPageLoadSpan(client, {
     name: initialPath,
@@ -92,9 +92,9 @@ function _instrumentNavigations(client: Client): void {
     const to = navigation.to;
 
     // for the origin we can fall back to window.location.pathname because in this emission, it still is set to the origin path
-    const rawRouteOrigin = (from && from.url.pathname) || (WINDOW && WINDOW.location && WINDOW.location.pathname);
+    const rawRouteOrigin = from?.url.pathname || WINDOW.location?.pathname;
 
-    const rawRouteDestination = to && to.url.pathname;
+    const rawRouteDestination = to?.url.pathname;
 
     // We don't want to create transactions for navigations of same origin and destination.
     // We need to look at the raw URL here because parameterized routes can still differ in their raw parameters.
@@ -102,8 +102,8 @@ function _instrumentNavigations(client: Client): void {
       return;
     }
 
-    const parameterizedRouteOrigin = from && from.route.id;
-    const parameterizedRouteDestination = to && to.route.id;
+    const parameterizedRouteOrigin = from?.route.id;
+    const parameterizedRouteDestination = to?.route.id;
 
     if (routingSpan) {
       // If a routing span is still open from a previous navigation, we finish it.

--- a/packages/sveltekit/src/server/handleError.ts
+++ b/packages/sveltekit/src/server/handleError.ts
@@ -9,7 +9,7 @@ import { flushIfServerless } from './utils';
 function defaultErrorHandler({ error }: Parameters<HandleServerError>[0]): ReturnType<HandleServerError> {
   // @ts-expect-error this conforms to the default implementation (including this ts-expect-error)
   // eslint-disable-next-line no-console
-  consoleSandbox(() => console.error(error && error.stack));
+  consoleSandbox(() => console.error(error?.stack));
 }
 
 type HandleServerErrorInput = Parameters<HandleServerError>[0];

--- a/packages/vercel-edge/src/integrations/wintercg-fetch.ts
+++ b/packages/vercel-edge/src/integrations/wintercg-fetch.ts
@@ -157,7 +157,7 @@ function createBreadcrumb(handlerData: HandlerDataFetch): void {
 
     breadcrumbData.request_body_size = handlerData.fetchData.request_body_size;
     breadcrumbData.response_body_size = handlerData.fetchData.response_body_size;
-    breadcrumbData.status_code = response && response.status;
+    breadcrumbData.status_code = response?.status;
 
     const hint: FetchBreadcrumbHint = {
       input: handlerData.args,

--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -41,7 +41,7 @@ export const attachErrorHandler = (app: Vue, options: VueOptions): void => {
 
     if (options.logErrors) {
       const hasConsole = typeof console !== 'undefined';
-      const message = `Error in ${lifecycleHook}: "${error && error.toString()}"`;
+      const message = `Error in ${lifecycleHook}: "${error?.toString()}"`;
 
       if (warnHandler) {
         (warnHandler as UnknownFunc).call(null, message, vm, trace);

--- a/packages/vue/src/pinia.ts
+++ b/packages/vue/src/pinia.ts
@@ -71,8 +71,8 @@ export const createSentryPiniaPlugin: (options?: SentryPiniaPluginOptions) => Pi
 
         if (typeof transformedState !== 'undefined' && transformedState !== null) {
           const client = getClient();
-          const options = client && client.getOptions();
-          const normalizationDepth = (options && options.normalizeDepth) || 3; // default state normalization depth to 3
+          const options = client?.getOptions();
+          const normalizationDepth = options?.normalizeDepth || 3; // default state normalization depth to 3
           const piniaStateContext = { type: 'pinia', value: transformedState };
 
           const newState = {

--- a/scripts/normalize-e2e-test-dump-transaction-events.js
+++ b/scripts/normalize-e2e-test-dump-transaction-events.js
@@ -56,7 +56,7 @@ glob.glob(
 
             transaction.spans.forEach(span => {
               const node = spanMap.get(span.span_id);
-              if (node && node.parent_span_id) {
+              if (node?.parent_span_id) {
                 const parentNode = spanMap.get(node.parent_span_id);
                 parentNode.children.push(node);
               }


### PR DESCRIPTION
This PR updates our code to use optional chaining, where possible.

This was mostly search-and-replace by `xx && xx.` regex, so there may def. be some remaining places, but this should cover a good amount of usage.