### PR TITLE
ref(browser): Temporarily add `sentry.previous_trace` span attribute

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -210,7 +210,7 @@ module.exports = [
     import: createImport('init'),
     ignore: ['next/router', 'next/constants'],
     gzip: true,
-    limit: '41 KB',
+    limit: '42 KB',
   },
   // SvelteKit SDK (ESM)
   {

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/previous-trace-links/default/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/previous-trace-links/default/test.ts
@@ -49,6 +49,10 @@ sentryTest("navigation spans link back to previous trace's root span", async ({ 
     },
   ]);
 
+  expect(navigation1TraceContext?.data).toMatchObject({
+    'sentry.previous_trace': `${pageloadTraceId}-${pageloadTraceContext?.span_id}-1`,
+  });
+
   expect(navigation2TraceContext?.links).toEqual([
     {
       trace_id: navigation1TraceId,
@@ -59,6 +63,10 @@ sentryTest("navigation spans link back to previous trace's root span", async ({ 
       },
     },
   ]);
+
+  expect(navigation2TraceContext?.data).toMatchObject({
+    'sentry.previous_trace': `${navigation1TraceId}-${navigation1TraceContext?.span_id}-1`,
+  });
 
   expect(pageloadTraceId).not.toEqual(navigation1TraceId);
   expect(navigation1TraceId).not.toEqual(navigation2TraceId);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/previous-trace-links/negatively-sampled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/previous-trace-links/negatively-sampled/test.ts
@@ -34,6 +34,10 @@ sentryTest('includes a span link to a previously negatively sampled span', async
       },
     ]);
 
+    expect(navigationTraceContext?.data).toMatchObject({
+      'sentry.previous_trace': expect.stringMatching(/[a-f0-9]{32}-[a-f0-9]{16}-0/),
+    });
+
     expect(navigationTraceContext?.trace_id).not.toEqual(navigationTraceContext?.links![0].trace_id);
   });
 });

--- a/dev-packages/e2e-tests/test-applications/vue-3/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/src/main.ts
@@ -24,11 +24,6 @@ Sentry.init({
     }),
     browserTracingIntegration({
       router,
-      instrumentPageLoad: false,
-      instrumentNavigation: false,
-      enableInp: false,
-      enableLongTask: false,
-      enableLongAnimationFrame: false,
     }),
   ],
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/vue-3/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/src/main.ts
@@ -24,6 +24,11 @@ Sentry.init({
     }),
     browserTracingIntegration({
       router,
+      instrumentPageLoad: false,
+      instrumentNavigation: false,
+      enableInp: false,
+      enableLongTask: false,
+      enableLongAnimationFrame: false,
     }),
   ],
   tunnel: `http://localhost:3031/`, // proxy server

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -40,6 +40,7 @@ import {
   startBrowserTracingPageLoadSpan,
 } from '../../src/tracing/browserTracingIntegration';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
+import { PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE } from '../../src/tracing/previousTrace';
 
 // We're setting up JSDom here because the Next.js routing instrumentations requires a few things to be present on pageload:
 // 1. Access to window.document API for `window.document.getElementById`
@@ -202,6 +203,7 @@ describe('browserTracingIntegration', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: `${span?.spanContext().traceId}-${span?.spanContext().spanId}-1`,
       },
       links: [
         {
@@ -239,6 +241,7 @@ describe('browserTracingIntegration', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: `${span2?.spanContext().traceId}-${span2?.spanContext().spanId}-1`,
       },
       links: [
         {
@@ -502,6 +505,7 @@ describe('browserTracingIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
+          [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: expect.stringMatching(/[a-f0-9]{32}-[a-f0-9]{16}-1/),
         },
         links: [
           {

--- a/packages/browser/test/tracing/previousTrace.test.ts
+++ b/packages/browser/test/tracing/previousTrace.test.ts
@@ -5,6 +5,7 @@ import {
   getPreviousTraceFromSessionStorage,
   PREVIOUS_TRACE_KEY,
   PREVIOUS_TRACE_MAX_DURATION,
+  PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE,
 } from '../../src/tracing/previousTrace';
 import { SentrySpan, spanToJSON, timestampInSeconds } from '@sentry/core';
 import { storePreviousTraceInSessionStorage } from '../../src/tracing/previousTrace';
@@ -34,7 +35,9 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(previousTraceInfo, currentSpan);
 
-    expect(spanToJSON(currentSpan).links).toEqual([
+    const spanJson = spanToJSON(currentSpan);
+
+    expect(spanJson.links).toEqual([
       {
         attributes: {
           'sentry.link.type': 'previous_trace',
@@ -44,6 +47,10 @@ describe('addPreviousTraceSpanLink', () => {
         sampled: true,
       },
     ]);
+
+    expect(spanJson.data).toMatchObject({
+      [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: '123-456-1',
+    });
 
     expect(updatedPreviousTraceInfo).toEqual({
       spanContext: currentSpan.spanContext(),
@@ -70,7 +77,11 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(previousTraceInfo, currentSpan);
 
-    expect(spanToJSON(currentSpan).links).toBeUndefined();
+    const spanJson = spanToJSON(currentSpan);
+
+    expect(spanJson.links).toBeUndefined();
+
+    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     // but still updates the previousTraceInfo to the current span
     expect(updatedPreviousTraceInfo).toEqual({
@@ -141,7 +152,9 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(undefined, currentSpan);
 
-    expect(spanToJSON(currentSpan).links).toBeUndefined();
+    const spanJson = spanToJSON(currentSpan);
+    expect(spanJson.links).toBeUndefined();
+    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     expect(updatedPreviousTraceInfo).toEqual({
       spanContext: currentSpan.spanContext(),
@@ -169,7 +182,9 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(previousTraceInfo, currentSpan);
 
-    expect(spanToJSON(currentSpan).links).toBeUndefined();
+    const spanJson = spanToJSON(currentSpan);
+    expect(spanJson.links).toBeUndefined();
+    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     expect(updatedPreviousTraceInfo).toBe(previousTraceInfo);
   });


### PR DESCRIPTION
EAP currently doesn't support storing span links. This is on the EAP team's radar but will only be tackled in the future. For now, to unblock our trace linking project, this PR converts the previous trace span link into a span attribute and adds it to the root span (just like the link). We can use this in the product to check for a span link and also query the next trace by this attribute.  

Initially, the idea was to convert the link in Relay to a span attribute but this sparked a bunch of convos around how to handle "internal" attributes and if we should keep such temporary things in Relay. Nothing changes about this with the code living in the SDK but it's more a one-off and easier for us to control so after disussing this with @mydea we settled on doing it in the SDK but also comitting to remove it once we can. 