### PR TITLE
fix(astro): Add vue to `registerEsmLoaderHooks`

### DIFF
--- a/packages/astro/src/server/sdk.ts
+++ b/packages/astro/src/server/sdk.ts
@@ -9,9 +9,30 @@ import { init as initNodeSdk } from '@sentry/node';
 export function init(options: NodeOptions): NodeClient | undefined {
   const opts = {
     ...options,
+    registerEsmLoaderHooks: mergeRegisterEsmLoaderHooks(options),
   };
 
   applySdkMetadata(opts, 'astro', ['astro', 'node']);
 
   return initNodeSdk(opts);
+}
+
+/**
+ * Adds /vue/ to the registerEsmLoaderHooks options and merges it with the old values in the array if one is defined.
+ * If the registerEsmLoaderHooks option is already a boolean, nothing is changed.
+ *
+ * Only exported for Testing purposes.
+ */
+export function mergeRegisterEsmLoaderHooks(options: NodeOptions): NodeOptions['registerEsmLoaderHooks'] {
+  if (typeof options.registerEsmLoaderHooks === 'object' && options.registerEsmLoaderHooks !== null) {
+    return {
+      // eslint-disable-next-line deprecation/deprecation
+      exclude: Array.isArray(options.registerEsmLoaderHooks.exclude)
+        ? // eslint-disable-next-line deprecation/deprecation
+          [...options.registerEsmLoaderHooks.exclude, /vue/]
+        : // eslint-disable-next-line deprecation/deprecation
+          options.registerEsmLoaderHooks.exclude ?? [/vue/],
+    };
+  }
+  return options.registerEsmLoaderHooks ?? { exclude: [/vue/] };
 }

--- a/packages/astro/test/server/sdk.test.ts
+++ b/packages/astro/test/server/sdk.test.ts
@@ -1,8 +1,8 @@
 import * as SentryNode from '@sentry/node';
-import { SDK_VERSION } from '@sentry/node';
-import { vi } from 'vitest';
+import { type NodeOptions, SDK_VERSION } from '@sentry/node';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { init } from '../../src/server/sdk';
+import { init, mergeRegisterEsmLoaderHooks } from '../../src/server/sdk';
 
 const nodeInit = vi.spyOn(SentryNode, 'init');
 
@@ -41,6 +41,44 @@ describe('Sentry server SDK', () => {
 
     it('returns client from init', () => {
       expect(init({})).not.toBeUndefined();
+    });
+  });
+
+  describe('mergeRegisterEsmLoaderHooks', () => {
+    it('merges exclude array when registerEsmLoaderHooks is an object with an exclude array', () => {
+      const options: NodeOptions = {
+        registerEsmLoaderHooks: { exclude: [/test/] },
+      };
+      const result = mergeRegisterEsmLoaderHooks(options);
+      expect(result).toEqual({ exclude: [/test/, /vue/] });
+    });
+
+    it('sets exclude array when registerEsmLoaderHooks is an object without an exclude array', () => {
+      const options: NodeOptions = {
+        registerEsmLoaderHooks: {},
+      };
+      const result = mergeRegisterEsmLoaderHooks(options);
+      expect(result).toEqual({ exclude: [/vue/] });
+    });
+
+    it('returns boolean when registerEsmLoaderHooks is a boolean', () => {
+      const options1: NodeOptions = {
+        registerEsmLoaderHooks: true,
+      };
+      const result1 = mergeRegisterEsmLoaderHooks(options1);
+      expect(result1).toBe(true);
+
+      const options2: NodeOptions = {
+        registerEsmLoaderHooks: false,
+      };
+      const result2 = mergeRegisterEsmLoaderHooks(options2);
+      expect(result2).toBe(false);
+    });
+
+    it('sets exclude array when registerEsmLoaderHooks is undefined', () => {
+      const options: NodeOptions = {};
+      const result = mergeRegisterEsmLoaderHooks(options);
+      expect(result).toEqual({ exclude: [/vue/] });
     });
   });
 });


### PR DESCRIPTION
Makes sure that `vue` is not wrapped and users don't get the error `$haml has already been declared`

closes https://github.com/getsentry/sentry-javascript/issues/13982
