### PR TITLE
test(browser): Test `moduleMetadataIntegration` in CDN bundle integration tests

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/init.js
@@ -1,8 +1,10 @@
 import * as Sentry from '@sentry/browser';
 
+import { moduleMetadataIntegration } from '@sentry/browser';
+
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [Sentry.moduleMetadataIntegration()],
+  integrations: [moduleMetadataIntegration()],
   beforeSend(event) {
     const moduleMetadataEntries = [];
 

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/test.ts
@@ -5,11 +5,6 @@ import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should provide module_metadata on stack frames in beforeSend', async ({ getLocalTestUrl, page }) => {
-  // moduleMetadataIntegration is not included in any CDN bundles
-  if (process.env.PW_BUNDLE?.startsWith('bundle')) {
-    sentryTest.skip();
-  }
-
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const errorEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/init.js
@@ -1,10 +1,13 @@
 import * as Sentry from '@sentry/browser';
 
+import { moduleMetadataIntegration } from '@sentry/browser';
+import { rewriteFramesIntegration } from '@sentry/browser';
+
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
-    Sentry.moduleMetadataIntegration(),
-    Sentry.rewriteFramesIntegration({
+    moduleMetadataIntegration(),
+    rewriteFramesIntegration({
       iteratee: frame => {
         return {
           ...frame,

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/test.ts
@@ -7,11 +7,6 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 sentryTest(
   'should provide module_metadata on stack frames in beforeSend even though an event processor (rewriteFramesIntegration) modified the filename',
   async ({ getLocalTestUrl, page }) => {
-    // moduleMetadataIntegration is not included in any CDN bundles
-    if (process.env.PW_BUNDLE?.startsWith('bundle')) {
-      sentryTest.skip();
-    }
-
     const url = await getLocalTestUrl({ testDir: __dirname });
 
     const errorEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch/test.ts
@@ -17,12 +17,8 @@ sentryTest('should create spans for fetch requests', async ({ getLocalTestUrl, p
 
   // We will wait 500ms for all envelopes to be sent. Generally, in all browsers, the last sent
   // envelope contains tracing data.
-  const events = await getMultipleSentryEnvelopeRequests<Event>(page, 1, {
-    url,
-    timeout: 10000,
-    envelopeType: 'transaction',
-  });
-  const tracingEvent = events[0];
+  const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 4, { url, timeout: 10000 });
+  const tracingEvent = envelopes.find(event => event.type === 'transaction')!; // last envelope contains tracing data on all browsers
 
   const requestSpans = tracingEvent.spans?.filter(({ op }) => op === 'http.client');
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch/test.ts
@@ -17,8 +17,12 @@ sentryTest('should create spans for fetch requests', async ({ getLocalTestUrl, p
 
   // We will wait 500ms for all envelopes to be sent. Generally, in all browsers, the last sent
   // envelope contains tracing data.
-  const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 4, { url, timeout: 10000 });
-  const tracingEvent = envelopes.find(event => event.type === 'transaction')!; // last envelope contains tracing data on all browsers
+  const events = await getMultipleSentryEnvelopeRequests<Event>(page, 1, {
+    url,
+    timeout: 10000,
+    envelopeType: 'transaction',
+  });
+  const tracingEvent = events[0];
 
   const requestSpans = tracingEvent.spans?.filter(({ op }) => op === 'http.client');
 


### PR DESCRIPTION
Just noticed that these tests were skipped for CDN bundles. Since we publish moduleMetadata CDN bundles since #13822, we can also enable these tests.  