### PR TITLE
feat(svelte)!: Disable component update tracking by default

### DIFF
--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -3,7 +3,7 @@ import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 import { componentTrackingPreprocessor, defaultComponentTrackingOptions } from './preprocessors';
 import type { SentryPreprocessorGroup, SentrySvelteConfigOptions, SvelteConfig } from './types';
 
-const DEFAULT_SENTRY_OPTIONS: SentrySvelteConfigOptions = {
+const defaultSentryOptions: SentrySvelteConfigOptions = {
   componentTracking: defaultComponentTrackingOptions,
 };
 
@@ -20,10 +20,10 @@ export function withSentryConfig(
   sentryOptions?: SentrySvelteConfigOptions,
 ): SvelteConfig {
   const mergedOptions = {
-    ...DEFAULT_SENTRY_OPTIONS,
+    ...defaultSentryOptions,
     ...sentryOptions,
     componentTracking: {
-      ...DEFAULT_SENTRY_OPTIONS.componentTracking,
+      ...defaultSentryOptions.componentTracking,
       ...sentryOptions?.componentTracking,
     },
   };

--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -22,30 +22,23 @@ export function withSentryConfig(
   const mergedOptions = {
     ...DEFAULT_SENTRY_OPTIONS,
     ...sentryOptions,
+    componentTracking: {
+      ...DEFAULT_SENTRY_OPTIONS.componentTracking,
+      ...sentryOptions?.componentTracking,
+    },
   };
 
   const originalPreprocessors = getOriginalPreprocessorArray(originalConfig);
 
-  // Map is insertion-order-preserving. It's important to add preprocessors
-  // to this map in the right order we want to see them being executed.
-  // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
-  const sentryPreprocessors = new Map<string, SentryPreprocessorGroup>();
-
-  const shouldTrackComponents = mergedOptions.componentTracking?.trackComponents;
-  if (shouldTrackComponents) {
-    const firstPassPreproc: SentryPreprocessorGroup = componentTrackingPreprocessor(mergedOptions.componentTracking);
-    sentryPreprocessors.set(firstPassPreproc.sentryId || '', firstPassPreproc);
+  // Bail if users already added the preprocessor
+  if (originalPreprocessors.find((p: PreprocessorGroup) => !!(p as SentryPreprocessorGroup).sentryId)) {
+    return originalConfig;
   }
 
-  // We prioritize user-added preprocessors, so we don't insert sentry processors if they
-  // have already been added by users.
-  originalPreprocessors.forEach((p: SentryPreprocessorGroup) => {
-    if (p.sentryId) {
-      sentryPreprocessors.delete(p.sentryId);
-    }
-  });
-
-  const mergedPreprocessors = [...sentryPreprocessors.values(), ...originalPreprocessors];
+  const mergedPreprocessors = [...originalPreprocessors];
+  if (mergedOptions.componentTracking.trackComponents) {
+    mergedPreprocessors.unshift(componentTrackingPreprocessor(mergedOptions.componentTracking));
+  }
 
   return {
     ...originalConfig,

--- a/packages/svelte/src/constants.ts
+++ b/packages/svelte/src/constants.ts
@@ -1,5 +1,0 @@
-export const UI_SVELTE_INIT = 'ui.svelte.init';
-
-export const UI_SVELTE_UPDATE = 'ui.svelte.update';
-
-export const DEFAULT_COMPONENT_NAME = 'Svelte Component';

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -2,8 +2,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { afterUpdate, beforeUpdate, onMount } from 'svelte';
 
-import { startInactiveSpan } from '@sentry/core';
-import { DEFAULT_COMPONENT_NAME, UI_SVELTE_INIT, UI_SVELTE_UPDATE } from './constants';
+import { logger, startInactiveSpan } from '@sentry/core';
 import type { TrackComponentOptions } from './types';
 
 const defaultTrackComponentOptions: {
@@ -29,21 +28,27 @@ export function trackComponent(options?: TrackComponentOptions): void {
 
   const customComponentName = mergedOptions.componentName;
 
-  const componentName = `<${customComponentName || DEFAULT_COMPONENT_NAME}>`;
+  const componentName = `<${customComponentName || 'Svelte Component'}>`;
 
   if (mergedOptions.trackInit) {
     recordInitSpan(componentName);
   }
 
   if (mergedOptions.trackUpdates) {
-    recordUpdateSpans(componentName);
+    try {
+      recordUpdateSpans(componentName);
+    } catch {
+      logger.warn(
+        "Cannot track component updates. This is likely because you're using Svelte 5 in Runes mode. Set `trackUpdates: false` in `withSentryConfig` or `trackComponent` to disable this warning.",
+      );
+    }
   }
 }
 
 function recordInitSpan(componentName: string): void {
   const initSpan = startInactiveSpan({
     onlyIfParent: true,
-    op: UI_SVELTE_INIT,
+    op: 'ui.svelte.init',
     name: componentName,
     attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.svelte' },
   });
@@ -58,7 +63,7 @@ function recordUpdateSpans(componentName: string): void {
   beforeUpdate(() => {
     updateSpan = startInactiveSpan({
       onlyIfParent: true,
-      op: UI_SVELTE_UPDATE,
+      op: 'ui.svelte.update',
       name: componentName,
       attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.svelte' },
     });

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -11,7 +11,7 @@ const defaultTrackComponentOptions: {
   componentName?: string;
 } = {
   trackInit: true,
-  trackUpdates: true,
+  trackUpdates: false,
 };
 
 /**

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -6,7 +6,7 @@ import type { ComponentTrackingInitOptions, SentryPreprocessorGroup, TrackCompon
 export const defaultComponentTrackingOptions: Required<ComponentTrackingInitOptions> = {
   trackComponents: true,
   trackInit: true,
-  trackUpdates: true,
+  trackUpdates: false,
 };
 
 export const FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID = 'FIRST_PASS_COMPONENT_TRACKING_PREPROCESSOR';

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -29,7 +29,7 @@ export type SpanOptions = {
    * onMount lifecycle hook. This span tells how long it takes a component
    * to be created and inserted into the DOM.
    *
-   * Defaults to true if component tracking is enabled
+   * @default `true` if component tracking is enabled
    */
   trackInit?: boolean;
 
@@ -37,7 +37,10 @@ export type SpanOptions = {
    * If true, a span is recorded between a component's beforeUpdate and afterUpdate
    * lifecycle hooks.
    *
-   * Defaults to true if component tracking is enabled
+   * Caution: Component updates can only be tracked in Svelte versions prior to version 5
+   * or in Svelte 5 in legacy mode (i.e. without Runes).
+   *
+   * @default `false` if component tracking is enabled
    */
   trackUpdates?: boolean;
 };

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -60,7 +60,7 @@ describe('withSentryConfig', () => {
 
     const wrappedConfig = withSentryConfig(originalConfig);
 
-    expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: [sentryPreproc] });
+    expect(wrappedConfig).toEqual({ ...originalConfig });
   });
 
   it('handles multiple wraps correctly by only adding our preprocessors once', () => {

--- a/packages/svelte/test/performance.test.ts
+++ b/packages/svelte/test/performance.test.ts
@@ -9,7 +9,6 @@ import { getClient, getCurrentScope, getIsolationScope, init, startSpan } from '
 
 import type { TransactionEvent } from '@sentry/core';
 
-// @ts-expect-error svelte import
 import DummyComponent from './components/Dummy.svelte';
 
 const PUBLIC_DSN = 'https://username@domain/123';
@@ -220,7 +219,7 @@ describe('Sentry.trackComponent()', () => {
     expect(transaction.spans![1]?.description).toEqual('<CustomComponentName>');
   });
 
-  it("doesn't do anything, if there's no ongoing transaction", async () => {
+  it("doesn't do anything, if there's no ongoing parent span", async () => {
     render(DummyComponent, {
       props: { options: { componentName: 'CustomComponentName' } },
     });
@@ -230,7 +229,7 @@ describe('Sentry.trackComponent()', () => {
     expect(transactions).toHaveLength(0);
   });
 
-  it("doesn't record update spans, if there's no ongoing root span at that time", async () => {
+  it("doesn't record update spans, if there's no ongoing parent span at that time", async () => {
     const component = startSpan({ name: 'outer' }, span => {
       expect(span).toBeDefined();
 

--- a/packages/svelte/test/preprocessors.test.ts
+++ b/packages/svelte/test/preprocessors.test.ts
@@ -24,7 +24,7 @@ function expectComponentCodeToBeModified(
   preprocessedComponents.forEach(cmp => {
     const expectedFunctionCallOptions = {
       trackInit: options?.trackInit ?? true,
-      trackUpdates: options?.trackUpdates ?? true,
+      trackUpdates: options?.trackUpdates ?? false,
       componentName: cmp.name,
     };
     const expectedFunctionCall = `trackComponent(${JSON.stringify(expectedFunctionCallOptions)});\n`;
@@ -115,7 +115,7 @@ describe('componentTrackingPreprocessor', () => {
 
       expect(cmp2?.newCode).toEqual(cmp2?.originalCode);
 
-      expectComponentCodeToBeModified([cmp1!, cmp3!], { trackInit: true, trackUpdates: true });
+      expectComponentCodeToBeModified([cmp1!, cmp3!], { trackInit: true, trackUpdates: false });
     });
 
     it('doesnt inject the function call to the same component more than once', () => {
@@ -149,7 +149,7 @@ describe('componentTrackingPreprocessor', () => {
         return { ...cmp, newCode: res.code, map: res.map };
       });
 
-      expectComponentCodeToBeModified([cmp11!, cmp2!], { trackInit: true, trackUpdates: true });
+      expectComponentCodeToBeModified([cmp11!, cmp2!], { trackInit: true });
       expect(cmp12!.newCode).toEqual(cmp12!.originalCode);
     });
 
@@ -228,7 +228,7 @@ describe('componentTrackingPreprocessor', () => {
 
       expect(processedCode.code).toEqual(
         '<script>import { trackComponent } from "@sentry/svelte";\n' +
-          'trackComponent({"trackInit":true,"trackUpdates":true,"componentName":"Cmp1"});\n\n' +
+          'trackComponent({"trackInit":true,"trackUpdates":false,"componentName":"Cmp1"});\n\n' +
           '</script>\n' +
           "<p>I'm just a plain component</p>\n" +
           '<style>p{margin-top:10px}</style>',
@@ -248,7 +248,7 @@ describe('componentTrackingPreprocessor', () => {
 
       expect(processedCode.code).toEqual(
         '<script>import { trackComponent } from "@sentry/svelte";\n' +
-          'trackComponent({"trackInit":true,"trackUpdates":true,"componentName":"Cmp2"});\n' +
+          'trackComponent({"trackInit":true,"trackUpdates":false,"componentName":"Cmp2"});\n' +
           "console.log('hi');</script>\n" +
           "<p>I'm a component with a script</p>\n" +
           '<style>p{margin-top:10px}</style>',
@@ -267,7 +267,7 @@ describe('componentTrackingPreprocessor', () => {
 
       expect(processedCode.code).toEqual(
         '<script>import { trackComponent } from "@sentry/svelte";\n' +
-          'trackComponent({"trackInit":true,"trackUpdates":true,"componentName":"unknown"});\n' +
+          'trackComponent({"trackInit":true,"trackUpdates":false,"componentName":"unknown"});\n' +
           "console.log('hi');</script>",
       );
     });


### PR DESCRIPTION
- **fix(v8/svelte): Guard component tracking `beforeUpdate` call**
- **feat(svelte)!: Disable component update tracking by default**
