### PR TITLE
doc(deno): Remove `deno.land` link

### DIFF
--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -12,7 +12,6 @@
 
 ## Links
 
-- [SDK on Deno registry](https://deno.land/x/sentry)
 - [Official SDK Docs](https://docs.sentry.io/quickstart/)
 - [TypeDoc](http://getsentry.github.io/sentry-javascript/)
 


### PR DESCRIPTION
- Ref #15087