### PR TITLE
feat(ember)!: Officially drop support for ember `<=3.x`

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -45,7 +45,7 @@ Support for the following Framework versions is dropped:
 - **Remix**: Version `1.x`
 - **TanStack Router**: Version `1.63.0` and lower
 - **SvelteKit**: SvelteKit version `1.x`
-- **Ember.js**: Ember.js version `3.x` and lower
+- **Ember.js**: Ember.js version `3.x` and lower (minimum supported version is `4.x`)
 
 ### TypeScript Version Policy
 

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -39,6 +39,14 @@
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "ember-cli": ">=4"
+  },
+  "peerDependenciesMeta": {
+    "ember-cli": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@ember/optional-features": "~1.3.0",
     "@ember/test-helpers": "4.0.4",


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/14263