### PR TITLE
perf(core): Remove usage of addNonEnumerableProperty from span utils

### DIFF
--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -126,12 +126,6 @@ export function makeTerserPlugin() {
           '_sentryId',
           // Keeps the frozen DSC on a Sentry Span
           '_frozenDsc',
-          // These are used to keep span & scope relationships
-          '_sentryRootSpan',
-          '_sentryChildSpans',
-          '_sentrySpan',
-          '_sentryScope',
-          '_sentryIsolationScope',
           // require-in-the-middle calls `Module._resolveFilename`. We cannot mangle this (AWS lambda layer bundle).
           '_resolveFilename',
           // Set on e.g. the shim feedbackIntegration to be able to detect it

--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -126,6 +126,9 @@ export function makeTerserPlugin() {
           '_sentryId',
           // Keeps the frozen DSC on a Sentry Span
           '_frozenDsc',
+          // These are used to keep span & scope relationships
+          '_sentryScope',
+          '_sentryIsolationScope',
           // require-in-the-middle calls `Module._resolveFilename`. We cannot mangle this (AWS lambda layer bundle).
           '_resolveFilename',
           // Set on e.g. the shim feedbackIntegration to be able to detect it

--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -124,8 +124,6 @@ export function makeTerserPlugin() {
           // These are used by instrument.ts in utils for identifying HTML elements & events
           '_sentryCaptured',
           '_sentryId',
-          // Keeps the frozen DSC on a Sentry Span
-          '_frozenDsc',
           // These are used to keep span & scope relationships
           '_sentryScope',
           '_sentryIsolationScope',

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,20 +1,14 @@
 import type { Scope } from '../scope';
 import type { Span } from '../types-hoist';
-import { addNonEnumerableProperty } from '../utils-hoist/object';
 
-const SCOPE_ON_START_SPAN_FIELD = '_sentryScope';
-const ISOLATION_SCOPE_ON_START_SPAN_FIELD = '_sentryIsolationScope';
-
-type SpanWithScopes = Span & {
-  [SCOPE_ON_START_SPAN_FIELD]?: Scope;
-  [ISOLATION_SCOPE_ON_START_SPAN_FIELD]?: Scope;
-};
+const SPAN_TO_SCOPE_MAP = new WeakMap<Span, Scope>();
+const SPAN_TO_ISOLATION_SCOPE_MAP = new WeakMap<Span, Scope>();
 
 /** Store the scope & isolation scope for a span, which can the be used when it is finished. */
 export function setCapturedScopesOnSpan(span: Span | undefined, scope: Scope, isolationScope: Scope): void {
   if (span) {
-    addNonEnumerableProperty(span, ISOLATION_SCOPE_ON_START_SPAN_FIELD, isolationScope);
-    addNonEnumerableProperty(span, SCOPE_ON_START_SPAN_FIELD, scope);
+    SPAN_TO_SCOPE_MAP.set(span, scope);
+    SPAN_TO_ISOLATION_SCOPE_MAP.set(span, isolationScope);
   }
 }
 
@@ -23,7 +17,7 @@ export function setCapturedScopesOnSpan(span: Span | undefined, scope: Scope, is
  */
 export function getCapturedScopesOnSpan(span: Span): { scope?: Scope; isolationScope?: Scope } {
   return {
-    scope: (span as SpanWithScopes)[SCOPE_ON_START_SPAN_FIELD],
-    isolationScope: (span as SpanWithScopes)[ISOLATION_SCOPE_ON_START_SPAN_FIELD],
+    scope: SPAN_TO_SCOPE_MAP.get(span),
+    isolationScope: SPAN_TO_ISOLATION_SCOPE_MAP.get(span),
   };
 }

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,14 +1,20 @@
 import type { Scope } from '../scope';
 import type { Span } from '../types-hoist';
+import { addNonEnumerableProperty } from '../utils-hoist/object';
 
-const SPAN_TO_SCOPE_MAP = new WeakMap<Span, Scope>();
-const SPAN_TO_ISOLATION_SCOPE_MAP = new WeakMap<Span, Scope>();
+const SCOPE_ON_START_SPAN_FIELD = '_sentryScope';
+const ISOLATION_SCOPE_ON_START_SPAN_FIELD = '_sentryIsolationScope';
+
+type SpanWithScopes = Span & {
+  [SCOPE_ON_START_SPAN_FIELD]?: Scope;
+  [ISOLATION_SCOPE_ON_START_SPAN_FIELD]?: Scope;
+};
 
 /** Store the scope & isolation scope for a span, which can the be used when it is finished. */
 export function setCapturedScopesOnSpan(span: Span | undefined, scope: Scope, isolationScope: Scope): void {
   if (span) {
-    SPAN_TO_SCOPE_MAP.set(span, scope);
-    SPAN_TO_ISOLATION_SCOPE_MAP.set(span, isolationScope);
+    addNonEnumerableProperty(span, ISOLATION_SCOPE_ON_START_SPAN_FIELD, isolationScope);
+    addNonEnumerableProperty(span, SCOPE_ON_START_SPAN_FIELD, scope);
   }
 }
 
@@ -17,7 +23,7 @@ export function setCapturedScopesOnSpan(span: Span | undefined, scope: Scope, is
  */
 export function getCapturedScopesOnSpan(span: Span): { scope?: Scope; isolationScope?: Scope } {
   return {
-    scope: SPAN_TO_SCOPE_MAP.get(span),
-    isolationScope: SPAN_TO_ISOLATION_SCOPE_MAP.get(span),
+    scope: (span as SpanWithScopes)[SCOPE_ON_START_SPAN_FIELD],
+    isolationScope: (span as SpanWithScopes)[ISOLATION_SCOPE_ON_START_SPAN_FIELD],
   };
 }

--- a/packages/core/src/utils/spanOnScope.ts
+++ b/packages/core/src/utils/spanOnScope.ts
@@ -1,12 +1,7 @@
 import type { Scope } from '../scope';
 import type { Span } from '../types-hoist';
-import { addNonEnumerableProperty } from '../utils-hoist/object';
 
-const SCOPE_SPAN_FIELD = '_sentrySpan';
-
-type ScopeWithMaybeSpan = Scope & {
-  [SCOPE_SPAN_FIELD]?: Span;
-};
+const SCOPE_TO_SPAN_MAP = new WeakMap<Scope, Span>();
 
 /**
  * Set the active span for a given scope.
@@ -14,10 +9,9 @@ type ScopeWithMaybeSpan = Scope & {
  */
 export function _setSpanForScope(scope: Scope, span: Span | undefined): void {
   if (span) {
-    addNonEnumerableProperty(scope as ScopeWithMaybeSpan, SCOPE_SPAN_FIELD, span);
+    SCOPE_TO_SPAN_MAP.set(scope, span);
   } else {
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete (scope as ScopeWithMaybeSpan)[SCOPE_SPAN_FIELD];
+    SCOPE_TO_SPAN_MAP.delete(scope);
   }
 }
 
@@ -25,6 +19,6 @@ export function _setSpanForScope(scope: Scope, span: Span | undefined): void {
  * Get the active span for a given scope.
  * NOTE: This should NOT be used directly, but is only used internally by the trace methods.
  */
-export function _getSpanForScope(scope: ScopeWithMaybeSpan): Span | undefined {
-  return scope[SCOPE_SPAN_FIELD];
+export function _getSpanForScope(scope: Scope): Span | undefined {
+  return SCOPE_TO_SPAN_MAP.get(scope);
 }

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -687,7 +687,7 @@ describe('startSpan', () => {
     expect.assertions(1);
     startSpan({ name: 'outer' }, (outerSpan: any) => {
       startSpan({ name: 'inner' }, innerSpan => {
-        const childSpans = Array.from(outerSpan._sentryChildSpans);
+        const childSpans = getSpanDescendants(outerSpan);
         expect(childSpans).toContain(innerSpan);
       });
     });
@@ -1178,7 +1178,7 @@ describe('startSpanManual', () => {
     expect.assertions(1);
     startSpan({ name: 'outer' }, (outerSpan: any) => {
       startSpanManual({ name: 'inner' }, innerSpan => {
-        const childSpans = Array.from(outerSpan._sentryChildSpans);
+        const childSpans = getSpanDescendants(outerSpan);
         expect(childSpans).toContain(innerSpan);
       });
     });
@@ -1591,7 +1591,7 @@ describe('startInactiveSpan', () => {
     expect.assertions(1);
     startSpan({ name: 'outer' }, (outerSpan: any) => {
       const innerSpan = startInactiveSpan({ name: 'inner' });
-      const childSpans = Array.from(outerSpan._sentryChildSpans);
+      const childSpans = getSpanDescendants(outerSpan);
       expect(childSpans).toContain(innerSpan);
     });
   });

--- a/packages/opentelemetry/src/utils/contextData.ts
+++ b/packages/opentelemetry/src/utils/contextData.ts
@@ -1,10 +1,7 @@
 import type { Context } from '@opentelemetry/api';
 import type { Scope } from '@sentry/core';
-import { addNonEnumerableProperty } from '@sentry/core';
 import { SENTRY_SCOPES_CONTEXT_KEY } from '../constants';
 import type { CurrentScopes } from '../types';
-
-const SCOPE_CONTEXT_FIELD = '_scopeContext';
 
 /**
  * Try to get the current scopes from the given OTEL context.
@@ -22,17 +19,19 @@ export function setScopesOnContext(context: Context, scopes: CurrentScopes): Con
   return context.setValue(SENTRY_SCOPES_CONTEXT_KEY, scopes);
 }
 
+const SCOPE_TO_CONTEXT_MAP = new WeakMap<Scope, Context>();
+
 /**
  * Set the context on the scope so we can later look it up.
  * We need this to get the context from the scope in the `trace` functions.
  */
 export function setContextOnScope(scope: Scope, context: Context): void {
-  addNonEnumerableProperty(scope, SCOPE_CONTEXT_FIELD, context);
+  SCOPE_TO_CONTEXT_MAP.set(scope, context);
 }
 
 /**
  * Get the context related to a scope.
  */
 export function getContextFromScope(scope: Scope): Context | undefined {
-  return (scope as { [SCOPE_CONTEXT_FIELD]?: Context })[SCOPE_CONTEXT_FIELD];
+  return SCOPE_TO_CONTEXT_MAP.get(scope);
 }


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/15725#issuecomment-2741985510

`addNonEnumerableProperty` is pretty expensive because of `Object.defineProperty`, so this changes usage of span utils (which are called frequently) to avoid usage of `addNonEnumerableProperty`.

`addNonEnumerableProperty` is replaced with weak maps, which has the added benefit of being more GC friendly (`addNonEnumerableProperty` causes hard references to be created between the objects).

The only downside of switching to this approach is that we lose the `try catch` built into `addNonEnumerableProperty`, but I think thats fine given the nature of the changed methods.
