### PR TITLE
feat(core): Improve error formatting in ZodErrors integration

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,5 +61,8 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "devDependencies": {
+    "zod": "^3.24.1"
+  }
 }

--- a/packages/core/src/integrations/zoderrors.ts
+++ b/packages/core/src/integrations/zoderrors.ts
@@ -151,7 +151,8 @@ export function applyZodErrorsToEvent(
   }
 
   try {
-    const flattenedIssues = hint.originalException.issues.slice(0, limit).map(flattenIssue);
+    const issuesToFlatten = saveZodIssuesAsAttachment ? hint.originalException.issues : hint.originalException.issues.slice(0, limit)
+    const flattenedIssues = issuesToFlatten.map(flattenIssue);
 
     if (saveZodIssuesAsAttachment) {
       // Sometimes having the full error details can be helpful.

--- a/packages/core/src/integrations/zoderrors.ts
+++ b/packages/core/src/integrations/zoderrors.ts
@@ -5,33 +5,45 @@ import { truncate } from '../utils-hoist/string';
 
 interface ZodErrorsOptions {
   key?: string;
+  /**
+   * Limits the number of Zod errors inlined in each Sentry event.
+   *
+   * @default 10
+   */
   limit?: number;
+  /**
+   * Save full error info as an attachment in Sentry
+   *
+   * @default false
+   */
+  saveAttachments?: boolean;
 }
 
 const DEFAULT_LIMIT = 10;
 const INTEGRATION_NAME = 'ZodErrors';
 
-// Simplified ZodIssue type definition
+/**
+ * Simplified ZodIssue type definition
+ */
 interface ZodIssue {
   path: (string | number)[];
   message?: string;
-  expected?: string | number;
-  received?: string | number;
+  expected?: unknown;
+  received?: unknown;
   unionErrors?: unknown[];
   keys?: unknown[];
+  invalid_literal?: unknown;
 }
 
 interface ZodError extends Error {
   issues: ZodIssue[];
-
-  get errors(): ZodError['issues'];
 }
 
 function originalExceptionIsZodError(originalException: unknown): originalException is ZodError {
   return (
     isError(originalException) &&
     originalException.name === 'ZodError' &&
-    Array.isArray((originalException as ZodError).errors)
+    Array.isArray((originalException as ZodError).issues)
   );
 }
 
@@ -45,9 +57,18 @@ type SingleLevelZodIssue<T extends ZodIssue> = {
 
 /**
  * Formats child objects or arrays to a string
- * That is preserved when sent to Sentry
+ * that is preserved when sent to Sentry.
+ *
+ * Without this, we end up with something like this in Sentry:
+ *
+ * [
+ *  [Object],
+ *  [Object],
+ *  [Object],
+ *  [Object]
+ * ]
  */
-function formatIssueTitle(issue: ZodIssue): SingleLevelZodIssue<ZodIssue> {
+export function flattenIssue(issue: ZodIssue): SingleLevelZodIssue<ZodIssue> {
   return {
     ...issue,
     path: 'path' in issue && Array.isArray(issue.path) ? issue.path.join('.') : undefined,
@@ -57,63 +78,141 @@ function formatIssueTitle(issue: ZodIssue): SingleLevelZodIssue<ZodIssue> {
 }
 
 /**
+ * Takes ZodError issue path array and returns a flattened version as a string.
+ * This makes it easier to display paths within a Sentry error message.
+ *
+ * Array indexes are normalized to reduce duplicate entries
+ *
+ * @param path ZodError issue path
+ * @returns flattened path
+ *
+ * @example
+ * flattenIssuePath([0, 'foo', 1, 'bar']) // -> '<array>.foo.<array>.bar'
+ */
+export function flattenIssuePath(path: Array<string | number>): string {
+  return path
+    .map(p => {
+      if (typeof p === 'number') {
+        return '<array>';
+      } else {
+        return p;
+      }
+    })
+    .join('.');
+}
+
+/**
  * Zod error message is a stringified version of ZodError.issues
  * This doesn't display well in the Sentry UI. Replace it with something shorter.
  */
-function formatIssueMessage(zodError: ZodError): string {
+export function formatIssueMessage(zodError: ZodError): string {
   const errorKeyMap = new Set<string | number | symbol>();
   for (const iss of zodError.issues) {
-    if (iss.path?.[0]) {
-      errorKeyMap.add(iss.path[0]);
+    const issuePath = flattenIssuePath(iss.path);
+    if (issuePath.length > 0) {
+      errorKeyMap.add(issuePath);
     }
   }
-  const errorKeys = Array.from(errorKeyMap);
 
+  const errorKeys = Array.from(errorKeyMap);
+  if (errorKeys.length === 0) {
+    // If there are no keys, then we're likely validating the root
+    // variable rather than a key within an object. This attempts
+    // to extract what type it was that failed to validate.
+    // For example, z.string().parse(123) would return "string" here.
+    let rootExpectedType = 'variable';
+    if (zodError.issues.length > 0) {
+      const iss = zodError.issues[0];
+      if (iss !== undefined && 'expected' in iss && typeof iss.expected === 'string') {
+        rootExpectedType = iss.expected;
+      }
+    }
+    return `Failed to validate ${rootExpectedType}`;
+  }
   return `Failed to validate keys: ${truncate(errorKeys.join(', '), 100)}`;
 }
 
 /**
- * Applies ZodError issues to an event extras and replaces the error message
+ * Applies ZodError issues to an event extra and replaces the error message
  */
-export function applyZodErrorsToEvent(limit: number, event: Event, hint?: EventHint): Event {
+export function applyZodErrorsToEvent(
+  limit: number,
+  saveAttachments: boolean | undefined,
+  event: Event,
+  hint: EventHint,
+): Event {
   if (
     !event.exception?.values ||
-    !hint?.originalException ||
+    !hint.originalException ||
     !originalExceptionIsZodError(hint.originalException) ||
     hint.originalException.issues.length === 0
   ) {
     return event;
   }
 
-  return {
-    ...event,
-    exception: {
-      ...event.exception,
-      values: [
-        {
-          ...event.exception.values[0],
-          value: formatIssueMessage(hint.originalException),
+  try {
+    const flattenedIssues = hint.originalException.issues.map(flattenIssue);
+
+    if (saveAttachments === true) {
+      // Sometimes having the full error details can be helpful.
+      // Attachments have much higher limits, so we can include the full list of issues.
+      if (!Array.isArray(hint.attachments)) {
+        hint.attachments = [];
+      }
+      hint.attachments.push({
+        filename: 'zod_issues.json',
+        data: JSON.stringify({
+          issues: flattenedIssues,
+        }),
+      });
+    }
+
+    return {
+      ...event,
+      exception: {
+        ...event.exception,
+        values: [
+          {
+            ...event.exception.values[0],
+            value: formatIssueMessage(hint.originalException),
+          },
+          ...event.exception.values.slice(1),
+        ],
+      },
+      extra: {
+        ...event.extra,
+        'zoderror.issues': flattenedIssues.slice(0, limit),
+      },
+    };
+  } catch (e) {
+    // Hopefully we never throw errors here, but record it
+    // with the event just in case.
+    return {
+      ...event,
+      extra: {
+        ...event.extra,
+        'zoderrors sentry integration parse error': {
+          message: 'an exception was thrown while processing ZodError within applyZodErrorsToEvent()',
+          error: e instanceof Error ? `${e.name}: ${e.message}\n${e.stack}` : 'unknown',
         },
-        ...event.exception.values.slice(1),
-      ],
-    },
-    extra: {
-      ...event.extra,
-      'zoderror.issues': hint.originalException.errors.slice(0, limit).map(formatIssueTitle),
-    },
-  };
+      },
+    };
+  }
 }
 
 const _zodErrorsIntegration = ((options: ZodErrorsOptions = {}) => {
-  const limit = options.limit || DEFAULT_LIMIT;
+  const limit = options.limit ?? DEFAULT_LIMIT;
 
   return {
     name: INTEGRATION_NAME,
-    processEvent(originalEvent, hint) {
-      const processedEvent = applyZodErrorsToEvent(limit, originalEvent, hint);
+    processEvent(originalEvent, hint): Event {
+      const processedEvent = applyZodErrorsToEvent(limit, options.saveAttachments, originalEvent, hint);
       return processedEvent;
     },
   };
 }) satisfies IntegrationFn;
 
+/**
+ * Sentry integration to process Zod errors, making them easier to work with in Sentry.
+ */
 export const zodErrorsIntegration = defineIntegration(_zodErrorsIntegration);

--- a/packages/core/src/integrations/zoderrors.ts
+++ b/packages/core/src/integrations/zoderrors.ts
@@ -151,7 +151,9 @@ export function applyZodErrorsToEvent(
   }
 
   try {
-    const issuesToFlatten = saveZodIssuesAsAttachment ? hint.originalException.issues : hint.originalException.issues.slice(0, limit)
+    const issuesToFlatten = saveZodIssuesAsAttachment
+      ? hint.originalException.issues
+      : hint.originalException.issues.slice(0, limit);
     const flattenedIssues = issuesToFlatten.map(flattenIssue);
 
     if (saveZodIssuesAsAttachment) {

--- a/packages/core/src/integrations/zoderrors.ts
+++ b/packages/core/src/integrations/zoderrors.ts
@@ -151,7 +151,7 @@ export function applyZodErrorsToEvent(
   }
 
   try {
-    const flattenedIssues = hint.originalException.issues.map(flattenIssue);
+    const flattenedIssues = hint.originalException.issues.slice(0, limit).map(flattenIssue);
 
     if (saveZodIssuesAsAttachment) {
       // Sometimes having the full error details can be helpful.

--- a/packages/core/src/integrations/zoderrors.ts
+++ b/packages/core/src/integrations/zoderrors.ts
@@ -12,11 +12,11 @@ interface ZodErrorsOptions {
    */
   limit?: number;
   /**
-   * Save full error info as an attachment in Sentry
+   * Save full list of Zod issues as an attachment in Sentry
    *
    * @default false
    */
-  saveAttachments?: boolean;
+  saveZodIssuesAsAttachment?: boolean;
 }
 
 const DEFAULT_LIMIT = 10;
@@ -137,7 +137,7 @@ export function formatIssueMessage(zodError: ZodError): string {
  */
 export function applyZodErrorsToEvent(
   limit: number,
-  saveAttachments: boolean | undefined,
+  saveZodIssuesAsAttachment: boolean = false,
   event: Event,
   hint: EventHint,
 ): Event {
@@ -153,7 +153,7 @@ export function applyZodErrorsToEvent(
   try {
     const flattenedIssues = hint.originalException.issues.map(flattenIssue);
 
-    if (saveAttachments === true) {
+    if (saveZodIssuesAsAttachment) {
       // Sometimes having the full error details can be helpful.
       // Attachments have much higher limits, so we can include the full list of issues.
       if (!Array.isArray(hint.attachments)) {
@@ -206,7 +206,7 @@ const _zodErrorsIntegration = ((options: ZodErrorsOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
     processEvent(originalEvent, hint): Event {
-      const processedEvent = applyZodErrorsToEvent(limit, options.saveAttachments, originalEvent, hint);
+      const processedEvent = applyZodErrorsToEvent(limit, options.saveZodIssuesAsAttachment, originalEvent, hint);
       return processedEvent;
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7892,12 +7892,7 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/history-4@npm:@types/history@4.7.8":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
-
-"@types/history-5@npm:@types/history@4.7.8":
+"@types/history-4@npm:@types/history@4.7.8", "@types/history-5@npm:@types/history@4.7.8":
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
   integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
@@ -27428,16 +27423,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -27540,14 +27526,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -30337,16 +30316,7 @@ wrangler@^3.67.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -30647,6 +30617,11 @@ zod@^3.22.3, zod@^3.22.4:
   version "3.23.8"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
+
+zod@^3.24.1:
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.1.tgz#27445c912738c8ad1e9de1bea0359fa44d9d35ee"
+  integrity sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==
 
 zone.js@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
- Include full key path rather than the top level key in title
- Improve message for validation issues with no path
- Add option to include extended issue information as an attachment

## Background

I tried using this integration, but found the error format in Sentry to be lacking.
I added tests to demonstrate how this will format issues.

## Screenshots
<img width="1682" alt="top-level-object" src="https://github.com/user-attachments/assets/2cc5cae7-08b2-4456-a51b-3a55bb45d9b1" />
<img width="1750" alt="nested-keys" src="https://github.com/user-attachments/assets/c86e5187-7f1e-497d-b950-97214714ef38" />
<img width="850" alt="attachments" src="https://github.com/user-attachments/assets/3e7a7ce7-f8c9-40f5-8035-5977777e4613" />


---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
