### PR TITLE
fix(v8/svelte): Guard component tracking `beforeUpdate` call

### DIFF
--- a/packages/svelte/src/constants.ts
+++ b/packages/svelte/src/constants.ts
@@ -1,5 +1,0 @@
-export const UI_SVELTE_INIT = 'ui.svelte.init';
-
-export const UI_SVELTE_UPDATE = 'ui.svelte.update';
-
-export const DEFAULT_COMPONENT_NAME = 'Svelte Component';

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -2,8 +2,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { afterUpdate, beforeUpdate, onMount } from 'svelte';
 
-import { startInactiveSpan } from '@sentry/core';
-import { DEFAULT_COMPONENT_NAME, UI_SVELTE_INIT, UI_SVELTE_UPDATE } from './constants';
+import { logger, startInactiveSpan } from '@sentry/core';
 import type { TrackComponentOptions } from './types';
 
 const defaultTrackComponentOptions: {
@@ -29,21 +28,27 @@ export function trackComponent(options?: TrackComponentOptions): void {
 
   const customComponentName = mergedOptions.componentName;
 
-  const componentName = `<${customComponentName || DEFAULT_COMPONENT_NAME}>`;
+  const componentName = `<${customComponentName || 'Svelte Component'}>`;
 
   if (mergedOptions.trackInit) {
     recordInitSpan(componentName);
   }
 
   if (mergedOptions.trackUpdates) {
-    recordUpdateSpans(componentName);
+    try {
+      recordUpdateSpans(componentName);
+    } catch {
+      logger.warn(
+        "Cannot track component updates. This is likely because you're using Svelte 5 in Runes mode. Set `trackUpdates: false` in `withSentryConfig` or `trackComponent` to disable this warning.",
+      );
+    }
   }
 }
 
 function recordInitSpan(componentName: string): void {
   const initSpan = startInactiveSpan({
     onlyIfParent: true,
-    op: UI_SVELTE_INIT,
+    op: 'ui.svelte.init',
     name: componentName,
     attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.svelte' },
   });
@@ -58,7 +63,7 @@ function recordUpdateSpans(componentName: string): void {
   beforeUpdate(() => {
     updateSpan = startInactiveSpan({
       onlyIfParent: true,
-      op: UI_SVELTE_UPDATE,
+      op: 'ui.svelte.update',
       name: componentName,
       attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.svelte' },
     });

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -60,7 +60,7 @@ describe('withSentryConfig', () => {
 
     const wrappedConfig = withSentryConfig(originalConfig);
 
-    expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: [sentryPreproc] });
+    expect(wrappedConfig).toEqual({ ...originalConfig });
   });
 
   it('handles multiple wraps correctly by only adding our preprocessors once', () => {

--- a/packages/svelte/test/performance.test.ts
+++ b/packages/svelte/test/performance.test.ts
@@ -9,7 +9,6 @@ import { getClient, getCurrentScope, getIsolationScope, init, startSpan } from '
 
 import type { TransactionEvent } from '@sentry/core';
 
-// @ts-expect-error svelte import
 import DummyComponent from './components/Dummy.svelte';
 
 const PUBLIC_DSN = 'https://username@domain/123';
@@ -32,7 +31,7 @@ describe('Sentry.trackComponent()', () => {
 
     init({
       dsn: PUBLIC_DSN,
-      enableTracing: true,
+      tracesSampleRate: 1.0,
       beforeSendTransaction,
     });
   });
@@ -220,7 +219,7 @@ describe('Sentry.trackComponent()', () => {
     expect(transaction.spans![1]?.description).toEqual('<CustomComponentName>');
   });
 
-  it("doesn't do anything, if there's no ongoing transaction", async () => {
+  it("doesn't do anything, if there's no ongoing parent span", async () => {
     render(DummyComponent, {
       props: { options: { componentName: 'CustomComponentName' } },
     });
@@ -230,7 +229,7 @@ describe('Sentry.trackComponent()', () => {
     expect(transactions).toHaveLength(0);
   });
 
-  it("doesn't record update spans, if there's no ongoing root span at that time", async () => {
+  it("doesn't record update spans, if there's no ongoing parent span at that time", async () => {
     const component = startSpan({ name: 'outer' }, span => {
       expect(span).toBeDefined();
 


### PR DESCRIPTION
This PR adds a guard the Svelte SDK's component update tracking feature to catch an error thrown by Svelte 5 in Runes mode. In Runes mode, components must not call the old `beforeUpdate` or `afterUpdate` lifecycle hooks. Usually, when users do this in their code, the Svelte compiler would throw a build error. However, since our `withSentryConfig` wrapper adds a preprocessor that sneaks such a function call in, the compiler doesn't notice this (at least not in the webpack loader as reported in #https://github.com/getsentry/sentry-javascript/issues/15259.

This PR also cleans up the preprocessor adding logic which was overcomplicated and a leftover from when we added more than one preprocessor to users' svelte configs. In general, I cleaned up some unnecessary stuff and terminology. 

I'll open a follow-up PR for v9 where I'll disable update tracking by default (see https://github.com/getsentry/sentry-javascript/issues/15259#issuecomment-2630468497)

closes #15259