### PR TITLE
fix(sveltekit): Correctly parse angle bracket type assertions for auto instrumentation

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/type-assertion/+page.svelte
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/type-assertion/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let data
+</script>
+
+<h1>Type Assertion</h1>
+
+<p>
+  TIL:
+<code>const myCanvas = <HTMLCanvasElement>document.getElementById("main_canvas");</code>
+  is equal to
+<code>const myCanvas = document.getElementById("main_canvas") as HTMLCanvasElement;</code>
+</p>
+
+<p>
+  Message: {data.msg}
+</p>

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/type-assertion/+page.svelte
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/type-assertion/+page.svelte
@@ -5,10 +5,8 @@
 <h1>Type Assertion</h1>
 
 <p>
-  TIL:
-<code>const myCanvas = <HTMLCanvasElement>document.getElementById("main_canvas");</code>
-  is equal to
-<code>const myCanvas = document.getElementById("main_canvas") as HTMLCanvasElement;</code>
+  This route only exists to ensure we don't emit a build error because of the angle bracket type assertion in +page.ts
+  see https://github.com/getsentry/sentry-javascript/issues/9318
 </p>
 
 <p>

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/type-assertion/+page.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/routes/type-assertion/+page.ts
@@ -1,0 +1,8 @@
+export async function load() {
+  let x: unknown = 'foo';
+  return {
+    // this angle bracket type assertion threw an auto instrumentation error
+    // see: https://github.com/getsentry/sentry-javascript/issues/9318
+    msg: <string>x,
+  };
+}

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -44,6 +44,7 @@
     }
   },
   "dependencies": {
+    "@babel/parser": "7.26.9",
     "@sentry/cloudflare": "9.5.0",
     "@sentry/core": "9.5.0",
     "@sentry/node": "9.5.0",
@@ -51,7 +52,7 @@
     "@sentry/svelte": "9.5.0",
     "@sentry/vite-plugin": "3.2.0",
     "magic-string": "0.30.7",
-    "magicast": "0.2.8",
+    "recast": "0.23.11",
     "sorcery": "1.0.0"
   },
   "devDependencies": {

--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -2,10 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as recast from 'recast';
 import t = recast.types.namedTypes;
-import type { ParserPlugin } from '@babel/parser';
-import { parse as babelParse } from '@babel/parser';
 import type { Plugin } from 'vite';
 import { WRAPPED_MODULE_SUFFIX } from '../common/utils';
+import { parser } from './recastTypescriptParser';
 
 export type AutoInstrumentSelection = {
   /**
@@ -102,56 +101,6 @@ export async function canWrapLoad(id: string, debug: boolean): Promise<boolean> 
   }
 
   const code = (await fs.promises.readFile(id, 'utf8')).toString();
-
-  // Taken from recast's typescript parser config, minus the JSX plugin
-  // see: https://github.com/benjamn/recast/blob/master/parsers/_babel_options.ts
-  // see: https://github.com/benjamn/recast/blob/master/parsers/babel-ts.ts
-  const parser = {
-    parse: (source: string) =>
-      babelParse(source, {
-        plugins: [
-          'typescript',
-          'asyncGenerators',
-          'bigInt',
-          'classPrivateMethods',
-          'classPrivateProperties',
-          'classProperties',
-          'classStaticBlock',
-          'decimal',
-          'decorators-legacy',
-          'doExpressions',
-          'dynamicImport',
-          'exportDefaultFrom',
-          'exportNamespaceFrom',
-          'functionBind',
-          'functionSent',
-          'importAssertions',
-          'exportExtensions' as ParserPlugin,
-          'importMeta',
-          'nullishCoalescingOperator',
-          'numericSeparator',
-          'objectRestSpread',
-          'optionalCatchBinding',
-          'optionalChaining',
-          [
-            'pipelineOperator',
-            {
-              proposal: 'minimal',
-            },
-          ],
-          [
-            'recordAndTuple',
-            {
-              syntaxType: 'hash',
-            },
-          ],
-          'throwExpressions',
-          'topLevelAwait',
-          'v8intrinsic',
-        ],
-        sourceType: 'module',
-      }),
-  };
 
   const ast = recast.parse(code, {
     parser,

--- a/packages/sveltekit/src/vite/recastTypescriptParser.ts
+++ b/packages/sveltekit/src/vite/recastTypescriptParser.ts
@@ -1,0 +1,85 @@
+// This babel parser config is taken from recast's typescript parser config, specifically from these two files:
+// see: https://github.com/benjamn/recast/blob/master/parsers/_babel_options.ts
+// see: https://github.com/benjamn/recast/blob/master/parsers/babel-ts.ts
+//
+// Changes:
+// - we don't add the 'jsx' plugin, to correctly parse TypeScript angle bracket type assertions
+//   (see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions)
+// - minor import and export changes
+// - merged the two files linked above into one for simplicity
+
+// Date of access: 2025-03-04
+// Commit: https://github.com/benjamn/recast/commit/ba5132174894b496285da9d001f1f2524ceaed3a
+
+// Recast license:
+
+// Copyright (c) 2012 Ben Newman <bn@cs.stanford.edu>
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import type { ParserPlugin } from '@babel/parser';
+import { parse as babelParse } from '@babel/parser';
+
+export const parser = {
+  parse: (source: string) =>
+    babelParse(source, {
+      plugins: [
+        'typescript',
+        'asyncGenerators',
+        'bigInt',
+        'classPrivateMethods',
+        'classPrivateProperties',
+        'classProperties',
+        'classStaticBlock',
+        'decimal',
+        'decorators-legacy',
+        'doExpressions',
+        'dynamicImport',
+        'exportDefaultFrom',
+        'exportNamespaceFrom',
+        'functionBind',
+        'functionSent',
+        'importAssertions',
+        'exportExtensions' as ParserPlugin,
+        'importMeta',
+        'nullishCoalescingOperator',
+        'numericSeparator',
+        'objectRestSpread',
+        'optionalCatchBinding',
+        'optionalChaining',
+        [
+          'pipelineOperator',
+          {
+            proposal: 'minimal',
+          },
+        ],
+        [
+          'recordAndTuple',
+          {
+            syntaxType: 'hash',
+          },
+        ],
+        'throwExpressions',
+        'topLevelAwait',
+        'v8intrinsic',
+      ],
+      sourceType: 'module',
+    }),
+};

--- a/packages/sveltekit/src/vite/recastTypescriptParser.ts
+++ b/packages/sveltekit/src/vite/recastTypescriptParser.ts
@@ -41,6 +41,11 @@ import type { Options } from 'recast';
 export const parser: Options['parser'] = {
   parse: (source: string) =>
     babelParse(source, {
+      strictMode: false,
+      allowImportExportEverywhere: true,
+      allowReturnOutsideFunction: true,
+      startLine: 1,
+      tokens: true,
       plugins: [
         'typescript',
         'asyncGenerators',

--- a/packages/sveltekit/src/vite/recastTypescriptParser.ts
+++ b/packages/sveltekit/src/vite/recastTypescriptParser.ts
@@ -36,8 +36,9 @@
 
 import type { ParserPlugin } from '@babel/parser';
 import { parse as babelParse } from '@babel/parser';
+import type { Options } from 'recast';
 
-export const parser = {
+export const parser: Options['parser'] = {
   parse: (source: string) =>
     babelParse(source, {
       plugins: [

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -140,7 +140,15 @@ describe('canWrapLoad', () => {
         return { props: { msg: res.toString() } }
       }`,
     ],
-
+    [
+      'export function declaration - with angle bracket type assertion',
+      `export async function load() {
+        let x: unknown = 'foo';
+        return {
+          msg: <string>x,
+        };
+      }`,
+    ],
     [
       'variable declaration (let)',
       `import {something} from 'somewhere';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1695,19 +1695,19 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.4", "@babel/parser@^7.18.10", "@babel/parser@^7.20.7", "@babel/parser@^7.21.8", "@babel/parser@^7.21.9", "@babel/parser@^7.22.10", "@babel/parser@^7.22.16", "@babel/parser@^7.23.5", "@babel/parser@^7.23.9", "@babel/parser@^7.25.3", "@babel/parser@^7.25.4", "@babel/parser@^7.25.6", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.3", "@babel/parser@^7.4.5", "@babel/parser@^7.7.0":
-  version "7.26.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.3.tgz#8c51c5db6ddf08134af1ddbacf16aaab48bac234"
-  integrity sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==
-  dependencies:
-    "@babel/types" "^7.26.3"
-
-"@babel/parser@^7.23.6", "@babel/parser@^7.26.9":
+"@babel/parser@7.26.9", "@babel/parser@^7.23.6", "@babel/parser@^7.26.9":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.9.tgz#d9e78bee6dc80f9efd8f2349dcfbbcdace280fd5"
   integrity sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==
   dependencies:
     "@babel/types" "^7.26.9"
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.4", "@babel/parser@^7.18.10", "@babel/parser@^7.20.7", "@babel/parser@^7.21.8", "@babel/parser@^7.22.10", "@babel/parser@^7.22.16", "@babel/parser@^7.23.5", "@babel/parser@^7.23.9", "@babel/parser@^7.25.3", "@babel/parser@^7.25.4", "@babel/parser@^7.25.6", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.3", "@babel/parser@^7.4.5", "@babel/parser@^7.7.0":
+  version "7.26.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.3.tgz#8c51c5db6ddf08134af1ddbacf16aaab48bac234"
+  integrity sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==
+  dependencies:
+    "@babel/types" "^7.26.3"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.24.4":
   version "7.24.4"
@@ -2829,7 +2829,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.20.7", "@babel/types@^7.21.5", "@babel/types@^7.22.10", "@babel/types@^7.22.15", "@babel/types@^7.22.17", "@babel/types@^7.22.19", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.25.4", "@babel/types@^7.25.6", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.26.3", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.7.2":
+"@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.20.7", "@babel/types@^7.22.10", "@babel/types@^7.22.15", "@babel/types@^7.22.17", "@babel/types@^7.22.19", "@babel/types@^7.23.6", "@babel/types@^7.23.9", "@babel/types@^7.24.7", "@babel/types@^7.24.8", "@babel/types@^7.25.4", "@babel/types@^7.25.6", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.26.3", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.7.2":
   version "7.26.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.3.tgz#37e79830f04c2b5687acc77db97fbc75fb81f3c0"
   integrity sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==
@@ -8509,12 +8509,7 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/history-4@npm:@types/history@4.7.8":
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
-  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
-
-"@types/history-5@npm:@types/history@4.7.8":
+"@types/history-4@npm:@types/history@4.7.8", "@types/history-5@npm:@types/history@4.7.8":
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
   integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
@@ -21326,15 +21321,6 @@ magic-string@^0.30.0, magic-string@^0.30.10, magic-string@^0.30.11, magic-string
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
 
-magicast@0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.2.8.tgz#02b298c65fbc5b7d1fce52ef779c59caf68cc9cf"
-  integrity sha512-zEnqeb3E6TfMKYXGyHv3utbuHNixr04o3/gVGviSzVQkbFiU46VZUd+Ea/1npKfvEsEWxBYuIksKzoztTDPg0A==
-  dependencies:
-    "@babel/parser" "^7.21.9"
-    "@babel/types" "^7.21.5"
-    recast "^0.23.2"
-
 magicast@^0.2.10:
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.2.11.tgz#d5d9339ec59e5322cf331460d8e3db2f6585f5d5"
@@ -26237,6 +26223,17 @@ realistic-structured-clone@^3.0.0:
     typeson "^6.1.0"
     typeson-registry "^1.0.0-alpha.20"
 
+recast@0.23.11:
+  version "0.23.11"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.11.tgz#8885570bb28cf773ba1dc600da7f502f7883f73f"
+  integrity sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==
+  dependencies:
+    ast-types "^0.16.1"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tiny-invariant "^1.3.3"
+    tslib "^2.0.1"
+
 recast@^0.18.1:
   version "0.18.10"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.10.tgz#605ebbe621511eb89b6356a7e224bff66ed91478"
@@ -26257,7 +26254,7 @@ recast@^0.20.5:
     source-map "~0.6.1"
     tslib "^2.0.1"
 
-recast@^0.23.2, recast@^0.23.4:
+recast@^0.23.4:
   version "0.23.9"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.9.tgz#587c5d3a77c2cfcb0c18ccce6da4361528c2587b"
   integrity sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==
@@ -28346,16 +28343,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -28458,14 +28446,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -28630,7 +28611,6 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
-  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"
@@ -31303,16 +31283,7 @@ wrangler@^3.67.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This PR

- removes `magicast` as a dependency of the Sveltekit SDK
- replaces it with direct usage of `recast` and `@babel/parser`. Both dependencies were already transitive dependencies beforehand but with this, we just hoist it up a level.
- configures `recast` to use the TypeScript parser, just like it configures it. We can't directly use the recast typscript parser because its export is not compatible with ESM (TODO: open issue in recast repo)
- Makes adjustments to our code (mostly type casts) due to slightly changed types. 
- Given that we have various tests that cover our AST walking logic I think this is a low-risk change overall.

closes https://github.com/getsentry/sentry-javascript/issues/9318