### PR TITLE
ci(v8): Pin node-integration-test version to `18.20.5`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -715,7 +715,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20, 22]
+        node: [14, 16, '18.20.5', 20, 22]
         typescript:
           - false
         include:


### PR DESCRIPTION
It _seems_ we've got way more flakes since 18.20.6 was released, let's see if this fixes this possibly...

Backport
