### PR TITLE
feat(node): Do not add HTTP & fetch span instrumentation if tracing is disabled

### DIFF
--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -2,7 +2,7 @@ import type { ClientRequest, IncomingMessage, RequestOptions, ServerResponse } f
 import { diag } from '@opentelemetry/api';
 import type { HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import type { Span } from '@sentry/core';
+import { Span, hasSpansEnabled } from '@sentry/core';
 import { defineIntegration, getClient } from '@sentry/core';
 import { generateInstrumentOnce } from '../../otel/instrument';
 import type { NodeClient } from '../../sdk/client';
@@ -136,8 +136,8 @@ export const instrumentOtelHttp = generateInstrumentOnce<HttpInstrumentationConf
 /** Exported only for tests. */
 export function _shouldInstrumentSpans(options: HttpOptions, clientOptions: Partial<NodeClientOptions> = {}): boolean {
   // If `spans` is passed in, it takes precedence
-  // Else, we by default emit spans, unless `skipOpenTelemetrySetup` is set to `true`
-  return typeof options.spans === 'boolean' ? options.spans : !clientOptions.skipOpenTelemetrySetup;
+  // Else, we by default emit spans, unless `skipOpenTelemetrySetup` is set to `true` or spans are not enabled
+  return typeof options.spans === 'boolean' ? options.spans : !clientOptions.skipOpenTelemetrySetup && hasSpansEnabled(clientOptions);
 }
 
 /**

--- a/packages/node/src/integrations/node-fetch/index.ts
+++ b/packages/node/src/integrations/node-fetch/index.ts
@@ -1,6 +1,6 @@
 import type { UndiciInstrumentationConfig } from '@opentelemetry/instrumentation-undici';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
-import type { IntegrationFn } from '@sentry/core';
+import { IntegrationFn, hasSpansEnabled } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration, getClient } from '@sentry/core';
 import { generateInstrumentOnce } from '../../otel/instrument';
 import type { NodeClient } from '../../sdk/client';
@@ -83,8 +83,10 @@ function getAbsoluteUrl(origin: string, path: string = '/'): string {
 
 function _shouldInstrumentSpans(options: NodeFetchOptions, clientOptions: Partial<NodeClientOptions> = {}): boolean {
   // If `spans` is passed in, it takes precedence
-  // Else, we by default emit spans, unless `skipOpenTelemetrySetup` is set to `true`
-  return typeof options.spans === 'boolean' ? options.spans : !clientOptions.skipOpenTelemetrySetup;
+  // Else, we by default emit spans, unless `skipOpenTelemetrySetup` is set to `true` or spans are not enabled
+  return typeof options.spans === 'boolean'
+    ? options.spans
+    : !clientOptions.skipOpenTelemetrySetup && hasSpansEnabled(clientOptions);
 }
 
 function getConfigWithDefaults(options: Partial<NodeFetchOptions> = {}): UndiciInstrumentationConfig {


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry-javascript/issues/15725, this PR stops adding the `HttpInstrumentation` / `UndiciInstrumentation` if tracing is not enabled.

I _think_ this should not really be breaking, as the integrations should not do anything else, if tracing is disabled 🤔 