### PR TITLE
test(node): Ensure client reports do not make tests flaky

### DIFF
--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/test.ts
@@ -6,6 +6,7 @@ afterAll(() => {
 
 test('should record client report for beforeSend', done => {
   createRunner(__dirname, 'scenario.ts')
+    .unignore('client_report')
     .expect({
       client_report: {
         discarded_events: [

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/test.ts
@@ -6,6 +6,7 @@ afterAll(() => {
 
 test('should record client report for event processors', done => {
   createRunner(__dirname, 'scenario.ts')
+    .unignore('client_report')
     .expect({
       client_report: {
         discarded_events: [

--- a/dev-packages/node-integration-tests/suites/client-reports/periodic-send/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/periodic-send/test.ts
@@ -6,6 +6,7 @@ afterAll(() => {
 
 test('should flush client reports automatically after the timeout interval', done => {
   createRunner(__dirname, 'scenario.ts')
+    .unignore('client_report')
     .expect({
       client_report: {
         discarded_events: [

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/test.ts
@@ -27,7 +27,6 @@ test('outgoing http requests are correctly instrumented when not sampled', done 
     .then(([SERVER_URL, closeTestServer]) => {
       createRunner(__dirname, 'scenario.ts')
         .withEnv({ SERVER_URL })
-        .ignore('client_report')
         .expect({
           event: {
             exception: {

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -152,7 +152,7 @@ export function createRunner(...paths: string[]) {
   let expectedEnvelopeHeaders: ExpectedEnvelopeHeader[] | undefined = undefined;
   const flags: string[] = [];
   // By default, we ignore session & sessions
-  const ignored: Set<EnvelopeItemType> = new Set(['session', 'sessions']);
+  const ignored: Set<EnvelopeItemType> = new Set(['session', 'sessions', 'client_report']);
   let withEnv: Record<string, string> = {};
   let withSentryServer = false;
   let dockerOptions: DockerOptions | undefined;


### PR DESCRIPTION
They are now ignored by default, unless we specifically want to test them.

Noticed e.g. here https://github.com/getsentry/sentry-javascript/actions/runs/12767810178/job/35587298600?pr=14999 that this can be flaky now.