### PR TITLE
feat(node): Add fastify `shouldHandleError`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-fastify/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/src/app.ts
@@ -81,6 +81,16 @@ app.get('/test-error', async function (req, res) {
   res.send({ exceptionId });
 });
 
+app.get('/test-4xx-error', async function (req, res) {
+  res.code(400);
+  throw new Error('This is a 4xx error');
+});
+
+app.get('/test-5xx-error', async function (req, res) {
+  res.code(500);
+  throw new Error('This is a 5xx error');
+});
+
 app.get<{ Params: { id: string } }>('/test-exception/:id', async function (req, res) {
   throw new Error(`This is an exception with id ${req.params.id}`);
 });

--- a/dev-packages/e2e-tests/test-applications/node-fastify/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/tests/errors.test.ts
@@ -36,17 +36,17 @@ test('Does not send 4xx errors by default', async ({ baseURL }) => {
   // Create a promise to wait for the 500 error
   const serverErrorPromise = waitForError('node-fastify', event => {
     // Looking for a 500 error that should be captured
-    return !!event.exception?.values?.[0]?.value?.includes('Internal Server Error');
+    return !!event.exception?.values?.[0]?.value?.includes('This is a 5xx error');
   });
 
-  // Make a request that will trigger a 404 error
-  const notFoundResponse = await fetch(`${baseURL}/non-existent-route`);
-  expect(notFoundResponse.status).toBe(404);
+  // Make a request that will trigger a 400 error
+  const notFoundResponse = await fetch(`${baseURL}/test-4xx-error`);
+  expect(notFoundResponse.status).toBe(400);
 
   // Make a request that will trigger a 500 error
-  await fetch(`${baseURL}/test-server-error`);
+  await fetch(`${baseURL}/test-5xx-error`);
 
   // Verify we receive the 500 error
   const errorEvent = await serverErrorPromise;
-  expect(errorEvent.exception?.values?.[0]?.value).toContain('Internal Server Error');
+  expect(errorEvent.exception?.values?.[0]?.value).toContain('This is a 5xx error');
 });

--- a/dev-packages/e2e-tests/test-applications/node-fastify/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/tests/errors.test.ts
@@ -28,3 +28,25 @@ test('Sends correct error event', async ({ baseURL }) => {
     parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
   });
 });
+
+test('Does not send 4xx errors by default', async ({ baseURL }) => {
+  // Define our test approach: we'll send both a 5xx and a 4xx request
+  // We should only see the 5xx error captured due to shouldHandleError's default behavior
+
+  // Create a promise to wait for the 500 error
+  const serverErrorPromise = waitForError('node-fastify', event => {
+    // Looking for a 500 error that should be captured
+    return !!event.exception?.values?.[0]?.value?.includes('Internal Server Error');
+  });
+
+  // Make a request that will trigger a 404 error
+  const notFoundResponse = await fetch(`${baseURL}/non-existent-route`);
+  expect(notFoundResponse.status).toBe(404);
+
+  // Make a request that will trigger a 500 error
+  await fetch(`${baseURL}/test-server-error`);
+
+  // Verify we receive the 500 error
+  const errorEvent = await serverErrorPromise;
+  expect(errorEvent.exception?.values?.[0]?.value).toContain('Internal Server Error');
+});


### PR DESCRIPTION
Supercedes https://github.com/getsentry/sentry-javascript/pull/13198

resolves https://github.com/getsentry/sentry-javascript/issues/13197

Aligns fastify error handler with the express one.

1. Adds `shouldHandleError` to allow users to configure if errors should be captured
2. Makes sure the default `shouldHandleError` does not capture errors for 4xx and 3xx status codes.

## Usage

```js
setupFastifyErrorHandler(app, {
  shouldHandleError(_error, _request, reply) {
    return statusCode >= 500 || statusCode <= 399;
  },
});
```