### PR TITLE
ci(e2e-test): Switch to `https://example.com` from http equivalent for Next.js e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-13/pages/fetch.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-13/pages/fetch.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 export default function FetchPage() {
   useEffect(() => {
     // test that a span is created in the pageload transaction for this fetch request
-    fetch('http://example.com').catch(() => {
+    fetch('https://example.com').catch(() => {
       // no-empty
     });
   }, []);

--- a/dev-packages/e2e-tests/test-applications/nextjs-13/tests/client/fetch.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-13/tests/client/fetch.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 
 test('should correctly instrument `fetch` for performance tracing', async ({ page }) => {
-  await page.route('http://example.com/**/*', route => {
+  await page.route('https://example.com/**/*', route => {
     return route.fulfill({
       status: 200,
       body: JSON.stringify({
@@ -34,8 +34,8 @@ test('should correctly instrument `fetch` for performance tracing', async ({ pag
       expect.objectContaining({
         data: {
           'http.method': 'GET',
-          url: 'http://example.com',
-          'http.url': 'http://example.com/',
+          url: 'https://example.com',
+          'http.url': 'https://example.com/',
           'server.address': 'example.com',
           type: 'fetch',
           'http.response_content_length': expect.any(Number),
@@ -43,7 +43,7 @@ test('should correctly instrument `fetch` for performance tracing', async ({ pag
           'sentry.op': 'http.client',
           'sentry.origin': 'auto.http.browser',
         },
-        description: 'GET http://example.com',
+        description: 'GET https://example.com',
         op: 'http.client',
         parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
         span_id: expect.stringMatching(/[a-f0-9]{16}/),

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/app/request-instrumentation/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/app/request-instrumentation/page.tsx
@@ -1,11 +1,11 @@
-import http from 'http';
+import https from 'https';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
-  await fetch('http://example.com/', { cache: 'no-cache' }).then(res => res.text());
+  await fetch('https://example.com/', { cache: 'no-cache' }).then(res => res.text());
   await new Promise<void>(resolve => {
-    http.get('http://example.com/', res => {
+    https.get('https://example.com/', res => {
       res.on('data', () => {
         // Noop consuming some data so that request can close :)
       });

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/playwright.config.ts
@@ -5,9 +5,15 @@ if (!testEnv) {
   throw new Error('No test env defined');
 }
 
-const config = getPlaywrightConfig({
-  startCommand: testEnv === 'development' ? 'pnpm next dev -p 3030' : 'pnpm next start -p 3030',
-  port: 3030,
-});
+const config = getPlaywrightConfig(
+  {
+    startCommand: testEnv === 'development' ? 'pnpm next dev -p 3030' : 'pnpm next start -p 3030',
+    port: 3030,
+  },
+  {
+    // This comes with the risk of tests leaking into each other but the tests run quite slow so we should parallelize
+    workers: '100%',
+  },
+);
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/playwright.config.ts
@@ -5,15 +5,9 @@ if (!testEnv) {
   throw new Error('No test env defined');
 }
 
-const config = getPlaywrightConfig(
-  {
-    startCommand: testEnv === 'development' ? 'pnpm next dev -p 3030' : 'pnpm next start -p 3030',
-    port: 3030,
-  },
-  {
-    // This comes with the risk of tests leaking into each other but the tests run quite slow so we should parallelize
-    workers: '100%',
-  },
-);
+const config = getPlaywrightConfig({
+  startCommand: testEnv === 'development' ? 'pnpm next dev -p 3030' : 'pnpm next start -p 3030',
+  port: 3030,
+});
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/tests/request-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/tests/request-instrumentation.test.ts
@@ -19,7 +19,7 @@ test('Should send a transaction with a fetch span', async ({ page }) => {
         'sentry.op': 'http.client',
         'sentry.origin': 'auto.http.otel.node_fetch',
       }),
-      description: 'GET http://example.com/',
+      description: 'GET https://example.com/',
     }),
   );
 
@@ -30,7 +30,7 @@ test('Should send a transaction with a fetch span', async ({ page }) => {
         'sentry.op': 'http.client',
         'sentry.origin': 'auto.http.otel.http',
       }),
-      description: 'GET http://example.com/',
+      description: 'GET https://example.com/',
     }),
   );
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/app/pageload-tracing/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/app/pageload-tracing/page.tsx
@@ -6,7 +6,7 @@ export default async function Page() {
 }
 
 export async function generateMetadata() {
-  (await fetch('http://example.com/', { cache: 'no-store' })).text();
+  (await fetch('https://example.com/', { cache: 'no-store' })).text();
 
   return {
     title: 'my title',

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/app/suspense-error/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/app/suspense-error/page.tsx
@@ -4,7 +4,7 @@ export const dynamic = 'force-dynamic';
 
 export default async function Page() {
   try {
-    use(fetch('http://example.com/'));
+    use(fetch('https://example.com/'));
   } catch (e) {
     Sentry.captureException(e); // This error should not be reported
     await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for any async event processors to run

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/app/server-action/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/app/server-action/page.tsx
@@ -9,7 +9,7 @@ export default function ServerComponent() {
       'myServerAction',
       { formData, headers: headers(), recordResponse: true },
       async () => {
-        await fetch('http://example.com/');
+        await fetch('https://example.com/');
         return { city: 'Vienna' };
       },
     );

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/pages/api/request-instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/pages/api/request-instrumentation.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 export default (_req: NextApiRequest, res: NextApiResponse) => {
   // make an outgoing request in order to test that the `Http` integration creates a span
-  get('http://example.com/', message => {
+  get('https://example.com/', message => {
     message.on('data', () => {
       // Noop consuming some data so that request can close :)
     });

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/request-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/request-instrumentation.test.ts
@@ -18,7 +18,7 @@ test.skip('Should send a transaction with a http span', async ({ request }) => {
         'sentry.op': 'http.client',
         'sentry.origin': 'auto.http.otel.http',
       }),
-      description: 'GET http://example.com/',
+      description: 'GET https://example.com/',
     }),
   );
 });


### PR DESCRIPTION
https seemed more reliable 🙃 