### PR TITLE
fix(cloudflare): Make `@cloudflare/workers-types` an optional peer dependency

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -51,8 +51,13 @@
   "dependencies": {
     "@sentry/core": "9.3.0"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@cloudflare/workers-types": "^4.x"
+  },
+  "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240725.0",


### PR DESCRIPTION
This PR redeclares the `@cloudflare/workers-types` package as an optional peer dependency rather than an optional dependency. With other SDKs now depending on `@sentry/cloudflare`, we'd pull in the type package into non-cloudflare projects. In the particular case reported in https://github.com/getsentry/sentry-javascript/issues/15536, this lead to global type definitions of `fetch` being overridden by the cloudflare types package (more details: https://github.com/getsentry/sentry-javascript/issues/15536#issuecomment-2693832856). 

I'm not sure if I'm missing something but since we only use the `@cloudflare/workers-types` for types, I think it's okay to make this an optional peer dependency. Which should avoid "polluting" non-CF projects with CF types. 

closes #15536