### PR TITLE
test(remix): Bump Remix version of integration tests to `2.16.3`

### DIFF
--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -8,16 +8,16 @@
     "start": "NODE_OPTIONS='--import=./instrument.server.mjs' remix-serve build/index.js"
   },
   "dependencies": {
-    "@remix-run/express": "2.15.2",
-    "@remix-run/node": "2.15.2",
-    "@remix-run/react": "2.15.2",
-    "@remix-run/serve": "2.15.2",
+    "@remix-run/express": "2.16.3",
+    "@remix-run/node": "2.16.3",
+    "@remix-run/react": "2.16.3",
+    "@remix-run/serve": "2.16.3",
     "@sentry/remix": "file:../..",
     "react": "^18",
     "react-dom": "^18"
   },
   "devDependencies": {
-    "@remix-run/dev": "2.15.2",
+    "@remix-run/dev": "2.16.3",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "nock": "^13.5.5",


### PR DESCRIPTION
Completes #15950 with the rest of the `@remix-run/*` dependencies.
