### PR TITLE
ref(opentelemetry): Remove usage of `parseUrl`

### DIFF
--- a/packages/opentelemetry/src/utils/getRequestSpanData.ts
+++ b/packages/opentelemetry/src/utils/getRequestSpanData.ts
@@ -6,7 +6,7 @@ import {
   SEMATTRS_HTTP_METHOD,
   SEMATTRS_HTTP_URL,
 } from '@opentelemetry/semantic-conventions';
-import { getSanitizedUrlString, parseUrl } from '@sentry/core';
+import { parseStringToURLObject, getSanitizedUrlStringFromUrlObject } from '@sentry/core';
 import type { SanitizedRequestData } from '@sentry/core';
 
 import { spanHasAttributes } from './spanTypes';
@@ -40,15 +40,15 @@ export function getRequestSpanData(span: Span | ReadableSpan): Partial<Sanitized
 
   try {
     if (typeof maybeUrlAttribute === 'string') {
-      const url = parseUrl(maybeUrlAttribute);
-
-      data.url = getSanitizedUrlString(url);
-
-      if (url.search) {
-        data['http.query'] = url.search;
-      }
-      if (url.hash) {
-        data['http.fragment'] = url.hash;
+      const parsedUrl = parseStringToURLObject(maybeUrlAttribute);
+      if (parsedUrl) {
+        data.url = getSanitizedUrlStringFromUrlObject(parsedUrl);
+        if (parsedUrl.search) {
+          data['http.query'] = parsedUrl.search;
+        }
+        if (parsedUrl.hash) {
+          data['http.fragment'] = parsedUrl.hash;
+        }
       }
     }
   } catch {

--- a/packages/opentelemetry/test/utils/getRequestSpanData.test.ts
+++ b/packages/opentelemetry/test/utils/getRequestSpanData.test.ts
@@ -42,7 +42,7 @@ describe('getRequestSpanData', () => {
     const data = getRequestSpanData(span);
 
     expect(data).toEqual({
-      url: 'http://example.com',
+      url: 'http://example.com/',
       'http.method': 'GET',
       'http.query': '?foo=bar',
       'http.fragment': '#baz',
@@ -58,7 +58,7 @@ describe('getRequestSpanData', () => {
     const data = getRequestSpanData(span);
 
     expect(data).toEqual({
-      url: 'http://example.com',
+      url: 'http://example.com/',
       'http.method': 'GET',
     });
   });


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/15939

`parseUrl` is expensive, so let's refactor to remove it. This makes the change for the opentelemetry package.

Removal of `getSanitizedUrlString` and `stripUrlQueryAndFragment` should also help with performance as we no longer have the js regex to compute.