### PR TITLE
fix(cjs): Use `module` instead of `require` for CJS check

### DIFF
--- a/packages/node/src/utils/commonjs.ts
+++ b/packages/node/src/utils/commonjs.ts
@@ -1,4 +1,8 @@
 /** Detect CommonJS. */
 export function isCjs(): boolean {
-  return typeof module !== 'undefined' && typeof module.exports !== 'undefined';
+  try {
+    return typeof module !== 'undefined' && module && typeof module.exports !== 'undefined';
+  } catch {
+    return false;
+  }
 }

--- a/packages/node/src/utils/commonjs.ts
+++ b/packages/node/src/utils/commonjs.ts
@@ -1,7 +1,7 @@
 /** Detect CommonJS. */
 export function isCjs(): boolean {
   try {
-    return typeof module !== 'undefined' && module && typeof module.exports !== 'undefined';
+    return typeof module !== 'undefined' && typeof module.exports !== 'undefined';
   } catch {
     return false;
   }

--- a/packages/node/src/utils/commonjs.ts
+++ b/packages/node/src/utils/commonjs.ts
@@ -1,4 +1,4 @@
 /** Detect CommonJS. */
 export function isCjs(): boolean {
-  return typeof require !== 'undefined';
+  return typeof module !== 'undefined' && typeof module.exports !== 'undefined';
 }


### PR DESCRIPTION
As `require` is supported in ESM as well from [Node 20.19.0](https://nodejs.org/en/blog/release/v20.19.0) onwards, the check does not work anymore. However, `module` is not available in ESM.

Also mentioned in this comment: https://github.com/getsentry/sentry-javascript/issues/14202#issuecomment-2761399514


[Node: Compatibility with CommonJS](https://nodejs.org/docs/latest-v15.x/api/esm.html#esm_interoperability_with_commonjs)

[Bun: Using require](https://bun.sh/docs/runtime/modules#using-require)
