### PR TITLE
test(e2e): Fix failing nextjs-t3 e2e test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-t3/src/trpc/react.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-t3/src/trpc/react.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { loggerLink, unstable_httpBatchStreamLink } from '@trpc/client';
+import { loggerLink, httpBatchStreamLink } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
 import { type inferRouterInputs, type inferRouterOutputs } from '@trpc/server';
 import { useState } from 'react';
@@ -46,7 +46,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
           enabled: op =>
             process.env.NODE_ENV === 'development' || (op.direction === 'down' && op.result instanceof Error),
         }),
-        unstable_httpBatchStreamLink({
+        httpBatchStreamLink({
           transformer: SuperJSON,
           url: getBaseUrl() + '/api/trpc',
           headers: () => {


### PR DESCRIPTION
https://github.com/trpc/trpc/pull/6617 removed an unstable API we used in the app. I just switched it over to use the stable replacement