### PR TITLE
feat(core): Rename `inboundFiltersIntegration` to `eventFiltersIntegration`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/manual-client/browser-context/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/browser-context/init.js
@@ -6,7 +6,7 @@ import {
   defaultStackParser,
   functionToStringIntegration,
   httpContextIntegration,
-  inboundFiltersIntegration,
+  eventFiltersIntegration,
   linkedErrorsIntegration,
   makeFetchTransport,
 } from '@sentry/browser';
@@ -16,7 +16,7 @@ const integrations = [
   functionToStringIntegration(),
   dedupeIntegration(),
   httpContextIntegration(),
-  inboundFiltersIntegration(),
+  eventFiltersIntegration(),
   linkedErrorsIntegration(),
 ];
 

--- a/dev-packages/browser-integration-tests/suites/manual-client/browser-context/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/browser-context/test.ts
@@ -38,7 +38,7 @@ sentryTest('allows to setup a client manually & capture exceptions', async ({ ge
     environment: 'local',
     release: '0.0.1',
     sdk: {
-      integrations: ['Breadcrumbs', 'FunctionToString', 'Dedupe', 'HttpContext', 'InboundFilters', 'LinkedErrors'],
+      integrations: ['Breadcrumbs', 'FunctionToString', 'Dedupe', 'HttpContext', 'EventFilters', 'LinkedErrors'],
       name: 'sentry.javascript.browser',
       version: expect.any(String),
       packages: [{ name: expect.any(String), version: expect.any(String) }],

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -34,6 +34,7 @@ export function getDefaultIntegrations(_options: BrowserOptions = {}): Integrati
   //  - https://github.com/getsentry/sentry-javascript/issues/2744
   return [
     // TODO(v10): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
+    // eslint-disable-next-line deprecation/deprecation
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     breadcrumbsIntegration(),

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -33,6 +33,7 @@ export function getDefaultIntegrations(_options: BrowserOptions = {}): Integrati
   //  - https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097
   //  - https://github.com/getsentry/sentry-javascript/issues/2744
   return [
+    // TODO(v10): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     breadcrumbsIntegration(),

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -59,6 +59,7 @@ export {
   hapiIntegration,
   httpIntegration,
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,
   kafkaIntegration,

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -58,6 +58,7 @@ export {
   graphqlIntegration,
   hapiIntegration,
   httpIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -54,7 +54,9 @@ export {
   localVariablesIntegration,
   requestDataIntegration,
   functionToStringIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   linkedErrorsIntegration,
   setMeasurement,
   getActiveSpan,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -49,7 +49,9 @@ export {
   withScope,
   withIsolationScope,
   functionToStringIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   dedupeIntegration,
   parameterize,
   startSession,

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -34,6 +34,8 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
    * `getDefaultIntegrations` but with an adjusted set of integrations.
    */
   return [
+    // TODO(v10): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
+    // eslint-disable-next-line deprecation/deprecation
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     browserApiErrorsIntegration(),

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -10,7 +10,7 @@ import {
   getGlobalScope,
   getIsolationScope,
   getReportDialogEndpoint,
-  inboundFiltersIntegration,
+  eventFiltersIntegration,
   lastEventId,
 } from '@sentry/core';
 import * as utils from '@sentry/core';
@@ -304,12 +304,12 @@ describe('SentryBrowser', () => {
       expect(localBeforeSend).toHaveBeenCalledTimes(2);
     });
 
-    it('should use inboundfilter rules of bound client', async () => {
+    it('should use eventFilters rules of bound client', async () => {
       const localBeforeSend = vi.fn();
       const options = getDefaultBrowserClientOptions({
         beforeSend: localBeforeSend,
         dsn,
-        integrations: [inboundFiltersIntegration({ ignoreErrors: ['capture'] })],
+        integrations: [eventFiltersIntegration({ ignoreErrors: ['capture'] })],
       });
       const client = new BrowserClient(options);
       setCurrentClient(client);

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -7,10 +7,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   SDK_VERSION,
+  eventFiltersIntegration,
   getGlobalScope,
   getIsolationScope,
   getReportDialogEndpoint,
-  eventFiltersIntegration,
   lastEventId,
 } from '@sentry/core';
 import * as utils from '@sentry/core';

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -74,7 +74,9 @@ export {
   requestDataIntegration,
   fsIntegration,
   functionToStringIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   linkedErrorsIntegration,
   setMeasurement,
   getActiveSpan,

--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -29,6 +29,8 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   // We return a copy of the defaultIntegrations here to avoid mutating this
   return [
     // Common
+    // TODO(v10): Replace with eventFiltersIntegration once we remove the deprecated `inboundFiltersIntegration`
+    // eslint-disable-next-line deprecation/deprecation
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -65,7 +65,9 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,
   extraErrorDataIntegration,

--- a/packages/cloudflare/src/sdk.ts
+++ b/packages/cloudflare/src/sdk.ts
@@ -20,6 +20,8 @@ export function getDefaultIntegrations(options: CloudflareOptions): Integration[
   const sendDefaultPii = options.sendDefaultPii ?? false;
   return [
     dedupeIntegration(),
+    // TODO(v10): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
+    // eslint-disable-next-line deprecation/deprecation
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,9 @@ export {
 export { DEFAULT_ENVIRONMENT } from './constants';
 export { addBreadcrumb } from './breadcrumbs';
 export { functionToStringIntegration } from './integrations/functiontostring';
-export { inboundFiltersIntegration } from './integrations/inboundfilters';
+// eslint-disable-next-line deprecation/deprecation
+export { inboundFiltersIntegration } from './integrations/eventFilters';
+export { eventFiltersIntegration } from './integrations/eventFilters';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
 export { moduleMetadataIntegration } from './integrations/metadata';
 export { requestDataIntegration } from './integrations/requestdata';

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -1,24 +1,24 @@
 import type { Event, EventProcessor, Integration } from '../../../src/types-hoist';
 
 import { describe, expect, it } from 'vitest';
-import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 import type { EventFiltersOptions } from '../../../src/integrations/eventFilters';
 import { eventFiltersIntegration } from '../../../src/integrations/eventFilters';
 import { inboundFiltersIntegration } from '../../../src/integrations/eventFilters';
+import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 const PUBLIC_DSN = 'https://username@domain/123';
 
 /**
- * Creates an instance of the InboundFilters integration and returns
- * the event processor that the InboundFilters integration creates.
+ * Creates an instance of the eventFiltersIntegration and returns
+ * the event processor that the eventFiltersIntegration creates.
  *
- * To test the InboundFilters integration, call this function and assert on
+ * To test the eventFiltersIntegration, call this function and assert on
  * how the event processor handles an event. For example, if you set up the
- * InboundFilters to filter out an SOME_EXCEPTION_EVENT.
+ * event filters to filter out an SOME_EXCEPTION_EVENT.
  *
  * ```
  * // some options that cause SOME_EXCEPTION_EVENT to be filtered
- * const eventProcessor = createInboundFiltersEventProcessor(options);
+ * const eventProcessor = eventFiltersIntegration(options);
  *
  * expect(eventProcessor(SOME_EXCEPTION_EVENT)).toBe(null);
  * ```
@@ -26,7 +26,7 @@ const PUBLIC_DSN = 'https://username@domain/123';
  * @param options options passed into the InboundFilters integration
  * @param clientOptions options passed into the mock Sentry client
  */
-function createInboundFiltersEventProcessor(
+function createEventFiltersEventProcessor(
   integrationFn: (opts: Partial<EventFiltersOptions>) => Integration,
   options: Partial<EventFiltersOptions> = {},
   clientOptions: Partial<EventFiltersOptions> = {},
@@ -339,14 +339,14 @@ describe.each([
 ])('%s', (_, integrationFn) => {
   describe('_isSentryError', () => {
     it('should work as expected', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(MESSAGE_EVENT);
       expect(eventProcessor(EXCEPTION_EVENT, {})).toBe(EXCEPTION_EVENT);
       expect(eventProcessor(SENTRY_EVENT, {})).toBe(null);
     });
 
     it('should be configurable', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, { ignoreInternal: false });
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, { ignoreInternal: false });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(MESSAGE_EVENT);
       expect(eventProcessor(EXCEPTION_EVENT, {})).toBe(EXCEPTION_EVENT);
       expect(eventProcessor(SENTRY_EVENT, {})).toBe(SENTRY_EVENT);
@@ -355,35 +355,35 @@ describe.each([
 
   describe('ignoreErrors', () => {
     it('string filter with partial match', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: ['capture'],
       });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(null);
     });
 
     it('ignores transaction event for filtering', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: ['transaction'],
       });
       expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(TRANSACTION_EVENT);
     });
 
     it('string filter with exact match', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: ['captureMessage'],
       });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(null);
     });
 
     it('regexp filter with partial match', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: [/capture/],
       });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(null);
     });
 
     it('regexp filter with exact match', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: [/^captureMessage$/],
       });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(null);
@@ -391,7 +391,7 @@ describe.each([
     });
 
     it('prefers message when both message and exception are available', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: [/captureMessage/],
       });
       const event = {
@@ -402,7 +402,7 @@ describe.each([
     });
 
     it('can use multiple filters', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: ['captureMessage', /SyntaxError/],
       });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(null);
@@ -410,44 +410,44 @@ describe.each([
     });
 
     it('uses default filters (script error)', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(null);
     });
 
     it('uses default filters (ResizeObserver)', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(RESIZEOBSERVER_EVENT, {})).toBe(null);
     });
 
     it('uses default filters (googletag)', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(GOOGLETAG_EVENT, {})).toBe(null);
     });
 
     it('uses default filters (Google App "gmo")', () => {
-      const eventProcessor = createInboundFiltersEventProcessor();
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(GOOGLE_APP_GMO, {})).toBe(null);
     });
 
     it('uses default filters (CEFSharp)', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(CEFSHARP_EVENT, {})).toBe(null);
     });
 
     it('uses default filters (FB Mobile Browser)', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(FB_MOBILE_BROWSER_EVENT, {})).toBe(null);
     });
 
     it('filters on last exception when multiple present', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: ['incorrect type given for parameter `chewToy`'],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_LINKED_ERRORS, {})).toBe(null);
     });
 
     it("doesn't filter on `cause` exception when multiple present", () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreErrors: ['`tooManyTreats` is not defined'],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_LINKED_ERRORS, {})).toBe(EXCEPTION_EVENT_WITH_LINKED_ERRORS);
