### PR TITLE
test(e2e): Fix node-express test transitive dependency

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express/package.json
@@ -15,15 +15,18 @@
     "@sentry/node": "latest || *",
     "@trpc/server": "10.45.2",
     "@trpc/client": "10.45.2",
-    "@types/express": "4.17.17",
+    "@types/express": "^4.17.21",
     "@types/node": "^18.19.1",
-    "express": "4.20.0",
+    "express": "^4.21.2",
     "typescript": "~5.0.0",
     "zod": "~3.22.4"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.1",
     "@sentry-internal/test-utils": "link:../../../test-utils"
+  },
+  "resolutions": {
+    "@types/qs": "6.9.17"
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/node-express/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/node-express/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "types": ["node"],
     "esModuleInterop": true,
-    "lib": ["es2018"],
+    "lib": ["es2020"],
     "strict": true,
     "outDir": "dist"
   },


### PR DESCRIPTION
It seems that `@types/qs` v 6.9.18 which was just released breaks this somehow...

Noticed here: https://github.com/getsentry/sentry-javascript/pull/14998