### PR TITLE
fix(react-router): Fix config type import

### DIFF
--- a/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
+++ b/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
@@ -1,5 +1,5 @@
 import { rm } from 'node:fs/promises';
-import type { Config } from '@react-router/dev/dist/config';
+import type { Config } from '@react-router/dev/config';
 import SentryCli from '@sentry/cli';
 import { glob } from 'glob';
 import type { SentryReactRouterBuildOptions } from '../types';


### PR DESCRIPTION
`@react-router/dev/dist/*` is not a [valid entry point](https://github.com/remix-run/react-router/blob/react-router%407.2.0/packages/react-router-dev/package.json#L15-L33). This results in `sentryOnBuildEnd` being typed as `any` as illustrated in [this CI run](https://github.com/namoscato/tiny-truths/actions/runs/13666446067/job/38208593045#step:7:11).

---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] ~If you've added code that should be tested, please add tests.~
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
