### PR TITLE
test(node): Run Prisma docker containers via test runner

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -16,12 +16,9 @@
     "build:types": "tsc -p tsconfig.types.json",
     "clean": "rimraf -g **/node_modules && run-p clean:script",
     "clean:script": "node scripts/clean.js",
-    "prisma-v5:init": "cd suites/tracing/prisma-orm-v5 && yarn && yarn setup",
-    "prisma-v6:init": "cd suites/tracing/prisma-orm-v6 && yarn && yarn setup",
     "lint": "eslint . --format stylish",
     "fix": "eslint . --format stylish --fix",
     "type-check": "tsc",
-    "pretest": "run-s --silent prisma-v5:init prisma-v6:init",
     "test": "jest --config ./jest.config.js",
     "test:watch": "yarn test --watch"
   },

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/package.json
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/package.json
@@ -7,10 +7,9 @@
     "node": ">=18"
   },
   "scripts": {
-    "db-up": "docker compose up -d",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev -n sentry-test",
-    "setup": "run-s --silent db-up generate migrate"
+    "setup": "run-s --silent generate migrate"
   },
   "keywords": [],
   "author": "",

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -1,8 +1,17 @@
-import { createRunner } from '../../../utils/runner';
+import { createRunner, cleanupChildProcesses } from '../../../utils/runner';
 
-describe('Prisma ORM Tests', () => {
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+describe('Prisma ORM v5 Tests', () => {
   test('CJS - should instrument PostgreSQL queries from Prisma ORM', done => {
     createRunner(__dirname, 'scenario.js')
+      .withDockerCompose({
+        workingDirectory: [__dirname],
+        readyMatches: ['port 5432'],
+        setupCommand: 'yarn setup',
+      })
       .expect({
         transaction: transaction => {
           expect(transaction.transaction).toBe('Test Transaction');

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -1,4 +1,4 @@
-import { createRunner, cleanupChildProcesses } from '../../../utils/runner';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -10,7 +10,7 @@ describe('Prisma ORM v5 Tests', () => {
       .withDockerCompose({
         workingDirectory: [__dirname],
         readyMatches: ['port 5432'],
-        setupCommand: 'yarn setup',
+        setupCommand: 'yarn && yarn setup',
       })
       .expect({
         transaction: transaction => {

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/package.json
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/package.json
@@ -7,10 +7,9 @@
     "node": ">=18"
   },
   "scripts": {
-    "db-up": "docker compose up -d",
     "generate": "prisma generate",
     "migrate": "prisma migrate dev -n sentry-test",
-    "setup": "run-s --silent db-up generate migrate"
+    "setup": "run-s --silent generate migrate"
   },
   "keywords": [],
   "author": "",

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -11,7 +11,7 @@ describe('Prisma ORM v6 Tests', () => {
       .withDockerCompose({
         workingDirectory: [__dirname],
         readyMatches: ['port 5432'],
-        setupCommand: 'yarn setup',
+        setupCommand: 'yarn && yarn setup',
       })
       .expect({
         transaction: transaction => {

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -1,9 +1,18 @@
 import type { SpanJSON } from '@sentry/core';
-import { createRunner } from '../../../utils/runner';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-describe('Prisma ORM Tests', () => {
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+describe('Prisma ORM v6 Tests', () => {
   test('CJS - should instrument PostgreSQL queries from Prisma ORM', done => {
     createRunner(__dirname, 'scenario.js')
+      .withDockerCompose({
+        workingDirectory: [__dirname],
+        readyMatches: ['port 5432'],
+        setupCommand: 'yarn setup',
+      })
       .expect({
         transaction: transaction => {
           expect(transaction.transaction).toBe('Test Transaction');

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { spawn, spawnSync } from 'child_process';
+import { execSync, spawn, spawnSync } from 'child_process';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { normalize } from '@sentry/core';
@@ -60,6 +60,10 @@ interface DockerOptions {
    * The strings to look for in the output to know that the docker compose is ready for the test to be run
    */
   readyMatches: string[];
+  /**
+   * The command to run after docker compose is up
+   */
+  setupCommand?: string;
 }
 
 /**
@@ -96,6 +100,9 @@ async function runDockerCompose(options: DockerOptions): Promise<VoidFunction> {
         if (text.includes(match)) {
           child.stdout.removeAllListeners();
           clearTimeout(timeout);
+          if (options.setupCommand) {
+            execSync(options.setupCommand, { cwd, stdio: 'inherit' });
+          }
           resolve(close);
         }
       }


### PR DESCRIPTION
This PR migrates the prisma tests to use the `withDockerCompose` option on the test runner. 

This means:
- Docker is only required if you're running tests that actually use docker
- Containers are automatically cleaned up after tests complete