### PR TITLE
fix(sveltekit): Guard `process` check when flushing events

### DIFF
--- a/packages/sveltekit/src/server-common/utils.ts
+++ b/packages/sveltekit/src/server-common/utils.ts
@@ -19,6 +19,10 @@ export function getTracePropagationData(event: RequestEvent): { sentryTrace: str
 
 /** Flush the event queue to ensure that events get sent to Sentry before the response is finished and the lambda ends */
 export async function flushIfServerless(): Promise<void> {
+  if (!process) {
+    return;
+  }
+
   const platformSupportsStreaming = !process.env.LAMBDA_TASK_ROOT && !process.env.VERCEL;
 
   if (!platformSupportsStreaming) {


### PR DESCRIPTION
not sure why but apparently `process` is not always available in CloudFlare pages, even with `compatibility_flags = ["nodejs_compat"]` set. This PR adds a guard to the one place where we access `process.env` in the SvelteKit SDK.

closes #15506 