### PR TITLE
feat(browser): Add `http.redirect_count` attribute to `browser.redirect` span

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -79,7 +79,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'replayCanvasIntegration'),
     gzip: true,
-    limit: '80.5 KB',
+    limit: '81 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay, Feedback)',

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -460,8 +460,11 @@ export function _addMeasureSpans(
   }
 }
 
-/** Instrument navigation entries */
-function _addNavigationSpans(span: Span, entry: PerformanceNavigationTiming, timeOrigin: number): void {
+/**
+ * Instrument navigation entries
+ * exported only for tests
+ */
+export function _addNavigationSpans(span: Span, entry: PerformanceNavigationTiming, timeOrigin: number): void {
   (['unloadEvent', 'redirect', 'domContentLoadedEvent', 'loadEvent', 'connect'] as const).forEach(event => {
     _addPerformanceNavigationTiming(span, entry, event, timeOrigin);
   });
@@ -511,6 +514,7 @@ function _addPerformanceNavigationTiming(
     name: entry.name,
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
+      ...(event === 'redirect' && entry.redirectCount != null ? { 'http.redirect_count': entry.redirectCount } : {}),
     },
   });
 }


### PR DESCRIPTION
This PR adds an `http.redirect_count` attribute to `browser.redirect` spans. The count is taken from the `navigation` performance entry and it describes the number of times a redirect happened. 

Two caveats:
- we can't detect more about redirects (e.g. the location the browser was redirected to)
- this only works for same-origin redirects. [According to MDN](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/redirectCount#value), cross-origin redirects are not taken into account. 

