### PR TITLE
test(gatsby): Migrate to vitest

### DIFF
--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     jsx: true,
   },
   // ignore these because they're not covered by a `tsconfig`, which makes eslint throw an error
-  ignorePatterns: ['gatsby-node.d.ts'],
+  ignorePatterns: ['gatsby-node.d.ts', 'setup/globalSetup.ts'],
   overrides: [
     {
       files: ['scripts/**/*.ts'],

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -75,8 +75,8 @@
     "clean": "rimraf build coverage *.d.ts sentry-gatsby-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "test": "yarn ts-node scripts/pretest.ts && yarn jest",
-    "test:watch": "yarn ts-node scripts/pretest.ts && yarn jest --watch",
+    "test": "vitest run",
+    "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"
   },
   "volta": {

--- a/packages/gatsby/setup/globalSetup.ts
+++ b/packages/gatsby/setup/globalSetup.ts
@@ -11,4 +11,8 @@ function ensurePluginTypes(): void {
   }
 }
 
-ensurePluginTypes();
+import type { GlobalSetupContext } from 'vitest/node';
+
+export default function setup(_: GlobalSetupContext) {
+  ensurePluginTypes();
+}

--- a/packages/gatsby/test/index.test.ts
+++ b/packages/gatsby/test/index.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest';
+
 import * as GatsbyIntegration from '../src/index';
 
 describe('package', () => {

--- a/packages/gatsby/test/sdk.test.ts
+++ b/packages/gatsby/test/sdk.test.ts
@@ -1,23 +1,26 @@
+import type { Mock } from 'vitest';
+import { describe, afterEach, expect, vi, test } from 'vitest';
+
 import { SDK_VERSION, init } from '@sentry/react';
 
 import { init as gatsbyInit } from '../src/sdk';
 
-jest.mock('@sentry/react', () => {
-  const actual = jest.requireActual('@sentry/react');
+vi.mock('@sentry/react', async requiredActual => {
+  const actual = (await requiredActual()) as any;
   return {
     ...actual,
-    init: jest.fn().mockImplementation(actual.init),
+    init: vi.fn().mockImplementation(actual.init),
   };
 });
 
-const reactInit = init as jest.Mock;
+const reactInit = init as Mock;
 
 describe('Initialize React SDK', () => {
   afterEach(() => reactInit.mockReset());
 
   test('Has correct SDK metadata', () => {
     gatsbyInit({});
-    const calledWith = reactInit.mock.calls[0][0];
+    const calledWith = reactInit.mock.calls[0]?.[0];
     const sdkMetadata = calledWith._metadata.sdk;
     expect(sdkMetadata.name).toStrictEqual('sentry.javascript.gatsby');
     expect(sdkMetadata.version).toBe(SDK_VERSION);
@@ -31,7 +34,7 @@ describe('Initialize React SDK', () => {
     test('not defined by default', () => {
       gatsbyInit({});
       expect(reactInit).toHaveBeenCalledTimes(1);
-      const callingObject = reactInit.mock.calls[0][0];
+      const callingObject = reactInit.mock.calls[0]?.[0];
       expect(callingObject.environment).not.toBeDefined();
     });
 
@@ -40,7 +43,7 @@ describe('Initialize React SDK', () => {
         environment: 'custom env!',
       });
       expect(reactInit).toHaveBeenCalledTimes(1);
-      const callingObject = reactInit.mock.calls[0][0];
+      const callingObject = reactInit.mock.calls[0]?.[0];
       expect(callingObject.environment).toStrictEqual('custom env!');
     });
   });

--- a/packages/gatsby/tsconfig.test.json
+++ b/packages/gatsby/tsconfig.test.json
@@ -1,11 +1,11 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["test/**/*"],
+  "include": ["test/**/*", "vite.config.ts", "setup/**/*"],
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node", "jest"],
+    "types": ["node"],
 
     // other package-specific, test-specific options
 

--- a/packages/gatsby/vite.config.ts
+++ b/packages/gatsby/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+import baseConfig from '../../vite/vite.config';
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    globalSetup: 'setup/globalSetup.ts',
+  },
+});


### PR DESCRIPTION
Ref #11084

Before: `6.437 s`

After: `1.23s`

The first thing we did was migrate the `pretest.ts` script to use a vitest global setup instead. This is cleaner, and should ensure it never gets lost in refactors either.

After that we did the conversion. The trickiest thing to change was `packages/gatsby/test/gatsby-node.test.ts`, as `gatsby-node.js` is a CJS file. This is tricky to patch properly with vitest for the spy. To get around this, we monkeypatch `Module._load` temporarily to load a stub which we defined in `vi.hoisted` (which hoists it to the top so it's always available).