### PR TITLE
fix(vue): Remove `logError` from `vueIntegration`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/vue-3/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/tests/errors.test.ts
@@ -19,7 +19,7 @@ test('sends an error', async ({ page }) => {
           type: 'Error',
           value: 'This is a Vue test error',
           mechanism: {
-            type: 'generic',
+            type: 'vue-errorHandler',
             handled: false,
           },
         },
@@ -47,7 +47,7 @@ test('sends an error with a parameterized transaction name', async ({ page }) =>
           type: 'Error',
           value: 'This is a Vue test error',
           mechanism: {
-            type: 'generic',
+            type: 'vue-errorHandler',
             handled: false,
           },
         },

--- a/dev-packages/e2e-tests/test-applications/vue-3/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/tests/errors.test.ts
@@ -19,7 +19,7 @@ test('sends an error', async ({ page }) => {
           type: 'Error',
           value: 'This is a Vue test error',
           mechanism: {
-            type: 'vue-errorHandler',
+            type: 'vue',
             handled: false,
           },
         },
@@ -47,7 +47,7 @@ test('sends an error with a parameterized transaction name', async ({ page }) =>
           type: 'Error',
           value: 'This is a Vue test error',
           mechanism: {
-            type: 'vue-errorHandler',
+            type: 'vue',
             handled: false,
           },
         },

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -217,6 +217,9 @@ The following changes are unlikely to affect users of the SDK. They are listed h
   });
   ```
 
+- The option `logErrors` in the `vueIntegration` has been removed. The Sentry Vue error handler will propagate the error to a user-defined error handler
+  or just re-throw the error (which will log the error without modifying).
+
 ## 5. Build Changes
 
 Previously the CJS versions of the SDK code (wrongfully) contained compatibility statements for default exports in ESM:
@@ -372,6 +375,9 @@ The Sentry metrics beta has ended and the metrics API has been removed from the 
     ],
   });
   ```
+
+- Deprecated `logErrors` in the `vueIntegration`. The Sentry Vue error handler will propagate the error to a user-defined error handler
+  or just re-throw the error (which will log the error without modifying).
 
 ## `@sentry/nuxt` and `@sentry/vue`
 

