### PR TITLE
perf(core): Remove `addNonEnumerableProperty` from `packages/core/src/tracing/utils.ts`

### DIFF
--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -130,8 +130,6 @@ export function makeTerserPlugin() {
           '_sentryRootSpan',
           '_sentryChildSpans',
           '_sentrySpan',
-          '_sentryScope',
-          '_sentryIsolationScope',
           // require-in-the-middle calls `Module._resolveFilename`. We cannot mangle this (AWS lambda layer bundle).
           '_resolveFilename',
           // Set on e.g. the shim feedbackIntegration to be able to detect it

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,20 +1,14 @@
 import type { Scope } from '../scope';
 import type { Span } from '../types-hoist';
-import { addNonEnumerableProperty } from '../utils-hoist/object';
 
-const SCOPE_ON_START_SPAN_FIELD = '_sentryScope';
-const ISOLATION_SCOPE_ON_START_SPAN_FIELD = '_sentryIsolationScope';
-
-type SpanWithScopes = Span & {
-  [SCOPE_ON_START_SPAN_FIELD]?: Scope;
-  [ISOLATION_SCOPE_ON_START_SPAN_FIELD]?: Scope;
-};
+const SPAN_TO_SCOPE_MAP = new WeakMap<Span, Scope>();
+const SPAN_TO_ISOLATION_SCOPE_MAP = new WeakMap<Span, Scope>();
 
 /** Store the scope & isolation scope for a span, which can the be used when it is finished. */
 export function setCapturedScopesOnSpan(span: Span | undefined, scope: Scope, isolationScope: Scope): void {
   if (span) {
-    addNonEnumerableProperty(span, ISOLATION_SCOPE_ON_START_SPAN_FIELD, isolationScope);
-    addNonEnumerableProperty(span, SCOPE_ON_START_SPAN_FIELD, scope);
+    SPAN_TO_SCOPE_MAP.set(span, scope);
+    SPAN_TO_ISOLATION_SCOPE_MAP.set(span, isolationScope);
   }
 }
 
@@ -23,7 +17,7 @@ export function setCapturedScopesOnSpan(span: Span | undefined, scope: Scope, is
  */
 export function getCapturedScopesOnSpan(span: Span): { scope?: Scope; isolationScope?: Scope } {
   return {
-    scope: (span as SpanWithScopes)[SCOPE_ON_START_SPAN_FIELD],
-    isolationScope: (span as SpanWithScopes)[ISOLATION_SCOPE_ON_START_SPAN_FIELD],
+    scope: SPAN_TO_SCOPE_MAP.get(span),
+    isolationScope: SPAN_TO_ISOLATION_SCOPE_MAP.get(span),
   };
 }

--- a/packages/core/test/lib/tracing/utils.test.ts
+++ b/packages/core/test/lib/tracing/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setCapturedScopesOnSpan, getCapturedScopesOnSpan } from '../../../src/tracing/utils';
+import type { Scope } from '../../../src/scope';
+import type { Span } from '../../../src/types-hoist';
+
+describe('tracing utils', () => {
+  let mockSpan: Span;
+  let mockScope: Scope;
+  let mockIsolationScope: Scope;
+
+  beforeEach(() => {
+    mockSpan = {} as Span;
+    mockScope = {} as Scope;
+    mockIsolationScope = {} as Scope;
+  });
+
+  describe('setCapturedScopesOnSpan', () => {
+    it('should store scope and isolation scope on span', () => {
+      setCapturedScopesOnSpan(mockSpan, mockScope, mockIsolationScope);
+      const captured = getCapturedScopesOnSpan(mockSpan);
+      expect(captured.scope).toBe(mockScope);
+      expect(captured.isolationScope).toBe(mockIsolationScope);
+    });
+
+    it('should handle undefined span', () => {
+      // Should not throw
+      setCapturedScopesOnSpan(undefined, mockScope, mockIsolationScope);
+    });
+  });
+
+  describe('getCapturedScopesOnSpan', () => {
+    it('should return undefined scopes when no scopes were set', () => {
+      const captured = getCapturedScopesOnSpan(mockSpan);
+      expect(captured.scope).toBeUndefined();
+      expect(captured.isolationScope).toBeUndefined();
+    });
+
+    it('should return stored scopes', () => {
+      setCapturedScopesOnSpan(mockSpan, mockScope, mockIsolationScope);
+      const captured = getCapturedScopesOnSpan(mockSpan);
+      expect(captured.scope).toBe(mockScope);
+      expect(captured.isolationScope).toBe(mockIsolationScope);
+    });
+  });
+});


### PR DESCRIPTION
Extracted from https://github.com/getsentry/sentry-javascript/pull/15765

resolves https://github.com/getsentry/sentry-javascript/issues/15810

`addNonEnumerableProperty` is pretty expensive because of `Object.defineProperty`, so this changes usage of span utils (which are called frequently) to avoid usage of `addNonEnumerableProperty`.

`addNonEnumerableProperty` is replaced with weak maps, which has the added benefit of being more GC friendly (`addNonEnumerableProperty` causes hard references to be created between the objects).

The only downside of switching to this approach is that we lose the `try catch` built into `addNonEnumerableProperty`, but I think thats fine given the nature of the changed methods.