### PR TITLE
fix(tss-react): Change `authToken` type to `string`

### DIFF
--- a/packages/tanstackstart-react/src/config/index.ts
+++ b/packages/tanstackstart-react/src/config/index.ts
@@ -9,7 +9,7 @@ export function wrapVinxiConfigWithSentry<C>(
     org?: string;
     project?: string;
     silent?: boolean;
-    authToken?: boolean;
+    authToken?: string;
   } = {},
 ): C {
   return config;


### PR DESCRIPTION
Reported in https://github.com/getsentry/sentry-javascript/issues/14990#issuecomment-2776182271
