### PR TITLE
ref(browser): Improve setting of propagation scope for navigation spans

### DIFF
--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -276,9 +276,9 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         addPerformanceEntries(span, { recordClsOnPageloadSpan: !enableStandaloneClsSpans });
         setActiveIdleSpan(client, undefined);
 
-        // A trace should to stay the consistent over the entire time span of one route.
-        // Therefore, we update the traceId/sampled properties on the propagation context.
-        // When a navigation happens, this is overwritten
+        // A trace should stay consistent over the entire timespan of one route - even after the pageload/navigation ended.
+        // Only when another navigation happens, we want to create a new trace.
+        // This way, e.g. errors that occur after the pageload span ended are still associated to the pageload trace.
         const scope = getCurrentScope();
         const oldPropagationContext = scope.getPropagationContext();
 
@@ -444,7 +444,6 @@ export function startBrowserTracingPageLoadSpan(
  * This will only do something if a browser tracing integration has been setup.
  */
 export function startBrowserTracingNavigationSpan(client: Client, spanOptions: StartSpanOptions): Span | undefined {
-  // Reset this to ensure we start a new trace, instead of continuing the last pageload/navigation trace
   getIsolationScope().setPropagationContext({ traceId: generateTraceId(), sampleRand: Math.random() });
   getCurrentScope().setPropagationContext({ traceId: generateTraceId(), sampleRand: Math.random() });
 

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -9,7 +9,7 @@ import {
   startTrackingLongTasks,
   startTrackingWebVitals,
 } from '@sentry-internal/browser-utils';
-import { Client, IntegrationFn, Span, StartSpanOptions, TransactionSource, dropUndefinedKeys } from '@sentry/core';
+import type { Client, IntegrationFn, Span, StartSpanOptions, TransactionSource } from '@sentry/core';
 import {
   GLOBAL_OBJ,
   SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON,
@@ -18,13 +18,13 @@ import {
   TRACING_DEFAULTS,
   addNonEnumerableProperty,
   browserPerformanceTimeOrigin,
+  dropUndefinedKeys,
   generateTraceId,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromSpan,
   getIsolationScope,
   getLocationHref,
-  getRootSpan,
   logger,
   propagationContextFromHeaders,
   registerSpanErrorInstrumentation,


### PR DESCRIPTION
Extracted this out of https://github.com/getsentry/sentry-javascript/pull/14955

Instead of registering a general hook & filtering there, we can just use the `beforeSpanEnd` hook that we already have/use to do this instead.