### PR TITLE
fix(core): Handle normalization of null prototypes correctly

### DIFF
--- a/packages/core/src/utils-hoist/normalize.ts
+++ b/packages/core/src/utils-hoist/normalize.ts
@@ -4,7 +4,7 @@ import { isSyntheticEvent, isVueViewModel } from './is';
 import { convertToPlainObject } from './object';
 import { getFunctionName } from './stacktrace';
 
-type Prototype = { constructor: (...args: unknown[]) => unknown };
+type Prototype = { constructor?: (...args: unknown[]) => unknown };
 // This is a hack to placate TS, relying on the fact that technically, arrays are objects with integer keys. Normally we
 // think of those keys as actual numbers, but `arr['0']` turns out to work just as well as `arr[0]`, and doing it this
 // way lets us use a single type in the places where behave as if we are only dealing with objects, even if some of them
@@ -264,7 +264,7 @@ function stringifyValue(
 function getConstructorName(value: unknown): string {
   const prototype: Prototype | null = Object.getPrototypeOf(value);
 
-  return prototype ? prototype.constructor.name : 'null prototype';
+  return prototype?.constructor ? prototype.constructor.name : 'null prototype';
 }
 
 /** Calculates bytes size of input string */

--- a/packages/core/test/utils-hoist/normalize.test.ts
+++ b/packages/core/test/utils-hoist/normalize.test.ts
@@ -484,6 +484,17 @@ describe('normalize()', () => {
         foo: '[VueViewModel]',
       });
     });
+
+    test('null prototype', () => {
+      const obj = Object.create(null);
+      expect(normalize(obj, 0)).toEqual('[null prototype]');
+    });
+
+    test('null prototype base', () => {
+      const base = Object.create(null);
+      const obj = Object.create(base);
+      expect(normalize(obj, 0)).toEqual('[null prototype]');
+    });
   });
 
   describe('can limit object to depth', () => {


### PR DESCRIPTION
Objects that are created from an Object with a null prototype were not correctly handled before. `Object.getPrototypeOf` of such objects does not return `null` directly but also do not have a constructor.

This fix guards against these cases.

Closes: https://github.com/getsentry/sentry-javascript/issues/15538