### PR TITLE
fix(core): Filter out unactionable Facebook Mobile browser error

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -19,6 +19,7 @@ const DEFAULT_IGNORE_ERRORS = [
   "vv().getRestrictions is not a function. (In 'vv().getRestrictions(1,a)', 'vv().getRestrictions' is undefined)", // Error thrown by GTM, seemingly not affecting end-users
   "Can't find variable: _AutofillCallbackHandler", // Unactionable error in instagram webview https://developers.facebook.com/community/threads/320013549791141/
   /^Non-Error promise rejection captured with value: Object Not Found Matching Id:\d+, MethodName:simulateEvent, ParamCount:\d+$/, // unactionable error from CEFSharp, a .NET library that embeds chromium in .NET apps
+  /^Java exception was raised during method invocation$/, // error from Facebook Mobile browser (https://github.com/getsentry/sentry-javascript/issues/15065)
 ];
 
 /** Options for the InboundFilters integration */

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -281,6 +281,17 @@ const CEFSHARP_EVENT: Event = {
   },
 };
 
+const FB_MOBILE_BROWSER_EVENT: Event = {
+  exception: {
+    values: [
+      {
+        type: 'Error',
+        value: 'Java exception was raised during method invocation',
+      },
+    ],
+  },
+};
+
 const MALFORMED_EVENT: Event = {
   exception: {
     values: [
@@ -400,6 +411,11 @@ describe('InboundFilters', () => {
     it('uses default filters (CEFSharp)', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(CEFSHARP_EVENT, {})).toBe(null);
+    });
+
+    it('uses default filters (FB Mobile Browser)', () => {
+      const eventProcessor = createInboundFiltersEventProcessor();
+      expect(eventProcessor(FB_MOBILE_BROWSER_EVENT, {})).toBe(null);
     });
 
     it('filters on last exception when multiple present', () => {


### PR DESCRIPTION
Filters out an unactionable error thrown by the Facebook Mobile browser web view.

Closes https://github.com/getsentry/sentry-javascript/issues/15065