### PR TITLE
perf(node): Remove `normalizedRequest` from scope after response is closed

### DIFF
--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -183,6 +183,12 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
           });
         }
 
+        response.once('close', () => {
+          // Remove normalized request from the scope after the response is finished
+          // This is to avoid keeping the request body in memory for too long.
+          isolationScope.setSDKProcessingMetadata({ normalizedRequest: undefined });
+        });
+
         return withIsolationScope(isolationScope, () => {
           return withScope(scope => {
             // Set a new propagationSpanId for this request


### PR DESCRIPTION
This should help reduce the memory pressure of the SDK.

https://github.com/getsentry/sentry-javascript/issues/15528

Draft because I need to think about how to test this.