### PR TITLE
fix(nuxt): Detect Azure Function runtime for flushing with timeout

### DIFF
--- a/packages/nuxt/src/runtime/plugins/sentry.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry.server.ts
@@ -52,7 +52,11 @@ export default defineNitroPlugin(nitroApp => {
 });
 
 async function flushIfServerless(): Promise<void> {
-  const isServerless = !!process.env.LAMBDA_TASK_ROOT || !!process.env.VERCEL || !!process.env.NETLIFY;
+  const isServerless =
+    !!process.env.FUNCTIONS_WORKER_RUNTIME || // Azure Functions
+    !!process.env.LAMBDA_TASK_ROOT || // AWS Lambda
+    !!process.env.VERCEL ||
+    !!process.env.NETLIFY;
 
   // @ts-expect-error This is not typed
   if (GLOBAL_OBJ[Symbol.for('@vercel/request-context')]) {


### PR DESCRIPTION
The debugging ability for Azure Functions when using Azure Static Web Apps is very limited. But as I could see some Sentry-related logs I **think** Sentry is generally initialized.

However, server-related logs don't show up in Sentry. This is **probably** because the Azure Function finishes before the error can be sent to Sentry.
By adding the Azure environment variable to check whether we should flush with a timeout, this should possibly fix the issue.

Logs in Application Insights:
![image](https://github.com/user-attachments/assets/ed5ccd37-be87-4338-946b-94ec543e08c5)
