### PR TITLE
feat(browser): Add `diagnoseSdkConnectivity()` function to programmatically detect possible connectivity issues

### DIFF
--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -29,7 +29,7 @@ export async function diagnoseSdkConnectivity(): Promise<
       // We are using the "sentry-sdks" org with id 447951 not to pollute any actual organizations.
       'https://o447951.ingest.sentry.io/api/1337/envelope/?sentry_version=7&sentry_key=1337&sentry_client=sentry.javascript.react%2F1.33.7',
       {
-        body: '',
+        body: '{}',
         method: 'POST',
         mode: 'cors',
         credentials: 'omit',

--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -1,0 +1,30 @@
+import { getCurrentScope } from '@sentry/core';
+
+/**
+ * A function to diagnose why the SDK might not be successfully sending data.
+ *
+ * Possible return values wrapped in a Promise:
+ * - `"no-client-active"` - There was no active client when the function was called. This possibly means that the SDK was not initialized yet.
+ * - `"sentry-unreachable"` - There was no active client when the function was called. This possibly means that the SDK was not initialized yet.
+ */
+export async function diagnoseSdk(): Promise<'no-client-active' | 'sentry-unreachable' | void> {
+  const client = getCurrentScope().getClient();
+
+  if (!client) {
+    return 'no-client-active';
+  }
+
+  try {
+    await fetch(
+      'https://o1337.ingest.sentry.io/api/1337/envelope/?sentry_version=7&sentry_key=1337&sentry_client=sentry.javascript.react%2F1.33.7',
+      {
+        body: '',
+        method: 'POST',
+        mode: 'cors',
+        credentials: 'omit',
+      },
+    );
+  } catch {
+    return 'sentry-unreachable';
+  }
+}

--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -5,7 +5,7 @@ import { getCurrentScope } from '@sentry/core';
  *
  * Possible return values wrapped in a Promise:
  * - `"no-client-active"` - There was no active client when the function was called. This possibly means that the SDK was not initialized yet.
- * - `"sentry-unreachable"` - There was no active client when the function was called. This possibly means that the SDK was not initialized yet.
+ * - `"sentry-unreachable"` - The Sentry SaaS servers were not reachable. This likely means that there is an ad blocker active on the page or that there are other connection issues.
  *
  * If the function doesn't detect an issue it resolves to `undefined`.
  */

--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -9,9 +9,17 @@ import { getClient } from '@sentry/core';
  *
  * If the function doesn't detect an issue it resolves to `undefined`.
  */
-export async function diagnoseSdk(): Promise<'no-client-active' | 'sentry-unreachable' | void> {
-  if (!getClient()) {
+export async function diagnoseSdkConnectivity(): Promise<
+  'no-client-active' | 'sentry-unreachable' | 'no-dsn-configured' | void
+> {
+  const client = getClient();
+
+  if (!client) {
     return 'no-client-active';
+  }
+
+  if (!client.getDsn()) {
+    return 'no-dsn-configured';
   }
 
   try {

--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -26,7 +26,8 @@ export async function diagnoseSdkConnectivity(): Promise<
     // If fetch throws, there is likely an ad blocker active or there are other connective issues.
     await fetch(
       // We want this to be as close as possible to an actual ingest URL so that ad blockers will actually block the request
-      'https://o1337.ingest.sentry.io/api/1337/envelope/?sentry_version=7&sentry_key=1337&sentry_client=sentry.javascript.react%2F1.33.7',
+      // We are using the "sentry-sdks" org with id 447951 not to pollute any actual organizations.
+      'https://o447951.ingest.sentry.io/api/1337/envelope/?sentry_version=7&sentry_key=1337&sentry_client=sentry.javascript.react%2F1.33.7',
       {
         body: '',
         method: 'POST',

--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -17,7 +17,9 @@ export async function diagnoseSdk(): Promise<'no-client-active' | 'sentry-unreac
   }
 
   try {
+    // If fetch throws, there is likely an ad blocker active or there are other connective issues.
     await fetch(
+      // We want this to be as close as possible to an actual ingest URL so that ad blockers will actually block the request
       'https://o1337.ingest.sentry.io/api/1337/envelope/?sentry_version=7&sentry_key=1337&sentry_client=sentry.javascript.react%2F1.33.7',
       {
         body: '',

--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -1,4 +1,4 @@
-import { getCurrentScope } from '@sentry/core';
+import { getClient } from '@sentry/core';
 
 /**
  * A function to diagnose why the SDK might not be successfully sending data.
@@ -10,9 +10,7 @@ import { getCurrentScope } from '@sentry/core';
  * If the function doesn't detect an issue it resolves to `undefined`.
  */
 export async function diagnoseSdk(): Promise<'no-client-active' | 'sentry-unreachable' | void> {
-  const client = getCurrentScope().getClient();
-
-  if (!client) {
+  if (!getClient()) {
     return 'no-client-active';
   }
 

--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -6,6 +6,8 @@ import { getCurrentScope } from '@sentry/core';
  * Possible return values wrapped in a Promise:
  * - `"no-client-active"` - There was no active client when the function was called. This possibly means that the SDK was not initialized yet.
  * - `"sentry-unreachable"` - There was no active client when the function was called. This possibly means that the SDK was not initialized yet.
+ *
+ * If the function doesn't detect an issue it resolves to `undefined`.
  */
 export async function diagnoseSdk(): Promise<'no-client-active' | 'sentry-unreachable' | void> {
   const client = getCurrentScope().getClient();

--- a/packages/browser/src/diagnose-sdk.ts
+++ b/packages/browser/src/diagnose-sdk.ts
@@ -27,7 +27,7 @@ export async function diagnoseSdkConnectivity(): Promise<
     await fetch(
       // We want this to be as close as possible to an actual ingest URL so that ad blockers will actually block the request
       // We are using the "sentry-sdks" org with id 447951 not to pollute any actual organizations.
-      'https://o447951.ingest.sentry.io/api/1337/envelope/?sentry_version=7&sentry_key=1337&sentry_client=sentry.javascript.react%2F1.33.7',
+      'https://o447951.ingest.sentry.io/api/1337/envelope/?sentry_version=7&sentry_key=1337&sentry_client=sentry.javascript.browser%2F1.33.7',
       {
         body: '{}',
         method: 'POST',

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -71,4 +71,4 @@ export { launchDarklyIntegration, buildLaunchDarklyFlagUsedHandler } from './int
 export { openFeatureIntegration, OpenFeatureIntegrationHook } from './integrations/featureFlags/openfeature';
 export { unleashIntegration } from './integrations/featureFlags/unleash';
 export { statsigIntegration } from './integrations/featureFlags/statsig';
-export { diagnoseSdk } from './diagnose-sdk';
+export { diagnoseSdkConnectivity } from './diagnose-sdk';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -71,3 +71,4 @@ export { launchDarklyIntegration, buildLaunchDarklyFlagUsedHandler } from './int
 export { openFeatureIntegration, OpenFeatureIntegrationHook } from './integrations/featureFlags/openfeature';
 export { unleashIntegration } from './integrations/featureFlags/unleash';
 export { statsigIntegration } from './integrations/featureFlags/statsig';
+export { diagnoseSdk } from './diagnose-sdk';


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/15780

Adds a function `diagnoseSdkConnectivity` that will resolve to various "error codes" for possible reasons why events might not land in Sentry.

Originally I wanted to add an API to detect ad blockers so we can show a notification in the example pages that the wizard creates. Then I quickly thought of a different case why the SDK might not send data so I extended the API to also detect if the SDK wasn't initialized yet. We can extend this function at any point if we come up with more cases.