### PR TITLE
fix(nuxt): Don't override Nuxt options if undefined

### DIFF
--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -142,7 +142,6 @@ export function changeNuxtSourceMapSettings(
   nuxt: Nuxt,
   sentryModuleOptions: SentryNuxtModuleOptions,
 ): { client: UserSourceMapSetting; server: UserSourceMapSetting } {
-  nuxt.options = nuxt.options || {};
   nuxt.options.sourcemap = nuxt.options.sourcemap ?? { server: undefined, client: undefined };
 
   let previousUserSourceMapSetting: { client: UserSourceMapSetting; server: UserSourceMapSetting } = {


### PR DESCRIPTION
Sometimes, the build fails because of this error: ` ERROR  Cannot set property options of #<Object> which has only a getter   `

As `nuxt.options` are always defined anyway (it's also not optional in the `Nuxt` type), we can safely delete the assertion to `{}` which causes the error to dissapear.
