### PR TITLE
test(e2e): Unflake replay recording data optional e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/tests/send-to-sentry.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/tests/send-to-sentry.test.ts
@@ -180,24 +180,26 @@ test('Sends a Replay recording to Sentry', async ({ browser }) => {
     .toBe(200);
 
   // now fetch the first recording segment
-  await expect
-    .poll(
-      async () => {
-        const response = await fetch(
-          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/recording-segments/?cursor=100%3A0%3A1`,
-          { headers: { Authorization: `Bearer ${authToken}` } },
-        );
+  const data = expect.poll(
+    async () => {
+      const response = await fetch(
+        `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/recording-segments/?cursor=100%3A0%3A1`,
+        { headers: { Authorization: `Bearer ${authToken}` } },
+      );
 
-        if (response.ok) {
-          const data = await response.json();
-          return data[0];
-        }
+      if (response.ok) {
+        const data = await response.json();
+        return data[0];
+      }
 
-        return response.status;
-      },
-      {
-        timeout: EVENT_POLLING_TIMEOUT,
-      },
-    )
-    .toEqual(ReplayRecordingData);
+      return response.status;
+    },
+    {
+      timeout: EVENT_POLLING_TIMEOUT,
+    },
+  );
+
+  // Check that that all expected data is present but relax the order
+  expect(data).toEqual(expect.arrayContaining(ReplayRecordingData));
+  expect(data).toHaveLength(ReplayRecordingData.length);
 });

--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/tests/send-to-sentry.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/tests/send-to-sentry.test.ts
@@ -180,26 +180,25 @@ test('Sends a Replay recording to Sentry', async ({ browser }) => {
     .toBe(200);
 
   // now fetch the first recording segment
-  const data = expect.poll(
-    async () => {
-      const response = await fetch(
-        `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/recording-segments/?cursor=100%3A0%3A1`,
-        { headers: { Authorization: `Bearer ${authToken}` } },
-      );
+  await expect
+    .poll(
+      async () => {
+        const response = await fetch(
+          `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/replays/${replayId}/recording-segments/?cursor=100%3A0%3A1`,
+          { headers: { Authorization: `Bearer ${authToken}` } },
+        );
 
-      if (response.ok) {
-        const data = await response.json();
-        return data[0];
-      }
+        if (response.ok) {
+          const data = await response.json();
+          return { data: data[0], length: data[0].length };
+        }
 
-      return response.status;
-    },
-    {
-      timeout: EVENT_POLLING_TIMEOUT,
-    },
-  );
-
-  // Check that that all expected data is present but relax the order
-  expect(data).toEqual(expect.arrayContaining(ReplayRecordingData));
-  expect(data).toHaveLength(ReplayRecordingData.length);
+        return response.status;
+      },
+      {
+        timeout: EVENT_POLLING_TIMEOUT,
+      },
+    )
+    // Check that that all expected data is present but relax the order to avoid flakes
+    .toEqual({ data: expect.arrayContaining(ReplayRecordingData), length: ReplayRecordingData.length });
 });


### PR DESCRIPTION
Relax the assertion for the replay recording data test so that we allow arbitrary order but still assert on the exact amount and contents of the received recording items.

closes #15167 