### PR TITLE
fix(node): Make log flushing logic more robust

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -671,6 +671,13 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   public on(hook: 'afterCaptureLog', callback: (log: Log) => void): () => void;
 
   /**
+   * A hook that is called when the client is flushing logs
+   *
+   * @returns {() => void} A function that, when executed, removes the registered callback.
+   */
+  public on(hook: 'flushLogs', callback: () => void): () => void;
+
+  /**
    * Register a hook on this client.
    */
   public on(hook: string, callback: unknown): () => void {
@@ -826,6 +833,11 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
    * Emit a hook event for client after capturing a log.
    */
   public emit(hook: 'afterCaptureLog', log: Log): void;
+
+  /**
+   * Emit a hook event for client flush logs
+   */
+  public emit(hook: 'flushLogs'): void;
 
   /**
    * Emit a hook that was previously registered via `on()`.

--- a/packages/core/src/logs/exports.ts
+++ b/packages/core/src/logs/exports.ts
@@ -163,6 +163,8 @@ export function _INTERNAL_flushLogsBuffer(client: Client, maybeLogBuffer?: Array
   // Clear the log buffer after envelopes have been constructed.
   logBuffer.length = 0;
 
+  client.emit('flushLogs');
+
   // sendEnvelope should not throw
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   client.sendEnvelope(envelope);

--- a/packages/core/test/lib/server-runtime-client.test.ts
+++ b/packages/core/test/lib/server-runtime-client.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, test, vi } from 'vitest';
 import { Scope, createTransport } from '../../src';
 import type { ServerRuntimeClientOptions } from '../../src/server-runtime-client';
 import { ServerRuntimeClient } from '../../src/server-runtime-client';
-import { _INTERNAL_captureLog } from '../../src/logs/exports';
+import { _INTERNAL_captureLog, _INTERNAL_flushLogsBuffer } from '../../src/logs/exports';
 
 const PUBLIC_DSN = 'https://username@domain/123';
 
@@ -256,8 +256,8 @@ describe('ServerRuntimeClient', () => {
       _INTERNAL_captureLog({ message: 'test1', level: 'info' }, client);
       _INTERNAL_captureLog({ message: 'test2', level: 'info' }, client);
 
-      // Trigger flush event
-      client.emit('flush');
+      // Trigger flush directly
+      _INTERNAL_flushLogsBuffer(client);
 
       expect(sendEnvelopeSpy).toHaveBeenCalledTimes(1);
       expect(client['_logWeight']).toBe(0); // Weight should be reset after flush

--- a/packages/node/src/sdk/client.ts
+++ b/packages/node/src/sdk/client.ts
@@ -4,7 +4,7 @@ import { trace } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import type { DynamicSamplingContext, Scope, ServerRuntimeClientOptions, TraceContext } from '@sentry/core';
-import { SDK_VERSION, ServerRuntimeClient, applySdkMetadata, logger } from '@sentry/core';
+import { _INTERNAL_flushLogsBuffer, SDK_VERSION, ServerRuntimeClient, applySdkMetadata, logger } from '@sentry/core';
 import { getTraceContextForScope } from '@sentry/opentelemetry';
 import { isMainThread, threadId } from 'worker_threads';
 import { DEBUG_BUILD } from '../debug-build';
@@ -18,6 +18,7 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
   private _tracer: Tracer | undefined;
   private _clientReportInterval: NodeJS.Timeout | undefined;
   private _clientReportOnExitFlushListener: (() => void) | undefined;
+  private _logOnExitFlushListener: (() => void) | undefined;
 
   public constructor(options: NodeClientOptions) {
     const clientOptions: ServerRuntimeClientOptions = {
@@ -40,6 +41,14 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
     );
 
     super(clientOptions);
+
+    if (this.getOptions()._experiments?.enableLogs) {
+      this._logOnExitFlushListener = () => {
+        _INTERNAL_flushLogsBuffer(this);
+      };
+
+      process.on('beforeExit', this._logOnExitFlushListener);
+    }
   }
 
   /** Get the OTEL tracer. */
@@ -82,6 +91,10 @@ export class NodeClient extends ServerRuntimeClient<NodeClientOptions> {
 
     if (this._clientReportOnExitFlushListener) {
       process.off('beforeExit', this._clientReportOnExitFlushListener);
+    }
+
+    if (this._logOnExitFlushListener) {
+      process.off('beforeExit', this._logOnExitFlushListener);
     }
 
     return super.close(timeout);


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-18

We got some user feedback that nodejs logging was too inconsistent. This PR improves that.

1. Add a new `flushLogs` client hook that allows us to reset server weight tracking logic more consistently. This also fixes a bug where we didn't reset weight tracking when calling `Sentry.flush`.
2. Add a `process.on('beforeExit'` listener to flush logs. Hooking onto `beforeExit` does not guarantee we flush all logs before exit, but it does increase the chances we do. 
4. Add an idle timeout that will flush logs after 5 seconds if no new logs are recorded. This should not leak memory because it is not an interval, but instead a timeout.