### PR TITLE
fix(nuxt): Delete Nuxt server template injection

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -62,18 +62,6 @@ export default defineNuxtModule<ModuleOptions>({
     const serverConfigFile = findDefaultSdkInitFile('server');
 
     if (serverConfigFile) {
-      if (moduleOptions.autoInjectServerSentry !== 'experimental_dynamic-import') {
-        addPluginTemplate({
-          mode: 'server',
-          filename: 'sentry-server-config.mjs',
-          getContents: () =>
-            // This won't actually import the server config in the build output (so no double init call). The import here is only needed for correctly resolving the Sentry release injection.
-            `import "${buildDirResolver.resolve(`/${serverConfigFile}`)}";
-            import { defineNuxtPlugin } from "#imports";
-            export default defineNuxtPlugin(() => {});`,
-        });
-      }
-
       addServerPlugin(moduleDirResolver.resolve('./runtime/plugins/sentry.server'));
     }
 


### PR DESCRIPTION
Follow-up for https://github.com/getsentry/sentry-javascript/pull/15710

The server config was still processed by Nuxt (not only Nitro) because the file was imported in a plugin template. This code can be deleted now, as the Sentry server config should only be processed on the Nitro-side.


fixes https://github.com/getsentry/sentry-javascript/issues/15628

