### PR TITLE
fix(core): Don't reverse values in event filters

### DIFF
--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -211,9 +211,9 @@ function _getEventFilterUrl(event: Event): string | null {
   try {
     // If there are linked exceptions or exception aggregates we only want to match against the top frame of the "root" (the main exception)
     // The root always comes last in linked exceptions
-    const rootException = [...(event.exception?.values ?? []).reverse()]?.find(
-      value => value.mechanism?.parent_id === undefined && value.stacktrace?.frames?.length,
-    );
+    const rootException = [...(event.exception?.values ?? [])]
+      .reverse()
+      ?.find(value => value.mechanism?.parent_id === undefined && value.stacktrace?.frames?.length);
     const frames = rootException?.stacktrace?.frames;
     return frames ? _getLastValidUrl(frames) : null;
   } catch (oO) {

--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -213,7 +213,7 @@ function _getEventFilterUrl(event: Event): string | null {
     // The root always comes last in linked exceptions
     const rootException = [...(event.exception?.values ?? [])]
       .reverse()
-      ?.find(value => value.mechanism?.parent_id === undefined && value.stacktrace?.frames?.length);
+      .find(value => value.mechanism?.parent_id === undefined && value.stacktrace?.frames?.length);
     const frames = rootException?.stacktrace?.frames;
     return frames ? _getLastValidUrl(frames) : null;
   } catch (oO) {


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/issues/15513#issuecomment-2700229716 noticed a regression I introduced, reversing exceptions in the event, because I fumbled a reverse() call into the wrong location.

Should be fixed asap.