### PR TITLE
ref: Bump es-compatibility to ES2022 for node-based packages

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -93,7 +93,7 @@
     "clean": "rimraf build dist-awslambda-layer coverage sentry-serverless-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./build/npm/cjs/*.js && es-check es2020 ./build/npm/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/npm/cjs/*.js && es-check es2022 ./build/npm/esm/*.js --module",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -62,7 +62,7 @@
     "clean": "rimraf build coverage sentry-bun-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./build/cjs/*.js && es-check es2020 ./build/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/cjs/*.js && es-check es2022 ./build/esm/*.js --module",
     "install:bun": "node ./scripts/install-bun.js",
     "test": "run-s install:bun test:bun",
     "test:bun": "bun test",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -80,7 +80,7 @@
     "clean": "rimraf build coverage sentry-cloudflare-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./build/cjs/*.js && es-check es2020 ./build/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/cjs/*.js && es-check es2022 ./build/esm/*.js --module",
     "test": "yarn test:unit",
     "test:unit": "vitest run",
     "test:watch": "vitest --watch",

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -39,7 +39,7 @@
     "fix": "eslint . --format stylish --fix",
     "prelint": "yarn deno-types",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./build/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/esm/*.js --module",
     "install:deno": "node ./scripts/install-deno.mjs",
     "test": "run-s install:deno deno-types test:unit",
     "test:unit": "deno test --allow-read --allow-run --no-check",

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -74,7 +74,7 @@
     "clean": "rimraf build coverage sentry-google-cloud-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./build/cjs/*.js && es-check es2020 ./build/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/cjs/*.js && es-check es2022 ./build/esm/*.js --module",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -77,7 +77,7 @@
     "clean": "rimraf build coverage sentry-nestjs-*.tgz ./*.d.ts ./*.d.ts.map",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./build/cjs/*.js && es-check es2020 ./build/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/cjs/*.js && es-check es2022 ./build/esm/*.js --module",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "yalc:publish": "yalc publish --push --sig"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -119,7 +119,7 @@
     "clean": "rimraf build coverage sentry-node-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./build/cjs/*.js && es-check es2020 ./build/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/cjs/*.js && es-check es2022 ./build/esm/*.js --module",
     "test": "yarn test:unit",
     "test:unit": "vitest run",
     "test:watch": "vitest --watch",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -73,7 +73,7 @@
     "clean": "rimraf build coverage sentry-opentelemetry-*.tgz",
     "fix": "eslint . --format stylish --fix",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./build/cjs/*.js && es-check es2020 ./build/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/cjs/*.js && es-check es2022 ./build/esm/*.js --module",
     "test": "yarn test:unit",
     "test:unit": "vitest run",
     "test:watch": "vitest --watch",

--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "clean": "rm -rf build && rm -rf lib",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2020 ./lib/cjs/*.js && es-check es2020 ./lib/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./lib/cjs/*.js && es-check es2022 ./lib/esm/*.js --module",
     "fix": "eslint . --format stylish --fix",
     "build": "yarn build:lib",
     "build:lib": "yarn build:types && rollup -c rollup.npm.config.mjs",


### PR DESCRIPTION
In preparation for OpenTelemetry v2, which targets ES2022, we bump the checks to ES2022 for node-based packages.