### PR TITLE
fix(node): Fix name of `vercelAIIntegration` to `VercelAI`

### DIFF
--- a/packages/node/src/integrations/tracing/vercelai/index.ts
+++ b/packages/node/src/integrations/tracing/vercelai/index.ts
@@ -5,11 +5,13 @@ import { generateInstrumentOnce } from '../../../otel/instrument';
 import { addOriginToSpan } from '../../../utils/addOriginToSpan';
 import { SentryVercelAiInstrumentation, sentryVercelAiPatched } from './instrumentation';
 
-export const instrumentVercelAi = generateInstrumentOnce('vercelAI', () => new SentryVercelAiInstrumentation({}));
+const INTEGRATION_NAME = 'VercelAI';
+
+export const instrumentVercelAi = generateInstrumentOnce(INTEGRATION_NAME, () => new SentryVercelAiInstrumentation({}));
 
 const _vercelAIIntegration = (() => {
   return {
-    name: 'vercelAI',
+    name: INTEGRATION_NAME,
     setupOnce() {
       instrumentVercelAi();
     },


### PR DESCRIPTION
We use capitalized integration names everywhere, except here.

Noticed this by chance, this is kind of breaking, so probably also should go into the migration guide - @lforst should I add this, but this will conflict with the big PR, so maybe we just add it there directly?