### PR TITLE
perf(nestjs): Remove usage of addNonEnumerableProperty

### DIFF
--- a/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
@@ -91,7 +91,7 @@ export class SentryNestInstrumentation extends InstrumentationBase {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _createWrapInjectable(): (original: any) => (options?: unknown) => (target: InjectableTarget) => any {
-    const SeenNestjsContextSet = new Set<MinimalNestJsExecutionContext>();
+    const SeenNestjsContextSet = new WeakSet<MinimalNestJsExecutionContext>();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return function wrapInjectable(original: any) {
       return function wrappedInjectable(options?: unknown) {

--- a/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
@@ -8,7 +8,6 @@ import {
 import type { Span } from '@sentry/core';
 import {
   SDK_VERSION,
-  addNonEnumerableProperty,
   getActiveSpan,
   isThenable,
   startInactiveSpan,
@@ -90,7 +89,9 @@ export class SentryNestInstrumentation extends InstrumentationBase {
   /**
    * Creates a wrapper function for the @Injectable decorator.
    */
-  private _createWrapInjectable() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _createWrapInjectable(): (original: any) => (options?: unknown) => (target: InjectableTarget) => any {
+    const SeenNestjsContextSet = new Set<MinimalNestJsExecutionContext>();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return function wrapInjectable(original: any) {
       return function wrappedInjectable(options?: unknown) {
@@ -197,8 +198,8 @@ export class SentryNestInstrumentation extends InstrumentationBase {
                         return withActiveSpan(parentSpan, () => {
                           const handleReturnObservable = Reflect.apply(originalHandle, thisArgHandle, argsHandle);
 
-                          if (!context._sentryInterceptorInstrumented) {
-                            addNonEnumerableProperty(context, '_sentryInterceptorInstrumented', true);
+                          if (!SeenNestjsContextSet.has(context)) {
+                            SeenNestjsContextSet.add(context);
                             afterSpan = startInactiveSpan(
                               getMiddlewareSpanOptions(target, 'Interceptors - After Route'),
                             );
@@ -209,8 +210,8 @@ export class SentryNestInstrumentation extends InstrumentationBase {
                       } else {
                         const handleReturnObservable = Reflect.apply(originalHandle, thisArgHandle, argsHandle);
 
-                        if (!context._sentryInterceptorInstrumented) {
-                          addNonEnumerableProperty(context, '_sentryInterceptorInstrumented', true);
+                        if (!SeenNestjsContextSet.has(context)) {
+                          SeenNestjsContextSet.add(context);
                           afterSpan = startInactiveSpan(getMiddlewareSpanOptions(target, 'Interceptors - After Route'));
                         }
 


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/15725#issuecomment-2741985510

Similar to the work done in https://github.com/getsentry/sentry-javascript/pull/15765 we can avoid usage of `addNonEnumerableProperty` with usage of a `WeakSet`.