### PR TITLE
ci: Pin node-integration-test version to `18.20.5`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -671,7 +671,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22]
+        node: ['18.20.5', 20, 22]
         typescript:
           - false
         include:


### PR DESCRIPTION
It _seems_ we've got way more flakes since 18.20.6 was released, let's see if this fixes this possibly...