### PR TITLE
test(node): Remove `import.meta.url` hacks

### DIFF
--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -15,7 +15,6 @@ import { defineConfig } from 'rollup';
 import {
   makeCleanupPlugin,
   makeDebugBuildStatementReplacePlugin,
-  makeImportMetaUrlReplacePlugin,
   makeNodeResolvePlugin,
   makeRrwebBuildPlugin,
   makeSucrasePlugin,
@@ -39,7 +38,6 @@ export function makeBaseNPMConfig(options = {}) {
   const nodeResolvePlugin = makeNodeResolvePlugin();
   const sucrasePlugin = makeSucrasePlugin({}, sucrase);
   const debugBuildStatementReplacePlugin = makeDebugBuildStatementReplacePlugin();
-  const importMetaUrlReplacePlugin = makeImportMetaUrlReplacePlugin();
   const cleanupPlugin = makeCleanupPlugin();
   const rrwebBuildPlugin = makeRrwebBuildPlugin({
     excludeShadowDom: undefined,
@@ -89,7 +87,6 @@ export function makeBaseNPMConfig(options = {}) {
       nodeResolvePlugin,
       sucrasePlugin,
       debugBuildStatementReplacePlugin,
-      importMetaUrlReplacePlugin,
       rrwebBuildPlugin,
       cleanupPlugin,
     ],

--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -83,13 +83,7 @@ export function makeBaseNPMConfig(options = {}) {
       interop: 'esModule',
     },
 
-    plugins: [
-      nodeResolvePlugin,
-      sucrasePlugin,
-      debugBuildStatementReplacePlugin,
-      rrwebBuildPlugin,
-      cleanupPlugin,
-    ],
+    plugins: [nodeResolvePlugin, sucrasePlugin, debugBuildStatementReplacePlugin, rrwebBuildPlugin, cleanupPlugin],
 
     // don't include imported modules from outside the package in the final output
     external: [

--- a/dev-packages/rollup-utils/plugins/npmPlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/npmPlugins.mjs
@@ -126,19 +126,6 @@ export function makeDebugBuildStatementReplacePlugin() {
 }
 
 /**
- * Because jest doesn't like `import.meta` statements but we still need it in the code base we instead use a magic
- * string that we replace with import.meta.url in the build.
- */
-export function makeImportMetaUrlReplacePlugin() {
-  return replace({
-    preventAssignment: false,
-    values: {
-      __IMPORT_META_URL_REPLACEMENT__: 'import.meta.url',
-    },
-  });
-}
-
-/**
  * Creates a plugin to replace build flags of rrweb with either a constant (if passed true/false) or with a safe statement that:
  * a) evaluates to `true`
  * b) can easily be modified by our users' bundlers to evaluate to false, facilitating the treeshaking of logger code.

--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -17,8 +17,6 @@ import { SentryContextManager } from '../otel/contextManager';
 import { isCjs } from '../utils/commonjs';
 import type { NodeClient } from './client';
 
-declare const __IMPORT_META_URL_REPLACEMENT__: string;
-
 // About 277h - this must fit into new Array(len)!
 const MAX_MAX_SPAN_WAIT_DURATION = 1_000_000;
 
@@ -45,15 +43,11 @@ export function maybeInitializeEsmLoader(): void {
 
   // Register hook was added in v20.6.0 and v18.19.0
   if (nodeMajor >= 22 || (nodeMajor === 20 && nodeMinor >= 6) || (nodeMajor === 18 && nodeMinor >= 19)) {
-    // We need to work around using import.meta.url directly because jest complains about it.
-    const importMetaUrl =
-      typeof __IMPORT_META_URL_REPLACEMENT__ !== 'undefined' ? __IMPORT_META_URL_REPLACEMENT__ : undefined;
-
-    if (!GLOBAL_OBJ._sentryEsmLoaderHookRegistered && importMetaUrl) {
+    if (!GLOBAL_OBJ._sentryEsmLoaderHookRegistered) {
       try {
         const { addHookMessagePort } = createAddHookMessageChannel();
         // @ts-expect-error register is available in these versions
-        moduleModule.register('import-in-the-middle/hook.mjs', importMetaUrl, {
+        moduleModule.register('import-in-the-middle/hook.mjs', import.meta.url, {
           data: { addHookMessagePort, include: [] },
           transferList: [addHookMessagePort],
         });


### PR DESCRIPTION
Jest didn't like usages of `import.meta.url` but now we're using Vitest, these hacks can be removed. 

Our Rollup config already converts this correctly when building our CommonJs output.
