### PR TITLE
ref(core): Ensure non-recording root spans have frozen DSC

### DIFF
--- a/packages/core/test/lib/tracing/idleSpan.test.ts
+++ b/packages/core/test/lib/tracing/idleSpan.test.ts
@@ -7,6 +7,7 @@ import {
   getActiveSpan,
   getClient,
   getCurrentScope,
+  getDynamicSamplingContextFromSpan,
   getGlobalScope,
   getIsolationScope,
   setCurrentClient,
@@ -60,6 +61,14 @@ describe('startIdleSpan', () => {
     const idleSpan = startIdleSpan({ name: 'foo' });
     expect(idleSpan).toBeDefined();
     expect(idleSpan).toBeInstanceOf(SentryNonRecordingSpan);
+    // DSC is still correctly set on the span
+    expect(getDynamicSamplingContextFromSpan(idleSpan)).toEqual({
+      environment: 'production',
+      public_key: '123',
+      sample_rate: '0',
+      sampled: 'false',
+      trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    });
 
     // not set as active span, though
     expect(getActiveSpan()).toBe(undefined);

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -15,6 +15,7 @@ import { getAsyncContextStrategy } from '../../../src/asyncContext';
 import {
   SentrySpan,
   continueTrace,
+  getDynamicSamplingContextFromSpan,
   registerSpanErrorInstrumentation,
   startInactiveSpan,
   startSpan,
@@ -217,6 +218,13 @@ describe('startSpan', () => {
 
     expect(span).toBeDefined();
     expect(span).toBeInstanceOf(SentryNonRecordingSpan);
+    expect(getDynamicSamplingContextFromSpan(span)).toEqual({
+      environment: 'production',
+      sample_rate: '0',
+      sampled: 'false',
+      trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      transaction: 'GET users/[id]',
+    });
   });
 
   it('creates & finishes span', async () => {
@@ -633,6 +641,13 @@ describe('startSpanManual', () => {
 
     expect(span).toBeDefined();
     expect(span).toBeInstanceOf(SentryNonRecordingSpan);
+    expect(getDynamicSamplingContextFromSpan(span)).toEqual({
+      environment: 'production',
+      sample_rate: '0',
+      sampled: 'false',
+      trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      transaction: 'GET users/[id]',
+    });
   });
 
   it('creates & finishes span', async () => {
@@ -971,6 +986,13 @@ describe('startInactiveSpan', () => {
 
     expect(span).toBeDefined();
     expect(span).toBeInstanceOf(SentryNonRecordingSpan);
+    expect(getDynamicSamplingContextFromSpan(span)).toEqual({
+      environment: 'production',
+      sample_rate: '0',
+      sampled: 'false',
+      trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      transaction: 'GET users/[id]',
+    });
   });
 
   it('creates & finishes span', async () => {


### PR DESCRIPTION
Otherwise, parts of the DSC will be missing - we try to make it as complete as we can.

Since the span cannot be updated anyhow (e.g. the name cannot be changed), we can safely freeze this at this time.

Extracted out of https://github.com/getsentry/sentry-javascript/pull/14955