### PR TITLE
feat(replay): Bump `rrweb` to 2.32.0-dev.0

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.44.1",
-    "@sentry-internal/rrweb": "2.32.0-dev.0",
+    "@sentry-internal/rrweb": "2.32.0-dev.1",
     "@sentry/browser": "8.45.0",
     "axios": "1.7.7",
     "babel-loader": "^8.2.2",

--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.44.1",
-    "@sentry-internal/rrweb": "2.31.0",
+    "@sentry-internal/rrweb": "2.32.0-dev.0",
     "@sentry/browser": "8.45.0",
     "axios": "1.7.7",
     "babel-loader": "^8.2.2",

--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.44.1",
-    "@sentry-internal/rrweb": "2.32.0-dev.1",
+    "@sentry-internal/rrweb": "2.32.0-dev.2",
     "@sentry/browser": "8.45.0",
     "axios": "1.7.7",
     "babel-loader": "^8.2.2",

--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.44.1",
-    "@sentry-internal/rrweb": "2.32.0-dev.2",
+    "@sentry-internal/rrweb": "2.32.0-dev.3",
     "@sentry/browser": "8.45.0",
     "axios": "1.7.7",
     "babel-loader": "^8.2.2",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@sentry-internal/rrweb": "2.32.0-dev.1"
