### PR TITLE
chore(ci/v8): Switch lambda layer name to `SentryNodeServerlessSDKv8`

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -146,8 +146,7 @@ targets:
   # whenever we release a new v8 version—otherwise we would overwrite the current major lambda layer.
   - name: aws-lambda-layer
     includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
-    # TODO(v9): change to `SentryNodeServerlessSDKv8` once v9 is released
-    layerName: SentryNodeServerlessSDK
+    layerName: SentryNodeServerlessSDKv8
     compatibleRuntimes:
       - name: node
         versions:


### PR DESCRIPTION
With the upcoming release of Sentry v9, we will stop publishing the AWS Lambda layer under `SentryNodeServerlessSDK` and instead use a version suffixed naming scheme.

We now have:
- `SentryNodeServerlessSDKv7`
- `SentryNodeServerlessSDKv8`
- `SentryNodeServerlessSDKv9`

If you're expecting to get updates for your v8 layer, please switch over to `SentryNodeServerlessSDKv8` otherwise upgrade to `SentryNodeServerlessSDKv9`.

Closes: #14842