### PR TITLE
ref(browser): Skip browser extension warning in non-debug builds

### DIFF
--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
+import { hasDebugLogs } from '../../../utils/helpers';
 
 sentryTest(
   'should not initialize when inside a Firefox/Safari browser extension',
@@ -18,9 +19,14 @@ sentryTest(
     });
 
     expect(isInitialized).toEqual(false);
-    expect(errorLogs.length).toEqual(1);
-    expect(errorLogs[0]).toEqual(
-      '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
-    );
+
+    if (hasDebugLogs()) {
+      expect(errorLogs.length).toEqual(1);
+      expect(errorLogs[0]).toEqual(
+        '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
+      );
+    } else {
+      expect(errorLogs.length).toEqual(0);
+    }
   },
 );

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
+import { hasDebugLogs } from '../../../utils/helpers';
 
 sentryTest('should not initialize when inside a Chrome browser extension', async ({ getLocalTestUrl, page }) => {
   const errorLogs: string[] = [];
@@ -16,8 +17,13 @@ sentryTest('should not initialize when inside a Chrome browser extension', async
   });
 
   expect(isInitialized).toEqual(false);
-  expect(errorLogs.length).toEqual(1);
-  expect(errorLogs[0]).toEqual(
-    '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
-  );
+
+  if (hasDebugLogs()) {
+    expect(errorLogs.length).toEqual(1);
+    expect(errorLogs[0]).toEqual(
+      '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
+    );
+  } else {
+    expect(errorLogs.length).toEqual(0);
+  }
 });

--- a/dev-packages/browser-integration-tests/utils/helpers.ts
+++ b/dev-packages/browser-integration-tests/utils/helpers.ts
@@ -303,6 +303,14 @@ export function shouldSkipFeatureFlagsTest(): boolean {
 }
 
 /**
+ * Returns true if the current bundle has debug logs.
+ */
+export function hasDebugLogs(): boolean {
+  const bundle = process.env.PW_BUNDLE;
+  return !bundle?.includes('min');
+}
+
+/**
  * Waits until a number of requests matching urlRgx at the given URL arrive.
  * If the timeout option is configured, this function will abort waiting, even if it hasn't received the configured
  * amount of requests, and returns all the events received up to that point in time.

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -172,7 +172,7 @@ declare const __SENTRY_RELEASE__: string | undefined;
 export function init(browserOptions: BrowserOptions = {}): Client | undefined {
   const options = applyDefaultOptions(browserOptions);
 
-  if (!options.skipBrowserExtensionCheck && shouldShowBrowserExtensionError()) {
+  if (DEBUG_BUILD && !options.skipBrowserExtensionCheck && shouldShowBrowserExtensionError()) {
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
       console.error(
@@ -182,12 +182,10 @@ export function init(browserOptions: BrowserOptions = {}): Client | undefined {
     return;
   }
 
-  if (DEBUG_BUILD) {
-    if (!supportsFetch()) {
-      logger.warn(
-        'No Fetch API detected. The Sentry SDK requires a Fetch API compatible environment to send events. Please add a Fetch API polyfill.',
-      );
-    }
+  if (DEBUG_BUILD && !supportsFetch()) {
+    logger.warn(
+      'No Fetch API detected. The Sentry SDK requires a Fetch API compatible environment to send events. Please add a Fetch API polyfill.',
+    );
   }
   const clientOptions: BrowserClientOptions = {
     ...options,

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -172,13 +172,15 @@ declare const __SENTRY_RELEASE__: string | undefined;
 export function init(browserOptions: BrowserOptions = {}): Client | undefined {
   const options = applyDefaultOptions(browserOptions);
 
-  if (DEBUG_BUILD && !options.skipBrowserExtensionCheck && shouldShowBrowserExtensionError()) {
-    consoleSandbox(() => {
-      // eslint-disable-next-line no-console
-      console.error(
-        '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
-      );
-    });
+  if (!options.skipBrowserExtensionCheck && shouldShowBrowserExtensionError()) {
+    if (DEBUG_BUILD) {
+      consoleSandbox(() => {
+        // eslint-disable-next-line no-console
+        console.error(
+          '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
+        );
+      });
+    }
     return;
   }
 


### PR DESCRIPTION
I think it is fair to exclude this here, saving a few bytes...?