### PR TITLE
feat(ci): Add junit reporters to jest/vitest, codecov test results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,6 +381,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload test results to Codecov
+        if: cancelled() == false
+        continue-on-error: true
+        uses: codecov/test-results-action@v1
+        with:
+          directory: packages/remix
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   job_bun_unit_tests:
     name: Bun Unit Tests
     needs: [job_get_metadata, job_build]
@@ -701,6 +709,14 @@ jobs:
         working-directory: dev-packages/node-integration-tests
         run: yarn test
 
+      - name: Upload test results to Codecov
+        if: cancelled() == false
+        continue-on-error: true
+        uses: codecov/test-results-action@v1
+        with:
+          directory: dev-packages/node-integration-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   job_remix_integration_tests:
     name: Remix (Node ${{ matrix.node }}) Tests
     needs: [job_get_metadata, job_build]
@@ -736,6 +752,14 @@ jobs:
         run: |
           cd packages/remix
           yarn test:integration:ci
+
+      - name: Upload test results to Codecov
+        if: cancelled() == false
+        continue-on-error: true
+        uses: codecov/test-results-action@v1
+        with:
+          directory: packages/remix
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   job_e2e_prepare:
     name: Prepare E2E tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,7 +386,7 @@ jobs:
         continue-on-error: true
         uses: codecov/test-results-action@v1
         with:
-          directory: packages/remix
+          files: packages/**/*.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   job_bun_unit_tests:
@@ -490,6 +490,14 @@ jobs:
       - name: Compute test coverage
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: cancelled() == false
+        continue-on-error: true
+        uses: codecov/test-results-action@v1
+        with:
+          files: packages/**/*.junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   job_browser_playwright_tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,7 +386,7 @@ jobs:
         continue-on-error: true
         uses: codecov/test-results-action@v1
         with:
-          files: packages/**/*.xml
+          files: packages/**/*.junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   job_bun_unit_tests:

--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -28,6 +28,15 @@ module.exports = {
   ...(process.env.CI
     ? {
         coverageReporters: ['json', 'lcov', 'clover'],
+        reporters: [
+          'default',
+          [
+            'jest-junit',
+            {
+              outputName: 'jest.junit.xml',
+            },
+          ],
+        ],
       }
     : {}),
 };

--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -34,6 +34,7 @@ module.exports = {
             'jest-junit',
             {
               outputName: 'jest.junit.xml',
+              classNameTemplate: '{filepath}',
             },
           ],
         ],

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "eslint": "7.32.0",
     "jest": "^27.5.1",
     "jest-environment-node": "^27.5.1",
+    "jest-junit": "^16.0.0",
     "jsdom": "^21.1.2",
     "lerna": "7.1.1",
     "madge": "7.0.0",

--- a/packages/angular/vitest.config.ts
+++ b/packages/angular/vitest.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
     coverage: {},
     globals: true,
     setupFiles: ['./setup-test.ts'],
-    reporters: ['default'],
     environment: 'jsdom',
   },
 });

--- a/packages/replay-internal/vitest.config.ts
+++ b/packages/replay-internal/vitest.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
   test: {
     ...baseConfig.test,
     setupFiles: ['./test.setup.ts'],
-    reporters: ['default'],
   },
 });

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
       reportsDirectory: './coverage',
     },
     reporters: ['default', 'junit'],
+    outputFile: {
+      junit: `vitest.junit.xml`,
+    },
     typecheck: {
       tsconfig: './tsconfig.test.json',
     },

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       enabled: true,
       reportsDirectory: './coverage',
     },
+    reporters: ['default', 'junit'],
     typecheck: {
       tsconfig: './tsconfig.test.json',
     },

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       enabled: true,
       reportsDirectory: './coverage',
     },
-    reporters: ['default', ...(process.env.CI ? ['junit'] : [])],
+    reporters: ['default', ...(process.env.CI ? [['junit', {classnameTemplate: '{filepath}'}] : [])],
     outputFile: {
       junit: 'vitest.junit.xml',
     },

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -10,9 +10,9 @@ export default defineConfig({
       enabled: true,
       reportsDirectory: './coverage',
     },
-    reporters: ['default', 'junit'],
+    reporters: ['default', ...(process.env.CI ? ['junit'] : [])],
     outputFile: {
-      junit: `vitest.junit.xml`,
+      junit: 'vitest.junit.xml',
     },
     typecheck: {
       tsconfig: './tsconfig.test.json',

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       enabled: true,
       reportsDirectory: './coverage',
     },
-    reporters: ['default', ...(process.env.CI ? [['junit', {classnameTemplate: '{filepath}'}] : [])],
+    reporters: ['default', ...(process.env.CI ? [['junit', { classnameTemplate: '{filepath}' }]] : [])],
     outputFile: {
       junit: 'vitest.junit.xml',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19066,6 +19066,16 @@ jest-jasmine2@^27.5.1:
     pretty-format "^27.5.1"
     throat "^6.0.1"
 
+jest-junit@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-16.0.0.tgz#d838e8c561cf9fdd7eb54f63020777eee4136785"
+  integrity sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz#6ec9d54c3579dd6e3e66d70e3498adf80fde3fb8"
@@ -30489,6 +30499,11 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
I noticed that not all of our tests were being tracked in codecov. This adds `jest-junit` reporter for our jest tests and configures vitest to use junit reporter (when `CI` env var is set).

This brings [the number of tests tracked](https://app.codecov.io/gh/getsentry/sentry-javascript/tests/feat-ci-jest-junit) from ~700 to 4.5k
