### PR TITLE
feat(node)!: Add support for Prisma v6 and drop v5 support

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -30,7 +30,7 @@
     "@nestjs/common": "10.4.6",
     "@nestjs/core": "10.4.6",
     "@nestjs/platform-express": "10.4.6",
-    "@prisma/client": "5.22.0",
+    "@prisma/client": "6.2.1",
     "@sentry/aws-serverless": "8.45.0",
     "@sentry/core": "8.45.0",
     "@sentry/node": "8.45.0",

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/package.json
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@prisma/client": "5.22.0",
-    "prisma": "5.22.0"
+    "@prisma/client": "6.2.1",
+    "prisma": "6.2.1"
   }
 }

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/prisma/schema.prisma
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/prisma/schema.prisma
@@ -5,7 +5,6 @@ datasource db {
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["tracing"]
 }
 
 model User {

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/scenario.js
@@ -16,14 +16,14 @@ const { PrismaClient } = require('@prisma/client');
 setInterval(() => {}, 1000);
 
 async function run() {
-  const client = new PrismaClient();
-
   await Sentry.startSpan(
     {
       name: 'Test Transaction',
       op: 'transaction',
     },
     async span => {
+      const client = new PrismaClient();
+
       await client.user.create({
         data: {
           name: 'Tilda',

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
@@ -1,3 +1,4 @@
+import { SpanJSON } from '@sentry/core';
 import { createRunner } from '../../../utils/runner';
 
 describe('Prisma ORM Tests', () => {
@@ -10,127 +11,73 @@ describe('Prisma ORM Tests', () => {
           const spans = transaction.spans || [];
           expect(spans.length).toBeGreaterThanOrEqual(5);
 
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                method: 'create',
-                model: 'User',
-                name: 'User.create',
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:client:operation',
-              status: 'ok',
-            }),
-          );
+          function expectPrismaSpanToIncludeSpanWith(span: Partial<SpanJSON>) {
+            expect(spans).toContainEqual(
+              expect.objectContaining({
+                ...span,
+                data: {
+                  ...span.data,
+                  'sentry.origin': 'auto.db.otel.prisma',
+                },
+                status: 'ok',
+              }),
+            );
+          }
 
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:client:serialize',
-              status: 'ok',
-            }),
-          );
+          expectPrismaSpanToIncludeSpanWith({
+            description: 'prisma:client:detect_platform',
+          });
 
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:client:connect',
-              status: 'ok',
-            }),
-          );
+          expectPrismaSpanToIncludeSpanWith({
+            description: 'prisma:client:load_engine',
+          });
 
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:engine',
-              status: 'ok',
-            }),
-          );
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'sentry.origin': 'auto.db.otel.prisma',
-                'sentry.op': 'db',
-                'db.system': 'postgresql',
-              },
-              description: 'prisma:engine:connection',
-              status: 'ok',
-              op: 'db',
-            }),
-          );
+          expectPrismaSpanToIncludeSpanWith({
+            description: 'prisma:client:operation',
+            data: {
+              method: 'create',
+              model: 'User',
+              name: 'User.create',
+            },
+          });
 
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'db.statement': expect.stringContaining(
-                  'INSERT INTO "public"."User" ("createdAt","email","name") VALUES ($1,$2,$3) RETURNING "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" /* traceparent',
-                ),
-                'sentry.origin': 'auto.db.otel.prisma',
-                'sentry.op': 'db',
-                'db.system': 'postgresql',
-                'otel.kind': 'CLIENT',
-              },
-              description: expect.stringContaining(
-                'INSERT INTO "public"."User" ("createdAt","email","name") VALUES ($1,$2,$3) RETURNING "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" /* traceparent',
-              ),
-              status: 'ok',
-              op: 'db',
-            }),
-          );
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:engine:serialize',
-              status: 'ok',
-            }),
-          );
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:engine:response_json_serialization',
-              status: 'ok',
-            }),
-          );
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                method: 'findMany',
-                model: 'User',
-                name: 'User.findMany',
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:client:operation',
-              status: 'ok',
-            }),
-          );
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:client:serialize',
-              status: 'ok',
-            }),
-          );
-          expect(spans).toContainEqual(
-            expect.objectContaining({
-              data: {
-                'sentry.origin': 'auto.db.otel.prisma',
-              },
-              description: 'prisma:engine',
-              status: 'ok',
-            }),
-          );
+          expectPrismaSpanToIncludeSpanWith({
+            description: 'prisma:client:serialize',
+          });
+
+          expectPrismaSpanToIncludeSpanWith({
+            description: 'prisma:client:connect',
+          });
+
+          expectPrismaSpanToIncludeSpanWith({
+            description: 'prisma:engine:connect',
+          });
+
+          expectPrismaSpanToIncludeSpanWith({
+            description: 'prisma:engine:query',
+          });
+
+          expectPrismaSpanToIncludeSpanWith({
+            data: {
+              'sentry.op': 'db',
+              'db.query.text':
+                'SELECT "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" FROM "public"."User" WHERE 1=1 OFFSET $1',
+              'db.system': 'postgresql',
+              'otel.kind': 'CLIENT',
+            },
+            description:
+              'SELECT "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" FROM "public"."User" WHERE 1=1 OFFSET $1',
+          });
+
+          expectPrismaSpanToIncludeSpanWith({
+            data: {
+              'sentry.op': 'db',
+              'db.query.text': 'DELETE FROM "public"."User" WHERE "public"."User"."email"::text LIKE $1',
+              'db.system': 'postgresql',
+              'otel.kind': 'CLIENT',
+            },
+            description: `DELETE FROM \"public\".\"User\" WHERE \"public\".\"User\".\"email\"::text LIKE $1`,
+          });
         },
       })
       .start(done);

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/yarn.lock
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/yarn.lock
@@ -2,57 +2,57 @@
 # yarn lockfile v1
 
 
