### PR TITLE
feat(core): Allow to specify depth to `dropUndefinedKeys`

### DIFF
--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -223,24 +223,27 @@ export class SentrySpan implements Span {
    * use `spanToJSON(span)` instead.
    */
   public getSpanJSON(): SpanJSON {
-    return dropUndefinedKeys({
-      data: this._attributes,
-      description: this._name,
-      op: this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP],
-      parent_span_id: this._parentSpanId,
-      span_id: this._spanId,
-      start_timestamp: this._startTime,
-      status: getStatusMessage(this._status),
-      timestamp: this._endTime,
-      trace_id: this._traceId,
-      origin: this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined,
-      profile_id: this._attributes[SEMANTIC_ATTRIBUTE_PROFILE_ID] as string | undefined,
-      exclusive_time: this._attributes[SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME] as number | undefined,
-      measurements: timedEventsToMeasurements(this._events),
-      is_segment: (this._isStandaloneSpan && getRootSpan(this) === this) || undefined,
-      segment_id: this._isStandaloneSpan ? getRootSpan(this).spanContext().spanId : undefined,
-      links: convertSpanLinksForEnvelope(this._links),
-    });
+    return dropUndefinedKeys(
+      {
+        data: this._attributes,
+        description: this._name,
+        op: this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP],
+        parent_span_id: this._parentSpanId,
+        span_id: this._spanId,
+        start_timestamp: this._startTime,
+        status: getStatusMessage(this._status),
+        timestamp: this._endTime,
+        trace_id: this._traceId,
+        origin: this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined,
+        profile_id: this._attributes[SEMANTIC_ATTRIBUTE_PROFILE_ID] as string | undefined,
+        exclusive_time: this._attributes[SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME] as number | undefined,
+        measurements: timedEventsToMeasurements(this._events),
+        is_segment: (this._isStandaloneSpan && getRootSpan(this) === this) || undefined,
+        segment_id: this._isStandaloneSpan ? getRootSpan(this).spanContext().spanId : undefined,
+        links: convertSpanLinksForEnvelope(this._links),
+      },
+      1,
+    );
   }
 
   /** @inheritdoc */

