### PR TITLE
fix(core): `fatal` events should set session as crashed

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -728,13 +728,9 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
   /** Updates existing session based on the provided event */
   protected _updateSessionFromEvent(session: Session, event: Event): void {
-    let crashed = false;
+    let crashed = event.level === 'fatal';
     let errored = false;
     const exceptions = event.exception?.values;
-
-    if (event.level === 'fatal') {
-      crashed = true;
-    }
 
     if (exceptions) {
       errored = true;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -732,6 +732,10 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     let errored = false;
     const exceptions = event.exception?.values;
 
+    if (event.level === 'fatal') {
+      crashed = true;
+    }
+
     if (exceptions) {
       errored = true;
 


### PR DESCRIPTION
In the Electron SDK, we have to manually set sessions as crashed when native crashes are encountered:
https://github.com/getsentry/sentry-electron/blob/dabd6daf0c19c2a6f224d1e721eb5d58c3cf61ac/src/main/integrations/sentry-minidump/index.ts#L175

This has the downside that if you return `null` in `beforeSend`, the event still impacts the release health crash rate.

I found that this was required because `_updateSessionFromEvent` in `@sentry/core` does not consider the Electron native events as a crash or an error because there are no exceptions in the event.

This PR ensures that any event with a `fatal` level is considered a crash.
