### PR TITLE
test(node): Use https version of example.com in Node integration tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
@@ -1,6 +1,5 @@
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
-const http = require('http');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -23,6 +22,8 @@ Sentry.init({
     }),
   ],
 });
+
+const https = require('https');
 
 // express must be required after Sentry is initialized
 const express = require('express');
@@ -55,7 +56,7 @@ startExpressServerAndSendPortToRunner(app);
 
 function makeHttpRequest(url) {
   return new Promise((resolve, reject) => {
-    http
+    https
       .get(url, res => {
         res.on('data', () => {});
         res.on('end', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
@@ -11,7 +11,7 @@ Sentry.init({
   integrations: [
     Sentry.httpIntegration({
       ignoreOutgoingRequests: (url, request) => {
-        if (url === 'http://example.com/blockUrl') {
+        if (url === 'https://example.com/blockUrl') {
           return true;
         }
 
@@ -34,16 +34,16 @@ const app = express();
 app.use(cors());
 
 app.get('/testUrl', (_req, response) => {
-  makeHttpRequest('http://example.com/blockUrl').then(() => {
-    makeHttpRequest('http://example.com/pass').then(() => {
+  makeHttpRequest('https://example.com/blockUrl').then(() => {
+    makeHttpRequest('https://example.com/pass').then(() => {
       response.send({ response: 'done' });
     });
   });
 });
 
 app.get('/testRequest', (_req, response) => {
-  makeHttpRequest('http://example.com/blockRequest').then(() => {
-    makeHttpRequest('http://example.com/pass').then(() => {
+  makeHttpRequest('https://example.com/blockRequest').then(() => {
+    makeHttpRequest('https://example.com/pass').then(() => {
       response.send({ response: 'done' });
     });
   });

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
@@ -137,11 +137,11 @@ describe('httpIntegration', () => {
 
             const requestSpans = event.spans?.filter(span => span.op === 'http.client');
             expect(requestSpans).toHaveLength(1);
-            expect(requestSpans![0]?.description).toBe('GET http://example.com/pass');
+            expect(requestSpans![0]?.description).toBe('GET https://example.com/pass');
 
             const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
             expect(breadcrumbs).toHaveLength(1);
-            expect(breadcrumbs![0]?.data?.url).toEqual('http://example.com/pass');
+            expect(breadcrumbs![0]?.data?.url).toEqual('https://example.com/pass');
           },
         })
         .start(done);
@@ -157,11 +157,11 @@ describe('httpIntegration', () => {
 
             const requestSpans = event.spans?.filter(span => span.op === 'http.client');
             expect(requestSpans).toHaveLength(1);
-            expect(requestSpans![0]?.description).toBe('GET http://example.com/pass');
+            expect(requestSpans![0]?.description).toBe('GET https://example.com/pass');
 
             const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
             expect(breadcrumbs).toHaveLength(1);
-            expect(breadcrumbs![0]?.data?.url).toEqual('http://example.com/pass');
+            expect(breadcrumbs![0]?.data?.url).toEqual('https://example.com/pass');
           },
         })
         .start(done);


### PR DESCRIPTION
Analogously to https://github.com/getsentry/sentry-javascript/pull/15052 this PR switches to the https version of example.com since the http version seems to have become unstable in the last couple of days. These tests failed a lot in CI recently.