--- a/packages/core/src/utils-hoist/object.ts
+++ b/packages/core/src/utils-hoist/object.ts
@@ -211,17 +211,22 @@ export function extractExceptionKeysForMessage(exception: Record<string, unknown
  *
  * Attention: This function keeps circular references in the returned object.
  */
-export function dropUndefinedKeys<T>(inputValue: T): T {
+export function dropUndefinedKeys<T>(inputValue: T, depth = Infinity): T {
   // This map keeps track of what already visited nodes map to.
   // Our Set - based memoBuilder doesn't work here because we want to the output object to have the same circular
   // references as the input object.
   const memoizationMap = new Map<unknown, unknown>();
 
   // This function just proxies `_dropUndefinedKeys` to keep the `memoBuilder` out of this function's API
-  return _dropUndefinedKeys(inputValue, memoizationMap);
+  return _dropUndefinedKeys(inputValue, memoizationMap, depth);
 }
 
-function _dropUndefinedKeys<T>(inputValue: T, memoizationMap: Map<unknown, unknown>): T {
+function _dropUndefinedKeys<T>(inputValue: T, memoizationMap: Map<unknown, unknown>, depth: number): T {
+  // If the max. depth is reached, return the input value as is
+  if (!depth) {
+    return inputValue;
+  }
+
   // Early return for primitive values
   if (inputValue === null || typeof inputValue !== 'object') {
     return inputValue;

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -91,14 +91,17 @@ export function httpRequestToRequestData(request: {
   // This is non-standard, but may be set on e.g. Next.js or Express requests
   const cookies = (request as PolymorphicRequest).cookies;
 
-  return dropUndefinedKeys({
-    url: absoluteUrl,
-    method: request.method,
-    query_string: extractQueryParamsFromUrl(url),
-    headers: headersToDict(headers),
-    cookies,
-    data,
-  });
+  return dropUndefinedKeys(
+    {
+      url: absoluteUrl,
+      method: request.method,
+      query_string: extractQueryParamsFromUrl(url),
+      headers: headersToDict(headers),
+      cookies,
+      data,
+    },
+    1,
+  );
 }
 
 function getAbsoluteUrl({

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -42,16 +42,19 @@ export function spanToTransactionTraceContext(span: Span): TraceContext {
   const { spanId: span_id, traceId: trace_id } = span.spanContext();
   const { data, op, parent_span_id, status, origin, links } = spanToJSON(span);
 
-  return dropUndefinedKeys({
-    parent_span_id,
-    span_id,
-    trace_id,
-    data,
-    op,
-    status,
-    origin,
-    links,
-  });
+  return dropUndefinedKeys(
+    {
+      parent_span_id,
+      span_id,
+      trace_id,
+      data,
+      op,
+      status,
+      origin,
+      links,
+    },
+    1,
+  );
 }
 
 /**
@@ -147,20 +150,23 @@ export function spanToJSON(span: Span): SpanJSON {
   if (spanIsOpenTelemetrySdkTraceBaseSpan(span)) {
     const { attributes, startTime, name, endTime, parentSpanId, status, links } = span;
 
-    return dropUndefinedKeys({
-      span_id,
-      trace_id,
-      data: attributes,
-      description: name,
-      parent_span_id: parentSpanId,
-      start_timestamp: spanTimeInputToSeconds(startTime),
-      // This is [0,0] by default in OTEL, in which case we want to interpret this as no end time
-      timestamp: spanTimeInputToSeconds(endTime) || undefined,
-      status: getStatusMessage(status),
-      op: attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP],
-      origin: attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined,
-      links: convertSpanLinksForEnvelope(links),
-    });
+    return dropUndefinedKeys(
+      {
+        span_id,
+        trace_id,
+        data: attributes,
+        description: name,
+        parent_span_id: parentSpanId,
+        start_timestamp: spanTimeInputToSeconds(startTime),
+        // This is [0,0] by default in OTEL, in which case we want to interpret this as no end time
+        timestamp: spanTimeInputToSeconds(endTime) || undefined,
+        status: getStatusMessage(status),
+        op: attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP],
+        origin: attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined,
+        links: convertSpanLinksForEnvelope(links),
+      },
+      1,
+    );
   }
 
   // Finally, at least we have `spanContext()`....

--- a/packages/core/test/utils-hoist/object.test.ts
+++ b/packages/core/test/utils-hoist/object.test.ts
@@ -208,6 +208,33 @@ describe('dropUndefinedKeys()', () => {
     });
   });
 
+  test('arrays with depth=1', () => {
+    expect(
+      dropUndefinedKeys(
+        {
+          a: [
+            1,
+            undefined,
+            {
+              a: 1,
+              b: undefined,
+            },
+          ],
+        },
+        1,
+      ),
+    ).toStrictEqual({
+      a: [
+        1,
+        undefined,
+        {
+          a: 1,
+          b: undefined,
+        },
+      ],
+    });
+  });
+
   test('nested objects', () => {
     expect(
       dropUndefinedKeys({
@@ -227,6 +254,65 @@ describe('dropUndefinedKeys()', () => {
         c: 2,
         e: {
           f: 3,
+        },
+      },
+    });
+  });
+
+  test('nested objects with depth=1', () => {
+    expect(
+      dropUndefinedKeys(
+        {
+          a: 1,
+          b: {
+            c: 2,
+            d: undefined,
+            e: {
+              f: 3,
+              g: undefined,
+            },
+          },
+          c: undefined,
+        },
+        1,
+      ),
+    ).toStrictEqual({
+      a: 1,
+      b: {
+        c: 2,
+        d: undefined,
+        e: {
+          f: 3,
+          g: undefined,
+        },
+      },
+    });
+  });
+
+  test('nested objects with depth=2', () => {
+    expect(
+      dropUndefinedKeys(
+        {
+          a: 1,
+          b: {
+            c: 2,
+            d: undefined,
+            e: {
+              f: 3,
+              g: undefined,
+            },
+          },
+          c: undefined,
+        },
+        2,
+      ),
+    ).toStrictEqual({
+      a: 1,
+      b: {
+        c: 2,
+        e: {
+          f: 3,
+          g: undefined,
         },
       },
     });

--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -356,7 +356,7 @@ function loadReplayOptionsFromClient(initialOptions: InitialReplayPluginOptions,
   const finalOptions: ReplayPluginOptions = {
     sessionSampleRate: 0,
     errorSampleRate: 0,
-    ...dropUndefinedKeys(initialOptions),
+    ...dropUndefinedKeys(initialOptions, 1),
   };
 
   const replaysSessionSampleRate = parseSampleRate(opt.replaysSessionSampleRate);


### PR DESCRIPTION
Today, `dropUndefinedKeys()` will iterate through all objects and arrays and make sure to drop undefined keys everywhere.

In reality, we do not need this behavior in most/many cases - often, just removing undefined values one level deep should be more than good enough (apart from cases like https://github.com/getsentry/sentry-javascript/pull/15781 where we maybe do not need it at all!)

So this PR introduces an optional second argument to `dropUndefinedKeys()` which is a depth, which defaults to `Infinity`. It will drop undefined keys recursively until it reaches this depth.

By specifying e.g. `1` there, only the top level of the passed in object will be checked for undefined values.