### PR TITLE
chore(svelte): Remove redundant component tracking config in e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/svelte-5/svelte.config.js
+++ b/dev-packages/e2e-tests/test-applications/svelte-5/svelte.config.js
@@ -8,7 +8,7 @@ const config = {
 };
 
 const configWithSentry = withSentryConfig(config, {
-  componentTracking: { trackUpdates: false, trackComponents: true, trackInit: true },
+  componentTracking: { trackComponents: true, trackInit: true },
 });
 
 export default configWithSentry;


### PR DESCRIPTION
Just came across this by chance. `trackUpdates: false` is already default behaviour since #15265. We should rather test against this in the e2e test app than explicitly opting out of update tracking.