### PR TITLE
fix(aws-lambda): Avoid overwriting root span name

### DIFF
--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -220,10 +220,7 @@ function enhanceScopeWithEnvironmentData(scope: Scope, context: Context, startTi
  * @param context AWS Lambda context that will be used to extract some part of the data
  */
 function enhanceScopeWithTransactionData(scope: Scope, context: Context): void {
-  scope.addEventProcessor(event => {
-    event.transaction = context.functionName;
-    return event;
-  });
+  scope.setTransactionName(context.functionName);
   scope.setTag('server_name', process.env._AWS_XRAY_DAEMON_ADDRESS || process.env.SENTRY_NAME || hostname());
   scope.setTag('url', `awslambda:///${context.functionName}`);
 }

--- a/packages/aws-serverless/test/sdk.test.ts
+++ b/packages/aws-serverless/test/sdk.test.ts
@@ -18,6 +18,7 @@ const mockScope = {
   setTag: jest.fn(),
   setContext: jest.fn(),
   addEventProcessor: jest.fn(),
+  setTransactionName: jest.fn(),
 };
 
 jest.mock('@sentry/node', () => {
@@ -81,12 +82,8 @@ const fakeCallback: Callback = (err, result) => {
 };
 
 function expectScopeSettings() {
-  expect(mockScope.addEventProcessor).toBeCalledTimes(1);
-  // Test than an event processor to add `transaction` is registered for the scope
-  const eventProcessor = mockScope.addEventProcessor.mock.calls[0][0];
-  const event: Event = {};
-  eventProcessor(event);
-  expect(event).toEqual({ transaction: 'functionName' });
+  expect(mockScope.setTransactionName).toBeCalledTimes(1);
+  expect(mockScope.setTransactionName).toBeCalledWith('functionName');
 
   expect(mockScope.setTag).toBeCalledWith('server_name', expect.anything());
 

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -342,12 +342,12 @@ export class Scope {
   }
 
   /**
-   * Sets the transaction name on the scope so that the name of the transaction
-   * (e.g. taken server route or page location) is attached to future events.
+   * Sets the transaction name on the scope so that the name of e.g. taken server route or
+   * the page location is attached to future events.
    *
    * IMPORTANT: Calling this function does NOT change the name of the currently active
-   * span. If you want to change the name of the active span, use `span.updateName()`
-   * instead.
+   * root span. If you want to change the name of the active root span, use
+   * `Sentry.updateSpanName(rootSpan, 'new name')` instead.
    *
    * By default, the SDK updates the scope's transaction name automatically on sensible
    * occasions, such as a page navigation or when handling a new request on the server.


### PR DESCRIPTION
Came across this by chance: Updating `event.transaction` in an event processor without checking for the type also always overwrites the root span name. To fix this, this PR calls `scope.updateTransactionName` which updates the error location "transaction" name on the scope. This is only applied to error events during event processing, so the intention is clearer than adding an event processor. 

This was mentioned in https://github.com/getsentry/sentry-javascript/issues/13391 but admittedly I must have misread the issue because I'm 99% sure the event processor was unintended behaviour from our end. 