### PR TITLE
fix(v8/core): `fatal` events should set session as crashed 

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -587,13 +587,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
   /** Updates existing session based on the provided event */
   protected _updateSessionFromEvent(session: Session, event: Event): void {
-    let crashed = false;
+    let crashed = event.level === 'fatal';
     let errored = false;
     const exceptions = event.exception && event.exception.values;
-
-    if (event.level === 'fatal') {
-      crashed = true;
-    }
 
     if (exceptions) {
       errored = true;

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -591,6 +591,10 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     let errored = false;
     const exceptions = event.exception && event.exception.values;
 
+    if (event.level === 'fatal') {
+      crashed = true;
+    }
+
     if (exceptions) {
       errored = true;
 


### PR DESCRIPTION
Backport of #15072