### PR TITLE
perf(core): Add short-circuits to `eventFilters` integration

### DIFF
--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -107,7 +107,7 @@ function _mergeOptions(
 }
 
 function _shouldDropEvent(event: Event, options: Partial<EventFiltersOptions>): boolean {
-  if (event.type === undefined) {
+  if (!event.type) {
     // Filter errors
 
     if (options.ignoreInternal && _isSentryError(event)) {

--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -35,17 +35,6 @@ export interface EventFiltersOptions {
 
 const INTEGRATION_NAME = 'EventFilters';
 
-const _eventFiltersIntegration = ((options: Partial<EventFiltersOptions> = {}) => {
-  return {
-    name: INTEGRATION_NAME,
-    processEvent(event, _hint, client) {
-      const clientOptions = client.getOptions();
-      const mergedOptions = _mergeOptions(options, clientOptions);
-      return _shouldDropEvent(event, mergedOptions) ? null : event;
-    },
-  };
-}) satisfies IntegrationFn;
-
 /**
  * An integration that filters out events (errors and transactions) based on:
  *
@@ -59,7 +48,23 @@ const _eventFiltersIntegration = ((options: Partial<EventFiltersOptions> = {}) =
  *
  * Events filtered by this integration will not be sent to Sentry.
  */
-export const eventFiltersIntegration = defineIntegration(_eventFiltersIntegration);
+export const eventFiltersIntegration = defineIntegration((options: Partial<EventFiltersOptions> = {}) => {
+  let mergedOptions: Partial<EventFiltersOptions> | undefined;
+  return {
+    name: INTEGRATION_NAME,
+    setup(client) {
+      const clientOptions = client.getOptions();
+      mergedOptions = _mergeOptions(options, clientOptions);
+    },
+    processEvent(event, _hint, client) {
+      if (!mergedOptions) {
+        const clientOptions = client.getOptions();
+        mergedOptions = _mergeOptions(options, clientOptions);
+      }
+      return _shouldDropEvent(event, mergedOptions) ? null : event;
+    },
+  };
+});
 
 /**
  * An integration that filters out events (errors and transactions) based on:
@@ -102,58 +107,64 @@ function _mergeOptions(
 }
 
 function _shouldDropEvent(event: Event, options: Partial<EventFiltersOptions>): boolean {
-  if (options.ignoreInternal && _isSentryError(event)) {
-    DEBUG_BUILD &&
-      logger.warn(`Event dropped due to being internal Sentry Error.\nEvent: ${getEventDescription(event)}`);
-    return true;
-  }
-  if (_isIgnoredError(event, options.ignoreErrors)) {
-    DEBUG_BUILD &&
-      logger.warn(
-        `Event dropped due to being matched by \`ignoreErrors\` option.\nEvent: ${getEventDescription(event)}`,
-      );
-    return true;
-  }
-  if (_isUselessError(event)) {
-    DEBUG_BUILD &&
-      logger.warn(
-        `Event dropped due to not having an error message, error type or stacktrace.\nEvent: ${getEventDescription(
-          event,
-        )}`,
-      );
-    return true;
-  }
-  if (_isIgnoredTransaction(event, options.ignoreTransactions)) {
-    DEBUG_BUILD &&
-      logger.warn(
-        `Event dropped due to being matched by \`ignoreTransactions\` option.\nEvent: ${getEventDescription(event)}`,
-      );
-    return true;
-  }
-  if (_isDeniedUrl(event, options.denyUrls)) {
-    DEBUG_BUILD &&
-      logger.warn(
-        `Event dropped due to being matched by \`denyUrls\` option.\nEvent: ${getEventDescription(
-          event,
-        )}.\nUrl: ${_getEventFilterUrl(event)}`,
-      );
-    return true;
-  }
-  if (!_isAllowedUrl(event, options.allowUrls)) {
-    DEBUG_BUILD &&
-      logger.warn(
-        `Event dropped due to not being matched by \`allowUrls\` option.\nEvent: ${getEventDescription(
-          event,
-        )}.\nUrl: ${_getEventFilterUrl(event)}`,
-      );
-    return true;
+  if (event.type === undefined) {
+    // Filter errors
+
+    if (options.ignoreInternal && _isSentryError(event)) {
+      DEBUG_BUILD &&
+        logger.warn(`Event dropped due to being internal Sentry Error.\nEvent: ${getEventDescription(event)}`);
+      return true;
+    }
+    if (_isIgnoredError(event, options.ignoreErrors)) {
+      DEBUG_BUILD &&
+        logger.warn(
+          `Event dropped due to being matched by \`ignoreErrors\` option.\nEvent: ${getEventDescription(event)}`,
+        );
+      return true;
+    }
+    if (_isUselessError(event)) {
+      DEBUG_BUILD &&
+        logger.warn(
+          `Event dropped due to not having an error message, error type or stacktrace.\nEvent: ${getEventDescription(
+            event,
+          )}`,
+        );
+      return true;
+    }
+    if (_isDeniedUrl(event, options.denyUrls)) {
+      DEBUG_BUILD &&
+        logger.warn(
+          `Event dropped due to being matched by \`denyUrls\` option.\nEvent: ${getEventDescription(
+            event,
+          )}.\nUrl: ${_getEventFilterUrl(event)}`,
+        );
+      return true;
+    }
+    if (!_isAllowedUrl(event, options.allowUrls)) {
+      DEBUG_BUILD &&
+        logger.warn(
+          `Event dropped due to not being matched by \`allowUrls\` option.\nEvent: ${getEventDescription(
+            event,
+          )}.\nUrl: ${_getEventFilterUrl(event)}`,
+        );
+      return true;
+    }
+  } else if (event.type === 'transaction') {
+    // Filter transactions
+
+    if (_isIgnoredTransaction(event, options.ignoreTransactions)) {
+      DEBUG_BUILD &&
+        logger.warn(
+          `Event dropped due to being matched by \`ignoreTransactions\` option.\nEvent: ${getEventDescription(event)}`,
+        );
+      return true;
+    }
   }
   return false;
 }
 
 function _isIgnoredError(event: Event, ignoreErrors?: Array<string | RegExp>): boolean {
-  // If event.type, this is not an error
-  if (event.type || !ignoreErrors || !ignoreErrors.length) {
+  if (!ignoreErrors?.length) {
     return false;
   }
 
@@ -161,7 +172,7 @@ function _isIgnoredError(event: Event, ignoreErrors?: Array<string | RegExp>): b
 }
 
 function _isIgnoredTransaction(event: Event, ignoreTransactions?: Array<string | RegExp>): boolean {
-  if (event.type !== 'transaction' || !ignoreTransactions || !ignoreTransactions.length) {
+  if (!ignoreTransactions?.length) {
     return false;
   }
 
@@ -223,11 +234,6 @@ function _getEventFilterUrl(event: Event): string | null {
 }
 
 function _isUselessError(event: Event): boolean {
-  if (event.type) {
-    // event is not an error
-    return false;
-  }
-
   // We only want to consider events for dropping that actually have recorded exception values.
   if (!event.exception?.values?.length) {
     return false;


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/15725

- Only does the options merging once
- Adds short circuiting for event types to avoid doing things multiple times/unnecessarily