### PR TITLE
test(browser): Avoid using `example.com` for browser-integration-tests

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/onreadystatechange/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/onreadystatechange/subject.js
@@ -1,6 +1,6 @@
 window.calls = {};
 const xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://example.com');
+xhr.open('GET', 'http://sentry-test-site.io');
 xhr.onreadystatechange = function wat() {
   window.calls[xhr.readyState] = window.calls[xhr.readyState] ? window.calls[xhr.readyState] + 1 : 1;
 };

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/onreadystatechange/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/onreadystatechange/test.ts
@@ -7,7 +7,7 @@ sentryTest(
   async ({ getLocalTestUrl, page }) => {
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.route('http://example.com/', route => {
+    await page.route('http://sentry-test-site.io/', route => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/replay/requests/subject.js
+++ b/dev-packages/browser-integration-tests/suites/replay/requests/subject.js
@@ -6,11 +6,11 @@ document.getElementById('go-background').addEventListener('click', () => {
 });
 
 document.getElementById('fetch').addEventListener('click', () => {
-  fetch('https://example.com', { method: 'POST', body: 'foo' });
+  fetch('https://sentry-test-site.io', { method: 'POST', body: 'foo' });
 });
 
 document.getElementById('xhr').addEventListener('click', () => {
   const xhr = new XMLHttpRequest();
-  xhr.open('GET', 'https://example.com');
+  xhr.open('GET', 'https://sentry-test-site.io');
   xhr.send();
 });

--- a/dev-packages/browser-integration-tests/suites/replay/requests/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/requests/test.ts
@@ -10,7 +10,7 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
     sentryTest.skip();
   }
 
-  await page.route('https://example.com', route => {
+  await page.route('https://sentry-test-site.io', route => {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -27,7 +27,7 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
 
   const { performanceSpans: spans0 } = getReplayRecordingContent(req0);
 
-  await Promise.all([page.waitForResponse('https://example.com'), page.locator('#fetch').click()]);
+  await Promise.all([page.waitForResponse('https://sentry-test-site.io'), page.locator('#fetch').click()]);
 
   const { performanceSpans: spans1 } = getReplayRecordingContent(await reqPromise1);
 
@@ -40,7 +40,7 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
     sentryTest.skip();
   }
 
-  await page.route('https://example.com', route => {
+  await page.route('https://sentry-test-site.io', route => {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -57,7 +57,7 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
 
   const { performanceSpans: spans0 } = getReplayRecordingContent(req0);
 
-  await Promise.all([page.waitForResponse('https://example.com'), page.locator('#xhr').click()]);
+  await Promise.all([page.waitForResponse('https://sentry-test-site.io'), page.locator('#xhr').click()]);
 
   const { performanceSpans: spans1 } = getReplayRecordingContent(await reqPromise1);
 

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/template.html
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/template.html
@@ -76,7 +76,7 @@
         document.getElementById('out').innerHTML += 'mutationButton clicked<br>';
       });
       document.getElementById('windowOpenButton').addEventListener('click', () => {
-        window.open('https://example.com/', '_blank');
+        window.open('https://github.com/', '_blank');
       });
 
       // Do nothing on these elements

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/windowOpen/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/windowOpen/test.ts
@@ -8,13 +8,6 @@ sentryTest('window.open() is considered for slow click', async ({ getLocalTestUr
     sentryTest.skip();
   }
 
-  await page.route('http://example.com/', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({}),
-    });
-  });
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -63,5 +56,5 @@ sentryTest('window.open() is considered for slow click', async ({ getLocalTestUr
   const pages = context.pages();
 
   expect(pages.length).toBe(2);
-  expect(pages[1].url()).toBe('https://example.com/');
+  expect(pages[1].url()).toBe('https://github.com/');
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/subject.js
@@ -1,1 +1,1 @@
-fetch('http://example.com/0').then(fetch('http://example.com/1').then(fetch('http://example.com/2')));
+fetch('http://sentry-test-site.io/0').then(fetch('http://sentry-test-site.io/1').then(fetch('http://sentry-test-site.io/2')));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/test.ts
@@ -10,7 +10,7 @@ sentryTest('should create fetch spans with http timing @firefox', async ({ brows
   if (shouldSkipTracingTest() || !supportedBrowsers.includes(browserName)) {
     sentryTest.skip();
   }
-  await page.route('http://example.com/*', async route => {
+  await page.route('http://sentry-test-site.io/*', async route => {
     const request = route.request();
     const postData = await request.postDataJSON();
 
@@ -33,7 +33,7 @@ sentryTest('should create fetch spans with http timing @firefox', async ({ brows
   await page.pause();
   requestSpans?.forEach((span, index) =>
     expect(span).toMatchObject({
-      description: `GET http://example.com/${index}`,
+      description: `GET http://sentry-test-site.io/${index}`,
       parent_span_id: tracingEvent.contexts?.trace?.span_id,
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled/template.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div>Rendered Before Long Animation Frame</div>
-    <script src="https://example.com/path/to/script.js"></script>
+    <script src="https://sentry-test-site.io/path/to/script.js"></script>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/template.html
@@ -8,6 +8,6 @@
     <button id="clickme">
       click me to start the long animation!
     </button>
-    <script src="https://example.com/path/to/script.js"></script>
+    <script src="https://sentry-test-site.io/path/to/script.js"></script>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/test.ts
@@ -33,7 +33,7 @@ sentryTest(
     expect(uiSpans?.length).toBeGreaterThanOrEqual(1);
 
     const topLevelUISpan = (uiSpans || []).find(
-      span => span.data?.['browser.script.invoker'] === 'https://example.com/path/to/script.js',
+      span => span.data?.['browser.script.invoker'] === 'https://sentry-test-site.io/path/to/script.js',
     )!;
     expect(topLevelUISpan).toEqual(
       expect.objectContaining({
@@ -41,9 +41,9 @@ sentryTest(
         description: 'Main UI thread blocked',
         parent_span_id: eventData.contexts?.trace?.span_id,
         data: {
-          'code.filepath': 'https://example.com/path/to/script.js',
+          'code.filepath': 'https://sentry-test-site.io/path/to/script.js',
           'browser.script.source_char_position': 0,
-          'browser.script.invoker': 'https://example.com/path/to/script.js',
+          'browser.script.invoker': 'https://sentry-test-site.io/path/to/script.js',
           'browser.script.invoker_type': 'classic-script',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long-animation-frame',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
@@ -98,7 +98,7 @@ sentryTest(
         data: {
           'browser.script.invoker': 'BUTTON#clickme.onclick',
           'browser.script.invoker_type': 'event-listener',
-          'code.filepath': 'https://example.com/path/to/script.js',
+          'code.filepath': 'https://sentry-test-site.io/path/to/script.js',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long-animation-frame',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
         },

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-non-chromium/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-non-chromium/template.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div>Rendered Before Long Task</div>
-    <script src="https://example.com/path/to/script.js"></script>
+    <script src="https://sentry-test-site.io/path/to/script.js"></script>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/template.html
@@ -8,6 +8,6 @@
     <button id="clickme">
       click me to start the long animation!
     </button>
-    <script src="https://example.com/path/to/script.js"></script>
+    <script src="https://sentry-test-site.io/path/to/script.js"></script>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/test.ts
@@ -35,7 +35,7 @@ sentryTest(
     expect(uiSpans?.length).toBeGreaterThanOrEqual(1);
 
     const topLevelUISpan = (uiSpans || []).find(
-      span => span.data?.['browser.script.invoker'] === 'https://example.com/path/to/script.js',
+      span => span.data?.['browser.script.invoker'] === 'https://sentry-test-site.io/path/to/script.js',
     )!;
     expect(topLevelUISpan).toEqual(
       expect.objectContaining({
@@ -43,9 +43,9 @@ sentryTest(
         description: 'Main UI thread blocked',
         parent_span_id: eventData.contexts?.trace?.span_id,
         data: {
-          'code.filepath': 'https://example.com/path/to/script.js',
+          'code.filepath': 'https://sentry-test-site.io/path/to/script.js',
           'browser.script.source_char_position': 0,
-          'browser.script.invoker': 'https://example.com/path/to/script.js',
+          'browser.script.invoker': 'https://sentry-test-site.io/path/to/script.js',
           'browser.script.invoker_type': 'classic-script',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long-animation-frame',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
@@ -100,7 +100,7 @@ sentryTest(
         data: {
           'browser.script.invoker': 'BUTTON#clickme.onclick',
           'browser.script.invoker_type': 'event-listener',
-          'code.filepath': 'https://example.com/path/to/script.js',
+          'code.filepath': 'https://sentry-test-site.io/path/to/script.js',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long-animation-frame',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
         },

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/template.html
@@ -5,7 +5,6 @@
   </head>
   <body>
     <div>Rendered Before Long Task</div>
-    <script src="https://example.com/path/to/script.js"></script>
 
     <button id="myButton">Start long task</button>
     <h1 id="myHeading">Heading</h1>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/test.ts
@@ -13,6 +13,8 @@ sentryTest(
     }
     const url = await getLocalTestUrl({ testDir: __dirname });
 
+    await page.route('**/path/to/script.js', route => route.fulfill({ path: `${__dirname}/assets/script.js` }));
+
     await page.goto(url);
 
     const navigationTransactionEventPromise = getFirstSentryEnvelopeRequest<Event>(page);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled/template.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div>Rendered Before Long Task</div>
-    <script src="https://example.com/path/to/script.js"></script>
+    <script src="https://sentry-test-site.io/path/to/script.js"></script>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/template.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div>Rendered Before Long Task</div>
-    <script src="https://example.com/path/to/script.js"></script>
+    <script src="https://sentry-test-site.io/path/to/script.js"></script>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/template.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div>Rendered Before Long Task</div>
-    <script src="https://example.com/path/to/script.js"></script>
+    <script src="https://sentry-test-site.io/path/to/script.js"></script>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/subject.js
@@ -1,1 +1,1 @@
-fetch('http://example.com/0').then(fetch('http://example.com/1').then(fetch('http://example.com/2')));
+fetch('http://sentry-test-site.io/0').then(fetch('http://sentry-test-site.io/1').then(fetch('http://sentry-test-site.io/2')));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/test.ts
@@ -15,7 +15,7 @@ sentryTest(
     const requests = (
       await Promise.all([
         page.goto(url),
-        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
       ])
     )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsNoMatch/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsNoMatch/subject.js
@@ -1,1 +1,1 @@
-fetch('http://example.com/0').then(fetch('http://example.com/1').then(fetch('http://example.com/2')));
+fetch('http://sentry-test-site.io/0').then(fetch('http://sentry-test-site.io/1').then(fetch('http://sentry-test-site.io/2')));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsNoMatch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsNoMatch/test.ts
@@ -15,7 +15,7 @@ sentryTest(
     const requests = (
       await Promise.all([
         page.goto(url),
-        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
       ])
     )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/init.js
@@ -6,6 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ instrumentNavigation: false, instrumentPageLoad: false })],
   tracesSampleRate: 1,
-  tracePropagationTargets: ['example.com'],
+  tracePropagationTargets: ['sentry-test-site.io'],
   release: '1.1.1',
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/subject.js
@@ -26,7 +26,7 @@ btnUpdateName.addEventListener('click', () => {
 });
 
 btnMakeRequest.addEventListener('click', () => {
-  fetch('https://example.com/api');
+  fetch('https://sentry-test-site.io/api');
 });
 
 btnCaptureError.addEventListener('click', () => {

--- a/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/test.ts
@@ -16,6 +16,14 @@ sentryTest('updates the DSC when the txn name is updated and high-quality', asyn
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
+  await page.route('http://sentry-test-site.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
   await page.goto(url);
 
   /*
@@ -168,7 +176,7 @@ sentryTest('updates the DSC when the txn name is updated and high-quality', asyn
 });
 
 async function makeRequestAndGetBaggageItems(page: Page): Promise<string[]> {
-  const requestPromise = page.waitForRequest('https://example.com/*');
+  const requestPromise = page.waitForRequest('https://sentry-test-site.io/*');
   await page.locator('#btnMakeRequest').click();
   const request = await requestPromise;
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/handlers-lcp/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/handlers-lcp/template.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div id="content"></div>
-    <img src="https://example.com/path/to/image.png" />
+    <img src="https://sentry-test-site.io/path/to/image.png" />
     <button type="button">Test button</button>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/template.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <img src="https://example.com/path/to/image.svg" />
-    <script src="https://example.com/path/to/script.js"></script>
-    <link href="https://example.com/path/to/style.css" type="text/css" rel="stylesheet" />
+    <img src="https://sentry-test-site.io/path/to/image.svg" />
+    <script src="https://sentry-test-site.io/path/to/script.js"></script>
+    <link href="https://sentry-test-site.io/path/to/style.css" type="text/css" rel="stylesheet" />
     <span>Rendered</span>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
@@ -13,7 +13,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
   const isWebkitRun = browserName === 'webkit';
 
   // Intercepting asset requests to avoid network-related flakiness and random retries (on Firefox).
-  await page.route('https://example.com/path/to/image.svg', (route: Route) =>
+  await page.route('https://sentry-test-site.io/path/to/image.svg', (route: Route) =>
     route.fulfill({
       path: `${__dirname}/assets/image.svg`,
       headers: {
@@ -22,7 +22,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
       },
     }),
   );
-  await page.route('https://example.com/path/to/script.js', (route: Route) =>
+  await page.route('https://sentry-test-site.io/path/to/script.js', (route: Route) =>
     route.fulfill({
       path: `${__dirname}/assets/script.js`,
       headers: {
@@ -31,7 +31,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
       },
     }),
   );
-  await page.route('https://example.com/path/to/style.css', (route: Route) =>
+  await page.route('https://sentry-test-site.io/path/to/style.css', (route: Route) =>
     route.fulfill({
       path: `${__dirname}/assets/style.css`,
       headers: {
@@ -58,7 +58,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
 
   const hasCdnBundle = (process.env.PW_BUNDLE || '').startsWith('bundle');
 
-  const expectedScripts = ['/init.bundle.js', '/subject.bundle.js', 'https://example.com/path/to/script.js'];
+  const expectedScripts = ['/init.bundle.js', '/subject.bundle.js', 'https://sentry-test-site.io/path/to/script.js'];
   if (hasCdnBundle) {
     expectedScripts.unshift('/cdn.bundle.js');
   }
@@ -67,7 +67,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
   expect(scriptSpans?.map(({ parent_span_id }) => parent_span_id)).toEqual(expectedScripts.map(() => spanId));
 
   const customScriptSpan = scriptSpans?.find(
-    ({ description }) => description === 'https://example.com/path/to/script.js',
+    ({ description }) => description === 'https://sentry-test-site.io/path/to/script.js',
   );
 
   expect(imgSpan).toEqual({
@@ -79,7 +79,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
       'network.protocol.version': 'unknown',
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.img',
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
-      'server.address': 'example.com',
+      'server.address': 'sentry-test-site.io',
       'url.same_origin': false,
       'url.scheme': 'https',
       ...(!isWebkitRun && {
@@ -87,7 +87,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
         'http.response_delivery_type': '',
       }),
     },
-    description: 'https://example.com/path/to/image.svg',
+    description: 'https://sentry-test-site.io/path/to/image.svg',
     op: 'resource.img',
     origin: 'auto.resource.browser.metrics',
     parent_span_id: spanId,
@@ -106,7 +106,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
       'network.protocol.version': 'unknown',
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.link',
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
-      'server.address': 'example.com',
+      'server.address': 'sentry-test-site.io',
       'url.same_origin': false,
       'url.scheme': 'https',
       ...(!isWebkitRun && {
@@ -114,7 +114,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
         'http.response_delivery_type': '',
       }),
     },
-    description: 'https://example.com/path/to/style.css',
+    description: 'https://sentry-test-site.io/path/to/style.css',
     op: 'resource.link',
     origin: 'auto.resource.browser.metrics',
     parent_span_id: spanId,
@@ -133,7 +133,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
       'network.protocol.version': 'unknown',
       'sentry.op': 'resource.script',
       'sentry.origin': 'auto.resource.browser.metrics',
-      'server.address': 'example.com',
+      'server.address': 'sentry-test-site.io',
       'url.same_origin': false,
       'url.scheme': 'https',
       ...(!isWebkitRun && {
@@ -141,7 +141,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
         'http.response_delivery_type': '',
       }),
     },
-    description: 'https://example.com/path/to/script.js',
+    description: 'https://sentry-test-site.io/path/to/script.js',
     op: 'resource.script',
     origin: 'auto.resource.browser.metrics',
     parent_span_id: spanId,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp/template.html
@@ -5,6 +5,6 @@
   </head>
   <body>
     <div id="content"></div>
-    <img src="https://example.com/my/image.png" />
+    <img src="https://sentry-test-site.io/my/image.png" />
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals/template.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div id="content"></div>
-    <img src="https://example.com/library/image.png" />
+    <img src="https://sentry-test-site.io/library/image.png" />
     <button type="button">Test button</button>
   </body>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/init.js
@@ -4,5 +4,5 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/subject.js
@@ -1,5 +1,5 @@
-fetch('http://example.com/0').then(
-  fetch('http://example.com/1', { headers: { 'X-Test-Header': 'existing-header' } }).then(
-    fetch('http://example.com/2'),
+fetch('http://sentry-test-site.io/0').then(
+  fetch('http://sentry-test-site.io/1', { headers: { 'X-Test-Header': 'existing-header' } }).then(
+    fetch('http://sentry-test-site.io/2'),
   ),
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/test.ts
@@ -15,7 +15,7 @@ sentryTest(
     const requests = (
       await Promise.all([
         page.goto(url),
-        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
       ])
     )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
   tracesSampleRate: 0,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/subject.js
@@ -1,5 +1,5 @@
-fetch('http://example.com/0').then(
-  fetch('http://example.com/1', { headers: { 'X-Test-Header': 'existing-header' } }).then(
-    fetch('http://example.com/2'),
+fetch('http://sentry-test-site.io/0').then(
+  fetch('http://sentry-test-site.io/1', { headers: { 'X-Test-Header': 'existing-header' } }).then(
+    fetch('http://sentry-test-site.io/2'),
   ),
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/test.ts
@@ -13,7 +13,7 @@ sentryTest('should attach `sentry-trace` header to unsampled fetch requests', as
   const requests = (
     await Promise.all([
       page.goto(url),
-      Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+      Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
     ])
   )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
   // no tracesSampleRate defined means TWP mode
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/subject.js
@@ -1,5 +1,5 @@
-fetch('http://example.com/0').then(
-  fetch('http://example.com/1', { headers: { 'X-Test-Header': 'existing-header' } }).then(
-    fetch('http://example.com/2'),
+fetch('http://sentry-test-site.io/0').then(
+  fetch('http://sentry-test-site.io/1', { headers: { 'X-Test-Header': 'existing-header' } }).then(
+    fetch('http://sentry-test-site.io/2'),
   ),
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/test.ts
@@ -15,7 +15,7 @@ sentryTest(
     const requests = (
       await Promise.all([
         page.goto(url),
-        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
       ])
     )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/subject.js
@@ -1,4 +1,4 @@
-const request = new Request('http://example.com/api/test/', {
+const request = new Request('http://sentry-test-site.io/api/test/', {
   headers: { foo: '11' },
 });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/test.ts
@@ -10,7 +10,7 @@ sentryTest(
       sentryTest.skip();
     }
 
-    const requestPromise = page.waitForRequest('http://example.com/api/test/');
+    const requestPromise = page.waitForRequest('http://sentry-test-site.io/api/test/');
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch/subject.js
@@ -1,5 +1,5 @@
-fetch('http://example.com/0').then(
-  fetch('http://example.com/1', { headers: { 'X-Test-Header': 'existing-header' } }).then(
-    fetch('http://example.com/2'),
+fetch('http://sentry-test-site.io/0').then(
+  fetch('http://sentry-test-site.io/1', { headers: { 'X-Test-Header': 'existing-header' } }).then(
+    fetch('http://sentry-test-site.io/2'),
   ),
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch/test.ts
@@ -11,7 +11,7 @@ sentryTest('should create spans for fetch requests', async ({ getLocalTestUrl, p
     sentryTest.skip();
   }
 
-  await page.route('http://example.com/*', route => route.fulfill({ body: 'ok' }));
+  await page.route('http://sentry-test-site.io/*', route => route.fulfill({ body: 'ok' }));
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -24,7 +24,7 @@ sentryTest('should create spans for fetch requests', async ({ getLocalTestUrl, p
 
   requestSpans?.forEach((span, index) =>
     expect(span).toMatchObject({
-      description: `GET http://example.com/${index}`,
+      description: `GET http://sentry-test-site.io/${index}`,
       parent_span_id: tracingEvent.contexts?.trace?.span_id,
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
@@ -32,9 +32,9 @@ sentryTest('should create spans for fetch requests', async ({ getLocalTestUrl, p
       trace_id: tracingEvent.contexts?.trace?.trace_id,
       data: {
         'http.method': 'GET',
-        'http.url': `http://example.com/${index}`,
-        url: `http://example.com/${index}`,
-        'server.address': 'example.com',
+        'http.url': `http://sentry-test-site.io/${index}`,
+        url: `http://sentry-test-site.io/${index}`,
+        'server.address': 'sentry-test-site.io',
         type: 'fetch',
       },
     }),
@@ -46,14 +46,14 @@ sentryTest('should attach `sentry-trace` header to fetch requests', async ({ get
     sentryTest.skip();
   }
 
-  await page.route('http://example.com/*', route => route.fulfill({ body: 'ok' }));
+  await page.route('http://sentry-test-site.io/*', route => route.fulfill({ body: 'ok' }));
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const requests = (
     await Promise.all([
       page.goto(url),
-      Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+      Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
     ])
   )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/init.js
@@ -5,7 +5,7 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
   tracesSampleRate: 1,
   autoSessionTracking: false,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/init.js
@@ -4,5 +4,5 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/subject.js
@@ -1,12 +1,12 @@
 const xhr_1 = new XMLHttpRequest();
-xhr_1.open('GET', 'http://example.com/0');
+xhr_1.open('GET', 'http://sentry-test-site.io/0');
 xhr_1.send();
 
 const xhr_2 = new XMLHttpRequest();
-xhr_2.open('GET', 'http://example.com/1');
+xhr_2.open('GET', 'http://sentry-test-site.io/1');
 xhr_2.setRequestHeader('X-Test-Header', 'existing-header');
 xhr_2.send();
 
 const xhr_3 = new XMLHttpRequest();
-xhr_3.open('GET', 'http://example.com/2');
+xhr_3.open('GET', 'http://sentry-test-site.io/2');
 xhr_3.send();

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/test.ts
@@ -15,7 +15,7 @@ sentryTest(
     const requests = (
       await Promise.all([
         page.goto(url),
-        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
       ])
     )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
   tracesSampleRate: 0,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/subject.js
@@ -1,12 +1,12 @@
 const xhr_1 = new XMLHttpRequest();
-xhr_1.open('GET', 'http://example.com/0');
+xhr_1.open('GET', 'http://sentry-test-site.io/0');
 xhr_1.send();
 
 const xhr_2 = new XMLHttpRequest();
-xhr_2.open('GET', 'http://example.com/1');
+xhr_2.open('GET', 'http://sentry-test-site.io/1');
 xhr_2.setRequestHeader('X-Test-Header', 'existing-header');
 xhr_2.send();
 
 const xhr_3 = new XMLHttpRequest();
-xhr_3.open('GET', 'http://example.com/2');
+xhr_3.open('GET', 'http://sentry-test-site.io/2');
 xhr_3.send();

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/test.ts
@@ -13,7 +13,7 @@ sentryTest('should attach `sentry-trace` header to unsampled xhr requests', asyn
   const requests = (
     await Promise.all([
       page.goto(url),
-      Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+      Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
     ])
   )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/init.js
@@ -5,5 +5,5 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/subject.js
@@ -1,12 +1,12 @@
 const xhr_1 = new XMLHttpRequest();
-xhr_1.open('GET', 'http://example.com/0');
+xhr_1.open('GET', 'http://sentry-test-site.io/0');
 xhr_1.send();
 
 const xhr_2 = new XMLHttpRequest();
-xhr_2.open('GET', 'http://example.com/1');
+xhr_2.open('GET', 'http://sentry-test-site.io/1');
 xhr_2.setRequestHeader('X-Test-Header', 'existing-header');
 xhr_2.send();
 
 const xhr_3 = new XMLHttpRequest();
-xhr_3.open('GET', 'http://example.com/2');
+xhr_3.open('GET', 'http://sentry-test-site.io/2');
 xhr_3.send();

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/test.ts
@@ -15,7 +15,7 @@ sentryTest(
     const requests = (
       await Promise.all([
         page.goto(url),
-        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+        Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
       ])
     )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr/subject.js
@@ -1,12 +1,12 @@
 const xhr_1 = new XMLHttpRequest();
-xhr_1.open('GET', 'http://example.com/0');
+xhr_1.open('GET', 'http://sentry-test-site.io/0');
 xhr_1.send();
 
 const xhr_2 = new XMLHttpRequest();
-xhr_2.open('GET', 'http://example.com/1');
+xhr_2.open('GET', 'http://sentry-test-site.io/1');
 xhr_2.setRequestHeader('X-Test-Header', 'existing-header');
 xhr_2.send();
 
 const xhr_3 = new XMLHttpRequest();
-xhr_3.open('GET', 'http://example.com/2');
+xhr_3.open('GET', 'http://sentry-test-site.io/2');
 xhr_3.send();

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr/test.ts
@@ -9,7 +9,7 @@ sentryTest('should create spans for XHR requests', async ({ getLocalTestUrl, pag
     sentryTest.skip();
   }
 
-  await page.route('http://example.com/*', route => route.fulfill({ body: 'ok' }));
+  await page.route('http://sentry-test-site.io/*', route => route.fulfill({ body: 'ok' }));
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -20,7 +20,7 @@ sentryTest('should create spans for XHR requests', async ({ getLocalTestUrl, pag
 
   requestSpans?.forEach((span, index) =>
     expect(span).toMatchObject({
-      description: `GET http://example.com/${index}`,
+      description: `GET http://sentry-test-site.io/${index}`,
       parent_span_id: eventData.contexts?.trace?.span_id,
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
@@ -28,9 +28,9 @@ sentryTest('should create spans for XHR requests', async ({ getLocalTestUrl, pag
       trace_id: eventData.contexts?.trace?.trace_id,
       data: {
         'http.method': 'GET',
-        'http.url': `http://example.com/${index}`,
-        url: `http://example.com/${index}`,
-        'server.address': 'example.com',
+        'http.url': `http://sentry-test-site.io/${index}`,
+        url: `http://sentry-test-site.io/${index}`,
+        'server.address': 'sentry-test-site.io',
         type: 'xhr',
       },
     }),
@@ -47,7 +47,7 @@ sentryTest('should attach `sentry-trace` header to XHR requests', async ({ getLo
   const requests = (
     await Promise.all([
       page.goto(url),
-      Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://example.com/${idx}`))),
+      Promise.all([0, 1, 2].map(idx => page.waitForRequest(`http://sentry-test-site.io/${idx}`))),
     ])
   )[1];
 

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/init.js
@@ -7,6 +7,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration(), feedbackIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation/test.ts
@@ -201,7 +201,7 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.route('http://example.com/**', route => {
+    await page.route('http://sentry-test-site.io/**', route => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -217,7 +217,7 @@ sentryTest(
       undefined,
       eventAndTraceHeaderRequestParser,
     );
-    const requestPromise = page.waitForRequest('http://example.com/*');
+    const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
     await page.goto(`${url}#foo`);
     await page.locator('#fetchBtn').click();
     const [[navigationEvent, navigationTraceHeader], request] = await Promise.all([
@@ -264,7 +264,7 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.route('http://example.com/**', route => {
+    await page.route('http://sentry-test-site.io/**', route => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -280,7 +280,7 @@ sentryTest(
       undefined,
       eventAndTraceHeaderRequestParser,
     );
-    const requestPromise = page.waitForRequest('http://example.com/*');
+    const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
     await page.goto(`${url}#foo`);
     await page.locator('#xhrBtn').click();
     const [[navigationEvent, navigationTraceHeader], request] = await Promise.all([

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/subject.js
@@ -5,12 +5,12 @@ errorBtn.addEventListener('click', () => {
 
 const fetchBtn = document.getElementById('fetchBtn');
 fetchBtn.addEventListener('click', async () => {
-  await fetch('http://example.com');
+  await fetch('http://sentry-test-site.io');
 });
 
 const xhrBtn = document.getElementById('xhrBtn');
 xhrBtn.addEventListener('click', () => {
   const xhr = new XMLHttpRequest();
-  xhr.open('GET', 'http://example.com');
+  xhr.open('GET', 'http://sentry-test-site.io');
   xhr.send();
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-meta/test.ts
@@ -207,7 +207,7 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.route('http://example.com/**', route => {
+    await page.route('http://sentry-test-site.io/**', route => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -220,7 +220,7 @@ sentryTest(
       undefined,
       eventAndTraceHeaderRequestParser,
     );
-    const requestPromise = page.waitForRequest('http://example.com/*');
+    const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
     await page.goto(url);
     await page.locator('#fetchBtn').click();
     const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);
@@ -259,7 +259,7 @@ sentryTest(
       sentryTest.skip();
     }
 
-    await page.route('http://example.com/**', route => {
+    await page.route('http://sentry-test-site.io/**', route => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -274,7 +274,7 @@ sentryTest(
       undefined,
       eventAndTraceHeaderRequestParser,
     );
-    const requestPromise = page.waitForRequest('http://example.com/*');
+    const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
     await page.goto(url);
     await page.locator('#xhrBtn').click();
     const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload/test.ts
@@ -197,7 +197,7 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.route('http://example.com/**', route => {
+    await page.route('http://sentry-test-site.io/**', route => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -210,7 +210,7 @@ sentryTest(
       undefined,
       eventAndTraceHeaderRequestParser,
     );
-    const requestPromise = page.waitForRequest('http://example.com/*');
+    const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
     await page.goto(url);
     await page.locator('#fetchBtn').click();
     const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);
@@ -254,7 +254,7 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.route('http://example.com/**', route => {
+    await page.route('http://sentry-test-site.io/**', route => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -267,7 +267,7 @@ sentryTest(
       undefined,
       eventAndTraceHeaderRequestParser,
     );
-    const requestPromise = page.waitForRequest('http://example.com/*');
+    const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
     await page.goto(url);
     await page.locator('#xhrBtn').click();
     const [[pageloadEvent, pageloadTraceHeader], request] = await Promise.all([pageloadEventPromise, requestPromise]);
@@ -311,7 +311,7 @@ sentryTest(
 
 //     const url = await getLocalTestUrl({ testDir: __dirname });
 
-//     await page.route('http://example.com/**', route => {
+//     await page.route('http://sentry-test-site.io/**', route => {
 //       return route.fulfill({
 //         status: 200,
 //         contentType: 'application/json',
@@ -346,7 +346,7 @@ sentryTest(
 //       trace_id: pageloadTraceId,
 //     });
 
-//     const requestPromise = page.waitForRequest('http://example.com/*');
+//     const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
 //     await page.locator('#xhrBtn').click();
 //     const request = await requestPromise;
 
@@ -369,7 +369,7 @@ sentryTest(
 
 //     const url = await getLocalTestUrl({ testDir: __dirname });
 
-//     await page.route('http://example.com/**', route => {
+//     await page.route('http://sentry-test-site.io/**', route => {
 //       return route.fulfill({
 //         status: 200,
 //         contentType: 'application/json',
@@ -406,7 +406,7 @@ sentryTest(
 //       trace_id: pageloadTraceId,
 //     });
 
-//     const requestPromise = page.waitForRequest('http://example.com/**');
+//     const requestPromise = page.waitForRequest('http://sentry-test-site.io/**');
 //     const customTransactionEventPromise = getFirstSentryEnvelopeRequest<EventAndTraceHeader>(
 //       page,
 //       undefined,

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/subject.js
@@ -2,7 +2,7 @@ const newTraceBtn = document.getElementById('newTrace');
 newTraceBtn.addEventListener('click', async () => {
   Sentry.startNewTrace(() => {
     Sentry.startSpan({ op: 'ui.interaction.click', name: 'new-trace' }, async () => {
-      await fetch('http://example.com');
+      await fetch('http://sentry-test-site.io');
     });
   });
 });
@@ -10,6 +10,6 @@ newTraceBtn.addEventListener('click', async () => {
 const oldTraceBtn = document.getElementById('oldTrace');
 oldTraceBtn.addEventListener('click', async () => {
   Sentry.startSpan({ op: 'ui.interaction.click', name: 'old-trace' }, async () => {
-    await fetch('http://example.com');
+    await fetch('http://sentry-test-site.io');
   });
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace/test.ts
@@ -17,7 +17,7 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.route('http://example.com/**', route => {
+    await page.route('http://sentry-test-site.io/**', route => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/subject.js
@@ -5,19 +5,19 @@ errorBtn.addEventListener('click', () => {
 
 const fetchBtn = document.getElementById('fetchBtn');
 fetchBtn.addEventListener('click', async () => {
-  await fetch('http://example.com');
+  await fetch('http://sentry-test-site.io');
 });
 
 const xhrBtn = document.getElementById('xhrBtn');
 xhrBtn.addEventListener('click', () => {
   const xhr = new XMLHttpRequest();
-  xhr.open('GET', 'http://example.com');
+  xhr.open('GET', 'http://sentry-test-site.io');
   xhr.send();
 });
 
 const spanAndFetchBtn = document.getElementById('spanAndFetchBtn');
 spanAndFetchBtn.addEventListener('click', () => {
   Sentry.startSpan({ name: 'custom-root-span' }, async () => {
-    await fetch('http://example.com');
+    await fetch('http://sentry-test-site.io');
   });
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/trace-header-merging/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/trace-header-merging/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/trace-header-merging/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/trace-header-merging/subject.js
@@ -8,10 +8,10 @@ fetchPojo.addEventListener('click', () => {
 
   // Make two fetch requests that reuse the same fetch object
   Sentry.startSpan({ name: 'does-not-matter-1' }, () =>
-    fetch('http://example.com/fetch-pojo', fetchOptions)
+    fetch('http://sentry-test-site.io/fetch-pojo', fetchOptions)
       .then(res => res.text())
       .then(() =>
-        Sentry.startSpan({ name: 'does-not-matter-2' }, () => fetch('http://example.com/fetch-pojo', fetchOptions)),
+        Sentry.startSpan({ name: 'does-not-matter-2' }, () => fetch('http://sentry-test-site.io/fetch-pojo', fetchOptions)),
       ),
   );
 });
@@ -26,10 +26,10 @@ fetchArray.addEventListener('click', () => {
 
   // Make two fetch requests that reuse the same fetch object
   Sentry.startSpan({ name: 'does-not-matter-1' }, () =>
-    fetch('http://example.com/fetch-array', fetchOptions)
+    fetch('http://sentry-test-site.io/fetch-array', fetchOptions)
       .then(res => res.text())
       .then(() =>
-        Sentry.startSpan({ name: 'does-not-matter-2' }, () => fetch('http://example.com/fetch-array', fetchOptions)),
+        Sentry.startSpan({ name: 'does-not-matter-2' }, () => fetch('http://sentry-test-site.io/fetch-array', fetchOptions)),
       ),
   );
 });
@@ -44,10 +44,10 @@ fetchHeaders.addEventListener('click', () => {
 
   // Make two fetch requests that reuse the same fetch object
   Sentry.startSpan({ name: 'does-not-matter-1' }, () =>
-    fetch('http://example.com/fetch-headers', fetchOptions)
+    fetch('http://sentry-test-site.io/fetch-headers', fetchOptions)
       .then(res => res.text())
       .then(() =>
-        Sentry.startSpan({ name: 'does-not-matter-2' }, () => fetch('http://example.com/fetch-headers', fetchOptions)),
+        Sentry.startSpan({ name: 'does-not-matter-2' }, () => fetch('http://sentry-test-site.io/fetch-headers', fetchOptions)),
       ),
   );
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/trace-header-merging/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/trace-header-merging/test.ts
@@ -50,15 +50,15 @@ sentryTest(
     await page.goto(url);
 
     await sentryTest.step('fetch with POJO', () =>
-      assertRequests({ page, buttonSelector: '#fetchPojo', requestMatcher: 'http://example.com/fetch-pojo' }),
+      assertRequests({ page, buttonSelector: '#fetchPojo', requestMatcher: 'http://sentry-test-site.io/fetch-pojo' }),
     );
 
     await sentryTest.step('fetch with array', () =>
-      assertRequests({ page, buttonSelector: '#fetchArray', requestMatcher: 'http://example.com/fetch-array' }),
+      assertRequests({ page, buttonSelector: '#fetchArray', requestMatcher: 'http://sentry-test-site.io/fetch-array' }),
     );
 
     await sentryTest.step('fetch with Headers instance', () =>
-      assertRequests({ page, buttonSelector: '#fetchHeaders', requestMatcher: 'http://example.com/fetch-headers' }),
+      assertRequests({ page, buttonSelector: '#fetchHeaders', requestMatcher: 'http://sentry-test-site.io/fetch-headers' }),
     );
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance/init.js
@@ -6,5 +6,5 @@ Sentry.init({
   // in browser TwP means not setting tracesSampleRate but adding browserTracingIntegration,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
-  tracePropagationTargets: ['http://example.com'],
+  tracePropagationTargets: ['http://sentry-test-site.io'],
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance/test.ts
@@ -105,7 +105,7 @@ sentryTest('outgoing fetch requests have new traceId after navigation', async ({
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.route('http://example.com/**', route => {
+  await page.route('http://sentry-test-site.io/**', route => {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -115,7 +115,7 @@ sentryTest('outgoing fetch requests have new traceId after navigation', async ({
 
   await page.goto(url);
 
-  const requestPromise = page.waitForRequest('http://example.com/*');
+  const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
   await page.locator('#fetchBtn').click();
   const request = await requestPromise;
   const headers = request.headers();
@@ -126,7 +126,7 @@ sentryTest('outgoing fetch requests have new traceId after navigation', async ({
 
   await page.goto(`${url}#navigation`);
 
-  const requestPromise2 = page.waitForRequest('http://example.com/*');
+  const requestPromise2 = page.waitForRequest('http://sentry-test-site.io/*');
   await page.locator('#fetchBtn').click();
   const request2 = await requestPromise2;
   const headers2 = request2.headers();
@@ -147,7 +147,7 @@ sentryTest('outgoing XHR requests have new traceId after navigation', async ({ g
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.route('http://example.com/**', route => {
+  await page.route('http://sentry-test-site.io/**', route => {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -157,7 +157,7 @@ sentryTest('outgoing XHR requests have new traceId after navigation', async ({ g
 
   await page.goto(url);
 
-  const requestPromise = page.waitForRequest('http://example.com/*');
+  const requestPromise = page.waitForRequest('http://sentry-test-site.io/*');
   await page.locator('#xhrBtn').click();
   const request = await requestPromise;
   const headers = request.headers();
@@ -168,7 +168,7 @@ sentryTest('outgoing XHR requests have new traceId after navigation', async ({ g
 
   await page.goto(`${url}#navigation`);
 
-  const requestPromise2 = page.waitForRequest('http://example.com/*');
+  const requestPromise2 = page.waitForRequest('http://sentry-test-site.io/*');
   await page.locator('#xhrBtn').click();
   const request2 = await requestPromise2;
   const headers2 = request2.headers();

--- a/dev-packages/browser-integration-tests/utils/replayEventTemplates.ts
+++ b/dev-packages/browser-integration-tests/utils/replayEventTemplates.ts
@@ -190,7 +190,7 @@ export const expectedFPPerformanceSpan = {
 
 export const expectedFetchPerformanceSpan = {
   op: 'resource.fetch',
-  description: 'https://example.com',
+  description: 'https://sentry-test-site.io',
   startTimestamp: expect.any(Number),
   endTimestamp: expect.any(Number),
   data: {
@@ -215,7 +215,7 @@ export const expectedFetchPerformanceSpan = {
 
 export const expectedXHRPerformanceSpan = {
   op: 'resource.xhr',
-  description: 'https://example.com',
+  description: 'https://sentry-test-site.io',
   startTimestamp: expect.any(Number),
   endTimestamp: expect.any(Number),
   data: {


### PR DESCRIPTION
Mostly we already add a route for this anyhow, but it can be confusing. So let's just use a proper non-existing URL there to ensure we notice issues earlier.