### PR TITLE
ref: Remove some usages of `dropUndefinedKeys()`

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import type { AstroConfig, AstroIntegration } from 'astro';
 
-import { consoleSandbox, dropUndefinedKeys } from '@sentry/core';
+import { consoleSandbox } from '@sentry/core';
 import { buildClientSnippet, buildSdkInitFileImportSnippet, buildServerSnippet } from './snippets';
 import type { SentryOptions } from './types';
 
@@ -62,34 +62,32 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                 sourcemap: computedSourceMapSettings.updatedSourceMapSetting,
               },
               plugins: [
-                sentryVitePlugin(
-                  dropUndefinedKeys({
-                    org: uploadOptions.org ?? env.SENTRY_ORG,
-                    project: uploadOptions.project ?? env.SENTRY_PROJECT,
-                    authToken: uploadOptions.authToken ?? env.SENTRY_AUTH_TOKEN,
-                    telemetry: uploadOptions.telemetry ?? true,
-                    _metaOptions: {
-                      telemetry: {
-                        metaFramework: 'astro',
-                      },
+                sentryVitePlugin({
+                  org: uploadOptions.org ?? env.SENTRY_ORG,
+                  project: uploadOptions.project ?? env.SENTRY_PROJECT,
+                  authToken: uploadOptions.authToken ?? env.SENTRY_AUTH_TOKEN,
+                  telemetry: uploadOptions.telemetry ?? true,
+                  _metaOptions: {
+                    telemetry: {
+                      metaFramework: 'astro',
                     },
-                    ...unstable_sentryVitePluginOptions,
-                    debug: options.debug ?? false,
-                    sourcemaps: {
-                      assets: uploadOptions.assets ?? [getSourcemapsAssetsGlob(config)],
-                      filesToDeleteAfterUpload:
-                        uploadOptions?.filesToDeleteAfterUpload ?? updatedFilesToDeleteAfterUpload,
-                      ...unstable_sentryVitePluginOptions?.sourcemaps,
-                    },
-                    bundleSizeOptimizations: {
-                      ...options.bundleSizeOptimizations,
-                      // TODO: with a future version of the vite plugin (probably 2.22.0) this re-mapping is not needed anymore
-                      // ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/582
-                      excludePerformanceMonitoring: options.bundleSizeOptimizations?.excludeTracing,
-                      ...unstable_sentryVitePluginOptions?.bundleSizeOptimizations,
-                    },
-                  }),
-                ),
+                  },
+                  ...unstable_sentryVitePluginOptions,
+                  debug: options.debug ?? false,
+                  sourcemaps: {
+                    assets: uploadOptions.assets ?? [getSourcemapsAssetsGlob(config)],
+                    filesToDeleteAfterUpload:
+                      uploadOptions?.filesToDeleteAfterUpload ?? updatedFilesToDeleteAfterUpload,
+                    ...unstable_sentryVitePluginOptions?.sourcemaps,
+                  },
+                  bundleSizeOptimizations: {
+                    ...options.bundleSizeOptimizations,
+                    // TODO: with a future version of the vite plugin (probably 2.22.0) this re-mapping is not needed anymore
+                    // ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/582
+                    excludePerformanceMonitoring: options.bundleSizeOptimizations?.excludeTracing,
+                    ...unstable_sentryVitePluginOptions?.bundleSizeOptimizations,
+                  },
+                }),
               ],
             },
           });

--- a/packages/browser-utils/src/metrics/inp.ts
+++ b/packages/browser-utils/src/metrics/inp.ts
@@ -6,7 +6,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   browserPerformanceTimeOrigin,
-  dropUndefinedKeys,
   getActiveSpan,
   getCurrentScope,
   getRootSpan,
