### PR TITLE
test(nuxt): Reduce version in Nuxt min test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@sentry/nuxt": "latest || *",
-    "nuxt": "3.16.0"
+    "nuxt": "3.7.0"
   },
   "devDependencies": {
     "@playwright/test": "~1.50.0",


### PR DESCRIPTION
Reducing version for E2E test which tests the minimum supported version for Nuxt.

Was bumped here: https://github.com/getsentry/sentry-javascript/pull/15744
