### PR TITLE
chore(v8/repo): Add missing v7 changelog entries

### DIFF
--- a/docs/changelog/v7.md
+++ b/docs/changelog/v7.md
@@ -3,13 +3,49 @@
 Support for Sentry SDK v7 will be dropped soon. We recommend migrating to the latest version of the SDK. You can migrate
 from `v7` of the SDK to `v8` by following the [migration guide](../../MIGRATION.md#upgrading-from-7x-to-8x).
 
+## 7.120.3
+
+- fix(v7/publish): Ensure discontinued packages are published with `latest` tag (#14926)
+
+## 7.120.2
+
+- fix(tracing-internal): Fix case when lrp keys offset is 0 (#14615)
+
+Work in this release contributed by @LubomirIgonda1. Thank you for your contribution!
+
+## 7.120.1
+
+- fix(v7/cdn): Ensure `_sentryModuleMetadata` is not mangled (#14357)
+
+Work in this release contributed by @gilisho. Thank you for your contribution!
+
+## 7.120.0
+
+- feat(v7/browser): Add moduleMetadataIntegration lazy loading support (#13822)
+
+Work in this release contributed by @gilisho. Thank you for your contribution!
+
+## 7.119.2
+
+- chore(nextjs/v7): Bump rollup to 2.79.2
+
+## 7.119.1
+
+- fix(browser/v7): Ensure wrap() only returns functions (#13838 backport)
+
+Work in this release contributed by @legobeat. Thank you for your contribution!
+
+## 7.119.0
+
+- backport(tracing): Report dropped spans for transactions (#13343)
+
 ## 7.118.0
 
 - fix(v7/bundle): Ensure CDN bundles do not overwrite `window.Sentry` (#12579)
 
 ## 7.117.0
 
-- feat(browser/v7): Publish browserprofling CDN bundle (#12224)
+- feat(browser/v7): Publish browser profiling CDN bundle (#12224)
 - fix(v7/publish): Add `v7` tag to `@sentry/replay` (#12304)
 
 ## 7.116.0


### PR DESCRIPTION
Adds a couple of missing changelog entries to the v8 branch, jus to keep things in sync. Will do the same for `develop` in a sec. Already includes #14960 