### PR TITLE
feat(core): Default filter unactionable error

### DIFF
--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -15,7 +15,7 @@ const DEFAULT_IGNORE_ERRORS = [
   /^ResizeObserver loop completed with undelivered notifications.$/, // The browser logs this when a ResizeObserver handler takes a bit longer. Usually this is not an actual issue though. It indicates slowness.
   /^Cannot redefine property: googletag$/, // This is thrown when google tag manager is used in combination with an ad blocker
   /^Can't find variable: gmo$/, // Error from Google Search App https://issuetracker.google.com/issues/396043331
-  "undefined is not an object (evaluating 'a.L')", // Random error that happens but not actionable or noticeable to end-users.
+  /^undefined is not an object \(evaluating 'a\.[A-Z]'\)$/, // Random error that happens but not actionable or noticeable to end-users.
   'can\'t redefine non-configurable property "solana"', // Probably a browser extension or custom browser (Brave) throwing this error
   "vv().getRestrictions is not a function. (In 'vv().getRestrictions(1,a)', 'vv().getRestrictions' is undefined)", // Error thrown by GTM, seemingly not affecting end-users
   "Can't find variable: _AutofillCallbackHandler", // Unactionable error in instagram webview https://developers.facebook.com/community/threads/320013549791141/

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -445,7 +445,7 @@ describe.each([
       expect(eventProcessor(FB_MOBILE_BROWSER_EVENT, {})).toBe(null);
     });
 
-    it("uses default filters (undefined is not an object (evaluating 'a.K'))", () => {
+    it("uses default filters (undefined is not an object (evaluating 'a.L'))", () => {
       const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(UNDEFINED_IS_NOT_AN_OBJECT_EVENT, {})).toBe(null);
     });

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -332,6 +332,12 @@ const TRANSACTION_EVENT_3: Event = {
   type: 'transaction',
 };
 
+const UNDEFINED_IS_NOT_AN_OBJECT_EVENT: Event = {
+  exception: {
+    values: [{ type: 'TypeError', value: "undefined is not an object (evaluating 'a.L')" }],
+  },
+};
+
 describe.each([
   // eslint-disable-next-line deprecation/deprecation
   ['InboundFilters', inboundFiltersIntegration],
@@ -437,6 +443,11 @@ describe.each([
     it('uses default filters (FB Mobile Browser)', () => {
       const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(FB_MOBILE_BROWSER_EVENT, {})).toBe(null);
+    });
+
+    it("uses default filters (undefined is not an object (evaluating 'a.K'))", () => {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
+      expect(eventProcessor(UNDEFINED_IS_NOT_AN_OBJECT_EVENT, {})).toBe(null);
     });
 
     it('filters on last exception when multiple present', () => {

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -332,11 +332,13 @@ const TRANSACTION_EVENT_3: Event = {
   type: 'transaction',
 };
 
-const UNDEFINED_IS_NOT_AN_OBJECT_EVENT: Event = {
-  exception: {
-    values: [{ type: 'TypeError', value: "undefined is not an object (evaluating 'a.L')" }],
-  },
-};
+function createUndefinedIsNotAnObjectEvent(evaluatingStr: string): Event {
+  return {
+    exception: {
+      values: [{ type: 'TypeError', value: `undefined is not an object (evaluating '${evaluatingStr}')` }],
+    },
+  };
+}
 
 describe.each([
   // eslint-disable-next-line deprecation/deprecation
@@ -447,7 +449,24 @@ describe.each([
 
     it("uses default filters (undefined is not an object (evaluating 'a.L'))", () => {
       const eventProcessor = createEventFiltersEventProcessor(integrationFn);
-      expect(eventProcessor(UNDEFINED_IS_NOT_AN_OBJECT_EVENT, {})).toBe(null);
+      expect(eventProcessor(createUndefinedIsNotAnObjectEvent('a.L'), {})).toBe(null);
+    });
+
+    it("uses default filters (undefined is not an object (evaluating 'a.K'))", () => {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
+      expect(eventProcessor(createUndefinedIsNotAnObjectEvent('a.K'), {})).toBe(null);
+    });
+
+    it("doesn't use default filters for (undefined is not an object (evaluating 'a.store'))", () => {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
+      const event = createUndefinedIsNotAnObjectEvent('a.store');
+      expect(eventProcessor(event, {})).toBe(event);
+    });
+
+    it("doesn't use default filters for (undefined is not an object (evaluating 'this._perf.domInteractive'))", () => {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
+      const event = createUndefinedIsNotAnObjectEvent('a.store');
+      expect(eventProcessor(event, {})).toBe(event);
     });
 
     it('filters on last exception when multiple present', () => {


### PR DESCRIPTION
We've been filtering a specific "undefined is not an object" error that referenced "a.L" in our error filters. However, similar errors occured with other uppercase letters (e.g. `a.K`) - they all represent the same class of non-actionable error.

This pr just updates the filter to use a regex for this pattern.

ref https://github.com/getsentry/sentry/issues/85531