-"@prisma/client@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.22.0.tgz#da1ca9c133fbefe89e0da781c75e1c59da5f8802"
-  integrity sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==
+"@prisma/client@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-6.2.1.tgz#3d7d0c8669bba490247e1ffff67b93a516bd789f"
+  integrity sha512-msKY2iRLISN8t5X0Tj7hU0UWet1u0KuxSPHWuf3IRkB4J95mCvGpyQBfQ6ufcmvKNOMQSq90O2iUmJEN2e5fiA==
 
-"@prisma/debug@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.22.0.tgz#58af56ed7f6f313df9fb1042b6224d3174bbf412"
-  integrity sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==
+"@prisma/debug@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-6.2.1.tgz#887719967c4942d125262e48f6c47c45d17c1f61"
+  integrity sha512-0KItvt39CmQxWkEw6oW+RQMD6RZ43SJWgEUnzxN8VC9ixMysa7MzZCZf22LCK5DSooiLNf8vM3LHZm/I/Ni7bQ==
 
-"@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2":
-  version "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz#d534dd7235c1ba5a23bacd5b92cc0ca3894c28f4"
-  integrity sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==
+"@prisma/engines-version@6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69":
+  version "6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69.tgz#b84ce3fab44bfa13a22669da02752330b61745b2"
+  integrity sha512-7tw1qs/9GWSX6qbZs4He09TOTg1ff3gYsB3ubaVNN0Pp1zLm9NC5C5MZShtkz7TyQjx7blhpknB7HwEhlG+PrQ==
 
-"@prisma/engines@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.22.0.tgz#28f3f52a2812c990a8b66eb93a0987816a5b6d84"
-  integrity sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==
+"@prisma/engines@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-6.2.1.tgz#14ef56bb780f02871a728667161d997a14aedb69"
+  integrity sha512-lTBNLJBCxVT9iP5I7Mn6GlwqAxTpS5qMERrhebkUhtXpGVkBNd/jHnNJBZQW4kGDCKaQg/r2vlJYkzOHnAb7ZQ==
   dependencies:
-    "@prisma/debug" "5.22.0"
-    "@prisma/engines-version" "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
-    "@prisma/fetch-engine" "5.22.0"
-    "@prisma/get-platform" "5.22.0"
+    "@prisma/debug" "6.2.1"
+    "@prisma/engines-version" "6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69"
+    "@prisma/fetch-engine" "6.2.1"
+    "@prisma/get-platform" "6.2.1"
 
-"@prisma/fetch-engine@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz#4fb691b483a450c5548aac2f837b267dd50ef52e"
-  integrity sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==
+"@prisma/fetch-engine@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-6.2.1.tgz#cd7eb7428a407105e0f3761dba536aefd41fc7f7"
+  integrity sha512-OO7O9d6Mrx2F9i+Gu1LW+DGXXyUFkP7OE5aj9iBfA/2jjDXEJjqa9X0ZmM9NZNo8Uo7ql6zKm6yjDcbAcRrw1A==
   dependencies:
