### PR TITLE
ref(flags): rename unleash integration param

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/badSignature/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/badSignature/init.js
@@ -7,7 +7,7 @@ window.UnleashClient = class {
 };
 
 window.Sentry = Sentry;
-window.sentryUnleashIntegration = Sentry.unleashIntegration({ unleashClientClass: window.UnleashClient });
+window.sentryUnleashIntegration = Sentry.unleashIntegration({ featureFlagClientClass: window.UnleashClient });
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/init.js
@@ -41,7 +41,7 @@ window.UnleashClient = class {
 };
 
 window.Sentry = Sentry;
-window.sentryUnleashIntegration = Sentry.unleashIntegration({ unleashClientClass: window.UnleashClient });
+window.sentryUnleashIntegration = Sentry.unleashIntegration({ featureFlagClientClass: window.UnleashClient });
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/packages/browser/src/integrations/featureFlags/unleash/integration.ts
+++ b/packages/browser/src/integrations/featureFlags/unleash/integration.ts
@@ -5,6 +5,10 @@ import { DEBUG_BUILD } from '../../../debug-build';
 import { copyFlagsFromScopeToEvent, insertFlagToScope } from '../../../utils/featureFlags';
 import type { UnleashClient, UnleashClientClass } from './types';
 
+export type UnleashIntegrationOptions = {
+  featureFlagClientClass: UnleashClientClass;
+};
+
 /**
  * Sentry integration for capturing feature flag evaluations from the Unleash SDK.
  *
@@ -17,19 +21,18 @@ import type { UnleashClient, UnleashClientClass } from './types';
  *
  * Sentry.init({
  *   dsn: '___PUBLIC_DSN___',
- *   integrations: [Sentry.unleashIntegration({unleashClientClass: UnleashClient})],
+ *   integrations: [Sentry.unleashIntegration({featureFlagClientClass: UnleashClient})],
  * });
  *
  * const unleash = new UnleashClient(...);
  * unleash.start();
  *
  * unleash.isEnabled('my-feature');
- * unleash.getVariant('other-feature');
  * Sentry.captureException(new Error('something went wrong'));
  * ```
  */
 export const unleashIntegration = defineIntegration(
-  ({ unleashClientClass }: { unleashClientClass: UnleashClientClass }) => {
+  ({ featureFlagClientClass: unleashClientClass }: UnleashIntegrationOptions) => {
     return {
       name: 'Unleash',
 

--- a/packages/browser/src/integrations/featureFlags/unleash/integration.ts
+++ b/packages/browser/src/integrations/featureFlags/unleash/integration.ts
@@ -5,7 +5,7 @@ import { DEBUG_BUILD } from '../../../debug-build';
 import { copyFlagsFromScopeToEvent, insertFlagToScope } from '../../../utils/featureFlags';
 import type { UnleashClient, UnleashClientClass } from './types';
 
-export type UnleashIntegrationOptions = {
+type UnleashIntegrationOptions = {
   featureFlagClientClass: UnleashClientClass;
 };
 


### PR DESCRIPTION
Renaming this parameter to keep the name consistent with [statsigIntegration](https://github.com/getsentry/sentry-javascript/pull/15319). We can reuse this generic name for future FF integrations.

This integration is not in use for v9 so we're directly changing the options type. Plan for v8: we'll define the same options type but with `featureFlagsClientClass` (new) and `unleashClientClass` (old) both optional, annotating the latter with `@deprecated`.