@@ -455,31 +455,31 @@ describe.each([
 
     describe('on exception', () => {
       it('uses exception data when message is unavailable', () => {
-        const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+        const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
           ignoreErrors: ['SyntaxError: unidentified ? at line 1337'],
         });
         expect(eventProcessor(EXCEPTION_EVENT, {})).toBe(null);
       });
 
       it('can match on exception value', () => {
-        const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+        const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
           ignoreErrors: [/unidentified \?/],
         });
         expect(eventProcessor(EXCEPTION_EVENT, {})).toBe(null);
       });
 
       it('can match on exception type', () => {
-        const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+        const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
           ignoreErrors: [/^SyntaxError/],
         });
         expect(eventProcessor(EXCEPTION_EVENT, {})).toBe(null);
       });
 
       it('should consider both `event.message` and the last exceptions `type` and `value`', () => {
-        const messageEventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+        const messageEventProcessor = createEventFiltersEventProcessor(integrationFn, {
           ignoreErrors: [/^ChunkError/],
         });
-        const valueEventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+        const valueEventProcessor = createEventFiltersEventProcessor(integrationFn, {
           ignoreErrors: [/^SyntaxError/],
         });
         expect(messageEventProcessor(EXCEPTION_EVENT_WITH_MESSAGE_AND_VALUE, {})).toBe(null);
@@ -490,35 +490,35 @@ describe.each([
 
   describe('ignoreTransactions', () => {
     it('string filter with partial match', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreTransactions: ['name'],
       });
       expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(null);
     });
 
     it('ignores error event for filtering', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreTransactions: ['capture'],
       });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(MESSAGE_EVENT);
     });
 
     it('string filter with exact match', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreTransactions: ['transaction name'],
       });
       expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(null);
     });
 
     it('regexp filter with partial match', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreTransactions: [/name/],
       });
       expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(null);
     });
 
     it('regexp filter with exact match', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreTransactions: [/^transaction name$/],
       });
       expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(null);
