### PR TITLE
ci: Make Next.js e2e build assertion smarter about latest

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
@@ -8,24 +8,45 @@ const nextjsVersion = packageJson.dependencies.next;
 const buildStdout = fs.readFileSync('.tmp_build_stdout', 'utf-8');
 const buildStderr = fs.readFileSync('.tmp_build_stderr', 'utf-8');
 
-// Assert that there was no funky build time warning when we are on a stable (pinned) version
-if (nextjsVersion !== 'latest' && !nextjsVersion.includes('-canary') && !nextjsVersion.includes('-rc')) {
-  assert.doesNotMatch(buildStderr, /Import trace for requested module/, `Build warning in output:\n${buildStderr}`); // This is Next.js/Webpack speech for "something is off"
-}
+const getLatestNextVersion = async () => {
+  try {
+    const response = await fetch('https://registry.npmjs.org/next/latest');
+    const data = await response.json();
+    return data.version as string;
+  } catch (error) {
+    return '0.0.0';
+  }
+};
 
-// Assert that all static components stay static and all dynamic components stay dynamic
-assert.match(buildStdout, /○ \/client-component/);
-assert.match(buildStdout, /● \/client-component\/parameter\/\[\.\.\.parameters\]/);
-assert.match(buildStdout, /● \/client-component\/parameter\/\[parameter\]/);
-assert.match(buildStdout, /(λ|ƒ) \/server-component/);
-assert.match(buildStdout, /(λ|ƒ) \/server-component\/parameter\/\[\.\.\.parameters\]/);
-assert.match(buildStdout, /(λ|ƒ) \/server-component\/parameter\/\[parameter\]/);
+(async () => {
+  // Assert that there was no funky build time warning when we are on a stable (pinned) version
+  if (
+    !nextjsVersion.includes('-canary') &&
+    !nextjsVersion.includes('-rc') &&
+    // If we install latest we cannot assert on "latest" because the package json will contain the actual version number
+    nextjsVersion !== (await getLatestNextVersion())
+  ) {
+    assert.doesNotMatch(
+      buildStderr,
+      /Import trace for requested module/, // This is Next.js/Webpack speech for "something is off"
+      `The E2E tests detected a build warning in the Next.js build output:\n\n--------------\n\n${buildStderr}\n\n--------------\n\n`,
+    );
+  }
 
-// Read the contents of the directory
-const files = fs.readdirSync(path.join(process.cwd(), '.next', 'static'));
-const mapFiles = files.filter(file => path.extname(file) === '.map');
-if (mapFiles.length > 0) {
-  throw new Error('Client bundle .map files found even though `sourcemaps.deleteSourcemapsAfterUpload` option is set!');
-}
+  // Assert that all static components stay static and all dynamic components stay dynamic
+  assert.match(buildStdout, /○ \/client-component/);
+  assert.match(buildStdout, /● \/client-component\/parameter\/\[\.\.\.parameters\]/);
+  assert.match(buildStdout, /● \/client-component\/parameter\/\[parameter\]/);
+  assert.match(buildStdout, /(λ|ƒ) \/server-component/);
+  assert.match(buildStdout, /(λ|ƒ) \/server-component\/parameter\/\[\.\.\.parameters\]/);
+  assert.match(buildStdout, /(λ|ƒ) \/server-component\/parameter\/\[parameter\]/);
 
-export {};
+  // Read the contents of the directory
+  const files = fs.readdirSync(path.join(process.cwd(), '.next', 'static'));
+  const mapFiles = files.filter(file => path.extname(file) === '.map');
+  if (mapFiles.length > 0) {
+    throw new Error(
+      'Client bundle .map files found even though `sourcemaps.deleteSourcemapsAfterUpload` option is set!',
+    );
+  }
+})();


### PR DESCRIPTION
Our previous logic had a bug where we compared 'latest' to the actual version number. I don't know how to get around this except for checking npm.