### PR TITLE
ci: Setup workspace node version in release actions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -41,6 +41,11 @@ jobs:
           version=${version/'prepare-release/'/''}
           echo "version=$version" >> $GITHUB_OUTPUT
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1
         if: github.event.pull_request.merged == true && steps.version-regex.outputs.match != '' && steps.get_version.outputs.version != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1
         env:


### PR DESCRIPTION
The release action is failing because of an engine field pinned to node 20 and the default installed version of node on our current ubuntu runner version is 18.