### PR TITLE
fix(core): Only fall back to `sendDefaultPii` for IP collection in `requestDataIntegration`

### DIFF
--- a/packages/core/src/integrations/requestdata.ts
+++ b/packages/core/src/integrations/requestdata.ts
@@ -23,7 +23,6 @@ const DEFAULT_INCLUDE: RequestDataIncludeOptions = {
   cookies: true,
   data: true,
   headers: true,
-  ip: false,
   query_string: true,
   url: true,
 };
@@ -44,7 +43,7 @@ const _requestDataIntegration = ((options: RequestDataIntegrationOptions = {}) =
 
       const includeWithDefaultPiiApplied: RequestDataIncludeOptions = {
         ...include,
-        ip: include.ip || client.getOptions().sendDefaultPii,
+        ip: include.ip ?? client.getOptions().sendDefaultPii,
       };
 
       if (normalizedRequest) {


### PR DESCRIPTION
As raised in https://github.com/getsentry/sentry-javascript/issues/5347#issuecomment-2606598918 we should only fall back to using `sendDefaultPii` so that users can do `include.ip: false` and `sendDefaultPii: true`, to have the sendDefaultPii behavior but not collect IPs from the integration.