### PR TITLE
feat(nextjs): Do not strip origin information from different origin stack frames

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -204,14 +204,14 @@ module.exports = [
     limit: '264 KB',
   },
   // Next.js SDK (ESM)
-  // {
-  //   name: '@sentry/nextjs (client)',
-  //   path: 'packages/nextjs/build/esm/client/index.js',
-  //   import: createImport('init'),
-  //   ignore: ['next/router', 'next/constants'],
-  //   gzip: true,
-  //   limit: '40 KB',
-  // },
+  {
+    name: '@sentry/nextjs (client)',
+    path: 'packages/nextjs/build/esm/client/index.js',
+    import: createImport('init'),
+    ignore: ['next/router', 'next/constants'],
+    gzip: true,
+    limit: '40 KB',
+  },
   // SvelteKit SDK (ESM)
   {
     name: '@sentry/sveltekit (client)',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -204,14 +204,14 @@ module.exports = [
     limit: '264 KB',
   },
   // Next.js SDK (ESM)
-  {
-    name: '@sentry/nextjs (client)',
-    path: 'packages/nextjs/build/esm/client/index.js',
-    import: createImport('init'),
-    ignore: ['next/router', 'next/constants'],
-    gzip: true,
-    limit: '40 KB',
-  },
+  // {
+  //   name: '@sentry/nextjs (client)',
+  //   path: 'packages/nextjs/build/esm/client/index.js',
+  //   import: createImport('init'),
+  //   ignore: ['next/router', 'next/constants'],
+  //   gzip: true,
+  //   limit: '40 KB',
+  // },
   // SvelteKit SDK (ESM)
   {
     name: '@sentry/sveltekit (client)',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -210,7 +210,7 @@ module.exports = [
     import: createImport('init'),
     ignore: ['next/router', 'next/constants'],
     gzip: true,
-    limit: '40 KB',
+    limit: '41 KB',
   },
   // SvelteKit SDK (ESM)
   {

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -1,4 +1,4 @@
-import { WINDOW, rewriteFramesIntegration } from '@sentry/browser';
+import { rewriteFramesIntegration } from '@sentry/browser';
 import { defineIntegration } from '@sentry/core';
 
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
@@ -17,8 +17,9 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
       // Turn `<origin>/<path>/_next/static/...` into `app:///_next/static/...`
       iteratee: frame => {
         if (experimentalThirdPartyOriginStackFrames) {
-          // Unguarded access to window causes hideous ci errors
-          const windowOrigin = typeof WINDOW !== 'undefined' && WINDOW.location ? WINDOW.location.origin : '';
+          // Not sure why but access to global WINDOW from @sentry/Browser causes hideous ci errors
+          // eslint-disable-next-line no-restricted-globals
+          const windowOrigin = typeof window !== 'undefined' && window.location ? window.location.origin : '';
           // A filename starting with the local origin and not ending with JS is most likely JS in HTML which we do not want to rewrite
           if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
             return frame;

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -18,7 +18,7 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
       iteratee: frame => {
         if (experimentalThirdPartyOriginStackFrames) {
           // Unguarded access to window causes hideous ci errors
-          const windowOrigin = typeof WINDOW !== 'undefined' ? WINDOW.location.origin : '';
+          const windowOrigin = typeof WINDOW !== 'undefined' && WINDOW.location ? WINDOW.location.origin : '';
           // A filename starting with the local origin and not ending with JS is most likely JS in HTML which we do not want to rewrite
           if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
             return frame;

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -1,4 +1,4 @@
-import { WINDOW, rewriteFramesIntegration } from '@sentry/browser';
+import { rewriteFramesIntegration } from '@sentry/browser';
 import { defineIntegration } from '@sentry/core';
 
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
@@ -18,7 +18,8 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
       iteratee: frame => {
         if (experimentalThirdPartyOriginStackFrames) {
           // Unguarded access to window causes hideous ci errors
-          const windowOrigin = typeof WINDOW !== 'undefined' && WINDOW.location ? WINDOW.location.origin : '';
+          // eslint-disable-next-line no-restricted-globals
+          const windowOrigin = typeof window !== 'undefined' && window.location ? window.location.origin : '';
           // A filename starting with the local origin and not ending with JS is most likely JS in HTML which we do not want to rewrite
           if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
             return frame;

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -8,6 +8,11 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
     const rewriteFramesInstance = rewriteFramesIntegration({
       // Turn `<origin>/<path>/_next/static/...` into `app:///_next/static/...`
       iteratee: frame => {
+        // A filename starting with the local origin and not ending with JS is most likely JS in HTML which we do not want to rewrite
+        if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
+          return frame;
+        }
+
         if (assetPrefix) {
           if (frame.filename?.startsWith(assetPrefix)) {
             frame.filename = frame.filename.replace(assetPrefix, 'app://');
@@ -25,13 +30,13 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
 
         // We need to URI-decode the filename because Next.js has wildcard routes like "/users/[id].js" which show up as "/users/%5id%5.js" in Error stacktraces.
         // The corresponding sources that Next.js generates have proper brackets so we also need proper brackets in the frame so that source map resolving works.
-        if (frame.filename?.startsWith('app:///_next')) {
+        if (frame.filename?.includes('/_next')) {
           frame.filename = decodeURI(frame.filename);
         }
 
         if (
           frame.filename?.match(
-            /^app:\/\/\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
+            /\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
           )
         ) {
           // We don't care about these frames. It's Next.js internal code.

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -1,16 +1,24 @@
-import { rewriteFramesIntegration } from '@sentry/browser';
+import { WINDOW, rewriteFramesIntegration } from '@sentry/browser';
 import { defineIntegration } from '@sentry/core';
 
+const windowOrigin = WINDOW.location.origin;
+
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
-  ({ assetPrefixPath }: { assetPrefixPath: string }) => {
+  ({ assetPrefix, basePath }: { assetPrefix?: string; basePath?: string }) => {
     const rewriteFramesInstance = rewriteFramesIntegration({
       // Turn `<origin>/<path>/_next/static/...` into `app:///_next/static/...`
       iteratee: frame => {
-        try {
-          const { origin } = new URL(frame.filename as string);
-          frame.filename = frame.filename?.replace(origin, 'app://').replace(assetPrefixPath, '');
-        } catch (err) {
-          // Filename wasn't a properly formed URL, so there's nothing we can do
+        if (assetPrefix) {
+          frame.filename = frame.filename?.replace(assetPrefix, 'app://');
+        } else if (basePath) {
+          try {
+            const { origin: frameOrigin } = new URL(frame.filename as string);
+            if (frameOrigin === windowOrigin) {
+              frame.filename = frame.filename?.replace(frameOrigin, 'app://').replace(basePath, '');
+            }
+          } catch (err) {
+            // Filename wasn't a properly formed URL, so there's nothing we can do
+          }
         }
 
         // We need to URI-decode the filename because Next.js has wildcard routes like "/users/[id].js" which show up as "/users/%5id%5.js" in Error stacktraces.

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -1,4 +1,5 @@
-import { WINDOW, rewriteFramesIntegration } from '@sentry/browser';
+// import { WINDOW, rewriteFramesIntegration } from '@sentry/browser';
+import { rewriteFramesIntegration } from '@sentry/browser';
 import { defineIntegration } from '@sentry/core';
 
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
@@ -17,11 +18,11 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
       // Turn `<origin>/<path>/_next/static/...` into `app:///_next/static/...`
       iteratee: frame => {
         if (experimentalThirdPartyOriginStackFrames) {
-          const windowOrigin = WINDOW.location.origin;
+          // const windowOrigin = WINDOW.location.origin;
           // A filename starting with the local origin and not ending with JS is most likely JS in HTML which we do not want to rewrite
-          if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
-            return frame;
-          }
+          // if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
+          //   return frame;
+          // }
 
           if (assetPrefix) {
             // If the user defined an asset prefix, we need to strip it so that we can match it with uploaded sourcemaps.
@@ -33,10 +34,10 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
             // If the user defined a base path, we need to strip it to match with uploaded sourcemaps.
             // We should only do this for same-origin filenames though, so that third party assets are not rewritten.
             try {
-              const { origin: frameOrigin } = new URL(frame.filename as string);
-              if (frameOrigin === windowOrigin) {
-                frame.filename = frame.filename?.replace(frameOrigin, 'app://').replace(basePath, '');
-              }
+              // const { origin: frameOrigin } = new URL(frame.filename as string);
+              // if (frameOrigin === windowOrigin) {
+              //   frame.filename = frame.filename?.replace(frameOrigin, 'app://').replace(basePath, '');
+              // }
             } catch (err) {
               // Filename wasn't a properly formed URL, so there's nothing we can do
             }

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -1,4 +1,4 @@
-import { rewriteFramesIntegration } from '@sentry/browser';
+import { rewriteFramesIntegration, WINDOW } from '@sentry/browser';
 import { defineIntegration } from '@sentry/core';
 
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
@@ -18,8 +18,7 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
       iteratee: frame => {
         if (experimentalThirdPartyOriginStackFrames) {
           // Unguarded access to window causes hideous ci errors
-          // eslint-disable-next-line no-restricted-globals
-          const windowOrigin = typeof window !== 'undefined' && window.location ? window.location.origin : '';
+          const windowOrigin = typeof WINDOW !== 'undefined' && WINDOW.location ? WINDOW.location.origin : '';
           // A filename starting with the local origin and not ending with JS is most likely JS in HTML which we do not want to rewrite
           if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
             return frame;

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -1,15 +1,17 @@
 import { WINDOW, rewriteFramesIntegration } from '@sentry/browser';
 import { defineIntegration } from '@sentry/core';
 
-const windowOrigin = WINDOW.location.origin;
-
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
   ({ assetPrefix, basePath }: { assetPrefix?: string; basePath?: string }) => {
+    const windowOrigin = WINDOW.location.origin;
+
     const rewriteFramesInstance = rewriteFramesIntegration({
       // Turn `<origin>/<path>/_next/static/...` into `app:///_next/static/...`
       iteratee: frame => {
         if (assetPrefix) {
-          frame.filename = frame.filename?.replace(assetPrefix, 'app://');
+          if (frame.filename?.startsWith(assetPrefix)) {
+            frame.filename = frame.filename.replace(assetPrefix, 'app://');
+          }
         } else if (basePath) {
           try {
             const { origin: frameOrigin } = new URL(frame.filename as string);

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -2,31 +2,49 @@ import { WINDOW, rewriteFramesIntegration } from '@sentry/browser';
 import { defineIntegration } from '@sentry/core';
 
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
-  ({ assetPrefix, basePath }: { assetPrefix?: string; basePath?: string }) => {
-    const windowOrigin = WINDOW.location.origin;
-
+  ({
+    assetPrefix,
+    basePath,
+    rewriteFramesAssetPrefixPath,
+    experimentalThirdPartyOriginStackFrames,
+  }: {
+    assetPrefix?: string;
+    basePath?: string;
+    rewriteFramesAssetPrefixPath: string;
+    experimentalThirdPartyOriginStackFrames: boolean;
+  }) => {
     const rewriteFramesInstance = rewriteFramesIntegration({
       // Turn `<origin>/<path>/_next/static/...` into `app:///_next/static/...`
       iteratee: frame => {
-        // A filename starting with the local origin and not ending with JS is most likely JS in HTML which we do not want to rewrite
-        if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
-          return frame;
-        }
-
-        if (assetPrefix) {
-          // If the user defined an asset prefix, we need to strip it so that we can match it with uploaded sourcemaps.
-          // assetPrefix always takes priority over basePath.
-          if (frame.filename?.startsWith(assetPrefix)) {
-            frame.filename = frame.filename.replace(assetPrefix, 'app://');
+        if (experimentalThirdPartyOriginStackFrames) {
+          const windowOrigin = WINDOW.location.origin;
+          // A filename starting with the local origin and not ending with JS is most likely JS in HTML which we do not want to rewrite
+          if (frame.filename?.startsWith(windowOrigin) && !frame.filename.endsWith('.js')) {
+            return frame;
           }
-        } else if (basePath) {
-          // If the user defined a base path, we need to strip it to match with uploaded sourcemaps.
-          // We should only do this for same-origin filenames though, so that third party assets are not rewritten.
-          try {
-            const { origin: frameOrigin } = new URL(frame.filename as string);
-            if (frameOrigin === windowOrigin) {
-              frame.filename = frame.filename?.replace(frameOrigin, 'app://').replace(basePath, '');
+
+          if (assetPrefix) {
+            // If the user defined an asset prefix, we need to strip it so that we can match it with uploaded sourcemaps.
+            // assetPrefix always takes priority over basePath.
+            if (frame.filename?.startsWith(assetPrefix)) {
+              frame.filename = frame.filename.replace(assetPrefix, 'app://');
             }
+          } else if (basePath) {
+            // If the user defined a base path, we need to strip it to match with uploaded sourcemaps.
+            // We should only do this for same-origin filenames though, so that third party assets are not rewritten.
+            try {
+              const { origin: frameOrigin } = new URL(frame.filename as string);
+              if (frameOrigin === windowOrigin) {
+                frame.filename = frame.filename?.replace(frameOrigin, 'app://').replace(basePath, '');
+              }
+            } catch (err) {
+              // Filename wasn't a properly formed URL, so there's nothing we can do
+            }
+          }
+        } else {
+          try {
+            const { origin } = new URL(frame.filename as string);
+            frame.filename = frame.filename?.replace(origin, 'app://').replace(rewriteFramesAssetPrefixPath, '');
           } catch (err) {
             // Filename wasn't a properly formed URL, so there's nothing we can do
           }
@@ -34,17 +52,32 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
 
         // We need to URI-decode the filename because Next.js has wildcard routes like "/users/[id].js" which show up as "/users/%5id%5.js" in Error stacktraces.
         // The corresponding sources that Next.js generates have proper brackets so we also need proper brackets in the frame so that source map resolving works.
-        if (frame.filename?.includes('/_next')) {
-          frame.filename = decodeURI(frame.filename);
-        }
+        if (experimentalThirdPartyOriginStackFrames) {
+          if (frame.filename?.includes('/_next')) {
+            frame.filename = decodeURI(frame.filename);
+          }
 
-        if (
-          frame.filename?.match(
-            /\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
-          )
-        ) {
-          // We don't care about these frames. It's Next.js internal code.
-          frame.in_app = false;
+          if (
+            frame.filename?.match(
+              /\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
+            )
+          ) {
+            // We don't care about these frames. It's Next.js internal code.
+            frame.in_app = false;
+          }
+        } else {
+          if (frame.filename?.startsWith('app:///_next')) {
+            frame.filename = decodeURI(frame.filename);
+          }
+
+          if (
+            frame.filename?.match(
+              /^app:\/\/\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
+            )
+          ) {
+            // We don't care about these frames. It's Next.js internal code.
+            frame.in_app = false;
+          }
         }
 
         return frame;

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -1,4 +1,4 @@
-import { rewriteFramesIntegration, WINDOW } from '@sentry/browser';
+import { WINDOW, rewriteFramesIntegration } from '@sentry/browser';
 import { defineIntegration } from '@sentry/core';
 
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -14,10 +14,14 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
         }
 
         if (assetPrefix) {
+          // If the user defined an asset prefix, we need to strip it so that we can match it with uploaded sourcemaps.
+          // assetPrefix always takes priority over basePath.
           if (frame.filename?.startsWith(assetPrefix)) {
             frame.filename = frame.filename.replace(assetPrefix, 'app://');
           }
         } else if (basePath) {
+          // If the user defined a base path, we need to strip it to match with uploaded sourcemaps.
+          // We should only do this for same-origin filenames though, so that third party assets are not rewritten.
           try {
             const { origin: frameOrigin } = new URL(frame.filename as string);
             if (frameOrigin === windowOrigin) {

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -16,8 +16,10 @@ export { captureUnderscoreErrorException } from '../common/pages-router-instrume
 export { browserTracingIntegration } from './browserTracingIntegration';
 
 const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
+  _sentryRewriteFramesAssetPrefixPath: string;
   _sentryAssetPrefix?: string;
   _sentryBasePath?: string;
+  _experimentalThirdPartyOriginStackFrames?: string;
 };
 
 // Treeshakable guard to remove all code related to tracing
@@ -70,9 +72,23 @@ function getDefaultIntegrations(options: BrowserOptions): Integration[] {
 
   // These values are injected at build time, based on the output directory specified in the build config. Though a default
   // is set there, we set it here as well, just in case something has gone wrong with the injection.
+  const rewriteFramesAssetPrefixPath =
+    process.env._sentryRewriteFramesAssetPrefixPath ||
+    globalWithInjectedValues._sentryRewriteFramesAssetPrefixPath ||
+    '';
   const assetPrefix = process.env._sentryAssetPrefix || globalWithInjectedValues._sentryAssetPrefix;
   const basePath = process.env._sentryBasePath || globalWithInjectedValues._sentryBasePath;
-  customDefaultIntegrations.push(nextjsClientStackFrameNormalizationIntegration({ assetPrefix, basePath }));
+  const experimentalThirdPartyOriginStackFrames =
+    process.env._experimentalThirdPartyOriginStackFrames === 'true' ||
+    globalWithInjectedValues._experimentalThirdPartyOriginStackFrames === 'true';
+  customDefaultIntegrations.push(
+    nextjsClientStackFrameNormalizationIntegration({
+      assetPrefix,
+      basePath,
+      rewriteFramesAssetPrefixPath,
+      experimentalThirdPartyOriginStackFrames,
+    }),
+  );
 
   return customDefaultIntegrations;
 }

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -16,7 +16,8 @@ export { captureUnderscoreErrorException } from '../common/pages-router-instrume
 export { browserTracingIntegration } from './browserTracingIntegration';
 
 const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
-  _sentryRewriteFramesAssetPrefixPath: string;
+  _sentryAssetPrefix?: string;
+  _sentryBasePath?: string;
 };
 
 // Treeshakable guard to remove all code related to tracing
@@ -67,13 +68,11 @@ function getDefaultIntegrations(options: BrowserOptions): Integration[] {
     customDefaultIntegrations.push(browserTracingIntegration());
   }
 
-  // This value is injected at build time, based on the output directory specified in the build config. Though a default
+  // These values are injected at build time, based on the output directory specified in the build config. Though a default
   // is set there, we set it here as well, just in case something has gone wrong with the injection.
-  const assetPrefixPath =
-    process.env._sentryRewriteFramesAssetPrefixPath ||
-    globalWithInjectedValues._sentryRewriteFramesAssetPrefixPath ||
-    '';
-  customDefaultIntegrations.push(nextjsClientStackFrameNormalizationIntegration({ assetPrefixPath }));
+  const assetPrefix = process.env._sentryAssetPrefix || globalWithInjectedValues._sentryAssetPrefix;
+  const basePath = process.env._sentryBasePath || globalWithInjectedValues._sentryBasePath;
+  customDefaultIntegrations.push(nextjsClientStackFrameNormalizationIntegration({ assetPrefix, basePath }));
 
   return customDefaultIntegrations;
 }

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -439,6 +439,16 @@ export type SentryBuildOptions = {
    * Defaults to `false`.
    */
   automaticVercelMonitors?: boolean;
+
+  /**
+   * Contains a set of experimental flags that might change in future releases. These flags enable
+   * features that are still in development and may be modified, renamed, or removed without notice.
+   * Use with caution in production environments.
+   *
+   */
+  _experimental?: Partial<{
+    thirdPartyOriginStackFrames: boolean;
+  }>;
 };
 
 export type NextConfigFunction = (

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -444,7 +444,6 @@ export type SentryBuildOptions = {
    * Contains a set of experimental flags that might change in future releases. These flags enable
    * features that are still in development and may be modified, renamed, or removed without notice.
    * Use with caution in production environments.
-   *
    */
   _experimental?: Partial<{
     thirdPartyOriginStackFrames: boolean;

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -595,6 +595,8 @@ function addValueInjectionLoader(
   buildContext: BuildContext,
   releaseName: string | undefined,
 ): void {
+  const assetPrefix = userNextConfig.assetPrefix || userNextConfig.basePath || '';
+
   const isomorphicValues = {
     // `rewritesTunnel` set by the user in Next.js config
     _sentryRewritesTunnelPath:
@@ -617,7 +619,15 @@ function addValueInjectionLoader(
 
   const clientValues = {
     ...isomorphicValues,
+    // Get the path part of `assetPrefix`, minus any trailing slash. (We use a placeholder for the origin if
+    // `assetPrefix` doesn't include one. Since we only care about the path, it doesn't matter what it is.)
+    _sentryRewriteFramesAssetPrefixPath: assetPrefix
+      ? new URL(assetPrefix, 'http://dogs.are.great').pathname.replace(/\/$/, '')
+      : '',
     _sentryAssetPrefix: userNextConfig.assetPrefix,
+    _sentryExperimentalThirdPartyOriginStackFrames: userSentryOptions._experimental?.thirdPartyOriginStackFrames
+      ? 'true'
+      : undefined,
   };
 
   if (buildContext.isServer) {

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -595,8 +595,6 @@ function addValueInjectionLoader(
   buildContext: BuildContext,
   releaseName: string | undefined,
 ): void {
-  const assetPrefix = userNextConfig.assetPrefix || userNextConfig.basePath || '';
-
   const isomorphicValues = {
     // `rewritesTunnel` set by the user in Next.js config
     _sentryRewritesTunnelPath:
@@ -619,11 +617,7 @@ function addValueInjectionLoader(
 
   const clientValues = {
     ...isomorphicValues,
-    // Get the path part of `assetPrefix`, minus any trailing slash. (We use a placeholder for the origin if
-    // `assetPrefix` doesn't include one. Since we only care about the path, it doesn't matter what it is.)
-    _sentryRewriteFramesAssetPrefixPath: assetPrefix
-      ? new URL(assetPrefix, 'http://dogs.are.great').pathname.replace(/\/$/, '')
-      : '',
+    _sentryAssetPrefix: userNextConfig.assetPrefix,
   };
 
   if (buildContext.isServer) {

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -250,7 +250,6 @@ function setUpTunnelRewriteRules(userNextConfig: NextConfigObject, tunnelPath: s
 
 // TODO: For Turbopack we need to pass the release name here and pick it up in the SDK
 function setUpBuildTimeVariables(userNextConfig: NextConfigObject, userSentryOptions: SentryBuildOptions): void {
-  const assetPrefix = userNextConfig.assetPrefix || userNextConfig.basePath || '';
   const basePath = userNextConfig.basePath ?? '';
   const rewritesTunnelPath =
     userSentryOptions.tunnelRoute !== undefined && userNextConfig.output !== 'export'
@@ -261,11 +260,6 @@ function setUpBuildTimeVariables(userNextConfig: NextConfigObject, userSentryOpt
     // Make sure that if we have a windows path, the backslashes are interpreted as such (rather than as escape
     // characters)
     _sentryRewriteFramesDistDir: userNextConfig.distDir?.replace(/\\/g, '\\\\') || '.next',
-    // Get the path part of `assetPrefix`, minus any trailing slash. (We use a placeholder for the origin if
-    // `assetPrefix` doesn't include one. Since we only care about the path, it doesn't matter what it is.)
-    _sentryRewriteFramesAssetPrefixPath: assetPrefix
-      ? new URL(assetPrefix, 'http://dogs.are.great').pathname.replace(/\/$/, '')
-      : '',
   };
 
   if (rewritesTunnelPath) {
@@ -274,6 +268,10 @@ function setUpBuildTimeVariables(userNextConfig: NextConfigObject, userSentryOpt
 
   if (basePath) {
     buildTimeVariables._sentryBasePath = basePath;
+  }
+
+  if (userNextConfig.assetPrefix) {
+    buildTimeVariables._sentryAssetPrefix = userNextConfig.assetPrefix;
   }
 
   if (typeof userNextConfig.env === 'object') {


### PR DESCRIPTION
**EDIT(cg): Moved this functionality behind `an _experimental.thirdPartyOriginStackFrames` config flag**

This change should drastically improve transparency on stack frames that come from third party origins while keeping existing sourcemapping functionality.

Example: `https://plausible.io/js/script.js` was **always** turned into `app:///js/script.js`, leading the user to believe "wtf is this".

By not stripping scripts on different origins from their origin in the stack trace, it should be way more transparent where errors originate from, potentially even improving sourcemaps via scraping if these scripts have propper source mapping urls/debug IDs.

Additionally, we should no longer strip js-in-html stack frames, also making those more transparent.

Considerations:
- May mess with grouping: I will go ahead and say the upsides outweigh the downsides here.
- Backwards compat: This should be fully backwards compatible with exisiting upload setups.