### PR TITLE
fix(core): Pass `module` into `loadModule`

### DIFF
--- a/packages/core/src/utils-hoist/node.ts
+++ b/packages/core/src/utils-hoist/node.ts
@@ -41,21 +41,23 @@ function dynamicRequire(mod: any, request: string): any {
  * That is to mimic the behavior of `require.resolve` exactly.
  *
  * @param moduleName module name to require
+ * @param existingModule module to use for requiring
  * @returns possibly required module
  */
-export function loadModule<T>(moduleName: string): T | undefined {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function loadModule<T>(moduleName: string, existingModule: any = module): T | undefined {
   let mod: T | undefined;
 
   try {
-    mod = dynamicRequire(module, moduleName);
+    mod = dynamicRequire(existingModule, moduleName);
   } catch (e) {
     // no-empty
   }
 
   if (!mod) {
     try {
-      const { cwd } = dynamicRequire(module, 'process');
-      mod = dynamicRequire(module, `${cwd()}/node_modules/${moduleName}`) as T;
+      const { cwd } = dynamicRequire(existingModule, 'process');
+      mod = dynamicRequire(existingModule, `${cwd()}/node_modules/${moduleName}`) as T;
     } catch (e) {
       // no-empty
     }

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -332,7 +332,7 @@ export function constructWebpackConfigFunction(
     // Symbolication for dev-mode errors is done elsewhere.
     if (!isDev) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { sentryWebpackPlugin } = loadModule<{ sentryWebpackPlugin: any }>('@sentry/webpack-plugin') ?? {};
+      const { sentryWebpackPlugin } = loadModule<{ sentryWebpackPlugin: any }>('@sentry/webpack-plugin', module) ?? {};
 
       if (sentryWebpackPlugin) {
         if (!userSentryOptions.sourcemaps?.disable) {

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -301,7 +301,7 @@ const makeWrappedCreateRequestHandler = () =>
 export function instrumentServer(): void {
   const pkg = loadModule<{
     createRequestHandler: CreateRequestHandlerFunction;
-  }>('@remix-run/server-runtime');
+  }>('@remix-run/server-runtime', module);
 
   if (!pkg) {
     DEBUG_BUILD && logger.warn('Remix SDK was unable to require `@remix-run/server-runtime` package.');


### PR DESCRIPTION
- [-] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
Certainly! Here’s a more elegantly phrased version of your content:

The `loadModule` function currently utilizes `require` to load modules starting from the `@sentry/core` directory. This approach is incompatible with package managers like pnpm, which do not hoist dependencies. Consequently, when another module, such as @sentry/nextjs, invokes `loadModule`, it fails to locate its own dependencies because the search initiates within the @sentry/core tree.

### Example Scenario

#### Current Behavior:
If @sentry/nextjs calls `loadModule('@sentry/webpack-plugin')`, the function attempts to locate @sentry/webpack-plugin within the dependencies of @sentry/core. This results in the module not being found if `@sentry/webpack-plugin` is not a dependency of `@sentry/core`.

#### Proposed Change:
With the current pull request, invoking `loadModule('@sentry/webpack-plugin', module)` directs the search to the dependencies of @sentry/nextjs instead of @sentry/core. This ensures that loadModule correctly resolves modules based on the calling module’s dependency tree, accommodating environments where dependencies are not hoisted.