### PR TITLE
fix(nuxt): ignore 300-400 status codes on app errors in Nuxt

### DIFF
--- a/packages/nuxt/src/runtime/plugins/sentry.client.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry.client.ts
@@ -1,6 +1,6 @@
 import { GLOBAL_OBJ, getClient } from '@sentry/core';
 import { browserTracingIntegration, vueIntegration } from '@sentry/vue';
-import { defineNuxtPlugin } from 'nuxt/app';
+import { defineNuxtPlugin, isNuxtError } from 'nuxt/app';
 import type { GlobalObjWithIntegrationOptions } from '../../client/vueIntegration';
 import { reportNuxtError } from '../utils';
 
@@ -66,6 +66,13 @@ export default defineNuxtPlugin({
     });
 
     nuxtApp.hook('app:error', error => {
+      // Do not handle 404 and 422
+      if (isNuxtError(error)) {
+        // Do not report if status code is 3xx or 4xx
+        if (error.statusCode >= 300 && error.statusCode < 500) {
+          return;
+        }
+      }
       reportNuxtError({ error });
     });
 


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

### Description

I noticed that Nuxt 300-400 status codes from the app are being reported to Sentry unnecessarily. There appears to be a guard against doing this on the server side errors but client side errors like 404 or 401s are being reported to Sentry.

I have simply added the same guard on the client side error reporter for the Nuxt integration of Sentry.
