### PR TITLE
feat(nuxt): add `silent`, `errorHandler`, `release` to `SourceMapsOptions`

### DIFF
--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -9,6 +9,37 @@ export type SentryNuxtServerOptions = Omit<Parameters<typeof initNode>[0] & obje
 
 type SourceMapsOptions = {
   /**
+   * Suppresses all logs.
+   *
+   * @default false
+   */
+  silent?: SentryVitePluginOptions['silent'];
+
+  /**
+   * When an error occurs during release creation or sourcemaps upload, the plugin will call this function.
+   *
+   * By default, the plugin will simply throw an error, thereby stopping the bundling process.
+   * If an `errorHandler` callback is provided, compilation will continue, unless an error is
+   * thrown in the provided callback.
+   *
+   * To allow compilation to continue but still emit a warning, set this option to the following:
+   *
+   * ```js
+   * (err) => {
+   *   console.warn(err);
+   * }
+   * ```
+   */
+  errorHandler?: SentryVitePluginOptions['errorHandler'];
+
+  /**
+   * Options related to managing the Sentry releases for a build.
+   *
+   * More info: https://docs.sentry.io/product/releases/
+   */
+  release?: SentryVitePluginOptions['release'];
+
+  /**
    * If this flag is `true`, and an auth token is detected, the Sentry SDK will
    * automatically generate and upload source maps to Sentry during a production build.
    *

--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -13,7 +13,7 @@ type SourceMapsOptions = {
    *
    * @default false
    */
-  silent?: SentryVitePluginOptions['silent'];
+  silent?: boolean;
 
   /**
    * When an error occurs during release creation or sourcemaps upload, the plugin will call this function.
@@ -30,14 +30,27 @@ type SourceMapsOptions = {
    * }
    * ```
    */
-  errorHandler?: SentryVitePluginOptions['errorHandler'];
+  errorHandler?: (err: Error) => void;
 
   /**
    * Options related to managing the Sentry releases for a build.
    *
    * More info: https://docs.sentry.io/product/releases/
    */
-  release?: SentryVitePluginOptions['release'];
+  release?: {
+    /**
+     * Unique identifier for the release you want to create.
+     *
+     * This value can also be specified via the `SENTRY_RELEASE` environment variable.
+     *
+     * Defaults to automatically detecting a value for your environment.
+     * This includes values for Cordova, Heroku, AWS CodeBuild, CircleCI, Xcode, and Gradle, and otherwise uses the git `HEAD`'s commit SHA.
+     * (the latter requires access to git CLI and for the root directory to be a valid repository)
+     *
+     * If you didn't provide a value and the plugin can't automatically detect one, no release will be created.
+     */
+    name?: string;
+  };
 
   /**
    * If this flag is `true`, and an auth token is detected, the Sentry SDK will

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -97,6 +97,7 @@ export function getPluginOptions(
     errorHandler: sourceMapsUploadOptions.errorHandler,
     release: {
       name: sourceMapsUploadOptions.release?.name,
+      ...moduleOptions?.unstable_sentryBundlerPluginOptions?.release,
     },
     _metaOptions: {
       telemetry: {

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -93,6 +93,9 @@ export function getPluginOptions(
     telemetry: sourceMapsUploadOptions.telemetry ?? true,
     url: sourceMapsUploadOptions.url ?? process.env.SENTRY_URL,
     debug: moduleOptions.debug ?? false,
+    silent: sourceMapsUploadOptions.silent ?? false,
+    errorHandler: sourceMapsUploadOptions.errorHandler,
+    release: sourceMapsUploadOptions.release,
     _metaOptions: {
       telemetry: {
         metaFramework: 'nuxt',

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -95,7 +95,9 @@ export function getPluginOptions(
     debug: moduleOptions.debug ?? false,
     silent: sourceMapsUploadOptions.silent ?? false,
     errorHandler: sourceMapsUploadOptions.errorHandler,
-    release: sourceMapsUploadOptions.release,
+    release: {
+      name: sourceMapsUploadOptions.release?.name,
+    },
     _metaOptions: {
       telemetry: {
         metaFramework: 'nuxt',


### PR DESCRIPTION
This pull request includes changes to enhance the configuration options for managing Sentry source maps in a Nuxt.js project. The most important changes include adding new options to suppress logs, handle errors during release creation, and manage Sentry releases.

Enhancements to Sentry source maps configuration:

* [`packages/nuxt/src/common/types.ts`](diffhunk://#diff-199725da81bbdbb2e85f3dfe2b1a2bf453b4c9755059e5050815d7fcde2f59a5R11-R41): Added `silent`, `errorHandler`, and `release` options to the `SourceMapsOptions` type to provide more control over logging, error handling, and release management.
* [`packages/nuxt/src/vite/sourceMaps.ts`](diffhunk://#diff-d511a0577f152ed6476e519722483c904cd2878586fdcd27f71c5587036bee37R96-R98): Updated the `getPluginOptions` function to include the new `silent`, `errorHandler`, and `release` options, allowing them to be used during the source maps upload process.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
