### PR TITLE
fix(node): Use `fatal` level for unhandled rejections in `strict` mode

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
@@ -1,0 +1,13 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'none' })],
+});
+
+setTimeout(() => {
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+Promise.reject('test rejection');

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
@@ -1,0 +1,14 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'strict' })],
+});
+
+setTimeout(() => {
+  // should not be called
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+Promise.reject('test rejection');

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
@@ -1,0 +1,12 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});
+
+setTimeout(() => {
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+Promise.reject(new Error('test rejection'));

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
@@ -1,0 +1,12 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});
+
+setTimeout(() => {
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+Promise.reject('test rejection');

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-strict.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-strict.ts
@@ -1,0 +1,12 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+  integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'strict' })],
+});
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+Promise.reject('test rejection');

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-warn.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-warn.ts
@@ -1,0 +1,11 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+});
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+Promise.reject('test rejection');

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
@@ -65,7 +65,7 @@ test rejection`);
 
       const testScriptPath = path.resolve(__dirname, 'mode-none.js');
 
-      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+      childProcess.execFile('node', [testScriptPath], { encoding: 'utf8' }, (err, stdout, stderr) => {
         expect(err).toBeNull();
         expect(stdout).toBe("I'm alive!");
         expect(stderr).toBe('');

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
@@ -15,7 +15,7 @@ describe('onUnhandledRejectionIntegration', () => {
 
       const testScriptPath = path.resolve(__dirname, 'mode-warn-string.js');
 
-      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+      childProcess.execFile('node', [testScriptPath], { encoding: 'utf8' }, (err, stdout, stderr) => {
         expect(err).toBeNull();
         expect(stdout).toBe("I'm alive!");
         expect(stderr.trim())
@@ -31,7 +31,7 @@ test rejection`);
 
       const testScriptPath = path.resolve(__dirname, 'mode-warn-error.js');
 
-      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+      childProcess.execFile('node', [testScriptPath], { encoding: 'utf8' }, (err, stdout, stderr) => {
         expect(err).toBeNull();
         expect(stdout).toBe("I'm alive!");
         expect(stderr)
@@ -48,7 +48,7 @@ Error: test rejection
 
       const testScriptPath = path.resolve(__dirname, 'mode-strict.js');
 
-      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+      childProcess.execFile('node', [testScriptPath], { encoding: 'utf8' }, (err, stdout, stderr) => {
         expect(err).not.toBeNull();
         expect(err?.code).toBe(1);
         expect(stdout).not.toBe("I'm alive!");

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
@@ -1,0 +1,127 @@
+import * as childProcess from 'child_process';
+import * as path from 'path';
+import { afterAll, describe, expect, test } from 'vitest';
+import { cleanupChildProcesses } from '../../../utils/runner';
+import { createRunner } from '../../../utils/runner';
+
+describe('onUnhandledRejectionIntegration', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  test('should show string-type promise rejection warnings by default', () =>
+    new Promise<void>(done => {
+      expect.assertions(3);
+
+      const testScriptPath = path.resolve(__dirname, 'mode-warn-string.js');
+
+      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+        expect(err).toBeNull();
+        expect(stdout).toBe("I'm alive!");
+        expect(stderr.trim())
+          .toBe(`This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
+test rejection`);
+        done();
+      });
+    }));
+
+  test('should show error-type promise rejection warnings by default', () =>
+    new Promise<void>(done => {
+      expect.assertions(3);
+
+      const testScriptPath = path.resolve(__dirname, 'mode-warn-error.js');
+
+      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+        expect(err).toBeNull();
+        expect(stdout).toBe("I'm alive!");
+        expect(stderr)
+          .toContain(`This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
+Error: test rejection
+    at Object.<anonymous>`);
+        done();
+      });
+    }));
+
+  test('should not close process on unhandled rejection in strict mode', () =>
+    new Promise<void>(done => {
+      expect.assertions(4);
+
+      const testScriptPath = path.resolve(__dirname, 'mode-strict.js');
+
+      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+        expect(err).not.toBeNull();
+        expect(err?.code).toBe(1);
+        expect(stdout).not.toBe("I'm alive!");
+        expect(stderr)
+          .toContain(`This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
+test rejection`);
+        done();
+      });
+    }));
+
+  test('should not close process or warn on unhandled rejection in none mode', () =>
+    new Promise<void>(done => {
+      expect.assertions(3);
+
+      const testScriptPath = path.resolve(__dirname, 'mode-none.js');
+
+      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+        expect(err).toBeNull();
+        expect(stdout).toBe("I'm alive!");
+        expect(stderr).toBe('');
+        done();
+      });
+    }));
+
+  test('captures exceptions for unhandled rejections', async () => {
+    await createRunner(__dirname, 'scenario-warn.ts')
+      .expect({
+        event: {
+          level: 'error',
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'test rejection',
+                mechanism: {
+                  type: 'onunhandledrejection',
+                  handled: false,
+                },
+                stacktrace: {
+                  frames: expect.any(Array),
+                },
+              },
+            ],
+          },
+        },
+      })
+      .start()
+      .completed();
+  });
+
+  test('captures exceptions for unhandled rejections in strict mode', async () => {
+    await createRunner(__dirname, 'scenario-strict.ts')
+      .expect({
+        event: {
+          level: 'fatal',
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'test rejection',
+                mechanism: {
+                  type: 'onunhandledrejection',
+                  handled: false,
+                },
+                stacktrace: {
+                  frames: expect.any(Array),
+                },
+              },
+            ],
+          },
+        },
+      })
+      .start()
+      .completed();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/13700

This also adds tests for unhandled rejections handling, which we did not really have before.