### PR TITLE
feat(v8/core): Add client outcomes for breadcrumbs buffer

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -446,7 +446,9 @@ class ScopeClass implements ScopeInterface {
     this._breadcrumbs.push(mergedBreadcrumb);
     if (this._breadcrumbs.length > maxCrumbs) {
       this._breadcrumbs = this._breadcrumbs.slice(-maxCrumbs);
-      this._client?.recordDroppedEvent('buffer_overflow', 'log_item');
+      if (this._client) {
+        this._client.recordDroppedEvent('buffer_overflow', 'log_item');
+      }
     }
 
     this._notifyScopeListeners();

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -443,9 +443,11 @@ class ScopeClass implements ScopeInterface {
       ...breadcrumb,
     };
 
-    const breadcrumbs = this._breadcrumbs;
-    breadcrumbs.push(mergedBreadcrumb);
-    this._breadcrumbs = breadcrumbs.length > maxCrumbs ? breadcrumbs.slice(-maxCrumbs) : breadcrumbs;
+    this._breadcrumbs.push(mergedBreadcrumb);
+    if (this._breadcrumbs.length > maxCrumbs) {
+      this._breadcrumbs = this._breadcrumbs.slice(-maxCrumbs);
+      this._client?.recordDroppedEvent('buffer_overflow', 'log_item');
+    }
 
     this._notifyScopeListeners();
 

--- a/packages/core/src/types-hoist/clientreport.ts
+++ b/packages/core/src/types-hoist/clientreport.ts
@@ -8,7 +8,8 @@ export type EventDropReason =
   | 'ratelimit_backoff'
   | 'sample_rate'
   | 'send_error'
-  | 'internal_sdk_error';
+  | 'internal_sdk_error'
+  | 'buffer_overflow';
 
 export type Outcome = {
   reason: EventDropReason;

--- a/packages/core/src/types-hoist/datacategory.ts
+++ b/packages/core/src/types-hoist/datacategory.ts
@@ -14,7 +14,7 @@ export type DataCategory =
   | 'replay'
   // Events with `event_type` csp, hpkp, expectct, expectstaple
   | 'security'
-  // Attachment bytes stored (unused for rate limiting
+  // Attachment bytes stored (unused for rate limiting)
   | 'attachment'
   // Session update events
   | 'session'
@@ -30,5 +30,9 @@ export type DataCategory =
   | 'metric_bucket'
   // Span
   | 'span'
+  // Log event
+  | 'log_item'
+  // Log bytes stored (unused for rate limiting)
+  | 'log_byte'
   // Unknown data category
   | 'unknown';

--- a/packages/core/test/lib/baseclient.test.ts
+++ b/packages/core/test/lib/baseclient.test.ts
@@ -201,6 +201,22 @@ describe('BaseClient', () => {
       expect(isolationScopeBreadcrumbs).toEqual([{ message: 'hello3', timestamp: expect.any(Number) }]);
     });
 
+    test('it records `buffer_overflow` client discard reason when buffer overflows', () => {
+      const options = getDefaultTestClientOptions({ maxBreadcrumbs: 1 });
+      const client = new TestClient(options);
+      const recordLostEventSpy = jest.spyOn(client, 'recordDroppedEvent');
+      setCurrentClient(client);
+      getIsolationScope().setClient(client);
+      client.init();
+
+      addBreadcrumb({ message: 'hello1' });
+      addBreadcrumb({ message: 'hello2' });
+      addBreadcrumb({ message: 'hello3' });
+
+      expect(recordLostEventSpy).toHaveBeenCalledTimes(2);
+      expect(recordLostEventSpy).toHaveBeenLastCalledWith('buffer_overflow', 'log_item');
+    });
+
     test('calls `beforeBreadcrumb` and adds the breadcrumb without any changes', () => {
       const beforeBreadcrumb = jest.fn(breadcrumb => breadcrumb);
       const options = getDefaultTestClientOptions({ beforeBreadcrumb });


### PR DESCRIPTION
ref https://github.com/getsentry/team-sdks/issues/116

backport of https://github.com/getsentry/sentry-javascript/pull/15082