### PR TITLE
chore(repo): Removing unused files

### DIFF
--- a/packages/replay-internal/src/session/index.ts
+++ b/packages/replay-internal/src/session/index.ts
@@ -1,1 +1,0 @@
-export * from './createSession';

--- a/packages/vercel-edge/src/transports/types.ts
+++ b/packages/vercel-edge/src/transports/types.ts
@@ -1,8 +1,0 @@
-import type { BaseTransportOptions } from '@sentry/core';
-
-export interface VercelEdgeTransportOptions extends BaseTransportOptions {
-  /** Fetch API init parameters. */
-  fetchOptions?: RequestInit;
-  /** Custom headers for the transport. */
-  headers?: { [key: string]: string };
-}


### PR DESCRIPTION
I think [remove-unused](https://removeunused.com/) found more unused files, this time in `replay-internal` and `vercel-edge`. `lint` and `test` commands run fine. All build tasks seem to be working although I cannot get `@sentry/profiling-node` to ever build locally due to some fun `gyp` stuff
 
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