-    "@prisma/debug" "5.22.0"
-    "@prisma/engines-version" "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
-    "@prisma/get-platform" "5.22.0"
+    "@prisma/debug" "6.2.1"
+    "@prisma/engines-version" "6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69"
+    "@prisma/get-platform" "6.2.1"
 
-"@prisma/get-platform@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.22.0.tgz#fc675bc9d12614ca2dade0506c9c4a77e7dddacd"
-  integrity sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==
+"@prisma/get-platform@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-6.2.1.tgz#34313cd0ee3587798ad33a7b57b6342dc8e66426"
+  integrity sha512-zp53yvroPl5m5/gXYLz7tGCNG33bhG+JYCm74ohxOq1pPnrL47VQYFfF3RbTZ7TzGWCrR3EtoiYMywUBw7UK6Q==
   dependencies:
-    "@prisma/debug" "5.22.0"
+    "@prisma/debug" "6.2.1"
 
 fsevents@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-prisma@5.22.0:
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.22.0.tgz#1f6717ff487cdef5f5799cc1010459920e2e6197"
-  integrity sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==
+prisma@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-6.2.1.tgz#457b210326d66d0e6f583cc6f9cd2819b984408f"
+  integrity sha512-hhyM0H13pQleQ+br4CkzGizS5I0oInoeTw3JfLw1BRZduBSQxPILlJLwi+46wZzj9Je7ndyQEMGw/n5cN2fknA==
   dependencies:
-    "@prisma/engines" "5.22.0"
+    "@prisma/engines" "6.2.1"
   optionalDependencies:
     fsevents "2.3.3"

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -40,14 +40,15 @@ If you need to support older browsers, we recommend transpiling your code using 
 
 **Deno:** The minimum supported Deno version is now **2.0.0**.
 
-### Framework Support Changes
+### Framework and Library Support Changes
 
-Support for the following Framework versions is dropped:
+Support for the following frameworks and library versions are dropped:
 
 - **Remix**: Version `1.x`
 - **TanStack Router**: Version `1.63.0` and lower (relevant when using `tanstackRouterBrowserTracingIntegration`)
-- **SvelteKit**: SvelteKit version `1.x`
-- **Ember.js**: Ember.js version `3.x` and lower (minimum supported version is `4.x`)
+- **SvelteKit**: Version `1.x`
+- **Ember.js**: Version `3.x` and lower (minimum supported version is `4.x`)
+- **Prisma**: Version `5.x`
 
 ### TypeScript Version Policy
 
@@ -105,6 +106,8 @@ Older Typescript versions _may_ still work, but we will not test them anymore an
 - The `tracesSampler` hook will no longer be called for _every_ span. Instead, it will only be called for "root spans". Root spans are spans that have no local parent span. Root spans may however have incoming trace data from a different service, for example when using distributed tracing.
 
 - The `childProcessIntegration`'s (previously `processThreadBreadcrumbIntegration`) `name` value has been changed from `"ProcessAndThreadBreadcrumbs"` to `"ChildProcess"`. This is relevant if you were filtering integrations by name.
+
+- The Prisma integration no longer supports Prisma v5. The `previewFeatures = ["tracing"]` option in your prisma client generator block is no longer required to use tracing with the Prisma integration.
 
 ### `@sentry/browser`
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -9,9 +9,7 @@
   "engines": {
     "node": ">=18"
   },
