### PR TITLE
fix(v8/solidstart): Do not copy release-injection map file

### DIFF
--- a/packages/solidstart/src/config/addInstrumentation.ts
+++ b/packages/solidstart/src/config/addInstrumentation.ts
@@ -45,7 +45,9 @@ export async function addInstrumentationFileToBuild(nitro: Nitro): Promise<void>
       try {
         const ssrAssetsPath = path.resolve(buildDir, 'build', 'ssr', 'assets');
         const assetsBuildDir = await fs.promises.readdir(ssrAssetsPath);
-        const releaseInjectionFile = assetsBuildDir.find(file => file.startsWith('_sentry-release-injection-file-'));
+        const releaseInjectionFile = assetsBuildDir.find(file =>
+          /^_sentry-release-injection-file-.*\.(js|mjs)$/.test(file),
+        );
 
         if (releaseInjectionFile) {
           const releaseSource = path.resolve(ssrAssetsPath, releaseInjectionFile);

--- a/packages/solidstart/test/config/addInstrumentation.test.ts
+++ b/packages/solidstart/test/config/addInstrumentation.test.ts
@@ -126,6 +126,23 @@ describe('addInstrumentationFileToBuild()', () => {
     expect(fsMkdirMock).not.toHaveBeenCalled();
   });
 
+  it('does not copy release injection file source map file', async () => {
+    fsExistsSyncMock.mockReturnValue(true);
+    fsReaddirMock.mockResolvedValueOnce(['_sentry-release-injection-file-test.js.map']);
+    fsCopyFileMock.mockResolvedValueOnce(true);
+    await addInstrumentationFileToBuild(nitroOptions);
+
+    await callNitroCloseHook();
+
+    expect(fsCopyFileMock).not.toHaveBeenCalledWith(
+      '/path/to/buildDir/build/ssr/assets/_sentry-release-injection-file-test.js.map',
+      '/path/to/serverDir/assets/_sentry-release-injection-file-test.js.map',
+    );
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(
+      '[Sentry SolidStart withSentry] Successfully created /path/to/serverDir/assets/_sentry-release-injection-file-test.js.map.',
+    );
+  });
+
   it('copies release injection file if available', async () => {
     fsExistsSyncMock.mockReturnValue(true);
     fsReaddirMock.mockResolvedValueOnce(['_sentry-release-injection-file-test.js']);


### PR DESCRIPTION
Backport of https://github.com/getsentry/sentry-javascript/pull/15302