### PR TITLE
feat(node): Add `ignoreIncomingRequestBody` to avoid capturing request bodies

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/tracing/server.js
+++ b/dev-packages/node-integration-tests/suites/express/tracing/server.js
@@ -8,6 +8,16 @@ Sentry.init({
   tracePropagationTargets: [/^(?!.*test).*$/],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
+  integrations: [
+    Sentry.httpIntegration({
+      ignoreIncomingRequestBody: (url) => {
+        if (url.includes('/test-post-ignore-body')) {
+          return true;
+        }
+        return false;
+      },
+    }),
+  ],
 });
 
 // express must be required after Sentry is initialized
@@ -40,6 +50,10 @@ app.get(['/test/arr/:id', /\/test\/arr[0-9]*\/required(path)?(\/optionalPath)?\/
 });
 
 app.post('/test-post', function (req, res) {
+  res.send({ status: 'ok', body: req.body });
+});
+
+app.post('/test-post-ignore-body', function (req, res) {
   res.send({ status: 'ok', body: req.body });
 });
 

--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -248,23 +248,23 @@ describe('express tracing', () => {
 
       test('correctly ignores request data', async () => {
         const runner = createRunner(__dirname, 'server.js')
-        .expect({
-          transaction: (e) => {
-            assertSentryTransaction(e, {
-              transaction: 'POST /test-post-ignore-body',
-              request: {
-                url: expect.stringMatching(/^http:\/\/localhost:(\d+)\/test-post-ignore-body$/),
-                method: 'POST',
-                headers: {
-                  'user-agent': expect.stringContaining(''),
-                  'content-type': 'application/octet-stream',
+          .expect({
+            transaction: e => {
+              assertSentryTransaction(e, {
+                transaction: 'POST /test-post-ignore-body',
+                request: {
+                  url: expect.stringMatching(/^http:\/\/localhost:(\d+)\/test-post-ignore-body$/),
+                  method: 'POST',
+                  headers: {
+                    'user-agent': expect.stringContaining(''),
+                    'content-type': 'application/octet-stream',
+                  },
                 },
-              },
-            });
-            // Ensure the request body has been ignored
-            expect(e).have.property('request').that.does.not.have.property('data');
-          },
-        })
+              });
+              // Ensure the request body has been ignored
+              expect(e).have.property('request').that.does.not.have.property('data');
+            },
+          })
           .start();
 
         runner.makeRequest('post', '/test-post-ignore-body', {

--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+import { assertSentryTransaction } from '../../../utils/assertions';
 
 describe('express tracing', () => {
   afterAll(() => {
@@ -241,6 +242,34 @@ describe('express tracing', () => {
         runner.makeRequest('post', '/test-post', {
           headers: { 'Content-Type': 'application/octet-stream' },
           data: body,
+        });
+        await runner.completed();
+      });
+
+      test('correctly ignores request data', async () => {
+        const runner = createRunner(__dirname, 'server.js')
+        .expect({
+          transaction: (e) => {
+            assertSentryTransaction(e, {
+              transaction: 'POST /test-post-ignore-body',
+              request: {
+                url: expect.stringMatching(/^http:\/\/localhost:(\d+)\/test-post-ignore-body$/),
+                method: 'POST',
+                headers: {
+                  'user-agent': expect.stringContaining(''),
+                  'content-type': 'application/octet-stream',
+                },
+              },
+            });
+            // Ensure the request body has been ignored
+            expect(e).have.property('request').that.does.not.have.property('data');
+          },
+        })
+          .start();
+
+        runner.makeRequest('post', '/test-post-ignore-body', {
+          headers: { 'Content-Type': 'application/octet-stream' },
+          data: Buffer.from('some plain text in buffer'),
         });
         await runner.completed();
       });

--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -74,6 +74,15 @@ interface HttpOptions {
   ignoreIncomingRequests?: (urlPath: string, request: IncomingMessage) => boolean;
 
   /**
+   * Do not capture the request body for incoming HTTP requests to URLs where the given callback returns `true`.
+   * This can be useful for long running requests where the body is not needed and we want to avoid capturing it.
+   *
+   * @param url Contains the entire URL, including query string (if any), protocol, host, etc. of the outgoing request.
+   * @param request Contains the {@type RequestOptions} object used to make the outgoing request.
+   */
+  ignoreIncomingRequestBody?: (url: string, request: RequestOptions) => boolean;
+
+  /**
    * If true, do not generate spans for incoming requests at all.
    * This is used by Remix to avoid generating spans for incoming requests, as it generates its own spans.
    */


### PR DESCRIPTION
This allows ignoring the request body for certain requests, which is very useful in situations of long-running requests with large/streaming request bodies which can result in a lot of memory usage

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
