### PR TITLE
feat(vue): Support Pinia v3

### DIFF
--- a/dev-packages/e2e-tests/test-applications/vue-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-3/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@sentry/vue": "latest || *",
-    "pinia": "^2.2.3",
+    "pinia": "^3.0.0",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -43,7 +43,7 @@
     "@sentry/core": "9.0.1"
   },
   "peerDependencies": {
-    "pinia": "2.x",
+    "pinia": "2.x || 3.x",
     "vue": "2.x || 3.x"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Pinia had a boring major release yesterday: [Migration Guide on their website](https://pinia.vuejs.org/cookbook/migration-v2-v3.html#Migrating-from-v2-to-v3).

As they mainly removed deprecations, I just upgraded the pinia to v3 in the E2E test.

closes https://github.com/getsentry/sentry-javascript/issues/15378
