### PR TITLE
feat(node): Add logging public APIs to Node SDKs

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -127,6 +127,7 @@ export {
   withScope,
   zodErrorsIntegration,
   profiler,
+  logger,
 } from '@sentry/node';
 
 export { init } from './server/sdk';

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -10,6 +10,7 @@ import type { NodeOptions } from '@sentry/node';
 import type { Client, Integration, Options, StackParser } from '@sentry/core';
 
 import type * as clientSdk from './index.client';
+import type * as serverSdk from './index.server';
 import sentryAstro from './index.server';
 
 /** Initializes Sentry Astro SDK */
@@ -25,5 +26,7 @@ export declare function close(timeout?: number | undefined): PromiseLike<boolean
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 
 export declare const Span: clientSdk.Span;
+
+export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;
 
 export default sentryAstro;

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -113,6 +113,7 @@ export {
   profiler,
   amqplibIntegration,
   vercelAIIntegration,
+  logger,
 } from '@sentry/node';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -132,6 +132,7 @@ export {
   profiler,
   amqplibIntegration,
   vercelAIIntegration,
+  logger,
 } from '@sentry/node';
 
 export {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -16,6 +16,7 @@ import type {
   FeedbackEvent,
   FetchBreadcrumbHint,
   Integration,
+  Log,
   MonitorConfig,
   Outcome,
   ParameterizedString,
@@ -622,6 +623,13 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   public on(hook: 'close', callback: () => void): () => void;
 
   /**
+   * A hook that is called before a log is captured
+   *
+   * @returns {() => void} A function that, when executed, removes the registered callback.
+   */
+  public on(hook: 'beforeCaptureLog', callback: (log: Log) => void): () => void;
+
+  /**
    * Register a hook on this client.
    */
   public on(hook: string, callback: unknown): () => void {
@@ -767,6 +775,11 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
    * Emit a hook event for client close
    */
   public emit(hook: 'close'): void;
+
+  /**
+   * Emit a hook event for client before capturing a log
+   */
+  public emit(hook: 'beforeCaptureLog', log: Log): void;
 
   /**
    * Emit a hook that was previously registered via `on()`.

--- a/packages/core/src/logs/index.ts
+++ b/packages/core/src/logs/index.ts
@@ -110,14 +110,14 @@ export function _INTERNAL_captureLog(log: Log, client = getClient(), scope = get
   const logBuffer = CLIENT_TO_LOG_BUFFER_MAP.get(client);
   if (logBuffer === undefined) {
     CLIENT_TO_LOG_BUFFER_MAP.set(client, [serializedLog]);
-    // Every time we initialize a new log buffer, we start a new interval to flush the buffer
-    return;
+  } else {
+    logBuffer.push(serializedLog);
+    if (logBuffer.length > MAX_LOG_BUFFER_SIZE) {
+      _INTERNAL_flushLogsBuffer(client, logBuffer);
+    }
   }
 
-  logBuffer.push(serializedLog);
-  if (logBuffer.length > MAX_LOG_BUFFER_SIZE) {
-    _INTERNAL_flushLogsBuffer(client, logBuffer);
-  }
+  client.emit('beforeCaptureLog', log);
 }
 
 /**

--- a/packages/core/src/types-hoist/log.ts
+++ b/packages/core/src/types-hoist/log.ts
@@ -41,7 +41,7 @@ export interface Log {
   /**
    * Arbitrary structured data that stores information about the log - e.g., userId: 100.
    */
-  attributes?: Record<string, string | number | boolean | Array<string | number | boolean>>;
+  attributes?: Record<string, unknown>;
 
   /**
    * The severity number - generally higher severity are levels like 'error' and lower are levels like 'debug'

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -113,6 +113,7 @@ export {
   amqplibIntegration,
   childProcessIntegration,
   vercelAIIntegration,
+  logger,
 } from '@sentry/node';
 
 export {

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -32,6 +32,8 @@ export declare const createReduxEnhancer: typeof clientSdk.createReduxEnhancer;
 export declare const showReportDialog: typeof clientSdk.showReportDialog;
 export declare const withErrorBoundary: typeof clientSdk.withErrorBoundary;
 
+export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;
+
 export { withSentryConfig } from './config';
 
 /**

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -150,3 +150,7 @@ export type {
   User,
   Span,
 } from '@sentry/core';
+
+import * as logger from './log';
+
+export { logger };

--- a/packages/node/src/log.ts
+++ b/packages/node/src/log.ts
@@ -3,6 +3,10 @@ import { format } from 'node:util';
 import type { LogSeverityLevel, Log } from '@sentry/core';
 import { _INTERNAL_captureLog } from '@sentry/core';
 
+type CaptureLogArgs =
+  | [message: string, attributes?: Log['attributes']]
+  | [messageTemplate: string, messageParams: Array<unknown>, attributes?: Log['attributes']];
+
 /**
  * Capture a log with the given level.
  *
@@ -10,259 +14,210 @@ import { _INTERNAL_captureLog } from '@sentry/core';
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
  */
-function captureLog(level: LogSeverityLevel, message: string, attributes?: Log['attributes']): void {
-  _INTERNAL_captureLog({ level, message, attributes });
+function captureLog(level: LogSeverityLevel, ...args: CaptureLogArgs): void {
+  const [messageOrMessageTemplate, paramsOrAttributes, maybeAttributes] = args;
+  if (Array.isArray(paramsOrAttributes)) {
+    const attributes = { ...maybeAttributes };
+    attributes['sentry.message.template'] = messageOrMessageTemplate;
+    paramsOrAttributes.forEach((param, index) => {
+      attributes[`sentry.message.param.${index}`] = param;
+    });
+    const message = format(messageOrMessageTemplate, ...paramsOrAttributes);
+    _INTERNAL_captureLog({ level, message, attributes });
+  } else {
+    _INTERNAL_captureLog({ level, message: messageOrMessageTemplate, attributes: paramsOrAttributes });
+  }
 }
 
 /**
  * @summary Capture a log with the `trace` level. Requires `_experiments.enableLogs` to be enabled.
  *
- * @param message - The message to log.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ * You can either pass a message and attributes or a message template, params and attributes.
  *
  * @example
  *
  * ```
- * Sentry.logger.trace('Hello world', { userId: 100 });
+ * Sentry.logger.trace('Starting database connection', {
+ *   database: 'users',
+ *   connectionId: 'conn_123'
+ * });
+ * ```
+ *
+ * @example With template strings
+ *
+ * ```
+ * Sentry.logger.trace('Database connection %s established for %s',
+ *   ['successful', 'users'],
+ *   { connectionId: 'conn_123' }
+ * );
  * ```
  */
-export function trace(message: string, attributes?: Log['attributes']): void {
-  captureLog('trace', message, attributes);
+export function trace(...args: CaptureLogArgs): void {
+  captureLog('trace', ...args);
 }
 
 /**
  * @summary Capture a log with the `debug` level. Requires `_experiments.enableLogs` to be enabled.
  *
- * @param message - The message to log.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ * You can either pass a message and attributes or a message template, params and attributes.
  *
  * @example
  *
  * ```
- * Sentry.logger.debug('Hello world', { userId: 100 });
+ * Sentry.logger.debug('Cache miss for user profile', {
+ *   userId: 'user_123',
+ *   cacheKey: 'profile:user_123'
+ * });
+ * ```
+ *
+ * @example With template strings
+ *
+ * ```
+ * Sentry.logger.debug('Cache %s for %s: %s',
+ *   ['miss', 'user profile', 'key not found'],
+ *   { userId: 'user_123' }
+ * );
  * ```
  */
-export function debug(message: string, attributes?: Log['attributes']): void {
-  captureLog('debug', message, attributes);
+export function debug(...args: CaptureLogArgs): void {
+  captureLog('debug', ...args);
 }
 
 /**
  * @summary Capture a log with the `info` level. Requires `_experiments.enableLogs` to be enabled.
  *
- * @param message - The message to log.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ * You can either pass a message and attributes or a message template, params and attributes.
  *
  * @example
  *
  * ```
- * Sentry.logger.info('Hello world', { userId: 100 });
+ * Sentry.logger.info('User profile updated', {
+ *   userId: 'user_123',
+ *   updatedFields: ['email', 'preferences']
+ * });
+ * ```
+ *
+ * @example With template strings
+ *
+ * ```
+ * Sentry.logger.info('User %s updated their %s',
+ *   ['John Doe', 'profile settings'],
+ *   { userId: 'user_123' }
+ * );
  * ```
  */
-export function info(message: string, attributes?: Log['attributes']): void {
-  captureLog('info', message, attributes);
+export function info(...args: CaptureLogArgs): void {
+  captureLog('info', ...args);
 }
 
 /**
  * @summary Capture a log with the `warn` level. Requires `_experiments.enableLogs` to be enabled.
  *
- * @param message - The message to log.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ * You can either pass a message and attributes or a message template, params and attributes.
  *
  * @example
  *
  * ```
- * Sentry.logger.warn('Hello world', { userId: 100 });
+ * Sentry.logger.warn('Rate limit approaching', {
+ *   endpoint: '/api/users',
+ *   currentRate: '95/100',
+ *   resetTime: '2024-03-20T10:00:00Z'
+ * });
+ * ```
+ *
+ * @example With template strings
+ *
+ * ```
+ * Sentry.logger.warn('Rate limit %s for %s: %s',
+ *   ['approaching', '/api/users', '95/100 requests'],
+ *   { resetTime: '2024-03-20T10:00:00Z' }
+ * );
  * ```
  */
-export function warn(message: string, attributes?: Log['attributes']): void {
-  captureLog('warn', message, attributes);
+export function warn(...args: CaptureLogArgs): void {
+  captureLog('warn', ...args);
 }
 
 /**
  * @summary Capture a log with the `error` level. Requires `_experiments.enableLogs` to be enabled.
  *
- * @param message - The message to log.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ * You can either pass a message and attributes or a message template, params and attributes.
  *
  * @example
  *
  * ```
- * Sentry.logger.error('Hello world', { userId: 100 });
+ * Sentry.logger.error('Failed to process payment', {
+ *   orderId: 'order_123',
+ *   errorCode: 'PAYMENT_FAILED',
+ *   amount: 99.99
+ * });
+ * ```
+ *
+ * @example With template strings
+ *
+ * ```
+ * Sentry.logger.error('Payment processing failed for order %s: %s',
+ *   ['order_123', 'insufficient funds'],
+ *   { amount: 99.99 }
+ * );
  * ```
  */
-export function error(message: string, attributes?: Log['attributes']): void {
-  captureLog('error', message, attributes);
+export function error(...args: CaptureLogArgs): void {
+  captureLog('error', ...args);
 }
 
 /**
  * @summary Capture a log with the `fatal` level. Requires `_experiments.enableLogs` to be enabled.
  *
- * @param message - The message to log.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ * You can either pass a message and attributes or a message template, params and attributes.
  *
  * @example
  *
  * ```
- * Sentry.logger.fatal('Hello world', { userId: 100 });
+ * Sentry.logger.fatal('Database connection pool exhausted', {
+ *   database: 'users',
+ *   activeConnections: 100,
+ *   maxConnections: 100
+ * });
+ * ```
+ *
+ * @example With template strings
+ *
+ * ```
+ * Sentry.logger.fatal('Database %s: %s connections active',
+ *   ['connection pool exhausted', '100/100'],
+ *   { database: 'users' }
+ * );
  * ```
  */
-export function fatal(message: string, attributes?: Log['attributes']): void {
-  captureLog('fatal', message, attributes);
+export function fatal(...args: CaptureLogArgs): void {
+  captureLog('fatal', ...args);
 }
 
 /**
  * @summary Capture a log with the `critical` level. Requires `_experiments.enableLogs` to be enabled.
  *
- * @param message - The message to log.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ * You can either pass a message and attributes or a message template, params and attributes.
  *
  * @example
  *
  * ```
- * Sentry.logger.critical('Hello world', { userId: 100 });
+ * Sentry.logger.critical('Service health check failed', {
+ *   service: 'payment-gateway',
+ *   status: 'DOWN',
+ *   lastHealthy: '2024-03-20T09:55:00Z'
+ * });
+ * ```
+ *
+ * @example With template strings
+ *
+ * ```
+ * Sentry.logger.critical('Service %s is %s',
+ *   ['payment-gateway', 'DOWN'],
+ *   { lastHealthy: '2024-03-20T09:55:00Z' }
+ * );
  * ```
  */
-export function critical(message: string, attributes?: Log['attributes']): void {
-  captureLog('critical', message, attributes);
-}
-
-/**
- * Capture a formatted log with the given level.
- *
- * @param level - The level of the log.
- * @param message - The message template.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
- */
-function captureLogFmt(
-  level: LogSeverityLevel,
-  messageTemplate: string,
-  params: Array<unknown>,
-  logAttributes: Log['attributes'] = {},
-): void {
-  const attributes = { ...logAttributes };
-  attributes['sentry.message.template'] = messageTemplate;
-  params.forEach((param, index) => {
-    attributes[`sentry.message.param.${index}`] = param;
-  });
-  const message = format(messageTemplate, ...params);
-  _INTERNAL_captureLog({ level, message, attributes });
-}
-
-/**
- * @summary Capture a formatted log with the `trace` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * @param message - The message to log.
- * @param params - The parameters to interpolate into the message.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
- *
- * @example
- *
- * ```
- * Sentry.logger.traceFmt('Hello world %s', ['foo'], { userId: 100 });
- * ```
- */
-export function traceFmt(message: string, params: Array<unknown>, attributes: Log['attributes'] = {}): void {
-  captureLogFmt('trace', message, params, attributes);
-}
-
-/**
- * @summary Capture a formatted log with the `debug` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * @param message - The message to log.
- * @param params - The parameters to interpolate into the message.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
- *
- * @example
- *
- * ```
- * Sentry.logger.debugFmt('Hello world %s', ['foo'], { userId: 100 });
- * ```
- */
-export function debugFmt(message: string, params: Array<unknown>, attributes: Log['attributes'] = {}): void {
-  captureLogFmt('debug', message, params, attributes);
-}
-
-/**
- * @summary Capture a formatted log with the `info` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * @param message - The message to log.
- * @param params - The parameters to interpolate into the message.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
- *
- * @example
- *
- * ```
- * Sentry.logger.infoFmt('Hello world %s', ['foo'], { userId: 100 });
- * ```
- */
-export function infoFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
-  captureLogFmt('info', message, params, attributes);
-}
-
-/**
- * @summary Capture a formatted log with the `warn` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * @param message - The message to log.
- * @param params - The parameters to interpolate into the message.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
- *
- * @example
- *
- * ```
- * Sentry.logger.warnFmt('Hello world %s', ['foo'], { userId: 100 });
- * ```
- */
-export function warnFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
-  captureLogFmt('warn', message, params, attributes);
-}
-
-/**
- * @summary Capture a formatted log with the `error` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * @param message - The message to log.
- * @param params - The parameters to interpolate into the message.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
- *
- * @example
- *
- * ```
- * Sentry.logger.errorFmt('Hello world %s', ['foo'], { userId: 100 });
- * ```
- */
-export function errorFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
-  captureLogFmt('error', message, params, attributes);
-}
-
-/**
- * @summary Capture a formatted log with the `fatal` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * @param message - The message to log.
- * @param params - The parameters to interpolate into the message.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
- *
- * @example
- *
- * ```
- * Sentry.logger.fatalFmt('Hello world %s', ['foo'], { userId: 100 });
- * ```
- */
-export function fatalFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
-  captureLogFmt('fatal', message, params, attributes);
-}
-
-/**
- * @summary Capture a formatted log with the `critical` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * @param message - The message to log.
- * @param params - The parameters to interpolate into the message.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
- *
- * @example
- *
- * ```
- * Sentry.logger.criticalFmt('Hello world %s', ['foo'], { userId: 100 });
- * ```
- */
-export function criticalFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
-  captureLogFmt('critical', message, params, attributes);
+export function critical(...args: CaptureLogArgs): void {
+  captureLog('critical', ...args);
 }

--- a/packages/node/src/log.ts
+++ b/packages/node/src/log.ts
@@ -1,0 +1,268 @@
+import { format } from 'node:util';
+
+import type { LogSeverityLevel, Log } from '@sentry/core';
+import { _INTERNAL_captureLog } from '@sentry/core';
+
+/**
+ * Capture a log with the given level.
+ *
+ * @param level - The level of the log.
+ * @param message - The message to log.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ */
+function captureLog(level: LogSeverityLevel, message: string, attributes?: Log['attributes']): void {
+  _INTERNAL_captureLog({ level, message, attributes });
+}
+
+/**
+ * @summary Capture a log with the `trace` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.trace('Hello world', { userId: 100 });
+ * ```
+ */
+export function trace(message: string, attributes?: Log['attributes']): void {
+  captureLog('trace', message, attributes);
+}
+
+/**
+ * @summary Capture a log with the `debug` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.debug('Hello world', { userId: 100 });
+ * ```
+ */
+export function debug(message: string, attributes?: Log['attributes']): void {
+  captureLog('debug', message, attributes);
+}
+
+/**
+ * @summary Capture a log with the `info` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.info('Hello world', { userId: 100 });
+ * ```
+ */
+export function info(message: string, attributes?: Log['attributes']): void {
+  captureLog('info', message, attributes);
+}
+
+/**
+ * @summary Capture a log with the `warn` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.warn('Hello world', { userId: 100 });
+ * ```
+ */
+export function warn(message: string, attributes?: Log['attributes']): void {
+  captureLog('warn', message, attributes);
+}
+
+/**
+ * @summary Capture a log with the `error` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.error('Hello world', { userId: 100 });
+ * ```
+ */
+export function error(message: string, attributes?: Log['attributes']): void {
+  captureLog('error', message, attributes);
+}
+
+/**
+ * @summary Capture a log with the `fatal` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.fatal('Hello world', { userId: 100 });
+ * ```
+ */
+export function fatal(message: string, attributes?: Log['attributes']): void {
+  captureLog('fatal', message, attributes);
+}
+
+/**
+ * @summary Capture a log with the `critical` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.critical('Hello world', { userId: 100 });
+ * ```
+ */
+export function critical(message: string, attributes?: Log['attributes']): void {
+  captureLog('critical', message, attributes);
+}
+
+/**
+ * Capture a formatted log with the given level.
+ *
+ * @param level - The level of the log.
+ * @param message - The message template.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ */
+function captureLogFmt(
+  level: LogSeverityLevel,
+  messageTemplate: string,
+  params: Array<unknown>,
+  logAttributes: Log['attributes'] = {},
+): void {
+  const attributes = { ...logAttributes };
+  attributes['sentry.message.template'] = messageTemplate;
+  params.forEach((param, index) => {
+    attributes[`sentry.message.param.${index}`] = param;
+  });
+  const message = format(messageTemplate, ...params);
+  _INTERNAL_captureLog({ level, message, attributes });
+}
+
+/**
+ * @summary Capture a formatted log with the `trace` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param params - The parameters to interpolate into the message.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.traceFmt('Hello world %s', ['foo'], { userId: 100 });
+ * ```
+ */
+export function traceFmt(message: string, params: Array<unknown>, attributes: Log['attributes'] = {}): void {
+  captureLogFmt('trace', message, params, attributes);
+}
+
+/**
+ * @summary Capture a formatted log with the `debug` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param params - The parameters to interpolate into the message.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.debugFmt('Hello world %s', ['foo'], { userId: 100 });
+ * ```
+ */
+export function debugFmt(message: string, params: Array<unknown>, attributes: Log['attributes'] = {}): void {
+  captureLogFmt('debug', message, params, attributes);
+}
+
+/**
+ * @summary Capture a formatted log with the `info` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param params - The parameters to interpolate into the message.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.infoFmt('Hello world %s', ['foo'], { userId: 100 });
+ * ```
+ */
+export function infoFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
+  captureLogFmt('info', message, params, attributes);
+}
+
+/**
+ * @summary Capture a formatted log with the `warn` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param params - The parameters to interpolate into the message.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.warnFmt('Hello world %s', ['foo'], { userId: 100 });
+ * ```
+ */
+export function warnFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
+  captureLogFmt('warn', message, params, attributes);
+}
+
+/**
+ * @summary Capture a formatted log with the `error` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param params - The parameters to interpolate into the message.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.errorFmt('Hello world %s', ['foo'], { userId: 100 });
+ * ```
+ */
+export function errorFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
+  captureLogFmt('error', message, params, attributes);
+}
+
+/**
+ * @summary Capture a formatted log with the `fatal` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param params - The parameters to interpolate into the message.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.fatalFmt('Hello world %s', ['foo'], { userId: 100 });
+ * ```
+ */
+export function fatalFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
+  captureLogFmt('fatal', message, params, attributes);
+}
+
+/**
+ * @summary Capture a formatted log with the `critical` level. Requires `_experiments.enableLogs` to be enabled.
+ *
+ * @param message - The message to log.
+ * @param params - The parameters to interpolate into the message.
+ * @param attributes - Arbitrary structured data that stores information about the log - e.g., userId: 100.
+ *
+ * @example
+ *
+ * ```
+ * Sentry.logger.criticalFmt('Hello world %s', ['foo'], { userId: 100 });
+ * ```
+ */
+export function criticalFmt(message: string, params: Array<unknown>, attributes?: Log['attributes']): void {
+  captureLogFmt('critical', message, params, attributes);
+}

--- a/packages/node/test/log.test.ts
+++ b/packages/node/test/log.test.ts
@@ -99,143 +99,30 @@ describe('Node Logger', () => {
     });
   });
 
