### PR TITLE
ref: Use `applySdkMetadata` everywhere

### DIFF
--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -2,11 +2,15 @@ import { existsSync } from 'fs';
 import { hostname } from 'os';
 import { basename, resolve } from 'path';
 import { types } from 'util';
-import type { Integration, Options, Scope, SdkMetadata, Span } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, logger } from '@sentry/core';
+import type { Integration, Options, Scope, Span } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  applySdkMetadata,
+  logger,
+} from '@sentry/core';
 import type { NodeClient, NodeOptions } from '@sentry/node';
 import {
-  SDK_VERSION,
   captureException,
   captureMessage,
   continueTrace,
@@ -73,22 +77,11 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
  */
 export function init(options: NodeOptions = {}): NodeClient | undefined {
   const opts = {
-    _metadata: {} as SdkMetadata,
     defaultIntegrations: getDefaultIntegrations(options),
     ...options,
   };
 
-  opts._metadata.sdk = opts._metadata.sdk || {
-    name: 'sentry.javascript.aws-serverless',
-    integrations: ['AWSLambda'],
-    packages: [
-      {
-        name: 'npm:@sentry/aws-serverless',
-        version: SDK_VERSION,
-      },
-    ],
-    version: SDK_VERSION,
-  };
+  applySdkMetadata(opts, 'aws-serverless');
 
   return initWithoutDefaultIntegrations(opts);
 }

--- a/packages/aws-serverless/test/sdk.test.ts
+++ b/packages/aws-serverless/test/sdk.test.ts
@@ -515,7 +515,6 @@ describe('AWSLambda', () => {
           _metadata: {
             sdk: {
               name: 'sentry.javascript.aws-serverless',
-              integrations: ['AWSLambda'],
               packages: [
                 {
                   name: 'npm:@sentry/aws-serverless',

--- a/packages/google-cloud-serverless/src/sdk.ts
+++ b/packages/google-cloud-serverless/src/sdk.ts
@@ -1,6 +1,7 @@
-import type { Integration, Options, SdkMetadata } from '@sentry/core';
+import type { Integration, Options } from '@sentry/core';
+import { applySdkMetadata } from '@sentry/core';
 import type { NodeClient, NodeOptions } from '@sentry/node';
-import { SDK_VERSION, getDefaultIntegrationsWithoutPerformance, init as initNode } from '@sentry/node';
+import { getDefaultIntegrationsWithoutPerformance, init as initNode } from '@sentry/node';
 
 import { googleCloudGrpcIntegration } from './integrations/google-cloud-grpc';
 import { googleCloudHttpIntegration } from './integrations/google-cloud-http';
@@ -28,21 +29,11 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
  */
 export function init(options: NodeOptions = {}): NodeClient | undefined {
   const opts = {
-    _metadata: {} as SdkMetadata,
     defaultIntegrations: getDefaultIntegrations(options),
     ...options,
   };
 
-  opts._metadata.sdk = opts._metadata.sdk || {
-    name: 'sentry.javascript.google-cloud-serverless',
-    packages: [
-      {
-        name: 'npm:@sentry/google-cloud-serverless',
-        version: SDK_VERSION,
-      },
-    ],
-    version: SDK_VERSION,
-  };
+  applySdkMetadata(opts, 'google-cloud-serverless');
 
   return initNode(opts);
 }

--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -1,29 +1,19 @@
-import { SDK_VERSION, getDefaultIntegrations, init as browserInit } from '@sentry/browser';
-
+import { getDefaultIntegrations, init as browserInit } from '@sentry/browser';
 import type { Client } from '@sentry/core';
+import { applySdkMetadata } from '@sentry/core';
 import { vueIntegration } from './integration';
 import type { Options } from './types';
 
 /**
  * Inits the Vue SDK
  */
-export function init(config: Partial<Omit<Options, 'tracingOptions'>> = {}): Client | undefined {
-  const options = {
-    _metadata: {
-      sdk: {
-        name: 'sentry.javascript.vue',
-        packages: [
-          {
-            name: 'npm:@sentry/vue',
-            version: SDK_VERSION,
-          },
-        ],
-        version: SDK_VERSION,
-      },
-    },
-    defaultIntegrations: [...getDefaultIntegrations(config), vueIntegration()],
-    ...config,
+export function init(options: Partial<Omit<Options, 'tracingOptions'>> = {}): Client | undefined {
+  const opts = {
+    defaultIntegrations: [...getDefaultIntegrations(options), vueIntegration()],
+    ...options,
   };
 
-  return browserInit(options);
+  applySdkMetadata(opts, 'vue');
+
+  return browserInit(opts);
 }


### PR DESCRIPTION
This was still set differently in a few places. This PR unifies this so we do this consistently.

For aws-serverless, we also still hard-coded the `AWSLambda` integration name, but this is already reflected via the `Aws` and `AwsLambda` integrations anyhow.