### PR TITLE
ref(core): Constrain `SdkProcessingMetadata` to known keys

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_ENVIRONMENT = 'production';
+
+export const SUPPRESS_TRACING_KEY = '__SENTRY_SUPPRESS_TRACING__';

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import type { Client } from './client';
+import type { SUPPRESS_TRACING_KEY } from './constants';
 import { updateSession } from './session';
 import type {
   Attachment,
@@ -54,7 +55,6 @@ export interface ScopeContext {
 }
 
 export interface SdkProcessingMetadata {
-  [key: string]: unknown;
   requestSession?: {
     status: 'ok' | 'errored' | 'crashed';
   };
@@ -64,6 +64,7 @@ export interface SdkProcessingMetadata {
   capturedSpanIsolationScope?: Scope;
   spanCountBeforeProcessing?: number;
   ipAddress?: string;
+  [SUPPRESS_TRACING_KEY]?: boolean;
 }
 
 /**

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -65,6 +65,9 @@ export interface SdkProcessingMetadata {
   spanCountBeforeProcessing?: number;
   ipAddress?: string;
   [SUPPRESS_TRACING_KEY]?: boolean;
+  // Used by profiling integrations. The profiling integrations refine this type to ensure
+  // type safety (for ex. see `isProfiledTransactionEvent` function in `@sentry/browser`).
+  profile?: unknown;
 }
 
 /**

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -32,8 +32,7 @@ import { SentryNonRecordingSpan } from './sentryNonRecordingSpan';
 import { SentrySpan } from './sentrySpan';
 import { SPAN_STATUS_ERROR } from './spanstatus';
 import { setCapturedScopesOnSpan } from './utils';
-
-const SUPPRESS_TRACING_KEY = '__SENTRY_SUPPRESS_TRACING__';
+import { SUPPRESS_TRACING_KEY } from '../constants';
 
 /**
  * Wraps a function with a transaction/span and finishes the span after the function is done.


### PR DESCRIPTION
After working on https://github.com/getsentry/sentry-javascript/pull/15570, I realized we should be more constrained about what we set on `SdkProcessingMetadata`.

This PR updates the `SdkProcessingMetadata` type to be more constrained, not allowing any key to be passed to it. This should make sure we are more critical of changes that could lead to increased memory pressure in the SDK (as `SdkProcessingMetadata` lives alongside the scope).