### PR TITLE
chore(ci): Add type task to canary issue template

### DIFF
--- a/.github/CANARY_FAILURE_TEMPLATE.md
+++ b/.github/CANARY_FAILURE_TEMPLATE.md
@@ -1,6 +1,7 @@
 ---
 title: '{{ env.TITLE }}'
 labels: 'Type: Tests, Waiting for: Product Owner'
+type: 'task'
 ---
 
 Canary tests failed: {{ env.RUN_LINK }}


### PR DESCRIPTION
Let's set `type: task` on the canary issue so we don't get issues without a type.