-  describe('Formatted logging methods', () => {
-    it('should export all formatted log methods', () => {
-      expect(nodeLogger.traceFmt).toBeTypeOf('function');
-      expect(nodeLogger.debugFmt).toBeTypeOf('function');
-      expect(nodeLogger.infoFmt).toBeTypeOf('function');
-      expect(nodeLogger.warnFmt).toBeTypeOf('function');
-      expect(nodeLogger.errorFmt).toBeTypeOf('function');
-      expect(nodeLogger.fatalFmt).toBeTypeOf('function');
-      expect(nodeLogger.criticalFmt).toBeTypeOf('function');
-    });
-
-    it('should format the message with trace level', () => {
-      nodeLogger.traceFmt('Hello %s', ['world'], { key: 'value' });
-
-      expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'trace',
-        message: 'Hello world',
-        attributes: {
-          key: 'value',
-          'sentry.message.template': 'Hello %s',
-          'sentry.message.param.0': 'world',
-        },
-      });
-    });
-
-    it('should format the message with debug level', () => {
-      nodeLogger.debugFmt('Count: %d', [42], { key: 'value' });
-
-      expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'debug',
-        message: 'Count: 42',
-        attributes: {
-          key: 'value',
-          'sentry.message.template': 'Count: %d',
-          'sentry.message.param.0': 42,
-        },
-      });
-    });
-
-    it('should format the message with info level', () => {
-      nodeLogger.infoFmt('User %s logged in from %s', ['John', 'Paris'], { userId: 123 });
-
+  describe('Template string logging', () => {
+    it('should handle template strings with parameters', () => {
+      nodeLogger.info('Hello %s, your balance is %d', ['John', 100], { userId: 123 });
       expect(mockCaptureLog).toHaveBeenCalledWith({
         level: 'info',
-        message: 'User John logged in from Paris',
+        message: 'Hello John, your balance is 100',
         attributes: {
           userId: 123,
-          'sentry.message.template': 'User %s logged in from %s',
+          'sentry.message.template': 'Hello %s, your balance is %d',
           'sentry.message.param.0': 'John',
-          'sentry.message.param.1': 'Paris',
+          'sentry.message.param.1': 100,
         },
       });
     });
 
-    it('should format the message with warn level', () => {
-      nodeLogger.warnFmt('Usage at %d%%', [95], { resource: 'CPU' });
-
+    it('should handle template strings without additional attributes', () => {
+      nodeLogger.debug('User %s logged in from %s', ['Alice', 'mobile']);
       expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'warn',
-        message: 'Usage at 95%',
+        level: 'debug',
+        message: 'User Alice logged in from mobile',
         attributes: {
-          resource: 'CPU',
-          'sentry.message.template': 'Usage at %d%%',
-          'sentry.message.param.0': 95,
-        },
-      });
-    });
-
-    it('should format the message with error level', () => {
-      nodeLogger.errorFmt('Failed to process %s: %s', ['payment', 'timeout'], { orderId: 'ORD-123' });
-
-      expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'error',
-        message: 'Failed to process payment: timeout',
-        attributes: {
-          orderId: 'ORD-123',
-          'sentry.message.template': 'Failed to process %s: %s',
-          'sentry.message.param.0': 'payment',
-          'sentry.message.param.1': 'timeout',
-        },
-      });
-    });
-
-    it('should format the message with fatal level', () => {
-      nodeLogger.fatalFmt('System crash in module %s', ['auth'], { shutdown: true });
-
-      expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'fatal',
-        message: 'System crash in module auth',
-        attributes: {
-          shutdown: true,
-          'sentry.message.template': 'System crash in module %s',
-          'sentry.message.param.0': 'auth',
-        },
-      });
-    });
-
-    it('should format the message with critical level', () => {
-      nodeLogger.criticalFmt('Database %s is down for %d minutes', ['customers', 30], { impact: 'high' });
-
-      expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'critical',
-        message: 'Database customers is down for 30 minutes',
-        attributes: {
-          impact: 'high',
-          'sentry.message.template': 'Database %s is down for %d minutes',
-          'sentry.message.param.0': 'customers',
-          'sentry.message.param.1': 30,
-        },
-      });
-    });
-
-    it('should handle complex formatting with multiple types', () => {
-      const obj = { name: 'test' };
-      nodeLogger.infoFmt('Values: %s, %d, %j', ['string', 42, obj]);
-
-      expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'info',
-        message: `Values: string, 42, ${JSON.stringify(obj)}`,
-        attributes: {
-          'sentry.message.template': 'Values: %s, %d, %j',
-          'sentry.message.param.0': 'string',
-          'sentry.message.param.1': 42,
-          'sentry.message.param.2': obj,
-        },
-      });
-    });
-
-    it('should use empty object as default for attributes', () => {
-      nodeLogger.infoFmt('Hello %s', ['world']);
-
-      expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'info',
-        message: 'Hello world',
-        attributes: {
-          'sentry.message.template': 'Hello %s',
-          'sentry.message.param.0': 'world',
+          'sentry.message.template': 'User %s logged in from %s',
+          'sentry.message.param.0': 'Alice',
+          'sentry.message.param.1': 'mobile',
         },
       });
     });

