### PR TITLE
Add cloudflare adapter detection and path generation

### DIFF
--- a/packages/sveltekit/src/vite/detectAdapter.ts
+++ b/packages/sveltekit/src/vite/detectAdapter.ts
@@ -5,7 +5,7 @@ import type { Package } from '@sentry/core';
 /**
  * Supported @sveltejs/adapters-[adapter] SvelteKit adapters
  */
-export type SupportedSvelteKitAdapters = 'node' | 'auto' | 'vercel' | 'other';
+export type SupportedSvelteKitAdapters = 'node' | 'auto' | 'vercel' | 'cloudflare' | 'other';
 
 /**
  * Tries to detect the used adapter for SvelteKit by looking at the dependencies.
@@ -21,6 +21,8 @@ export async function detectAdapter(debug?: boolean): Promise<SupportedSvelteKit
     adapter = 'vercel';
   } else if (allDependencies['@sveltejs/adapter-node']) {
     adapter = 'node';
+  } else if (allDependencies['@sveltejs/adapter-cloudflare']) {
+    adapter = 'cloudflare';
   } else if (allDependencies['@sveltejs/adapter-auto']) {
     adapter = 'auto';
   }

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -52,6 +52,10 @@ export async function getAdapterOutputDir(svelteConfig: Config, adapter: Support
   if (adapter === 'node') {
     return getNodeAdapterOutputDir(svelteConfig);
   }
+  if (adapter === 'cloudflare') {
+    // Cloudflare outputs to outDir\cloudflare as the output dir
+    return path.join(svelteConfig.kit?.outDir || '.svelte-kit', 'cloudflare');
+  }
 
   // Auto and Vercel adapters simply use config.kit.outDir
   // Let's also use this directory for the 'other' case

--- a/packages/sveltekit/test/vite/detectAdapter.test.ts
+++ b/packages/sveltekit/test/vite/detectAdapter.test.ts
@@ -27,7 +27,7 @@ describe('detectAdapter', () => {
   const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-  it.each(['auto', 'vercel', 'node'])(
+  it.each(['auto', 'vercel', 'node', 'cloudflare'])(
     'returns the adapter name (adapter %s) and logs it to the console',
     async adapter => {
       pkgJson.dependencies[`@sveltejs/adapter-${adapter}`] = '1.0.0';
@@ -68,6 +68,7 @@ describe('detectAdapter', () => {
     pkgJson.dependencies['@sveltejs/adapter-auto'] = '1.0.0';
     pkgJson.dependencies['@sveltejs/adapter-vercel'] = '1.0.0';
     pkgJson.dependencies['@sveltejs/adapter-node'] = '1.0.0';
+    pkgJson.dependencies['@sveltejs/adapter-cloudflare'] = '1.0.0';
 
     const detectedAdapter = await detectAdapter();
     expect(detectedAdapter).toEqual('vercel');
@@ -75,5 +76,8 @@ describe('detectAdapter', () => {
     delete pkgJson.dependencies['@sveltejs/adapter-vercel'];
     const detectedAdapter2 = await detectAdapter();
     expect(detectedAdapter2).toEqual('node');
+    delete pkgJson.dependencies['@sveltejs/adapter-node'];
+    const detectedAdapter3 = await detectAdapter();
+    expect(detectedAdapter3).toEqual('cloudflare');
   });
 });

--- a/packages/sveltekit/test/vite/svelteConfig.test.ts
+++ b/packages/sveltekit/test/vite/svelteConfig.test.ts
@@ -68,6 +68,11 @@ describe('getAdapterOutputDir', () => {
     expect(outputDir).toEqual('customBuildDir');
   });
 
+  it('returns the output directory of the Cloudflare adapter', async () => {
+    const outputDir = await getAdapterOutputDir({ kit: { outDir: 'customOutDir' } }, 'cloudflare');
+    expect(outputDir).toEqual('customOutDir/cloudflare');
+  });
+
   it.each(['vercel', 'auto', 'other'] as SupportedSvelteKitAdapters[])(
     'returns the config.kit.outdir directory for adapter-%s',
     async adapter => {
@@ -75,6 +80,8 @@ describe('getAdapterOutputDir', () => {
       expect(outputDir).toEqual('customOutDir/output');
     },
   );
+
+
 
   it('falls back to the default out dir for all other adapters if outdir is not specified in the config', async () => {
     const outputDir = await getAdapterOutputDir({ kit: {} }, 'vercel');

--- a/packages/sveltekit/test/vite/svelteConfig.test.ts
+++ b/packages/sveltekit/test/vite/svelteConfig.test.ts
@@ -81,8 +81,6 @@ describe('getAdapterOutputDir', () => {
     },
   );
 
-
-
   it('falls back to the default out dir for all other adapters if outdir is not specified in the config', async () => {
     const outputDir = await getAdapterOutputDir({ kit: {} }, 'vercel');
     expect(outputDir).toEqual('.svelte-kit/output');


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

This PR expands upon #14672 by adding detection of the @sveltejs/adapter-cloudflare adapter and defining it's output directory (cloudflare as opposed to output). I've tested it with a Cloudflare Pages project and it was successful in building and uploading sourcemaps, whereas relying on 'other' caused an infinite loop and an OOM when trying to upload sourcemaps.
