### PR TITLE
fix(node): Ensure httpIntegration propagates traces

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/scenario.ts
@@ -1,0 +1,61 @@
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  integrations: [Sentry.httpIntegration({ spans: false })],
+  transport: loggingTransport,
+  // Ensure this gets a correct hint
+  beforeBreadcrumb(breadcrumb, hint) {
+    breadcrumb.data = breadcrumb.data || {};
+    const req = hint?.request as { path?: string };
+    breadcrumb.data.ADDED_PATH = req?.path;
+    return breadcrumb;
+  },
+});
+
+import * as http from 'http';
+
+async function run(): Promise<void> {
+  Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v0`);
+  await makeHttpGet(`${process.env.SERVER_URL}/api/v1`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v2`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v3`);
+
+  Sentry.captureException(new Error('foo'));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+run();
+
+function makeHttpRequest(url: string): Promise<void> {
+  return new Promise<void>(resolve => {
+    http
+      .request(url, httpRes => {
+        httpRes.on('data', () => {
+          // we don't care about data
+        });
+        httpRes.on('end', () => {
+          resolve();
+        });
+      })
+      .end();
+  });
+}
+
+function makeHttpGet(url: string): Promise<void> {
+  return new Promise<void>(resolve => {
+    http.get(url, httpRes => {
+      httpRes.on('data', () => {
+        // we don't care about data
+      });
+      httpRes.on('end', () => {
+        resolve();
+      });
+    });
+  });
+}

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/test.ts
@@ -1,10 +1,11 @@
+import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 import { createTestServer } from '../../../../utils/server';
 
-test('outgoing http requests are correctly instrumented with tracing & spans disabled', done => {
+test('outgoing http requests are correctly instrumented with tracing & spans disabled', async () => {
   expect.assertions(11);
 
-  createTestServer(done)
+  const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', headers => {
       expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})$/));
       expect(headers['sentry-trace']).not.toEqual('00000000000000000000000000000000-0000000000000000');
@@ -23,73 +24,75 @@ test('outgoing http requests are correctly instrumented with tracing & spans dis
       expect(headers['baggage']).toBeUndefined();
       expect(headers['sentry-trace']).toBeUndefined();
     })
-    .start()
-    .then(([SERVER_URL, closeTestServer]) => {
-      createRunner(__dirname, 'scenario.ts')
-        .withEnv({ SERVER_URL })
-        .ensureNoErrorOutput()
-        .expect({
-          event: {
-            exception: {
-              values: [
-                {
-                  type: 'Error',
-                  value: 'foo',
-                },
-              ],
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .ensureNoErrorOutput()
+    .expect({
+      event: {
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'foo',
             },
-            breadcrumbs: [
-              {
-                message: 'manual breadcrumb',
-                timestamp: expect.any(Number),
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v0`,
-                  status_code: 200,
-                  ADDED_PATH: '/api/v0',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v1`,
-                  status_code: 200,
-                  ADDED_PATH: '/api/v1',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v2`,
-                  status_code: 200,
-                  ADDED_PATH: '/api/v2',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-              {
-                category: 'http',
-                data: {
-                  'http.method': 'GET',
-                  url: `${SERVER_URL}/api/v3`,
-                  status_code: 200,
-                  ADDED_PATH: '/api/v3',
-                },
-                timestamp: expect.any(Number),
-                type: 'http',
-              },
-            ],
+          ],
+        },
+        breadcrumbs: [
+          {
+            message: 'manual breadcrumb',
+            timestamp: expect.any(Number),
           },
-        })
-        .start(closeTestServer);
-    });
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v0`,
+              status_code: 200,
+              ADDED_PATH: '/api/v0',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v1`,
+              status_code: 200,
+              ADDED_PATH: '/api/v1',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v2`,
+              status_code: 200,
+              ADDED_PATH: '/api/v2',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+          {
+            category: 'http',
+            data: {
+              'http.method': 'GET',
+              url: `${SERVER_URL}/api/v3`,
+              status_code: 200,
+              ADDED_PATH: '/api/v3',
+            },
+            timestamp: expect.any(Number),
+            type: 'http',
+          },
+        ],
+      },
+    })
+    .start()
+    .completed();
+
+  closeTestServer();
 });

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/test.ts
@@ -1,0 +1,95 @@
+import { createRunner } from '../../../../utils/runner';
+import { createTestServer } from '../../../../utils/server';
+
+test('outgoing http requests are correctly instrumented with tracing & spans disabled', done => {
+  expect.assertions(11);
+
+  createTestServer(done)
+    .get('/api/v0', headers => {
+      expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})$/));
+      expect(headers['sentry-trace']).not.toEqual('00000000000000000000000000000000-0000000000000000');
+      expect(headers['baggage']).toEqual(expect.any(String));
+    })
+    .get('/api/v1', headers => {
+      expect(headers['sentry-trace']).toEqual(expect.stringMatching(/^([a-f0-9]{32})-([a-f0-9]{16})$/));
+      expect(headers['sentry-trace']).not.toEqual('00000000000000000000000000000000-0000000000000000');
+      expect(headers['baggage']).toEqual(expect.any(String));
+    })
+    .get('/api/v2', headers => {
+      expect(headers['baggage']).toBeUndefined();
+      expect(headers['sentry-trace']).toBeUndefined();
+    })
+    .get('/api/v3', headers => {
+      expect(headers['baggage']).toBeUndefined();
+      expect(headers['sentry-trace']).toBeUndefined();
+    })
+    .start()
+    .then(([SERVER_URL, closeTestServer]) => {
+      createRunner(__dirname, 'scenario.ts')
+        .withEnv({ SERVER_URL })
+        .ensureNoErrorOutput()
+        .expect({
+          event: {
+            exception: {
+              values: [
+                {
+                  type: 'Error',
+                  value: 'foo',
+                },
+              ],
+            },
+            breadcrumbs: [
+              {
+                message: 'manual breadcrumb',
+                timestamp: expect.any(Number),
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v0`,
+                  status_code: 200,
+                  ADDED_PATH: '/api/v0',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v1`,
+                  status_code: 200,
+                  ADDED_PATH: '/api/v1',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v2`,
+                  status_code: 200,
+                  ADDED_PATH: '/api/v2',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v3`,
+                  status_code: 200,
+                  ADDED_PATH: '/api/v3',
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+            ],
+          },
+        })
+        .start(closeTestServer);
+    });
+});

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -268,12 +268,10 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
           ? getMergedHeadersForRequestOptions(url, optionsParsed, instrumentation._propagationDecisionMap)
           : undefined;
 
-          // If we are not proapgating traces, we skip touching the args for the request at all
-        const request = mergedHeaders
-          ? (original.apply(this, getOutgoingRequestArgsWithHeaders(argsCopy, mergedHeaders)) as ReturnType<
-              typeof http.request
-            >)
-          : (original.apply(this, args) as ReturnType<typeof http.request>);
+        // If we are not proapgating traces, we skip touching the args for the request at all
+        const request: ReturnType<typeof http.request> = mergedHeaders
+          ? original.apply(this, getOutgoingRequestArgsWithHeaders(argsCopy, mergedHeaders))
+          : original.apply(this, args);
 
         request.prependListener('response', (response: http.IncomingMessage) => {
           const _breadcrumbs = instrumentation.getConfig().breadcrumbs;

--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -160,6 +160,9 @@ export const httpIntegration = defineIntegration((options: HttpOptions = {}) => 
         // If spans are not instrumented, it means the HttpInstrumentation has not been added
         // In that case, we want to handle incoming trace extraction ourselves
         extractIncomingTraceFromHeader: !instrumentSpans,
+        // If spans are not instrumented, it means the HttpInstrumentation has not been added
+        // In that case, we want to handle trace propagation ourselves
+        propagateTraceInOutgoingRequests: !instrumentSpans,
       });
     },
   };


### PR DESCRIPTION
This is another stab at https://github.com/getsentry/sentry-javascript/pull/15233, which was reverted here: https://github.com/getsentry/sentry-javascript/pull/15354, with a different implementation.  

Today we would not propagate traces in outgoing http requests if:

1. The user configures `httpIntegration({ spans: false })`
2. ..._or_ the user has a custom OTEL setup
3. _and_ the user does not add their own `HttpInstrumentation`

Admittedly and edge case. More importantly, though, by actually adding distributed tracing information here, we are unblocked from potentially stopping to ship the http-instrumentation to users that do not need spans (and/or have a custom otel setup).

It is required to make https://github.com/getsentry/sentry-javascript/pull/15730 work.
