### PR TITLE
fix(nuxt): Only use filename with file extension from command

### DIFF
--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -30,7 +30,7 @@ export function findDefaultSdkInitFile(type: 'server' | 'client'): string | unde
  *  Extracts the filename from a node command with a path.
  */
 export function getFilenameFromNodeStartCommand(nodeCommand: string): string | null {
-  const regex = /[^/\\]+$/;
+  const regex = /[^/\\]+\.[^/\\]+$/;
   const match = nodeCommand.match(regex);
   return match ? match[0] : null;
 }

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -107,6 +107,12 @@ describe('getFilenameFromPath', () => {
     const filename = getFilenameFromNodeStartCommand(path);
     expect(filename).toBeNull();
   });
+
+  it('should return null for commands without file extensions', () => {
+    const path = 'npx @azure/static-web-apps-cli start .output/public --api-location .output/server';
+    const filename = getFilenameFromNodeStartCommand(path);
+    expect(filename).toBeNull();
+  });
 });
 
 describe('removeSentryQueryFromPath', () => {


### PR DESCRIPTION
The Nuxt SDK also uses the preview command to determine where to put the Sentry top-level import. Like this: `node .output/server/index.mjs` (would add Sentry to `index.mjs`)

However, the function to get the file name also used folder names without file extensions which led to Sentry not being included at the top of the index file.

This was a problem in e.g. Azure as the command is the following: `npx @azure/static-web-apps-cli start ./public --api-location ./server`

