### PR TITLE
fix(nextjs): Flush with `waitUntil` in `captureRequestError`

### DIFF
--- a/packages/nextjs/src/common/captureRequestError.ts
+++ b/packages/nextjs/src/common/captureRequestError.ts
@@ -1,5 +1,6 @@
-import type { RequestEventData } from '@sentry/core';
+import { RequestEventData, vercelWaitUntil } from '@sentry/core';
 import { captureException, headersToDict, withScope } from '@sentry/core';
+import { flushSafelyWithTimeout } from './utils/responseEnd';
 
 type RequestInfo = {
   path: string;
@@ -39,5 +40,7 @@ export function captureRequestError(error: unknown, request: RequestInfo, errorC
         handled: false,
       },
     });
+
+    vercelWaitUntil(flushSafelyWithTimeout());
   });
 }

--- a/packages/nextjs/src/common/captureRequestError.ts
+++ b/packages/nextjs/src/common/captureRequestError.ts
@@ -1,4 +1,5 @@
-import { RequestEventData, vercelWaitUntil } from '@sentry/core';
+import type { RequestEventData } from '@sentry/core';
+import { vercelWaitUntil } from '@sentry/core';
 import { captureException, headersToDict, withScope } from '@sentry/core';
 import { flushSafelyWithTimeout } from './utils/responseEnd';
 


### PR DESCRIPTION
Ensure that server component errors reliably flush on vercel.