### PR TITLE
ref: Avoid `dropUndefinedKeys` for `spanToJSON` calls

### DIFF
--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -26,7 +26,6 @@ import type {
 } from '../types-hoist';
 import type { SpanLink } from '../types-hoist/link';
 import { logger } from '../utils-hoist/logger';
-import { dropUndefinedKeys } from '../utils-hoist/object';
 import { generateSpanId, generateTraceId } from '../utils-hoist/propagationContext';
 import { timestampInSeconds } from '../utils-hoist/time';
 import {
@@ -223,7 +222,7 @@ export class SentrySpan implements Span {
    * use `spanToJSON(span)` instead.
    */
   public getSpanJSON(): SpanJSON {
-    return dropUndefinedKeys({
+    return {
       data: this._attributes,
       description: this._name,
       op: this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP],
@@ -240,7 +239,7 @@ export class SentrySpan implements Span {
       is_segment: (this._isStandaloneSpan && getRootSpan(this) === this) || undefined,
       segment_id: this._isStandaloneSpan ? getRootSpan(this).spanContext().spanId : undefined,
       links: convertSpanLinksForEnvelope(this._links),
-    });
+    };
   }
 
   /** @inheritdoc */

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -147,7 +147,7 @@ export function spanToJSON(span: Span): SpanJSON {
   if (spanIsOpenTelemetrySdkTraceBaseSpan(span)) {
     const { attributes, startTime, name, endTime, parentSpanId, status, links } = span;
 
-    return dropUndefinedKeys({
+    return {
       span_id,
       trace_id,
       data: attributes,
@@ -160,7 +160,7 @@ export function spanToJSON(span: Span): SpanJSON {
       op: attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP],
       origin: attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined,
       links: convertSpanLinksForEnvelope(links),
-    });
+    };
   }
 
   // Finally, at least we have `spanContext()`....

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -75,26 +75,6 @@ describe('SentrySpan', () => {
       expect(serialized).toHaveProperty('span_id', 'd');
       expect(serialized).toHaveProperty('trace_id', 'c');
     });
-
-    test('should drop all `undefined` values', () => {
-      const spanA = new SentrySpan({ traceId: 'a', spanId: 'b' });
-      const spanB = new SentrySpan({
-        parentSpanId: spanA.spanContext().spanId,
-        spanId: 'd',
-        traceId: 'c',
-      });
-      const serialized = spanToJSON(spanB);
-      expect(serialized).toStrictEqual({
-        start_timestamp: expect.any(Number),
-        parent_span_id: 'b',
-        span_id: 'd',
-        trace_id: 'c',
-        origin: 'manual',
-        data: {
-          'sentry.origin': 'manual',
-        },
-      });
-    });
   });
 
   describe('end', () => {


### PR DESCRIPTION
We probably don't need this!