### PR TITLE
fix(core): Do not abbreviate message parameter attribute 

### DIFF
--- a/packages/core/src/logs/exports.ts
+++ b/packages/core/src/logs/exports.ts
@@ -108,7 +108,7 @@ export function _INTERNAL_captureLog(
     const { __sentry_template_string__, __sentry_template_values__ = [] } = message;
     logAttributes['sentry.message.template'] = __sentry_template_string__;
     __sentry_template_values__.forEach((param, index) => {
-      logAttributes[`sentry.message.param.${index}`] = param;
+      logAttributes[`sentry.message.parameter.${index}`] = param;
     });
   }
 


### PR DESCRIPTION
Generally for attribute keys we prefer to avoid abbreviation. For example in OTEL, [`net.X`](https://github.com/getsentry/sentry-conventions/blob/main/generated/attributes/net.md) was renamed to [`network.X`](https://github.com/getsentry/sentry-conventions/blob/main/generated/attributes/network.md)