### PR TITLE
ref: Avoid using `SentryError` for PromiseBuffer control flow

### DIFF
--- a/packages/cloudflare/src/transport.ts
+++ b/packages/cloudflare/src/transport.ts
@@ -1,5 +1,13 @@
-import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/core';
-import { SentryError, createTransport, suppressTracing } from '@sentry/core';
+import type {
+  BaseTransportOptions,
+  Transport,
+  TransportMakeRequestResponse,
+  TransportRequest} from '@sentry/core';
+import {
+  SENTRY_BUFFER_FULL_ERROR,
+  createTransport,
+  suppressTracing,
+} from '@sentry/core';
 
 export interface CloudflareTransportOptions extends BaseTransportOptions {
   /** Fetch API init parameters. */
@@ -38,7 +46,7 @@ export class IsolatedPromiseBuffer {
    */
   public add(taskProducer: () => PromiseLike<TransportMakeRequestResponse>): PromiseLike<TransportMakeRequestResponse> {
     if (this._taskProducers.length >= this._bufferSize) {
-      return Promise.reject(new SentryError('Not adding Promise because buffer limit was reached.'));
+      return Promise.reject(SENTRY_BUFFER_FULL_ERROR);
     }
 
     this._taskProducers.push(taskProducer);

--- a/packages/cloudflare/src/transport.ts
+++ b/packages/cloudflare/src/transport.ts
@@ -1,13 +1,5 @@
-import type {
-  BaseTransportOptions,
-  Transport,
-  TransportMakeRequestResponse,
-  TransportRequest} from '@sentry/core';
-import {
-  SENTRY_BUFFER_FULL_ERROR,
-  createTransport,
-  suppressTracing,
-} from '@sentry/core';
+import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/core';
+import { SENTRY_BUFFER_FULL_ERROR, createTransport, suppressTracing } from '@sentry/core';
 
 export interface CloudflareTransportOptions extends BaseTransportOptions {
   /** Fetch API init parameters. */

--- a/packages/cloudflare/test/transport.test.ts
+++ b/packages/cloudflare/test/transport.test.ts
@@ -1,4 +1,4 @@
-import { createEnvelope, serializeEnvelope } from '@sentry/core';
+import { SENTRY_BUFFER_FULL_ERROR, createEnvelope, serializeEnvelope } from '@sentry/core';
 import type { EventEnvelope, EventItem } from '@sentry/core';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 
@@ -140,7 +140,12 @@ describe('IsolatedPromiseBuffer', () => {
     await ipb.add(task2);
     await ipb.add(task3);
 
-    await expect(ipb.add(task4)).rejects.toThrowError('Not adding Promise because buffer limit was reached.');
+    try {
+      await ipb.add(task4);
+      throw new Error('Should not be called');
+    } catch (error) {
+      expect(error).toBe(SENTRY_BUFFER_FULL_ERROR);
+    }
   });
 
   it('should not throw when one of the tasks throws when drained', async () => {

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -14,9 +14,8 @@ import {
   forEachEnvelopeItem,
   serializeEnvelope,
 } from '../utils-hoist/envelope';
-import { SentryError } from '../utils-hoist/error';
 import { logger } from '../utils-hoist/logger';
-import { type PromiseBuffer, makePromiseBuffer } from '../utils-hoist/promisebuffer';
+import { type PromiseBuffer, makePromiseBuffer, SENTRY_BUFFER_FULL_ERROR } from '../utils-hoist/promisebuffer';
 import { type RateLimits, isRateLimited, updateRateLimits } from '../utils-hoist/ratelimit';
 import { resolvedSyncPromise } from '../utils-hoist/syncpromise';
 
@@ -85,7 +84,7 @@ export function createTransport(
     return buffer.add(requestTask).then(
       result => result,
       error => {
-        if (error instanceof SentryError) {
+        if (error === SENTRY_BUFFER_FULL_ERROR) {
           DEBUG_BUILD && logger.error('Skipped sending event because buffer is full.');
           recordEnvelopeLoss('queue_overflow');
           return resolvedSyncPromise({});

--- a/packages/core/src/utils-hoist/index.ts
+++ b/packages/core/src/utils-hoist/index.ts
@@ -53,7 +53,7 @@ export {
   objectify,
 } from './object';
 export { basename, dirname, isAbsolute, join, normalizePath, relative, resolve } from './path';
-export { makePromiseBuffer } from './promisebuffer';
+export { makePromiseBuffer, SENTRY_BUFFER_FULL_ERROR } from './promisebuffer';
 export type { PromiseBuffer } from './promisebuffer';
 
 export { severityLevelFromString } from './severity';

--- a/packages/core/src/utils-hoist/promisebuffer.ts
+++ b/packages/core/src/utils-hoist/promisebuffer.ts
@@ -1,4 +1,3 @@
-import { SentryError } from './error';
 import { SyncPromise, rejectedSyncPromise, resolvedSyncPromise } from './syncpromise';
 
 export interface PromiseBuffer<T> {
@@ -8,6 +7,8 @@ export interface PromiseBuffer<T> {
   add(taskProducer: () => PromiseLike<T>): PromiseLike<T>;
   drain(timeout?: number): PromiseLike<boolean>;
 }
+
+export const SENTRY_BUFFER_FULL_ERROR = Symbol('SentryBufferFullError');
 
 /**
  * Creates an new PromiseBuffer object with the specified limit
@@ -42,7 +43,7 @@ export function makePromiseBuffer<T>(limit?: number): PromiseBuffer<T> {
    */
   function add(taskProducer: () => PromiseLike<T>): PromiseLike<T> {
     if (!isReady()) {
-      return rejectedSyncPromise(new SentryError('Not adding Promise because buffer limit was reached.'));
+      return rejectedSyncPromise(SENTRY_BUFFER_FULL_ERROR);
     }
 
     // start the task and add its promise to the queue

--- a/packages/core/src/utils-hoist/promisebuffer.ts
+++ b/packages/core/src/utils-hoist/promisebuffer.ts
@@ -8,7 +8,7 @@ export interface PromiseBuffer<T> {
   drain(timeout?: number): PromiseLike<boolean>;
 }
 
-export const SENTRY_BUFFER_FULL_ERROR = Symbol('SentryBufferFullError');
+export const SENTRY_BUFFER_FULL_ERROR = Symbol.for('SentryBufferFullError');
 
 /**
  * Creates an new PromiseBuffer object with the specified limit

--- a/packages/vercel-edge/src/transports/index.ts
+++ b/packages/vercel-edge/src/transports/index.ts
@@ -1,13 +1,5 @@
-import type {
-  BaseTransportOptions,
-  Transport,
-  TransportMakeRequestResponse,
-  TransportRequest} from '@sentry/core';
-import {
-  SENTRY_BUFFER_FULL_ERROR,
-  createTransport,
-  suppressTracing,
-} from '@sentry/core';
+import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/core';
+import { SENTRY_BUFFER_FULL_ERROR, createTransport, suppressTracing } from '@sentry/core';
 
 export interface VercelEdgeTransportOptions extends BaseTransportOptions {
   /** Fetch API init parameters. */

--- a/packages/vercel-edge/src/transports/index.ts
+++ b/packages/vercel-edge/src/transports/index.ts
@@ -1,5 +1,13 @@
-import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/core';
-import { SentryError, createTransport, suppressTracing } from '@sentry/core';
+import type {
+  BaseTransportOptions,
+  Transport,
+  TransportMakeRequestResponse,
+  TransportRequest} from '@sentry/core';
+import {
+  SENTRY_BUFFER_FULL_ERROR,
+  createTransport,
+  suppressTracing,
+} from '@sentry/core';
 
 export interface VercelEdgeTransportOptions extends BaseTransportOptions {
   /** Fetch API init parameters. */
@@ -38,7 +46,7 @@ export class IsolatedPromiseBuffer {
    */
   public add(taskProducer: () => PromiseLike<TransportMakeRequestResponse>): PromiseLike<TransportMakeRequestResponse> {
     if (this._taskProducers.length >= this._bufferSize) {
-      return Promise.reject(new SentryError('Not adding Promise because buffer limit was reached.'));
+      return Promise.reject(SENTRY_BUFFER_FULL_ERROR);
     }
 
     this._taskProducers.push(taskProducer);

--- a/packages/vercel-edge/test/transports/index.test.ts
+++ b/packages/vercel-edge/test/transports/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
 
-import { createEnvelope, serializeEnvelope } from '@sentry/core';
+import { SENTRY_BUFFER_FULL_ERROR, createEnvelope, serializeEnvelope } from '@sentry/core';
 import type { EventEnvelope, EventItem } from '@sentry/core';
 
 import type { VercelEdgeTransportOptions } from '../../src/transports';
@@ -139,7 +139,12 @@ describe('IsolatedPromiseBuffer', () => {
     await ipb.add(task2);
     await ipb.add(task3);
 
-    await expect(ipb.add(task4)).rejects.toThrowError('Not adding Promise because buffer limit was reached.');
+    try {
+      await ipb.add(task4);
+      throw new Error('Should not be called');
+    } catch (error) {
+      expect(error).toBe(SENTRY_BUFFER_FULL_ERROR);
+    }
   });
 
   it('should not throw when one of the tasks throws when drained', async () => {


### PR DESCRIPTION
This replaces usage of `SentryError` for promise buffer control flow.
Instead, we can use a symbol and just check this directly, we do not even care about the message here.

ref https://github.com/getsentry/sentry-javascript/issues/15725#issuecomment-2750892929

