### PR TITLE
ref(svelte): Remove SvelteKit detection

### DIFF
--- a/packages/svelte/src/sdk.ts
+++ b/packages/svelte/src/sdk.ts
@@ -1,7 +1,6 @@
 import type { BrowserOptions } from '@sentry/browser';
-import { WINDOW } from '@sentry/browser';
-import { addEventProcessor, init as browserInit } from '@sentry/browser';
-import type { Client, EventProcessor } from '@sentry/core';
+import { init as browserInit } from '@sentry/browser';
+import type { Client } from '@sentry/core';
 import { applySdkMetadata } from '@sentry/core';
 /**
  * Inits the Svelte SDK
@@ -13,48 +12,5 @@ export function init(options: BrowserOptions): Client | undefined {
 
   applySdkMetadata(opts, 'svelte');
 
-  const client = browserInit(opts);
-
-  detectAndReportSvelteKit();
-
-  return client;
-}
-
-/**
- * Adds a global event processor to detect if the SDK is initialized in a SvelteKit frontend,
- * in which case we add SvelteKit an event.modules entry to outgoing events.
- * SvelteKit detection is performed only once, when the event processor is called for the
- * first time. We cannot perform this check upfront (directly when init is called) because
- * at this time, the HTML element might not yet be accessible.
- */
-export function detectAndReportSvelteKit(): void {
-  let detectedSvelteKit: boolean | undefined = undefined;
-
-  const svelteKitProcessor: EventProcessor = event => {
-    if (detectedSvelteKit === undefined) {
-      detectedSvelteKit = isSvelteKitApp();
-    }
-    if (detectedSvelteKit) {
-      event.modules = {
-        svelteKit: 'latest',
-        ...event.modules,
-      };
-    }
-    return event;
-  };
-  svelteKitProcessor.id = 'svelteKitProcessor';
-
-  addEventProcessor(svelteKitProcessor);
-}
-
-/**
- * To actually detect a SvelteKit frontend, we search the DOM for a special
- * div that's inserted by SvelteKit when the page is rendered. It's identified
- * by its id, 'svelte-announcer', and it's used to improve page accessibility.
- * This div is not present when only using Svelte without SvelteKit.
- *
- * @see https://github.com/sveltejs/kit/issues/307 for more information
- */
-export function isSvelteKitApp(): boolean {
-  return !!WINDOW.document.querySelector('div#svelte-announcer');
+  return browserInit(opts);
 }

--- a/packages/svelte/test/sdk.test.ts
+++ b/packages/svelte/test/sdk.test.ts
@@ -6,19 +6,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SDK_VERSION } from '@sentry/browser';
 import * as SentryBrowser from '@sentry/browser';
-import type { EventProcessor } from '@sentry/core';
 
-import { detectAndReportSvelteKit, init as svelteInit, isSvelteKitApp } from '../src/sdk';
-
-let passedEventProcessor: EventProcessor | undefined;
+import { init as svelteInit } from '../src/sdk';
 
 const browserInit = vi.spyOn(SentryBrowser, 'init');
-const addEventProcessor = vi
-  .spyOn(SentryBrowser, 'addEventProcessor')
-  .mockImplementation((eventProcessor: EventProcessor) => {
-    passedEventProcessor = eventProcessor;
-    return () => {};
-  });
 
 describe('Initialize Svelte SDk', () => {
   beforeEach(() => {
@@ -82,56 +73,5 @@ describe('Initialize Svelte SDk', () => {
     });
 
     expect(client).not.toBeUndefined();
-  });
-});
-
-describe('detectAndReportSvelteKit()', () => {
-  const originalHtmlBody = document.body.innerHTML;
-  beforeEach(() => {
-    vi.clearAllMocks();
-    document.body.innerHTML = originalHtmlBody;
-    passedEventProcessor = undefined;
-  });
-
-  it('registers an event processor', async () => {
-    detectAndReportSvelteKit();
-
-    expect(addEventProcessor).toHaveBeenCalledTimes(1);
-    expect(passedEventProcessor?.id).toEqual('svelteKitProcessor');
-  });
-
-  it('adds "SvelteKit" as a module to the event, if SvelteKit was detected', () => {
-    document.body.innerHTML += '<div id="svelte-announcer">Home</div>';
-    detectAndReportSvelteKit();
-
-    const processedEvent = passedEventProcessor?.({} as unknown as any, {});
-
-    expect(processedEvent).toBeDefined();
-    expect(processedEvent).toEqual({ modules: { svelteKit: 'latest' } });
-  });
-
-  it("doesn't add anything to the event, if SvelteKit was not detected", () => {
-    document.body.innerHTML = '';
-    detectAndReportSvelteKit();
-
-    const processedEvent = passedEventProcessor?.({} as unknown as any, {});
-
-    expect(processedEvent).toBeDefined();
-    expect(processedEvent).toEqual({});
-  });
-
-  describe('isSvelteKitApp()', () => {
-    it('returns true if the svelte-announcer div is present', () => {
-      document.body.innerHTML += '<div id="svelte-announcer">Home</div>';
-      expect(isSvelteKitApp()).toBe(true);
-    });
-    it('returns false if the svelte-announcer div is not present (but similar elements)', () => {
-      document.body.innerHTML += '<div id="svelte-something">Home</div>';
-      expect(isSvelteKitApp()).toBe(false);
-    });
-    it('returns false if no div is present', () => {
-      document.body.innerHTML = '';
-      expect(isSvelteKitApp()).toBe(false);
-    });
   });
 });


### PR DESCRIPTION
When we first created the Svelte SDK, we wanted to gauge how often it is used in a SvelteKit application. Therefore we added some SvelteKit detection logic to annotate events coming from the Svelte SDK. Since we have a SvelteKit SDK now, we don't need to track this anymore. Saves a few bytes, too.

This PR therefore removes the detection and event processing logic