@@ -526,7 +526,7 @@ describe.each([
     });
 
     it('can use multiple filters', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         ignoreTransactions: ['transaction name 2', /transaction/],
       });
       expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(null);
@@ -535,27 +535,27 @@ describe.each([
     });
 
     it('uses default filters', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(null);
       expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(TRANSACTION_EVENT);
     });
 
     it('disable default error filters', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, { disableErrorDefaults: true });
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, { disableErrorDefaults: true });
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(SCRIPT_ERROR_EVENT);
     });
   });
 
   describe('denyUrls/allowUrls', () => {
     it('should filter captured message based on its stack trace using string filter', () => {
-      const eventProcessorDeny = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessorDeny = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['https://awesome-analytics.io'],
       });
       expect(eventProcessorDeny(MESSAGE_EVENT_WITH_STACKTRACE, {})).toBe(null);
     });
 
     it('should allow denyUrls to take precedence', () => {
-      const eventProcessorBoth = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessorBoth = createEventFiltersEventProcessor(integrationFn, {
         allowUrls: ['https://awesome-analytics.io'],
         denyUrls: ['https://awesome-analytics.io'],
       });
@@ -563,63 +563,63 @@ describe.each([
     });
 
     it('should filter captured message based on its stack trace using regexp filter', () => {
-      const eventProcessorDeny = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessorDeny = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: [/awesome-analytics\.io/],
       });
       expect(eventProcessorDeny(MESSAGE_EVENT_WITH_STACKTRACE, {})).toBe(null);
     });
 
     it('should not filter captured messages with no stacktraces', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['https://awesome-analytics.io'],
       });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(MESSAGE_EVENT);
     });
 
     it('should filter captured exception based on its stack trace using string filter', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['https://awesome-analytics.io'],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_FRAMES, {})).toBe(null);
     });
 
     it('should filter captured exception based on its stack trace using regexp filter', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: [/awesome-analytics\.io/],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_FRAMES, {})).toBe(null);
     });
 
     it("should not filter events that don't match the filtered values", () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['some-other-domain.com'],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_FRAMES, {})).toBe(EXCEPTION_EVENT_WITH_FRAMES);
     });
 
     it('should be able to use multiple filters', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['some-other-domain.com', /awesome-analytics\.io/],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_FRAMES, {})).toBe(null);
     });
 
     it('should not fail with malformed event event', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['https://awesome-analytics.io'],
       });
       expect(eventProcessor(MALFORMED_EVENT, {})).toBe(MALFORMED_EVENT);
     });
 
     it('should search for script names when there is an anonymous callback at the last frame', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['https://awesome-analytics.io/some/file.js'],
       });
       expect(eventProcessor(MESSAGE_EVENT_WITH_ANON_LAST_FRAME, {})).toBe(null);
     });
 
     it('should search for script names when the last frame is from native code', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn, {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['https://awesome-analytics.io/some/file.js'],
       });
       expect(eventProcessor(MESSAGE_EVENT_WITH_NATIVE_LAST_FRAME, {})).toBe(null);
