### PR TITLE
test(node): Remove last example.com requests in node integration tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
@@ -14,51 +14,6 @@ describe('httpIntegration', () => {
       return;
     }
 
-    createTestServer(done)
-      .get('/api/v0', () => {}, 200)
-      .start()
-      .then(([SERVER_URL, closeTestServer]) => {
-        createRunner(__dirname, 'server.js')
-          .withEnv({ SERVER_URL })
-          .expect({
-            transaction: {
-              contexts: {
-                trace: {
-                  span_id: expect.stringMatching(/[a-f0-9]{16}/),
-                  trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-                  data: {
-                    url: expect.stringMatching(/\/test$/),
-                    'http.response.status_code': 200,
-                    attr1: 'yes',
-                    attr2: 'yes',
-                    attr3: 'yes',
-                  },
-                  op: 'http.server',
-                  status: 'ok',
-                },
-              },
-              extra: {
-                requestHookCalled: {
-                  url: expect.stringMatching(/\/test$/),
-                  method: 'GET',
-                },
-                responseHookCalled: {
-                  url: expect.stringMatching(/\/test$/),
-                  method: 'GET',
-                },
-                applyCustomAttributesOnSpanCalled: {
-                  reqUrl: expect.stringMatching(/\/test$/),
-                  reqMethod: 'GET',
-                  resUrl: expect.stringMatching(/\/test$/),
-                  resMethod: 'GET',
-                },
-              },
-            },
-          })
-          .start(closeTestServer)
-          .makeRequest('get', '/test');
-      });
-
     createRunner(__dirname, 'server.js')
       .expect({
         transaction: {

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
@@ -1,4 +1,5 @@
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+import { createTestServer } from '../../../utils/server';
 
 describe('httpIntegration', () => {
   afterAll(() => {
@@ -12,6 +13,51 @@ describe('httpIntegration', () => {
       done();
       return;
     }
+
+    createTestServer(done)
+      .get('/api/v0', () => {}, 200)
+      .start()
+      .then(([SERVER_URL, closeTestServer]) => {
+        createRunner(__dirname, 'server.js')
+          .withEnv({ SERVER_URL })
+          .expect({
+            transaction: {
+              contexts: {
+                trace: {
+                  span_id: expect.stringMatching(/[a-f0-9]{16}/),
+                  trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+                  data: {
+                    url: expect.stringMatching(/\/test$/),
+                    'http.response.status_code': 200,
+                    attr1: 'yes',
+                    attr2: 'yes',
+                    attr3: 'yes',
+                  },
+                  op: 'http.server',
+                  status: 'ok',
+                },
+              },
+              extra: {
+                requestHookCalled: {
+                  url: expect.stringMatching(/\/test$/),
+                  method: 'GET',
+                },
+                responseHookCalled: {
+                  url: expect.stringMatching(/\/test$/),
+                  method: 'GET',
+                },
+                applyCustomAttributesOnSpanCalled: {
+                  reqUrl: expect.stringMatching(/\/test$/),
+                  reqMethod: 'GET',
+                  resUrl: expect.stringMatching(/\/test$/),
+                  resMethod: 'GET',
+                },
+              },
+            },
+          })
+          .start(closeTestServer)
+          .makeRequest('get', '/test');
+      });
 
     createRunner(__dirname, 'server.js')
       .expect({
@@ -130,43 +176,55 @@ describe('httpIntegration', () => {
 
   describe("doesn't create child spans or breadcrumbs for outgoing requests ignored via `ignoreOutgoingRequests`", () => {
     test('via the url param', done => {
-      const runner = createRunner(__dirname, 'server-ignoreOutgoingRequests.js')
-        .expect({
-          transaction: event => {
-            expect(event.transaction).toBe('GET /testUrl');
+      createTestServer(done)
+        .get('/blockUrl', () => {}, 200)
+        .get('/pass', () => {}, 200)
+        .start()
+        .then(([SERVER_URL, closeTestServer]) => {
+          createRunner(__dirname, 'server-ignoreOutgoingRequests.js')
+            .withEnv({ SERVER_URL })
+            .expect({
+              transaction: event => {
+                expect(event.transaction).toBe('GET /testUrl');
 
-            const requestSpans = event.spans?.filter(span => span.op === 'http.client');
-            expect(requestSpans).toHaveLength(1);
-            expect(requestSpans![0]?.description).toBe('GET https://example.com/pass');
+                const requestSpans = event.spans?.filter(span => span.op === 'http.client');
+                expect(requestSpans).toHaveLength(1);
+                expect(requestSpans![0]?.description).toBe(`GET ${SERVER_URL}/pass`);
 
-            const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
-            expect(breadcrumbs).toHaveLength(1);
-            expect(breadcrumbs![0]?.data?.url).toEqual('https://example.com/pass');
-          },
-        })
-        .start(done);
-
-      runner.makeRequest('get', '/testUrl');
+                const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
+                expect(breadcrumbs).toHaveLength(1);
+                expect(breadcrumbs![0]?.data?.url).toEqual(`${SERVER_URL}/pass`);
+              },
+            })
+            .start(closeTestServer)
+            .makeRequest('get', '/testUrl');
+        });
     });
 
     test('via the request param', done => {
-      const runner = createRunner(__dirname, 'server-ignoreOutgoingRequests.js')
-        .expect({
-          transaction: event => {
-            expect(event.transaction).toBe('GET /testRequest');
+      createTestServer(done)
+        .get('/blockUrl', () => {}, 200)
+        .get('/pass', () => {}, 200)
+        .start()
+        .then(([SERVER_URL, closeTestServer]) => {
+          createRunner(__dirname, 'server-ignoreOutgoingRequests.js')
+            .withEnv({ SERVER_URL })
+            .expect({
+              transaction: event => {
+                expect(event.transaction).toBe('GET /testRequest');
 
-            const requestSpans = event.spans?.filter(span => span.op === 'http.client');
-            expect(requestSpans).toHaveLength(1);
-            expect(requestSpans![0]?.description).toBe('GET https://example.com/pass');
+                const requestSpans = event.spans?.filter(span => span.op === 'http.client');
+                expect(requestSpans).toHaveLength(1);
+                expect(requestSpans![0]?.description).toBe(`GET ${SERVER_URL}/pass`);
 
-            const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
-            expect(breadcrumbs).toHaveLength(1);
-            expect(breadcrumbs![0]?.data?.url).toEqual('https://example.com/pass');
-          },
-        })
-        .start(done);
-
-      runner.makeRequest('get', '/testRequest');
+                const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
+                expect(breadcrumbs).toHaveLength(1);
+                expect(breadcrumbs![0]?.data?.url).toEqual(`${SERVER_URL}/pass`);
+              },
+            })
+            .start(closeTestServer)
+            .makeRequest('get', '/testRequest');
+        });
     });
   });
 });


### PR DESCRIPTION
Refactors two flaky Node integration tests that made requests to example.com. Now we just spin up our own test server instead. 