### PR TITLE
ref(nextjs): Fix Next.js vercel-edge runtime package information

### DIFF
--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -50,7 +50,7 @@ export function init(options: VercelEdgeOptions = {}): void {
     ...options,
   };
 
-  applySdkMetadata(opts, 'nextjs');
+  applySdkMetadata(opts, 'nextjs', ['nextjs', 'vercel-edge']);
 
   const client = vercelEdgeInit(opts);
 


### PR DESCRIPTION
Noticed this was "incorrect" here, for all other places it seems correct.