### PR TITLE
chore(deps): Bump `rrweb` to `2.35.0`

### DIFF
--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@sentry-internal/rrweb": "2.34.0"
+    "@sentry-internal/rrweb": "2.35.0"
   },
   "dependencies": {
     "@sentry-internal/replay": "9.9.0",

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -71,8 +71,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "9.9.0",
-    "@sentry-internal/rrweb": "2.34.0",
-    "@sentry-internal/rrweb-snapshot": "2.34.0",
+    "@sentry-internal/rrweb": "2.35.0",
+    "@sentry-internal/rrweb-snapshot": "2.35.0",
     "fflate": "0.8.2",
     "jest-matcher-utils": "^29.0.0",
     "jsdom-worker": "^0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6660,10 +6660,22 @@
   dependencies:
     "@sentry-internal/rrweb-snapshot" "2.34.0"
 
+"@sentry-internal/rrdom@2.35.0":
+  version "2.35.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.35.0.tgz#27dbdfe3249afb65a31f3b680cd0cc92ed2001dd"
+  integrity sha512-sWZjJpv7/Fu1po5ibzGUojWLMGn/GgqsayE8dqbwI6F2x5gMVYL0/yIk+9Qii0ei3Su3BybWHfftZs+5r2Bong==
+  dependencies:
+    "@sentry-internal/rrweb-snapshot" "2.35.0"
+
 "@sentry-internal/rrweb-snapshot@2.34.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.34.0.tgz#79c2049b6c887e3c128d5fa80d6f745a61dd0e68"
   integrity sha512-9Tb8jwVufn5GLV0d/CTuoZWo2O06ZB+xWeTJdEkbtJ6PAmO/Q7GQI3uNIx0pfFEnXP+0Km8CKKxpwkEM0z2m6w==
+
+"@sentry-internal/rrweb-snapshot@2.35.0":
+  version "2.35.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.35.0.tgz#656f4716e3bdda151f122868f6f92d5f4224967c"
+  integrity sha512-CyERHnGWIkuCtw4xYJMoyDUv+5vj38HBd0upeEhKyYzjZ8rOttwsFjfZUBdotsP8O0/RVt9KIPRbSRESC1qSJw==
 
 "@sentry-internal/rrweb-types@2.34.0":
   version "2.34.0"
@@ -6671,6 +6683,14 @@
   integrity sha512-6g5TN8YjqxrZOSQZGMLeZ2XYXdmqaKzPdIzKRySK+rKT/1fJE2gcefJEPDxiix0z/6/v5hGu/Ia8+wbJ7ACHwQ==
   dependencies:
     "@sentry-internal/rrweb-snapshot" "2.34.0"
+    "@types/css-font-loading-module" "0.0.7"
+
+"@sentry-internal/rrweb-types@2.35.0":
+  version "2.35.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.35.0.tgz#b2e63879a23593505fc3e28aa811e718de71f15f"
+  integrity sha512-D0mu2bgtvYD8MGijZDSD+q3FC8fDVRvNJD4canKvI3Wy9/LHTPbJ6F4U544vp5VrdBGCYIf/cxuJwmyZDfl5RQ==
+  dependencies:
+    "@sentry-internal/rrweb-snapshot" "2.35.0"
     "@types/css-font-loading-module" "0.0.7"
 
 "@sentry-internal/rrweb@2.34.0":
@@ -6681,6 +6701,20 @@
     "@sentry-internal/rrdom" "2.34.0"
     "@sentry-internal/rrweb-snapshot" "2.34.0"
     "@sentry-internal/rrweb-types" "2.34.0"
+    "@types/css-font-loading-module" "0.0.7"
+    "@xstate/fsm" "^1.4.0"
+    base64-arraybuffer "^1.0.1"
+    fflate "^0.4.4"
+    mitt "^3.0.0"
+
+"@sentry-internal/rrweb@2.35.0":
+  version "2.35.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.35.0.tgz#ae10b9aaf3ee379164ec52f1186ee053d369b0a3"
+  integrity sha512-Zy3bnzL9GY6SFTZ5x5YNxtkmIUiaLSppLA41xn6zc4UWSYI4DcA+M8OGxI4TiHkQVJhhjwBG1CevrLyrBxyEgA==
+  dependencies:
+    "@sentry-internal/rrdom" "2.35.0"
+    "@sentry-internal/rrweb-snapshot" "2.35.0"
+    "@sentry-internal/rrweb-types" "2.35.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"
@@ -28153,7 +28187,6 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
-  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/15559
(added this so the user gets notified in the ticket once this is released)