### PR TITLE
test(browser-utils): Add test to make sure we run `originalHistoryFunction` if urls are the same

### DIFF
--- a/packages/browser-utils/test/instrument/history.test.ts
+++ b/packages/browser-utils/test/instrument/history.test.ts
@@ -1,13 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import { WINDOW } from '../../src/types';
-import { afterEach } from 'node:test';
 
 import { instrumentHistory } from './../../src/instrument/history';
+import * as instrumentHandlersModule from '@sentry/core';
 
 describe('instrumentHistory', () => {
   const originalHistory = WINDOW.history;
   WINDOW.addEventListener = vi.fn();
-
   afterEach(() => {
     // @ts-expect-error - this is fine for testing
     WINDOW.history = originalHistory;
@@ -53,6 +52,68 @@ describe('instrumentHistory', () => {
     expect(WINDOW.history).toEqual({
       replaceState: undefined, // unpatched
       pushState: expect.any(Function), // patched function
+    });
+  });
+
+  it('does not trigger handlers when the URLs are the same', () => {
+    const triggerHandlerSpy = vi.spyOn(instrumentHandlersModule, 'triggerHandlers');
+    const pushStateMock = vi.fn();
+
+    // @ts-expect-error - this is fine for testing
+    WINDOW.history = {
+      pushState: pushStateMock,
+      replaceState: () => {},
+    };
+
+    instrumentHistory();
+
+    // First call with URL1 to set lastHref
+    WINDOW.history.pushState({}, '', 'https://example.com/page1');
+    expect(pushStateMock).toHaveBeenCalledTimes(1);
+
+    // Reset mocks to check next call
+    pushStateMock.mockClear();
+    vi.mocked(triggerHandlerSpy).mockClear();
+
+    // Call with the same URL
+    WINDOW.history.pushState({}, '', 'https://example.com/page1');
+
+    expect(pushStateMock).toHaveBeenCalledTimes(1);
+    expect(triggerHandlerSpy).not.toHaveBeenCalled();
+  });
+
+  it('triggers handlers when the URLs are different', () => {
+    const triggerHandlerSpy = vi.spyOn(instrumentHandlersModule, 'triggerHandlers');
+    // Setup a mock for history.pushState
+    const pushStateMock = vi.fn();
+
+    // @ts-expect-error - this is fine for testing
+    WINDOW.history = {
+      pushState: pushStateMock,
+      replaceState: () => {},
+    };
+
+    // Run the instrumentation
+    instrumentHistory();
+
+    // First call with URL1 to set lastHref
+    WINDOW.history.pushState({}, '', 'https://example.com/page1');
+    expect(pushStateMock).toHaveBeenCalledTimes(1);
+
+    // Reset mocks to check next call
+    pushStateMock.mockClear();
+    vi.mocked(triggerHandlerSpy).mockClear();
+
+    // Call with a different URL
+    WINDOW.history.pushState({}, '', 'https://example.com/page2');
+
+    // Original function should be called
+    expect(pushStateMock).toHaveBeenCalledTimes(1);
+
+    // triggerHandlers should be called with from and to data
+    expect(triggerHandlerSpy).toHaveBeenCalledWith('history', {
+      from: 'https://example.com/page1',
+      to: 'https://example.com/page2',
     });
   });
 });


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/15594
