### PR TITLE
profiling: bump chunk interval to 60s

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -30,7 +30,7 @@ import {
   makeProfileChunkEnvelope,
 } from './utils';
 
-const CHUNK_INTERVAL_MS = 5000;
+const CHUNK_INTERVAL_MS = 1000 * 60;
 const PROFILE_MAP = new LRUMap<string, RawThreadCpuProfile>(50);
 const PROFILE_TIMEOUTS: Record<string, NodeJS.Timeout> = {};
 

--- a/packages/profiling-node/test/spanProfileUtils.test.ts
+++ b/packages/profiling-node/test/spanProfileUtils.test.ts
@@ -501,7 +501,7 @@ describe('continuous profiling', () => {
     expect(startProfilingSpy).not.toHaveBeenCalledTimes(1);
     Sentry.profiler.startProfiler();
 
-    jest.advanceTimersByTime(5001);
+    jest.advanceTimersByTime(60_001);
     expect(stopProfilingSpy).toHaveBeenCalledTimes(1);
     expect(startProfilingSpy).toHaveBeenCalledTimes(2);
   });
@@ -518,7 +518,7 @@ describe('continuous profiling', () => {
     Sentry.profiler.startProfiler();
     const profilerId = getProfilerId();
 
-    jest.advanceTimersByTime(5001);
+    jest.advanceTimersByTime(60_001);
     expect(stopProfilingSpy).toHaveBeenCalledTimes(1);
     expect(startProfilingSpy).toHaveBeenCalledTimes(2);
     expect(getProfilerId()).toBe(profilerId);
@@ -552,7 +552,7 @@ describe('continuous profiling', () => {
     expect(startProfilingSpy).not.toHaveBeenCalledTimes(1);
     Sentry.profiler.startProfiler();
 
-    jest.advanceTimersByTime(5001);
+    jest.advanceTimersByTime(60_001);
     expect(stopProfilingSpy).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Bump profiling chunk interval to 60s as per [spec](https://www.notion.so/sentry/Continuous-UI-Profiling-SDK-API-Spec-17e8b10e4b5d80c59a40c6e114470934)