### PR TITLE
chore: Remove unused ts directive

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/test.ts
@@ -182,8 +182,5 @@ async function captureErrorAndGetEnvelopeTraceHeader(page: Page): Promise<Partia
 
   const [, errorEnvelopeTraceHeader] = (await errorEventPromise)[0];
 
-  // @ts-expect-error - EventEnvelopeHeaders type in (types/envelope.ts) suggests that trace_id is optional,
-  // which the DynamicSamplingContext type does not permit.
-  // TODO(v9): We should adjust the EventEnvelopeHeaders type because the trace header always needs to have a trace_id
   return errorEnvelopeTraceHeader;
 }


### PR DESCRIPTION
This pr just removes an unused directive in a test.