### PR TITLE
profiling: add platform to chunk envelope

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -516,7 +516,7 @@ class ContinuousProfiler {
     const metadata = this._client.getSdkMetadata();
     const tunnel = this._client.getOptions().tunnel;
 
-    const envelope = makeProfileChunkEnvelope('javascript.node', chunk, metadata?.sdk, tunnel, dsn);
+    const envelope = makeProfileChunkEnvelope('node', chunk, metadata?.sdk, tunnel, dsn);
     transport.send(envelope).then(null, reason => {
       DEBUG_BUILD && logger.error('Error while sending profile chunk envelope:', reason);
     });

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -516,7 +516,7 @@ class ContinuousProfiler {
     const metadata = this._client.getSdkMetadata();
     const tunnel = this._client.getOptions().tunnel;
 
-    const envelope = makeProfileChunkEnvelope(chunk, metadata?.sdk, tunnel, dsn);
+    const envelope = makeProfileChunkEnvelope('node', chunk, metadata?.sdk, tunnel, dsn);
     transport.send(envelope).then(null, reason => {
       DEBUG_BUILD && logger.error('Error while sending profile chunk envelope:', reason);
     });

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -516,7 +516,7 @@ class ContinuousProfiler {
     const metadata = this._client.getSdkMetadata();
     const tunnel = this._client.getOptions().tunnel;
 
-    const envelope = makeProfileChunkEnvelope('node', chunk, metadata?.sdk, tunnel, dsn);
+    const envelope = makeProfileChunkEnvelope('javascript.node', chunk, metadata?.sdk, tunnel, dsn);
     transport.send(envelope).then(null, reason => {
       DEBUG_BUILD && logger.error('Error while sending profile chunk envelope:', reason);
     });

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -400,6 +400,7 @@ export function createEventEnvelopeHeaders(
  * Creates a standalone profile_chunk envelope.
  */
 export function makeProfileChunkEnvelope(
+  platform: 'node',
   chunk: ProfileChunk,
   sdkInfo: SdkInfo | undefined,
   tunnel: string | undefined,
@@ -407,6 +408,7 @@ export function makeProfileChunkEnvelope(
 ): ProfileChunkEnvelope {
   const profileChunkHeader: ProfileChunkItem[0] = {
     type: 'profile_chunk',
+    platform: platform,
   };
 
   return createEnvelope<ProfileChunkEnvelope>(createEventEnvelopeHeaders(sdkInfo, tunnel, dsn), [

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -400,7 +400,7 @@ export function createEventEnvelopeHeaders(
  * Creates a standalone profile_chunk envelope.
  */
 export function makeProfileChunkEnvelope(
-  platform: 'node',
+  platform: 'javascript.node',
   chunk: ProfileChunk,
   sdkInfo: SdkInfo | undefined,
   tunnel: string | undefined,

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -400,7 +400,7 @@ export function createEventEnvelopeHeaders(
  * Creates a standalone profile_chunk envelope.
  */
 export function makeProfileChunkEnvelope(
-  platform: 'javascript.node',
+  platform: 'node',
   chunk: ProfileChunk,
   sdkInfo: SdkInfo | undefined,
   tunnel: string | undefined,

--- a/packages/profiling-node/src/utils.ts
+++ b/packages/profiling-node/src/utils.ts
@@ -408,7 +408,7 @@ export function makeProfileChunkEnvelope(
 ): ProfileChunkEnvelope {
   const profileChunkHeader: ProfileChunkItem[0] = {
     type: 'profile_chunk',
-    platform: platform,
+    platform,
   };
 
   return createEnvelope<ProfileChunkEnvelope>(createEventEnvelopeHeaders(sdkInfo, tunnel, dsn), [

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -643,7 +643,9 @@ describe('ProfilingIntegration', () => {
       Sentry.profiler.stopProfiler();
       vi.advanceTimersByTime(1000);
 
-      expect(transportSpy.mock.calls?.[0]?.[0]?.[1]?.[0]?.[0]?.type).toBe('profile_chunk');
+      const envelopeHeaders = transportSpy.mock.calls?.[0]?.[0]?.[1]?.[0]?.[0];
+      expect(envelopeHeaders?.type).toBe('profile_chunk');
+      expect(envelopeHeaders?.platform).toBe('node');
     });
 
     it('sets global profile context', async () => {

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -645,7 +645,7 @@ describe('ProfilingIntegration', () => {
 
       const envelopeHeaders = transportSpy.mock.calls?.[0]?.[0]?.[1]?.[0]?.[0];
       expect(envelopeHeaders?.type).toBe('profile_chunk');
-      expect(envelopeHeaders?.platform).toBe('node');
+      expect(envelopeHeaders?.platform).toBe('javascript.node');
     });
 
     it('sets global profile context', async () => {

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -645,7 +645,7 @@ describe('ProfilingIntegration', () => {
 
       const envelopeHeaders = transportSpy.mock.calls?.[0]?.[0]?.[1]?.[0]?.[0];
       expect(envelopeHeaders?.type).toBe('profile_chunk');
-      expect(envelopeHeaders?.platform).toBe('javascript.node');
+      expect(envelopeHeaders?.platform).toBe('node');
     });
 
     it('sets global profile context', async () => {


### PR DESCRIPTION
We need to send the platform as part of envelope headers as this is the item that relay is checking to manage rate limiting. We only care about backend (node) and in the future frontend.

@AbhiPrasad please correct me here to use the correct convention, would `javascript.node` be more appropriate? The only requirement really is to have all nodejs platform types be of a single platform type, so we dont need to maintain the ever growing list in relay