### PR TITLE
fix(profiling-node): Add binary path to support `@electron/rebuild`

### DIFF
--- a/packages/profiling-node/src/cpu_profiler.ts
+++ b/packages/profiling-node/src/cpu_profiler.ts
@@ -54,6 +54,13 @@ export function importCppBindingsModule(): PrivateV8CpuProfilerBindings {
     return createdRequire(`${binaryPath}.node`);
   }
 
+  // @electron/rebuild generates the binary in the generic node-gyp directory
+  try {
+    return createdRequire('../../build/Release/sentry_cpu_profiler.node');
+  } catch (_) {
+    // ignore
+  }
+
   // We need the fallthrough so that in the end, we can fallback to the dynamic require.
   // This is for cases where precompiled binaries were not provided, but may have been compiled from source.
   if (platform === 'darwin') {
@@ -167,13 +174,6 @@ export function importCppBindingsModule(): PrivateV8CpuProfilerBindings {
         }
       }
     }
-  }
-
-  // @electron/rebuild generates the binary in the generic node-gyp directory
-  try {
-    return createdRequire('../../build/Release/sentry_cpu_profiler.node');
-  } catch (_) {
-    // ignore
   }
 
   const built_from_source_path = resolve(esmCompatibleDirname, '..', `sentry_cpu_profiler-${identifier}`);

--- a/packages/profiling-node/src/cpu_profiler.ts
+++ b/packages/profiling-node/src/cpu_profiler.ts
@@ -169,6 +169,13 @@ export function importCppBindingsModule(): PrivateV8CpuProfilerBindings {
     }
   }
 
+  // @electron/rebuild generates the binary in the generic node-gyp directory
+  try {
+    return createdRequire('../../build/Release/sentry_cpu_profiler.node');
+  } catch (_) {
+    // ignore
+  }
+
   const built_from_source_path = resolve(esmCompatibleDirname, '..', `sentry_cpu_profiler-${identifier}`);
   return createdRequire(`${built_from_source_path}.node`);
 }

--- a/packages/profiling-node/src/cpu_profiler.ts
+++ b/packages/profiling-node/src/cpu_profiler.ts
@@ -54,11 +54,16 @@ export function importCppBindingsModule(): PrivateV8CpuProfilerBindings {
     return createdRequire(`${binaryPath}.node`);
   }
 
-  // @electron/rebuild generates the binary in the generic node-gyp directory
-  try {
-    return createdRequire('../../build/Release/sentry_cpu_profiler.node');
-  } catch (_) {
-    // ignore
+  if (process.versions.electron) {
+    try {
+      // @electron/rebuild generates the binary in the generic node-gyp directory
+      return createdRequire('../../build/Release/sentry_cpu_profiler.node');
+    } catch (_) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Could not find '@sentry/profiling-node' binary. You should use '@electron/rebuild' to rebuild the native module.",
+      );
+    }
   }
 
   // We need the fallthrough so that in the end, we can fallback to the dynamic require.


### PR DESCRIPTION
To work with Electron, native modules need to be rebuilt with Electrons modified Node.js headers. This can be achieved using `@electron/rebuild` but this results in the binary being outputted into the standard node-gyp output directory.

This PR ensures that `@electron/rebuild` output path is attempted first.
