### PR TITLE
feat(core): Add `parseStringToURL` method

### DIFF
--- a/packages/core/src/utils-hoist/url.ts
+++ b/packages/core/src/utils-hoist/url.ts
@@ -8,7 +8,7 @@ type PartialURL = {
 };
 
 interface URLwithCanParse extends URL {
-  canParse: (url: string) => boolean;
+  canParse: (url: string, base?: string | URL | undefined) => boolean;
 }
 
 /**
@@ -17,16 +17,16 @@ interface URLwithCanParse extends URL {
  * @param url - The URL to parse
  * @returns The parsed URL object or undefined if the URL is invalid
  */
-export function parseStringToURL(url: string): URL | undefined {
+export function parseStringToURL(url: string, base?: string | URL | undefined): URL | undefined {
   try {
+    // Use `canParse` to short-circuit the URL constructor if it's not a valid URL
+    // This is faster than trying to construct the URL and catching the error
     // Node 20+, Chrome 120+, Firefox 115+, Safari 17+
-    if ('canParse' in URL) {
-      // Use `canParse` to short-circuit the URL constructor if it's not a valid URL
-      // This is faster than trying to construct the URL and catching the error
-      return (URL as unknown as URLwithCanParse).canParse(url) ? new URL(url) : undefined;
-    } else {
-      return new URL(url);
+    if ('canParse' in URL && !(URL as unknown as URLwithCanParse).canParse(url, base)) {
+      return undefined;
     }
+
+    return new URL(url, base);
   } catch {
     // empty body
   }

--- a/packages/core/src/utils-hoist/url.ts
+++ b/packages/core/src/utils-hoist/url.ts
@@ -7,6 +7,33 @@ type PartialURL = {
   hash?: string;
 };
 
+interface URLwithCanParse extends URL {
+  canParse: (url: string) => boolean;
+}
+
+/**
+ * Parses string to a URL object
+ *
+ * @param url - The URL to parse
+ * @returns The parsed URL object or undefined if the URL is invalid
+ */
+export function parseStringToURL(url: string): URL | undefined {
+  try {
+    // Node 20+, Chrome 120+, Firefox 115+, Safari 17+
+    if ('canParse' in URL) {
+      // Use `canParse` to short-circuit the URL constructor if it's not a valid URL
+      // This is faster than trying to construct the URL and catching the error
+      return (URL as unknown as URLwithCanParse).canParse(url) ? new URL(url) : undefined;
+    } else {
+      return new URL(url);
+    }
+  } catch {
+    // empty body
+  }
+
+  return undefined;
+}
+
 /**
  * Parses string form of URL into an object
  * // borrowed from https://tools.ietf.org/html/rfc3986#appendix-B

--- a/packages/core/test/utils-hoist/url.test.ts
+++ b/packages/core/test/utils-hoist/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from '../../src/utils-hoist/url';
+import { getSanitizedUrlString, parseStringToURL, parseUrl, stripUrlQueryAndFragment } from '../../src/utils-hoist/url';
 
 describe('stripQueryStringAndFragment', () => {
   const urlString = 'http://dogs.are.great:1231/yay/';
@@ -194,5 +194,22 @@ describe('parseUrl', () => {
     ],
   ])('returns parsed partial URL object for %s', (url: string, expected: any) => {
     expect(parseUrl(url)).toEqual(expected);
+  });
+});
+
+describe('parseStringToURL', () => {
+  it('returns undefined for invalid URLs', () => {
+    expect(parseStringToURL('invalid-url')).toBeUndefined();
+  });
+
+  it('returns a URL object for valid URLs', () => {
+    expect(parseStringToURL('https://somedomain.com')).toBeInstanceOf(URL);
+  });
+
+  it('does not throw an error if URl.canParse is not defined', () => {
+    const canParse = (URL as any).canParse;
+    delete (URL as any).canParse;
+    expect(parseStringToURL('https://somedomain.com')).toBeInstanceOf(URL);
+    (URL as any).canParse = canParse;
   });
 });


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/15767

Now that we support ES2020 (aka not IE11 anymore) and Node.js 18+, we can get rid of `parseUrl` in favor of a method that just uses the built-in URL object. This will save us some bundle size (given we can remove that regex), and we get performance benefits from using native code.

https://github.com/getsentry/sentry-javascript/blob/3d63621714b31c1ea4c2ab2d90d5684a36805a43/packages/core/src/utils-hoist/url.ts#L17

Instead of just blanket replacing `parseUrl`, we'll slowly convert all it's usages to using a new helper, `parseStringToURL`.

Given we are updating the core package, I also went ahead and converted `parseUrl` usage in `packages/core/src/fetch.ts`

