### PR TITLE
feat(browser): Attach host as part of error message to "Failed to fetch" errors

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -40,7 +40,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration'),
     gzip: true,
-    limit: '37.5 KB',
+    limit: '38 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay)',

--- a/dev-packages/browser-integration-tests/suites/errors/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch/init.js
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  transportOptions: {
+    fetchOptions: {
+      // See: https://github.com/microsoft/playwright/issues/34497
+      keepalive: false,
+    },
+  },
+});

--- a/dev-packages/browser-integration-tests/suites/errors/fetch/subject.js
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch/subject.js
@@ -1,0 +1,41 @@
+// Based on possible TypeError exceptions from https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch
+
+// Network error (e.g. ad-blocked, offline, page does not exist, ...)
+window.networkError = () => {
+  fetch('http://sentry-test-external.io/does-not-exist');
+};
+
+// Invalid header also produces TypeError
+window.invalidHeaderName = () => {
+  fetch('http://sentry-test-external.io/invalid-header-name', { headers: { 'C ontent-Type': 'text/xml' } });
+};
+
+// Invalid header value also produces TypeError
+window.invalidHeaderValue = () => {
+  fetch('http://sentry-test-external.io/invalid-header-value', { headers: ['Content-Type', 'text/html', 'extra'] });
+};
+
+// Invalid URL scheme
+window.invalidUrlScheme = () => {
+  fetch('blub://sentry-test-external.io/invalid-scheme');
+};
+
+// URL includes credentials
+window.credentialsInUrl = () => {
+  fetch('https://user:password@sentry-test-external.io/credentials-in-url');
+};
+
+// Invalid mode
+window.invalidMode = () => {
+  fetch('https://sentry-test-external.io/invalid-mode', { mode: 'navigate' });
+};
+
+// Invalid request method
+window.invalidMethod = () => {
+  fetch('http://sentry-test-external.io/invalid-method', { method: 'CONNECT' });
+};
+
+// No-cors mode with cors-required method
+window.noCorsMethod = () => {
+  fetch('http://sentry-test-external.io/no-cors-method', { mode: 'no-cors', method: 'PUT' });
+};

--- a/dev-packages/browser-integration-tests/suites/errors/fetch/subject.js
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch/subject.js
@@ -5,6 +5,10 @@ window.networkError = () => {
   fetch('http://sentry-test-external.io/does-not-exist');
 };
 
