### PR TITLE
ref(core): Update log types to explicitly reference otel

### DIFF
--- a/packages/core/src/types-hoist/envelope.ts
+++ b/packages/core/src/types-hoist/envelope.ts
@@ -5,7 +5,7 @@ import type { LegacyCSPReport } from './csp';
 import type { DsnComponents } from './dsn';
 import type { Event } from './event';
 import type { FeedbackEvent, UserFeedback } from './feedback';
-import type { Log } from './log';
+import type { SerializedOtelLog } from './log';
 import type { Profile, ProfileChunk } from './profiling';
 import type { ReplayEvent, ReplayRecordingData } from './replay';
 import type { SdkInfo } from './sdkinfo';
@@ -87,7 +87,7 @@ type CheckInItemHeaders = { type: 'check_in' };
 type ProfileItemHeaders = { type: 'profile' };
 type ProfileChunkItemHeaders = { type: 'profile_chunk' };
 type SpanItemHeaders = { type: 'span' };
-type LogItemHeaders = { type: 'otel_log' };
+type OtelLogItemHeaders = { type: 'otel_log' };
 type RawSecurityHeaders = { type: 'raw_security'; sentry_release?: string; sentry_environment?: string };
 
 export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event>;
@@ -104,7 +104,7 @@ export type FeedbackItem = BaseEnvelopeItem<FeedbackItemHeaders, FeedbackEvent>;
 export type ProfileItem = BaseEnvelopeItem<ProfileItemHeaders, Profile>;
 export type ProfileChunkItem = BaseEnvelopeItem<ProfileChunkItemHeaders, ProfileChunk>;
 export type SpanItem = BaseEnvelopeItem<SpanItemHeaders, Partial<SpanJSON>>;
-export type LogItem = BaseEnvelopeItem<LogItemHeaders, Log>;
+export type OtelLogItem = BaseEnvelopeItem<OtelLogItemHeaders, SerializedOtelLog>;
 export type RawSecurityItem = BaseEnvelopeItem<RawSecurityHeaders, LegacyCSPReport>;
 
 export type EventEnvelopeHeaders = { event_id: string; sent_at: string; trace?: Partial<DynamicSamplingContext> };
@@ -113,7 +113,7 @@ type CheckInEnvelopeHeaders = { trace?: DynamicSamplingContext };
 type ClientReportEnvelopeHeaders = BaseEnvelopeHeaders;
 type ReplayEnvelopeHeaders = BaseEnvelopeHeaders;
 type SpanEnvelopeHeaders = BaseEnvelopeHeaders & { trace?: DynamicSamplingContext };
-type LogEnvelopeHeaders = BaseEnvelopeHeaders & { trace?: DynamicSamplingContext };
+type OtelLogEnvelopeHeaders = BaseEnvelopeHeaders & { trace?: DynamicSamplingContext };
 
 export type EventEnvelope = BaseEnvelope<
   EventEnvelopeHeaders,
@@ -126,7 +126,7 @@ export type CheckInEnvelope = BaseEnvelope<CheckInEnvelopeHeaders, CheckInItem>;
 export type SpanEnvelope = BaseEnvelope<SpanEnvelopeHeaders, SpanItem>;
 export type ProfileChunkEnvelope = BaseEnvelope<BaseEnvelopeHeaders, ProfileChunkItem>;
 export type RawSecurityEnvelope = BaseEnvelope<BaseEnvelopeHeaders, RawSecurityItem>;
-export type LogEnvelope = BaseEnvelope<LogEnvelopeHeaders, LogItem>;
+export type OtelLogEnvelope = BaseEnvelope<OtelLogEnvelopeHeaders, OtelLogItem>;
 
 export type Envelope =
   | EventEnvelope
@@ -137,6 +137,6 @@ export type Envelope =
   | CheckInEnvelope
   | SpanEnvelope
   | RawSecurityEnvelope
-  | LogEnvelope;
+  | OtelLogEnvelope;
 
 export type EnvelopeItem = Envelope[1][number];

--- a/packages/core/src/types-hoist/index.ts
+++ b/packages/core/src/types-hoist/index.ts
@@ -110,7 +110,7 @@ export type {
   TraceFlag,
 } from './span';
 export type { SpanStatus } from './spanStatus';
-export type { Log, LogAttribute, LogSeverityLevel, LogAttributeValueType } from './log';
+export type { SerializedOtelLog, LogAttribute, LogSeverityLevel, LogAttributeValueType } from './log';
 export type { TimedEvent } from './timedEvent';
 export type { StackFrame } from './stackframe';
 export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';

--- a/packages/core/src/types-hoist/log.ts
+++ b/packages/core/src/types-hoist/log.ts
@@ -5,7 +5,9 @@ export type LogAttributeValueType =
       stringValue: string;
     }
   | {
-      intValue: number;
+      // integers must be represented as a string
+      // because JSON cannot differentiate between integers and floats
+      intValue: string;
     }
   | {
       boolValue: boolean;
@@ -19,7 +21,7 @@ export type LogAttribute = {
   value: LogAttributeValueType;
 };
 
-export interface Log {
+export interface SerializedOtelLog {
   /**
    * The severity level of the log.
    *


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/15530 I added types for the log envelope and log item.

This PR comes and explicitly references that these added types were otel logs. For more details, see the logs spec in develop: https://github.com/getsentry/sentry-docs/pull/12920.


Note I used `Otel` everywhere here, but I'm also fine with switching to `OpenTelemetry`.