### PR TITLE
ref(core)!: Move `shutdownTimeout` option type from core to node

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -53,9 +53,7 @@ export function applyDefaultOptions(optionsArg: BrowserOptions = {}): BrowserOpt
     release:
       typeof __SENTRY_RELEASE__ === 'string' // This allows build tooling to find-and-replace __SENTRY_RELEASE__ to inject a release value
         ? __SENTRY_RELEASE__
-        : WINDOW.SENTRY_RELEASE?.id // This supports the variable that sentry-webpack-plugin injects
-          ? WINDOW.SENTRY_RELEASE.id
-          : undefined,
+        : WINDOW.SENTRY_RELEASE?.id, // This supports the variable that sentry-webpack-plugin injects
     sendClientReports: true,
   };
 

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -139,15 +139,6 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   normalizeMaxBreadth?: number;
 
   /**
-   * Controls how many milliseconds to wait before shutting down. The default is
-   * SDK-specific but typically around 2 seconds. Setting this too low can cause
-   * problems for sending events from command line applications. Setting it too
-   * high can cause the application to block for users with network connectivity
-   * problems.
-   */
-  shutdownTimeout?: number;
-
-  /**
    * A pattern for error messages which should not be sent to Sentry.
    * By default, all errors will be sent.
    */

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -120,6 +120,14 @@ export interface BaseNodeOptions {
    */
   disableInstrumentationWarnings?: boolean;
 
+  /**
+   * Controls how many milliseconds to wait before shutting down. The default is 2 seconds. Setting this too low can cause
+   * problems for sending events from command line applications. Setting it too
+   * high can cause the application to block for users with network connectivity
+   * problems.
+   */
+  shutdownTimeout?: number;
+
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(this: void, error: Error): void;
 }


### PR DESCRIPTION
We used to have `shutdownTimeout` in the core client options, but this option only applies in node, so we can move it there. Also fixing a small unnecessary check I noticed along the way.

This is technically breaking, but should not affect anybody as this option is not used (and documented) anywhere outside of node.