### PR TITLE
fix(core): Add Google `gmo` error to Inbound Filters

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -14,6 +14,7 @@ const DEFAULT_IGNORE_ERRORS = [
   /^Javascript error: Script error\.? on line 0$/,
   /^ResizeObserver loop completed with undelivered notifications.$/, // The browser logs this when a ResizeObserver handler takes a bit longer. Usually this is not an actual issue though. It indicates slowness.
   /^Cannot redefine property: googletag$/, // This is thrown when google tag manager is used in combination with an ad blocker
+  /^Can't find variable: gmo$/, // Error from Google Search App https://issuetracker.google.com/issues/396043331
   "undefined is not an object (evaluating 'a.L')", // Random error that happens but not actionable or noticeable to end-users.
   'can\'t redefine non-configurable property "solana"', // Probably a browser extension or custom browser (Brave) throwing this error
   "vv().getRestrictions is not a function. (In 'vv().getRestrictions(1,a)', 'vv().getRestrictions' is undefined)", // Error thrown by GTM, seemingly not affecting end-users

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -269,6 +269,12 @@ const GOOGLETAG_EVENT: Event = {
   },
 };
 
+const GOOGLE_APP_GMO: Event = {
+  exception: {
+    values: [{ type: 'ReferenceError', value: "Can't find variable: gmo" }],
+  },
+};
+
 const CEFSHARP_EVENT: Event = {
   exception: {
     values: [
@@ -395,6 +401,11 @@ describe('InboundFilters', () => {
     it('uses default filters (googletag)', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(GOOGLETAG_EVENT, {})).toBe(null);
+    });
+
+    it('uses default filters (Google App "gmo")', () => {
+      const eventProcessor = createInboundFiltersEventProcessor();
+      expect(eventProcessor(GOOGLE_APP_GMO, {})).toBe(null);
     });
 
     it('uses default filters (CEFSharp)', () => {


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/15389
