### PR TITLE
chore(react-router): Add package as npm target in craft 

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -114,6 +114,9 @@ targets:
   - name: npm
     id: '@sentry/astro'
     includeNames: /^sentry-astro-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/react-router'
+    includeNames: /^sentry-react-router-\d.*\.tgz$/
 
   ## 7. Other Packages
   ## 7.1

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# Official Sentry SDK for React Router (Framework) (EXPERIMENTAL)
+# Official Sentry SDK for React Router Framework (EXPERIMENTAL)
 
 [![npm version](https://img.shields.io/npm/v/@sentry/react-router.svg)](https://www.npmjs.com/package/@sentry/react-router)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/react-router.svg)](https://www.npmjs.com/package/@sentry/react-router)


### PR DESCRIPTION
Adds a craft entry for publishing `@sentry/react-router` to npm

closes https://github.com/getsentry/sentry-javascript/issues/14725