### PR TITLE
feat(react): Export captureReactException method

### DIFF
--- a/packages/react/src/error.ts
+++ b/packages/react/src/error.ts
@@ -1,6 +1,5 @@
-import { captureException } from '@sentry/browser';
+import { captureException, withScope } from '@sentry/browser';
 import { isError } from '@sentry/core';
-import type { EventHint } from '@sentry/core';
 import { version } from 'react';
 import type { ErrorInfo } from 'react';
 
@@ -46,7 +45,7 @@ export function captureReactException(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any,
   { componentStack }: ErrorInfo,
-  hint?: EventHint,
+  hint?: Parameters<typeof captureException>[1],
 ): string {
   // If on React version >= 17, create stack trace from componentStack param and links
   // to to the original error using `error.cause` otherwise relies on error param for stacktrace.
@@ -65,11 +64,9 @@ export function captureReactException(
     setCause(error, errorBoundaryError);
   }
 
-  return captureException(error, {
-    ...hint,
-    captureContext: {
-      contexts: { react: { componentStack } },
-    },
+  return withScope(scope => {
+    scope.setContext('react', { componentStack });
+    return captureException(error, hint);
   });
 }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,7 @@
 export * from '@sentry/browser';
 
 export { init } from './sdk';
-export { reactErrorHandler } from './error';
+export { captureReactException, reactErrorHandler } from './error';
 export { Profiler, withProfiler, useProfiler } from './profiler';
 export type { ErrorBoundaryProps, FallbackRender } from './errorboundary';
 export { ErrorBoundary, withErrorBoundary } from './errorboundary';


### PR DESCRIPTION
This PR exports the `captureReactException` method from the React package, making it available as a public API. Additionally, it refactors the implementation to use `withScope` instead of directly passing context to `captureException`. This was done so that the arguments to `captureReactException` better align to `captureException`.

This was requested by a user, but I also need it for my conference talk in a couple weeks 😅 

Users can now directly access and use this method in their applications:

```javascript
import * as Sentry from '@sentry/react';

class ErrorBoundary extends React.Component {
  componentDidCatch(error, info) {
    Sentry.captureReactException(error, info);
  }

  render() {
    return this.props.children;
  }
}
```

The reason why `captureReactException` is named as such and not `captureReactErrorBoundaryException` is because it can be used in other scenarios as well, like with the new React 19 error APIs. Therefore it was generalized to just be `captureReactException`.
