### PR TITLE
fix(core): Version carrier rather than use SDK version

### DIFF
--- a/packages/core/src/carrier.ts
+++ b/packages/core/src/carrier.ts
@@ -19,7 +19,7 @@ type VersionedCarrier = {
 /**
  * IMPORTANT - This must be updated if any breaking changes are made to the 'SentryCarrier' interface.
  */
-const CARRIER_VERSION = '9';
+export const CARRIER_VERSION = '9';
 
 export interface SentryCarrier {
   acs?: AsyncContextStrategy;

--- a/packages/core/test/lib/carrier.test.ts
+++ b/packages/core/test/lib/carrier.test.ts
@@ -1,5 +1,5 @@
 import { getSentryCarrier } from '../../src/carrier';
-import { SDK_VERSION } from '../../src/utils-hoist/version';
+import { CARRIER_VERSION } from '../../src/carrier';
 
 describe('getSentryCarrier', () => {
   describe('base case (one SDK)', () => {
@@ -11,8 +11,8 @@ describe('getSentryCarrier', () => {
 
       expect(globalObject).toEqual({
         __SENTRY__: {
-          version: SDK_VERSION,
-          [SDK_VERSION]: {},
+          version: CARRIER_VERSION,
+          [CARRIER_VERSION]: {},
         },
       });
     });
@@ -20,8 +20,8 @@ describe('getSentryCarrier', () => {
     it('returns the existing sentry carrier object if it already exists', () => {
       const originalGlobalObject = {
         __SENTRY__: {
-          version: SDK_VERSION,
-          [SDK_VERSION]: {
+          version: CARRIER_VERSION,
+          [CARRIER_VERSION]: {
             acs: {},
           },
         },
@@ -42,13 +42,14 @@ describe('getSentryCarrier', () => {
   describe('multiple (older) SDKs', () => {
     it("returns the version of the sentry carrier object of the SDK's version rather than the one set in .version", () => {
       const sentryCarrier = getSentryCarrier({
-        // @ts-expect-error - this is just a test object
         __SENTRY__: {
           version: '8.0.0', // another SDK set this
           '8.0.0': {
+            // @ts-expect-error - this is just a test object
             stack: {},
           },
-          [SDK_VERSION]: {
+          [CARRIER_VERSION]: {
+            // @ts-expect-error - this is just a test object
             acs: {},
           },
           hub: {},
@@ -82,7 +83,7 @@ describe('getSentryCarrier', () => {
           '8.0.0': {
             acs: {},
           },
-          [SDK_VERSION]: {},
+          [CARRIER_VERSION]: {},
         },
       });
     });


### PR DESCRIPTION
The carrier was originally versioned in this PR:
- #12188

We chose to use the SDK version as the key for the carrier. This means that if any SDK versions don't match, weird behaviour occurs where things just don't work:
- https://github.com/getsentry/sentry-javascript/discussions/13978
- https://github.com/getsentry/sentry-electron/issues/1052

While debugging the above issue myself, I also managed to install incompatible versions and it took me **forever** to work out what was going on.

The issues linked in #12188 were all caused by changes in the carrier interface between v7 and v8 and users upgrading. We don't need to update the carrier version on every release, only when the interface changes. This does add some extra things to consider in PR's and reviews but we're often thinking about semver everywhere anyway. I think this is preferable to what we have now where all versions have to match exactly.

This PR keeps `__SENTRY__.version` and how the versioning works so I don't think this would require changes in Spotlight or the loader.

### Alternative Approaches

If we end up with multiple versions of `@sentry/core`, we could log warnings to the console. The downside here is it's not always easy to guide users in fixing this problem.

