### PR TITLE
feat(node): Only add span listeners for instrumentation when used

### DIFF
--- a/packages/node/src/integrations/tracing/connect.ts
+++ b/packages/node/src/integrations/tracing/connect.ts
@@ -104,7 +104,7 @@ function addConnectSpanAttributes(span: Span): void {
     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: `${type}.connect`,
   });
 
-  // Also update the name, we don't need to "middleware - " prefix
+  // Also update the name, we don't need the "middleware - " prefix
   const name = attributes['connect.name'];
   if (typeof name === 'string') {
     span.updateName(name);

--- a/packages/node/src/integrations/tracing/knex.ts
+++ b/packages/node/src/integrations/tracing/knex.ts
@@ -1,7 +1,7 @@
 import { KnexInstrumentation } from '@opentelemetry/instrumentation-knex';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration, spanToJSON } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/core';
-import { generateInstrumentOnce } from '../../otel/instrument';
+import { generateInstrumentOnce, instrumentWhenWrapped } from '../../otel/instrument';
 
 const INTEGRATION_NAME = 'Knex';
 
@@ -11,21 +11,26 @@ export const instrumentKnex = generateInstrumentOnce(
 );
 
 const _knexIntegration = (() => {
+  let instrumentationWrappedCallback: undefined | ((callback: () => void) => void);
+
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
-      instrumentKnex();
+      const instrumentation = instrumentKnex();
+      instrumentationWrappedCallback = instrumentWhenWrapped(instrumentation);
     },
 
     setup(client) {
-      client.on('spanStart', span => {
-        const { data } = spanToJSON(span);
-        // knex.version is always set in the span data
-        // https://github.com/open-telemetry/opentelemetry-js-contrib/blob/0309caeafc44ac9cb13a3345b790b01b76d0497d/plugins/node/opentelemetry-instrumentation-knex/src/instrumentation.ts#L138
-        if ('knex.version' in data) {
-          span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.knex');
-        }
-      });
+      instrumentationWrappedCallback?.(() =>
+        client.on('spanStart', span => {
+          const { data } = spanToJSON(span);
+          // knex.version is always set in the span data
+          // https://github.com/open-telemetry/opentelemetry-js-contrib/blob/0309caeafc44ac9cb13a3345b790b01b76d0497d/plugins/node/opentelemetry-instrumentation-knex/src/instrumentation.ts#L138
+          if ('knex.version' in data) {
+            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.knex');
+          }
+        }),
+      );
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/node/src/integrations/tracing/tedious.ts
+++ b/packages/node/src/integrations/tracing/tedious.ts
@@ -1,7 +1,7 @@
 import { TediousInstrumentation } from '@opentelemetry/instrumentation-tedious';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration, spanToJSON } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/core';
-import { generateInstrumentOnce } from '../../otel/instrument';
+import { generateInstrumentOnce, instrumentWhenWrapped } from '../../otel/instrument';
 
 const TEDIUS_INSTRUMENTED_METHODS = new Set([
   'callProcedure',
@@ -17,25 +17,30 @@ const INTEGRATION_NAME = 'Tedious';
 export const instrumentTedious = generateInstrumentOnce(INTEGRATION_NAME, () => new TediousInstrumentation({}));
 
 const _tediousIntegration = (() => {
+  let instrumentationWrappedCallback: undefined | ((callback: () => void) => void);
+
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
-      instrumentTedious();
+      const instrumentation = instrumentTedious();
+      instrumentationWrappedCallback = instrumentWhenWrapped(instrumentation);
     },
 
     setup(client) {
-      client.on('spanStart', span => {
-        const { description, data } = spanToJSON(span);
-        // Tedius integration always set a span name and `db.system` attribute to `mssql`.
-        if (!description || data['db.system'] !== 'mssql') {
-          return;
-        }
+      instrumentationWrappedCallback?.(() =>
+        client.on('spanStart', span => {
+          const { description, data } = spanToJSON(span);
+          // Tedius integration always set a span name and `db.system` attribute to `mssql`.
+          if (!description || data['db.system'] !== 'mssql') {
+            return;
+          }
 
-        const operation = description.split(' ')[0] || '';
-        if (TEDIUS_INSTRUMENTED_METHODS.has(operation)) {
-          span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.tedious');
-        }
-      });
+          const operation = description.split(' ')[0] || '';
+          if (TEDIUS_INSTRUMENTED_METHODS.has(operation)) {
+            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.tedious');
+          }
+        }),
+      );
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/node/src/integrations/tracing/vercelai/index.ts
+++ b/packages/node/src/integrations/tracing/vercelai/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, defineIntegration, spanToJSON } from '@sentry/core';
 import type { IntegrationFn } from '@sentry/core';
-import { generateInstrumentOnce } from '../../../otel/instrument';
+import { generateInstrumentOnce, instrumentWhenWrapped } from '../../../otel/instrument';
 import { addOriginToSpan } from '../../../utils/addOriginToSpan';
 import { SentryVercelAiInstrumentation, sentryVercelAiPatched } from './instrumentation';
 
@@ -10,145 +10,151 @@ const INTEGRATION_NAME = 'VercelAI';
 export const instrumentVercelAi = generateInstrumentOnce(INTEGRATION_NAME, () => new SentryVercelAiInstrumentation({}));
 
 const _vercelAIIntegration = (() => {
+  let instrumentationWrappedCallback: undefined | ((callback: () => void) => void);
+
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
-      instrumentVercelAi();
-    },
-    processEvent(event) {
-      if (event.type === 'transaction' && event.spans?.length) {
-        for (const span of event.spans) {
-          const { data: attributes, description: name } = span;
-
-          if (!name || span.origin !== 'auto.vercelai.otel') {
-            continue;
-          }
-
-          if (attributes['ai.usage.completionTokens'] != undefined) {
-            attributes['ai.completion_tokens.used'] = attributes['ai.usage.completionTokens'];
-          }
-          if (attributes['ai.usage.promptTokens'] != undefined) {
-            attributes['ai.prompt_tokens.used'] = attributes['ai.usage.promptTokens'];
-          }
-          if (
-            typeof attributes['ai.usage.completionTokens'] == 'number' &&
-            typeof attributes['ai.usage.promptTokens'] == 'number'
-          ) {
-            attributes['ai.total_tokens.used'] =
-              attributes['ai.usage.completionTokens'] + attributes['ai.usage.promptTokens'];
-          }
-        }
-      }
-
-      return event;
+      const instrumentation = instrumentVercelAi();
+      instrumentationWrappedCallback = instrumentWhenWrapped(instrumentation);
     },
     setup(client) {
-      client.on('spanStart', span => {
-        if (!sentryVercelAiPatched) {
-          return;
-        }
+      instrumentationWrappedCallback?.(() => {
+        client.on('spanStart', span => {
+          if (!sentryVercelAiPatched) {
+            return;
+          }
 
-        const { data: attributes, description: name } = spanToJSON(span);
+          const { data: attributes, description: name } = spanToJSON(span);
 
-        if (!name) {
-          return;
-        }
+          if (!name) {
+            return;
+          }
 
-        // The id of the model
-        const aiModelId = attributes['ai.model.id'];
+          // The id of the model
+          const aiModelId = attributes['ai.model.id'];
 
-        // the provider of the model
-        const aiModelProvider = attributes['ai.model.provider'];
+          // the provider of the model
+          const aiModelProvider = attributes['ai.model.provider'];
 
-        // both of these must be defined for the integration to work
-        if (typeof aiModelId !== 'string' || typeof aiModelProvider !== 'string' || !aiModelId || !aiModelProvider) {
-          return;
-        }
+          // both of these must be defined for the integration to work
+          if (typeof aiModelId !== 'string' || typeof aiModelProvider !== 'string' || !aiModelId || !aiModelProvider) {
+            return;
+          }
 
-        let isPipelineSpan = false;
+          let isPipelineSpan = false;
 
-        switch (name) {
-          case 'ai.generateText': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.generateText');
-            isPipelineSpan = true;
-            break;
+          switch (name) {
+            case 'ai.generateText': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.generateText');
+              isPipelineSpan = true;
+              break;
+            }
+            case 'ai.generateText.doGenerate': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run.doGenerate');
+              break;
+            }
+            case 'ai.streamText': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.streamText');
+              isPipelineSpan = true;
+              break;
+            }
+            case 'ai.streamText.doStream': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run.doStream');
+              break;
+            }
+            case 'ai.generateObject': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.generateObject');
+              isPipelineSpan = true;
+              break;
+            }
+            case 'ai.generateObject.doGenerate': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run.doGenerate');
+              break;
+            }
+            case 'ai.streamObject': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.streamObject');
+              isPipelineSpan = true;
+              break;
+            }
+            case 'ai.streamObject.doStream': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run.doStream');
+              break;
+            }
+            case 'ai.embed': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.embed');
+              isPipelineSpan = true;
+              break;
+            }
+            case 'ai.embed.doEmbed': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.embeddings');
+              break;
+            }
+            case 'ai.embedMany': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.embedMany');
+              isPipelineSpan = true;
+              break;
+            }
+            case 'ai.embedMany.doEmbed': {
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.embeddings');
+              break;
+            }
+            case 'ai.toolCall':
+            case 'ai.stream.firstChunk':
+            case 'ai.stream.finish':
+              span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run');
+              break;
           }
-          case 'ai.generateText.doGenerate': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run.doGenerate');
-            break;
-          }
-          case 'ai.streamText': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.streamText');
-            isPipelineSpan = true;
-            break;
-          }
-          case 'ai.streamText.doStream': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run.doStream');
-            break;
-          }
-          case 'ai.generateObject': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.generateObject');
-            isPipelineSpan = true;
-            break;
-          }
-          case 'ai.generateObject.doGenerate': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run.doGenerate');
-            break;
-          }
-          case 'ai.streamObject': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.streamObject');
-            isPipelineSpan = true;
-            break;
-          }
-          case 'ai.streamObject.doStream': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run.doStream');
-            break;
-          }
-          case 'ai.embed': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.embed');
-            isPipelineSpan = true;
-            break;
-          }
-          case 'ai.embed.doEmbed': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.embeddings');
-            break;
-          }
-          case 'ai.embedMany': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.pipeline.embedMany');
-            isPipelineSpan = true;
-            break;
-          }
-          case 'ai.embedMany.doEmbed': {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.embeddings');
-            break;
-          }
-          case 'ai.toolCall':
-          case 'ai.stream.firstChunk':
-          case 'ai.stream.finish':
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'ai.run');
-            break;
-        }
 
