### PR TITLE
fix(node): Allow for `undefined` transport to be passed in

### DIFF
--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -214,7 +214,6 @@ function getClientOptions(
   const tracesSampleRate = getTracesSampleRate(options.tracesSampleRate);
 
   const baseOptions = dropUndefinedKeys({
-    transport: makeNodeTransport,
     dsn: process.env.SENTRY_DSN,
     environment: process.env.SENTRY_ENVIRONMENT,
     sendClientReports: true,
@@ -223,6 +222,7 @@ function getClientOptions(
   const overwriteOptions = dropUndefinedKeys({
     release,
     tracesSampleRate,
+    transport: options.transport || makeNodeTransport,
   });
 
   const mergedOptions = {

--- a/packages/node/test/sdk/init.test.ts
+++ b/packages/node/test/sdk/init.test.ts
@@ -211,4 +211,9 @@ describe('validateOpenTelemetrySetup', () => {
     expect(errorSpy).toBeCalledWith(expect.stringContaining('You have to set up the SentrySpanProcessor.'));
     expect(warnSpy).toBeCalledWith(expect.stringContaining('You have to set up the SentrySampler.'));
   });
+
+  // Regression test for https://github.com/getsentry/sentry-javascript/issues/15558
+  it('accepts an undefined transport', () => {
+    init({ dsn: PUBLIC_DSN, transport: undefined });
+  });
 });


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/15558

The Node SDK init options allow for `transport` to be set as `undefined`, but this breaks because of an error `TypeError: options.transport is not a function`.

You can see a reproduction of this here: https://stackblitz.com/edit/stackblitz-starters-phh3lfmy?file=index.ts

To fix this, we make sure we use `makeNodeTransport` if `options.transport` is set to `undefined`.