### PR TITLE
fix(core): Fix `allowUrls` and `denyUrls` for linked and aggregate exceptions

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -47,7 +47,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration'),
     gzip: true,
-    limit: '75.1 KB',
+    limit: '75.2 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - with treeshaking flags',

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -172,13 +172,12 @@ function _getLastValidUrl(frames: StackFrame[] = []): string | null {
 
 function _getEventFilterUrl(event: Event): string | null {
   try {
-    let frames;
-    try {
-      // @ts-expect-error we only care about frames if the whole thing here is defined
-      frames = event.exception.values[0].stacktrace.frames;
-    } catch (e) {
-      // ignore
-    }
+    // If there are linked exceptions or exception aggregates we only want to match against the top frame of the "root" (the main exception)
+    // The root always comes last in linked exceptions
+    const rootException = [...(event.exception?.values ?? []).reverse()]?.find(
+      value => value.mechanism?.parent_id === undefined && value.stacktrace?.frames?.length,
+    );
+    const frames = rootException?.stacktrace?.frames;
     return frames ? _getLastValidUrl(frames) : null;
   } catch (oO) {
     DEBUG_BUILD && logger.error(`Cannot extract url for event ${getEventDescription(event)}`);

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -38,7 +38,6 @@ function createEventFiltersEventProcessor(
       dsn: PUBLIC_DSN,
       ...clientOptions,
       defaultIntegrations: false,
-      // eslint-disable-next-line deprecation/deprecation
       integrations: [integration],
     }),
   );
@@ -707,28 +706,28 @@ describe.each([
     });
 
     it('should apply denyUrls to the "root" error of a linked exception', () => {
-      const eventProcessor = createInboundFiltersEventProcessor({
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['https://main-error.com'],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_LINKED_ERRORS, {})).toBe(null);
     });
 
     it('should apply denyUrls to the "root" error of an aggregate exception', () => {
-      const eventProcessor = createInboundFiltersEventProcessor({
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         denyUrls: ['https://main-error.com'],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_AGGREGATE_ERRORS, {})).toBe(null);
     });
 
     it('should apply allowUrls to the "most root" exception in the event if there are exceptions without stacktrace', () => {
-      const eventProcessor = createInboundFiltersEventProcessor({
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         allowUrls: ['https://some-error-that-is-not-main-error.com'],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_LINKED_ERRORS_WITHOUT_STACKTRACE, {})).toBe(null);
     });
 
     it('should not apply allowUrls to the event when the "root" exception of an aggregate error doesn\'t have a stacktrace', () => {
-      const eventProcessor = createInboundFiltersEventProcessor({
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn, {
         allowUrls: ['https://some-error-that-doesnt-match-anything.com'],
       });
       expect(eventProcessor(EXCEPTION_EVENT_WITH_AGGREGATE_ERRORS_WITHOUT_STACKTRACE, {})).toBe(


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/15513

The allowUrls and denyUrls logic up until now only looked at the first entry in the values field of an error event which is complete bogus for aggregate errors and linked errors because the "root" event in the former is one without parent id and in the latter simply the latest entry in the values array.