### PR TITLE
fix(browser): Call original function on early return from patched history API

### DIFF
--- a/packages/browser-utils/src/instrument/history.ts
+++ b/packages/browser-utils/src/instrument/history.ts
@@ -51,7 +51,7 @@ function instrumentHistory(): void {
         lastHref = to;
 
         if (from === to) {
-          return;
+          return originalHistoryFunction.apply(this, args);
         }
 
         const handlerData = { from, to } satisfies HandlerDataHistory;


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/14696 an early `return` was introduced that alters the default behavior of the underlying history API that is being patched.

Instead of just returning, the original/underlying function should be called to keep the default behavior.


