### PR TITLE
feat(browser): Add `multiplexedtransport.js` CDN bundle

### DIFF
--- a/dev-packages/browser-integration-tests/suites/transport/multiplexed/init.js
+++ b/dev-packages/browser-integration-tests/suites/transport/multiplexed/init.js
@@ -1,12 +1,12 @@
 import * as Sentry from '@sentry/browser';
 
-import { makeFetchTransport, makeMultiplexedTransport } from '@sentry/browser';
+import { makeMultiplexedTransport } from '@sentry/browser';
 
 window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  transport: makeMultiplexedTransport(makeFetchTransport, ({ getEvent }) => {
+  transport: makeMultiplexedTransport(Sentry.makeFetchTransport, ({ getEvent }) => {
     const event = getEvent('event');
 
     if (event.tags.to === 'a') {

--- a/dev-packages/browser-integration-tests/suites/transport/multiplexed/init.js
+++ b/dev-packages/browser-integration-tests/suites/transport/multiplexed/init.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 
-import { makeMultiplexedTransport, makeFetchTransport } from '@sentry/browser';
+import { makeFetchTransport, makeMultiplexedTransport } from '@sentry/browser';
 
 window.Sentry = Sentry;
 

--- a/dev-packages/browser-integration-tests/suites/transport/multiplexed/init.js
+++ b/dev-packages/browser-integration-tests/suites/transport/multiplexed/init.js
@@ -1,0 +1,20 @@
+import * as Sentry from '@sentry/browser';
+
+import { makeMultiplexedTransport, makeFetchTransport } from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  transport: makeMultiplexedTransport(makeFetchTransport, ({ getEvent }) => {
+    const event = getEvent('event');
+
+    if (event.tags.to === 'a') {
+      return ['https://public@dsn.ingest.sentry.io/1337'];
+    } else if (event.tags.to === 'b') {
+      return ['https://public@dsn.ingest.sentry.io/1337'];
+    } else {
+      throw new Error('Unknown destination');
+    }
+  }),
+});

--- a/dev-packages/browser-integration-tests/suites/transport/multiplexed/subject.js
+++ b/dev-packages/browser-integration-tests/suites/transport/multiplexed/subject.js
@@ -1,0 +1,10 @@
+setTimeout(() => {
+  Sentry.withScope(scope => {
+    scope.setTag('to', 'a');
+    Sentry.captureException(new Error('Error a'));
+  });
+  Sentry.withScope(scope => {
+    scope.setTag('to', 'b');
+    Sentry.captureException(new Error('Error b'));
+  });
+}, 0);

--- a/dev-packages/browser-integration-tests/suites/transport/multiplexed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/transport/multiplexed/test.ts
@@ -1,0 +1,20 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/core';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getMultipleSentryEnvelopeRequests } from '../../../utils/helpers';
+
+sentryTest('sends event to DSNs specified in makeMultiplexedTransport', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const errorEvents = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { envelopeType: 'event', url });
+
+  expect(errorEvents).toHaveLength(2);
+
+  const [evt1, evt2] = errorEvents;
+
+  const errorA = evt1?.tags?.to === 'a' ? evt1 : evt2;
+  const errorB = evt1?.tags?.to === 'b' ? evt1 : evt2;
+
+  expect(errorA.tags?.to).toBe('a');
+  expect(errorB.tags?.to).toBe('b');
+});

--- a/dev-packages/browser-integration-tests/utils/generatePlugin.ts
+++ b/dev-packages/browser-integration-tests/utils/generatePlugin.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import type { Package } from '@sentry/core';
+import { type Package } from '@sentry/core';
 import HtmlWebpackPlugin, { createHtmlTagObject } from 'html-webpack-plugin';
 import type { Compiler } from 'webpack';
 
@@ -36,6 +36,8 @@ const IMPORTED_INTEGRATION_CDN_BUNDLE_PATHS: Record<string, string> = {
   reportingObserverIntegration: 'reportingobserver',
   feedbackIntegration: 'feedback',
   moduleMetadataIntegration: 'modulemetadata',
+  // technically, this is not an integration, but let's add it anyway for simplicity
+  makeMultiplexedTransport: 'multiplexedtransport',
 };
 
 const BUNDLE_PATHS: Record<string, Record<string, string>> = {

--- a/packages/browser/rollup.bundle.config.mjs
+++ b/packages/browser/rollup.bundle.config.mjs
@@ -36,6 +36,19 @@ reexportedPluggableIntegrationFiles.forEach(integrationName => {
   builds.push(...makeBundleConfigVariants(integrationsBundleConfig));
 });
 
+// Bundle config for additional exports we don't want to include in the main SDK bundle
+// if we need more of these, we can generalize the config as for pluggable integrations
+builds.push(
+  ...makeBundleConfigVariants(
+    makeBaseBundleConfig({
+      bundleType: 'addon',
+      entrypoints: ['src/pluggable-exports-bundle/index.multiplexedtransport.ts'],
+      licenseTitle: '@sentry/browser - multiplexedtransport',
+      outputFileBase: () => 'bundles/multiplexedtransport',
+    }),
+  ),
+);
+
 const baseBundleConfig = makeBaseBundleConfig({
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.ts'],

--- a/packages/browser/src/pluggable-exports-bundle/index.multiplexedtransport.ts
+++ b/packages/browser/src/pluggable-exports-bundle/index.multiplexedtransport.ts
@@ -1,0 +1,1 @@
+export { makeMultiplexedTransport } from '@sentry/core';


### PR DESCRIPTION
This PR adds a pluggable CDN bundle for `makeMultiplexedTransport`, an API we export from `@sentry/browser` but not from the browser SDK CDN bundles. After discussing #15041, we settled on avoiding to add the export to the bundle directly, as it would unnecessarily increase bundle size for the majority of our user base. 

However, we'll enable using the multiplexed transport in a CDN bundle setup by publishing a pluggable addon bundle for this API that users can add just like our pluggable integration CDN bundles. 

Will open a PR for docs in a bit

closes #15041 
supersedes #14925 