### PR TITLE
fix: Remove critical log severity level

### DIFF
--- a/packages/browser/src/log.ts
+++ b/packages/browser/src/log.ts
@@ -257,36 +257,4 @@ export function fatal(message: ParameterizedString, attributes?: Log['attributes
   captureLog('fatal', message, attributes);
 }
 
-/**
- * @summary Capture a log with the `critical` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * @param message - The message to log.
- * @param attributes - Arbitrary structured data that stores information about the log - e.g., { security: 'breach', severity: 'high' }.
- *
- * @example
- *
- * ```
- * Sentry.logger.critical('Security breach detected', {
- *   type: 'unauthorized_access',
- *   user: '132123',
- *   endpoint: '/api/admin',
- *   timestamp: Date.now()
- * });
- * ```
- *
- * @example With template strings
- *
- * ```
- * Sentry.logger.critical(Sentry.logger.fmt`Multiple failed login attempts from user ${user}`, {
- *   attempts: 10,
- *   timeWindow: '5m',
- *   blocked: true,
- *   timestamp: Date.now()
- * });
- * ```
- */
-export function critical(message: ParameterizedString, attributes?: Log['attributes']): void {
-  captureLog('critical', message, attributes);
-}
-
 export { fmt } from '@sentry/core';

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -334,7 +334,6 @@ describe('SentryBrowser', () => {
       expect(logger.warn).toBeDefined();
       expect(logger.error).toBeDefined();
       expect(logger.fatal).toBeDefined();
-      expect(logger.critical).toBeDefined();
     });
   });
 });

--- a/packages/browser/test/log.test.ts
+++ b/packages/browser/test/log.test.ts
@@ -64,7 +64,6 @@ describe('Logger', () => {
       expect(logger.warn).toBeTypeOf('function');
       expect(logger.error).toBeTypeOf('function');
       expect(logger.fatal).toBeTypeOf('function');
-      expect(logger.critical).toBeTypeOf('function');
     });
 
     it('should call _INTERNAL_captureLog with trace level', () => {

--- a/packages/browser/test/log.test.ts
+++ b/packages/browser/test/log.test.ts
@@ -150,20 +150,6 @@ describe('Logger', () => {
         undefined,
       );
     });
-
-    it('should call _INTERNAL_captureLog with critical level', () => {
-      logger.critical('Test critical message', { key: 'value' });
-      expect(mockCaptureLog).toHaveBeenCalledWith(
-        {
-          level: 'critical',
-          message: 'Test critical message',
-          attributes: { key: 'value' },
-          severityNumber: undefined,
-        },
-        expect.any(Object),
-        undefined,
-      );
-    });
   });
 
   describe('Automatic flushing', () => {

--- a/packages/core/src/types-hoist/log.ts
+++ b/packages/core/src/types-hoist/log.ts
@@ -1,6 +1,6 @@
 import type { ParameterizedString } from './parameterize';
 
-export type LogSeverityLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal' | 'critical';
+export type LogSeverityLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 export type SerializedLogAttributeValueType =
   | {

--- a/packages/node/src/log.ts
+++ b/packages/node/src/log.ts
@@ -194,32 +194,4 @@ export function fatal(...args: CaptureLogArgs): void {
   captureLog('fatal', ...args);
 }
 
-/**
- * @summary Capture a log with the `critical` level. Requires `_experiments.enableLogs` to be enabled.
- *
- * You can either pass a message and attributes or a message template, params and attributes.
- *
- * @example
- *
- * ```
- * Sentry.logger.critical('Service health check failed', {
- *   service: 'payment-gateway',
- *   status: 'DOWN',
- *   lastHealthy: '2024-03-20T09:55:00Z'
- * });
- * ```
- *
- * @example With template strings
- *
- * ```
- * Sentry.logger.critical('Service %s is %s',
- *   ['payment-gateway', 'DOWN'],
- *   { lastHealthy: '2024-03-20T09:55:00Z' }
- * );
- * ```
- */
-export function critical(...args: CaptureLogArgs): void {
-  captureLog('critical', ...args);
-}
-
 export { fmt } from '@sentry/core';

--- a/packages/node/test/log.test.ts
+++ b/packages/node/test/log.test.ts
@@ -32,7 +32,6 @@ describe('Node Logger', () => {
       expect(nodeLogger.warn).toBeTypeOf('function');
       expect(nodeLogger.error).toBeTypeOf('function');
       expect(nodeLogger.fatal).toBeTypeOf('function');
-      expect(nodeLogger.critical).toBeTypeOf('function');
     });
 
     it('should call _INTERNAL_captureLog with trace level', () => {

--- a/packages/node/test/log.test.ts
+++ b/packages/node/test/log.test.ts
@@ -88,15 +88,6 @@ describe('Node Logger', () => {
         attributes: { key: 'value' },
       });
     });
-
-    it('should call _INTERNAL_captureLog with critical level', () => {
-      nodeLogger.critical('Test critical message', { key: 'value' });
-      expect(mockCaptureLog).toHaveBeenCalledWith({
-        level: 'critical',
-        message: 'Test critical message',
-        attributes: { key: 'value' },
-      });
-    });
   });
 
   describe('Template string logging', () => {


### PR DESCRIPTION
This isn't part of the spec, and will break ingestion if we allow things to be sent.