### PR TITLE
ci: Update labels for remix integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -747,7 +747,7 @@ jobs:
         run: yarn test
 
   job_remix_integration_tests:
-    name: Remix v2 (Node ${{ matrix.node }}) Tests
+    name: Remix (Node ${{ matrix.node }}) Tests
     needs: [job_get_metadata, job_build]
     if: needs.job_build.outputs.changed_remix == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -747,7 +747,7 @@ jobs:
         run: yarn test
 
   job_remix_integration_tests:
-    name: Remix v${{ matrix.remix }} (Node ${{ matrix.node }}) Tests
+    name: Remix v2 (Node ${{ matrix.node }}) Tests
     needs: [job_get_metadata, job_build]
     if: needs.job_build.outputs.changed_remix == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-20.04

--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -15,12 +15,7 @@ export * from '@sentry/react';
 // function signature is the same as in the server SDK.
 // See issue: https://github.com/getsentry/sentry-javascript/issues/9594
 /* eslint-disable @typescript-eslint/no-unused-vars */
-export async function captureRemixServerException(
-  err: unknown,
-  name: string,
-  request: Request,
-  isRemixV2?: boolean,
-): Promise<void> {
+export async function captureRemixServerException(err: unknown, name: string, request: Request): Promise<void> {
   DEBUG_BUILD &&
     logger.warn(
       '`captureRemixServerException` is a server-only function and should not be called in the browser. ' +

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -18,12 +18,7 @@ export declare const contextLinesIntegration: typeof clientSdk.contextLinesInteg
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
-export declare function captureRemixServerException(
-  err: unknown,
-  name: string,
-  request: Request,
-  isRemixV2?: boolean,
-): Promise<void>;
+export declare function captureRemixServerException(err: unknown, name: string, request: Request): Promise<void>;
 
 // This variable is not a runtime variable but just a type to tell typescript that the methods below can either come
 // from the client SDK or from the server SDK. TypeScript is smart enough to understand that these resolve to the same


### PR DESCRIPTION
- Updates the label for remix integration tests.
- Updates client types for captureRemixServerException params (forgot to remove these as they serve no real purpose)

Follow up to https://github.com/getsentry/sentry-javascript/pull/14988