### PR TITLE
feat(replay): Add experimental option to record cross origin iframes

### DIFF
--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -150,6 +150,8 @@ export class Replay implements Integration {
           // this can happen if the error is frozen or does not allow mutation for other reasons
         }
       },
+
+      recordCrossOriginIframes: Boolean(_experiments.recordCrossOriginIframes),
     };
 
     this._initialOptions = {

--- a/packages/replay-internal/src/types/replay.ts
+++ b/packages/replay-internal/src/types/replay.ts
@@ -230,6 +230,7 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
     traceInternals: boolean;
     continuousCheckout: number;
     autoFlushOnFeedback: boolean;
+    recordCrossOriginIframes: boolean;
   }>;
 }
 


### PR DESCRIPTION
This allows users to record cross origin iframes by enabling the experimental option: `_experiments.recordCrossOriginIframe`
