### PR TITLE
test(node-integration): Migrate to Vitest

### DIFF
--- a/dev-packages/node-integration-tests/jest.config.js
+++ b/dev-packages/node-integration-tests/jest.config.js
@@ -1,9 +1,0 @@
-const baseConfig = require('../../jest/jest.config.js');
-
-module.exports = {
-  globalSetup: '<rootDir>/utils/setup-tests.ts',
-  ...baseConfig,
-  testMatch: ['**/test.ts'],
-  setupFilesAfterEnv: ['./jest.setup.js'],
-  coverageReporters: ['json', 'lcov', 'clover'],
-};

--- a/dev-packages/node-integration-tests/jest.setup.js
+++ b/dev-packages/node-integration-tests/jest.setup.js
@@ -1,8 +1,0 @@
-const { cleanupChildProcesses } = require('./utils/runner');
-
-// Default timeout: 15s
-jest.setTimeout(15000);
-
-afterEach(() => {
-  cleanupChildProcesses();
-});

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -21,7 +21,7 @@
     "fix": "eslint . --format stylish --fix",
     "type-check": "tsc",
     "pretest": "yarn express-v5-install",
-    "test": "jest --config ./jest.config.js",
+    "test": "vitest run",
     "test:no-prisma": "jest --config ./jest.config.js",
     "test:watch": "yarn test --watch"
   },

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -22,7 +22,6 @@
     "type-check": "tsc",
     "pretest": "yarn express-v5-install",
     "test": "vitest run",
