### PR TITLE
feat: Stop using `dropUndefinedKeys`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3/server/plugins/customNitroErrorHandler.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/server/plugins/customNitroErrorHandler.ts
@@ -1,4 +1,4 @@
-import { Context, GLOBAL_OBJ, dropUndefinedKeys, flush, logger, vercelWaitUntil } from '@sentry/core';
+import { Context, GLOBAL_OBJ, flush, logger, vercelWaitUntil } from '@sentry/core';
 import * as SentryNode from '@sentry/node';
 import { H3Error } from 'h3';
 import type { CapturedErrorContext } from 'nitropack';
@@ -36,24 +36,22 @@ export default defineNitroPlugin(nitroApp => {
 });
 
 function extractErrorContext(errorContext: CapturedErrorContext): Context {
-  const structuredContext: Context = {
-    method: undefined,
-    path: undefined,
-    tags: undefined,
-  };
+  const ctx: Context = {};
 
-  if (errorContext) {
-    if (errorContext.event) {
-      structuredContext.method = errorContext.event._method || undefined;
-      structuredContext.path = errorContext.event._path || undefined;
-    }
-
-    if (Array.isArray(errorContext.tags)) {
-      structuredContext.tags = errorContext.tags || undefined;
-    }
+  if (!errorContext) {
+    return ctx;
   }
 
-  return dropUndefinedKeys(structuredContext);
+  if (errorContext.event) {
+    ctx.method = errorContext.event._method;
+    ctx.path = errorContext.event._path;
+  }
+
+  if (Array.isArray(errorContext.tags)) {
+    ctx.tags = errorContext.tags;
+  }
+
+  return ctx;
 }
 
 async function flushIfServerless(): Promise<void> {

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -728,6 +728,7 @@ describe('browserTracingIntegration', () => {
         sampled: true,
         sampleRand: expect.any(Number),
         dsc: {
+          release: undefined,
           environment: 'production',
           public_key: 'examplePublicKey',
           sample_rate: '1',
@@ -768,6 +769,7 @@ describe('browserTracingIntegration', () => {
         sampled: false,
         sampleRand: expect.any(Number),
         dsc: {
+          release: undefined,
           environment: 'production',
           public_key: 'examplePublicKey',
           sample_rate: '0',
@@ -892,6 +894,7 @@ describe('browserTracingIntegration', () => {
 
       expect(dynamicSamplingContext).toBeDefined();
       expect(dynamicSamplingContext).toStrictEqual({
+        release: undefined,
         environment: 'production',
         public_key: 'examplePublicKey',
         sample_rate: '1',

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -8,7 +8,7 @@ import {
   baggageHeaderToDynamicSamplingContext,
   dynamicSamplingContextToSentryBaggageHeader,
 } from '../utils-hoist/baggage';
-import { addNonEnumerableProperty, dropUndefinedKeys } from '../utils-hoist/object';
+import { addNonEnumerableProperty } from '../utils-hoist/object';
 import { hasSpansEnabled } from '../utils/hasSpansEnabled';
 import { getRootSpan, spanIsSampled, spanToJSON } from '../utils/spanUtils';
 import { getCapturedScopesOnSpan } from './utils';
@@ -41,12 +41,21 @@ export function getDynamicSamplingContextFromClient(trace_id: string, client: Cl
 
   const { publicKey: public_key } = client.getDsn() || {};
 
-  const dsc = dropUndefinedKeys({
+  // Instead of conditionally adding non-undefined values, we add them and then remove them if needed
+  // otherwise, the order of baggage entries changes, which "breaks" a bunch of tests etc.
+  const dsc: DynamicSamplingContext = {
     environment: options.environment || DEFAULT_ENVIRONMENT,
     release: options.release,
     public_key,
     trace_id,
-  }) satisfies DynamicSamplingContext;
+  };
+
+  if (!dsc.release) {
+    delete dsc.release;
+  }
+  if (!dsc.public_key) {
+    delete dsc.public_key;
+  }
 
   client.emit('createDsc', dsc);
 

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -50,13 +50,6 @@ export function getDynamicSamplingContextFromClient(trace_id: string, client: Cl
     trace_id,
   };
 
-  if (!dsc.release) {
-    delete dsc.release;
-  }
-  if (!dsc.public_key) {
-    delete dsc.public_key;
-  }
-
   client.emit('createDsc', dsc);
 
   return dsc;

--- a/packages/core/src/types-hoist/envelope.ts
+++ b/packages/core/src/types-hoist/envelope.ts
@@ -17,7 +17,7 @@ import type { SpanJSON } from './span';
 // Based on https://github.com/getsentry/relay/blob/b23b8d3b2360a54aaa4d19ecae0231201f31df5e/relay-sampling/src/lib.rs#L685-L707
 export type DynamicSamplingContext = {
   trace_id: string;
-  public_key: DsnComponents['publicKey'];
+  public_key?: DsnComponents['publicKey'];
   sample_rate?: string;
   release?: string;
   environment?: string;

--- a/packages/core/src/types-hoist/envelope.ts
+++ b/packages/core/src/types-hoist/envelope.ts
@@ -17,7 +17,7 @@ import type { SpanJSON } from './span';
 // Based on https://github.com/getsentry/relay/blob/b23b8d3b2360a54aaa4d19ecae0231201f31df5e/relay-sampling/src/lib.rs#L685-L707
 export type DynamicSamplingContext = {
   trace_id: string;
-  public_key?: DsnComponents['publicKey'];
+  public_key: DsnComponents['publicKey'];
   sample_rate?: string;
   release?: string;
   environment?: string;

--- a/packages/core/src/utils-hoist/anr.ts
+++ b/packages/core/src/utils-hoist/anr.ts
@@ -81,12 +81,12 @@ export function callFrameToStackFrame(
   const colno = frame.location.columnNumber ? frame.location.columnNumber + 1 : undefined;
   const lineno = frame.location.lineNumber ? frame.location.lineNumber + 1 : undefined;
 
-  return dropUndefinedKeys({
+  return {
     filename,
     module: getModuleFromFilename(filename),
     function: frame.functionName || UNKNOWN_FUNCTION,
     colno,
     lineno,
     in_app: filename ? filenameIsInApp(filename) : undefined,
-  });
+  };
 }

--- a/packages/core/src/utils-hoist/anr.ts
+++ b/packages/core/src/utils-hoist/anr.ts
@@ -1,6 +1,5 @@
 import type { StackFrame } from '../types-hoist';
 import { filenameIsInApp } from './node-stack-trace';
-import { dropUndefinedKeys } from './object';
 import { UNKNOWN_FUNCTION } from './stacktrace';
 
 type WatchdogReturn = {

--- a/packages/core/src/utils-hoist/envelope.ts
+++ b/packages/core/src/utils-hoist/envelope.ts
@@ -18,7 +18,6 @@ import type {
 
 import { dsnToString } from './dsn';
 import { normalize } from './normalize';
-import { dropUndefinedKeys } from './object';
 import { GLOBAL_OBJ } from './worldwide';
 
 /**

--- a/packages/core/src/utils-hoist/envelope.ts
+++ b/packages/core/src/utils-hoist/envelope.ts
@@ -196,13 +196,13 @@ export function createAttachmentEnvelopeItem(attachment: Attachment): Attachment
   const buffer = typeof attachment.data === 'string' ? encodeUTF8(attachment.data) : attachment.data;
 
   return [
-    dropUndefinedKeys({
+    {
       type: 'attachment',
       length: buffer.length,
       filename: attachment.filename,
       content_type: attachment.contentType,
       attachment_type: attachment.attachmentType,
-    }),
+    },
     buffer,
   ];
 }

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -45,6 +45,7 @@ export { normalize, normalizeToSize, normalizeUrlToBase } from './normalize';
 export {
   addNonEnumerableProperty,
   convertToPlainObject,
+  // eslint-disable-next-line deprecation/deprecation
   dropUndefinedKeys,
   extractExceptionKeysForMessage,
   fill,

--- a/packages/core/src/utils-hoist/object.ts
+++ b/packages/core/src/utils-hoist/object.ts
@@ -210,6 +210,8 @@ export function extractExceptionKeysForMessage(exception: Record<string, unknown
  * Works recursively on objects and arrays.
  *
  * Attention: This function keeps circular references in the returned object.
+ *
+ * @deprecated This function is no longer used by the SDK and will be removed in a future major version.
  */
 export function dropUndefinedKeys<T>(inputValue: T): T {
   // This map keeps track of what already visited nodes map to.

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -91,14 +91,14 @@ export function httpRequestToRequestData(request: {
   // This is non-standard, but may be set on e.g. Next.js or Express requests
   const cookies = (request as PolymorphicRequest).cookies;
 
-  return dropUndefinedKeys({
+  return {
     url: absoluteUrl,
     method: request.method,
     query_string: extractQueryParamsFromUrl(url),
     headers: headersToDict(headers),
     cookies,
     data,
-  });
+  };
 }
 
 function getAbsoluteUrl({

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -1,6 +1,5 @@
 import type { PolymorphicRequest, RequestEventData } from '../types-hoist';
 import type { WebFetchHeaders, WebFetchRequest } from '../types-hoist/webfetchapi';
-import { dropUndefinedKeys } from '../utils-hoist/object';
 
 /**
  * Transforms a `Headers` object that implements the `Web Fetch API` (https://developer.mozilla.org/en-US/docs/Web/API/Headers) into a simple key-value dict.

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -42,7 +42,7 @@ export function spanToTransactionTraceContext(span: Span): TraceContext {
   const { spanId: span_id, traceId: trace_id } = span.spanContext();
   const { data, op, parent_span_id, status, origin, links } = spanToJSON(span);
 
-  return dropUndefinedKeys({
+  return {
     parent_span_id,
     span_id,
     trace_id,
@@ -51,7 +51,7 @@ export function spanToTransactionTraceContext(span: Span): TraceContext {
     status,
     origin,
     links,
-  });
+  };
 }
 
 /**
@@ -67,11 +67,11 @@ export function spanToTraceContext(span: Span): TraceContext {
 
   const span_id = isRemote ? scope?.getPropagationContext().propagationSpanId || generateSpanId() : spanId;
 
-  return dropUndefinedKeys({
+  return {
     parent_span_id,
     span_id,
     trace_id,
-  });
+  };
 }
 
 /**

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -21,7 +21,7 @@ import type {
 } from '../types-hoist';
 import type { SpanLink, SpanLinkJSON } from '../types-hoist/link';
 import { consoleSandbox } from '../utils-hoist/logger';
-import { addNonEnumerableProperty, dropUndefinedKeys } from '../utils-hoist/object';
+import { addNonEnumerableProperty } from '../utils-hoist/object';
 import { generateSpanId } from '../utils-hoist/propagationContext';
 import { timestampInSeconds } from '../utils-hoist/time';
 import { generateSentryTraceHeader } from '../utils-hoist/tracing';

--- a/packages/core/src/utils/transactionEvent.ts
+++ b/packages/core/src/utils/transactionEvent.ts
@@ -1,6 +1,5 @@
 import { SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME, SEMANTIC_ATTRIBUTE_PROFILE_ID } from '../semanticAttributes';
 import type { SpanJSON, TransactionEvent } from '../types-hoist';
-import { dropUndefinedKeys } from '../utils-hoist';
 
 /**
  * Converts a transaction event to a span JSON object.
@@ -8,7 +7,7 @@ import { dropUndefinedKeys } from '../utils-hoist';
 export function convertTransactionEventToSpanJson(event: TransactionEvent): SpanJSON {
   const { trace_id, parent_span_id, span_id, status, origin, data, op } = event.contexts?.trace ?? {};
 
-  return dropUndefinedKeys({
+  return {
     data: data ?? {},
     description: event.transaction,
     op,
@@ -23,14 +22,14 @@ export function convertTransactionEventToSpanJson(event: TransactionEvent): Span
     exclusive_time: data?.[SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME] as number | undefined,
     measurements: event.measurements,
     is_segment: true,
-  });
+  };
 }
 
 /**
  * Converts a span JSON object to a transaction event.
  */
 export function convertSpanJsonToTransactionEvent(span: SpanJSON): TransactionEvent {
-  const event: TransactionEvent = {
+  return {
     type: 'transaction',
     timestamp: span.timestamp,
     start_timestamp: span.start_timestamp,
@@ -52,6 +51,4 @@ export function convertSpanJsonToTransactionEvent(span: SpanJSON): TransactionEv
     },
     measurements: span.measurements,
   };
-
-  return dropUndefinedKeys(event);
 }

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -70,6 +70,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
     const dynamicSamplingContext = getDynamicSamplingContextFromSpan(rootSpan);
 
     expect(dynamicSamplingContext).toStrictEqual({
+      public_key: undefined,
       release: '1.0.1',
       environment: 'production',
       sampled: 'true',
@@ -88,6 +89,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
     const dynamicSamplingContext = getDynamicSamplingContextFromSpan(rootSpan);
 
     expect(dynamicSamplingContext).toStrictEqual({
+      public_key: undefined,
       release: '1.0.1',
       environment: 'production',
       sampled: 'true',
@@ -111,6 +113,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
     const dynamicSamplingContext = getDynamicSamplingContextFromSpan(rootSpan);
 
     expect(dynamicSamplingContext).toStrictEqual({
+      public_key: undefined,
       release: '1.0.1',
       environment: 'production',
       sampled: 'true',
@@ -166,6 +169,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
     const dynamicSamplingContext = getDynamicSamplingContextFromSpan(rootSpan);
 
     expect(dynamicSamplingContext).toStrictEqual({
+      public_key: undefined,
       release: '1.0.1',
       environment: 'production',
       trace_id: expect.stringMatching(/^[a-f0-9]{32}$/),

--- a/packages/core/test/utils-hoist/object.test.ts
+++ b/packages/core/test/utils-hoist/object.test.ts
@@ -169,6 +169,7 @@ describe('extractExceptionKeysForMessage()', () => {
   });
 });
 
+/* eslint-disable deprecation/deprecation */
 describe('dropUndefinedKeys()', () => {
   test('simple case', () => {
     expect(
@@ -314,6 +315,7 @@ describe('dropUndefinedKeys()', () => {
     expect(droppedChicken.lays[0] === droppedChicken).toBe(true);
   });
 });
+/* eslint-enable deprecation/deprecation */
 
 describe('objectify()', () => {
   describe('stringifies nullish values', () => {

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -9,16 +9,23 @@ import type { ComponentPublicInstance } from 'vue';
  *  Extracts the relevant context information from the error context (H3Event in Nitro Error)
  *  and created a structured context object.
  */
-export function extractErrorContext(errorContext: CapturedErrorContext): Context {
-  if (!errorContext.event) {
-    return {};
+export function extractErrorContext(errorContext: CapturedErrorContext | undefined): Context {
+  const ctx: Context = {};
+
+  if (!errorContext) {
+    return ctx;
   }
 
-  return {
-    method: errorContext.event._method,
-    path: errorContext.event._path,
-    tags: Array.isArray(errorContext.tags) ? errorContext.tags : undefined,
-  };
+  if (errorContext.event) {
+    ctx.method = errorContext.event._method;
+    ctx.path = errorContext.event._path;
+  }
+
+  if (Array.isArray(errorContext.tags)) {
+    ctx.tags = errorContext.tags;
+  }
+
+  return ctx;
 }
 
 /**

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -1,5 +1,5 @@
 import type { ClientOptions, Context } from '@sentry/core';
-import { captureException, dropUndefinedKeys, getClient, getTraceMetaTags } from '@sentry/core';
+import { captureException, getClient, getTraceMetaTags } from '@sentry/core';
 import type { VueOptions } from '@sentry/vue/src/types';
 import type { CapturedErrorContext } from 'nitropack';
 import type { NuxtRenderHTMLContext } from 'nuxt/app';
@@ -10,24 +10,15 @@ import type { ComponentPublicInstance } from 'vue';
  *  and created a structured context object.
  */
 export function extractErrorContext(errorContext: CapturedErrorContext): Context {
-  const structuredContext: Context = {
-    method: undefined,
-    path: undefined,
-    tags: undefined,
-  };
-
-  if (errorContext) {
-    if (errorContext.event) {
-      structuredContext.method = errorContext.event._method || undefined;
-      structuredContext.path = errorContext.event._path || undefined;
-    }
-
-    if (Array.isArray(errorContext.tags)) {
-      structuredContext.tags = errorContext.tags || undefined;
-    }
+  if (!errorContext.event) {
+    return {};
   }
 
-  return dropUndefinedKeys(structuredContext);
+  return {
+    method: errorContext.event._method,
+    path: errorContext.event._path,
+    tags: Array.isArray(errorContext.tags) ? errorContext.tags : undefined,
+  };
 }
 
 /**

--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -1,5 +1,5 @@
 import type { BrowserClientReplayOptions, Client, Integration, IntegrationFn, ReplayRecordingMode } from '@sentry/core';
-import { consoleSandbox, dropUndefinedKeys, isBrowser, parseSampleRate } from '@sentry/core';
+import { consoleSandbox, isBrowser, parseSampleRate } from '@sentry/core';
 import {
   DEFAULT_FLUSH_MAX_DELAY,
   DEFAULT_FLUSH_MIN_DELAY,

--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -356,7 +356,7 @@ function loadReplayOptionsFromClient(initialOptions: InitialReplayPluginOptions,
   const finalOptions: ReplayPluginOptions = {
     sessionSampleRate: 0,
     errorSampleRate: 0,
-    ...dropUndefinedKeys(initialOptions),
+    ...initialOptions,
   };
 
   const replaysSessionSampleRate = parseSampleRate(opt.replaysSessionSampleRate);

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -1,4 +1,3 @@
-import { dropUndefinedKeys } from '@sentry/core';
 import type { Plugin } from 'vite';
 import type { AutoInstrumentSelection } from './autoInstrument';
 import { makeAutoInstrumentationPlugin } from './autoInstrument';
@@ -104,5 +103,5 @@ export function generateVitePluginOptions(
     }
   }
 
-  return dropUndefinedKeys(sentryVitePluginsOptions);
+  return sentryVitePluginsOptions;
 }


### PR DESCRIPTION
This removes the last remaining usages of `dropUndefinedKeys` in the SDK.

It also deprecates the export from `@sentry/core` for future removal.