### PR TITLE
ci(v8): Tag packages with v8

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -12,7 +12,8 @@
   "type": "module",
   "module": "build/fesm2015/sentry-angular.mjs",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "peerDependencies": {
     "@angular/common": ">= 14.x <= 19.x",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -50,7 +50,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "peerDependencies": {
     "astro": ">=3.x || >=4.0.0-beta || >=5.x"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry-internal/browser-utils": "8.54.0",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry/core": "8.54.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "TODO(v9):": "Remove these dependencies",
   "devDependencies": {

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -18,7 +18,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "files": [
     "/build"

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -10,7 +10,8 @@
     "ember-addon"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "directories": {
     "doc": "doc",

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -19,7 +19,8 @@
   ],
   "main": "src/index.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry-internal/eslint-plugin-sdk": "8.54.0",

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -19,7 +19,8 @@
   ],
   "main": "src/index.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "scripts": {
     "clean": "yarn rimraf sentry-internal-eslint-plugin-sdk-*.tgz",

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry/core": "8.54.0"

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -42,7 +42,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry/core": "8.54.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -73,7 +73,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -62,7 +62,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry/core": "8.54.0"

--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -36,7 +36,8 @@
     "node": ">=14.18"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "files": [
     "/lib",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry/browser": "8.54.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -49,7 +49,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -52,7 +52,8 @@
     "yalc:publish": "yalc publish --push --sig"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "repository": {
     "type": "git",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry/browser": "8.54.0",

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -28,7 +28,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "peerDependencies": {
     "@sveltejs/kit": "1.x || 2.x",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -7,7 +7,8 @@
   "author": "Sentry",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "files": [
     "tsconfig.json"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "latest"
   },
   "dependencies": {
     "@sentry/core": "8.54.0"

--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry/browser": "8.54.0",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8"
   },
   "dependencies": {
     "@sentry/browser": "8.54.0",


### PR DESCRIPTION
Tags all packages on the v8 branch with the `v8` tag on npm, except for utils which was removed in v9 and should therefore still receive the latest tag.

Resolves https://github.com/getsentry/sentry-javascript/issues/14938