--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -30,7 +30,7 @@ export const attachErrorHandler = (app: Vue, options: VueOptions): void => {
     setTimeout(() => {
       captureException(error, {
         captureContext: { contexts: { vue: metadata } },
-        mechanism: { handled: !!originalErrorHandler, type: 'vue-errorHandler' },
+        mechanism: { handled: !!originalErrorHandler, type: 'vue' },
       });
     });
 

--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -1,11 +1,11 @@
-import { captureException, consoleSandbox } from '@sentry/core';
+import { captureException } from '@sentry/core';
 import type { ViewModel, Vue, VueOptions } from './types';
 import { formatComponentName, generateComponentTrace } from './vendor/components';
 
 type UnknownFunc = (...args: unknown[]) => void;
 
 export const attachErrorHandler = (app: Vue, options: VueOptions): void => {
-  const { errorHandler: originalErrorHandler, warnHandler, silent } = app.config;
+  const { errorHandler: originalErrorHandler } = app.config;
 
   app.config.errorHandler = (error: Error, vm: ViewModel, lifecycleHook: string): void => {
     const componentName = formatComponentName(vm, false);
@@ -30,27 +30,15 @@ export const attachErrorHandler = (app: Vue, options: VueOptions): void => {
     setTimeout(() => {
       captureException(error, {
         captureContext: { contexts: { vue: metadata } },
-        mechanism: { handled: false },
+        mechanism: { handled: !!originalErrorHandler, type: 'vue-errorHandler' },
       });
     });
 
     // Check if the current `app.config.errorHandler` is explicitly set by the user before calling it.
     if (typeof originalErrorHandler === 'function' && app.config.errorHandler) {
       (originalErrorHandler as UnknownFunc).call(app, error, vm, lifecycleHook);
-    }
-
-    if (options.logErrors) {
-      const hasConsole = typeof console !== 'undefined';
-      const message = `Error in ${lifecycleHook}: "${error && error.toString()}"`;
-
-      if (warnHandler) {
-        (warnHandler as UnknownFunc).call(null, message, vm, trace);
-      } else if (hasConsole && !silent) {
-        consoleSandbox(() => {
-          // eslint-disable-next-line no-console
-          console.error(`[Vue warn]: ${message}${trace}`);
-        });
-      }
+    } else {
+      throw error;
     }
   };
 };

--- a/packages/vue/src/integration.ts
+++ b/packages/vue/src/integration.ts
@@ -10,7 +10,6 @@ const globalWithVue = GLOBAL_OBJ as typeof GLOBAL_OBJ & { Vue: Vue };
 const DEFAULT_CONFIG: VueOptions = {
   Vue: globalWithVue.Vue,
   attachProps: true,
-  logErrors: true,
   attachErrorHandler: true,
   tracingOptions: {
     hooks: DEFAULT_HOOKS,

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -42,12 +42,6 @@ export interface VueOptions {
   attachProps: boolean;
 
   /**
-   * When set to `true`, original Vue's `logError` will be called as well.
-   * https://github.com/vuejs/vue/blob/c2b1cfe9ccd08835f2d99f6ce60f67b4de55187f/src/core/util/error.js#L38-L48
-   */
-  logErrors: boolean;
-
-  /**
    *  By default, Sentry attaches an error handler to capture exceptions and report them to Sentry.
    *  When `attachErrorHandler` is set to `false`, automatic error reporting is disabled.
    *

--- a/packages/vue/test/errorHandler.test.ts
+++ b/packages/vue/test/errorHandler.test.ts
@@ -28,7 +28,7 @@ describe('attachErrorHandler', () => {
 
         // assert
         t.expect.errorToHaveBeenCaptured().withoutProps();
-        t.expect.errorToHaveBeenCaptured().withMechanismMetadata({ handled: false, type: 'vue-errorHandler' });
+        t.expect.errorToHaveBeenCaptured().withMechanismMetadata({ handled: false, type: 'vue' });
       });
     });
 
@@ -49,7 +49,7 @@ describe('attachErrorHandler', () => {
 
             // assert
             t.expect.errorToHaveBeenCaptured().withoutProps();
-            t.expect.errorToHaveBeenCaptured().withMechanismMetadata({ handled: false, type: 'vue-errorHandler' });
+            t.expect.errorToHaveBeenCaptured().withMechanismMetadata({ handled: false, type: 'vue' });
           });
         });
 
@@ -148,7 +148,7 @@ describe('attachErrorHandler', () => {
         vi.runAllTimers();
 
         // assert
-        t.expect.errorToHaveBeenCaptured().withMechanismMetadata({ handled: false, type: 'vue-errorHandler' });
+        t.expect.errorToHaveBeenCaptured().withMechanismMetadata({ handled: false, type: 'vue' });
       });
 
       it('should mark error as handled and properly delegate to error handler', () => {
@@ -169,7 +169,7 @@ describe('attachErrorHandler', () => {
 
         // assert
         t.expect.errorHandlerSpy.toHaveBeenCalledWith(expect.any(Error), vm, 'stub-lifecycle-hook');
-        t.expect.errorToHaveBeenCaptured().withMechanismMetadata({ handled: true, type: 'vue-errorHandler' });
+        t.expect.errorToHaveBeenCaptured().withMechanismMetadata({ handled: true, type: 'vue' });
       });
     });
   });
@@ -307,7 +307,7 @@ const testHarness = ({
           withoutProps: () => {
             expect(contexts).not.toHaveProperty('vue.propsData');
           },
-          withMechanismMetadata: (mechanism: { handled: boolean; type: 'vue-errorHandler' }) => {
+          withMechanismMetadata: (mechanism: { handled: boolean; type: 'vue' }) => {
             expect(mechanismMetadata).toEqual(mechanism);
           },
         };


### PR DESCRIPTION
Removes `logError` and always re-throws the error when it's not handled by the user.

PR for v8 (without removing `logError`): https://github.com/getsentry/sentry-javascript/pull/14943

Logging the error has been a problem in the past already (see https://github.com/getsentry/sentry-javascript/pull/7310). By just re-throwing the error we don't mess around with the initial message and stacktrace.
