### PR TITLE
feat(v8/vue): Support Pinia v3

### DIFF
--- a/dev-packages/e2e-tests/test-applications/vue-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-3/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@sentry/vue": "latest || *",
-    "pinia": "^2.2.3",
+    "pinia": "^3.0.0",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5"
   },

--- a/dev-packages/e2e-tests/test-applications/vue-3/src/stores/cart.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/src/stores/cart.ts
@@ -1,7 +1,6 @@
 import { acceptHMRUpdate, defineStore } from 'pinia';
 
-export const useCartStore = defineStore({
-  id: 'cart',
+export const useCartStore = defineStore('cart', {
   state: () => ({
     rawItems: [] as string[],
   }),

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -44,7 +44,7 @@
     "@sentry/core": "8.54.0"
   },
   "peerDependencies": {
-    "pinia": "2.x",
+    "pinia": "2.x || 3.x",
     "vue": "2.x || 3.x"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
backport of https://github.com/getsentry/sentry-javascript/pull/15383
