### PR TITLE
chore(tests): Fix coverage file exclusions

### DIFF
--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -8,6 +8,16 @@ export default defineConfig({
     coverage: {
       enabled: true,
       reportsDirectory: './coverage',
+      exclude: [
+        '**/node_modules/**',
+        '**/test/**',
+        '**/tests/**',
+        '**/__tests__/**',
+        '**/rollup*.config.*',
+        '**/build/**',
+        '.eslint*',
+        'vite.config.*',
+      ],
     },
     reporters: ['default', ...(process.env.CI ? [['junit', { classnameTemplate: '{filepath}' }]] : [])],
     outputFile: {


### PR DESCRIPTION
When running some unit tests locally, I noticed that the coverage summary contained files like `vite.config.ts` or `.eslintrc` as well as transpiled code in `build`. These files shouldn't be in the coverage reports and neither have an influence on the overall coverage score.