### PR TITLE
ci: Disable v8 compile cache functionality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ env:
 
   # https://bsky.app/profile/joyeecheung.bsky.social/post/3lhy6o54fo22h
   # Apparently some of our CI failures are attributable to a corrupt v8 cache, causing v8 failures with: "Check failed: current == end_slot_index.".
+  # This option both controls the `v8-compile-cache-lib` and `v8-compile-cache` packages.
   DISABLE_V8_COMPILE_CACHE: '1'
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ env:
     nx-Linux-${{ github.ref }}
     nx-Linux
 
+  # https://bsky.app/profile/joyeecheung.bsky.social/post/3lhy6o54fo22h
+  # Apparently some of our CI failures are attributable to a corrupt v8 cache, causing v8 failures with: "Check failed: current == end_slot_index.".
+  DISABLE_V8_COMPILE_CACHE: '1'
+
 jobs:
   job_get_metadata:
     name: Get Metadata


### PR DESCRIPTION
https://bsky.app/profile/joyeecheung.bsky.social/post/3lhy7xpe3ok2h

We are seeing failures coming from v8 and a node maintainer pointed us to the v8 compile cache packages creating a corrupted cache. Disabling should get rid of the failures.