+    "@sentry-internal/rrweb": "2.32.0-dev.2"
   },
   "dependencies": {
     "@sentry-internal/replay": "8.45.0",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@sentry-internal/rrweb": "2.32.0-dev.2"
+    "@sentry-internal/rrweb": "2.32.0-dev.3"
   },
   "dependencies": {
     "@sentry-internal/replay": "8.45.0",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@sentry-internal/rrweb": "2.32.0-dev.0"
+    "@sentry-internal/rrweb": "2.32.0-dev.1"
   },
   "dependencies": {
     "@sentry-internal/replay": "8.45.0",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@sentry-internal/rrweb": "2.31.0"
+    "@sentry-internal/rrweb": "2.32.0-dev.0"
   },
   "dependencies": {
     "@sentry-internal/replay": "8.45.0",

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -69,8 +69,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "8.45.0",
-    "@sentry-internal/rrweb": "2.31.0",
-    "@sentry-internal/rrweb-snapshot": "2.31.0",
+    "@sentry-internal/rrweb": "2.32.0-dev.0",
+    "@sentry-internal/rrweb-snapshot": "2.32.0-dev.0",
     "fflate": "0.8.2",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -69,8 +69,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "8.45.0",
-    "@sentry-internal/rrweb": "2.32.0-dev.1",
-    "@sentry-internal/rrweb-snapshot": "2.32.0-dev.1",
+    "@sentry-internal/rrweb": "2.32.0-dev.2",
+    "@sentry-internal/rrweb-snapshot": "2.32.0-dev.2",
     "fflate": "0.8.2",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -69,8 +69,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "8.45.0",
-    "@sentry-internal/rrweb": "2.32.0-dev.2",
-    "@sentry-internal/rrweb-snapshot": "2.32.0-dev.2",
+    "@sentry-internal/rrweb": "2.32.0-dev.3",
+    "@sentry-internal/rrweb-snapshot": "2.32.0-dev.3",
     "fflate": "0.8.2",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -69,8 +69,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "8.45.0",
-    "@sentry-internal/rrweb": "2.32.0-dev.0",
-    "@sentry-internal/rrweb-snapshot": "2.32.0-dev.0",
+    "@sentry-internal/rrweb": "2.32.0-dev.1",
+    "@sentry-internal/rrweb-snapshot": "2.32.0-dev.1",
     "fflate": "0.8.2",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6537,34 +6537,34 @@
     "@angular-devkit/schematics" "14.2.13"
     jsonc-parser "3.1.0"
 
-"@sentry-internal/rrdom@2.32.0-dev.1":
-  version "2.32.0-dev.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.32.0-dev.1.tgz#f84cdff9c99952b010a99abe7029dd1847be89e3"
-  integrity sha512-07yupHgbVIF7eRNy7K6NBm/2FM7I+q04HPNpsaAZQ5E6PgNUOPdJ5YtdrKLPkGCQa4YUsK0hQo6AFLsJb3u2OQ==
+"@sentry-internal/rrdom@2.32.0-dev.2":
+  version "2.32.0-dev.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.32.0-dev.2.tgz#624d39c0c5086c74673fa20246851c6ec6a38efd"
+  integrity sha512-bjahxy+RKU+lk61p6IH8XrbyeJYb05PZd7lqQ/VcvFEuas5lUGvavwMIDLmqJM3SugPqkIv2PlVvYqdPi483sQ==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.1"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.2"
 
-"@sentry-internal/rrweb-snapshot@2.32.0-dev.1":
-  version "2.32.0-dev.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.32.0-dev.1.tgz#67fbcb3b88818683e59882572b3b02b18873df6c"
-  integrity sha512-w66xQsof7DKBwRcNFnN40XBofxFLx6I9/H09qHST+uYrTw0XyJvndRrkxAPpFsca+Fe6E4PanrEL1GRPKgq0DQ==
+"@sentry-internal/rrweb-snapshot@2.32.0-dev.2":
+  version "2.32.0-dev.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.32.0-dev.2.tgz#c33ccdb00765490c9415400b714baa06f0d47134"
+  integrity sha512-u6lTltSFDp9IP9pquwMjQiSxD34xoH/o2GT0U6fgJvwt30RTsN5Q6NYWufHPOz/lj3EzOxG0415yp/fMWKSmOg==
 
-"@sentry-internal/rrweb-types@2.32.0-dev.1":
-  version "2.32.0-dev.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.32.0-dev.1.tgz#3b665030b375b73bdd898d98516f881a1fb16b66"
-  integrity sha512-ALJ2R1HC3VJ9TfTLqyNsEGBa3X5F/uefrP24uKkDtfVSwdw8bESMmwKYNhl5/PON+RizZZsgGZeJ8O1o+s4R/g==
+"@sentry-internal/rrweb-types@2.32.0-dev.2":
+  version "2.32.0-dev.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.32.0-dev.2.tgz#6a4657dfb309dd92ced336bb6b656b885a80e281"
+  integrity sha512-fdPcSRskcVbJT3KKyOPSgibbwiiQ3a3oepJ3LULJZYcPZCdU1ToBI50NqyNGnsIIHuSEb/WkLKIbgee/uqkTMw==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.1"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.2"
     "@types/css-font-loading-module" "0.0.7"
 
-"@sentry-internal/rrweb@2.32.0-dev.1":
-  version "2.32.0-dev.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.32.0-dev.1.tgz#55a6c136cb65297ef7e1077a86c5b9a145535c3a"
-  integrity sha512-GMSPAdMDHDuCfNxYdqAWWkJao9DJSTxS/SAiyKcCQC7RgMHIC1UWJ+GVQ3tOnlPXJxTnMxkHQ73hvbgxoGx64Q==
+"@sentry-internal/rrweb@2.32.0-dev.2":
+  version "2.32.0-dev.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.32.0-dev.2.tgz#4f56cb5ca6257b8367df8f30fb3ad95248299bd2"
+  integrity sha512-r1/AtswnXnD+fFfp2PN59xoYsUlG9g/mIoGj1Z6QOYmt517S8burpAuB4hZ2YTITbCZG/0X5acaTQuNAC0svjQ==
   dependencies:
-    "@sentry-internal/rrdom" "2.32.0-dev.1"
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.1"
-    "@sentry-internal/rrweb-types" "2.32.0-dev.1"
+    "@sentry-internal/rrdom" "2.32.0-dev.2"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.2"
+    "@sentry-internal/rrweb-types" "2.32.0-dev.2"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6537,34 +6537,34 @@
     "@angular-devkit/schematics" "14.2.13"
     jsonc-parser "3.1.0"
 
-"@sentry-internal/rrdom@2.32.0-dev.2":
-  version "2.32.0-dev.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.32.0-dev.2.tgz#624d39c0c5086c74673fa20246851c6ec6a38efd"
-  integrity sha512-bjahxy+RKU+lk61p6IH8XrbyeJYb05PZd7lqQ/VcvFEuas5lUGvavwMIDLmqJM3SugPqkIv2PlVvYqdPi483sQ==
+"@sentry-internal/rrdom@2.32.0-dev.3":
+  version "2.32.0-dev.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.32.0-dev.3.tgz#f0cb2c523c61b9504c2e9ceb40e77b23cf8cc8eb"
+  integrity sha512-eUIm/ZqWKdlWzwY3Z6zm8iGjUgFdN+iY73ahP9wr/cTSjl9DJlg9845gEXA9NiQuK8fCOsDbNrfECI10JlLjCA==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.2"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.3"
 
-"@sentry-internal/rrweb-snapshot@2.32.0-dev.2":
-  version "2.32.0-dev.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.32.0-dev.2.tgz#c33ccdb00765490c9415400b714baa06f0d47134"
-  integrity sha512-u6lTltSFDp9IP9pquwMjQiSxD34xoH/o2GT0U6fgJvwt30RTsN5Q6NYWufHPOz/lj3EzOxG0415yp/fMWKSmOg==
+"@sentry-internal/rrweb-snapshot@2.32.0-dev.3":
+  version "2.32.0-dev.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.32.0-dev.3.tgz#3f1a596cfedea84d6d5bf9c32794bc657cadbf2d"
+  integrity sha512-ZDJ7F9K47S3XYtG5DADOCgaiOTSc7uXmZVkKHq03Cajjv+qrkQ8lPwoNI/8uGZ8bzw4Y2ruPRl8S/CTh0Rz3eQ==
 
-"@sentry-internal/rrweb-types@2.32.0-dev.2":
-  version "2.32.0-dev.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.32.0-dev.2.tgz#6a4657dfb309dd92ced336bb6b656b885a80e281"
-  integrity sha512-fdPcSRskcVbJT3KKyOPSgibbwiiQ3a3oepJ3LULJZYcPZCdU1ToBI50NqyNGnsIIHuSEb/WkLKIbgee/uqkTMw==
+"@sentry-internal/rrweb-types@2.32.0-dev.3":
+  version "2.32.0-dev.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.32.0-dev.3.tgz#0a760b234db3a29197afbe0a4dbe046d8c6cc87e"
+  integrity sha512-wLUx+dmnC6xeIr3Nbpu1n79JlyKJrAFOb6W8Z6ZumfQVDXmjc4YFACtB+XKoHlwm9WUPzdnEct9QmOMOdLUFTw==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.2"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.3"
     "@types/css-font-loading-module" "0.0.7"
 
-"@sentry-internal/rrweb@2.32.0-dev.2":
-  version "2.32.0-dev.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.32.0-dev.2.tgz#4f56cb5ca6257b8367df8f30fb3ad95248299bd2"
-  integrity sha512-r1/AtswnXnD+fFfp2PN59xoYsUlG9g/mIoGj1Z6QOYmt517S8burpAuB4hZ2YTITbCZG/0X5acaTQuNAC0svjQ==
+"@sentry-internal/rrweb@2.32.0-dev.3":
+  version "2.32.0-dev.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.32.0-dev.3.tgz#15c0e09dcbb212934df1cb617c2df83060bea55b"
+  integrity sha512-mhujbk/FCyvbcEm35nrBAUr+a+G6GCngRUMD5PuvoGh9p6IoDrbocNgjhF+H/TlCor03KnOxLhw40FGCJnoeFg==
   dependencies:
-    "@sentry-internal/rrdom" "2.32.0-dev.2"
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.2"
-    "@sentry-internal/rrweb-types" "2.32.0-dev.2"
+    "@sentry-internal/rrdom" "2.32.0-dev.3"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.3"
+    "@sentry-internal/rrweb-types" "2.32.0-dev.3"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6537,34 +6537,34 @@
     "@angular-devkit/schematics" "14.2.13"
     jsonc-parser "3.1.0"
 
-"@sentry-internal/rrdom@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.31.0.tgz#548773964167ec104d3cbb9d7a4b25103c091e06"
-  integrity sha512-6sCgyKZy0Jpkb0wQ2XYLNcJjCETfbjHJ5jroAm2mU1imoSBlAldtNTdMc0wk8MaX/0q5qkMlr78SiYFf7xo12Q==
+"@sentry-internal/rrdom@2.32.0-dev.0":
+  version "2.32.0-dev.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.32.0-dev.0.tgz#262a3f0798110e47181bd52d1be197600dd79edd"
+  integrity sha512-Yt7TEnEUPK++/xIBNHkIy8HEDzBk116RIfZUr5bPY+m0Wm0cgVaYf6EI2U4F/HcaCck+RYJqkxeQfTUN1j5tRw==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.31.0"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.0"
 
-"@sentry-internal/rrweb-snapshot@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.31.0.tgz#7a86d02429a490f6367d7aead0548fad7e0c9487"
-  integrity sha512-uGyJPfmOaiSZOZyd5HFiI8aCd/pPOtrZB89BJBgdB63++wD9Fry8OoWvRORzTo+N+Squummkq3Iucjm/yGdbAw==
+"@sentry-internal/rrweb-snapshot@2.32.0-dev.0":
+  version "2.32.0-dev.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.32.0-dev.0.tgz#2ff8a97053fdb3c3be9e615e54c2d2c5cbde587d"
+  integrity sha512-Nb5gvy5y5u5Y48NFLatkW3e5F7cV504LaBtwhmdXXUobpbSo/NHiLzl4OEnmwV6hB4W/87XZj44GlgtYKmOBsg==
 
-"@sentry-internal/rrweb-types@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.31.0.tgz#daf766526efff760eb6020ddf22c6432db9ff6a6"
-  integrity sha512-rWNCU6KaYopmd+353KBbRuNftpqfI97GdNFeCmB1wwwV/S2CW/lVcEn1uzMwzs8blm3YL2i/O+ykONxecQj+BQ==
+"@sentry-internal/rrweb-types@2.32.0-dev.0":
+  version "2.32.0-dev.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.32.0-dev.0.tgz#e32de6aa5018eb6ff4c0be88c87002fa46ec17ef"
+  integrity sha512-jtfUkAZ0/2HDa+R8wVl68M0dJXp+a7/szbXhU859lunBRM3sWL4hUeQkUnWEJSuUVcjUD71Mhw8iYc+1weFeOA==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.31.0"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.0"
     "@types/css-font-loading-module" "0.0.7"
 
-"@sentry-internal/rrweb@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.31.0.tgz#69c6f6a4304c4d7446c3a1cc1c9b044d5dc4f040"
-  integrity sha512-u1uobvl5qnjtdhL2lrzbpwROZagc5xT1P2lANXxrKpLOUpp2+jMSjq0Zt2TElj+2aHlqh4lkDsj/OIa/FBHnnQ==
+"@sentry-internal/rrweb@2.32.0-dev.0":
+  version "2.32.0-dev.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.32.0-dev.0.tgz#db80d794860aa59bb6bbdccef759fc9d1c6789b3"
+  integrity sha512-zmAES6oLpfjQ/16RhznHnomRMvRL4Iu/zuRM0elwUJ/+uZdaCgFez3uZLC14Hfc0ljIEQlsQ4fhQEq/qYvRpQQ==
   dependencies:
-    "@sentry-internal/rrdom" "2.31.0"
-    "@sentry-internal/rrweb-snapshot" "2.31.0"
-    "@sentry-internal/rrweb-types" "2.31.0"
+    "@sentry-internal/rrdom" "2.32.0-dev.0"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.0"
+    "@sentry-internal/rrweb-types" "2.32.0-dev.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6537,34 +6537,34 @@
     "@angular-devkit/schematics" "14.2.13"
     jsonc-parser "3.1.0"
 
-"@sentry-internal/rrdom@2.32.0-dev.0":
-  version "2.32.0-dev.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.32.0-dev.0.tgz#262a3f0798110e47181bd52d1be197600dd79edd"
-  integrity sha512-Yt7TEnEUPK++/xIBNHkIy8HEDzBk116RIfZUr5bPY+m0Wm0cgVaYf6EI2U4F/HcaCck+RYJqkxeQfTUN1j5tRw==
+"@sentry-internal/rrdom@2.32.0-dev.1":
+  version "2.32.0-dev.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.32.0-dev.1.tgz#f84cdff9c99952b010a99abe7029dd1847be89e3"
+  integrity sha512-07yupHgbVIF7eRNy7K6NBm/2FM7I+q04HPNpsaAZQ5E6PgNUOPdJ5YtdrKLPkGCQa4YUsK0hQo6AFLsJb3u2OQ==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.0"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.1"
 
-"@sentry-internal/rrweb-snapshot@2.32.0-dev.0":
-  version "2.32.0-dev.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.32.0-dev.0.tgz#2ff8a97053fdb3c3be9e615e54c2d2c5cbde587d"
-  integrity sha512-Nb5gvy5y5u5Y48NFLatkW3e5F7cV504LaBtwhmdXXUobpbSo/NHiLzl4OEnmwV6hB4W/87XZj44GlgtYKmOBsg==
+"@sentry-internal/rrweb-snapshot@2.32.0-dev.1":
+  version "2.32.0-dev.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.32.0-dev.1.tgz#67fbcb3b88818683e59882572b3b02b18873df6c"
+  integrity sha512-w66xQsof7DKBwRcNFnN40XBofxFLx6I9/H09qHST+uYrTw0XyJvndRrkxAPpFsca+Fe6E4PanrEL1GRPKgq0DQ==
 
-"@sentry-internal/rrweb-types@2.32.0-dev.0":
-  version "2.32.0-dev.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.32.0-dev.0.tgz#e32de6aa5018eb6ff4c0be88c87002fa46ec17ef"
-  integrity sha512-jtfUkAZ0/2HDa+R8wVl68M0dJXp+a7/szbXhU859lunBRM3sWL4hUeQkUnWEJSuUVcjUD71Mhw8iYc+1weFeOA==
+"@sentry-internal/rrweb-types@2.32.0-dev.1":
+  version "2.32.0-dev.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.32.0-dev.1.tgz#3b665030b375b73bdd898d98516f881a1fb16b66"
+  integrity sha512-ALJ2R1HC3VJ9TfTLqyNsEGBa3X5F/uefrP24uKkDtfVSwdw8bESMmwKYNhl5/PON+RizZZsgGZeJ8O1o+s4R/g==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.0"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.1"
     "@types/css-font-loading-module" "0.0.7"
 
-"@sentry-internal/rrweb@2.32.0-dev.0":
-  version "2.32.0-dev.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.32.0-dev.0.tgz#db80d794860aa59bb6bbdccef759fc9d1c6789b3"
-  integrity sha512-zmAES6oLpfjQ/16RhznHnomRMvRL4Iu/zuRM0elwUJ/+uZdaCgFez3uZLC14Hfc0ljIEQlsQ4fhQEq/qYvRpQQ==
+"@sentry-internal/rrweb@2.32.0-dev.1":
+  version "2.32.0-dev.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.32.0-dev.1.tgz#55a6c136cb65297ef7e1077a86c5b9a145535c3a"
+  integrity sha512-GMSPAdMDHDuCfNxYdqAWWkJao9DJSTxS/SAiyKcCQC7RgMHIC1UWJ+GVQ3tOnlPXJxTnMxkHQ73hvbgxoGx64Q==
   dependencies:
-    "@sentry-internal/rrdom" "2.32.0-dev.0"
-    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.0"
-    "@sentry-internal/rrweb-types" "2.32.0-dev.0"
+    "@sentry-internal/rrdom" "2.32.0-dev.1"
+    "@sentry-internal/rrweb-snapshot" "2.32.0-dev.1"
+    "@sentry-internal/rrweb-types" "2.32.0-dev.1"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
* Merged upstream PRs to change build system to [mostly] use vite.

Ref https://github.com/getsentry/rrweb/pull/234