@@ -628,32 +628,32 @@ describe.each([
 
   describe('useless errors', () => {
     it("should drop event with exceptions that don't have any message, type or stack trace", () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(USELESS_EXCEPTION_EVENT, {})).toBe(null);
     });
 
     it('should drop event with just a generic error without stacktrace or message', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(USELESS_ERROR_EXCEPTION_EVENT, {})).toBe(null);
     });
 
     it('should not drop event with a message', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(EVENT_WITH_MESSAGE, {})).toBe(EVENT_WITH_MESSAGE);
     });
 
     it('should not drop event with an exception that has a type', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(EVENT_WITH_TYPE, {})).toBe(EVENT_WITH_TYPE);
     });
 
     it('should not drop event with an exception that has a stacktrace', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(EVENT_WITH_STACKTRACE, {})).toBe(EVENT_WITH_STACKTRACE);
     });
 
     it('should not drop event with an exception that has a value', () => {
-      const eventProcessor = createInboundFiltersEventProcessor(integrationFn);
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(EVENT_WITH_VALUE, {})).toBe(EVENT_WITH_VALUE);
     });
   });

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -61,7 +61,9 @@ export {
   startSpanManual,
   startNewTrace,
   suppressTracing,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   linkedErrorsIntegration,
   functionToStringIntegration,
   requestDataIntegration,

--- a/packages/deno/src/sdk.ts
+++ b/packages/deno/src/sdk.ts
@@ -24,6 +24,8 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   // We return a copy of the defaultIntegrations here to avoid mutating this
   return [
     // Common
+    // TODO(v10): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
+    // eslint-disable-next-line deprecation/deprecation
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -55,7 +55,9 @@ export {
   requestDataIntegration,
   fsIntegration,
   functionToStringIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   linkedErrorsIntegration,
   setMeasurement,
   getActiveSpan,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -75,7 +75,9 @@ export {
   withMonitor,
   requestDataIntegration,
   functionToStringIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   linkedErrorsIntegration,
   addEventProcessor,
   setContext,

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -51,6 +51,8 @@ function getCjsOnlyIntegrations(): Integration[] {
 export function getDefaultIntegrationsWithoutPerformance(): Integration[] {
   return [
     // Common
+    // TODO(v10): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
+    // eslint-disable-next-line deprecation/deprecation
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),

--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -82,6 +82,7 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -47,7 +47,9 @@ export {
   graphqlIntegration,
   hapiIntegration,
   httpIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,
   knexIntegration,

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -50,7 +50,9 @@ export {
   graphqlIntegration,
   hapiIntegration,
   httpIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,
   knexIntegration,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -52,7 +52,9 @@ export {
   graphqlIntegration,
   hapiIntegration,
   httpIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,
   knexIntegration,

--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -43,6 +43,7 @@ export {
   getSpanStatusFromHttpCode,
   getTraceData,
   getTraceMetaTags,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
   isInitialized,
   lastEventId,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -65,7 +65,9 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
+  eventFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,
   extraErrorDataIntegration,

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -51,6 +51,8 @@ const nodeStackParser = createStackParser(nodeStackLineParser());
 export function getDefaultIntegrations(options: Options): Integration[] {
   return [
     dedupeIntegration(),
+    // TODO(v10): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
+    // eslint-disable-next-line deprecation/deprecation
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),


### PR DESCRIPTION
This PR deprecates and renames the `inboundFiltersIntegration` to `eventFiltersIntegration` to improve the integration name and avoid ambiguity with the product. See #15431 for reasons for the renaming.

ref #15431 