### PR TITLE
fix(react): Import default for hoistNonReactStatics

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -2,8 +2,8 @@ import type { ReportDialogOptions } from '@sentry/browser';
 import { getClient, showReportDialog, withScope } from '@sentry/browser';
 import { logger } from '@sentry/core';
 import type { Scope } from '@sentry/core';
-import { hoistNonReactStatics } from './hoist-non-react-statics';
 import * as React from 'react';
+import { hoistNonReactStatics } from './hoist-non-react-statics';
 
 import { DEBUG_BUILD } from './debug-build';
 import { captureReactException } from './error';

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -2,7 +2,7 @@ import type { ReportDialogOptions } from '@sentry/browser';
 import { getClient, showReportDialog, withScope } from '@sentry/browser';
 import { logger } from '@sentry/core';
 import type { Scope } from '@sentry/core';
-import hoistNonReactStatics from 'hoist-non-react-statics';
+import { hoistNonReactStatics } from './hoist-non-react-statics';
 import * as React from 'react';
 
 import { DEBUG_BUILD } from './debug-build';

--- a/packages/react/src/hoist-non-react-statics.ts
+++ b/packages/react/src/hoist-non-react-statics.ts
@@ -1,0 +1,5 @@
+import * as hoistNonReactStaticsImport from 'hoist-non-react-statics';
+
+// Ensure we use the default export from hoist-non-react-statics if available,
+// falling back to the module itself. This handles both ESM and CJS usage.
+export const hoistNonReactStatics = hoistNonReactStaticsImport.default || hoistNonReactStaticsImport;

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,8 +1,12 @@
 import { startInactiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON, timestampInSeconds, withActiveSpan } from '@sentry/core';
-import hoistNonReactStatics from 'hoist-non-react-statics';
+import * as hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
+
+// Ensure we use the default export from hoist-non-react-statics if available,
+// falling back to the module itself. This handles both ESM and CJS usage.
+const hoistStatics: typeof hoistNonReactStatics.default = hoistNonReactStatics.default || hoistNonReactStatics;
 
 import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from './constants';
 
@@ -170,7 +174,7 @@ function withProfiler<P extends Record<string, any>>(
 
   // Copy over static methods from Wrapped component to Profiler HOC
   // See: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over
-  hoistNonReactStatics(Wrapped, WrappedComponent);
+  hoistStatics(Wrapped, WrappedComponent);
   return Wrapped;
 }
 
@@ -236,4 +240,4 @@ function useProfiler(
   }, []);
 }
 
-export { withProfiler, Profiler, useProfiler };
+export { Profiler, useProfiler, withProfiler };

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,14 +1,11 @@
 import { startInactiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON, timestampInSeconds, withActiveSpan } from '@sentry/core';
-import * as hoistNonReactStatics from 'hoist-non-react-statics';
+
 import * as React from 'react';
 
-// Ensure we use the default export from hoist-non-react-statics if available,
-// falling back to the module itself. This handles both ESM and CJS usage.
-const hoistStatics: typeof hoistNonReactStatics.default = hoistNonReactStatics.default || hoistNonReactStatics;
-
 import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from './constants';
+import { hoistNonReactStatics } from './hoist-non-react-statics';
 
 export const UNKNOWN_COMPONENT = 'unknown';
 
@@ -174,7 +171,7 @@ function withProfiler<P extends Record<string, any>>(
 
   // Copy over static methods from Wrapped component to Profiler HOC
   // See: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over
-  hoistStatics(Wrapped, WrappedComponent);
+  hoistNonReactStatics(Wrapped, WrappedComponent);
   return Wrapped;
 }
 

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,7 +1,6 @@
 import { startInactiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON, timestampInSeconds, withActiveSpan } from '@sentry/core';
-
 import * as React from 'react';
 
 import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from './constants';

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -14,7 +14,7 @@ import {
   spanToJSON,
 } from '@sentry/core';
 import type { Client, Integration, Span, TransactionSource } from '@sentry/core';
-import hoistNonReactStatics from 'hoist-non-react-statics';
+import { hoistNonReactStatics } from './hoist-non-react-statics';
 import * as React from 'react';
 import type { ReactElement } from 'react';
 

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -14,9 +14,9 @@ import {
   spanToJSON,
 } from '@sentry/core';
 import type { Client, Integration, Span, TransactionSource } from '@sentry/core';
-import { hoistNonReactStatics } from './hoist-non-react-statics';
 import * as React from 'react';
 import type { ReactElement } from 'react';
+import { hoistNonReactStatics } from './hoist-non-react-statics';
 
 import type { Action, Location } from './types';
 

--- a/packages/react/src/reactrouterv6-compat-utils.tsx
+++ b/packages/react/src/reactrouterv6-compat-utils.tsx
@@ -22,7 +22,7 @@ import {
 } from '@sentry/core';
 import * as React from 'react';
 
-import hoistNonReactStatics from 'hoist-non-react-statics';
+import { hoistNonReactStatics } from './hoist-non-react-statics';
 import { DEBUG_BUILD } from './debug-build';
 import type {
   Action,

--- a/packages/react/src/reactrouterv6-compat-utils.tsx
+++ b/packages/react/src/reactrouterv6-compat-utils.tsx
@@ -22,8 +22,8 @@ import {
 } from '@sentry/core';
 import * as React from 'react';
 
-import { hoistNonReactStatics } from './hoist-non-react-statics';
 import { DEBUG_BUILD } from './debug-build';
+import { hoistNonReactStatics } from './hoist-non-react-statics';
 import type {
   Action,
   AgnosticDataRouteMatch,


### PR DESCRIPTION
This came up during upgrading Sentry to our v9 alpha (https://github.com/getsentry/sentry/pull/84258).

Currently our import emits this line in cjs:
`hoistNonReactStatics.default(Wrapped, WrappedComponent);`
Which results in a runtime error (at least in jest runners).

With this change I updated the import to use `import * as hoistNonReactStaticsImport from 'hoist-non-react-statics';` which solves the issue but breaks our ts-check. For this I moved the import into a fallback util function which satisfies ts.

