### PR TITLE
chore: Remove date range for LICENSEs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2012-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2012 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/angular/LICENSE
+++ b/packages/angular/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/astro/LICENSE
+++ b/packages/astro/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/aws-serverless/LICENSE
+++ b/packages/aws-serverless/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2020 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/browser-utils/LICENSE
+++ b/packages/browser-utils/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2020 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/browser/LICENSE
+++ b/packages/browser/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/bun/LICENSE
+++ b/packages/bun/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/cloudflare/LICENSE
+++ b/packages/cloudflare/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/deno/LICENSE
+++ b/packages/deno/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/ember/LICENSE
+++ b/packages/ember/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2020 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/eslint-config-sdk/LICENSE
+++ b/packages/eslint-config-sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2020 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/eslint-plugin-sdk/LICENSE
+++ b/packages/eslint-plugin-sdk/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2020 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/feedback/LICENSE
+++ b/packages/feedback/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/gatsby/LICENSE
+++ b/packages/gatsby/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2020 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/google-cloud-serverless/LICENSE
+++ b/packages/google-cloud-serverless/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/integration-shims/LICENSE
+++ b/packages/integration-shims/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/nestjs/LICENSE
+++ b/packages/nestjs/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/nextjs/LICENSE
+++ b/packages/nextjs/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2021 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/node/LICENSE
+++ b/packages/node/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/nuxt/LICENSE
+++ b/packages/nuxt/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/opentelemetry/LICENSE
+++ b/packages/opentelemetry/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/profiling-node/LICENSE
+++ b/packages/profiling-node/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2022 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/remix/LICENSE
+++ b/packages/remix/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2022 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/replay-canvas/LICENSE
+++ b/packages/replay-canvas/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/replay-internal/LICENSE
+++ b/packages/replay-internal/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2022 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/replay-worker/LICENSE
+++ b/packages/replay-worker/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/solid/LICENSE
+++ b/packages/solid/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/solidstart/LICENSE
+++ b/packages/solidstart/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/svelte/LICENSE
+++ b/packages/svelte/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2022 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/sveltekit/LICENSE
+++ b/packages/sveltekit/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/types/LICENSE
+++ b/packages/types/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/typescript/LICENSE
+++ b/packages/typescript/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/vercel-edge/LICENSE
+++ b/packages/vercel-edge/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/vue/LICENSE
+++ b/packages/vue/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/packages/wasm/LICENSE
+++ b/packages/wasm/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2025 Functional Software, Inc. dba Sentry
+Copyright (c) 2021 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
While updating the date ranges for multiple PRs, Michi pointed out that we don't need date ranges for our licenses. This is a follow-up on https://github.com/getsentry/sentry-javascript/pull/15134. I'm sorry about the fuzz.

In our internal [Open Source Legal Policy](https://www.notion.so/sentry/Open-Source-Legal-Policy-ac4885d265cb4d7898a01c060b061e42), we decided that licenses don't require a data range. This also has the advantage of not updating the date range yearly.

#skip-changelog

cc @gavin-zee