### PR TITLE
feat(nextjs): Warn when client was initialized more than once

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -1,4 +1,5 @@
 import type { Client, EventProcessor, Integration } from '@sentry/core';
+import { consoleSandbox } from '@sentry/core';
 import { getGlobalScope } from '@sentry/core';
 import { GLOBAL_OBJ, addEventProcessor, applySdkMetadata } from '@sentry/core';
 import type { BrowserOptions } from '@sentry/react';
@@ -16,6 +17,8 @@ export * from '../common';
 export { captureUnderscoreErrorException } from '../common/pages-router-instrumentation/_error';
 export { browserTracingIntegration } from './browserTracingIntegration';
 
+let clientIsInitialized = false;
+
 const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   _sentryRewriteFramesAssetPrefixPath: string;
   _sentryAssetPrefix?: string;
@@ -29,6 +32,16 @@ declare const __SENTRY_TRACING__: boolean;
 
 /** Inits the Sentry NextJS SDK on the browser with the React SDK. */
 export function init(options: BrowserOptions): Client | undefined {
+  if (clientIsInitialized) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[@sentry/nextjs] You are calling `Sentry.init()` more than once on the client. This can happen if you have both a `sentry.client.config.ts` and a `instrumentation-client.ts` file with `Sentry.init()` calls. It is recommended to call `Sentry.init()` once in `instrumentation-client.ts`.',
+      );
+    });
+  }
+  clientIsInitialized = true;
+
   const opts = {
     environment: getVercelEnv(true) || process.env.NODE_ENV,
     defaultIntegrations: getDefaultIntegrations(options),


### PR DESCRIPTION
With the addition on `instrumentation-client.ts` the likelihood of `Sentry.init()` rose starkly so I figured it might be worth printing a warning.

Resolves https://github.com/getsentry/sentry-wizard/issues/930