### PR TITLE
build(profiling-node): Fix output directory & caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -35,8 +35,6 @@
       "outputs": [
         "{projectRoot}/build/esm",
         "{projectRoot}/build/cjs",
-        "{projectRoot}/build/lib/esm",
-        "{projectRoot}/build/lib/cjs",
         "{projectRoot}/build/npm/esm",
         "{projectRoot}/build/npm/cjs"
       ]

--- a/packages/profiling-node/.eslintignore
+++ b/packages/profiling-node/.eslintignore
@@ -1,4 +1,4 @@
 node_modules/
 build/
-lib/
+build/
 coverage/

--- a/packages/profiling-node/.eslintrc.js
+++ b/packages/profiling-node/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   extends: ['../../.eslintrc.js'],
 
-  ignorePatterns: ['lib/**/*', 'examples/**/*', 'vitest.config.ts'],
+  ignorePatterns: ['build/**/*', 'examples/**/*', 'vitest.config.ts'],
   rules: {
     '@sentry-internal/sdk/no-class-field-initializers': 'off',
   },

--- a/packages/profiling-node/.gitignore
+++ b/packages/profiling-node/.gitignore
@@ -2,5 +2,5 @@
 
 # compiled output
 /node_modules/
-/lib/
+/build/
 

--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -6,26 +6,26 @@
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/profiling-node",
   "author": "Sentry",
   "license": "MIT",
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/types/index.d.ts",
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
+  "types": "build/types/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "import": {
-        "types": "./lib/types/index.d.ts",
-        "default": "./lib/esm/index.js"
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
       },
       "require": {
-        "types": "./lib/types/index.d.ts",
-        "default": "./lib/cjs/index.js"
+        "types": "./build/types/index.d.ts",
+        "default": "./build/cjs/index.js"
       }
     }
   },
   "typesVersions": {
     "<5.0": {
-      "lib/types/index.d.ts": [
-        "lib/types-ts3.8/index.d.ts"
+      "build/types/index.d.ts": [
+        "build/types-ts3.8/index.d.ts"
       ]
     }
   },
@@ -39,19 +39,18 @@
     "access": "public"
   },
   "files": [
-    "/lib",
+    "/build",
     "package.json",
     "/scripts/prune-profiler-binaries.js"
   ],
   "scripts": {
-    "clean": "rm -rf build && rm -rf lib",
+    "clean": "rm -rf build",
     "lint": "eslint . --format stylish",
-    "lint:es-compatibility": "es-check es2022 ./lib/cjs/*.js && es-check es2022 ./lib/esm/*.js --module",
+    "lint:es-compatibility": "es-check es2022 ./build/cjs/*.js && es-check es2022 ./build/esm/*.js --module",
     "fix": "eslint . --format stylish --fix",
-    "build": "yarn build:lib",
-    "build:lib": "yarn build:types && rollup -c rollup.npm.config.mjs",
-    "build:transpile": "yarn build:lib",
-    "build:types:downlevel": "yarn downlevel-dts lib/types lib/types-ts3.8 --to ts3.8",
+    "build": "yarn build:types && yarn build:transpile",
+    "build:transpile": "yarn rollup -c rollup.npm.config.mjs",
+    "build:types:downlevel": "yarn downlevel-dts build/types build/types-ts3.8 --to ts3.8",
     "build:types": "tsc -p tsconfig.types.json && yarn build:types:downlevel",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:dev": "yarn clean && yarn build",

--- a/packages/profiling-node/rollup.npm.config.mjs
+++ b/packages/profiling-node/rollup.npm.config.mjs
@@ -4,7 +4,7 @@ export default makeNPMConfigVariants(
   makeBaseNPMConfig({
     packageSpecificConfig: {
       output: {
-        dir: 'lib',
+        dir: 'build',
         // set exports to 'named' or 'auto' so that rollup doesn't warn
         exports: 'named',
         // set preserveModules to false because for profiling we actually want

--- a/packages/profiling-node/tsconfig.json
+++ b/packages/profiling-node/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "esnext",
     "lib": ["es2018"],
-    "outDir": "lib",
+    "outDir": "build",
     "types": ["node"]
   },
   "include": ["src/**/*"]

--- a/packages/profiling-node/tsconfig.types.json
+++ b/packages/profiling-node/tsconfig.types.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "outDir": "lib/types",
+    "outDir": "build/types",
     "types": ["node"]
   },
   "files": ["src/index.ts"]


### PR DESCRIPTION
This used to build into `/lib` which is not covered by nx (it was changed there but slightly incorrectly, covering `/build/lib` instead of `/lib`). But overall, the way to go here is to just use our standard structure, which is `build/`, then this should all just work :D