### PR TITLE
feat(solidstart)!: No longer export `sentrySolidStartVite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,50 +12,6 @@
 
 Work in this release was contributed by @tjhiggins, @GrizliK1988, @davidturissini, @nwalters512, @aloisklink, @arturovt, @benjick, @maximepvrt, @mstrokin, and @kunal-511. Thank you for your contributions!
 
-- **feat(solidstart)!: Default to `--import` setup and add `autoInjectServerSentry` ([#14862](https://github.com/getsentry/sentry-javascript/pull/14862))**
-
-To enable the SolidStart SDK, wrap your SolidStart Config with `withSentry`. The `sentrySolidStartVite` plugin is now automatically
-added by `withSentry` and you can pass the Sentry build-time options like this:
-
-```js
-import { defineConfig } from '@solidjs/start/config';
-import { withSentry } from '@sentry/solidstart';
-
-export default defineConfig(
-  withSentry(
-    {
-      /* Your SolidStart config options... */
-    },
-    {
-      // Options for setting up source maps
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-    },
-  ),
-);
-```
-
-With the `withSentry` wrapper, the Sentry server config should not be added to the `public` directory anymore.
-Add the Sentry server config in `src/instrument.server.ts`. Then, the server config will be placed inside the server build output as `instrument.server.mjs`.
-
-Now, there are two options to set up the SDK:
-
-1. **(recommended)** Provide an `--import` CLI flag to the start command like this (path depends on your server setup):
-   `node --import ./.output/server/instrument.server.mjs .output/server/index.mjs`
-2. Add `autoInjectServerSentry: 'top-level-import'` and the Sentry config will be imported at the top of the server entry (comes with tracing limitations)
-   ```js
-   withSentry(
-     {
-       /* Your SolidStart config options... */
-     },
-     {
-       // Optional: Install Sentry with a top-level import
-       autoInjectServerSentry: 'top-level-import',
-     },
-   );
-   ```
-
 ## 9.0.0-alpha.0
 
 This is an alpha release of the upcoming major release of version 9.

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -234,6 +234,10 @@ Sentry.init({
 - The `addNormalizedRequestDataToEvent` method has been removed. Use `httpRequestToRequestData` instead and put the resulting object directly on `event.request`.
 - A `sampleRand` field on `PropagationContext` is now required. This is relevant if you used `scope.setPropagationContext(...)`
 
+### `@sentry/solidstart`
+
+- The `sentrySolidStartVite` plugin is no longer exported. Instead, wrap the SolidStart config with `withSentry` and provide Sentry options as the second parameter.
+
 #### Other/Internal Changes
 
 The following changes are unlikely to affect users of the SDK. They are listed here only for completion sake, and to alert users that may be relying on internal behavior.

--- a/docs/migration/v8-to-v9.md
+++ b/docs/migration/v8-to-v9.md
@@ -236,7 +236,19 @@ Sentry.init({
 
 ### `@sentry/solidstart`
 
-- The `sentrySolidStartVite` plugin is no longer exported. Instead, wrap the SolidStart config with `withSentry` and provide Sentry options as the second parameter.
+- The `sentrySolidStartVite` plugin is no longer exported. Instead, wrap the SolidStart config with `withSentry` and
+  provide Sentry options as the second parameter.
+
+  ```
+  // app.config.ts
+  import { defineConfig } from '@solidjs/start/config';
+  import { withSentry } from '@sentry/solidstart';
+
+  export default defineConfig(withSentry(
+    { /* SolidStart config */ },
+    { /* Sentry build-time config (like project and org) */ })
+  );
+  ```
 
 #### Other/Internal Changes
 

--- a/packages/solidstart/src/config/withSentry.ts
+++ b/packages/solidstart/src/config/withSentry.ts
@@ -1,6 +1,6 @@
 import { logger } from '@sentry/core';
 import type { Nitro } from 'nitropack';
-import { addSentryPluginToVite } from '../vite';
+import { addSentryPluginToVite } from '../vite/sentrySolidStartVite';
 import type { SentrySolidStartPluginOptions } from '../vite/types';
 import {
   addDynamicImportEntryFileWrapper,

--- a/packages/solidstart/src/index.server.ts
+++ b/packages/solidstart/src/index.server.ts
@@ -1,3 +1,2 @@
 export * from './server';
-export * from './vite';
 export * from './config';

--- a/packages/solidstart/src/index.types.ts
+++ b/packages/solidstart/src/index.types.ts
@@ -3,7 +3,6 @@
 // exports in this file - which we do below.
 export * from './client';
 export * from './server';
-export * from './vite';
 export * from './config';
 
 import type { Client, Integration, Options, StackParser } from '@sentry/core';

--- a/packages/solidstart/src/vite/index.ts
+++ b/packages/solidstart/src/vite/index.ts
@@ -1,1 +1,0 @@
-export * from './sentrySolidStartVite';


### PR DESCRIPTION
Since the default way of setting up the SDK and passing the Sentry options is by wrapping the SolidStart config with `withSentry`, the previous method of using the `sentrySolidStartVite` plugin is no longer supported.