### PR TITLE
test(nuxt): Fix failing e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/package.json
@@ -18,7 +18,6 @@
     "nuxt": "^3.14.0"
   },
   "devDependencies": {
-    "@nuxt/test-utils": "^3.14.1",
     "@playwright/test": "~1.50.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/playwright.config.ts
@@ -1,19 +1,10 @@
-import { fileURLToPath } from 'node:url';
-import type { ConfigOptions } from '@nuxt/test-utils/playwright';
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
-
-const nuxtConfigOptions: ConfigOptions = {
-  nuxt: {
-    rootDir: fileURLToPath(new URL('.', import.meta.url)),
-  },
-};
 
 /*  Make sure to import from '@nuxt/test-utils/playwright' in the tests
  *  Like this: import { expect, test } from '@nuxt/test-utils/playwright' */
 
 const config = getPlaywrightConfig({
   startCommand: `pnpm start`,
-  use: { ...nuxtConfigOptions },
 });
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/tests/errors.client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@nuxt/test-utils/playwright';
+import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/test-utils';
 
 test.describe('client-side errors', async () => {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/tests/tracing.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/tests/tracing.client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@nuxt/test-utils/playwright';
+import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 import type { Span } from '@sentry/nuxt';
 

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
@@ -20,7 +20,6 @@
     "nuxt": "3.7.0"
   },
   "devDependencies": {
-    "@nuxt/test-utils": "^3.14.1",
     "@playwright/test": "~1.50.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/playwright.config.ts
@@ -1,19 +1,7 @@
-import { fileURLToPath } from 'node:url';
-import type { ConfigOptions } from '@nuxt/test-utils/playwright';
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
-
-const nuxtConfigOptions: ConfigOptions = {
-  nuxt: {
-    rootDir: fileURLToPath(new URL('.', import.meta.url)),
-  },
-};
-
-/*  Make sure to import from '@nuxt/test-utils/playwright' in the tests
- *  Like this: import { expect, test } from '@nuxt/test-utils/playwright' */
 
 const config = getPlaywrightConfig({
   startCommand: `pnpm start:import`,
-  use: { ...nuxtConfigOptions },
 });
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/tests/errors.client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@nuxt/test-utils/playwright';
+import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/test-utils';
 
 test.describe('client-side errors', async () => {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/tests/tracing.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/tests/tracing.client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@nuxt/test-utils/playwright';
+import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 import type { Span } from '@sentry/nuxt';
 

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/package.json
@@ -18,7 +18,6 @@
     "nuxt": "^3.14.0"
   },
   "devDependencies": {
-    "@nuxt/test-utils": "^3.14.1",
     "@playwright/test": "~1.50.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   }

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/playwright.config.ts
@@ -1,19 +1,7 @@
-import { fileURLToPath } from 'node:url';
-import type { ConfigOptions } from '@nuxt/test-utils/playwright';
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
-
-const nuxtConfigOptions: ConfigOptions = {
-  nuxt: {
-    rootDir: fileURLToPath(new URL('.', import.meta.url)),
-  },
-};
-
-/*  Make sure to import from '@nuxt/test-utils/playwright' in the tests
- *  Like this: import { expect, test } from '@nuxt/test-utils/playwright' */
 
 const config = getPlaywrightConfig({
   startCommand: `pnpm start`,
-  use: { ...nuxtConfigOptions },
 });
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/tests/errors.client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@nuxt/test-utils/playwright';
+import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/test-utils';
 
 test.describe('client-side errors', async () => {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/tests/tracing.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/tests/tracing.client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@nuxt/test-utils/playwright';
+import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 import type { Span } from '@sentry/nuxt';
 

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
@@ -19,7 +19,6 @@
     "nuxt": "^3.14.0"
   },
   "devDependencies": {
-    "@nuxt/test-utils": "^3.14.1",
     "@playwright/test": "~1.50.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   }

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/playwright.config.ts
@@ -1,19 +1,19 @@
 import { fileURLToPath } from 'node:url';
-import type { ConfigOptions } from '@nuxt/test-utils/playwright';
+// import type { ConfigOptions } from '@nuxt/test-utils/playwright';
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
 
-const nuxtConfigOptions: ConfigOptions = {
-  nuxt: {
-    rootDir: fileURLToPath(new URL('.', import.meta.url)),
-  },
-};
+// const nuxtConfigOptions: ConfigOptions = {
+//   nuxt: {
+//     rootDir: fileURLToPath(new URL('.', import.meta.url)),
+//   },
+// };
 
 /*  Make sure to import from '@nuxt/test-utils/playwright' in the tests
  *  Like this: import { expect, test } from '@nuxt/test-utils/playwright' */
 
 const config = getPlaywrightConfig({
   startCommand: `pnpm start:import`,
-  use: { ...nuxtConfigOptions },
+  // use: { ...nuxtConfigOptions },
 });
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/playwright.config.ts
@@ -1,19 +1,7 @@
-import { fileURLToPath } from 'node:url';
-// import type { ConfigOptions } from '@nuxt/test-utils/playwright';
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
-
-// const nuxtConfigOptions: ConfigOptions = {
-//   nuxt: {
-//     rootDir: fileURLToPath(new URL('.', import.meta.url)),
-//   },
-// };
-
-/*  Make sure to import from '@nuxt/test-utils/playwright' in the tests
- *  Like this: import { expect, test } from '@nuxt/test-utils/playwright' */
 
 const config = getPlaywrightConfig({
   startCommand: `pnpm start:import`,
-  // use: { ...nuxtConfigOptions },
 });
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/tests/errors.client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@nuxt/test-utils/playwright';
+import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/test-utils';
 
 test.describe('client-side errors', async () => {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/tests/tracing.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/tests/tracing.client.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@nuxt/test-utils/playwright';
+import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 import type { Span } from '@sentry/nuxt';
 

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
@@ -20,7 +20,6 @@
     "nuxt": "^3.13.2"
   },
   "devDependencies": {
-    "@nuxt/test-utils": "^3.14.2",
     "@playwright/test": "~1.50.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/playwright.config.ts
@@ -1,19 +1,7 @@
-import { fileURLToPath } from 'node:url';
-import type { ConfigOptions } from '@nuxt/test-utils/playwright';
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
-
-const nuxtConfigOptions: ConfigOptions = {
-  nuxt: {
-    rootDir: fileURLToPath(new URL('.', import.meta.url)),
-  },
-};
-
-/*  Make sure to import from '@nuxt/test-utils/playwright' in the tests
- *  Like this: import { expect, test } from '@nuxt/test-utils/playwright' */
 
 const config = getPlaywrightConfig({
   startCommand: `pnpm start:import`,
-  use: { ...nuxtConfigOptions },
 });
 
 export default config;


### PR DESCRIPTION
Not sure why this only started happening now but it seems like `import { test, describe } from '@nuxt/test-utils/playwright` instead of from `@playwright/test` builds a nuxt application on every test. This seems in line with what @s1gr1d found out about the purpose of Nuxt E2E which is to create small test apps on every `test` function invocation.

We don't want this functionallity anyway, so let's get rid of this depenency and only import form `@playwright/test`. 
