### PR TITLE
chore: Fix link in migration doc

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,7 +5,7 @@ These docs walk through how to migrate our JavaScript SDKs through different maj
 - Upgrading from [SDK 4.x to 5.x/6.x](./docs/migration/v4-to-v5_v6.md)
 - Upgrading from [SDK 6.x to 7.x](./docs/migration/v6-to-v7.md)
 - Upgrading from [SDK 7.x to 8.x](./docs/migration/v7-to-v8.md)
-- Upgrading from [SDK 8.x to 9.x](./docs/migration/v8-to-v9.md#upgrading-from-7x-to-8x)
+- Upgrading from [SDK 8.x to 9.x](#upgrading-from-8x-to-9x)
 
 # Upgrading from 8.x to 9.x
 


### PR DESCRIPTION
I thought about deleting the link as well, but I figured once we start documenting `Deprecation in 9.x` it would be good to have a link.