### PR TITLE
ref(v8/core): Don't set `this.name` to `new.target.prototype.constructor.name`

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -721,11 +721,10 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
         if (DEBUG_BUILD) {
           // If something's gone wrong, log the error as a warning. If it's just us having used a `SentryError` for
           // control flow, log just the message (no stack) as a log-level log.
-          const sentryError = reason as SentryError;
-          if (sentryError.logLevel === 'log') {
-            logger.log(sentryError.message);
+          if (reason instanceof SentryError && reason.logLevel === 'log') {
+            logger.log(reason.message);
           } else {
-            logger.warn(sentryError);
+            logger.warn(reason);
           }
         }
         return undefined;

--- a/packages/core/src/utils-hoist/error.ts
+++ b/packages/core/src/utils-hoist/error.ts
@@ -2,9 +2,6 @@ import type { ConsoleLevel } from '../types-hoist';
 
 /** An error emitted by Sentry SDKs and related utilities. */
 export class SentryError extends Error {
-  /** Display name of this error instance. */
-  public name: string;
-
   public logLevel: ConsoleLevel;
 
   public constructor(
@@ -13,11 +10,6 @@ export class SentryError extends Error {
   ) {
     super(message);
 
-    this.name = new.target.prototype.constructor.name;
-    // This sets the prototype to be `Error`, not `SentryError`. It's unclear why we do this, but commenting this line
-    // out causes various (seemingly totally unrelated) playwright tests consistently time out. FYI, this makes
-    // instances of `SentryError` fail `obj instanceof SentryError` checks.
-    Object.setPrototypeOf(this, new.target.prototype);
     this.logLevel = logLevel;
   }
 }


### PR DESCRIPTION
Backport, fixes https://github.com/getsentry/sentry-javascript/issues/15214