### PR TITLE
fix(vue): allow pinia 3 in @sentry/vue peer deps

### DIFF
--- a/dev-packages/e2e-tests/test-applications/vue-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-3/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@sentry/vue": "latest || *",
-    "pinia": "^2.2.3",
+    "pinia": "^3.0.0",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -43,7 +43,7 @@
     "@sentry/core": "9.0.1"
   },
   "peerDependencies": {
-    "pinia": "2.x",
+    "pinia": "2.x || 3.x",
     "vue": "2.x || 3.x"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
This resolves issues with Pinia 3 and npm throwing conflicts with `@sentry/vue`:

```
npm error Conflicting peer dependency: pinia@2.3.1
npm error node_modules/pinia
npm error   peerOptional pinia@"2.x" from @sentry/vue@9.0.1
npm error   node_modules/@sentry/vue
npm error     dev @sentry/vue@"9.0.1" from the root project
```
Changelog: https://github.com/vuejs/pinia/blob/v3/packages/pinia/CHANGELOG.md

There's no real user-facing changes here and everything still seems to work from my basic testing, but please let me know if I can do anything else to help validate here.