### PR TITLE
fix(nuxt): Add Nitro Rollup plugin to inject Sentry server config

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -113,7 +113,7 @@ export default defineNuxtModule<ModuleOptions>({
         });
 
         if (moduleOptions.autoInjectServerSentry !== 'experimental_dynamic-import') {
-          addServerConfigToBuild(moduleOptions, nuxt, nitro, serverConfigFile);
+          addServerConfigToBuild(moduleOptions, nitro, serverConfigFile);
 
           if (moduleOptions.debug) {
             const serverDirResolver = createResolver(nitro.options.output.serverDir);


### PR DESCRIPTION
Previously, the Sentry server config was added by adding another entry point in the rollup options of Vite. Since Nuxt changed `preserveModules` to `true`, this did not work anymore. The aim of this change in Nuxt is to avoid duplicating what the Nitro build would do. 

This means, that we now don't change the Rollup options in Vite anymore (affects Nuxt as a whole) but only the Rollup options during the Nitro build.

The added plugin will emit a new file and returns the Sentry config code there.

fixes https://github.com/getsentry/sentry-javascript/issues/15628 
