### PR TITLE
fix(browser): Fix incorrect previous trace max duration

### DIFF
--- a/packages/browser/src/tracing/previousTrace.ts
+++ b/packages/browser/src/tracing/previousTrace.ts
@@ -16,7 +16,7 @@ export interface PreviousTraceInfo {
 }
 
 // 1h in seconds
-export const PREVIOUS_TRACE_MAX_DURATION = 216_000;
+export const PREVIOUS_TRACE_MAX_DURATION = 3600;
 
 // session storage key
 export const PREVIOUS_TRACE_KEY = 'sentry_previous_trace';


### PR DESCRIPTION
Small amend to #15569 - we want a duration of 1h and not 60h 🤦‍♂️ 
h/t @s1gr1d for noticing! 