--- a/packages/node/test/log.test.ts
+++ b/packages/node/test/log.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as sentryCore from '@sentry/core';
+import * as nodeLogger from '../src/log';
+
+// Mock the core functions
+vi.mock('@sentry/core', async () => {
+  const actual = await vi.importActual('@sentry/core');
+  return {
+    ...actual,
+    _INTERNAL_captureLog: vi.fn(),
+  };
+});
+
+describe('Node Logger', () => {
+  // Use the mocked function
+  const mockCaptureLog = vi.mocked(sentryCore._INTERNAL_captureLog);
+
+  beforeEach(() => {
+    // Reset mocks
+    mockCaptureLog.mockClear();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Basic logging methods', () => {
+    it('should export all log methods', () => {
+      expect(nodeLogger.trace).toBeTypeOf('function');
+      expect(nodeLogger.debug).toBeTypeOf('function');
+      expect(nodeLogger.info).toBeTypeOf('function');
+      expect(nodeLogger.warn).toBeTypeOf('function');
+      expect(nodeLogger.error).toBeTypeOf('function');
+      expect(nodeLogger.fatal).toBeTypeOf('function');
+      expect(nodeLogger.critical).toBeTypeOf('function');
+    });
+
+    it('should call _INTERNAL_captureLog with trace level', () => {
+      nodeLogger.trace('Test trace message', { key: 'value' });
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'trace',
+        message: 'Test trace message',
+        attributes: { key: 'value' },
+      });
+    });
+
+    it('should call _INTERNAL_captureLog with debug level', () => {
+      nodeLogger.debug('Test debug message', { key: 'value' });
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'debug',
+        message: 'Test debug message',
+        attributes: { key: 'value' },
+      });
+    });
+
+    it('should call _INTERNAL_captureLog with info level', () => {
+      nodeLogger.info('Test info message', { key: 'value' });
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'info',
+        message: 'Test info message',
+        attributes: { key: 'value' },
+      });
+    });
+
+    it('should call _INTERNAL_captureLog with warn level', () => {
+      nodeLogger.warn('Test warn message', { key: 'value' });
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'warn',
+        message: 'Test warn message',
+        attributes: { key: 'value' },
+      });
+    });
+
+    it('should call _INTERNAL_captureLog with error level', () => {
+      nodeLogger.error('Test error message', { key: 'value' });
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'error',
+        message: 'Test error message',
+        attributes: { key: 'value' },
+      });
+    });
+
+    it('should call _INTERNAL_captureLog with fatal level', () => {
+      nodeLogger.fatal('Test fatal message', { key: 'value' });
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'fatal',
+        message: 'Test fatal message',
+        attributes: { key: 'value' },
+      });
+    });
+
+    it('should call _INTERNAL_captureLog with critical level', () => {
+      nodeLogger.critical('Test critical message', { key: 'value' });
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'critical',
+        message: 'Test critical message',
+        attributes: { key: 'value' },
+      });
+    });
+  });
+
+  describe('Formatted logging methods', () => {
+    it('should export all formatted log methods', () => {
+      expect(nodeLogger.traceFmt).toBeTypeOf('function');
+      expect(nodeLogger.debugFmt).toBeTypeOf('function');
+      expect(nodeLogger.infoFmt).toBeTypeOf('function');
+      expect(nodeLogger.warnFmt).toBeTypeOf('function');
+      expect(nodeLogger.errorFmt).toBeTypeOf('function');
+      expect(nodeLogger.fatalFmt).toBeTypeOf('function');
+      expect(nodeLogger.criticalFmt).toBeTypeOf('function');
+    });
+
+    it('should format the message with trace level', () => {
+      nodeLogger.traceFmt('Hello %s', ['world'], { key: 'value' });
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'trace',
+        message: 'Hello world',
+        attributes: {
+          key: 'value',
+          'sentry.message.template': 'Hello %s',
+          'sentry.message.param.0': 'world',
+        },
+      });
+    });
+
+    it('should format the message with debug level', () => {
+      nodeLogger.debugFmt('Count: %d', [42], { key: 'value' });
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'debug',
+        message: 'Count: 42',
+        attributes: {
+          key: 'value',
+          'sentry.message.template': 'Count: %d',
+          'sentry.message.param.0': 42,
+        },
+      });
+    });
+
+    it('should format the message with info level', () => {
+      nodeLogger.infoFmt('User %s logged in from %s', ['John', 'Paris'], { userId: 123 });
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'info',
+        message: 'User John logged in from Paris',
+        attributes: {
+          userId: 123,
+          'sentry.message.template': 'User %s logged in from %s',
+          'sentry.message.param.0': 'John',
+          'sentry.message.param.1': 'Paris',
+        },
+      });
+    });
+
+    it('should format the message with warn level', () => {
+      nodeLogger.warnFmt('Usage at %d%%', [95], { resource: 'CPU' });
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'warn',
+        message: 'Usage at 95%',
+        attributes: {
+          resource: 'CPU',
+          'sentry.message.template': 'Usage at %d%%',
+          'sentry.message.param.0': 95,
+        },
+      });
+    });
+
+    it('should format the message with error level', () => {
+      nodeLogger.errorFmt('Failed to process %s: %s', ['payment', 'timeout'], { orderId: 'ORD-123' });
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'error',
+        message: 'Failed to process payment: timeout',
+        attributes: {
+          orderId: 'ORD-123',
+          'sentry.message.template': 'Failed to process %s: %s',
+          'sentry.message.param.0': 'payment',
+          'sentry.message.param.1': 'timeout',
+        },
+      });
+    });
+
+    it('should format the message with fatal level', () => {
+      nodeLogger.fatalFmt('System crash in module %s', ['auth'], { shutdown: true });
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'fatal',
+        message: 'System crash in module auth',
+        attributes: {
+          shutdown: true,
+          'sentry.message.template': 'System crash in module %s',
+          'sentry.message.param.0': 'auth',
+        },
+      });
+    });
+
+    it('should format the message with critical level', () => {
+      nodeLogger.criticalFmt('Database %s is down for %d minutes', ['customers', 30], { impact: 'high' });
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'critical',
+        message: 'Database customers is down for 30 minutes',
+        attributes: {
+          impact: 'high',
+          'sentry.message.template': 'Database %s is down for %d minutes',
+          'sentry.message.param.0': 'customers',
+          'sentry.message.param.1': 30,
+        },
+      });
+    });
+
+    it('should handle complex formatting with multiple types', () => {
+      const obj = { name: 'test' };
+      nodeLogger.infoFmt('Values: %s, %d, %j', ['string', 42, obj]);
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'info',
+        message: `Values: string, 42, ${JSON.stringify(obj)}`,
+        attributes: {
+          'sentry.message.template': 'Values: %s, %d, %j',
+          'sentry.message.param.0': 'string',
+          'sentry.message.param.1': 42,
+          'sentry.message.param.2': obj,
+        },
+      });
+    });
+
+    it('should use empty object as default for attributes', () => {
+      nodeLogger.infoFmt('Hello %s', ['world']);
+
+      expect(mockCaptureLog).toHaveBeenCalledWith({
+        level: 'info',
+        message: 'Hello world',
+        attributes: {
+          'sentry.message.template': 'Hello %s',
+          'sentry.message.param.0': 'world',
+        },
+      });
+    });
+  });
+});