-  "files": [
-    "/build"
-  ],
+  "files": ["/build"],
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
@@ -56,9 +54,7 @@
   },
   "typesVersions": {
     "<5.0": {
-      "build/types/index.d.ts": [
-        "build/types-ts3.8/index.d.ts"
-      ]
+      "build/types/index.d.ts": ["build/types-ts3.8/index.d.ts"]
     }
   },
   "publishConfig": {
@@ -95,7 +91,7 @@
     "@opentelemetry/resources": "^1.30.1",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/semantic-conventions": "^1.28.0",
-    "@prisma/instrumentation": "5.22.0",
+    "@prisma/instrumentation": "6.2.1",
     "@sentry/core": "8.45.0",
     "@sentry/opentelemetry": "8.45.0",
     "import-in-the-middle": "^1.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5560,12 +5560,12 @@
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 
-"@opentelemetry/api-logs@0.53.0":
-  version "0.53.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz#c478cbd8120ec2547b64edfa03a552cfe42170be"
-  integrity sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==
+"@opentelemetry/api-logs@0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.56.0.tgz#68f8c51ca905c260b610c8a3c67d3f9fa3d59a45"
+  integrity sha512-Wr39+94UNNG3Ei9nv3pHd4AJ63gq5nSemMRpCd8fPwDL9rN3vK26lzxfH27mw16XzOSO+TpyQwBAMaLxaPWG0g==
   dependencies:
-    "@opentelemetry/api" "^1.0.0"
+    "@opentelemetry/api" "^1.3.0"
 
 "@opentelemetry/api-logs@0.57.1":
   version "0.57.1"
@@ -5574,7 +5574,7 @@
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@1.9.0", "@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0":
+"@opentelemetry/api@1.9.0", "@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
@@ -5851,12 +5851,12 @@
     semver "^7.5.2"
     shimmer "^1.2.1"
 
-"@opentelemetry/instrumentation@^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0":
-  version "0.53.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz#e6369e4015eb5112468a4d45d38dcada7dad892d"
-  integrity sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==
+"@opentelemetry/instrumentation@^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.56.0.tgz#3330ce16d9235a548efa1019a4a7f01414edd44a"
+  integrity sha512-2KkGBKE+FPXU1F0zKww+stnlUxUTlBvLCiWdP63Z9sqXYeNI/ziNzsxAp4LAdUcTQmXjw1IWgvm5CAb/BHy99w==
   dependencies:
-    "@opentelemetry/api-logs" "0.53.0"
+    "@opentelemetry/api-logs" "0.56.0"
     "@types/shimmer" "^1.2.0"
     import-in-the-middle "^1.8.1"
     require-in-the-middle "^7.1.1"
@@ -5901,7 +5901,7 @@
     "@opentelemetry/api" "^0.12.0"
     "@opentelemetry/core" "^0.12.0"
 
-"@opentelemetry/sdk-trace-base@^1.22", "@opentelemetry/sdk-trace-base@^1.30.1":
+"@opentelemetry/sdk-trace-base@^1.30.1":
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz#41a42234096dc98e8f454d24551fc80b816feb34"
   integrity sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==
@@ -6066,19 +6066,17 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.28.tgz#d45e01c4a56f143ee69c54dd6b12eade9e270a73"
   integrity sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==
 
-"@prisma/client@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.22.0.tgz#da1ca9c133fbefe89e0da781c75e1c59da5f8802"
-  integrity sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==
+"@prisma/client@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-6.2.1.tgz#3d7d0c8669bba490247e1ffff67b93a516bd789f"
+  integrity sha512-msKY2iRLISN8t5X0Tj7hU0UWet1u0KuxSPHWuf3IRkB4J95mCvGpyQBfQ6ufcmvKNOMQSq90O2iUmJEN2e5fiA==
 
-"@prisma/instrumentation@5.22.0":
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-5.22.0.tgz#c39941046e9886e17bdb47dbac45946c24d579aa"
-  integrity sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==
+"@prisma/instrumentation@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-6.2.1.tgz#261b885467d36759b7ca01d1b2ca4e1120bda886"
+  integrity sha512-QrcWRAwNHXX4nHXB+Q94nfm701gPQsR4zkaxYV6qCiENopRi8yYvXt6FNIvxbuwEiWW5Zid6DoWwIsBKJ/5r5w==
   dependencies:
-    "@opentelemetry/api" "^1.8"
-    "@opentelemetry/instrumentation" "^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0"
-    "@opentelemetry/sdk-trace-base" "^1.22"
+    "@opentelemetry/instrumentation" "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0"
 
 "@protobuf-ts/plugin-framework@^2.0.7", "@protobuf-ts/plugin-framework@^2.9.4":
   version "2.9.4"


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/14793

In v9 of the SDK, we are dropping support for Prisma v5 in favour of Prisma v6.

Prisma v6 gives us much better traces, as well as the ability to enable prisma tracing without needing to update your prisma config.

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/e06cd5c4-fdab-4e1b-aedc-1b6653fdc0ae" />

This PR does not enable the Prisma integration by default, I will do that in a follow up PR where we can debate if we want to do it immediately for v9, or wait a little longer for it.