### PR TITLE
fix(nuxt): Use `SentryNuxtServerOptions` type for server init

### DIFF
--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -3,9 +3,9 @@ import type { SentryRollupPluginOptions } from '@sentry/rollup-plugin';
 import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 import type { init as initVue } from '@sentry/vue';
 
-// Omitting 'app' as the Nuxt SDK will add the app instance in the client plugin (users do not have to provide this)
+// Omitting Vue 'app' as the Nuxt SDK will add the app instance in the client plugin (users do not have to provide this)
 export type SentryNuxtClientOptions = Omit<Parameters<typeof initVue>[0] & object, 'app'>;
-export type SentryNuxtServerOptions = Omit<Parameters<typeof initNode>[0] & object, 'app'>;
+export type SentryNuxtServerOptions = Parameters<typeof initNode>[0];
 
 type SourceMapsOptions = {
   /**

--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -4,8 +4,9 @@ import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 import type { init as initVue } from '@sentry/vue';
 
 // Omitting Vue 'app' as the Nuxt SDK will add the app instance in the client plugin (users do not have to provide this)
+// Adding `& object` helps TS with inferring that this is not `undefined` but an object type
 export type SentryNuxtClientOptions = Omit<Parameters<typeof initVue>[0] & object, 'app'>;
-export type SentryNuxtServerOptions = Parameters<typeof initNode>[0];
+export type SentryNuxtServerOptions = Parameters<typeof initNode>[0] & object;
 
 type SourceMapsOptions = {
   /**

--- a/packages/nuxt/src/index.types.ts
+++ b/packages/nuxt/src/index.types.ts
@@ -1,7 +1,6 @@
 import type { Client, Integration, Options, StackParser } from '@sentry/core';
-import type { SentryNuxtClientOptions } from './common/types';
+import type { SentryNuxtClientOptions, SentryNuxtServerOptions } from './common/types';
 import type * as clientSdk from './index.client';
-import type * as serverSdk from './index.server';
 
 // We export everything from both the client part of the SDK and from the server part. Some of the exports collide,
 // which is not allowed, unless we re-export the colliding exports in this file - which we do below.
@@ -9,7 +8,7 @@ export * from './index.client';
 export * from './index.server';
 
 // re-export colliding types
-export declare function init(options: Options | SentryNuxtClientOptions | serverSdk.NodeOptions): Client | undefined;
+export declare function init(options: Options | SentryNuxtClientOptions | SentryNuxtServerOptions): Client | undefined;
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];


### PR DESCRIPTION
We actually have a concrete type for the `init` on the server-side. However, this type was not used so far. Additionally, I removed the `Omit` of `'app'` as there is no `'app'` on the Node types anyway.
