### PR TITLE
fix(sveltekit): Guard process variable

### DIFF
--- a/packages/sveltekit/src/server-common/utils.ts
+++ b/packages/sveltekit/src/server-common/utils.ts
@@ -19,7 +19,7 @@ export function getTracePropagationData(event: RequestEvent): { sentryTrace: str
 
 /** Flush the event queue to ensure that events get sent to Sentry before the response is finished and the lambda ends */
 export async function flushIfServerless(): Promise<void> {
-  if (!process) {
+  if (typeof process === 'undefined') {
     return;
   }
 


### PR DESCRIPTION
`process` was guarded in https://github.com/getsentry/sentry-javascript/pull/15516 already, but it still did not fix the problem as the variable `process` is not even available so the code still broke. This is another attempt to fix "process is undefined" reported in https://github.com/getsentry/sentry-javascript/issues/15506
