### PR TITLE
test(e2e/nextjs): Avoid making request to example.com 

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/app/request-instrumentation/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/app/request-instrumentation/page.tsx
@@ -3,9 +3,9 @@ import https from 'https';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
-  await fetch('https://example.com/', { cache: 'no-cache' }).then(res => res.text());
+  await fetch('https://github.com/', { cache: 'no-cache' }).then(res => res.text());
   await new Promise<void>(resolve => {
-    https.get('https://example.com/', res => {
+    https.get('https://github.com/', res => {
       res.on('data', () => {
         // Noop consuming some data so that request can close :)
       });

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/tests/request-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/tests/request-instrumentation.test.ts
@@ -19,7 +19,7 @@ test('Should send a transaction with a fetch span', async ({ page }) => {
         'sentry.op': 'http.client',
         'sentry.origin': 'auto.http.otel.node_fetch',
       }),
-      description: 'GET https://example.com/',
+      description: 'GET https://github.com/',
     }),
   );
 
@@ -30,7 +30,7 @@ test('Should send a transaction with a fetch span', async ({ page }) => {
         'sentry.op': 'http.client',
         'sentry.origin': 'auto.http.otel.http',
       }),
-      description: 'GET https://example.com/',
+      description: 'GET https://github.com/',
     }),
   );
 });


### PR DESCRIPTION
example.com still seems flaky, let's avoid making requests to it