@@ -101,11 +100,11 @@ function _trackINP(): () => void {
     const routeName = spanToUse ? spanToJSON(spanToUse).description : getCurrentScope().getScopeData().transactionName;
 
     const name = htmlTreeAsString(entry.target);
-    const attributes: SpanAttributes = dropUndefinedKeys({
+    const attributes: SpanAttributes = {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser.inp',
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: `ui.interaction.${interactionType}`,
       [SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME]: entry.duration,
-    });
+    };
 
     const span = startStandaloneWebVitalSpan({
       name,

--- a/packages/core/src/checkin.ts
+++ b/packages/core/src/checkin.ts
@@ -8,7 +8,6 @@ import type {
 } from './types-hoist';
 import { dsnToString } from './utils-hoist/dsn';
 import { createEnvelope } from './utils-hoist/envelope';
-import { dropUndefinedKeys } from './utils-hoist/object';
 
 /**
  * Create envelope from check in item.
@@ -36,7 +35,7 @@ export function createCheckInEnvelope(
   }
 
   if (dynamicSamplingContext) {
-    headers.trace = dropUndefinedKeys(dynamicSamplingContext) as DynamicSamplingContext;
+    headers.trace = dynamicSamplingContext as DynamicSamplingContext;
   }
 
   const item = createCheckInEnvelopeItem(checkIn);

--- a/packages/core/src/feedback.ts
+++ b/packages/core/src/feedback.ts
@@ -1,6 +1,5 @@
 import { getClient, getCurrentScope } from './currentScopes';
 import type { EventHint, FeedbackEvent, SendFeedbackParams } from './types-hoist';
-import { dropUndefinedKeys } from './utils-hoist/object';
 
 /**
  * Send user feedback to Sentry.
@@ -14,14 +13,14 @@ export function captureFeedback(
 
   const feedbackEvent: FeedbackEvent = {
     contexts: {
-      feedback: dropUndefinedKeys({
+      feedback: {
         contact_email: email,
         name,
         message,
         url,
         source,
         associated_event_id: associatedEventId,
-      }),
+      },
     },
     type: 'feedback',
     level: 'info',

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,5 +1,5 @@
 import type { SerializedSession, Session, SessionContext, SessionStatus } from './types-hoist';
-import { dropUndefinedKeys, timestampInSeconds, uuid4 } from './utils-hoist';
+import { timestampInSeconds, uuid4 } from './utils-hoist';
 
 /**
  * Creates a new `Session` object by setting certain default parameters. If optional @param context
@@ -137,7 +137,7 @@ export function closeSession(session: Session, status?: Exclude<SessionStatus, '
  * @returns a JSON object of the passed session
  */
 function sessionToJSON(session: Session): SerializedSession {
-  return dropUndefinedKeys({
+  return {
     sid: `${session.sid}`,
     init: session.init,
     // Make sure that sec is converted to ms for date constructor
@@ -154,5 +154,5 @@ function sessionToJSON(session: Session): SerializedSession {
       ip_address: session.ipAddress,
       user_agent: session.userAgent,
     },
-  });
+  };
 }

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -46,7 +46,7 @@ export function getDynamicSamplingContextFromClient(trace_id: string, client: Cl
     release: options.release,
     public_key,
     trace_id,
-  }) as DynamicSamplingContext;
+  }) satisfies DynamicSamplingContext;
 
   client.emit('createDsc', dsc);
 

--- a/packages/replay-internal/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/networkUtils.ts
@@ -1,6 +1,6 @@
 import { serializeFormData } from '@sentry-internal/browser-utils';
 import type { NetworkMetaWarning } from '@sentry-internal/browser-utils';
-import { dropUndefinedKeys, stringMatchesSomePattern } from '@sentry/core';
+import { stringMatchesSomePattern } from '@sentry/core';
 
 import { NETWORK_BODY_MAX_SIZE, WINDOW } from '../../constants';
 import type {
@@ -98,12 +98,12 @@ export function makeNetworkReplayBreadcrumb(
     start: startTimestamp / 1000,
     end: endTimestamp / 1000,
     name: url,
-    data: dropUndefinedKeys({
+    data: {
       method,
       statusCode,
       request,
       response,
-    }),
+    },
   };
 
   return result;

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -1,6 +1,6 @@
 import { navigating, page } from '$app/stores';
 import type { Client, Integration, Span } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, dropUndefinedKeys } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import {
   WINDOW,
   browserTracingIntegration as originalBrowserTracingIntegration,
@@ -113,7 +113,7 @@ function _instrumentNavigations(client: Client): void {
       routingSpan.end();
     }
 
-    const navigationInfo = dropUndefinedKeys({
+    const navigationInfo = {
       //  `navigation.type` denotes the origin of the navigation. e.g.:
       //   - link (clicking on a link)
       //   - goto (programmatic via goto() or redirect())
@@ -121,7 +121,7 @@ function _instrumentNavigations(client: Client): void {
       'sentry.sveltekit.navigation.type': navigation.type,
       'sentry.sveltekit.navigation.from': parameterizedRouteOrigin || undefined,
       'sentry.sveltekit.navigation.to': parameterizedRouteDestination || undefined,
-    });
+    };
 
     startBrowserTracingNavigationSpan(client, {
       name: parameterizedRouteDestination || rawRouteDestination || 'unknown',


### PR DESCRIPTION
In some places this should not really be needed, so we can skip this.