### PR TITLE
feat(nuxt): Add `peerDependency` for `require-in-the-middle`

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -39,7 +39,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "nuxt": ">=3.7.0 || 4.x"
+    "nuxt": ">=3.7.0 || 4.x",
+    "require-in-the-middle": "<=7.4.0"
   },
   "dependencies": {
     "@nuxt/kit": "^3.13.2",


### PR DESCRIPTION
`require-in-the-middle` uses `require.resolve()`, rather than `require('resolve').sync()` since version `7.5.0`. This causes ESM applications (like Nuxt) to break ([see issue here](https://github.com/nodejs/require-in-the-middle/issues/110)).

Vite adds `require-in-the-middle` to the bundle but the code is not safe to run in ESM ([Vite issue](https://github.com/vitejs/vite/issues/19403)). 

We can probably revert this change after this is merged: https://github.com/nodejs/require-in-the-middle/pull/111

Closes https://github.com/getsentry/sentry-javascript/issues/15423
Closes https://github.com/getsentry/sentry-javascript/issues/15410
