### PR TITLE
chore(node): Bump `@opentelemetry/instrumentation-pg` to `0.51.0`

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -88,7 +88,7 @@
     "@opentelemetry/instrumentation-mongoose": "0.46.0",
     "@opentelemetry/instrumentation-mysql": "0.45.0",
     "@opentelemetry/instrumentation-mysql2": "0.45.0",
-    "@opentelemetry/instrumentation-pg": "0.50.0",
+    "@opentelemetry/instrumentation-pg": "0.51.0",
     "@opentelemetry/instrumentation-redis-4": "0.46.0",
     "@opentelemetry/instrumentation-tedious": "0.18.0",
     "@opentelemetry/instrumentation-undici": "0.10.0",


### PR DESCRIPTION
There's a new version. Not being on the new version means iitm won't patch `pg`.