### PR TITLE
fix(browser): Ensure that `performance.measure` spans have a positive duration

### DIFF
--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -425,7 +425,7 @@ export function _addMeasureSpans(
   startTime: number,
   duration: number,
   timeOrigin: number,
-): number {
+): void {
   const navEntry = getNavigationEntry(false);
   const requestTime = msToSec(navEntry ? navEntry.requestStart : 0);
   // Because performance.measure accepts arbitrary timestamps it can produce
@@ -450,13 +450,14 @@ export function _addMeasureSpans(
     attributes['sentry.browser.measure_start_time'] = measureStartTimestamp;
   }
 
-  startAndEndSpan(span, measureStartTimestamp, measureEndTimestamp, {
-    name: entry.name as string,
-    op: entry.entryType as string,
-    attributes,
-  });
-
-  return measureStartTimestamp;
+  // Measurements from third parties can be off, which would create invalid spans, dropping transactions in the process.
+  if (measureStartTimestamp <= measureEndTimestamp) {
+    startAndEndSpan(span, measureStartTimestamp, measureEndTimestamp, {
+      name: entry.name as string,
+      op: entry.entryType as string,
+      attributes,
+    });
+  }
 }
 
 /** Instrument navigation entries */

--- a/packages/browser-utils/test/browser/browserMetrics.test.ts
+++ b/packages/browser-utils/test/browser/browserMetrics.test.ts
@@ -92,6 +92,29 @@ describe('_addMeasureSpans', () => {
       }),
     );
   });
+
+  it('drops measurement spans with negative duration', () => {
+    const spans: Span[] = [];
+
+    getClient()?.on('spanEnd', span => {
+      spans.push(span);
+    });
+
+    const entry = {
+      entryType: 'measure',
+      name: 'measure-1',
+      duration: 10,
+      startTime: 12,
+    } as PerformanceEntry;
+
+    const timeOrigin = 100;
+    const startTime = 23;
+    const duration = -50;
+
+    _addMeasureSpans(span, entry, startTime, duration, timeOrigin);
+
+    expect(spans).toHaveLength(0);
+  });
 });
 
 describe('_addResourceSpans', () => {


### PR DESCRIPTION
Third parties may emit measurments with negative durations, causing invalid spans to be emitted, causing relay to drop transactions.