+window.networkErrorSubdomain = () => {
+  fetch('http://subdomain.sentry-test-external.io/does-not-exist');
+};
+
 // Invalid header also produces TypeError
 window.invalidHeaderName = () => {
   fetch('http://sentry-test-external.io/invalid-header-name', { headers: { 'C ontent-Type': 'text/xml' } });

--- a/dev-packages/browser-integration-tests/suites/errors/fetch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch/test.ts
@@ -1,0 +1,260 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../utils/fixtures';
+import { envelopeRequestParser, waitForErrorRequest } from '../../../utils/helpers';
+
+sentryTest('handles fetch network errors @firefox', async ({ getLocalTestUrl, page, browserName }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const reqPromise = waitForErrorRequest(page);
+  await page.goto(url);
+  await page.evaluate('networkError()');
+
+  const eventData = envelopeRequestParser(await reqPromise);
+
+  const errorMap: Record<string, string> = {
+    chromium: 'Failed to fetch (sentry-test-external.io)',
+    webkit: 'Load failed (sentry-test-external.io)',
+    firefox: 'NetworkError when attempting to fetch resource. (sentry-test-external.io)',
+  };
+
+  const error = errorMap[browserName];
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'TypeError',
+    value: error,
+    mechanism: {
+      handled: false,
+      type: 'onunhandledrejection',
+    },
+  });
+});
+
+sentryTest('handles fetch invalid header name errors @firefox', async ({ getLocalTestUrl, page, browserName }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const reqPromise = waitForErrorRequest(page);
+  await page.goto(url);
+  await page.evaluate('invalidHeaderName()');
+
+  const eventData = envelopeRequestParser(await reqPromise);
+
+  const errorMap: Record<string, string> = {
+    chromium: "Failed to execute 'fetch' on 'Window': Invalid name",
+    webkit: "Invalid header name: 'C ontent-Type'",
+    firefox: 'Window.fetch: c ontent-type is an invalid header name.',
+  };
+
+  const error = errorMap[browserName];
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'TypeError',
+    value: error,
+    mechanism: {
+      handled: false,
+      type: 'onunhandledrejection',
+    },
+    stacktrace: {
+      frames: expect.any(Array),
+    },
+  });
+});
+
+sentryTest('handles fetch invalid header value errors @firefox', async ({ getLocalTestUrl, page, browserName }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const reqPromise = waitForErrorRequest(page);
+  await page.goto(url);
+  await page.evaluate('invalidHeaderValue()');
+
+  const eventData = envelopeRequestParser(await reqPromise);
+
+  const errorMap: Record<string, string> = {
+    chromium:
+      "Failed to execute 'fetch' on 'Window': Failed to read the 'headers' property from 'RequestInit': The provided value cannot be converted to a sequence.",
+    webkit: 'Value is not a sequence',
+    firefox:
+      "Window.fetch: Element of sequence<sequence<ByteString>> branch of (sequence<sequence<ByteString>> or record<ByteString, ByteString>) can't be converted to a sequence.",
+  };
+
+  const error = errorMap[browserName];
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'TypeError',
+    value: error,
+    mechanism: {
+      handled: false,
+      type: 'onunhandledrejection',
+    },
+    stacktrace: {
+      frames: expect.any(Array),
+    },
+  });
+});
+
+sentryTest('handles fetch invalid URL scheme errors @firefox', async ({ getLocalTestUrl, page, browserName }) => {
+  await page.route('http://sentry-test-external.io/**', route => {
+    return route.fulfill({
+      status: 200,
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const reqPromise = waitForErrorRequest(page);
+  await page.goto(url);
+  await page.evaluate('invalidUrlScheme()');
+
+  const eventData = envelopeRequestParser(await reqPromise);
+
+  const errorMap: Record<string, string> = {
+    chromium: 'Failed to fetch (sentry-test-external.io)',
+    webkit: 'Load failed (sentry-test-external.io)',
+    firefox: 'NetworkError when attempting to fetch resource. (sentry-test-external.io)',
+  };
+
+  const error = errorMap[browserName];
+
+  /**
+   * This kind of error does show a helpful warning in the console, e.g.:
+   * Fetch API cannot load blub://sentry-test-external.io/invalid-scheme. URL scheme "blub" is not supported.
+   * But it seems we cannot really access this in the SDK :(
+   */
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'TypeError',
+    value: error,
+    mechanism: {
+      handled: false,
+      type: 'onunhandledrejection',
+    },
+    stacktrace: {
+      frames: expect.any(Array),
+    },
+  });
+});
+
+sentryTest('handles fetch credentials in url errors @firefox', async ({ getLocalTestUrl, page, browserName }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const reqPromise = waitForErrorRequest(page);
+  await page.goto(url);
+  await page.evaluate('credentialsInUrl()');
+
+  const eventData = envelopeRequestParser(await reqPromise);
+
+  const errorMap: Record<string, string> = {
+    chromium:
+      "Failed to execute 'fetch' on 'Window': Request cannot be constructed from a URL that includes credentials: https://user:password@sentry-test-external.io/credentials-in-url",
+    webkit: 'URL is not valid or contains user credentials.',
+    firefox:
+      'Window.fetch: https://user:password@sentry-test-external.io/credentials-in-url is an url with embedded credentials.',
+  };
+
+  const error = errorMap[browserName];
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'TypeError',
+    value: error,
+    mechanism: {
+      handled: false,
+      type: 'onunhandledrejection',
+    },
+    stacktrace: {
+      frames: expect.any(Array),
+    },
+  });
+});
+
+sentryTest('handles fetch invalid mode errors @firefox', async ({ getLocalTestUrl, page, browserName }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const reqPromise = waitForErrorRequest(page);
+  await page.goto(url);
+  await page.evaluate('invalidMode()');
+
+  const eventData = envelopeRequestParser(await reqPromise);
+
+  const errorMap: Record<string, string> = {
+    chromium:
+      "Failed to execute 'fetch' on 'Window': Cannot construct a Request with a RequestInit whose mode member is set as 'navigate'.",
+    webkit: 'Request constructor does not accept navigate fetch mode.',
+    firefox: 'Window.fetch: Invalid request mode navigate.',
+  };
+
+  const error = errorMap[browserName];
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'TypeError',
+    value: error,
+    mechanism: {
+      handled: false,
+      type: 'onunhandledrejection',
+    },
+    stacktrace: {
+      frames: expect.any(Array),
+    },
+  });
+});
+
+sentryTest('handles fetch invalid request method errors @firefox', async ({ getLocalTestUrl, page, browserName }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const reqPromise = waitForErrorRequest(page);
+  await page.goto(url);
+  await page.evaluate('invalidMethod()');
+
+  const eventData = envelopeRequestParser(await reqPromise);
+
+  const errorMap: Record<string, string> = {
+    chromium: "Failed to execute 'fetch' on 'Window': 'CONNECT' HTTP method is unsupported.",
+    webkit: 'Method is forbidden.',
+    firefox: 'Window.fetch: Invalid request method CONNECT.',
+  };
+
+  const error = errorMap[browserName];
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'TypeError',
+    value: error,
+    mechanism: {
+      handled: false,
+      type: 'onunhandledrejection',
+    },
+    stacktrace: {
+      frames: expect.any(Array),
+    },
+  });
+});
+
+sentryTest(
+  'handles fetch no-cors mode with cors-required method errors @firefox',
+  async ({ getLocalTestUrl, page, browserName }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
+    const reqPromise = waitForErrorRequest(page);
+    await page.goto(url);
+    await page.evaluate('noCorsMethod()');
+
+    const eventData = envelopeRequestParser(await reqPromise);
+
+    const errorMap: Record<string, string> = {
+      chromium: "Failed to execute 'fetch' on 'Window': 'PUT' is unsupported in no-cors mode.",
+      webkit: 'Method must be GET, POST or HEAD in no-cors mode.',
+      firefox: 'Window.fetch: Invalid request method PUT.',
+    };
+
+    const error = errorMap[browserName];
+
+    expect(eventData.exception?.values).toHaveLength(1);
+    expect(eventData.exception?.values?.[0]).toMatchObject({
+      type: 'TypeError',
+      value: error,
+      mechanism: {
+        handled: false,
+        type: 'onunhandledrejection',
+      },
+      stacktrace: {
+        frames: expect.any(Array),
+      },
+    });
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/errors/fetch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch/test.ts
@@ -39,9 +39,9 @@ sentryTest('handles fetch network errors on subdomains @firefox', async ({ getLo
   const eventData = envelopeRequestParser(await reqPromise);
 
   const errorMap: Record<string, string> = {
-    chromium: 'Failed to fetch (sentry-test-external.io)',
-    webkit: 'Load failed (sentry-test-external.io)',
-    firefox: 'NetworkError when attempting to fetch resource. (sentry-test-external.io)',
+    chromium: 'Failed to fetch (subdomain.sentry-test-external.io)',
+    webkit: 'Load failed (subdomain.sentry-test-external.io)',
+    firefox: 'NetworkError when attempting to fetch resource. (subdomain.sentry-test-external.io)',
   };
 
   const error = errorMap[browserName];

--- a/packages/core/src/utils-hoist/instrument/fetch.ts
+++ b/packages/core/src/utils-hoist/instrument/fetch.ts
@@ -120,10 +120,7 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
           ) {
             try {
               const url = new URL(handlerData.fetchData.url);
-              // We only want to take the top-level domain, e.g. xxx.sentry.io should become sentry.io
-              // We do this to avoid noise when there may be dynamic subdomains
-              const host = url.host.split('.').slice(-2).join('.');
-              error.message = `${error.message} (${host})`;
+              error.message = `${error.message} (${url.host})`;
             } catch {
               // ignore it if errors happen here
             }

--- a/packages/core/src/utils-hoist/instrument/fetch.ts
+++ b/packages/core/src/utils-hoist/instrument/fetch.ts
@@ -120,7 +120,10 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
           ) {
             try {
               const url = new URL(handlerData.fetchData.url);
-              error.message = `${error.message} (${url.host})`;
+              // We only want to take the top-level domain, e.g. xxx.sentry.io should become sentry.io
+              // We do this to avoid noise when there may be dynamic subdomains
+              const host = url.host.split('.').slice(-2).join('.');
+              error.message = `${error.message} (${host})`;
             } catch {
               // ignore it if errors happen here
             }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/15709

This also adds tests for the various types of TypeErrors that fetch can produce.