### PR TITLE
feat(node): Add `processSessionIntegration`

### DIFF
--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -345,6 +345,7 @@ The `enableTracing` option was removed. In v9, to emulate `enableTracing: true`,
 To enable session tracking, it is recommended to unset `autoSessionTracking` and ensure that either, in browser environments the `browserSessionIntegration` is added, or in server environments the `httpIntegration` is added.
 
 To disable session tracking, it is recommended unset `autoSessionTracking` and to remove the `browserSessionIntegration` in browser environments, or in server environments configure the `httpIntegration` with the `trackIncomingRequestsAsSessions` option set to `false`.
+Additionally, in Node.js environments, a session was automatically created for every node process when `autoSessionTracking` was set to `true`. This behavior has been replaced by the `processSessionIntegration` which is configured by default.
 
 - **The metrics API has been removed from the SDK.**
 

--- a/packages/node/src/integrations/processSession.ts
+++ b/packages/node/src/integrations/processSession.ts
@@ -1,0 +1,31 @@
+import { defineIntegration, endSession, getIsolationScope, startSession } from '@sentry/core';
+
+const INTEGRATION_NAME = 'ProcessSession';
+
+/**
+ * Records a Session for the current process to track release health.
+ */
+export const processSessionIntegration = defineIntegration(() => {
+  return {
+    name: INTEGRATION_NAME,
+    setupOnce() {
+      startSession();
+
+      // Emitted in the case of healthy sessions, error of `mechanism.handled: true` and unhandledrejections because
+      // The 'beforeExit' event is not emitted for conditions causing explicit termination,
+      // such as calling process.exit() or uncaught exceptions.
+      // Ref: https://nodejs.org/api/process.html#process_event_beforeexit
+      process.on('beforeExit', () => {
+        const session = getIsolationScope().getSession();
+
+        // Only call endSession, if the Session exists on Scope and SessionStatus is not a
+        // Terminal Status i.e. Exited or Crashed because
+        // "When a session is moved away from ok it must not be updated anymore."
+        // Ref: https://develop.sentry.dev/sdk/sessions/
+        if (session?.status !== 'ok') {
+          endSession();
+        }
+      });
+    },
+  };
+});


### PR DESCRIPTION
Pulls the default logic to create a session for each Node process into an integration. This is done so you can replicate the `autoSessionTracking: false` behavior for these "process sessions".

Ref: https://github.com/getsentry/sentry-javascript/issues/14299