-        addOriginToSpan(span, 'auto.vercelai.otel');
+          addOriginToSpan(span, 'auto.vercelai.otel');
 
-        const nameWthoutAi = name.replace('ai.', '');
-        span.setAttribute('ai.pipeline.name', nameWthoutAi);
-        span.updateName(nameWthoutAi);
+          const nameWthoutAi = name.replace('ai.', '');
+          span.setAttribute('ai.pipeline.name', nameWthoutAi);
+          span.updateName(nameWthoutAi);
 
-        // If a Telemetry name is set and it is a pipeline span, use that as the operation name
-        const functionId = attributes['ai.telemetry.functionId'];
-        if (functionId && typeof functionId === 'string' && isPipelineSpan) {
-          span.updateName(functionId);
-          span.setAttribute('ai.pipeline.name', functionId);
-        }
+          // If a Telemetry name is set and it is a pipeline span, use that as the operation name
+          const functionId = attributes['ai.telemetry.functionId'];
+          if (functionId && typeof functionId === 'string' && isPipelineSpan) {
+            span.updateName(functionId);
+            span.setAttribute('ai.pipeline.name', functionId);
+          }
 
-        if (attributes['ai.prompt']) {
-          span.setAttribute('ai.input_messages', attributes['ai.prompt']);
-        }
-        if (attributes['ai.model.id']) {
-          span.setAttribute('ai.model_id', attributes['ai.model.id']);
-        }
-        span.setAttribute('ai.streaming', name.includes('stream'));
+          if (attributes['ai.prompt']) {
+            span.setAttribute('ai.input_messages', attributes['ai.prompt']);
+          }
+          if (attributes['ai.model.id']) {
+            span.setAttribute('ai.model_id', attributes['ai.model.id']);
+          }
+          span.setAttribute('ai.streaming', name.includes('stream'));
+        });
+
+        client.addEventProcessor(event => {
+          if (event.type === 'transaction' && event.spans?.length) {
+            for (const span of event.spans) {
+              const { data: attributes, description: name } = span;
+
+              if (!name || span.origin !== 'auto.vercelai.otel') {
+                continue;
+              }
+
+              if (attributes['ai.usage.completionTokens'] != undefined) {
+                attributes['ai.completion_tokens.used'] = attributes['ai.usage.completionTokens'];
+              }
+              if (attributes['ai.usage.promptTokens'] != undefined) {
+                attributes['ai.prompt_tokens.used'] = attributes['ai.usage.promptTokens'];
+              }
+              if (
+                typeof attributes['ai.usage.completionTokens'] == 'number' &&
+                typeof attributes['ai.usage.promptTokens'] == 'number'
+              ) {
+                attributes['ai.total_tokens.used'] =
+                  attributes['ai.usage.completionTokens'] + attributes['ai.usage.promptTokens'];
+              }
+            }
+          }
+
+          return event;
+        });
       });
     },
   };

