### PR TITLE
chore(lint): Remove `biome-ignore` comments

### DIFF
--- a/dev-packages/e2e-tests/test-applications/generic-ts3.8/index.ts
+++ b/dev-packages/e2e-tests/test-applications/generic-ts3.8/index.ts
@@ -1,10 +1,5 @@
-// biome-ignore lint/nursery/noUnusedImports:
 import * as _SentryReplay from '@sentry-internal/replay';
-// biome-ignore lint/nursery/noUnusedImports: we need to import the SDK to ensure tsc check the types
 import * as _SentryBrowser from '@sentry/browser';
-// biome-ignore lint/nursery/noUnusedImports:
 import * as _SentryCore from '@sentry/core';
-// biome-ignore lint/nursery/noUnusedImports:
 import * as _SentryNode from '@sentry/node';
-// biome-ignore lint/nursery/noUnusedImports:
 import * as _SentryWasm from '@sentry/wasm';

--- a/dev-packages/e2e-tests/test-applications/react-17/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-17/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-17/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-17/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const User = () => {

--- a/dev-packages/e2e-tests/test-applications/react-19/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-19/src/index.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-// biome-ignore lint/nursery/noUnusedImports: <explanation>
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import Index from './pages/Index';

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/LazyLoadedInnerRoute.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/LazyLoadedInnerRoute.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Route, Routes } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const User = () => {

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const User = () => {

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const Index = () => {

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-router-5/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-5/src/index.tsx
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/react';
 import { createBrowserHistory } from 'history';
-// biome-ignore lint/nursery/noUnusedImports: <explanation>
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Route, Router, Switch } from 'react-router-dom';

--- a/dev-packages/e2e-tests/test-applications/react-router-5/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-5/src/pages/Index.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-router-5/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-5/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const User = (params: { id: string }) => {

--- a/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/pages/Index.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const User = () => {

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/SSE.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/SSE.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const fetchSSE = async ({ timeout, abort = false }: { timeout: boolean; abort?: boolean }) => {

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const User = () => {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router';
 

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/pages/SSE.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/pages/SSE.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const fetchSSE = async ({ timeout, abort = false }: { timeout: boolean; abort?: boolean }) => {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const User = () => {

--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/src/pages/Index.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/src/pages/User.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/src/pages/User.tsx
@@ -1,4 +1,3 @@
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 
 const User = () => {

--- a/dev-packages/size-limit-gh-action/utils/SizeLimitFormatter.mjs
+++ b/dev-packages/size-limit-gh-action/utils/SizeLimitFormatter.mjs
@@ -91,7 +91,6 @@ export class SizeLimitFormatter {
 
     return results.reduce((current, result) => {
       return {
-        // biome-ignore lint/performance/noAccumulatingSpread: <explanation>
         ...current,
         [result.name]: {
           name: result.name,

--- a/packages/browser/test/loader.js
+++ b/packages/browser/test/loader.js
@@ -1,4 +1,3 @@
-// biome-ignore format: Disabled due to trailing comma not working in IE10/11
 (function(
   _window,
   _document,

--- a/packages/feedback/src/modal/components/Dialog.tsx
+++ b/packages/feedback/src/modal/components/Dialog.tsx
@@ -1,5 +1,4 @@
 import type { FeedbackFormData, FeedbackInternalOptions } from '@sentry/core';
-// biome-ignore lint/nursery/noUnusedImports: reason
 import { Fragment, h } from 'preact'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import type { VNode } from 'preact';
 import { useCallback, useMemo, useState } from 'preact/hooks';

--- a/packages/feedback/src/modal/components/DialogHeader.tsx
+++ b/packages/feedback/src/modal/components/DialogHeader.tsx
@@ -1,5 +1,4 @@
 import type { FeedbackInternalOptions } from '@sentry/core';
-// biome-ignore lint/nursery/noUnusedImports: reason
 import { h } from 'preact'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import type { VNode } from 'preact';
 import { useMemo } from 'preact/hooks';

--- a/packages/feedback/src/modal/components/Form.tsx
+++ b/packages/feedback/src/modal/components/Form.tsx
@@ -5,7 +5,6 @@ import type {
   FeedbackScreenshotIntegration,
   SendFeedback,
 } from '@sentry/core';
-// biome-ignore lint/nursery/noUnusedImports: reason
 import { h } from 'preact'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import type { JSX, VNode } from 'preact';
 import { useCallback, useState } from 'preact/hooks';

--- a/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
+++ b/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
@@ -1,6 +1,5 @@
 import type { FeedbackInternalOptions, FeedbackModalIntegration } from '@sentry/core';
 import type { ComponentType, VNode, h as hType } from 'preact';
-// biome-ignore lint/nursery/noUnusedImports: reason
 import { h } from 'preact'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import type * as Hooks from 'preact/hooks';
 import { WINDOW } from '../../constants';

--- a/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
+++ b/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
@@ -12,7 +12,6 @@ export type ValueInjectionLoaderOptions = {
 // This regex is shamelessly stolen from: https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/7f984482c73e4284e8b12a08dfedf23b5a82f0af/packages/bundler-plugin-core/src/index.ts#L535-L539
 const SKIP_COMMENT_AND_DIRECTIVE_REGEX =
   // Note: CodeQL complains that this regex potentially has n^2 runtime. This likely won't affect realistic files.
-  // biome-ignore lint/complexity/useRegexLiterals: No user input
   new RegExp('^(?:\\s*|/\\*(?:.|\\r|\\n)*?\\*/|//.*[\\n\\r])*(?:"[^"]*";?|\'[^\']*\';?)?');
 
 /**

--- a/packages/nextjs/src/config/templates/serverComponentWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/serverComponentWrapperTemplate.ts
@@ -4,7 +4,6 @@ import * as Sentry from '@sentry/nextjs';
 // API) we use a shim if it doesn't exist. The logic for this is in the wrapping loader.
 import * as origModule from '__SENTRY_NEXTJS_REQUEST_ASYNC_STORAGE_SHIM__';
 // @ts-expect-error We use `__SENTRY_WRAPPING_TARGET_FILE__` as a placeholder for the path to the file being wrapped.
-// biome-ignore lint/nursery/noUnusedImports: Biome doesn't understand the shim with variable import path
 import * as serverComponentModule from '__SENTRY_WRAPPING_TARGET_FILE__';
 
 import type { RequestAsyncStorage } from './requestAsyncStorageShim';

--- a/packages/react/test/reactrouter-cross-usage.test.tsx
+++ b/packages/react/test/reactrouter-cross-usage.test.tsx
@@ -35,7 +35,6 @@ import {
   wrapUseRoutesV6,
 } from '../src/reactrouterv6';
 
-
 const mockStartBrowserTracingPageLoadSpan = vi.fn();
 const mockStartBrowserTracingNavigationSpan = vi.fn();
 
@@ -75,7 +74,6 @@ vi.mock('@sentry/core', async requireActual => {
     },
   };
 });
-
 
 vi.mock('@sentry/core', async requireActual => {
   const actual = (await requireActual()) as any;

--- a/packages/react/test/reactrouterv3.test.tsx
+++ b/packages/react/test/reactrouterv3.test.tsx
@@ -13,7 +13,6 @@ import {
   setCurrentClient,
 } from '@sentry/core';
 import { act, render } from '@testing-library/react';
-// biome-ignore lint/nursery/noUnusedImports: <explanation>
 import * as React from 'react';
 import { IndexRoute, Route, Router, createMemoryHistory, createRoutes, match } from 'react-router-3';
 import { reactRouterV3BrowserTracingIntegration } from '../src/reactrouterv3';

--- a/packages/react/test/reactrouterv4.test.tsx
+++ b/packages/react/test/reactrouterv4.test.tsx
@@ -13,7 +13,6 @@ import {
 } from '@sentry/core';
 import { act, render } from '@testing-library/react';
 import { createMemoryHistory } from 'history-4';
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Route, Router, Switch, matchPath } from 'react-router-4';
 

--- a/packages/react/test/reactrouterv5.test.tsx
+++ b/packages/react/test/reactrouterv5.test.tsx
@@ -13,7 +13,6 @@ import {
 } from '@sentry/core';
 import { act, render } from '@testing-library/react';
 import { createMemoryHistory } from 'history-4';
-// biome-ignore lint/nursery/noUnusedImports: Need React import for JSX
 import * as React from 'react';
 import { Route, Router, Switch, matchPath } from 'react-router-5';
 


### PR DESCRIPTION
These are no longer required since:
- #15461 