### PR TITLE
feat(nextjs): Add `use client` directive to client SDK entrypoints

### DIFF
--- a/packages/nextjs/rollup.npm.config.mjs
+++ b/packages/nextjs/rollup.npm.config.mjs
@@ -18,6 +18,22 @@ export default [
       // the name doesn't match an SDK dependency)
       packageSpecificConfig: {
         external: ['next/router', 'next/constants', 'next/headers', 'stacktrace-parser'],
+
+        // Next.js and our users are more happy when our client code has the "use client" directive
+        plugins: [
+          {
+            name: 'sentry-internal-add-use-client-directive-to-client-entry-points-plugin-extravaganza',
+            banner: chunk => {
+              if (
+                chunk.isEntry &&
+                (chunk.facadeModuleId.endsWith('/src/index.client.ts') ||
+                  chunk.facadeModuleId.endsWith('/src/client/index.ts'))
+              ) {
+                return '"use client";';
+              }
+            },
+          },
+        ],
       },
     }),
   ),


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/10366