### PR TITLE
feat(v8/nuxt): Add `enabled` to disable Sentry module (#15337)

### DIFF
--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -96,6 +96,13 @@ type SourceMapsOptions = {
  */
 export type SentryNuxtModuleOptions = {
   /**
+   * Enable the Sentry Nuxt Module.
+   *
+   * @default true
+   */
+  enabled?: boolean;
+
+  /**
    * Options for the Sentry Vite plugin to customize the source maps upload process.
    *
    * These options are always read from the `sentry` module options in the `nuxt.config.(js|ts).

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -18,7 +18,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {},
   setup(moduleOptionsParam, nuxt) {
-    if (moduleOptionsParam?.enabled === false) {
+    if ('enabled' in moduleOptionsParam && moduleOptionsParam.enabled === false) {
       return;
     }
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -18,6 +18,10 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {},
   setup(moduleOptionsParam, nuxt) {
+    if (moduleOptionsParam?.enabled === false) {
+      return;
+    }
+
     const moduleOptions = {
       ...moduleOptionsParam,
       autoInjectServerSentry: moduleOptionsParam.autoInjectServerSentry,


### PR DESCRIPTION
Backport of https://github.com/getsentry/sentry-javascript/pull/15337
