### PR TITLE
ref(core): Remove unused special handling for `Debug` integration

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -60,19 +60,7 @@ export function getIntegrationsToSetup(options: Pick<Options, 'defaultIntegratio
     integrations = defaultIntegrations;
   }
 
-  const finalIntegrations = filterDuplicates(integrations);
-
-  // The `Debug` integration prints copies of the `event` and `hint` which will be passed to `beforeSend` or
-  // `beforeSendTransaction`. It therefore has to run after all other integrations, so that the changes of all event
-  // processors will be reflected in the printed values. For lack of a more elegant way to guarantee that, we therefore
-  // locate it and, assuming it exists, pop it out of its current spot and shove it onto the end of the array.
-  const debugIndex = finalIntegrations.findIndex(integration => integration.name === 'Debug');
-  if (debugIndex > -1) {
-    const [debugInstance] = finalIntegrations.splice(debugIndex, 1) as [Integration];
-    finalIntegrations.push(debugInstance);
-  }
-
-  return finalIntegrations;
+  return filterDuplicates(integrations);
 }
 
 /**

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -189,29 +189,6 @@ describe('getIntegrationsToSetup', () => {
     });
   });
 
-  describe('puts `Debug` integration last', () => {
-    // No variations here (default vs user, duplicates, user array vs user function, etc) because by the time we're
-    // dealing with the `Debug` integration, all of the combining and deduping has already been done
-    const noDebug = [new MockIntegration('ChaseSquirrels')];
-    const debugNotLast = [new MockIntegration('Debug'), new MockIntegration('CatchTreats')];
-    const debugAlreadyLast = [new MockIntegration('ChaseSquirrels'), new MockIntegration('Debug')];
-
-    const testCases: TestCase[] = [
-      // each test case is [testName, defaultIntegrations, userIntegrations, expectedResult]
-      ['`Debug` not present', false, noDebug, ['ChaseSquirrels']],
-      ['`Debug` not originally last', false, debugNotLast, ['CatchTreats', 'Debug']],
-      ['`Debug` already last', false, debugAlreadyLast, ['ChaseSquirrels', 'Debug']],
-    ];
-
-    test.each(testCases)('%s', (_, defaultIntegrations, userIntegrations, expected) => {
-      const integrations = getIntegrationsToSetup({
-        defaultIntegrations,
-        integrations: userIntegrations,
-      });
-      expect(integrations.map(i => i.name)).toEqual(expected);
-    });
-  });
-
   it('works with empty array', () => {
     const integrations = getIntegrationsToSetup({
       integrations: [],
@@ -304,29 +281,6 @@ describe('getIntegrationsToSetup', () => {
     expect(integrations.map(i => i.name)).toEqual(['foo', 'bar']);
     expect((integrations[0] as any).order).toEqual('firstUser');
     expect((integrations[1] as any).order).toEqual('secondUser');
-  });
-
-  it('always moves Debug integration to the end of the list', () => {
-    let integrations = getIntegrationsToSetup({
-      defaultIntegrations: [new MockIntegration('Debug'), new MockIntegration('foo')],
-      integrations: [new MockIntegration('bar')],
-    });
-
-    expect(integrations.map(i => i.name)).toEqual(['foo', 'bar', 'Debug']);
-
-    integrations = getIntegrationsToSetup({
-      defaultIntegrations: [new MockIntegration('foo')],
-      integrations: [new MockIntegration('Debug'), new MockIntegration('bar')],
-    });
-
-    expect(integrations.map(i => i.name)).toEqual(['foo', 'bar', 'Debug']);
-
-    integrations = getIntegrationsToSetup({
-      defaultIntegrations: [new MockIntegration('Debug')],
-      integrations: [new MockIntegration('foo')],
-    });
-
-    expect(integrations.map(i => i.name)).toEqual(['foo', 'Debug']);
   });
 });
 


### PR DESCRIPTION
This integration is removed in v9 so we do not need this code anymore. Noticed this by chance 😅 
