### PR TITLE
feat(nuxt): Add `url` to `SourcemapsUploadOptions`

### DIFF
--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -33,6 +33,13 @@ type SourceMapsOptions = {
   org?: string;
 
   /**
+   * The URL of your Sentry instance if you're using self-hosted Sentry.
+   *
+   * @default https://sentry.io by default the plugin will point towards the Sentry SaaS URL
+   */
+  url?: string;
+
+  /**
    * The project slug of your Sentry project.
    * Instead of specifying this option, you can also set the `SENTRY_PROJECT` environment variable.
    */

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -91,6 +91,7 @@ export function getPluginOptions(
     project: sourceMapsUploadOptions.project ?? process.env.SENTRY_PROJECT,
     authToken: sourceMapsUploadOptions.authToken ?? process.env.SENTRY_AUTH_TOKEN,
     telemetry: sourceMapsUploadOptions.telemetry ?? true,
+    url: sourceMapsUploadOptions.url ?? process.env.SENTRY_URL,
     debug: moduleOptions.debug ?? false,
     _metaOptions: {
       telemetry: {

--- a/packages/nuxt/test/vite/sourceMaps.test.ts
+++ b/packages/nuxt/test/vite/sourceMaps.test.ts
@@ -20,6 +20,7 @@ describe('getPluginOptions', () => {
       SENTRY_ORG: 'default-org',
       SENTRY_PROJECT: 'default-project',
       SENTRY_AUTH_TOKEN: 'default-token',
+      SENTRY_URL: 'https://santry.io',
     };
 
     process.env = { ...defaultEnv };
@@ -31,6 +32,7 @@ describe('getPluginOptions', () => {
         org: 'default-org',
         project: 'default-project',
         authToken: 'default-token',
+        url: 'https://santry.io',
         telemetry: true,
         sourcemaps: expect.objectContaining({
           rewriteSources: expect.any(Function),
@@ -114,6 +116,7 @@ describe('getPluginOptions', () => {
           assets: ['custom-assets/**/*'],
           filesToDeleteAfterUpload: ['delete-this.js'],
         },
+        url: 'https://santry.io',
       },
       debug: true,
       unstable_sentryBundlerPluginOptions: {
@@ -124,6 +127,7 @@ describe('getPluginOptions', () => {
         release: {
           name: 'test-release',
         },
+        url: 'https://suntry.io',
       },
     };
     const options = getPluginOptions(customOptions, false);
@@ -140,6 +144,7 @@ describe('getPluginOptions', () => {
         release: expect.objectContaining({
           name: 'test-release',
         }),
+        url: 'https://suntry.io',
       }),
     );
   });


### PR DESCRIPTION
The build error in question is for self-hosted sentry instances, where a config URL is pointing to sentry.io and the token was generated on our self-hosted instance with a different URL

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
