### PR TITLE
fix(remix): Use correct types export for `@sentry/remix/cloudflare`

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -33,7 +33,7 @@
     "./cloudflare": {
       "import": "./build/esm/cloudflare/index.js",
       "require": "./build/cjs/cloudflare/index.js",
-      "types": "./build/types/cloudflare/index.types.d.ts",
+      "types": "./build/types/cloudflare/index.d.ts",
       "default": "./build/esm/cloudflare/index.js"
     },
     "./import": {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/5610#issuecomment-2701586784