### PR TITLE
test(node): Extend timeouts for Prisma tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -1,5 +1,8 @@
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
+// When running docker compose, we need a larger timeout, as this takes some time...
+jest.setTimeout(75000);
+
 afterAll(() => {
   cleanupChildProcesses();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -1,6 +1,9 @@
 import type { SpanJSON } from '@sentry/core';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
+// When running docker compose, we need a larger timeout, as this takes some time...
+jest.setTimeout(75000);
+
 afterAll(() => {
   cleanupChildProcesses();
 });


### PR DESCRIPTION
After moving to setup docker via the test runner, the tests became flakey:
https://github.com/getsentry/sentry-javascript/actions/runs/13312637861/job/37179132147?pr=15404#step:6:314
https://github.com/getsentry/sentry-javascript/actions/runs/13327476657/job/37223999432?pr=15404#step:6:347

This PR extends the timeouts.