--- a/packages/nuxt/src/index.types.ts
+++ b/packages/nuxt/src/index.types.ts
@@ -1,6 +1,7 @@
 import type { Client, Integration, Options, StackParser } from '@sentry/core';
 import type { SentryNuxtClientOptions, SentryNuxtServerOptions } from './common/types';
 import type * as clientSdk from './index.client';
+import type * as serverSdk from './index.server';
 
 // We export everything from both the client part of the SDK and from the server part. Some of the exports collide,
 // which is not allowed, unless we re-export the colliding exports in this file - which we do below.
@@ -13,3 +14,5 @@ export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsInteg
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
+
+export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;

--- a/packages/react-router/src/index.types.ts
+++ b/packages/react-router/src/index.types.ts
@@ -15,3 +15,5 @@ export declare const contextLinesIntegration: typeof clientSdk.contextLinesInteg
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const defaultStackParser: StackParser;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
+
+export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -21,6 +21,8 @@ export declare const defaultStackParser: StackParser;
 
 export declare function captureRemixServerException(err: unknown, name: string, request: Request): Promise<void>;
 
+export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;
+
 // This variable is not a runtime variable but just a type to tell typescript that the methods below can either come
 // from the client SDK or from the server SDK. TypeScript is smart enough to understand that these resolve to the same
 // methods from `@sentry/core`.

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -112,6 +112,7 @@ export {
   withMonitor,
   withScope,
   zodErrorsIntegration,
+  logger,
 } from '@sentry/node';
 
 // Keeping the `*` exports for backwards compatibility and types

