### PR TITLE
fix(sveltekit): Avoid request body double read errors

### DIFF
--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -46,8 +46,6 @@ function mockEvent(override: Record<string, unknown> = {}): Parameters<Handle>[0
     ...override,
   };
 
-  event.request.clone = () => event.request;
-
   return event;
 }
 


### PR DESCRIPTION
This PR attempts to fix an unreproducible bug reported in https://github.com/getsentry/sentry-javascript/issues/14583: It seems like our SDK calling `clone` on the `request` object passed to SvelteKit request handlers causes double read errors when the request body is consumed in user code. 

While I'm not sure about this, my best guess is that it has something to do with SvelteKit [creating a new request object](https://github.com/sveltejs/kit/blob/ca1d09f09ed123f72a98de031a34ec6db68fe915/packages/kit/src/exports/node/index.js#L123-L133) from the actual incoming request in a special way.

This PR removes the `clone()` call (tests would fail if it was still called) from our request handler. This is safe because our SDK does not consume the request body. Cloning here was a precautionary measure that apparently backfired. 
If it turns out that this doesn't fix the problem, we should revert this PR. 