### PR TITLE
feat: Only emit `__esModule` properties in CJS modules when there is a default export

### DIFF
--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -30,7 +30,6 @@ const packageDotJSON = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), '.
 export function makeBaseNPMConfig(options = {}) {
   const {
     entrypoints = ['src/index.ts'],
-    esModuleInterop = false,
     hasBundles = false,
     packageSpecificConfig = {},
     sucrase = {},
@@ -83,16 +82,7 @@ export function makeBaseNPMConfig(options = {}) {
       // (We don't need it, so why waste the bytes?)
       freeze: false,
 
-      // Equivalent to `esModuleInterop` in tsconfig.
-      // Controls whether rollup emits helpers to handle special cases where turning
-      //     `import * as dogs from 'dogs'`
-      // into
-      //     `const dogs = require('dogs')`
-      // doesn't work.
-      //
-      // `auto` -> emit helpers
-      // `esModule` -> don't emit helpers
-      interop: esModuleInterop ? 'auto' : 'esModule',
+      interop: 'esModule',
     },
 
     plugins: [

--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -56,9 +56,8 @@ export function makeBaseNPMConfig(options = {}) {
 
       sourcemap: true,
 
-      // Include __esModule property when generating exports
-      // Before the upgrade to Rollup 4 this was included by default and when it was gone it broke tests
-      esModule: true,
+      // Include __esModule property when there is a default prop
+      esModule: 'if-default-prop',
 
       // output individual files rather than one big bundle
       preserveModules: true,

--- a/packages/react/rollup.npm.config.mjs
+++ b/packages/react/rollup.npm.config.mjs
@@ -2,7 +2,6 @@ import { makeBaseNPMConfig, makeNPMConfigVariants } from '@sentry-internal/rollu
 
 export default makeNPMConfigVariants(
   makeBaseNPMConfig({
-    esModuleInterop: true,
     packageSpecificConfig: {
       external: ['react', 'react/jsx-runtime'],
     },

--- a/packages/react/test/sdk.test.ts
+++ b/packages/react/test/sdk.test.ts
@@ -2,6 +2,13 @@ import * as SentryBrowser from '@sentry/browser';
 import { version } from 'react';
 import { init } from '../src/sdk';
 
+jest.mock('@sentry/browser', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('@sentry/browser'),
+  };
+});
+
 describe('init', () => {
   it('sets the React version (if available) in the global scope', () => {
     const setContextSpy = jest.spyOn(SentryBrowser, 'setContext');

--- a/packages/remix/test/index.client.test.ts
+++ b/packages/remix/test/index.client.test.ts
@@ -2,6 +2,13 @@ import * as SentryReact from '@sentry/react';
 
 import { init } from '../src/index.client';
 
+jest.mock('@sentry/react', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('@sentry/react'),
+  };
+});
+
 const reactInit = jest.spyOn(SentryReact, 'init');
 
 describe('Client init()', () => {

--- a/packages/remix/test/index.server.test.ts
+++ b/packages/remix/test/index.server.test.ts
@@ -2,6 +2,13 @@ import * as SentryNode from '@sentry/node';
 
 import { init } from '../src/index.server';
 
+jest.mock('@sentry/node', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('@sentry/node'),
+  };
+});
+
 const nodeInit = jest.spyOn(SentryNode, 'init');
 
 describe('Server init()', () => {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/3105

By having the `__esModule` property in files where we don't have default exports we may trick tooling into thinking that there would be a default export. The probability of that happening nowadays is pretty low, but since `__esModule` is a non-standard property we should limit it to the minimum.