--- a/packages/solidstart/src/index.types.ts
+++ b/packages/solidstart/src/index.types.ts
@@ -22,3 +22,5 @@ export declare const defaultStackParser: StackParser;
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function lastEventId(): string | undefined;
+
+export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -115,6 +115,7 @@ export {
   withMonitor,
   withScope,
   zodErrorsIntegration,
+  logger,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -53,3 +53,5 @@ export declare function flush(timeout?: number | undefined): PromiseLike<boolean
 export declare function lastEventId(): string | undefined;
 
 export declare function trackComponent(options: clientSdk.TrackingOptions): ReturnType<typeof clientSdk.trackComponent>;
+
+export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -117,6 +117,7 @@ export {
   withMonitor,
   withScope,
   zodErrorsIntegration,
+  logger,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/tanstackstart-react/src/index.types.ts
+++ b/packages/tanstackstart-react/src/index.types.ts
@@ -25,3 +25,5 @@ export declare const ErrorBoundary: typeof clientSdk.ErrorBoundary;
 export declare const createReduxEnhancer: typeof clientSdk.createReduxEnhancer;
 export declare const showReportDialog: typeof clientSdk.showReportDialog;
 export declare const withErrorBoundary: typeof clientSdk.withErrorBoundary;
+
+export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/15526

Continuing off the work from https://github.com/getsentry/sentry-javascript/pull/15763, this PR adds the logging public API to the Node SDK. It also adds a basic weight-based flushing strategy to the SDK that is in the server-runtime client.

The main file added was `log.ts`. In that file I've added  logger methods for `trace`, `debug`, `info`, `warn`, `error`, `fatal` (the log severity levels) as well as an internal capture log helper all these methods call.

Usage:

```js
import * as Sentry from "@sentry/node";

Sentry.init({
  dsn: "your-dsn-here",
  _experiments: {
    enableLogs: true  // This is required to use the logging features
  }
});

// Trace level (lowest severity)
Sentry.logger.trace("This is a trace message", { userId: 123 });

// Debug level
Sentry.logger.debug("This is a debug message", { component: "UserProfile" });

// Info level
Sentry.logger.info("User %s logged in successfully", [123]);

// Warning level
Sentry.logger.warn("API response was slow", { responseTime: 2500 });

// Error level
Sentry.logger.error("Failed to load user %s data", [123], { errorCode: 404 });

// Critical level
Sentry.logger.critical("Database connection failed", { dbHost: "primary-db" });

// Fatal level (highest severity)
Sentry.logger.fatal("Application is shutting down unexpectedly", { memory: "exhausted" });
```