### PR TITLE
feat(deno): Deprecate Deno SDK as published on deno.land

### DIFF
--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -12,7 +12,6 @@
 
 ## Links
 
-- [SDK on Deno registry](https://deno.land/x/sentry)
 - [Official SDK Docs](https://docs.sentry.io/quickstart/)
 - [TypeDoc](http://getsentry.github.io/sentry-javascript/)
 
@@ -21,14 +20,13 @@ The Sentry Deno SDK is in beta. Please help us improve the SDK by
 
 ## Usage
 
+> DEPRECATION NOTICE: The Sentry Deno SDK as published on the Deno registry (deno.land) is deprecated.
+> Import the package from the npm registry instead.
+
 To use this SDK, call `Sentry.init(options)` as early as possible in the main entry module. This will initialize the SDK
 and hook into the environment. Note that you can turn off almost all side effects using the respective options.
 
 ```javascript
-// Import from the Deno registry
-import * as Sentry from 'https://deno.land/x/sentry/index.mjs';
-
-// or import from npm registry
 import * as Sentry from 'npm:@sentry/deno';
 
 Sentry.init({


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/15088

Deprecates the Deno SDK as it is published on deno.land and instead recommends importing from the npm registry.