### PR TITLE
feat(astro): Accept all vite-plugin options

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -79,14 +79,14 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                       assets: uploadOptions.assets ?? [getSourcemapsAssetsGlob(config)],
                       filesToDeleteAfterUpload:
                         uploadOptions?.filesToDeleteAfterUpload ?? updatedFilesToDeleteAfterUpload,
-                      ...unstable_sentryVitePluginOptions?.sourcemaps
+                      ...unstable_sentryVitePluginOptions?.sourcemaps,
                     },
                     bundleSizeOptimizations: {
                       ...options.bundleSizeOptimizations,
                       // TODO: with a future version of the vite plugin (probably 2.22.0) this re-mapping is not needed anymore
                       // ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/582
                       excludePerformanceMonitoring: options.bundleSizeOptimizations?.excludeTracing,
-                      ...unstable_sentryVitePluginOptions?.bundleSizeOptimizations
+                      ...unstable_sentryVitePluginOptions?.bundleSizeOptimizations,
                     },
                   }),
                 ),

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -68,24 +68,26 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                     project: uploadOptions.project ?? env.SENTRY_PROJECT,
                     authToken: uploadOptions.authToken ?? env.SENTRY_AUTH_TOKEN,
                     telemetry: uploadOptions.telemetry ?? true,
+                    _metaOptions: {
+                      telemetry: {
+                        metaFramework: 'astro',
+                      },
+                    },
+                    ...unstable_sentryVitePluginOptions,
+                    debug: options.debug ?? false,
                     sourcemaps: {
                       assets: uploadOptions.assets ?? [getSourcemapsAssetsGlob(config)],
                       filesToDeleteAfterUpload:
                         uploadOptions?.filesToDeleteAfterUpload ?? updatedFilesToDeleteAfterUpload,
+                      ...unstable_sentryVitePluginOptions?.sourcemaps
                     },
                     bundleSizeOptimizations: {
                       ...options.bundleSizeOptimizations,
                       // TODO: with a future version of the vite plugin (probably 2.22.0) this re-mapping is not needed anymore
                       // ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/582
                       excludePerformanceMonitoring: options.bundleSizeOptimizations?.excludeTracing,
+                      ...unstable_sentryVitePluginOptions?.bundleSizeOptimizations
                     },
-                    _metaOptions: {
-                      telemetry: {
-                        metaFramework: 'astro',
-                      },
-                    },
-                    debug: options.debug ?? false,
-                    ...unstable_sentryVitePluginOptions
                   }),
                 ),
               ],

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -30,7 +30,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
         };
 
         const sourceMapsNeeded = sdkEnabled.client || sdkEnabled.server;
-        const uploadOptions = options.sourceMapsUploadOptions || {};
+        const { unstable_sentryVitePluginOptions, ...uploadOptions } = options.sourceMapsUploadOptions || {};
         const shouldUploadSourcemaps = (sourceMapsNeeded && uploadOptions?.enabled) ?? true;
 
         // We don't need to check for AUTH_TOKEN here, because the plugin will pick it up from the env
@@ -85,6 +85,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                       },
                     },
                     debug: options.debug ?? false,
+                    ...unstable_sentryVitePluginOptions
                   }),
                 ),
               ],

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -97,7 +97,7 @@ type SourceMapsOptions = {
    *
    * Furthermore, some options are untested with Astro specifically. Use with caution.
    */
-  unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>
+  unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>;
 };
 
 type BundleSizeOptimizationOptions = {

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -1,5 +1,6 @@
 import type { BrowserOptions } from '@sentry/browser';
 import type { Options } from '@sentry/core';
+import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 
 type SdkInitPaths = {
   /**
@@ -83,6 +84,20 @@ type SourceMapsOptions = {
    * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
    */
   filesToDeleteAfterUpload?: string | Array<string>;
+
+  /**
+   * Options to further customize the Sentry Vite Plugin (@sentry/vite-plugin) behavior directly.
+   * Options specified in this object take precedence over all other options.
+   *
+   * @see https://www.npmjs.com/package/@sentry/vite-plugin/v/2.14.2#options which lists all available options.
+   *
+   * Warning: Options within this object are subject to change at any time.
+   * We DO NOT guarantee semantic versioning for these options, meaning breaking
+   * changes can occur at any time within a major SDK version.
+   *
+   * Furthermore, some options are untested with Astro specifically. Use with caution.
+   */
+  unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>
 };
 
 type BundleSizeOptimizationOptions = {

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -205,7 +205,7 @@ describe('sentryAstro integration', () => {
   it('prefers user-specified unstable vite plugin options and merges them with default values', async () => {
     const integration = sentryAstro({
       bundleSizeOptimizations: {
-        excludeReplayShadowDom: true
+        excludeReplayShadowDom: true,
       },
       sourceMapsUploadOptions: {
         enabled: true,
@@ -221,9 +221,9 @@ describe('sentryAstro integration', () => {
             ignore: ['bar/*.js'],
           },
           bundleSizeOptimizations: {
-            excludeReplayIframe: true
-          }
-        }
+            excludeReplayIframe: true,
+          },
+        },
       },
     });
     // @ts-expect-error - the hook exists, and we only need to pass what we actually use
@@ -249,8 +249,8 @@ describe('sentryAstro integration', () => {
         },
         bundleSizeOptimizations: {
           excludeReplayShadowDom: true,
-          excludeReplayIframe: true
-        }
+          excludeReplayIframe: true,
+        },
       }),
     );
   });

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -202,23 +202,27 @@ describe('sentryAstro integration', () => {
     );
   });
 
-  it('prefers user-specified unstable vite plugin options over everything else', async () => {
+  it('prefers user-specified unstable vite plugin options and merges them with default values', async () => {
     const integration = sentryAstro({
+      bundleSizeOptimizations: {
+        excludeReplayShadowDom: true
+      },
       sourceMapsUploadOptions: {
         enabled: true,
         org: 'my-org',
         project: 'my-project',
         assets: ['dist/server/**/*, dist/client/**/*'],
-        debug: true,
         unstable_sentryVitePluginOptions: {
           org: 'my-other-org',
           project: 'my-other-project',
           applicationKey: 'my-application-key',
-          debug: false,
           sourcemaps: {
             assets: ['foo/*.js'],
             ignore: ['bar/*.js'],
           },
+          bundleSizeOptimizations: {
+            excludeReplayIframe: true
+          }
         }
       },
     });
@@ -238,11 +242,15 @@ describe('sentryAstro integration', () => {
         org: 'my-other-org',
         project: 'my-other-project',
         applicationKey: 'my-application-key',
-        debug: false,
         sourcemaps: {
           assets: ['foo/*.js'],
           ignore: ['bar/*.js'],
+          filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
         },
+        bundleSizeOptimizations: {
+          excludeReplayShadowDom: true,
+          excludeReplayIframe: true
+        }
       }),
     );
   });


### PR DESCRIPTION
Adds support for `unstable_sentryVitePluginOptions` which can be used to pass any valid vite-plugin option.

Fixes #15601

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

---

Hello 👋 this is my first ever contribution in this repository. I hope I understood and followed all the contribution guides correctly. Please let me know if I need to fix something, add more tests, refactor something. Or feel free to push more commits yourself - whichever working style you prefer!

I tried to base my implementation of this feature for sentry/astro on the existing implementation for sentry/sveltekit, from where I copied for example the type comment.