### PR TITLE
feat(nuxt): Add nuxt release registry craft entry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -195,6 +195,8 @@ targets:
         onlyIfPresent: /^sentry-google-cloud-serverless-\d.*\.tgz$/
       'npm:@sentry/nextjs':
         onlyIfPresent: /^sentry-nextjs-\d.*\.tgz$/
+      'npm:@sentry/nuxt':
+        onlyIfPresent: /^sentry-nuxt-\d.*\.tgz$/
       'npm:@sentry/node':
         onlyIfPresent: /^sentry-node-\d.*\.tgz$/
       'npm:@sentry/react':


### PR DESCRIPTION
Turns out we never added the release registry entry for nuxt. The corresponding [folder exists in the release registry repo](https://github.com/getsentry/sentry-release-registry/tree/master/packages/npm/%40sentry/nuxt).