-    "test:no-prisma": "jest --config ./jest.config.js",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -1,4 +1,5 @@
 import type { Event } from '@sentry/core';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
 const ANR_EVENT = {
@@ -111,18 +112,23 @@ describe('should report ANR when event loop blocked', () => {
     cleanupChildProcesses();
   });
 
-  test('CJS', done => {
-    createRunner(__dirname, 'basic.js').withMockSentryServer().expect({ event: ANR_EVENT_WITH_DEBUG_META }).start(done);
-  });
-
-  test('ESM', done => {
-    createRunner(__dirname, 'basic.mjs')
+  test('CJS', async () => {
+    await createRunner(__dirname, 'basic.js')
       .withMockSentryServer()
       .expect({ event: ANR_EVENT_WITH_DEBUG_META })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('Custom appRootPath', done => {
+  test('ESM', async () => {
+    await createRunner(__dirname, 'basic.mjs')
+      .withMockSentryServer()
+      .expect({ event: ANR_EVENT_WITH_DEBUG_META })
+      .start()
+      .completed();
+  });
+
+  test('Custom appRootPath', async () => {
     const ANR_EVENT_WITH_SPECIFIC_DEBUG_META: Event = {
       ...ANR_EVENT_WITH_SCOPE,
       debug_meta: {
@@ -136,52 +142,57 @@ describe('should report ANR when event loop blocked', () => {
       },
     };
 
-    createRunner(__dirname, 'app-path.mjs')
+    await createRunner(__dirname, 'app-path.mjs')
       .withMockSentryServer()
       .expect({ event: ANR_EVENT_WITH_SPECIFIC_DEBUG_META })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('multiple events via maxAnrEvents', done => {
-    createRunner(__dirname, 'basic-multiple.mjs')
+  test('multiple events via maxAnrEvents', async () => {
+    await createRunner(__dirname, 'basic-multiple.mjs')
       .withMockSentryServer()
       .expect({ event: ANR_EVENT_WITH_DEBUG_META })
       .expect({ event: ANR_EVENT_WITH_DEBUG_META })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('blocked indefinitely', done => {
-    createRunner(__dirname, 'indefinite.mjs').withMockSentryServer().expect({ event: ANR_EVENT }).start(done);
+  test('blocked indefinitely', async () => {
+    await createRunner(__dirname, 'indefinite.mjs')
+      .withMockSentryServer()
+      .expect({ event: ANR_EVENT })
+      .start()
+      .completed();
   });
 
-  test("With --inspect the debugger isn't used", done => {
-    createRunner(__dirname, 'basic.mjs')
+  test("With --inspect the debugger isn't used", async () => {
+    await createRunner(__dirname, 'basic.mjs')
       .withMockSentryServer()
       .withFlags('--inspect')
       .expect({ event: ANR_EVENT_WITHOUT_STACKTRACE })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should exit', done => {
+  test('should exit', async () => {
     const runner = createRunner(__dirname, 'should-exit.js').start();
 
-    setTimeout(() => {
-      expect(runner.childHasExited()).toBe(true);
-      done();
-    }, 5_000);
+    await new Promise(resolve => setTimeout(resolve, 5_000));
+
+    expect(runner.childHasExited()).toBe(true);
   });
 
-  test('should exit forced', done => {
+  test('should exit forced', async () => {
     const runner = createRunner(__dirname, 'should-exit-forced.js').start();
 
-    setTimeout(() => {
-      expect(runner.childHasExited()).toBe(true);
-      done();
-    }, 5_000);
+    await new Promise(resolve => setTimeout(resolve, 5_000));
+
+    expect(runner.childHasExited()).toBe(true);
   });
 
-  test('With session', done => {
-    createRunner(__dirname, 'basic-session.js')
+  test('With session', async () => {
+    await createRunner(__dirname, 'basic-session.js')
       .withMockSentryServer()
       .unignore('session')
       .expect({
@@ -194,15 +205,16 @@ describe('should report ANR when event loop blocked', () => {
         },
       })
       .expect({ event: ANR_EVENT_WITH_SCOPE })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('from forked process', done => {
-    createRunner(__dirname, 'forker.js').expect({ event: ANR_EVENT_WITH_SCOPE }).start(done);
+  test('from forked process', async () => {
+    await createRunner(__dirname, 'forker.js').expect({ event: ANR_EVENT_WITH_SCOPE }).start().completed();
   });
 
-  test('worker can be stopped and restarted', done => {
-    createRunner(__dirname, 'stop-and-start.js').expect({ event: ANR_EVENT_WITH_SCOPE }).start(done);
+  test('worker can be stopped and restarted', async () => {
+    await createRunner(__dirname, 'stop-and-start.js').expect({ event: ANR_EVENT_WITH_SCOPE }).start().completed();
   });
 
   const EXPECTED_ISOLATED_EVENT = {
@@ -231,10 +243,11 @@ describe('should report ANR when event loop blocked', () => {
     },
   };
 
-  test('fetches correct isolated scope', done => {
-    createRunner(__dirname, 'isolated.mjs')
+  test('fetches correct isolated scope', async () => {
+    await createRunner(__dirname, 'isolated.mjs')
       .withMockSentryServer()
       .expect({ event: EXPECTED_ISOLATED_EVENT })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/s3/test.ts
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/s3/test.ts
@@ -8,7 +8,7 @@ const EXPECTED_TRANSCATION = {
       description: 'S3.PutObject',
       op: 'rpc',
       origin: 'auto.otel.aws',
-      data: {
+      data: expect.objectContaining({
         'sentry.origin': 'auto.otel.aws',
         'sentry.op': 'rpc',
         'rpc.system': 'aws-api',
@@ -17,7 +17,7 @@ const EXPECTED_TRANSCATION = {
         'aws.region': 'us-east-1',
         'aws.s3.bucket': 'ot-demo-test',
         'otel.kind': 'CLIENT',
-      },
+      }),
     }),
   ]),
 };

--- a/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/s3/test.ts
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/s3/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 const EXPECTED_TRANSCATION = {
@@ -26,7 +27,11 @@ describe('awsIntegration', () => {
     cleanupChildProcesses();
   });
 
-  test('should auto-instrument aws-sdk v2 package.', done => {
-    createRunner(__dirname, 'scenario.js').ignore('event').expect({ transaction: EXPECTED_TRANSCATION }).start(done);
+  test('should auto-instrument aws-sdk v2 package.', async () => {
+    await createRunner(__dirname, 'scenario.js')
+      .ignore('event')
+      .expect({ transaction: EXPECTED_TRANSCATION })
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/breadcrumbs/process-thread/test.ts
+++ b/dev-packages/node-integration-tests/suites/breadcrumbs/process-thread/test.ts
@@ -1,4 +1,5 @@
 import type { Event } from '@sentry/core';
+import { afterAll, expect, test } from 'vitest';
 import { conditionalTest } from '../../../utils';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
@@ -39,10 +40,11 @@ conditionalTest({ min: 20 })('should capture process and thread breadcrumbs', ()
     cleanupChildProcesses();
   });
 
-  test('ESM', done => {
-    createRunner(__dirname, 'app.mjs')
+  test('ESM', async () => {
+    await createRunner(__dirname, 'app.mjs')
       .withMockSentryServer()
       .expect({ event: EVENT as Event })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/child-process/test.ts
+++ b/dev-packages/node-integration-tests/suites/child-process/test.ts
@@ -1,4 +1,5 @@
 import type { Event } from '@sentry/core';
+import { afterAll, describe, expect, test } from 'vitest';
 import { conditionalTest } from '../../utils';
 import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
@@ -44,22 +45,22 @@ describe('should capture child process events', () => {
   });
 
   conditionalTest({ min: 20 })('worker', () => {
-    test('ESM', done => {
-      createRunner(__dirname, 'worker.mjs').expect({ event: WORKER_EVENT }).start(done);
+    test('ESM', async () => {
+      await createRunner(__dirname, 'worker.mjs').expect({ event: WORKER_EVENT }).start().completed();
     });
 
-    test('CJS', done => {
-      createRunner(__dirname, 'worker.js').expect({ event: WORKER_EVENT }).start(done);
+    test('CJS', async () => {
+      await createRunner(__dirname, 'worker.js').expect({ event: WORKER_EVENT }).start().completed();
     });
   });
 
   conditionalTest({ min: 20 })('fork', () => {
-    test('ESM', done => {
-      createRunner(__dirname, 'fork.mjs').expect({ event: CHILD_EVENT }).start(done);
+    test('ESM', async () => {
+      await createRunner(__dirname, 'fork.mjs').expect({ event: CHILD_EVENT }).start().completed();
     });
 
-    test('CJS', done => {
-      createRunner(__dirname, 'fork.js').expect({ event: CHILD_EVENT }).start(done);
+    test('CJS', async () => {
+      await createRunner(__dirname, 'fork.js').expect({ event: CHILD_EVENT }).start().completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should record client report for beforeSend', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should record client report for beforeSend', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .unignore('client_report')
     .expect({
       client_report: {
@@ -29,5 +30,6 @@ test('should record client report for beforeSend', done => {
         ],
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should record client report for event processors', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should record client report for event processors', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .unignore('client_report')
     .expect({
       client_report: {
@@ -29,5 +30,6 @@ test('should record client report for event processors', done => {
         ],
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/client-reports/periodic-send/test.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/periodic-send/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should flush client reports automatically after the timeout interval', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should flush client reports automatically after the timeout interval', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .unignore('client_report')
     .expect({
       client_report: {
@@ -18,5 +19,6 @@ test('should flush client reports automatically after the timeout interval', don
         ],
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/contextLines/filename-with-spaces/test.ts
+++ b/dev-packages/node-integration-tests/suites/contextLines/filename-with-spaces/test.ts
@@ -1,12 +1,13 @@
 import { join } from 'path';
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
 describe('ContextLines integration in ESM', () => {
-  test('reads encoded context lines from filenames with spaces', done => {
+  test('reads encoded context lines from filenames with spaces', async () => {
     expect.assertions(1);
     const instrumentPath = join(__dirname, 'instrument.mjs');
 
-    createRunner(__dirname, 'scenario with space.mjs')
+    await createRunner(__dirname, 'scenario with space.mjs')
       .withFlags('--import', instrumentPath)
       .expect({
         event: {
@@ -34,15 +35,16 @@ describe('ContextLines integration in ESM', () => {
           },
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 });
 
 describe('ContextLines integration in CJS', () => {
-  test('reads context lines from filenames with spaces', done => {
+  test('reads context lines from filenames with spaces', async () => {
     expect.assertions(1);
 
-    createRunner(__dirname, 'scenario with space.cjs')
+    await createRunner(__dirname, 'scenario with space.cjs')
       .expect({
         event: {
           exception: {
@@ -77,6 +79,7 @@ describe('ContextLines integration in CJS', () => {
           },
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/cron/cron/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/cron/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('cron instrumentation', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('cron instrumentation', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       check_in: {
         check_in_id: expect.any(String),
@@ -71,5 +72,6 @@ test('cron instrumentation', done => {
         exception: { values: [{ type: 'Error', value: 'Error in cron job' }] },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('node-cron instrumentation', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('node-cron instrumentation', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       check_in: {
         check_in_id: expect.any(String),
@@ -71,5 +72,6 @@ test('node-cron instrumentation', done => {
         exception: { values: [{ type: 'Error', value: 'Error in cron job' }] },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/cron/node-schedule/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-schedule/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('node-schedule instrumentation', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('node-schedule instrumentation', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       check_in: {
         check_in_id: expect.any(String),
@@ -71,5 +72,6 @@ test('node-schedule instrumentation', done => {
         exception: { values: [{ type: 'Error', value: 'Error in cron job' }] },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/test.ts
+++ b/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'child_process';
 import { join } from 'path';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses } from '../../../utils/runner';
 
 afterAll(() => {

--- a/dev-packages/node-integration-tests/suites/esm/modules-integration/test.ts
+++ b/dev-packages/node-integration-tests/suites/esm/modules-integration/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
@@ -5,7 +6,7 @@ afterAll(() => {
 });
 
 describe('modulesIntegration', () => {
-  test('does not crash ESM setups', done => {
-    createRunner(__dirname, 'app.mjs').ensureNoErrorOutput().start(done);
+  test('does not crash ESM setups', async () => {
+    await createRunner(__dirname, 'app.mjs').ensureNoErrorOutput().start().completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/esm/warn-esm/test.ts
+++ b/dev-packages/node-integration-tests/suites/esm/warn-esm/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {

--- a/dev-packages/node-integration-tests/suites/express-v5/handle-error-scope-data-loss/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/handle-error-scope-data-loss/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
@@ -13,8 +14,8 @@ afterAll(() => {
  *
  * This test nevertheless covers the behavior so that we're aware.
  */
-test('withScope scope is NOT applied to thrown error caught by global handler', done => {
-  createRunner(__dirname, 'server.ts')
+test('withScope scope is NOT applied to thrown error caught by global handler', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .expect({
       event: {
         exception: {
@@ -42,15 +43,16 @@ test('withScope scope is NOT applied to thrown error caught by global handler', 
         tags: expect.not.objectContaining({ local: expect.anything() }),
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/withScope', { expectError: true });
+    .start();
+  runner.makeRequest('get', '/test/withScope', { expectError: true });
+  await runner.completed();
 });
 
 /**
  * This test shows that the isolation scope set tags are applied correctly to the error.
  */
-test('isolation scope is applied to thrown error caught by global handler', done => {
-  createRunner(__dirname, 'server.ts')
+test('isolation scope is applied to thrown error caught by global handler', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .expect({
       event: {
         exception: {
@@ -80,6 +82,7 @@ test('isolation scope is applied to thrown error caught by global handler', done
         },
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/isolationScope', { expectError: true });
+    .start();
+  runner.makeRequest('get', '/test/isolationScope', { expectError: true });
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/handle-error-tracesSampleRate-0/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/handle-error-tracesSampleRate-0/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture and send Express controller error with txn name if tracesSampleRate is 0', done => {
-  createRunner(__dirname, 'server.ts')
+test('should capture and send Express controller error with txn name if tracesSampleRate is 0', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({
       event: {
@@ -33,6 +34,7 @@ test('should capture and send Express controller error with txn name if tracesSa
         transaction: 'GET /test/express/:id',
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/express/123', { expectError: true });
+    .start();
+  runner.makeRequest('get', '/test/express/123', { expectError: true });
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/handle-error-tracesSampleRate-unset/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/handle-error-tracesSampleRate-unset/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture and send Express controller error if tracesSampleRate is not set.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should capture and send Express controller error if tracesSampleRate is not set.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({
       event: {
@@ -32,6 +33,7 @@ test('should capture and send Express controller error if tracesSampleRate is no
         },
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/express/123', { expectError: true });
+    .start();
+  runner.makeRequest('get', '/test/express/123', { expectError: true });
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-init/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-init/test.ts
@@ -1,10 +1,11 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('allows to call init multiple times', done => {
+test('allows to call init multiple times', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       event: {
@@ -59,7 +60,7 @@ test('allows to call init multiple times', done => {
         },
       },
     })
-    .start(done);
+    .start();
 
   runner
     .makeRequest('get', '/test/no-init')
@@ -67,4 +68,5 @@ test('allows to call init multiple times', done => {
     .then(() => runner.makeRequest('get', '/test/init'))
     .then(() => runner.makeRequest('get', '/test/error/2'))
     .then(() => runner.makeRequest('get', '/test/error/3'));
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-infix-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-infix-parameterized/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct url with common infixes with multiple parameterized routers.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct url with common infixes with multiple parameterized routers.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/user/3212');
+    .start();
+  runner.makeRequest('get', '/api/v1/user/3212');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-infix/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-infix/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct url with common infixes with multiple routers.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct url with common infixes with multiple routers.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api2/v1/test' } })
-    .start(done)
-    .makeRequest('get', '/api2/v1/test');
+    .start();
+  runner.makeRequest('get', '/api2/v1/test');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix-parameterized-reverse/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix-parameterized-reverse/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct urls with multiple parameterized routers (use order reversed).', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct urls with multiple parameterized routers (use order reversed).', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/user/1234/');
+    .start();
+  runner.makeRequest('get', '/api/v1/user/1234/');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix-parameterized/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct urls with multiple parameterized routers.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct urls with multiple parameterized routers.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/user/1234/');
+    .start();
+  runner.makeRequest('get', '/api/v1/user/1234/');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix-same-length-parameterized copy/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix-same-length-parameterized copy/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct url with multiple parameterized routers of the same length (use order reversed).', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct url with multiple parameterized routers of the same length (use order reversed).', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/1234/');
+    .start();
+  runner.makeRequest('get', '/api/v1/1234/');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix-same-length-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix-same-length-parameterized/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct url with multiple parameterized routers of the same length.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct url with multiple parameterized routers of the same length.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/1234/');
+    .start();
+  runner.makeRequest('get', '/api/v1/1234/');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/common-prefix/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct urls with multiple routers.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct urls with multiple routers.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/test' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/test');
+    .start();
+  runner.makeRequest('get', '/api/v1/test');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/complex-router/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/complex-router/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
@@ -5,7 +6,7 @@ afterAll(() => {
 });
 
 describe('complex-router', () => {
-  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route', done => {
+  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
       transaction_info: {
@@ -13,14 +14,15 @@ describe('complex-router', () => {
       },
     };
 
-    createRunner(__dirname, 'server.ts')
+    const runner = createRunner(__dirname, 'server.ts')
       .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
-      .start(done)
-      .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456');
+      .start();
+    runner.makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456');
+    await runner.completed();
   });
 
-  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url has query params', done => {
+  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url has query params', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
       transaction_info: {
@@ -28,14 +30,15 @@ describe('complex-router', () => {
       },
     };
 
-    createRunner(__dirname, 'server.ts')
+    const runner = createRunner(__dirname, 'server.ts')
       .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
-      .start(done)
-      .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456?param=1');
+      .start();
+    runner.makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456?param=1');
+    await runner.completed();
   });
 
-  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url ends with trailing slash and has query params', done => {
+  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url ends with trailing slash and has query params', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
       transaction_info: {
@@ -43,10 +46,11 @@ describe('complex-router', () => {
       },
     };
 
-    createRunner(__dirname, 'server.ts')
+    const runner = createRunner(__dirname, 'server.ts')
       .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
-      .start(done)
-      .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456/?param=1');
+      .start();
+    runner.makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456/?param=1');
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/middle-layer-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/multiple-routers/middle-layer-parameterized/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
@@ -6,7 +7,7 @@ afterAll(() => {
 
 // Before Node 16, parametrization is not working properly here
 describe('middle-layer-parameterized', () => {
-  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route', done => {
+  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'GET /api/v1/users/:userId/posts/:postId',
       transaction_info: {
@@ -14,10 +15,11 @@ describe('middle-layer-parameterized', () => {
       },
     };
 
-    createRunner(__dirname, 'server.ts')
+    const runner = createRunner(__dirname, 'server.ts')
       .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
-      .start(done)
-      .makeRequest('get', '/api/v1/users/123/posts/456');
+      .start();
+    runner.makeRequest('get', '/api/v1/users/123/posts/456');
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/requestUser/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/requestUser/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('express user handling', () => {
@@ -5,22 +6,23 @@ describe('express user handling', () => {
     cleanupChildProcesses();
   });
 
-  test('ignores user from request', done => {
+  test('ignores user from request', async () => {
     expect.assertions(2);
 
-    createRunner(__dirname, 'server.js')
+    const runner = createRunner(__dirname, 'server.js')
       .expect({
         event: event => {
           expect(event.user).toBeUndefined();
           expect(event.exception?.values?.[0]?.value).toBe('error_1');
         },
       })
-      .start(done)
-      .makeRequest('get', '/test1', { expectError: true });
+      .start();
+    runner.makeRequest('get', '/test1', { expectError: true });
+    await runner.completed();
   });
 
-  test('using setUser in middleware works', done => {
-    createRunner(__dirname, 'server.js')
+  test('using setUser in middleware works', async () => {
+    const runner = createRunner(__dirname, 'server.js')
       .expect({
         event: {
           user: {
@@ -36,7 +38,8 @@ describe('express user handling', () => {
           },
         },
       })
-      .start(done)
-      .makeRequest('get', '/test2', { expectError: true });
+      .start();
+    runner.makeRequest('get', '/test2', { expectError: true });
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-header-assign/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-header-assign/test.ts
@@ -1,4 +1,5 @@
 import { parseBaggageHeader } from '@sentry/core';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-header-out/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-header-out/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from './server';
 

--- a/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-other-vendors/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-other-vendors/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from './server';
 

--- a/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-transaction-name/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/baggage-transaction-name/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/trace-header-assign/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/trace-header-assign/test.ts
@@ -1,4 +1,5 @@
 import { TRACEPARENT_REGEXP } from '@sentry/core';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/trace-header-out/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/sentry-trace/trace-header-out/test.ts
@@ -1,4 +1,5 @@
 import { TRACEPARENT_REGEXP } from '@sentry/core';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express-v5/setupExpressErrorHandler/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/setupExpressErrorHandler/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('express setupExpressErrorHandler', () => {
@@ -6,7 +7,7 @@ describe('express setupExpressErrorHandler', () => {
   });
 
   describe('CJS', () => {
-    test('allows to pass options to setupExpressErrorHandler', done => {
+    test('allows to pass options to setupExpressErrorHandler', async () => {
       const runner = createRunner(__dirname, 'server.js')
         .expect({
           event: {
@@ -19,12 +20,13 @@ describe('express setupExpressErrorHandler', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       // this error is filtered & ignored
       runner.makeRequest('get', '/test1', { expectError: true });
       // this error is actually captured
       runner.makeRequest('get', '/test2', { expectError: true });
+      await runner.completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/span-isolationScope/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/span-isolationScope/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('correctly applies isolation scope to span', done => {
-  createRunner(__dirname, 'server.ts')
+test('correctly applies isolation scope to span', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .expect({
       transaction: {
         transaction: 'GET /test/isolationScope',
@@ -33,6 +34,7 @@ test('correctly applies isolation scope to span', done => {
         },
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/isolationScope');
+    .start();
+  runner.makeRequest('get', '/test/isolationScope');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/tracing/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('express tracing', () => {
@@ -6,8 +7,8 @@ describe('express tracing', () => {
   });
 
   describe('CJS', () => {
-    test('should create and send transactions for Express routes and spans for middlewares.', done => {
-      createRunner(__dirname, 'server.js')
+    test('should create and send transactions for Express routes and spans for middlewares.', async () => {
+      const runner = createRunner(__dirname, 'server.js')
         .expect({
           transaction: {
             contexts: {
@@ -44,12 +45,13 @@ describe('express tracing', () => {
             ]),
           },
         })
-        .start(done)
-        .makeRequest('get', '/test/express');
+        .start();
+      runner.makeRequest('get', '/test/express');
+      await runner.completed();
     });
 
-    test('should set a correct transaction name for routes specified in RegEx', done => {
-      createRunner(__dirname, 'server.js')
+    test('should set a correct transaction name for routes specified in RegEx', async () => {
+      const runner = createRunner(__dirname, 'server.js')
         .expect({
           transaction: {
             transaction: 'GET /\\/test\\/regex/',
@@ -70,8 +72,9 @@ describe('express tracing', () => {
             },
           },
         })
-        .start(done)
-        .makeRequest('get', '/test/regex');
+        .start();
+      runner.makeRequest('get', '/test/regex');
+      await runner.completed();
     });
 
     test.each([['array1'], ['array5']])(
@@ -137,7 +140,7 @@ describe('express tracing', () => {
     }) as any);
 
     describe('request data', () => {
-      test('correctly captures JSON request data', done => {
+      test('correctly captures JSON request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
@@ -156,12 +159,13 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done);
+          .start();
 
         runner.makeRequest('post', '/test-post', { data: { foo: 'bar', other: 1 } });
+        await runner.completed();
       });
 
-      test('correctly captures plain text request data', done => {
+      test('correctly captures plain text request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
@@ -177,15 +181,16 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done);
+          .start();
 
         runner.makeRequest('post', '/test-post', {
           headers: { 'Content-Type': 'text/plain' },
           data: 'some plain text',
         });
+        await runner.completed();
       });
 
-      test('correctly captures text buffer request data', done => {
+      test('correctly captures text buffer request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
@@ -201,15 +206,16 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done);
+          .start();
 
         runner.makeRequest('post', '/test-post', {
           headers: { 'Content-Type': 'application/octet-stream' },
           data: Buffer.from('some plain text in buffer'),
         });
+        await runner.completed();
       });
 
-      test('correctly captures non-text buffer request data', done => {
+      test('correctly captures non-text buffer request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
@@ -226,7 +232,7 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done);
+          .start();
 
         const body = new Uint8Array([1, 2, 3, 4, 5]).buffer;
 
@@ -234,6 +240,7 @@ describe('express tracing', () => {
           headers: { 'Content-Type': 'application/octet-stream' },
           data: body,
         });
+        await runner.completed();
       });
     });
   });

--- a/dev-packages/node-integration-tests/suites/express-v5/tracing/tracesSampler/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/tracing/tracesSampler/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('express tracesSampler', () => {
@@ -6,19 +7,20 @@ describe('express tracesSampler', () => {
   });
 
   describe('CJS', () => {
-    test('correctly samples & passes data to tracesSampler', done => {
+    test('correctly samples & passes data to tracesSampler', async () => {
       const runner = createRunner(__dirname, 'server.js')
         .expect({
           transaction: {
             transaction: 'GET /test/:id',
           },
         })
-        .start(done);
+        .start();
 
       // This is not sampled
       runner.makeRequest('get', '/test2?q=1');
       // This is sampled
       runner.makeRequest('get', '/test/123?q=1');
+      await runner.completed();
     });
   });
 });
@@ -29,16 +31,17 @@ describe('express tracesSampler includes normalizedRequest data', () => {
   });
 
   describe('CJS', () => {
-    test('correctly samples & passes data to tracesSampler', done => {
+    test('correctly samples & passes data to tracesSampler', async () => {
       const runner = createRunner(__dirname, 'scenario-normalizedRequest.js')
         .expect({
           transaction: {
             transaction: 'GET /test-normalized-request',
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('get', '/test-normalized-request?query=123');
+      await runner.completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/tracing/withError/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/tracing/withError/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('express tracing experimental', () => {
@@ -6,8 +7,8 @@ describe('express tracing experimental', () => {
   });
 
   describe('CJS', () => {
-    test('should apply the scope transactionName to error events', done => {
-      createRunner(__dirname, 'server.js')
+    test('should apply the scope transactionName to error events', async () => {
+      const runner = createRunner(__dirname, 'server.js')
         .ignore('transaction')
         .expect({
           event: {
@@ -21,8 +22,9 @@ describe('express tracing experimental', () => {
             transaction: 'GET /test/:id1/:id2',
           },
         })
-        .start(done)
-        .makeRequest('get', '/test/123/abc?q=1');
+        .start();
+      runner.makeRequest('get', '/test/123/abc?q=1');
+      await runner.completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/express-v5/without-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/without-tracing/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
@@ -5,7 +6,7 @@ afterAll(() => {
 });
 
 describe('express without tracing', () => {
-  test('correctly applies isolation scope even without tracing', done => {
+  test('correctly applies isolation scope even without tracing', async () => {
     const runner = createRunner(__dirname, 'server.ts')
       .expect({
         event: {
@@ -25,13 +26,14 @@ describe('express without tracing', () => {
           },
         },
       })
-      .start(done);
+      .start();
 
     runner.makeRequest('get', '/test/isolationScope/1');
+    await runner.completed();
   });
 
   describe('request data', () => {
-    test('correctly captures JSON request data', done => {
+    test('correctly captures JSON request data', async () => {
       const runner = createRunner(__dirname, 'server.ts')
         .expect({
           event: {
@@ -50,12 +52,13 @@ describe('express without tracing', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('post', '/test-post', { data: { foo: 'bar', other: 1 } });
+      await runner.completed();
     });
 
-    test('correctly captures plain text request data', done => {
+    test('correctly captures plain text request data', async () => {
       const runner = createRunner(__dirname, 'server.ts')
         .expect({
           event: {
@@ -71,7 +74,7 @@ describe('express without tracing', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('post', '/test-post', {
         headers: {
@@ -79,9 +82,10 @@ describe('express without tracing', () => {
         },
         data: 'some plain text',
       });
+      await runner.completed();
     });
 
-    test('correctly captures text buffer request data', done => {
+    test('correctly captures text buffer request data', async () => {
       const runner = createRunner(__dirname, 'server.ts')
         .expect({
           event: {
@@ -97,15 +101,16 @@ describe('express without tracing', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('post', '/test-post', {
         headers: { 'Content-Type': 'application/octet-stream' },
         data: Buffer.from('some plain text in buffer'),
       });
+      await runner.completed();
     });
 
-    test('correctly captures non-text buffer request data', done => {
+    test('correctly captures non-text buffer request data', async () => {
       const runner = createRunner(__dirname, 'server.ts')
         .expect({
           event: {
@@ -122,11 +127,12 @@ describe('express without tracing', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       const body = new Uint8Array([1, 2, 3, 4, 5]).buffer;
 
       runner.makeRequest('post', '/test-post', { headers: { 'Content-Type': 'application/octet-stream' }, data: body });
+      await runner.completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
@@ -13,8 +14,8 @@ afterAll(() => {
  *
  * This test nevertheless covers the behavior so that we're aware.
  */
-test('withScope scope is NOT applied to thrown error caught by global handler', done => {
-  createRunner(__dirname, 'server.ts')
+test('withScope scope is NOT applied to thrown error caught by global handler', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .expect({
       event: {
         exception: {
@@ -42,15 +43,18 @@ test('withScope scope is NOT applied to thrown error caught by global handler', 
         tags: expect.not.objectContaining({ local: expect.anything() }),
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/withScope', { expectError: true });
+    .start();
+
+  runner.makeRequest('get', '/test/withScope', { expectError: true });
+
+  await runner.completed();
 });
 
 /**
  * This test shows that the isolation scope set tags are applied correctly to the error.
  */
-test('isolation scope is applied to thrown error caught by global handler', done => {
-  createRunner(__dirname, 'server.ts')
+test('isolation scope is applied to thrown error caught by global handler', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .expect({
       event: {
         exception: {
@@ -80,6 +84,9 @@ test('isolation scope is applied to thrown error caught by global handler', done
         },
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/isolationScope', { expectError: true });
+    .start();
+
+  runner.makeRequest('get', '/test/isolationScope', { expectError: true });
+
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-0/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-0/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture and send Express controller error with txn name if tracesSampleRate is 0', done => {
-  createRunner(__dirname, 'server.ts')
+test('should capture and send Express controller error with txn name if tracesSampleRate is 0', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({
       event: {
@@ -33,6 +34,7 @@ test('should capture and send Express controller error with txn name if tracesSa
         transaction: 'GET /test/express/:id',
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/express/123', { expectError: true });
+    .start();
+  runner.makeRequest('get', '/test/express/123', { expectError: true });
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-unset/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-unset/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture and send Express controller error if tracesSampleRate is not set.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should capture and send Express controller error if tracesSampleRate is not set.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({
       event: {
@@ -32,6 +33,8 @@ test('should capture and send Express controller error if tracesSampleRate is no
         },
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/express/123', { expectError: true });
+    .start();
+
+  runner.makeRequest('get', '/test/express/123', { expectError: true });
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-init/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-init/test.ts
@@ -1,10 +1,11 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('allows to call init multiple times', done => {
+test('allows to call init multiple times', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       event: {
@@ -59,7 +60,7 @@ test('allows to call init multiple times', done => {
         },
       },
     })
-    .start(done);
+    .start();
 
   runner
     .makeRequest('get', '/test/no-init')
@@ -67,4 +68,6 @@ test('allows to call init multiple times', done => {
     .then(() => runner.makeRequest('get', '/test/init'))
     .then(() => runner.makeRequest('get', '/test/error/2'))
     .then(() => runner.makeRequest('get', '/test/error/3'));
+
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct url with common infixes with multiple parameterized routers.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct url with common infixes with multiple parameterized routers.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/user/3212');
+    .start();
+  runner.makeRequest('get', '/api/v1/user/3212');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct url with common infixes with multiple routers.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct url with common infixes with multiple routers.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api2/v1/test' } })
-    .start(done)
-    .makeRequest('get', '/api2/v1/test');
+    .start();
+  runner.makeRequest('get', '/api2/v1/test');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct urls with multiple parameterized routers (use order reversed).', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct urls with multiple parameterized routers (use order reversed).', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/user/1234/');
+    .start();
+  runner.makeRequest('get', '/api/v1/user/1234/');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct urls with multiple parameterized routers.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct urls with multiple parameterized routers.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/user/1234/');
+    .start();
+  runner.makeRequest('get', '/api/v1/user/1234/');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct url with multiple parameterized routers of the same length (use order reversed).', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct url with multiple parameterized routers of the same length (use order reversed).', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/1234/');
+    .start();
+  runner.makeRequest('get', '/api/v1/1234/');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct url with multiple parameterized routers of the same length.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct url with multiple parameterized routers of the same length.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/:userId' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/1234/');
+    .start();
+  runner.makeRequest('get', '/api/v1/1234/');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/test.ts
@@ -1,13 +1,15 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should construct correct urls with multiple routers.', done => {
-  createRunner(__dirname, 'server.ts')
+test('should construct correct urls with multiple routers.', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .ignore('transaction')
     .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/test' } })
-    .start(done)
-    .makeRequest('get', '/api/v1/test');
+    .start();
+  runner.makeRequest('get', '/api/v1/test');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
@@ -5,7 +6,7 @@ afterAll(() => {
 });
 
 describe('complex-router', () => {
-  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route', done => {
+  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
       transaction_info: {
@@ -13,14 +14,15 @@ describe('complex-router', () => {
       },
     };
 
-    createRunner(__dirname, 'server.ts')
+    const runner = createRunner(__dirname, 'server.ts')
       .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
-      .start(done)
-      .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456');
+      .start();
+    runner.makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456');
+    await runner.completed();
   });
 
-  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url has query params', done => {
+  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url has query params', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
       transaction_info: {
@@ -28,14 +30,15 @@ describe('complex-router', () => {
       },
     };
 
-    createRunner(__dirname, 'server.ts')
+    const runner = createRunner(__dirname, 'server.ts')
       .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
-      .start(done)
-      .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456?param=1');
+      .start();
+    runner.makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456?param=1');
+    await runner.completed();
   });
 
-  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url ends with trailing slash and has query params', done => {
+  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url ends with trailing slash and has query params', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
       transaction_info: {
@@ -43,10 +46,11 @@ describe('complex-router', () => {
       },
     };
 
-    createRunner(__dirname, 'server.ts')
+    const runner = createRunner(__dirname, 'server.ts')
       .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
-      .start(done)
-      .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456/?param=1');
+      .start();
+    runner.makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456/?param=1');
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
@@ -6,7 +7,7 @@ afterAll(() => {
 
 // Before Node 16, parametrization is not working properly here
 describe('middle-layer-parameterized', () => {
-  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route', done => {
+  test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'GET /api/v1/users/:userId/posts/:postId',
       transaction_info: {
@@ -14,10 +15,11 @@ describe('middle-layer-parameterized', () => {
       },
     };
 
-    createRunner(__dirname, 'server.ts')
+    const runner = createRunner(__dirname, 'server.ts')
       .ignore('event')
       .expect({ transaction: EXPECTED_TRANSACTION as any })
-      .start(done)
-      .makeRequest('get', '/api/v1/users/123/posts/456');
+      .start();
+    runner.makeRequest('get', '/api/v1/users/123/posts/456');
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/express/requestUser/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/requestUser/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('express user handling', () => {
@@ -5,22 +6,23 @@ describe('express user handling', () => {
     cleanupChildProcesses();
   });
 
-  test('ignores user from request', done => {
+  test('ignores user from request', async () => {
     expect.assertions(2);
 
-    createRunner(__dirname, 'server.js')
+    const runner = createRunner(__dirname, 'server.js')
       .expect({
         event: event => {
           expect(event.user).toBeUndefined();
           expect(event.exception?.values?.[0]?.value).toBe('error_1');
         },
       })
-      .start(done)
-      .makeRequest('get', '/test1', { expectError: true });
+      .start();
+    runner.makeRequest('get', '/test1', { expectError: true });
+    await runner.completed();
   });
 
-  test('using setUser in middleware works', done => {
-    createRunner(__dirname, 'server.js')
+  test('using setUser in middleware works', async () => {
+    const runner = createRunner(__dirname, 'server.js')
       .expect({
         event: {
           user: {
@@ -36,7 +38,8 @@ describe('express user handling', () => {
           },
         },
       })
-      .start(done)
-      .makeRequest('get', '/test2', { expectError: true });
+      .start();
+    runner.makeRequest('get', '/test2', { expectError: true });
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -1,4 +1,5 @@
 import { parseBaggageHeader } from '@sentry/core';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from './server';
 

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from './server';
 

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
@@ -1,4 +1,5 @@
 import { TRACEPARENT_REGEXP } from '@sentry/core';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
@@ -1,4 +1,5 @@
 import { TRACEPARENT_REGEXP } from '@sentry/core';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 

--- a/dev-packages/node-integration-tests/suites/express/setupExpressErrorHandler/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/setupExpressErrorHandler/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('express setupExpressErrorHandler', () => {
@@ -6,7 +7,7 @@ describe('express setupExpressErrorHandler', () => {
   });
 
   describe('CJS', () => {
-    test('allows to pass options to setupExpressErrorHandler', done => {
+    test('allows to pass options to setupExpressErrorHandler', async () => {
       const runner = createRunner(__dirname, 'server.js')
         .expect({
           event: {
@@ -19,12 +20,14 @@ describe('express setupExpressErrorHandler', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       // this error is filtered & ignored
       runner.makeRequest('get', '/test1', { expectError: true });
       // this error is actually captured
       runner.makeRequest('get', '/test2', { expectError: true });
+
+      await runner.completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/express/span-isolationScope/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/span-isolationScope/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('correctly applies isolation scope to span', done => {
-  createRunner(__dirname, 'server.ts')
+test('correctly applies isolation scope to span', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
     .expect({
       transaction: {
         transaction: 'GET /test/isolationScope',
@@ -33,6 +34,7 @@ test('correctly applies isolation scope to span', done => {
         },
       },
     })
-    .start(done)
-    .makeRequest('get', '/test/isolationScope');
+    .start();
+  runner.makeRequest('get', '/test/isolationScope');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('express tracing', () => {
@@ -6,8 +7,8 @@ describe('express tracing', () => {
   });
 
   describe('CJS', () => {
-    test('should create and send transactions for Express routes and spans for middlewares.', done => {
-      createRunner(__dirname, 'server.js')
+    test('should create and send transactions for Express routes and spans for middlewares.', async () => {
+      const runner = createRunner(__dirname, 'server.js')
         .expect({
           transaction: {
             contexts: {
@@ -44,12 +45,13 @@ describe('express tracing', () => {
             ]),
           },
         })
-        .start(done)
-        .makeRequest('get', '/test/express');
+        .start();
+      runner.makeRequest('get', '/test/express');
+      await runner.completed();
     });
 
-    test('should set a correct transaction name for routes specified in RegEx', done => {
-      createRunner(__dirname, 'server.js')
+    test('should set a correct transaction name for routes specified in RegEx', async () => {
+      const runner = createRunner(__dirname, 'server.js')
         .expect({
           transaction: {
             transaction: 'GET /\\/test\\/regex/',
@@ -70,8 +72,9 @@ describe('express tracing', () => {
             },
           },
         })
-        .start(done)
-        .makeRequest('get', '/test/regex');
+        .start();
+      runner.makeRequest('get', '/test/regex');
+      await runner.completed();
     });
 
     test.each([['array1'], ['array5']])(
@@ -139,7 +142,7 @@ describe('express tracing', () => {
     }) as any);
 
     describe('request data', () => {
-      test('correctly captures JSON request data', done => {
+      test('correctly captures JSON request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
@@ -158,12 +161,13 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done);
+          .start();
 
         runner.makeRequest('post', '/test-post', { data: { foo: 'bar', other: 1 } });
+        await runner.completed();
       });
 
-      test('correctly captures plain text request data', done => {
+      test('correctly captures plain text request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
@@ -179,15 +183,16 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done);
+          .start();
 
         runner.makeRequest('post', '/test-post', {
           headers: { 'Content-Type': 'text/plain' },
           data: 'some plain text',
         });
+        await runner.completed();
       });
 
-      test('correctly captures text buffer request data', done => {
+      test('correctly captures text buffer request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
@@ -203,15 +208,16 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done);
+          .start();
 
         runner.makeRequest('post', '/test-post', {
           headers: { 'Content-Type': 'application/octet-stream' },
           data: Buffer.from('some plain text in buffer'),
         });
+        await runner.completed();
       });
 
-      test('correctly captures non-text buffer request data', done => {
+      test('correctly captures non-text buffer request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
@@ -228,7 +234,7 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done);
+          .start();
 
         const body = new Uint8Array([1, 2, 3, 4, 5]).buffer;
 
@@ -236,6 +242,7 @@ describe('express tracing', () => {
           headers: { 'Content-Type': 'application/octet-stream' },
           data: body,
         });
+        await runner.completed();
       });
     });
   });

--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('express tracesSampler', () => {
@@ -6,19 +7,20 @@ describe('express tracesSampler', () => {
   });
 
   describe('CJS', () => {
-    test('correctly samples & passes data to tracesSampler', done => {
+    test('correctly samples & passes data to tracesSampler', async () => {
       const runner = createRunner(__dirname, 'server.js')
         .expect({
           transaction: {
             transaction: 'GET /test/:id',
           },
         })
-        .start(done);
+        .start();
 
       // This is not sampled
       runner.makeRequest('get', '/test2?q=1');
       // This is sampled
       runner.makeRequest('get', '/test/123?q=1');
+      await runner.completed();
     });
   });
 });
@@ -29,16 +31,17 @@ describe('express tracesSampler includes normalizedRequest data', () => {
   });
 
   describe('CJS', () => {
-    test('correctly samples & passes data to tracesSampler', done => {
+    test('correctly samples & passes data to tracesSampler', async () => {
       const runner = createRunner(__dirname, 'scenario-normalizedRequest.js')
         .expect({
           transaction: {
             transaction: 'GET /test-normalized-request',
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('get', '/test-normalized-request?query=123');
+      await runner.completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/express/tracing/withError/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/withError/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('express tracing experimental', () => {
@@ -6,8 +7,8 @@ describe('express tracing experimental', () => {
   });
 
   describe('CJS', () => {
-    test('should apply the scope transactionName to error events', done => {
-      createRunner(__dirname, 'server.js')
+    test('should apply the scope transactionName to error events', async () => {
+      const runner = createRunner(__dirname, 'server.js')
         .ignore('transaction')
         .expect({
           event: {
@@ -21,8 +22,9 @@ describe('express tracing experimental', () => {
             transaction: 'GET /test/:id1/:id2',
           },
         })
-        .start(done)
-        .makeRequest('get', '/test/123/abc?q=1');
+        .start();
+      runner.makeRequest('get', '/test/123/abc?q=1');
+      await runner.completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
@@ -5,7 +6,7 @@ afterAll(() => {
 });
 
 describe('express without tracing', () => {
-  test('correctly applies isolation scope even without tracing', done => {
+  test('correctly applies isolation scope even without tracing', async () => {
     const runner = createRunner(__dirname, 'server.ts')
       .expect({
         event: {
@@ -25,13 +26,14 @@ describe('express without tracing', () => {
           },
         },
       })
-      .start(done);
+      .start();
 
     runner.makeRequest('get', '/test/isolationScope/1');
+    await runner.completed();
   });
 
   describe('request data', () => {
-    test('correctly captures JSON request data', done => {
+    test('correctly captures JSON request data', async () => {
       const runner = createRunner(__dirname, 'server.ts')
         .expect({
           event: {
@@ -50,12 +52,13 @@ describe('express without tracing', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('post', '/test-post', { data: { foo: 'bar', other: 1 } });
+      await runner.completed();
     });
 
-    test('correctly captures plain text request data', done => {
+    test('correctly captures plain text request data', async () => {
       const runner = createRunner(__dirname, 'server.ts')
         .expect({
           event: {
@@ -71,7 +74,7 @@ describe('express without tracing', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('post', '/test-post', {
         headers: {
@@ -79,9 +82,10 @@ describe('express without tracing', () => {
         },
         data: 'some plain text',
       });
+      await runner.completed();
     });
 
-    test('correctly captures text buffer request data', done => {
+    test('correctly captures text buffer request data', async () => {
       const runner = createRunner(__dirname, 'server.ts')
         .expect({
           event: {
@@ -97,15 +101,16 @@ describe('express without tracing', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('post', '/test-post', {
         headers: { 'Content-Type': 'application/octet-stream' },
         data: Buffer.from('some plain text in buffer'),
       });
+      await runner.completed();
     });
 
-    test('correctly captures non-text buffer request data', done => {
+    test('correctly captures non-text buffer request data', async () => {
       const runner = createRunner(__dirname, 'server.ts')
         .expect({
           event: {
@@ -122,11 +127,12 @@ describe('express without tracing', () => {
             },
           },
         })
-        .start(done);
+        .start();
 
       const body = new Uint8Array([1, 2, 3, 4, 5]).buffer;
 
       runner.makeRequest('post', '/test-post', { headers: { 'Content-Type': 'application/octet-stream' }, data: body });
+      await runner.completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/fs-instrumentation/test.ts
+++ b/dev-packages/node-integration-tests/suites/fs-instrumentation/test.ts
@@ -28,7 +28,8 @@ test('should create spans for fs operations that take target argument', async ()
     })
     .start();
 
-  expect(runner.makeRequest('get', '/readFile-error')).resolves.toBe('done');
+  const result = await runner.makeRequest('get', '/readFile-error');
+  expect(result).toEqual('done');
   await runner.completed();
 });
 
@@ -73,7 +74,8 @@ test('should create spans for fs operations that take one path', async () => {
     })
     .start();
 
-  expect(runner.makeRequest('get', '/readFile')).resolves.toBe('done');
+  const result = await runner.makeRequest('get', '/readFile');
+  expect(result).toEqual('done');
   await runner.completed();
 });
 
@@ -121,7 +123,8 @@ test('should create spans for fs operations that take src and dest arguments', a
     })
     .start();
 
-  expect(runner.makeRequest('get', '/copyFile')).resolves.toBe('done');
+  const result = await runner.makeRequest('get', '/copyFile');
+  expect(result).toEqual('done');
   await runner.completed();
 });
 
@@ -169,7 +172,8 @@ test('should create spans for fs operations that take existing path and new path
     })
     .start();
 
-  expect(runner.makeRequest('get', '/link')).resolves.toBe('done');
+  const result = await runner.makeRequest('get', '/link');
+  expect(result).toEqual('done');
   await runner.completed();
 });
 
@@ -214,7 +218,8 @@ test('should create spans for fs operations that take prefix argument', async ()
     })
     .start();
 
-  expect(runner.makeRequest('get', '/mkdtemp')).resolves.toBe('done');
+  const result = await runner.makeRequest('get', '/mkdtemp');
+  expect(result).toEqual('done');
   await runner.completed();
 });
 
@@ -262,6 +267,7 @@ test('should create spans for fs operations that take target argument', async ()
     })
     .start();
 
-  expect(runner.makeRequest('get', '/symlink')).resolves.toBe('done');
+  const result = await runner.makeRequest('get', '/symlink');
+  expect(result).toEqual('done');
   await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/fs-instrumentation/test.ts
+++ b/dev-packages/node-integration-tests/suites/fs-instrumentation/test.ts
@@ -1,11 +1,12 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/node';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should create spans for fs operations that take target argument', done => {
+test('should create spans for fs operations that take target argument', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       transaction: {
@@ -25,12 +26,13 @@ test('should create spans for fs operations that take target argument', done => 
         ]),
       },
     })
-    .start(done);
+    .start();
 
   expect(runner.makeRequest('get', '/readFile-error')).resolves.toBe('done');
+  await runner.completed();
 });
 
-test('should create spans for fs operations that take one path', done => {
+test('should create spans for fs operations that take one path', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       transaction: {
@@ -69,12 +71,13 @@ test('should create spans for fs operations that take one path', done => {
         ]),
       },
     })
-    .start(done);
+    .start();
 
   expect(runner.makeRequest('get', '/readFile')).resolves.toBe('done');
+  await runner.completed();
 });
 
-test('should create spans for fs operations that take src and dest arguments', done => {
+test('should create spans for fs operations that take src and dest arguments', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       transaction: {
@@ -116,12 +119,13 @@ test('should create spans for fs operations that take src and dest arguments', d
         ]),
       },
     })
-    .start(done);
+    .start();
 
   expect(runner.makeRequest('get', '/copyFile')).resolves.toBe('done');
+  await runner.completed();
 });
 
-test('should create spans for fs operations that take existing path and new path arguments', done => {
+test('should create spans for fs operations that take existing path and new path arguments', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       transaction: {
@@ -163,12 +167,13 @@ test('should create spans for fs operations that take existing path and new path
         ]),
       },
     })
-    .start(done);
+    .start();
 
   expect(runner.makeRequest('get', '/link')).resolves.toBe('done');
+  await runner.completed();
 });
 
-test('should create spans for fs operations that take prefix argument', done => {
+test('should create spans for fs operations that take prefix argument', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       transaction: {
@@ -207,12 +212,13 @@ test('should create spans for fs operations that take prefix argument', done => 
         ]),
       },
     })
-    .start(done);
+    .start();
 
   expect(runner.makeRequest('get', '/mkdtemp')).resolves.toBe('done');
+  await runner.completed();
 });
 
-test('should create spans for fs operations that take target argument', done => {
+test('should create spans for fs operations that take target argument', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       transaction: {
@@ -254,7 +260,8 @@ test('should create spans for fs operations that take target argument', done => 
         ]),
       },
     })
-    .start(done);
+    .start();
 
   expect(runner.makeRequest('get', '/symlink')).resolves.toBe('done');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/no-code/test.ts
+++ b/dev-packages/node-integration-tests/suites/no-code/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
 const EVENT = {
@@ -16,21 +17,23 @@ describe('no-code init', () => {
     cleanupChildProcesses();
   });
 
-  test('CJS', done => {
-    createRunner(__dirname, 'app.js')
+  test('CJS', async () => {
+    await createRunner(__dirname, 'app.js')
       .withFlags('--require=@sentry/node/init')
       .withMockSentryServer()
       .expect({ event: EVENT })
-      .start(done);
+      .start()
+      .completed();
   });
 
   describe('--import', () => {
-    test('ESM', done => {
-      createRunner(__dirname, 'app.mjs')
+    test('ESM', async () => {
+      await createRunner(__dirname, 'app.mjs')
         .withFlags('--import=@sentry/node/init')
         .withMockSentryServer()
         .expect({ event: EVENT })
-        .start(done);
+        .start()
+        .completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/proxy/test.ts
+++ b/dev-packages/node-integration-tests/suites/proxy/test.ts
@@ -1,16 +1,18 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('proxies sentry requests', done => {
-  createRunner(__dirname, 'basic.js')
+test('proxies sentry requests', async () => {
+  await createRunner(__dirname, 'basic.js')
     .withMockSentryServer()
     .expect({
       event: {
         message: 'Hello, via proxy!',
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -1,10 +1,11 @@
 import * as path from 'path';
+import { afterAll, describe, expect, test } from 'vitest';
 import { conditionalTest } from '../../../utils';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // This test takes some time because it connects the debugger etc.
 // So we increase the timeout here
-jest.setTimeout(45_000);
+// vi.setTimeout(45_000);
 
 const EXPECTED_LOCAL_VARIABLES_EVENT = {
   exception: {
@@ -42,8 +43,8 @@ describe('LocalVariables integration', () => {
     cleanupChildProcesses();
   });
 
-  test('Should not include local variables by default', done => {
-    createRunner(__dirname, 'no-local-variables.js')
+  test('Should not include local variables by default', async () => {
+    await createRunner(__dirname, 'no-local-variables.js')
       .expect({
         event: event => {
           for (const frame of event.exception?.values?.[0]?.stacktrace?.frames || []) {
@@ -51,41 +52,53 @@ describe('LocalVariables integration', () => {
           }
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('Should include local variables when enabled', done => {
-    createRunner(__dirname, 'local-variables.js').expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT }).start(done);
+  test('Should include local variables when enabled', async () => {
+    await createRunner(__dirname, 'local-variables.js')
+      .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
+      .start()
+      .completed();
   });
 
-  test('Should include local variables when instrumenting via --require', done => {
+  test('Should include local variables when instrumenting via --require', async () => {
     const requirePath = path.resolve(__dirname, 'local-variables-instrument.js');
 
-    createRunner(__dirname, 'local-variables-no-sentry.js')
+    await createRunner(__dirname, 'local-variables-no-sentry.js')
       .withFlags(`--require=${requirePath}`)
       .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('Should include local variables with ESM', done => {
-    createRunner(__dirname, 'local-variables-caught.mjs').expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT }).start(done);
+  test('Should include local variables with ESM', async () => {
+    await createRunner(__dirname, 'local-variables-caught.mjs')
+      .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
+      .start()
+      .completed();
   });
 
   conditionalTest({ min: 19 })('Node v19+', () => {
-    test('Should not import inspector when not in use', done => {
-      createRunner(__dirname, 'deny-inspector.mjs').ensureNoErrorOutput().start(done);
+    test('Should not import inspector when not in use', async () => {
+      await createRunner(__dirname, 'deny-inspector.mjs').ensureNoErrorOutput().start().completed();
     });
   });
 
   conditionalTest({ min: 20 })('Node v20+', () => {
-    test('Should retain original local variables when error is re-thrown', done => {
-      createRunner(__dirname, 'local-variables-rethrow.js')
+    test('Should retain original local variables when error is re-thrown', async () => {
+      await createRunner(__dirname, 'local-variables-rethrow.js')
         .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
-        .start(done);
+        .start()
+        .completed();
     });
   });
 
-  test('Includes local variables for caught exceptions when enabled', done => {
-    createRunner(__dirname, 'local-variables-caught.js').expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT }).start(done);
+  test('Includes local variables for caught exceptions when enabled', async () => {
+    await createRunner(__dirname, 'local-variables-caught.js')
+      .expect({ event: EXPECTED_LOCAL_VARIABLES_EVENT })
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -1,52 +1,13 @@
 import * as childProcess from 'child_process';
 import * as path from 'path';
+import { describe, expect, test } from 'vitest';
 
 describe('OnUncaughtException integration', () => {
-  test('should close process on uncaught error with no additional listeners registered', done => {
-    expect.assertions(3);
-
-    const testScriptPath = path.resolve(__dirname, 'no-additional-listener-test-script.js');
-
-    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
-      expect(err).not.toBeNull();
-      expect(err?.code).toBe(1);
-      expect(stdout).not.toBe("I'm alive!");
-      done();
-    });
-  });
-
-  test('should not close process on uncaught error when additional listeners are registered', done => {
-    expect.assertions(2);
-
-    const testScriptPath = path.resolve(__dirname, 'additional-listener-test-script.js');
-
-    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
-      expect(err).toBeNull();
-      expect(stdout).toBe("I'm alive!");
-      done();
-    });
-  });
-
-  test('should log entire error object to console stderr', done => {
-    expect.assertions(2);
-
-    const testScriptPath = path.resolve(__dirname, 'log-entire-error-to-console.js');
-
-    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stderr) => {
-      expect(err).not.toBeNull();
-      const errString = err?.toString() || '';
-
-      expect(errString).toContain(stderr);
-
-      done();
-    });
-  });
-
-  describe('with `exitEvenIfOtherHandlersAreRegistered` set to false', () => {
-    test('should close process on uncaught error with no additional listeners registered', done => {
+  test('should close process on uncaught error with no additional listeners registered', () =>
+    new Promise<void>(done => {
       expect.assertions(3);
 
-      const testScriptPath = path.resolve(__dirname, 'mimic-native-behaviour-no-additional-listener-test-script.js');
+      const testScriptPath = path.resolve(__dirname, 'no-additional-listener-test-script.js');
 
       childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
         expect(err).not.toBeNull();
@@ -54,18 +15,63 @@ describe('OnUncaughtException integration', () => {
         expect(stdout).not.toBe("I'm alive!");
         done();
       });
-    });
+    }));
 
-    test('should not close process on uncaught error when additional listeners are registered', done => {
+  test('should not close process on uncaught error when additional listeners are registered', () =>
+    new Promise<void>(done => {
       expect.assertions(2);
 
-      const testScriptPath = path.resolve(__dirname, 'mimic-native-behaviour-additional-listener-test-script.js');
+      const testScriptPath = path.resolve(__dirname, 'additional-listener-test-script.js');
 
       childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
         expect(err).toBeNull();
         expect(stdout).toBe("I'm alive!");
         done();
       });
-    });
+    }));
+
+  test('should log entire error object to console stderr', () =>
+    new Promise<void>(done => {
+      expect.assertions(2);
+
+      const testScriptPath = path.resolve(__dirname, 'log-entire-error-to-console.js');
+
+      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stderr) => {
+        expect(err).not.toBeNull();
+        const errString = err?.toString() || '';
+
+        expect(errString).toContain(stderr);
+
+        done();
+      });
+    }));
+
+  describe('with `exitEvenIfOtherHandlersAreRegistered` set to false', () => {
+    test('should close process on uncaught error with no additional listeners registered', () =>
+      new Promise<void>(done => {
+        expect.assertions(3);
+
+        const testScriptPath = path.resolve(__dirname, 'mimic-native-behaviour-no-additional-listener-test-script.js');
+
+        childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
+          expect(err).not.toBeNull();
+          expect(err?.code).toBe(1);
+          expect(stdout).not.toBe("I'm alive!");
+          done();
+        });
+      }));
+
+    test('should not close process on uncaught error when additional listeners are registered', () =>
+      new Promise<void>(done => {
+        expect.assertions(2);
+
+        const testScriptPath = path.resolve(__dirname, 'mimic-native-behaviour-additional-listener-test-script.js');
+
+        childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
+          expect(err).toBeNull();
+          expect(stdout).toBe("I'm alive!");
+          done();
+        });
+      }));
   });
 });

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
@@ -1,15 +1,17 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should add an empty breadcrumb, when an empty object is given', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should add an empty breadcrumb, when an empty object is given', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'test-empty-obj',
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should add multiple breadcrumbs', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should add multiple breadcrumbs', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'test_multi_breadcrumbs',
@@ -21,5 +22,6 @@ test('should add multiple breadcrumbs', done => {
         ],
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
@@ -1,7 +1,8 @@
+import { test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('should add a simple breadcrumb', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should add a simple breadcrumb', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'test_simple',
@@ -14,5 +15,6 @@ test('should add a simple breadcrumb', done => {
         ],
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should work inside catch block', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should work inside catch block', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         exception: {
@@ -39,5 +40,6 @@ test('should work inside catch block', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture an empty object', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should capture an empty object', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         exception: {
@@ -22,5 +23,6 @@ test('should capture an empty object', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture a simple error with message', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should capture a simple error with message', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         exception: {
@@ -25,5 +26,6 @@ test('should capture a simple error with message', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/parameterized_message/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/parameterized_message/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture a parameterized representation of the message', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should capture a parameterized representation of the message', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         logentry: {
@@ -14,5 +15,6 @@ test('should capture a parameterized representation of the message', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -1,16 +1,18 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture a simple message string', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should capture a simple message string', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'Message',
         level: 'info',
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_attachStackTrace/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_attachStackTrace/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('capture a simple message string with a stack trace if `attachStackTrace` is `true`', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('capture a simple message string with a stack trace if `attachStackTrace` is `true`', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'Message',
@@ -21,5 +22,6 @@ test('capture a simple message string with a stack trace if `attachStackTrace` i
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
@@ -1,16 +1,18 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture with different severity levels', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should capture with different severity levels', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({ event: { message: 'debug_message', level: 'debug' } })
     .expect({ event: { message: 'info_message', level: 'info' } })
     .expect({ event: { message: 'warning_message', level: 'warning' } })
     .expect({ event: { message: 'error_message', level: 'error' } })
     .expect({ event: { message: 'fatal_message', level: 'fatal' } })
     .expect({ event: { message: 'log_message', level: 'log' } })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/configureScope/clear_scope/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/configureScope/clear_scope/test.ts
@@ -1,15 +1,17 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should clear previously set properties of a scope', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should clear previously set properties of a scope', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'cleared_scope',
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should set different properties of a scope', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should set different properties of a scope', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'configured_scope',
@@ -20,5 +21,6 @@ test('should set different properties of a scope', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/scopes/initialScopes/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/scopes/initialScopes/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should apply scopes correctly', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should apply scopes correctly', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'outer_before',
@@ -34,5 +35,6 @@ test('should apply scopes correctly', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/scopes/isolationScope/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/scopes/isolationScope/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should apply scopes correctly', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should apply scopes correctly', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'outer_before',
@@ -51,5 +52,6 @@ test('should apply scopes correctly', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should record multiple contexts', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should record multiple contexts', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'multiple_contexts',
@@ -18,5 +19,6 @@ test('should record multiple contexts', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
@@ -1,11 +1,13 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should normalize non-serializable context', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should normalize non-serializable context', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({ event: { message: 'non_serializable', contexts: {} } })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should set a simple context', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should set a simple context', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'simple_context_object',
@@ -16,5 +17,6 @@ test('should set a simple context', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should record multiple extras of different types', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should record multiple extras of different types', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'multiple_extras',
@@ -15,5 +16,6 @@ test('should record multiple extras of different types', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
@@ -1,16 +1,18 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should normalize non-serializable extra', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should normalize non-serializable extra', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'non_serializable',
         extra: {},
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should set a simple extra', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should set a simple extra', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'simple_extra',
@@ -19,5 +20,6 @@ test('should set a simple extra', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
@@ -1,16 +1,18 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should set extras from multiple consecutive calls', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should set extras from multiple consecutive calls', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'consecutive_calls',
         extra: { extra: [], Infinity: 2, null: 0, obj: { foo: ['bar', 'baz', 1] } },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should record an extras object', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should record an extras object', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'multiple_extras',
@@ -17,5 +18,6 @@ test('should record an extras object', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setMeasurement/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setMeasurement/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should attach measurement to transaction', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should attach measurement to transaction', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       transaction: {
         transaction: 'some_transaction',
@@ -16,5 +17,6 @@ test('should attach measurement to transaction', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should set primitive tags', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should set primitive tags', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'primitive_tags',
@@ -18,5 +19,6 @@ test('should set primitive tags', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should set primitive tags', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should set primitive tags', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'primitive_tags',
@@ -18,5 +19,6 @@ test('should set primitive tags', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should unset user', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should unset user', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({ event: { message: 'no_user' } })
     .expect({
       event: {
@@ -18,5 +19,6 @@ test('should unset user', done => {
       },
     })
     .expect({ event: { message: 'unset_user' } })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should update user', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should update user', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'first_user',
@@ -23,5 +24,6 @@ test('should update user', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage/test.ts
@@ -1,12 +1,13 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/node';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('sends a manually started root span with source custom', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('sends a manually started root span with source custom', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       transaction: {
         transaction: 'test_span',
@@ -20,11 +21,12 @@ test('sends a manually started root span with source custom', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });
 
-test("doesn't change the name for manually started spans even if attributes triggering inference are set", done => {
-  createRunner(__dirname, 'scenario.ts')
+test("doesn't change the name for manually started spans even if attributes triggering inference are set", async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       transaction: {
         transaction: 'test_span',
@@ -38,5 +40,6 @@ test("doesn't change the name for manually started spans even if attributes trig
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/test.ts
@@ -1,13 +1,14 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should send manually started parallel root spans in root context', done => {
+test('should send manually started parallel root spans in root context', async () => {
   expect.assertions(7);
 
-  createRunner(__dirname, 'scenario.ts')
+  await createRunner(__dirname, 'scenario.ts')
     .expect({ transaction: { transaction: 'test_span_1' } })
     .expect({
       transaction: transaction => {
@@ -25,5 +26,6 @@ test('should send manually started parallel root spans in root context', done =>
         expect(trace1Id).not.toBe(traceId);
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope-with-parentSpanId/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope-with-parentSpanId/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should send manually started parallel root spans outside of root context with parentSpanId', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should send manually started parallel root spans outside of root context with parentSpanId', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({ transaction: { transaction: 'test_span_1' } })
     .expect({
       transaction: transaction => {
@@ -21,5 +22,6 @@ test('should send manually started parallel root spans outside of root context w
         expect(trace1Id).not.toBe(traceId);
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope/test.ts
@@ -1,13 +1,14 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should send manually started parallel root spans outside of root context', done => {
+test('should send manually started parallel root spans outside of root context', async () => {
   expect.assertions(6);
 
-  createRunner(__dirname, 'scenario.ts')
+  await createRunner(__dirname, 'scenario.ts')
     .expect({ transaction: { transaction: 'test_span_1' } })
     .expect({
       transaction: transaction => {
@@ -23,5 +24,6 @@ test('should send manually started parallel root spans outside of root context',
         expect(trace1Id).not.toBe(traceId);
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/updateName-method/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/updateName-method/test.ts
@@ -1,11 +1,12 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/node';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('updates the span name when calling `span.updateName`', done => {
+test('updates the span name when calling `span.updateName`', async () => {
   createRunner(__dirname, 'scenario.ts')
     .expect({
       transaction: {
@@ -20,5 +21,6 @@ test('updates the span name when calling `span.updateName`', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/updateSpanName-function/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/updateSpanName-function/test.ts
@@ -1,12 +1,13 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/node';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('updates the span name and source when calling `updateSpanName`', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('updates the span name and source when calling `updateSpanName`', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       transaction: {
         transaction: 'new name',
@@ -20,5 +21,6 @@ test('updates the span name and source when calling `updateSpanName`', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/with-nested-spans/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/with-nested-spans/test.ts
@@ -1,4 +1,5 @@
 import type { SpanJSON } from '@sentry/core';
+import { afterAll, expect, test } from 'vitest';
 import { assertSentryTransaction } from '../../../../utils/assertions';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
@@ -6,8 +7,8 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should report finished spans as children of the root transaction.', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should report finished spans as children of the root transaction.', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       transaction: transaction => {
         const rootSpanId = transaction.contexts?.trace?.span_id;
@@ -41,5 +42,6 @@ test('should report finished spans as children of the root transaction.', done =
         });
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
@@ -1,11 +1,12 @@
+import { afterAll, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should allow nested scoping', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('should allow nested scoping', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       event: {
         message: 'root_before',
@@ -53,5 +54,6 @@ test('should allow nested scoping', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
@@ -1,10 +1,11 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-afterEach(() => {
+afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should aggregate successful and crashed sessions', done => {
+test('should aggregate successful and crashed sessions', async () => {
   const runner = createRunner(__dirname, '..', 'server.ts')
     .ignore('transaction', 'event')
     .unignore('sessions')
@@ -19,9 +20,10 @@ test('should aggregate successful and crashed sessions', done => {
         ],
       },
     })
-    .start(done);
+    .start();
 
   runner.makeRequest('get', '/test/success');
   runner.makeRequest('get', '/test/error_unhandled', { expectError: true });
   runner.makeRequest('get', '/test/success_next');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
@@ -1,10 +1,11 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-afterEach(() => {
+afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should aggregate successful, crashed and erroneous sessions', done => {
+test('should aggregate successful, crashed and erroneous sessions', async () => {
   const runner = createRunner(__dirname, '..', 'server.ts')
     .ignore('transaction', 'event')
     .unignore('sessions')
@@ -20,9 +21,10 @@ test('should aggregate successful, crashed and erroneous sessions', done => {
         ],
       },
     })
-    .start(done);
+    .start();
 
   runner.makeRequest('get', '/test/success');
   runner.makeRequest('get', '/test/error_handled');
   runner.makeRequest('get', '/test/error_unhandled', { expectError: true });
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
@@ -1,10 +1,11 @@
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-afterEach(() => {
+afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should aggregate successful sessions', done => {
+test('should aggregate successful sessions', async () => {
   const runner = createRunner(__dirname, '..', 'server.ts')
     .ignore('transaction', 'event')
     .unignore('sessions')
@@ -18,9 +19,10 @@ test('should aggregate successful sessions', done => {
         ],
       },
     })
-    .start(done);
+    .start();
 
   runner.makeRequest('get', '/test/success');
   runner.makeRequest('get', '/test/success_next');
   runner.makeRequest('get', '/test/success_slow');
+  await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/ai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/ai/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // `ai` SDK only support Node 18+
@@ -6,7 +7,7 @@ describe('ai', () => {
     cleanupChildProcesses();
   });
 
-  test('creates ai related spans', done => {
+  test('creates ai related spans', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'main',
       spans: expect.arrayContaining([
@@ -125,6 +126,6 @@ describe('ai', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+    await createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/amqplib/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/amqplib/test.ts
@@ -1,9 +1,6 @@
 import type { TransactionEvent } from '@sentry/core';
-import { afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
-
-// When running docker compose, we need a larger timeout, as this takes some time.
-vi.setConfig({ testTimeout: 90_000 });
 
 const EXPECTED_MESSAGE_SPAN_PRODUCER = expect.objectContaining({
   op: 'message',
@@ -32,7 +29,7 @@ describe('amqplib auto-instrumentation', () => {
     cleanupChildProcesses();
   });
 
-  test('should be able to send and receive messages', async () => {
+  test('should be able to send and receive messages', { timeout: 90_000 }, async () => {
     await createRunner(__dirname, 'scenario-message.ts')
       .withDockerCompose({
         workingDirectory: [__dirname],

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
 // Graphql Instrumentation emits some spans by default on server start
@@ -6,7 +7,7 @@ const EXPECTED_START_SERVER_TRANSACTION = {
 };
 
 describe('GraphQL/Apollo Tests', () => {
-  test('should instrument GraphQL queries used from Apollo Server.', done => {
+  test('should instrument GraphQL queries used from Apollo Server.', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -23,13 +24,14 @@ describe('GraphQL/Apollo Tests', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-query.js')
+    await createRunner(__dirname, 'scenario-query.js')
       .expect({ transaction: EXPECTED_START_SERVER_TRANSACTION })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should instrument GraphQL mutations used from Apollo Server.', done => {
+  test('should instrument GraphQL mutations used from Apollo Server.', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -47,9 +49,10 @@ describe('GraphQL/Apollo Tests', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-mutation.js')
+    await createRunner(__dirname, 'scenario-mutation.js')
       .expect({ transaction: EXPECTED_START_SERVER_TRANSACTION })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/connect/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/connect/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('connect auto-instrumentation', () => {
@@ -35,26 +36,27 @@ describe('connect auto-instrumentation', () => {
     },
   };
 
-  test('CJS - should auto-instrument `connect` package.', done => {
-    createRunner(__dirname, 'scenario.js')
-      .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done)
-      .makeRequest('get', '/');
+  test('CJS - should auto-instrument `connect` package.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start();
+    runner.makeRequest('get', '/');
+    await runner.completed();
   });
 
-  test('CJS - should capture errors in `connect` middleware.', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('CJS - should capture errors in `connect` middleware.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js')
       .ignore('transaction')
       .expect({ event: EXPECTED_EVENT })
-      .start(done)
-      .makeRequest('get', '/error');
+      .start();
+    runner.makeRequest('get', '/error');
+    await runner.completed();
   });
 
-  test('CJS - should report errored transactions.', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('CJS - should report errored transactions.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js')
       .ignore('event')
       .expect({ transaction: { transaction: 'GET /error' } })
-      .start(done)
-      .makeRequest('get', '/error');
+      .start();
+    runner.makeRequest('get', '/error');
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/dataloader/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/dataloader/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('dataloader auto-instrumentation', () => {
@@ -31,10 +32,9 @@ describe('dataloader auto-instrumentation', () => {
     ]),
   };
 
-  test('should auto-instrument `dataloader` package.', done => {
-    createRunner(__dirname, 'scenario.js')
-      .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done)
-      .makeRequest('get', '/');
+  test('should auto-instrument `dataloader` package.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start();
+    runner.makeRequest('get', '/');
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/test.ts
@@ -1,7 +1,8 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('envelope header for error event during active unsampled span is correct', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('envelope header for error event during active unsampled span is correct', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .ignore('transaction')
     .expectHeader({
       event: {
@@ -16,5 +17,6 @@ test('envelope header for error event during active unsampled span is correct', 
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/test.ts
@@ -1,7 +1,8 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('envelope header for error event during active span is correct', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('envelope header for error event during active span is correct', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .ignore('transaction')
     .expectHeader({
       event: {
@@ -17,5 +18,6 @@ test('envelope header for error event during active span is correct', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/test.ts
@@ -1,7 +1,8 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('envelope header for error events is correct', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('envelope header for error events is correct', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expectHeader({
       event: {
         trace: {
@@ -12,5 +13,6 @@ test('envelope header for error events is correct', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('tracesSampleRate propagation', () => {
@@ -7,8 +8,8 @@ describe('tracesSampleRate propagation', () => {
 
   const traceId = '12345678123456781234567812345678';
 
-  test('uses sample rate from incoming baggage header in trace envelope item', done => {
-    createRunner(__dirname, 'server.js')
+  test('uses sample rate from incoming baggage header in trace envelope item', async () => {
+    const runner = createRunner(__dirname, 'server.js')
       .expectHeader({
         transaction: {
           trace: {
@@ -20,12 +21,13 @@ describe('tracesSampleRate propagation', () => {
           },
         },
       })
-      .start(done)
-      .makeRequest('get', '/test', {
-        headers: {
-          'sentry-trace': `${traceId}-1234567812345678-1`,
-          baggage: `sentry-sample_rate=0.05,sentry-trace_id=${traceId},sentry-sampled=true,sentry-transaction=myTransaction,sentry-sample_rand=0.42`,
-        },
-      });
+      .start();
+    runner.makeRequest('get', '/test', {
+      headers: {
+        'sentry-trace': `${traceId}-1234567812345678-1`,
+        baggage: `sentry-sample_rate=0.05,sentry-trace_id=${traceId},sentry-sampled=true,sentry-transaction=myTransaction,sentry-sample_rand=0.42`,
+      },
+    });
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/test.ts
@@ -1,7 +1,8 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('envelope header for transaction event of route correct', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('envelope header for transaction event of route correct', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expectHeader({
       transaction: {
         trace: {
@@ -16,5 +17,6 @@ test('envelope header for transaction event of route correct', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/test.ts
@@ -1,7 +1,8 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('envelope header for transaction event with source=url correct', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('envelope header for transaction event with source=url correct', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expectHeader({
       transaction: {
         trace: {
@@ -15,5 +16,6 @@ test('envelope header for transaction event with source=url correct', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/test.ts
@@ -1,7 +1,8 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('envelope header for transaction event is correct', done => {
-  createRunner(__dirname, 'scenario.ts')
+test('envelope header for transaction event is correct', async () => {
+  await createRunner(__dirname, 'scenario.ts')
     .expectHeader({
       transaction: {
         trace: {
@@ -16,5 +17,6 @@ test('envelope header for transaction event is correct', done => {
         },
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('genericPool auto instrumentation', () => {
@@ -5,7 +6,7 @@ describe('genericPool auto instrumentation', () => {
     cleanupChildProcesses();
   });
 
-  test('should auto-instrument `genericPool` package when calling pool.require()', done => {
+  test('should auto-instrument `genericPool` package when calling pool.require()', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -29,6 +30,6 @@ describe('genericPool auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+    await createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/hapi/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/hapi/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('hapi auto-instrumentation', () => {
@@ -35,27 +36,27 @@ describe('hapi auto-instrumentation', () => {
     },
   };
 
-  test('CJS - should auto-instrument `@hapi/hapi` package.', done => {
-    createRunner(__dirname, 'scenario.js')
-      .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done)
-      .makeRequest('get', '/');
+  test('CJS - should auto-instrument `@hapi/hapi` package.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start();
+    runner.makeRequest('get', '/');
+    await runner.completed();
   });
 
-  test('CJS - should handle returned plain errors in routes.', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('CJS - should handle returned plain errors in routes.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js')
       .expect({
         transaction: {
           transaction: 'GET /error',
         },
       })
       .expect({ event: EXPECTED_ERROR_EVENT })
-      .start(done)
-      .makeRequest('get', '/error', { expectError: true });
+      .start();
+    runner.makeRequest('get', '/error', { expectError: true });
+    await runner.completed();
   });
 
-  test('CJS - should assign parameterized transactionName to error.', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('CJS - should assign parameterized transactionName to error.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js')
       .expect({
         event: {
           ...EXPECTED_ERROR_EVENT,
@@ -63,31 +64,34 @@ describe('hapi auto-instrumentation', () => {
         },
       })
       .ignore('transaction')
-      .start(done)
-      .makeRequest('get', '/error/123', { expectError: true });
+      .start();
+    runner.makeRequest('get', '/error/123', { expectError: true });
+    await runner.completed();
   });
 
-  test('CJS - should handle returned Boom errors in routes.', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('CJS - should handle returned Boom errors in routes.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js')
       .expect({
         transaction: {
           transaction: 'GET /boom-error',
         },
       })
       .expect({ event: EXPECTED_ERROR_EVENT })
-      .start(done)
-      .makeRequest('get', '/boom-error', { expectError: true });
+      .start();
+    runner.makeRequest('get', '/boom-error', { expectError: true });
+    await runner.completed();
   });
 
-  test('CJS - should handle promise rejections in routes.', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('CJS - should handle promise rejections in routes.', async () => {
+    const runner = createRunner(__dirname, 'scenario.js')
       .expect({
         transaction: {
           transaction: 'GET /promise-error',
         },
       })
       .expect({ event: EXPECTED_ERROR_EVENT })
-      .start(done)
-      .makeRequest('get', '/promise-error', { expectError: true });
+      .start();
+    runner.makeRequest('get', '/promise-error', { expectError: true });
+    await runner.completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic/test.ts
@@ -1,10 +1,11 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('captures spans for outgoing fetch requests', done => {
+test('captures spans for outgoing fetch requests', async () => {
   expect.assertions(3);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', () => {
       // Just ensure we're called
       expect(true).toBe(true);
@@ -17,32 +18,33 @@ test('captures spans for outgoing fetch requests', done => {
       },
       404,
     )
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .expect({
+      transaction: {
+        transaction: 'test_transaction',
+        spans: expect.arrayContaining([
+          expect.objectContaining({
+            description: expect.stringMatching(/GET .*\/api\/v0/),
+            op: 'http.client',
+            origin: 'auto.http.otel.node_fetch',
+            status: 'ok',
+          }),
+          expect.objectContaining({
+            description: expect.stringMatching(/GET .*\/api\/v1/),
+            op: 'http.client',
+            origin: 'auto.http.otel.node_fetch',
+            status: 'not_found',
+            data: expect.objectContaining({
+              'http.response.status_code': 404,
+            }),
+          }),
+        ]),
+      },
+    })
     .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .expect({
-          transaction: {
-            transaction: 'test_transaction',
-            spans: expect.arrayContaining([
-              expect.objectContaining({
-                description: expect.stringMatching(/GET .*\/api\/v0/),
-                op: 'http.client',
-                origin: 'auto.http.otel.node_fetch',
-                status: 'ok',
-              }),
-              expect.objectContaining({
-                description: expect.stringMatching(/GET .*\/api\/v1/),
-                op: 'http.client',
-                origin: 'auto.http.otel.node_fetch',
-                status: 'not_found',
-                data: expect.objectContaining({
-                  'http.response.status_code': 404,
-                }),
-              }),
-            ]),
-          },
-        })
-        .start(closeTestServer);
-    });
+    .completed();
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-strip-query/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-strip-query/test.ts
@@ -1,53 +1,55 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('strips and handles query params in spans of outgoing fetch requests', done => {
+test('strips and handles query params in spans of outgoing fetch requests', async () => {
   expect.assertions(4);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0/users', () => {
       // Just ensure we're called
       expect(true).toBe(true);
     })
-    .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .expect({
-          transaction: txn => {
-            expect(txn.transaction).toEqual('test_transaction');
-            expect(txn.spans).toHaveLength(1);
-            expect(txn.spans?.[0]).toMatchObject({
-              data: {
-                url: `${SERVER_URL}/api/v0/users`,
-                'url.full': `${SERVER_URL}/api/v0/users?id=1`,
-                'url.path': '/api/v0/users',
-                'url.query': '?id=1',
-                'url.scheme': 'http',
-                'http.query': 'id=1',
-                'http.request.method': 'GET',
-                'http.request.method_original': 'GET',
-                'http.response.header.content-length': 0,
-                'http.response.status_code': 200,
-                'network.peer.address': '::1',
-                'network.peer.port': expect.any(Number),
-                'otel.kind': 'CLIENT',
-                'server.port': expect.any(Number),
-                'user_agent.original': 'node',
-                'sentry.op': 'http.client',
-                'sentry.origin': 'auto.http.otel.node_fetch',
-                'server.address': 'localhost',
-              },
-              description: `GET ${SERVER_URL}/api/v0/users`,
-              op: 'http.client',
-              origin: 'auto.http.otel.node_fetch',
-              status: 'ok',
-              parent_span_id: txn.contexts?.trace?.span_id,
-              span_id: expect.stringMatching(/[a-f0-9]{16}/),
-              trace_id: txn.contexts?.trace?.trace_id,
-            });
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .expect({
+      transaction: txn => {
+        expect(txn.transaction).toEqual('test_transaction');
+        expect(txn.spans).toHaveLength(1);
+        expect(txn.spans?.[0]).toMatchObject({
+          data: {
+            url: `${SERVER_URL}/api/v0/users`,
+            'url.full': `${SERVER_URL}/api/v0/users?id=1`,
+            'url.path': '/api/v0/users',
+            'url.query': '?id=1',
+            'url.scheme': 'http',
+            'http.query': 'id=1',
+            'http.request.method': 'GET',
+            'http.request.method_original': 'GET',
+            'http.response.header.content-length': 0,
+            'http.response.status_code': 200,
+            'network.peer.address': '::1',
+            'network.peer.port': expect.any(Number),
+            'otel.kind': 'CLIENT',
+            'server.port': expect.any(Number),
+            'user_agent.original': 'node',
+            'sentry.op': 'http.client',
+            'sentry.origin': 'auto.http.otel.node_fetch',
+            'server.address': 'localhost',
           },
-        })
-        .start(closeTestServer);
-    });
+          description: `GET ${SERVER_URL}/api/v0/users`,
+          op: 'http.client',
+          origin: 'auto.http.otel.node_fetch',
+          status: 'ok',
+          parent_span_id: txn.contexts?.trace?.span_id,
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: txn.contexts?.trace?.trace_id,
+        });
+      },
+    })
+    .start()
+    .completed();
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-basic/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-basic/test.ts
@@ -1,10 +1,11 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('captures spans for outgoing http requests', done => {
+test('captures spans for outgoing http requests', async () => {
   expect.assertions(3);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', () => {
       // Just ensure we're called
       expect(true).toBe(true);
@@ -17,32 +18,33 @@ test('captures spans for outgoing http requests', done => {
       },
       404,
     )
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .expect({
+      transaction: {
+        transaction: 'test_transaction',
+        spans: expect.arrayContaining([
+          expect.objectContaining({
+            description: expect.stringMatching(/GET .*\/api\/v0/),
+            op: 'http.client',
+            origin: 'auto.http.otel.http',
+            status: 'ok',
+          }),
+          expect.objectContaining({
+            description: expect.stringMatching(/GET .*\/api\/v1/),
+            op: 'http.client',
+            origin: 'auto.http.otel.http',
+            status: 'not_found',
+            data: expect.objectContaining({
+              'http.response.status_code': 404,
+            }),
+          }),
+        ]),
+      },
+    })
     .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .expect({
-          transaction: {
-            transaction: 'test_transaction',
-            spans: expect.arrayContaining([
-              expect.objectContaining({
-                description: expect.stringMatching(/GET .*\/api\/v0/),
-                op: 'http.client',
-                origin: 'auto.http.otel.http',
-                status: 'ok',
-              }),
-              expect.objectContaining({
-                description: expect.stringMatching(/GET .*\/api\/v1/),
-                op: 'http.client',
-                origin: 'auto.http.otel.http',
-                status: 'not_found',
-                data: expect.objectContaining({
-                  'http.response.status_code': 404,
-                }),
-              }),
-            ]),
-          },
-        })
-        .start(closeTestServer);
-    });
+    .completed();
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-strip-query/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-strip-query/test.ts
@@ -1,53 +1,56 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('strips and handles query params in spans of outgoing http requests', done => {
+test('strips and handles query params in spans of outgoing http requests', async () => {
   expect.assertions(4);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0/users', () => {
       // Just ensure we're called
       expect(true).toBe(true);
     })
-    .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .expect({
-          transaction: txn => {
-            expect(txn.transaction).toEqual('test_transaction');
-            expect(txn.spans).toHaveLength(1);
-            expect(txn.spans?.[0]).toMatchObject({
-              data: {
-                url: `${SERVER_URL}/api/v0/users`,
-                'http.url': `${SERVER_URL}/api/v0/users?id=1`,
-                'http.target': '/api/v0/users?id=1',
-                'http.flavor': '1.1',
-                'http.host': expect.stringMatching(/localhost:\d+$/),
-                'http.method': 'GET',
-                'http.query': 'id=1',
-                'http.response.status_code': 200,
-                'http.response_content_length_uncompressed': 0,
-                'http.status_code': 200,
-                'http.status_text': 'OK',
-                'net.peer.ip': '::1',
-                'net.peer.name': 'localhost',
-                'net.peer.port': expect.any(Number),
-                'net.transport': 'ip_tcp',
-                'otel.kind': 'CLIENT',
-                'sentry.op': 'http.client',
-                'sentry.origin': 'auto.http.otel.http',
-              },
-              description: `GET ${SERVER_URL}/api/v0/users`,
-              op: 'http.client',
-              origin: 'auto.http.otel.http',
-              status: 'ok',
-              parent_span_id: txn.contexts?.trace?.span_id,
-              span_id: expect.stringMatching(/[a-f0-9]{16}/),
-              trace_id: txn.contexts?.trace?.trace_id,
-            });
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .expect({
+      transaction: txn => {
+        expect(txn.transaction).toEqual('test_transaction');
+        expect(txn.spans).toHaveLength(1);
+        expect(txn.spans?.[0]).toMatchObject({
+          data: {
+            url: `${SERVER_URL}/api/v0/users`,
+            'http.url': `${SERVER_URL}/api/v0/users?id=1`,
+            'http.target': '/api/v0/users?id=1',
+            'http.flavor': '1.1',
+            'http.host': expect.stringMatching(/localhost:\d+$/),
+            'http.method': 'GET',
+            'http.query': 'id=1',
+            'http.response.status_code': 200,
+            'http.response_content_length_uncompressed': 0,
+            'http.status_code': 200,
+            'http.status_text': 'OK',
+            'net.peer.ip': '::1',
+            'net.peer.name': 'localhost',
+            'net.peer.port': expect.any(Number),
+            'net.transport': 'ip_tcp',
+            'otel.kind': 'CLIENT',
+            'sentry.op': 'http.client',
+            'sentry.origin': 'auto.http.otel.http',
           },
-        })
-        .start(closeTestServer);
-    });
+          description: `GET ${SERVER_URL}/api/v0/users`,
+          op: 'http.client',
+          origin: 'auto.http.otel.http',
+          status: 'ok',
+          parent_span_id: txn.contexts?.trace?.span_id,
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: txn.contexts?.trace?.trace_id,
+        });
+      },
+    })
+    .start()
+    .completed();
+
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 import { createTestServer } from '../../../utils/server';
 
@@ -6,15 +7,14 @@ describe('httpIntegration', () => {
     cleanupChildProcesses();
   });
 
-  test('allows to pass instrumentation options to integration', done => {
+  test('allows to pass instrumentation options to integration', async () => {
     // response shape seems different on Node 14, so we skip this there
     const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
     if (nodeMajorVersion <= 14) {
-      done();
       return;
     }
 
-    createRunner(__dirname, 'server.js')
+    const runner = createRunner(__dirname, 'server.js')
       .expect({
         transaction: {
           contexts: {
@@ -50,12 +50,13 @@ describe('httpIntegration', () => {
           },
         },
       })
-      .start(done)
-      .makeRequest('get', '/test');
+      .start();
+    runner.makeRequest('get', '/test');
+    await runner.completed();
   });
 
-  test('allows to pass experimental config through to integration', done => {
-    createRunner(__dirname, 'server-experimental.js')
+  test('allows to pass experimental config through to integration', async () => {
+    const runner = createRunner(__dirname, 'server-experimental.js')
       .expect({
         transaction: {
           contexts: {
@@ -73,12 +74,13 @@ describe('httpIntegration', () => {
           },
         },
       })
-      .start(done)
-      .makeRequest('get', '/test');
+      .start();
+    runner.makeRequest('get', '/test');
+    await runner.completed();
   });
 
   describe("doesn't create a root span for incoming requests ignored via `ignoreIncomingRequests`", () => {
-    test('via the url param', done => {
+    test('via the url param', async () => {
       const runner = createRunner(__dirname, 'server-ignoreIncomingRequests.js')
         .expect({
           transaction: {
@@ -97,13 +99,14 @@ describe('httpIntegration', () => {
             transaction: 'GET /test',
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('get', '/liveness'); // should be ignored
       runner.makeRequest('get', '/test');
+      await runner.completed();
     });
 
-    test('via the request param', done => {
+    test('via the request param', async () => {
       const runner = createRunner(__dirname, 'server-ignoreIncomingRequests.js')
         .expect({
           transaction: {
@@ -122,64 +125,68 @@ describe('httpIntegration', () => {
             transaction: 'GET /test',
           },
         })
-        .start(done);
+        .start();
 
       runner.makeRequest('post', '/readiness'); // should be ignored
       runner.makeRequest('get', '/test');
+      await runner.completed();
     });
   });
 
   describe("doesn't create child spans or breadcrumbs for outgoing requests ignored via `ignoreOutgoingRequests`", () => {
-    test('via the url param', done => {
-      createTestServer(done)
+    test('via the url param', async () => {
+      const [SERVER_URL, closeTestServer] = await createTestServer()
         .get('/blockUrl', () => {}, 200)
         .get('/pass', () => {}, 200)
-        .start()
-        .then(([SERVER_URL, closeTestServer]) => {
-          createRunner(__dirname, 'server-ignoreOutgoingRequests.js')
-            .withEnv({ SERVER_URL })
-            .expect({
-              transaction: event => {
-                expect(event.transaction).toBe('GET /testUrl');
+        .start();
 
-                const requestSpans = event.spans?.filter(span => span.op === 'http.client');
-                expect(requestSpans).toHaveLength(1);
-                expect(requestSpans![0]?.description).toBe(`GET ${SERVER_URL}/pass`);
+      const runner = createRunner(__dirname, 'server-ignoreOutgoingRequests.js')
+        .withEnv({ SERVER_URL })
+        .expect({
+          transaction: event => {
+            expect(event.transaction).toBe('GET /testUrl');
 
-                const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
-                expect(breadcrumbs).toHaveLength(1);
-                expect(breadcrumbs![0]?.data?.url).toEqual(`${SERVER_URL}/pass`);
-              },
-            })
-            .start(closeTestServer)
-            .makeRequest('get', '/testUrl');
-        });
+            const requestSpans = event.spans?.filter(span => span.op === 'http.client');
+            expect(requestSpans).toHaveLength(1);
+            expect(requestSpans![0]?.description).toBe(`GET ${SERVER_URL}/pass`);
+
+            const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
+            expect(breadcrumbs).toHaveLength(1);
+            expect(breadcrumbs![0]?.data?.url).toEqual(`${SERVER_URL}/pass`);
+          },
+        })
+        .start(closeTestServer);
+      runner.makeRequest('get', '/testUrl');
+      await runner.completed();
+      closeTestServer();
     });
 
-    test('via the request param', done => {
-      createTestServer(done)
+    test('via the request param', async () => {
+      const [SERVER_URL, closeTestServer] = await createTestServer()
         .get('/blockUrl', () => {}, 200)
         .get('/pass', () => {}, 200)
-        .start()
-        .then(([SERVER_URL, closeTestServer]) => {
-          createRunner(__dirname, 'server-ignoreOutgoingRequests.js')
-            .withEnv({ SERVER_URL })
-            .expect({
-              transaction: event => {
-                expect(event.transaction).toBe('GET /testRequest');
+        .start();
 
-                const requestSpans = event.spans?.filter(span => span.op === 'http.client');
-                expect(requestSpans).toHaveLength(1);
-                expect(requestSpans![0]?.description).toBe(`GET ${SERVER_URL}/pass`);
+      const runner = createRunner(__dirname, 'server-ignoreOutgoingRequests.js')
+        .withEnv({ SERVER_URL })
+        .expect({
+          transaction: event => {
+            expect(event.transaction).toBe('GET /testRequest');
 
-                const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
-                expect(breadcrumbs).toHaveLength(1);
-                expect(breadcrumbs![0]?.data?.url).toEqual(`${SERVER_URL}/pass`);
-              },
-            })
-            .start(closeTestServer)
-            .makeRequest('get', '/testRequest');
-        });
+            const requestSpans = event.spans?.filter(span => span.op === 'http.client');
+            expect(requestSpans).toHaveLength(1);
+            expect(requestSpans![0]?.description).toBe(`GET ${SERVER_URL}/pass`);
+
+            const breadcrumbs = event.breadcrumbs?.filter(b => b.category === 'http');
+            expect(breadcrumbs).toHaveLength(1);
+            expect(breadcrumbs![0]?.data?.url).toEqual(`${SERVER_URL}/pass`);
+          },
+        })
+        .start();
+      runner.makeRequest('get', '/testRequest');
+
+      await runner.completed();
+      closeTestServer();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('kafkajs', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
@@ -1,15 +1,16 @@
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(60_000);
+vi.setConfig({ testTimeout: 60_000 });
 
 describe('kafkajs', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  test('traces producers and consumers', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('traces producers and consumers', async () => {
+    await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({
         workingDirectory: [__dirname],
         readyMatches: ['9092'],
@@ -50,6 +51,7 @@ describe('kafkajs', () => {
           },
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
@@ -1,15 +1,12 @@
 import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-// When running docker compose, we need a larger timeout, as this takes some time...
-vi.setConfig({ testTimeout: 60_000 });
-
 describe('kafkajs', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  test('traces producers and consumers', async () => {
+  test('traces producers and consumers', { timeout: 60_000 }, async () => {
     await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({
         workingDirectory: [__dirname],

--- a/dev-packages/node-integration-tests/suites/tracing/knex/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, test, vi } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
-vi.setConfig({ testTimeout: 90_000 });
-
 describe('knex auto instrumentation', () => {
   // Update this if another knex version is installed
   const KNEX_VERSION = '2.5.1';
 
-  test('should auto-instrument `knex` package when using `pg` client', async () => {
+  test('should auto-instrument `knex` package when using `pg` client', { timeout: 60_000 }, async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -67,7 +65,7 @@ describe('knex auto instrumentation', () => {
       .completed();
   });
 
-  test('should auto-instrument `knex` package when using `mysql2` client', async () => {
+  test('should auto-instrument `knex` package when using `mysql2` client', { timeout: 60_000 }, async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([

--- a/dev-packages/node-integration-tests/suites/tracing/knex/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
 describe('knex auto instrumentation', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/knex/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/test.ts
@@ -1,13 +1,13 @@
+import { describe, expect, test, vi } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
-// When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(90000);
+vi.setConfig({ testTimeout: 90_000 });
 
 describe('knex auto instrumentation', () => {
   // Update this if another knex version is installed
   const KNEX_VERSION = '2.5.1';
 
-  test('should auto-instrument `knex` package when using `pg` client', done => {
+  test('should auto-instrument `knex` package when using `pg` client', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -60,13 +60,14 @@ describe('knex auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-withPostgres.js')
+    await createRunner(__dirname, 'scenario-withPostgres.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should auto-instrument `knex` package when using `mysql2` client', done => {
+  test('should auto-instrument `knex` package when using `mysql2` client', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -121,9 +122,10 @@ describe('knex auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-withMysql2.js')
+    await createRunner(__dirname, 'scenario-withMysql2.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port: 3306'] })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/linking/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/test.ts
@@ -1,10 +1,11 @@
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
 describe('span links', () => {
-  test('should link spans by adding "links" to span options', done => {
+  test('should link spans by adding "links" to span options', async () => {
     let span1_traceId: string, span1_spanId: string;
 
-    createRunner(__dirname, 'scenario-span-options.ts')
+    await createRunner(__dirname, 'scenario-span-options.ts')
       .expect({
         transaction: event => {
           expect(event.transaction).toBe('parent1');
@@ -28,13 +29,14 @@ describe('span links', () => {
           ]);
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should link spans with addLink() in trace context', done => {
+  test('should link spans with addLink() in trace context', async () => {
     let span1_traceId: string, span1_spanId: string;
 
-    createRunner(__dirname, 'scenario-addLink.ts')
+    await createRunner(__dirname, 'scenario-addLink.ts')
       .expect({
         transaction: event => {
           expect(event.transaction).toBe('span1');
@@ -60,13 +62,14 @@ describe('span links', () => {
           ]);
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should link spans with addLinks() in trace context', done => {
+  test('should link spans with addLinks() in trace context', async () => {
     let span1_traceId: string, span1_spanId: string, span2_traceId: string, span2_spanId: string;
 
-    createRunner(__dirname, 'scenario-addLinks.ts')
+    await createRunner(__dirname, 'scenario-addLinks.ts')
       .expect({
         transaction: event => {
           expect(event.transaction).toBe('span1');
@@ -107,11 +110,12 @@ describe('span links', () => {
           ]);
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should link spans with addLink() in nested startSpan() calls', done => {
-    createRunner(__dirname, 'scenario-addLink-nested.ts')
+  test('should link spans with addLink() in nested startSpan() calls', async () => {
+    await createRunner(__dirname, 'scenario-addLink-nested.ts')
       .expect({
         transaction: event => {
           expect(event.transaction).toBe('parent1');
@@ -146,11 +150,12 @@ describe('span links', () => {
           ]);
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should link spans with addLinks() in nested startSpan() calls', done => {
-    createRunner(__dirname, 'scenario-addLinks-nested.ts')
+  test('should link spans with addLinks() in nested startSpan() calls', async () => {
+    await createRunner(__dirname, 'scenario-addLinks-nested.ts')
       .expect({
         transaction: event => {
           expect(event.transaction).toBe('parent1');
@@ -182,6 +187,7 @@ describe('span links', () => {
           ]);
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/lru-memoizer/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/lru-memoizer/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('lru-memoizer', () => {
@@ -5,8 +6,8 @@ describe('lru-memoizer', () => {
     cleanupChildProcesses();
   });
 
-  test('keeps outer context inside the memoized inner functions', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('keeps outer context inside the memoized inner functions', async () => {
+    await createRunner(__dirname, 'scenario.js')
       // We expect only one transaction and nothing else.
       // A failed test will result in an error event being sent to Sentry.
       // Which will fail this suite.
@@ -24,6 +25,7 @@ describe('lru-memoizer', () => {
           },
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/maxSpans/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/maxSpans/test.ts
@@ -1,18 +1,20 @@
 import type { SpanJSON } from '@sentry/core';
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
-test('it limits spans to 1000', done => {
+test('it limits spans to 1000', async () => {
   const expectedSpans: SpanJSON[] = [];
   for (let i = 0; i < 1000; i++) {
     expectedSpans.push(expect.objectContaining({ description: `child ${i}` }));
   }
 
-  createRunner(__dirname, 'scenario.ts')
+  await createRunner(__dirname, 'scenario.ts')
     .expect({
       transaction: {
         transaction: 'parent',
         spans: expectedSpans,
       },
     })
-    .start(done);
+    .start()
+    .completed();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('errors in TwP mode have same trace in trace context and getTraceData()', () => {
@@ -6,8 +7,8 @@ describe('errors in TwP mode have same trace in trace context and getTraceData()
   });
 
   // In a request handler, the spanId is consistent inside of the request
-  test('in incoming request', done => {
-    createRunner(__dirname, 'server.js')
+  test('in incoming request', async () => {
+    const runner = createRunner(__dirname, 'server.js')
       .expect({
         event: event => {
           const { contexts } = event;
@@ -27,13 +28,14 @@ describe('errors in TwP mode have same trace in trace context and getTraceData()
           expect(traceData.metaTags).not.toContain('sentry-sampled=');
         },
       })
-      .start(done)
-      .makeRequest('get', '/test');
+      .start();
+    runner.makeRequest('get', '/test');
+    await runner.completed();
   });
 
   // Outside of a request handler, the spanId is random
-  test('outside of a request handler', done => {
-    createRunner(__dirname, 'no-server.js')
+  test('outside of a request handler', async () => {
+    await createRunner(__dirname, 'no-server.js')
       .expect({
         event: event => {
           const { contexts } = event;
@@ -59,6 +61,7 @@ describe('errors in TwP mode have same trace in trace context and getTraceData()
           expect(traceData.metaTags).not.toContain('sentry-sampled=');
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('getTraceMetaTags', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('getTraceMetaTags', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb/test.ts
@@ -1,5 +1,6 @@
 import { MongoMemoryServer } from 'mongodb-memory-server-global';
 
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('MongoDB experimental Test', () => {
@@ -170,7 +171,7 @@ describe('MongoDB experimental Test', () => {
     ],
   };
 
-  test('CJS - should auto-instrument `mongodb` package.', done => {
-    createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+  test('CJS - should auto-instrument `mongodb` package.', async () => {
+    await createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose/test.ts
@@ -1,5 +1,6 @@
 import { MongoMemoryServer } from 'mongodb-memory-server-global';
 
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('Mongoose experimental Test', () => {
@@ -45,7 +46,7 @@ describe('Mongoose experimental Test', () => {
     ]),
   };
 
-  test('CJS - should auto-instrument `mongoose` package.', done => {
-    createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+  test('CJS - should auto-instrument `mongoose` package.', async () => {
+    await createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('mysql auto instrumentation', () => {
@@ -5,7 +6,7 @@ describe('mysql auto instrumentation', () => {
     cleanupChildProcesses();
   });
 
-  test('should auto-instrument `mysql` package when using connection.connect()', done => {
+  test('should auto-instrument `mysql` package when using connection.connect()', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -32,10 +33,13 @@ describe('mysql auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-withConnect.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+    await createRunner(__dirname, 'scenario-withConnect.js')
+      .expect({ transaction: EXPECTED_TRANSACTION })
+      .start()
+      .completed();
   });
 
-  test('should auto-instrument `mysql` package when using query without callback', done => {
+  test('should auto-instrument `mysql` package when using query without callback', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -62,10 +66,13 @@ describe('mysql auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-withoutCallback.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+    await createRunner(__dirname, 'scenario-withoutCallback.js')
+      .expect({ transaction: EXPECTED_TRANSACTION })
+      .start()
+      .completed();
   });
 
-  test('should auto-instrument `mysql` package without connection.connect()', done => {
+  test('should auto-instrument `mysql` package without connection.connect()', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -92,6 +99,9 @@ describe('mysql auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-withoutConnect.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+    await createRunner(__dirname, 'scenario-withoutConnect.js')
+      .expect({ transaction: EXPECTED_TRANSACTION })
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2/test.ts
@@ -1,15 +1,12 @@
 import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-// When running docker compose, we need a larger timeout, as this takes some time...
-vi.setConfig({ testTimeout: 75_000 });
-
 describe('mysql2 auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  test('should auto-instrument `mysql` package without connection.connect()', async () => {
+  test('should auto-instrument `mysql` package without connection.connect()', { timeout: 75_000 }, async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2/test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('mysql2 auto instrumentation', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2/test.ts
@@ -1,14 +1,15 @@
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(75000);
+vi.setConfig({ testTimeout: 75_000 });
 
 describe('mysql2 auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  test('should auto-instrument `mysql` package without connection.connect()', done => {
+  test('should auto-instrument `mysql` package without connection.connect()', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -35,9 +36,10 @@ describe('mysql2 auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario.js')
+    await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port: 3306'] })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/test.ts
@@ -1,11 +1,8 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
-// When running docker compose, we need a larger timeout, as this takes some time...
-vi.setConfig({ testTimeout: 575 });
-
 describe('postgres auto instrumentation', () => {
-  test('should auto-instrument `pg` package', async () => {
+  test('should auto-instrument `pg` package', { timeout: 60_000 }, async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/test.ts
@@ -1,10 +1,11 @@
+import { describe, expect, test, vi } from 'vitest';
 import { createRunner } from '../../../utils/runner';
 
 // When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(75000);
+vi.setConfig({ testTimeout: 575 });
 
 describe('postgres auto instrumentation', () => {
-  test('should auto-instrument `pg` package', done => {
+  test('should auto-instrument `pg` package', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -48,9 +49,10 @@ describe('postgres auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario.js')
+    await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -1,15 +1,12 @@
-import { afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
-
-// When running docker compose, we need a larger timeout, as this takes some time...
-vi.setConfig({ testTimeout: 75_000 });
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
 describe('Prisma ORM v5 Tests', () => {
-  test('CJS - should instrument PostgreSQL queries from Prisma ORM', async () => {
+  test('CJS - should instrument PostgreSQL queries from Prisma ORM', { timeout: 75_000 }, async () => {
     await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({
         workingDirectory: [__dirname],

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -1,15 +1,16 @@
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(75000);
+vi.setConfig({ testTimeout: 75_000 });
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
 describe('Prisma ORM v5 Tests', () => {
-  test('CJS - should instrument PostgreSQL queries from Prisma ORM', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('CJS - should instrument PostgreSQL queries from Prisma ORM', async () => {
+    await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({
         workingDirectory: [__dirname],
         readyMatches: ['port 5432'],
@@ -76,6 +77,7 @@ describe('Prisma ORM v5 Tests', () => {
           );
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -2,15 +2,12 @@ import type { SpanJSON } from '@sentry/core';
 import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-// When running docker compose, we need a larger timeout, as this takes some time...
-vi.setConfig({ testTimeout: 75_000 });
-
 afterAll(() => {
   cleanupChildProcesses();
 });
 
 describe('Prisma ORM v6 Tests', () => {
-  test('CJS - should instrument PostgreSQL queries from Prisma ORM', async () => {
+  test('CJS - should instrument PostgreSQL queries from Prisma ORM', { timeout: 75_000 }, async () => {
     await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({
         workingDirectory: [__dirname],

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -1,5 +1,5 @@
 import type { SpanJSON } from '@sentry/core';
-import { afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 afterAll(() => {

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -1,16 +1,17 @@
 import type { SpanJSON } from '@sentry/core';
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(75000);
+vi.setConfig({ testTimeout: 75_000 });
 
 afterAll(() => {
   cleanupChildProcesses();
 });
 
 describe('Prisma ORM v6 Tests', () => {
-  test('CJS - should instrument PostgreSQL queries from Prisma ORM', done => {
-    createRunner(__dirname, 'scenario.js')
+  test('CJS - should instrument PostgreSQL queries from Prisma ORM', async () => {
+    await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({
         workingDirectory: [__dirname],
         readyMatches: ['port 5432'],
@@ -92,6 +93,7 @@ describe('Prisma ORM v6 Tests', () => {
           });
         },
       })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/test.ts
@@ -1,15 +1,12 @@
-import { afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
-
-// When running docker compose, we need a larger timeout, as this takes some time...
-vi.setConfig({ testTimeout: 90_000 });
 
 describe('redis cache auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  test('should not add cache spans when key is not prefixed', async () => {
+  test('should not add cache spans when key is not prefixed', { timeout: 60_000 }, async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Span',
       spans: expect.arrayContaining([
@@ -47,7 +44,7 @@ describe('redis cache auto instrumentation', () => {
       .completed();
   });
 
-  test('should create cache spans for prefixed keys (ioredis)', async () => {
+  test('should create cache spans for prefixed keys (ioredis)', { timeout: 60_000 }, async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Span',
       spans: expect.arrayContaining([

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/test.ts
@@ -1,14 +1,15 @@
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(90000);
+vi.setConfig({ testTimeout: 90_000 });
 
 describe('redis cache auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  test('should not add cache spans when key is not prefixed', done => {
+  test('should not add cache spans when key is not prefixed', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Span',
       spans: expect.arrayContaining([
@@ -39,13 +40,14 @@ describe('redis cache auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-ioredis.js')
+    await createRunner(__dirname, 'scenario-ioredis.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port=6379'] })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should create cache spans for prefixed keys (ioredis)', done => {
+  test('should create cache spans for prefixed keys (ioredis)', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Span',
       spans: expect.arrayContaining([
@@ -137,13 +139,14 @@ describe('redis cache auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-ioredis.js')
+    await createRunner(__dirname, 'scenario-ioredis.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port=6379'] })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 
-  test('should create cache spans for prefixed keys (redis-4)', done => {
+  test('should create cache spans for prefixed keys (redis-4)', async () => {
     const EXPECTED_REDIS_CONNECT = {
       transaction: 'redis-connect',
     };
@@ -227,10 +230,11 @@ describe('redis cache auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-redis-4.js')
+    await createRunner(__dirname, 'scenario-redis-4.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port=6379'] })
       .expect({ transaction: EXPECTED_REDIS_CONNECT })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/redis/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/redis/test.ts
@@ -1,14 +1,15 @@
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 // When running docker compose, we need a larger timeout, as this takes some time...
-jest.setTimeout(75000);
+vi.setConfig({ testTimeout: 75_000 });
 
 describe('redis auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  test('should auto-instrument `ioredis` package when using redis.set() and redis.get()', done => {
+  test('should auto-instrument `ioredis` package when using redis.set() and redis.get()', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Span',
       spans: expect.arrayContaining([
@@ -41,9 +42,10 @@ describe('redis auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario-ioredis.js')
+    await createRunner(__dirname, 'scenario-ioredis.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port=6379'] })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/redis/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/redis/test.ts
@@ -1,15 +1,12 @@
-import { afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test} from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
-
-// When running docker compose, we need a larger timeout, as this takes some time...
-vi.setConfig({ testTimeout: 75_000 });
 
 describe('redis auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  test('should auto-instrument `ioredis` package when using redis.set() and redis.get()', async () => {
+  test('should auto-instrument `ioredis` package when using redis.set() and redis.get()', { timeout: 75_000 }, async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Span',
       spans: expect.arrayContaining([

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/test.ts
@@ -1,77 +1,78 @@
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
 describe('outgoing fetch', () => {
-  test('outgoing fetch requests create breadcrumbs', done => {
-    createTestServer(done)
-      .start()
-      .then(([SERVER_URL, closeTestServer]) => {
-        createRunner(__dirname, 'scenario.ts')
-          .withEnv({ SERVER_URL })
-          .ensureNoErrorOutput()
-          .expect({
-            event: {
-              breadcrumbs: [
-                {
-                  message: 'manual breadcrumb',
-                  timestamp: expect.any(Number),
-                },
-                {
-                  category: 'http',
-                  data: {
-                    'http.method': 'GET',
-                    url: `${SERVER_URL}/api/v0`,
-                    status_code: 404,
-                    ADDED_PATH: '/api/v0',
-                  },
-                  timestamp: expect.any(Number),
-                  type: 'http',
-                },
-                {
-                  category: 'http',
-                  data: {
-                    'http.method': 'GET',
-                    url: `${SERVER_URL}/api/v1`,
-                    status_code: 404,
-                    ADDED_PATH: '/api/v1',
-                  },
-                  timestamp: expect.any(Number),
-                  type: 'http',
-                },
-                {
-                  category: 'http',
-                  data: {
-                    'http.method': 'GET',
-                    url: `${SERVER_URL}/api/v2`,
-                    status_code: 404,
-                    ADDED_PATH: '/api/v2',
-                  },
-                  timestamp: expect.any(Number),
-                  type: 'http',
-                },
-                {
-                  category: 'http',
-                  data: {
-                    'http.method': 'GET',
-                    url: `${SERVER_URL}/api/v3`,
-                    status_code: 404,
-                    ADDED_PATH: '/api/v3',
-                  },
-                  timestamp: expect.any(Number),
-                  type: 'http',
-                },
-              ],
-              exception: {
-                values: [
-                  {
-                    type: 'Error',
-                    value: 'foo',
-                  },
-                ],
-              },
+  test('outgoing fetch requests create breadcrumbs', async () => {
+    const [SERVER_URL, closeTestServer] = await createTestServer().start();
+
+    await createRunner(__dirname, 'scenario.ts')
+      .withEnv({ SERVER_URL })
+      .ensureNoErrorOutput()
+      .expect({
+        event: {
+          breadcrumbs: [
+            {
+              message: 'manual breadcrumb',
+              timestamp: expect.any(Number),
             },
-          })
-          .start(closeTestServer);
-      });
+            {
+              category: 'http',
+              data: {
+                'http.method': 'GET',
+                url: `${SERVER_URL}/api/v0`,
+                status_code: 404,
+                ADDED_PATH: '/api/v0',
+              },
+              timestamp: expect.any(Number),
+              type: 'http',
+            },
+            {
+              category: 'http',
+              data: {
+                'http.method': 'GET',
+                url: `${SERVER_URL}/api/v1`,
+                status_code: 404,
+                ADDED_PATH: '/api/v1',
+              },
+              timestamp: expect.any(Number),
+              type: 'http',
+            },
+            {
+              category: 'http',
+              data: {
+                'http.method': 'GET',
+                url: `${SERVER_URL}/api/v2`,
+                status_code: 404,
+                ADDED_PATH: '/api/v2',
+              },
+              timestamp: expect.any(Number),
+              type: 'http',
+            },
+            {
+              category: 'http',
+              data: {
+                'http.method': 'GET',
+                url: `${SERVER_URL}/api/v3`,
+                status_code: 404,
+                ADDED_PATH: '/api/v3',
+              },
+              timestamp: expect.any(Number),
+              type: 'http',
+            },
+          ],
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'foo',
+              },
+            ],
+          },
+        },
+      })
+      .start()
+      .completed();
+    closeTestServer();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing-no-spans/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing-no-spans/test.ts
@@ -1,11 +1,12 @@
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
 describe('outgoing fetch', () => {
-  test('outgoing fetch requests are correctly instrumented with tracing & spans are disabled', done => {
+  test('outgoing fetch requests are correctly instrumented with tracing & spans are disabled', async () => {
     expect.assertions(11);
 
-    createTestServer(done)
+    const [SERVER_URL, closeTestServer] = await createTestServer()
       .get('/api/v0', headers => {
         expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})$/));
         expect(headers['sentry-trace']).not.toEqual('00000000000000000000000000000000-0000000000000000');
@@ -24,24 +25,25 @@ describe('outgoing fetch', () => {
         expect(headers['baggage']).toBeUndefined();
         expect(headers['sentry-trace']).toBeUndefined();
       })
-      .start()
-      .then(([SERVER_URL, closeTestServer]) => {
-        createRunner(__dirname, 'scenario.ts')
-          .withEnv({ SERVER_URL })
-          .ensureNoErrorOutput()
-          .expect({
-            event: {
-              exception: {
-                values: [
-                  {
-                    type: 'Error',
-                    value: 'foo',
-                  },
-                ],
+      .start();
+
+    await createRunner(__dirname, 'scenario.ts')
+      .withEnv({ SERVER_URL })
+      .ensureNoErrorOutput()
+      .expect({
+        event: {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'foo',
               },
-            },
-          })
-          .start(closeTestServer);
-      });
+            ],
+          },
+        },
+      })
+      .start()
+      .completed();
+    closeTestServer;
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing/test.ts
@@ -1,11 +1,12 @@
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
 describe('outgoing fetch', () => {
-  test('outgoing fetch requests are correctly instrumented with tracing disabled', done => {
+  test('outgoing fetch requests are correctly instrumented with tracing disabled', async () => {
     expect.assertions(11);
 
-    createTestServer(done)
+    const [SERVER_URL, closeTestServer] = await createTestServer()
       .get('/api/v0', headers => {
         expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})$/));
         expect(headers['sentry-trace']).not.toEqual('00000000000000000000000000000000-0000000000000000');
@@ -24,24 +25,25 @@ describe('outgoing fetch', () => {
         expect(headers['baggage']).toBeUndefined();
         expect(headers['sentry-trace']).toBeUndefined();
       })
-      .start()
-      .then(([SERVER_URL, closeTestServer]) => {
-        createRunner(__dirname, 'scenario.ts')
-          .withEnv({ SERVER_URL })
-          .ensureNoErrorOutput()
-          .expect({
-            event: {
-              exception: {
-                values: [
-                  {
-                    type: 'Error',
-                    value: 'foo',
-                  },
-                ],
+      .start();
+
+    await createRunner(__dirname, 'scenario.ts')
+      .withEnv({ SERVER_URL })
+      .ensureNoErrorOutput()
+      .expect({
+        event: {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'foo',
               },
-            },
-          })
-          .start(closeTestServer);
-      });
+            ],
+          },
+        },
+      })
+      .start()
+      .completed();
+    closeTestServer();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-sampled-no-active-span/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-sampled-no-active-span/test.ts
@@ -1,11 +1,12 @@
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
 describe('outgoing fetch', () => {
-  test('outgoing sampled fetch requests without active span are correctly instrumented', done => {
+  test('outgoing sampled fetch requests without active span are correctly instrumented', async () => {
     expect.assertions(11);
 
-    createTestServer(done)
+    const [SERVER_URL, closeTestServer] = await createTestServer()
       .get('/api/v0', headers => {
         expect(headers['baggage']).toEqual(expect.any(String));
         expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})$/));
@@ -24,23 +25,24 @@ describe('outgoing fetch', () => {
         expect(headers['baggage']).toBeUndefined();
         expect(headers['sentry-trace']).toBeUndefined();
       })
-      .start()
-      .then(([SERVER_URL, closeTestServer]) => {
-        createRunner(__dirname, 'scenario.ts')
-          .withEnv({ SERVER_URL })
-          .expect({
-            event: {
-              exception: {
-                values: [
-                  {
-                    type: 'Error',
-                    value: 'foo',
-                  },
-                ],
+      .start();
+
+    await createRunner(__dirname, 'scenario.ts')
+      .withEnv({ SERVER_URL })
+      .expect({
+        event: {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'foo',
               },
-            },
-          })
-          .start(closeTestServer);
-      });
+            ],
+          },
+        },
+      })
+      .start()
+      .completed();
+    closeTestServer();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/test.ts
@@ -1,75 +1,76 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('outgoing http requests create breadcrumbs', done => {
-  createTestServer(done)
-    .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .ensureNoErrorOutput()
-        .expect({
-          event: {
-            breadcrumbs: [
-              {
-                message: 'manual breadcrumb',
-                timestamp: expect.any(Number),
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v0`,
-                  status_code: 404,
-                  ADDED_PATH: '/api/v0',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v1`,
-                  status_code: 404,
-                  ADDED_PATH: '/api/v1',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v2`,
-                  status_code: 404,
-                  ADDED_PATH: '/api/v2',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v3`,
-                  status_code: 404,
-                  ADDED_PATH: '/api/v3',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-            ],
-            exception: {
-              values: [
-                {
-                  type: 'Error',
-                  value: 'foo',
-                },
-              ],
-            },
+test('outgoing http requests create breadcrumbs', async () => {
+  const [SERVER_URL, closeTestServer] = await createTestServer().start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .ensureNoErrorOutput()
+    .expect({
+      event: {
+        breadcrumbs: [
+          {
+            message: 'manual breadcrumb',
+            timestamp: expect.any(Number),
           },
-        })
-        .start(closeTestServer);
-    });
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v0`,
+              status_code: 404,
+              ADDED_PATH: '/api/v0',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v1`,
+              status_code: 404,
+              ADDED_PATH: '/api/v1',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v2`,
+              status_code: 404,
+              ADDED_PATH: '/api/v2',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v3`,
+              status_code: 404,
+              ADDED_PATH: '/api/v3',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+        ],
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'foo',
+            },
+          ],
+        },
+      },
+    })
+    .start()
+    .completed();
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/test.ts
@@ -1,10 +1,11 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('outgoing http requests are correctly instrumented with tracing disabled', done => {
+test('outgoing http requests are correctly instrumented with tracing disabled', async () => {
   expect.assertions(11);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', headers => {
       expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})$/));
       expect(headers['sentry-trace']).not.toEqual('00000000000000000000000000000000-0000000000000000');
@@ -23,73 +24,74 @@ test('outgoing http requests are correctly instrumented with tracing disabled', 
       expect(headers['baggage']).toBeUndefined();
       expect(headers['sentry-trace']).toBeUndefined();
     })
-    .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .ensureNoErrorOutput()
-        .expect({
-          event: {
-            exception: {
-              values: [
-                {
-                  type: 'Error',
-                  value: 'foo',
-                },
-              ],
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .ensureNoErrorOutput()
+    .expect({
+      event: {
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'foo',
             },
-            breadcrumbs: [
-              {
-                message: 'manual breadcrumb',
-                timestamp: expect.any(Number),
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v0`,
-                  status_code: 200,
-                  ADDED_PATH: '/api/v0',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v1`,
-                  status_code: 200,
-                  ADDED_PATH: '/api/v1',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v2`,
-                  status_code: 200,
-                  ADDED_PATH: '/api/v2',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v3`,
-                  status_code: 200,
-                  ADDED_PATH: '/api/v3',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-            ],
+          ],
+        },
+        breadcrumbs: [
+          {
+            message: 'manual breadcrumb',
+            timestamp: expect.any(Number),
           },
-        })
-        .start(closeTestServer);
-    });
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v0`,
+              status_code: 200,
+              ADDED_PATH: '/api/v0',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v1`,
+              status_code: 200,
+              ADDED_PATH: '/api/v1',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v2`,
+              status_code: 200,
+              ADDED_PATH: '/api/v2',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v3`,
+              status_code: 200,
+              ADDED_PATH: '/api/v3',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+        ],
+      },
+    })
+    .start()
+    .completed();
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-esm/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-esm/test.ts
@@ -1,12 +1,13 @@
 import { join } from 'path';
+import { describe, expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
 describe('outgoing http in ESM', () => {
-  test('outgoing sampled http requests are correctly instrumented in ESM', done => {
+  test('outgoing sampled http requests are correctly instrumented in ESM', async () => {
     expect.assertions(11);
 
-    createTestServer(done)
+    const [SERVER_URL, closeTestServer] = await createTestServer()
       .get('/api/v0', headers => {
         expect(headers['baggage']).toEqual(expect.any(String));
         expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})-1$/));
@@ -25,18 +26,19 @@ describe('outgoing http in ESM', () => {
         expect(headers['baggage']).toBeUndefined();
         expect(headers['sentry-trace']).toBeUndefined();
       })
+      .start();
+
+    const instrumentPath = join(__dirname, 'instrument.mjs');
+    await createRunner(__dirname, 'scenario.mjs')
+      .withFlags('--import', instrumentPath)
+      .withEnv({ SERVER_URL })
+      .expect({
+        transaction: {
+          // we're not too concerned with the actual transaction here since this is tested elsewhere
+        },
+      })
       .start()
-      .then(([SERVER_URL, closeTestServer]) => {
-        const instrumentPath = join(__dirname, 'instrument.mjs');
-        createRunner(__dirname, 'scenario.mjs')
-          .withFlags('--import', instrumentPath)
-          .withEnv({ SERVER_URL })
-          .expect({
-            transaction: {
-              // we're not too concerned with the actual transaction here since this is tested elsewhere
-            },
-          })
-          .start(closeTestServer);
-      });
+      .completed();
+    closeTestServer();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-no-active-span/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-no-active-span/test.ts
@@ -1,10 +1,11 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('outgoing sampled http requests without active span are correctly instrumented', done => {
+test('outgoing sampled http requests without active span are correctly instrumented', async () => {
   expect.assertions(11);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', headers => {
       expect(headers['baggage']).toEqual(expect.any(String));
       expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})$/));
@@ -23,22 +24,23 @@ test('outgoing sampled http requests without active span are correctly instrumen
       expect(headers['baggage']).toBeUndefined();
       expect(headers['sentry-trace']).toBeUndefined();
     })
-    .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .expect({
-          event: {
-            exception: {
-              values: [
-                {
-                  type: 'Error',
-                  value: 'foo',
-                },
-              ],
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .expect({
+      event: {
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'foo',
             },
-          },
-        })
-        .start(closeTestServer);
-    });
+          ],
+        },
+      },
+    })
+    .start()
+    .completed();
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled/test.ts
@@ -1,10 +1,11 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('outgoing sampled http requests are correctly instrumented', done => {
+test('outgoing sampled http requests are correctly instrumented', async () => {
   expect.assertions(11);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', headers => {
       expect(headers['baggage']).toEqual(expect.any(String));
       expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})-1$/));
@@ -23,15 +24,16 @@ test('outgoing sampled http requests are correctly instrumented', done => {
       expect(headers['baggage']).toBeUndefined();
       expect(headers['sentry-trace']).toBeUndefined();
     })
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .expect({
+      transaction: {
+        // we're not too concerned with the actual transaction here since this is tested elsewhere
+      },
+    })
     .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .expect({
-          transaction: {
-            // we're not too concerned with the actual transaction here since this is tested elsewhere
-          },
-        })
-        .start(closeTestServer);
-    });
+    .completed();
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/test.ts
@@ -1,10 +1,11 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('outgoing http requests are correctly instrumented when not sampled', done => {
+test('outgoing http requests are correctly instrumented when not sampled', async () => {
   expect.assertions(11);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', headers => {
       expect(headers['baggage']).toEqual(expect.any(String));
       expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})-0$/));
@@ -23,22 +24,23 @@ test('outgoing http requests are correctly instrumented when not sampled', done 
       expect(headers['baggage']).toBeUndefined();
       expect(headers['sentry-trace']).toBeUndefined();
     })
-    .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .expect({
-          event: {
-            exception: {
-              values: [
-                {
-                  type: 'Error',
-                  value: 'foo',
-                },
-              ],
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .expect({
+      event: {
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'foo',
             },
-          },
-        })
-        .start(closeTestServer);
-    });
+          ],
+        },
+      },
+    })
+    .start()
+    .completed();
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rand-propagation/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rand-propagation/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 describe('sample_rand propagation', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/no-tracing-enabled/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/no-tracing-enabled/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('parentSampleRate propagation with no tracing enabled', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate-0/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate-0/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('parentSampleRate propagation with tracesSampleRate=0', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('parentSampleRate propagation with tracesSampleRate', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampler/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampler/test.ts
@@ -1,3 +1,4 @@
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 describe('parentSampleRate propagation with tracesSampler', () => {

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
@@ -1,6 +1,7 @@
+import { afterAll, describe, expect, test, vi } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-jest.setTimeout(75000);
+vi.setConfig({ testTimeout: 75_000 });
 
 // Tedious version we are testing against only supports Node 18+
 // https://github.com/tediousjs/tedious/blob/8310c455a2cc1cba83c1ca3c16677da4f83e12a9/package.json#L38
@@ -9,7 +10,7 @@ describe('tedious auto instrumentation', () => {
     cleanupChildProcesses();
   });
 
-  test('should auto-instrument `tedious` package', done => {
+  test('should auto-instrument `tedious` package', async () => {
     const EXPECTED_TRANSACTION = {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([
@@ -44,9 +45,10 @@ describe('tedious auto instrumentation', () => {
       ]),
     };
 
-    createRunner(__dirname, 'scenario.js')
+    await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['1433'] })
       .expect({ transaction: EXPECTED_TRANSACTION })
-      .start(done);
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
@@ -1,11 +1,7 @@
-import { afterAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-vi.setConfig({ testTimeout: 75_000 });
-
-// Tedious version we are testing against only supports Node 18+
-// https://github.com/tediousjs/tedious/blob/8310c455a2cc1cba83c1ca3c16677da4f83e12a9/package.json#L38
-describe('tedious auto instrumentation', () => {
+describe('tedious auto instrumentation', {timeout: 75_000}, () => {
   afterAll(() => {
     cleanupChildProcesses();
   });

--- a/dev-packages/node-integration-tests/tsconfig.test.json
+++ b/dev-packages/node-integration-tests/tsconfig.test.json
@@ -1,14 +1,14 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["suites/**/*.ts"],
+  "include": ["suites/**/*.ts", "vitest.config.ts"],
 
   "compilerOptions": {
     // Although this seems wrong to include `DOM` here, it's necessary to make
     // global fetch available in tests in lower Node versions.
     "lib": ["DOM", "ES2018"],
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node", "jest"]
+    "types": ["node"]
 
     // other package-specific, test-specific options
   }

--- a/dev-packages/node-integration-tests/tsconfig.test.json
+++ b/dev-packages/node-integration-tests/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["suites/**/*.ts", "vitest.config.ts"],
+  "include": ["suites/**/*.ts", "vite.config.ts"],
 
   "compilerOptions": {
     // Although this seems wrong to include `DOM` here, it's necessary to make

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -276,7 +276,7 @@ export function createRunner(...paths: string[]) {
 
             try {
               if (!expected) {
-                throw new Error(`No more expected envelope items but we received ${JSON.stringify(header)}`);
+                return;
               }
 
               assertEnvelopeHeader(header, expected);
@@ -294,7 +294,7 @@ export function createRunner(...paths: string[]) {
           // Catch any error or failed assertions and pass them to done to end the test quickly
           try {
             if (!expected) {
-              throw new Error(`No more expected envelope items but we received a '${envelopeItemType}' item`);
+             return;
             }
 
             const expectedType = Object.keys(expected)[0];

--- a/dev-packages/node-integration-tests/utils/server.ts
+++ b/dev-packages/node-integration-tests/utils/server.ts
@@ -42,8 +42,9 @@ type HeaderAssertCallback = (headers: Record<string, string | string[] | undefin
 
 /** Creates a test server that can be used to check headers */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function createTestServer(done: (error?: unknown) => void) {
+export function createTestServer() {
   const gets: Array<[string, HeaderAssertCallback, number]> = [];
+  let error: unknown | undefined;
 
   return {
     get: function (path: string, callback: HeaderAssertCallback, result = 200) {
@@ -58,7 +59,7 @@ export function createTestServer(done: (error?: unknown) => void) {
           try {
             callback(req.headers);
           } catch (e) {
-            done(e);
+            error = e;
           }
 
           res.status(result).send();
@@ -70,9 +71,11 @@ export function createTestServer(done: (error?: unknown) => void) {
           const address = server.address() as AddressInfo;
           resolve([
             `http://localhost:${address.port}`,
-            (error?: unknown) => {
+            () => {
               server.close();
-              done(error);
+              if (error) {
+                throw error;
+              }
             },
           ]);
         });

--- a/dev-packages/node-integration-tests/vite.config.ts
+++ b/dev-packages/node-integration-tests/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import baseConfig from '../../vite/vite.config';
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    maxConcurrency: 4,
+    include: ['./**/test.ts'],
+    testTimeout: 15000,
+  },
+});

--- a/dev-packages/node-integration-tests/vite.config.ts
+++ b/dev-packages/node-integration-tests/vite.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
   ...baseConfig,
   test: {
     ...baseConfig.test,
-    maxConcurrency: 4,
+    isolate: false,
+    coverage: {
+      enabled: false,
+    },
     include: ['./**/test.ts'],
     testTimeout: 15000,
   },


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/11084

Sorry for the huge PR, it was quite unavoidable! Vitest doesn't support the `done` callback that most Node integration tests used with Jest.

This PR:
- Modifies all tests to:
  - Use Vitest imports
  - Use async rather than callback
- Changes test runner and test server to be async 
  - `runner.start(done)` becomes `await runner.start().completed()` 
  - `createTestServer()` close function now throws any errors that occurred