### PR TITLE
WIP: Handling uncaught errors in SolidStart

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solidstart/src/routes/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/routes/index.tsx
@@ -25,6 +25,12 @@ export default function Home() {
         <li>
           <A href="/back-navigation">Test back navigation</A>
         </li>
+        <li>
+          <A href="/uncaught-route-error">Test uncaught errors in routes</A>
+        </li>
+        <li>
+          <A href="/server-error-without-instrumentation">Test uncaught errors in server action without instrumentation wrapper</A>
+        </li>
       </ul>
     </>
   );

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/routes/uncaught-route-error.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/routes/uncaught-route-error.tsx
@@ -1,0 +1,3 @@
+export default function UncaughtErrorPage() {
+  throw new Error('Uncaught error thrown in UncaughtErrorPage route from Solid Start E2E test app');
+}

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/routes/uncaught-server-error-without-instrumentation.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/routes/uncaught-server-error-without-instrumentation.tsx
@@ -1,0 +1,13 @@
+import { createAsync } from '@solidjs/router';
+const getPrefecture = async () => {
+  'use server';
+  throw new Error('Error thrown from Solid Start E2E test app server route without instrumentation wrapper');
+
+  return { prefecture: 'Kanagawa' };
+};
+
+export default function UncaughtServerErrorWithoutInstrumentationPage() {
+  const data = createAsync(() => getPrefecture());
+
+  return <div>Prefecture: {data()?.prefecture}</div>;
+}

--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/uncaught.errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/uncaught.errors.server.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test.describe('server-side errors', () => {
+  test('captures server action error', async ({ page }) => {
+    const errorEventPromise = waitForError('solidstart', errorEvent => {
+      return errorEvent?.exception?.values?.[0]?.value === 'Error thrown from Solid Start E2E test app server route without instrumentation wrapper';
+    });
+
+    await page.goto(`/uncaught-server-error-without-instrumentation`);
+
+    const error = await errorEventPromise;
+
+    expect(error).toMatchObject({
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'Error thrown from Solid Start E2E test app server route without instrumentation wrapper',
+            mechanism: {
+              type: 'solidstart',
+              handled: false,
+            },
+          },
+        ],
+      },
+      transaction: 'GET /uncaught-server-error-without-instrumentation',
+    });
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/uncaught.route.error.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/uncaught.route.error.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test.describe('client-side errors', () => {
+  test('captures error thrown on click', async ({ page }) => {
+    const errorPromise = waitForError('solidstart', async errorEvent => {
+      return errorEvent?.exception?.values?.[0]?.value === 'Uncaught error thrown in UncaughtErrorPage route from Solid Start E2E test app';
+    });
+
+    await page.goto(`/uncaught-route-error`);
+    const error = await errorPromise;
+
+    expect(error).toMatchObject({
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'Uncaught error thrown in UncaughtErrorPage route from Solid Start E2E test app',
+            mechanism: {
+              handled: false,
+            },
+          },
+        ],
+      },
+      transaction: '/uncaught-route-error',
+    });
+    expect(error.transaction).toEqual('/uncaught-route-error');
+  });
+});


### PR DESCRIPTION
The SDK cannot currently deal with uncaught errors properly. Neither in routes nor in server actions as demonstrated by the two e2e tests in this PR.

ref: https://github.com/getsentry/sentry-javascript/issues/15242