### PR TITLE
chore(ci): Remove `type` from canary failure template

### DIFF
--- a/.github/CANARY_FAILURE_TEMPLATE.md
+++ b/.github/CANARY_FAILURE_TEMPLATE.md
@@ -1,7 +1,6 @@
 ---
 title: '{{ env.TITLE }}'
 labels: 'Type: Tests, Waiting for: Product Owner'
-type: 'Task'
 ---
 
 Canary tests failed: {{ env.RUN_LINK }}

--- a/.github/CANARY_FAILURE_TEMPLATE.md
+++ b/.github/CANARY_FAILURE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ---
 title: '{{ env.TITLE }}'
 labels: 'Type: Tests, Waiting for: Product Owner'
-type: 'task'
+type: 'Task'
 ---
 
 Canary tests failed: {{ env.RUN_LINK }}


### PR DESCRIPTION
Apparently `type` is not yet supported by https://github.com/JasonEtco/create-an-issue

ref https://github.com/getsentry/sentry-javascript/pull/15562