### PR TITLE
feat(replay): Update rrweb packages to 2.32.0

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "~1.50.0",
-    "@sentry-internal/rrweb": "2.31.0",
+    "@sentry-internal/rrweb": "2.32.0",
     "@sentry/browser": "9.1.0",
     "axios": "1.7.7",
     "babel-loader": "^8.2.2",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@sentry-internal/rrweb": "2.31.0"
+    "@sentry-internal/rrweb": "2.32.0"
   },
   "dependencies": {
     "@sentry-internal/replay": "9.1.0",

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -69,8 +69,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "9.1.0",
-    "@sentry-internal/rrweb": "2.31.0",
-    "@sentry-internal/rrweb-snapshot": "2.31.0",
+    "@sentry-internal/rrweb": "2.32.0",
+    "@sentry-internal/rrweb-snapshot": "2.32.0",
     "fflate": "0.8.2",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6548,34 +6548,34 @@
     detect-libc "^2.0.2"
     node-abi "^3.61.0"
 
-"@sentry-internal/rrdom@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.31.0.tgz#548773964167ec104d3cbb9d7a4b25103c091e06"
-  integrity sha512-6sCgyKZy0Jpkb0wQ2XYLNcJjCETfbjHJ5jroAm2mU1imoSBlAldtNTdMc0wk8MaX/0q5qkMlr78SiYFf7xo12Q==
+"@sentry-internal/rrdom@2.32.0":
+  version "2.32.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.32.0.tgz#1c219b49456fe036b43db6e4a82204f0bda9e7b8"
+  integrity sha512-VDkBdw7V0lkIcJbnwzaCVHQArP261H1LSvHfwhmyhdPzpB+l4oqJ3AbukgubA9J7cJPYok9lZVsO4UnLFSb72A==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.31.0"
+    "@sentry-internal/rrweb-snapshot" "2.32.0"
 
-"@sentry-internal/rrweb-snapshot@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.31.0.tgz#7a86d02429a490f6367d7aead0548fad7e0c9487"
-  integrity sha512-uGyJPfmOaiSZOZyd5HFiI8aCd/pPOtrZB89BJBgdB63++wD9Fry8OoWvRORzTo+N+Squummkq3Iucjm/yGdbAw==
+"@sentry-internal/rrweb-snapshot@2.32.0":
+  version "2.32.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.32.0.tgz#742501036ff6e4f78792308330ff2dce2605785e"
+  integrity sha512-cJQAxYqdV3s/l/kDv90sUv3h5aYYgbZARNVFT9jVvyapeQuGTJEuTHal7rv5ZbTW+/ZqHsXBiZ8maqSpztTrgg==
 
-"@sentry-internal/rrweb-types@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.31.0.tgz#daf766526efff760eb6020ddf22c6432db9ff6a6"
-  integrity sha512-rWNCU6KaYopmd+353KBbRuNftpqfI97GdNFeCmB1wwwV/S2CW/lVcEn1uzMwzs8blm3YL2i/O+ykONxecQj+BQ==
+"@sentry-internal/rrweb-types@2.32.0":
+  version "2.32.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.32.0.tgz#eb2fdec664d15a04637c9332fa79b677b5070583"
+  integrity sha512-LBWYRhwLiMRi8DtulSVAM9QOocZWwH6AjaAz91Y1sqBdfndcjNTn4zM/kChg2dXSjyz3uKJ9t3uoPlhOgwt55w==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.31.0"
+    "@sentry-internal/rrweb-snapshot" "2.32.0"
     "@types/css-font-loading-module" "0.0.7"
 
-"@sentry-internal/rrweb@2.31.0":
-  version "2.31.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.31.0.tgz#69c6f6a4304c4d7446c3a1cc1c9b044d5dc4f040"
-  integrity sha512-u1uobvl5qnjtdhL2lrzbpwROZagc5xT1P2lANXxrKpLOUpp2+jMSjq0Zt2TElj+2aHlqh4lkDsj/OIa/FBHnnQ==
+"@sentry-internal/rrweb@2.32.0":
+  version "2.32.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.32.0.tgz#b66aa6f76967487df46cda6926d6e19f1b4c56e0"
+  integrity sha512-55e03XiHR5cjA6cDXG82V/PRiwSZWWLwOz7Vm8LY5cTw5jsI20JRgR2yATTSdnsCTGdmErTMRv19NdvvdH+Nxg==
   dependencies:
-    "@sentry-internal/rrdom" "2.31.0"
-    "@sentry-internal/rrweb-snapshot" "2.31.0"
-    "@sentry-internal/rrweb-types" "2.31.0"
+    "@sentry-internal/rrdom" "2.32.0"
+    "@sentry-internal/rrweb-snapshot" "2.32.0"
+    "@sentry-internal/rrweb-types" "2.32.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"
@@ -27727,7 +27727,6 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
-  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"


### PR DESCRIPTION
Includes the following:

- https://github.com/getsentry/rrweb/pull/239
- https://github.com/getsentry/rrweb/pull/237
- https://github.com/getsentry/rrweb/pull/238
- https://github.com/getsentry/rrweb/pull/234
- https://github.com/rrweb-io/rrweb/pull/1501
- https://github.com/rrweb-io/rrweb/pull/1500
- https://github.com/rrweb-io/rrweb/pull/1033
- https://github.com/getsentry/rrweb/pull/233
- https://github.com/getsentry/rrweb/pull/229
