### PR TITLE
feat(gatsby): Preserve user-provided source map settings

### DIFF
--- a/packages/gatsby/test/gatsby-node.test.ts
+++ b/packages/gatsby/test/gatsby-node.test.ts
@@ -28,12 +28,12 @@ describe('onCreateWebpackConfig', () => {
       setWebpackConfig: jest.fn(),
     };
 
-    const getConfig = jest.fn();
+    const getConfig = jest.fn().mockReturnValue({ devtool: 'source-map' });
 
     onCreateWebpackConfig({ actions, getConfig }, {});
 
     expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1);
-    expect(actions.setWebpackConfig).toHaveBeenLastCalledWith({ plugins: expect.any(Array) });
+    expect(actions.setWebpackConfig).toHaveBeenLastCalledWith({ devtool: 'source-map', plugins: expect.any(Array) });
   });
 
   it('does not set a webpack config if enableClientWebpackPlugin is false', () => {
@@ -41,30 +41,121 @@ describe('onCreateWebpackConfig', () => {
       setWebpackConfig: jest.fn(),
     };
 
-    const getConfig = jest.fn();
+    const getConfig = jest.fn().mockReturnValue({ devtool: 'source-map' });
 
     onCreateWebpackConfig({ actions, getConfig }, { enableClientWebpackPlugin: false });
 
     expect(actions.setWebpackConfig).toHaveBeenCalledTimes(0);
   });
 
-  it('sets sourceMapFilesToDeleteAfterUpload when provided in options', () => {
+  describe('delete source maps after upload', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
     const actions = {
       setWebpackConfig: jest.fn(),
     };
 
     const getConfig = jest.fn();
 
-    onCreateWebpackConfig({ actions, getConfig }, { deleteSourcemapsAfterUpload: true });
+    it('sets sourceMapFilesToDeleteAfterUpload when provided in options', () => {
+      const actions = {
+        setWebpackConfig: jest.fn(),
+      };
 
-    expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1);
+      const getConfig = jest.fn().mockReturnValue({ devtool: 'source-map' });
 
-    expect(sentryWebpackPlugin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourcemaps: expect.objectContaining({
-          filesToDeleteAfterUpload: ['./public/**/*.map'],
+      onCreateWebpackConfig({ actions, getConfig }, { deleteSourcemapsAfterUpload: true });
+
+      expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1);
+
+      expect(sentryWebpackPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourcemaps: expect.objectContaining({
+            filesToDeleteAfterUpload: ['./public/**/*.map'],
+          }),
         }),
-      }),
-    );
+      );
+    });
+
+    test.each([
+      {
+        name: 'without provided options: sets hidden source maps and deletes source maps',
+        initialConfig: undefined,
+        options: {},
+        expected: {
+          devtool: 'hidden-source-map',
+          deleteSourceMaps: true,
+        },
+      },
+      {
+        name: "preserves enabled source-map and doesn't delete",
+        initialConfig: { devtool: 'source-map' },
+        options: {},
+        expected: {
+          devtool: 'source-map',
+          deleteSourceMaps: false,
+        },
+      },
+      {
+        name: "preserves enabled hidden-source-map and doesn't delete",
+        initialConfig: { devtool: 'hidden-source-map' },
+        options: {},
+        expected: {
+          devtool: 'hidden-source-map',
+          deleteSourceMaps: false,
+        },
+      },
+      {
+        name: 'deletes source maps, when user explicitly sets it',
+        initialConfig: { devtool: 'eval' },
+        options: {},
+        expected: {
+          devtool: 'hidden-source-map',
+          deleteSourceMaps: true,
+        },
+      },
+      {
+        name: 'explicit deleteSourcemapsAfterUpload true',
+        initialConfig: { devtool: 'source-map' },
+        options: { deleteSourcemapsAfterUpload: true },
+        expected: {
+          devtool: 'source-map',
+          deleteSourceMaps: true,
+        },
+      },
+      {
+        name: 'explicit deleteSourcemapsAfterUpload false',
+        initialConfig: { devtool: 'hidden-source-map' },
+        options: { deleteSourcemapsAfterUpload: false },
+        expected: {
+          devtool: 'hidden-source-map',
+          deleteSourceMaps: false,
+        },
+      },
+    ])('$name', ({ initialConfig, options, expected }) => {
+      getConfig.mockReturnValue(initialConfig);
+
+      onCreateWebpackConfig({ actions: actions, getConfig: getConfig }, options);
+
+      expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1);
+
+      expect(actions.setWebpackConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          devtool: expected.devtool,
+          plugins: expect.arrayContaining([expect.any(Object)]),
+        }),
+      );
+
+      expect(sentryWebpackPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourcemaps: expect.objectContaining({
+            assets: ['./public/**'],
+            filesToDeleteAfterUpload: expected.deleteSourceMaps ? ['./public/**/*.map'] : undefined,
+          }),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/14993

Generates source maps and deletes them after uploading them to Sentry per default.

Scenarios:
1. users set `config.devtool` to generate source maps -> keep `config.devtool` (a.k.a. source map) setting
2. users set `config.devtool` to something different that "source-map" or "hidden-source-map"
3. `config.devtool` is not defined

--> In case 3 we are automatically setting `filesToDeleteafterUpload`
But `deleteFilesAfterUpload: true` overwrites the behavior and will always delete the source maps. Also in case 1 and 2.
