### PR TITLE
feat(bun): Update Bun integration to support routes & optional fetch

### DIFF
--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -1,4 +1,5 @@
 import type { IntegrationFn, RequestEventData, SpanAttributes } from '@sentry/core';
+import type { BunRequest, ServeOptions } from 'bun';
 import {
   SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -40,11 +41,17 @@ const _bunServerIntegration = (() => {
  */
 export const bunServerIntegration = defineIntegration(_bunServerIntegration);
 
+let originalServe: typeof Bun.serve;
+
 /**
  * Instruments Bun.serve by patching it's options.
  */
 export function instrumentBunServe(): void {
-  Bun.serve = new Proxy(Bun.serve, {
+  if (!originalServe) {
+    originalServe = Bun.serve;
+  }
+
+  Bun.serve = new Proxy(originalServe, {
     apply(serveTarget, serveThisArg, serveArgs: Parameters<typeof Bun.serve>) {
       instrumentBunServeOptions(serveArgs[0]);
       const server: ReturnType<typeof Bun.serve> = serveTarget.apply(serveThisArg, serveArgs);
@@ -53,7 +60,7 @@ export function instrumentBunServe(): void {
       // We can't use a Proxy for this as Bun does `instanceof` checks internally that fail if we
       // wrap the Server instance.
       const originalReload: typeof server.reload = server.reload.bind(server);
-      server.reload = (serveOptions: Parameters<typeof Bun.serve>[0]) => {
+      server.reload = (serveOptions: ServeOptions) => {
         instrumentBunServeOptions(serveOptions);
         return originalReload(serveOptions);
       };
@@ -67,75 +74,285 @@ export function instrumentBunServe(): void {
  * Instruments Bun.serve `fetch` option to automatically create spans and capture errors.
  */
 function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]): void {
-  serveOptions.fetch = new Proxy(serveOptions.fetch, {
-    apply(fetchTarget, fetchThisArg, fetchArgs: Parameters<typeof serveOptions.fetch>) {
-      return withIsolationScope(isolationScope => {
-        const request = fetchArgs[0];
-        const upperCaseMethod = request.method.toUpperCase();
-        if (upperCaseMethod === 'OPTIONS' || upperCaseMethod === 'HEAD') {
-          return fetchTarget.apply(fetchThisArg, fetchArgs);
-        }
+  const originalFetch: typeof serveOptions.fetch = serveOptions?.fetch;
+  // Instrument the fetch handler
+  if (typeof originalFetch === 'function') {
+    serveOptions.fetch = new Proxy(originalFetch, {
+      apply(fetchTarget, fetchThisArg, fetchArgs: Parameters<typeof originalFetch>) {
+        return withIsolationScope(isolationScope => {
+          const request = fetchArgs[0];
+          const upperCaseMethod = request.method.toUpperCase();
+          if (upperCaseMethod === 'OPTIONS' || upperCaseMethod === 'HEAD') {
+            return fetchTarget.apply(fetchThisArg, fetchArgs);
+          }
 
-        const parsedUrl = parseUrl(request.url);
-        const attributes: SpanAttributes = {
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.bun.serve',
-          [SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD]: request.method || 'GET',
-          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
-        };
-        if (parsedUrl.search) {
-          attributes['http.query'] = parsedUrl.search;
-        }
+          const parsedUrl = parseUrl(request.url);
+          const attributes: SpanAttributes = {
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.bun.serve',
+            [SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD]: request.method || 'GET',
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+          };
+          if (parsedUrl.search) {
+            attributes['http.query'] = parsedUrl.search;
+          }
 
-        const url = getSanitizedUrlString(parsedUrl);
+          const url = getSanitizedUrlString(parsedUrl);
 
-        isolationScope.setSDKProcessingMetadata({
-          normalizedRequest: {
-            url,
-            method: request.method,
-            headers: request.headers.toJSON(),
-            query_string: extractQueryParamsFromUrl(url),
-          } satisfies RequestEventData,
-        });
+          isolationScope.setSDKProcessingMetadata({
+            normalizedRequest: {
+              url,
+              method: request.method,
+              headers: request.headers.toJSON(),
+              query_string: extractQueryParamsFromUrl(url),
+            } satisfies RequestEventData,
+          });
 
-        return continueTrace(
-          { sentryTrace: request.headers.get('sentry-trace') || '', baggage: request.headers.get('baggage') },
-          () => {
-            return startSpan(
-              {
-                attributes,
-                op: 'http.server',
-                name: `${request.method} ${parsedUrl.path || '/'}`,
-              },
-              async span => {
-                try {
-                  const response = await (fetchTarget.apply(fetchThisArg, fetchArgs) as ReturnType<
-                    typeof serveOptions.fetch
-                  >);
-                  if (response?.status) {
-                    setHttpStatus(span, response.status);
-                    isolationScope.setContext('response', {
-                      headers: response.headers.toJSON(),
-                      status_code: response.status,
-                    });
-                  }
-                  return response;
-                } catch (e) {
-                  captureException(e, {
-                    mechanism: {
-                      type: 'bun',
-                      handled: false,
-                      data: {
-                        function: 'serve',
+          return continueTrace(
+            { sentryTrace: request.headers.get('sentry-trace') || '', baggage: request.headers.get('baggage') },
+            () => {
+              return startSpan(
+                {
+                  attributes,
+                  op: 'http.server',
+                  name: `${request.method} ${parsedUrl.path || '/'}`,
+                },
+                async span => {
+                  try {
+                    const response = await (fetchTarget.apply(fetchThisArg, fetchArgs) as ReturnType<
+                      typeof originalFetch
+                    >);
+                    if (response?.status) {
+                      setHttpStatus(span, response.status);
+                      isolationScope.setContext('response', {
+                        headers: response.headers.toJSON(),
+                        status_code: response.status,
+                      });
+                    }
+                    return response;
+                  } catch (e) {
+                    captureException(e, {
+                      mechanism: {
+                        type: 'bun',
+                        handled: false,
+                        data: {
+                          function: 'serve',
+                        },
                       },
-                    },
-                  });
-                  throw e;
-                }
+                    });
+                    throw e;
+                  }
+                },
+              );
+            },
+          );
+        });
+      },
+    });
+  }
+
+  // Instrument routes if present
+  if (
+    (typeof serveOptions?.routes === 'object' || typeof serveOptions?.routes === 'function') &&
+    // Hono routes. This was an issue in Bun.
+    !Array.isArray(serveOptions?.routes)
+  ) {
+    serveOptions.routes = instrumentBunServeRoutes(serveOptions.routes) as typeof serveOptions.routes;
+  }
+}
+
+/**
+ * Instruments the routes option in Bun.serve()
+ */
+function instrumentBunServeRoutes(
+  routes: NonNullable<Parameters<typeof Bun.serve>[0]['routes']>,
+): Parameters<typeof Bun.serve>[0]['routes'] {
+  let anyMatches = false;
+  const instrumentedRoutes: Parameters<typeof Bun.serve>[0]['routes'] = {};
+
+  for (const [routePath, handler] of Object.entries(routes)) {
+    if (handler === null || handler === undefined || !routePath.startsWith('/')) {
+      instrumentedRoutes[routePath] = handler;
+      continue;
+    }
+
+    // Case 2: Route handler function
+    if (typeof handler === 'function') {
+      anyMatches = true;
+      instrumentedRoutes[routePath] = new Proxy(handler, {
+        apply(handlerTarget, handlerThisArg, handlerArgs) {
+          return withIsolationScope(isolationScope => {
+            const request = handlerArgs[0] as BunRequest;
+            const upperCaseMethod = request.method.toUpperCase();
+            if (upperCaseMethod === 'OPTIONS' || upperCaseMethod === 'HEAD') {
+              return handlerTarget.apply(handlerThisArg, handlerArgs);
+            }
+
+            const parsedUrl = parseUrl(request.url);
+            const attributes: SpanAttributes = {
+              [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.bun.serve.route',
+              [SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD]: request.method || 'GET',
+              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+            };
+            if (parsedUrl.search) {
+              attributes['http.query'] = parsedUrl.search;
+            }
+
+            const url = getSanitizedUrlString(parsedUrl);
+
+            isolationScope.setSDKProcessingMetadata({
+              normalizedRequest: {
+                url,
+                method: request.method,
+                headers: request.headers.toJSON(),
+                query_string: extractQueryParamsFromUrl(url),
+                // For routes with parameters, add them to request data
+                ...(request.params ? { params: request.params } : {}),
+              } satisfies RequestEventData,
+            });
+
+            return continueTrace(
+              { sentryTrace: request.headers.get('sentry-trace') || '', baggage: request.headers.get('baggage') },
+              () => {
+                // Use routePath for the name to capture route parameters
+                return startSpan(
+                  {
+                    attributes,
+                    op: 'http.server',
+                    name: `${request.method} ${routePath}`,
+                  },
+                  async span => {
+                    try {
+                      const response = await (handlerTarget.apply(handlerThisArg, handlerArgs) as
+                        | Promise<Response>
+                        | Response);
+                      if (response?.status) {
+                        setHttpStatus(span, response.status);
+                        isolationScope.setContext('response', {
+                          headers: response.headers.toJSON(),
+                          status_code: response.status,
+                        });
+                      }
+                      return response;
+                    } catch (e) {
+                      captureException(e, {
+                        mechanism: {
+                          type: 'bun',
+                          handled: false,
+                          data: {
+                            function: 'serve.route',
+                          },
+                        },
+                      });
+                      throw e;
+                    }
+                  },
+                );
               },
             );
-          },
-        );
+          });
+        },
       });
-    },
-  });
+      continue;
+    }
+
+    // Case 3: HTTP method handlers object { GET: fn, POST: fn, ... }
+    if (typeof handler === 'object') {
+      const methodHandlers = handler as Record<string, unknown>;
+      const instrumentedMethodHandlers: Record<string, unknown> = {};
+
+      for (const [method, methodHandler] of Object.entries(methodHandlers)) {
+        if (typeof methodHandler === 'function') {
+          anyMatches = true;
+          instrumentedMethodHandlers[method] = new Proxy(methodHandler, {
+            apply(methodHandlerTarget, methodHandlerThisArg, methodHandlerArgs) {
+              return withIsolationScope(isolationScope => {
+                const request = methodHandlerArgs[0] as BunRequest;
+                const upperCaseMethod = method.toUpperCase();
+                if (upperCaseMethod === 'OPTIONS' || upperCaseMethod === 'HEAD') {
+                  return methodHandlerTarget.apply(methodHandlerThisArg, methodHandlerArgs);
+                }
+
+                const parsedUrl = parseUrl(request.url);
+                const attributes: SpanAttributes = {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.bun.serve.route.method',
+                  [SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD]: upperCaseMethod,
+                  [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+                };
+                if (parsedUrl.search) {
+                  attributes['http.query'] = parsedUrl.search;
+                }
+
+                const url = getSanitizedUrlString(parsedUrl);
+
+                isolationScope.setSDKProcessingMetadata({
+                  normalizedRequest: {
+                    url,
+                    method: upperCaseMethod,
+                    headers: request.headers.toJSON(),
+                    query_string: extractQueryParamsFromUrl(url),
+                    // For routes with parameters, add them to request data
+                    ...(request.params ? { params: request.params } : {}),
+                  } satisfies RequestEventData,
+                });
+
+                return continueTrace(
+                  { sentryTrace: request.headers.get('sentry-trace') || '', baggage: request.headers.get('baggage') },
+                  () => {
+                    return startSpan(
+                      {
+                        attributes,
+                        op: 'http.server',
+                        name: `${upperCaseMethod} ${routePath}`,
+                      },
+                      async span => {
+                        try {
+                          const response = await (methodHandlerTarget.apply(methodHandlerThisArg, methodHandlerArgs) as
+                            | Promise<Response>
+                            | Response);
+                          if (response?.status) {
+                            setHttpStatus(span, response.status);
+                            isolationScope.setContext('response', {
+                              headers: response.headers.toJSON(),
+                              status_code: response.status,
+                            });
+                          }
+                          return response;
+                        } catch (e) {
+                          captureException(e, {
+                            mechanism: {
+                              type: 'bun',
+                              handled: false,
+                              data: {
+                                function: 'serve.route.method',
+                              },
+                            },
+                          });
+                          throw e;
+                        }
+                      },
+                    );
+                  },
+                );
+              });
+            },
+          });
+        } else {
+          // If method handler is not a function (e.g., static response), keep it as is
+          instrumentedMethodHandlers[method] = methodHandler;
+        }
+      }
+
+      instrumentedRoutes[routePath] = instrumentedMethodHandlers;
+      continue;
+    }
+
+    // Default case: keep the handler as is if it's not a recognized type
+    instrumentedRoutes[routePath] = handler;
+  }
+
+  if (!anyMatches) {
+    return routes;
+  }
+
+  return instrumentedRoutes;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11211,9 +11211,9 @@ builtins@^5.0.0, builtins@^5.0.1:
     semver "^7.0.0"
 
 bun-types@latest:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/bun-types/-/bun-types-1.0.1.tgz#8bcb10ae3a1548a39f0932fdb365f4b3a649efba"
-  integrity sha512-7NrXqhMIaNKmWn2dSWEQ50znMZqrN/5Z0NBMXvQTRu/+Y1CvoXRznFy0pnqLe024CeZgVdXoEpARNO1JZLAPGw==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/bun-types/-/bun-types-1.2.8.tgz#b6f373bac4054449a9d5150475b829f58c089f09"
+  integrity sha512-D5npfxKIGuYe9dTHLK1hi4XFmbMdKYoLrgyd25rrUyCrnyU4ljmQW7vDdonvibKeyU72mZuixIhQ2J+q6uM0Mg==
 
 bundle-name@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/15941

This updates the `@sentry/bun` package to support instrumenting `routes` and to no longer throw an error when omitting `fetch`. This also updates `bun-types` from 1.0.1 to 1.2.8 (which includes the types for routes).

This does not include the code for updating node:http to support our migration away from wrapping `Request` & `Response` to support node:http servers better. It was less clear how to handle that, but it will likely involve wrapping `node:http` instead of `Bun.serve`.

Also, it seems that the tests did not pass previously when running `bun test` due to shared global state between files (probably the sdk test file). It still does not pass when run on multiple files. It does pass individually though. 

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Additional notes:
- The `import-in-the-middle` usage needs in `@sentry/node` needs to be disabled in Bun for now or else it will throw an error at runtime
- A bunch of this PR was generated by Claude, so review carefully

Feel free to use this PR as a starting point (or discard) and close if you think that's better