### PR TITLE
feat(core)!: Stop accepting `event` as argument for `recordDroppedEvent`

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -193,6 +193,7 @@ Sentry.init({
 The following changes are unlikely to affect users of the SDK. They are listed here only for completion sake, and to alert users that may be relying on internal behavior.
 
 - `client._prepareEvent()` now requires a currentScope & isolationScope to be passed as last arugments
+- `client.recordDroppedEvent()` no longer accepts an `event` as third argument. The event was no longer used for some time, instead you can (optionally) pass a count of dropped events as third argument.
 
 ### `@sentry/nestjs`
 

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -1,17 +1,13 @@
+import { DEBUG_BUILD } from '../debug-build';
 import type {
   Envelope,
   EnvelopeItem,
-  EnvelopeItemType,
-  Event,
   EventDropReason,
-  EventItem,
   InternalBaseTransportOptions,
   Transport,
   TransportMakeRequestResponse,
   TransportRequestExecutor,
 } from '../types-hoist';
-
-import { DEBUG_BUILD } from '../debug-build';
 import {
   createEnvelope,
   envelopeItemTypeToDataCategory,
@@ -49,8 +45,7 @@ export function createTransport(
     forEachEnvelopeItem(envelope, (item, type) => {
       const dataCategory = envelopeItemTypeToDataCategory(type);
       if (isRateLimited(rateLimits, dataCategory)) {
-        const event: Event | undefined = getEventForEnvelopeItem(item, type);
-        options.recordDroppedEvent('ratelimit_backoff', dataCategory, event);
+        options.recordDroppedEvent('ratelimit_backoff', dataCategory);
       } else {
         filteredEnvelopeItems.push(item);
       }
@@ -66,8 +61,7 @@ export function createTransport(
     // Creates client report for each item in an envelope
     const recordEnvelopeLoss = (reason: EventDropReason): void => {
       forEachEnvelopeItem(filteredEnvelope, (item, type) => {
-        const event: Event | undefined = getEventForEnvelopeItem(item, type);
-        options.recordDroppedEvent(reason, envelopeItemTypeToDataCategory(type), event);
+        options.recordDroppedEvent(reason, envelopeItemTypeToDataCategory(type));
       });
     };
 
@@ -106,12 +100,4 @@ export function createTransport(
     send,
     flush,
   };
-}
-
-function getEventForEnvelopeItem(item: Envelope[1][number], type: EnvelopeItemType): Event | undefined {
-  if (type !== 'event' && type !== 'transaction') {
-    return undefined;
-  }
-
-  return Array.isArray(item) ? (item as EventItem)[1] : undefined;
 }

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -1517,9 +1517,7 @@ describe('Client', () => {
       client.captureEvent({ message: 'hello' }, {});
 
       expect(beforeSend).toHaveBeenCalled();
-      expect(recordLostEventSpy).toHaveBeenCalledWith('before_send', 'error', {
-        message: 'hello',
-      });
+      expect(recordLostEventSpy).toHaveBeenCalledWith('before_send', 'error');
     });
 
     test('`beforeSendTransaction` records dropped events', () => {
@@ -1539,10 +1537,7 @@ describe('Client', () => {
       client.captureEvent({ transaction: '/dogs/are/great', type: 'transaction' });
 
       expect(beforeSendTransaction).toHaveBeenCalled();
-      expect(recordLostEventSpy).toHaveBeenCalledWith('before_send', 'transaction', {
-        transaction: '/dogs/are/great',
-        type: 'transaction',
-      });
+      expect(recordLostEventSpy).toHaveBeenCalledWith('before_send', 'transaction');
     });
 
     test('event processor drops error event when it returns `null`', () => {
@@ -1594,9 +1589,7 @@ describe('Client', () => {
 
       client.captureEvent({ message: 'hello' }, {}, scope);
 
-      expect(recordLostEventSpy).toHaveBeenCalledWith('event_processor', 'error', {
-        message: 'hello',
-      });
+      expect(recordLostEventSpy).toHaveBeenCalledWith('event_processor', 'error');
     });
 
     test('event processor records dropped transaction events', () => {
@@ -1612,10 +1605,7 @@ describe('Client', () => {
 
       client.captureEvent({ transaction: '/dogs/are/great', type: 'transaction' }, {}, scope);
 
-      expect(recordLostEventSpy).toHaveBeenCalledWith('event_processor', 'transaction', {
-        transaction: '/dogs/are/great',
-        type: 'transaction',
-      });
+      expect(recordLostEventSpy).toHaveBeenCalledWith('event_processor', 'transaction');
     });
 
     test('mutating transaction name with event processors sets transaction-name-change metadata', () => {
@@ -1704,9 +1694,7 @@ describe('Client', () => {
       const recordLostEventSpy = jest.spyOn(client, 'recordDroppedEvent');
 
       client.captureEvent({ message: 'hello' }, {});
-      expect(recordLostEventSpy).toHaveBeenCalledWith('sample_rate', 'error', {
-        message: 'hello',
-      });
+      expect(recordLostEventSpy).toHaveBeenCalledWith('sample_rate', 'error');
     });
 
     test('captures logger message', () => {

--- a/packages/core/test/lib/transports/base.test.ts
+++ b/packages/core/test/lib/transports/base.test.ts
@@ -135,9 +135,7 @@ describe('createTransport', () => {
 
         await transport.send(ERROR_ENVELOPE);
         expect(requestExecutor).not.toHaveBeenCalled();
-        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'error', {
-          event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
-        });
+        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'error');
         requestExecutor.mockClear();
         recordDroppedEventCallback.mockClear();
 
@@ -179,9 +177,7 @@ describe('createTransport', () => {
 
         await transport.send(ERROR_ENVELOPE); // Error envelope should not be sent because of pending rate limit
         expect(requestExecutor).not.toHaveBeenCalled();
-        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'error', {
-          event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
-        });
+        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'error');
         requestExecutor.mockClear();
         recordDroppedEventCallback.mockClear();
 
@@ -223,23 +219,19 @@ describe('createTransport', () => {
 
         await transport.send(TRANSACTION_ENVELOPE); // Transaction envelope should not be sent because of pending rate limit
         expect(requestExecutor).not.toHaveBeenCalled();
-        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'transaction', {
-          event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
-        });
+        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'transaction');
         requestExecutor.mockClear();
         recordDroppedEventCallback.mockClear();
 
         await transport.send(ERROR_ENVELOPE); // Error envelope should not be sent because of pending rate limit
         expect(requestExecutor).not.toHaveBeenCalled();
-        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'error', {
-          event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
-        });
+        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'error');
         requestExecutor.mockClear();
         recordDroppedEventCallback.mockClear();
 
         await transport.send(ATTACHMENT_ENVELOPE); // Attachment envelope should not be sent because of pending rate limit
         expect(requestExecutor).not.toHaveBeenCalled();
-        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'attachment', undefined);
+        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'attachment');
         requestExecutor.mockClear();
         recordDroppedEventCallback.mockClear();
 
@@ -287,17 +279,13 @@ describe('createTransport', () => {
 
         await transport.send(TRANSACTION_ENVELOPE); // Transaction envelope should not be sent because of pending rate limit
         expect(requestExecutor).not.toHaveBeenCalled();
-        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'transaction', {
-          event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
-        });
+        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'transaction');
         requestExecutor.mockClear();
         recordDroppedEventCallback.mockClear();
 
         await transport.send(ERROR_ENVELOPE); // Error envelope should not be sent because of pending rate limit
         expect(requestExecutor).not.toHaveBeenCalled();
-        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'error', {
-          event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
-        });
+        expect(recordDroppedEventCallback).toHaveBeenCalledWith('ratelimit_backoff', 'error');
         requestExecutor.mockClear();
         recordDroppedEventCallback.mockClear();
 

--- a/packages/replay-internal/src/util/sendReplayRequest.ts
+++ b/packages/replay-internal/src/util/sendReplayRequest.ts
@@ -53,7 +53,7 @@ export async function sendReplayRequest({
 
   if (!replayEvent) {
     // Taken from baseclient's `_processEvent` method, where this is handled for errors/transactions
-    client.recordDroppedEvent('event_processor', 'replay', baseEvent);
+    client.recordDroppedEvent('event_processor', 'replay');
     DEBUG_BUILD && logger.info('An event processor returned `null`, will not send event.');
     return resolvedSyncPromise({});
   }


### PR DESCRIPTION
The event was no longer used for some time, instead you can (optionally) pass a count of dropped events as third argument. This has been around since v7, so we can finally clean this up here, which should also save some bytes.

This was not really deprecated before, but is also more an intimate API so I do not expect this to affect users too much. Also, deprecating arguments like this does not really work well with eslint anyhow, so even if we would deprecate it it is unlikely users would find out anyhow.