--- a/packages/node/src/otel/instrument.ts
+++ b/packages/node/src/otel/instrument.ts
@@ -7,19 +7,22 @@ export const INSTRUMENTED: Record<string, Instrumentation> = {};
  * Instrument an OpenTelemetry instrumentation once.
  * This will skip running instrumentation again if it was already instrumented.
  */
-export function generateInstrumentOnce<Options = unknown>(
+export function generateInstrumentOnce<
+  Options = unknown,
+  InstrumentationInstance extends Instrumentation = Instrumentation,
+>(
   name: string,
-  creator: (options?: Options) => Instrumentation,
-): ((options?: Options) => void) & { id: string } {
+  creator: (options?: Options) => InstrumentationInstance,
+): ((options?: Options) => InstrumentationInstance) & { id: string } {
   return Object.assign(
     (options?: Options) => {
-      const instrumented = INSTRUMENTED[name];
+      const instrumented = INSTRUMENTED[name] as InstrumentationInstance | undefined;
       if (instrumented) {
         // If options are provided, ensure we update them
         if (options) {
           instrumented.setConfig(options);
         }
-        return;
+        return instrumented;
       }
 
       const instrumentation = creator(options);
@@ -28,7 +31,35 @@ export function generateInstrumentOnce<Options = unknown>(
       registerInstrumentations({
         instrumentations: [instrumentation],
       });
+
+      return instrumentation;
     },
     { id: name },
   );
+}
+
+/**
+ * Ensure a given callback is called when the instrumentation is actually wrapping something.
+ * This can be used to ensure some logic is only called when the instrumentation is actually active.
+ * This depends on wrapping `_wrap` (inception!). If this is not possible (e.g. the property name is mangled, ...)
+ * the callback will be called immediately.
+ */
+export function callWhenWrapped<T extends Instrumentation>(instrumentation: T, callback: () => void): void {
+  if (!hasWrap(instrumentation)) {
+    callback();
+    return;
+  }
+
+  const originalWrap = instrumentation['_wrap'];
+
+  instrumentation['_wrap'] = (...args: Parameters<typeof originalWrap>) => {
+    callback();
+    return originalWrap(...args);
+  };
+}
+
+function hasWrap<T extends Instrumentation>(
+  instrumentation: T,
+): instrumentation is T & { _wrap: (...args: unknown[]) => unknown } {
+  return typeof (instrumentation as T & { _wrap?: (...args: unknown[]) => unknown })['_wrap'] === 'function';
 }

--- a/packages/node/test/utils/instrument.test.ts
+++ b/packages/node/test/utils/instrument.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, vi, expect } from 'vitest';
+import { instrumentWhenWrapped } from '../../src/otel/instrument';
+
+describe('instrumentWhenWrapped', () => {
+  test('calls callback immediately when instrumentation has no _wrap method', () => {
+    const callback = vi.fn();
+    const instrumentation = {} as any;
+
+    const registerCallback = instrumentWhenWrapped(instrumentation);
+    registerCallback(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls callback when _wrap is called', () => {
+    const callback = vi.fn();
+    const originalWrap = vi.fn();
+    const instrumentation = {
+      _wrap: originalWrap,
+    } as any;
+
+    const registerCallback = instrumentWhenWrapped(instrumentation);
+    registerCallback(callback);
+
+    // Callback should not be called yet
+    expect(callback).not.toHaveBeenCalled();
+
+    // Call _wrap
+    instrumentation._wrap();
+
+    // Callback should be called once
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(originalWrap).toHaveBeenCalled();
+  });
+
+  test('calls multiple callbacks when _wrap is called', () => {
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+    const originalWrap = vi.fn();
+    const instrumentation = {
+      _wrap: originalWrap,
+    } as any;
+
+    const registerCallback = instrumentWhenWrapped(instrumentation);
+    registerCallback(callback1);
+    registerCallback(callback2);
+
+    // Callbacks should not be called yet
+    expect(callback1).not.toHaveBeenCalled();
+    expect(callback2).not.toHaveBeenCalled();
+
+    // Call _wrap
+    instrumentation._wrap();
+
+    // Both callbacks should be called once
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(originalWrap).toHaveBeenCalled();
+  });
+
+  test('calls callback immediately if already wrapped', () => {
+    const callback = vi.fn();
+    const originalWrap = vi.fn();
+    const instrumentation = {
+      _wrap: originalWrap,
+    } as any;
+
+    // Call _wrap first
+    instrumentation._wrap();
+
+    const registerCallback = instrumentWhenWrapped(instrumentation);
+    registerCallback(callback);
+
+    // Callback should be called immediately
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(originalWrap).toHaveBeenCalled();
+  });
+
+  test('passes through arguments to original _wrap', () => {
+    const callback = vi.fn();
+    const originalWrap = vi.fn();
+    const instrumentation = {
+      _wrap: originalWrap,
+    } as any;
+
+    const registerCallback = instrumentWhenWrapped(instrumentation);
+    registerCallback(callback);
+
+    // Call _wrap with arguments
+    const args = ['arg1', 'arg2'];
+    instrumentation._wrap(...args);
+
+    expect(originalWrap).toHaveBeenCalledWith(...args);
+  });
+});

--- a/packages/node/test/utils/instrument.test.ts
+++ b/packages/node/test/utils/instrument.test.ts
@@ -65,10 +65,11 @@ describe('instrumentWhenWrapped', () => {
       _wrap: originalWrap,
     } as any;
 
+    const registerCallback = instrumentWhenWrapped(instrumentation);
+
     // Call _wrap first
     instrumentation._wrap();
 
-    const registerCallback = instrumentWhenWrapped(instrumentation);
     registerCallback(callback);
 
     // Callback should be called immediately


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-javascript/issues/15725#issuecomment-2740015011, this PR is an idea to avoid registering `on('spanStart')` hooks for all the node libraries that do not have proper hooks, unless they are used.

Today, for OTEL instrumentation that does not provide span hooks, we fall back to `client.on('spanStart')` to enhance/mutate spans emitted by the instrumentation. This PR improved this by only registering the `spanStart` client hook if we detect that the OTEL instrumentation is actually wrapping something. This avoids us calling a bunch of span callbacks each time a span is started, when it is not even needed.

For this, a new `instrumentWhenWrapped` utility is added which can be passed an instrumentation. This works by monkey-patching `_wrap` on the instrumentation, and ensuring a callback is only called conditionally.

Note: For some (e.g. connect, fastify) we register `spanStart` in the error handler, which is even better, so there we do not need this logic.