### PR TITLE
fix(core): Prefix release and environment correctly

### DIFF
--- a/packages/core/src/logs/exports.ts
+++ b/packages/core/src/logs/exports.ts
@@ -97,11 +97,11 @@ export function _INTERNAL_captureLog(
   };
 
   if (release) {
-    logAttributes.release = release;
+    logAttributes['sentry.release'] = release;
   }
 
   if (environment) {
-    logAttributes.environment = environment;
+    logAttributes['sentry.environment'] = environment;
   }
 
   if (isParameterizedString(message)) {

--- a/packages/core/test/lib/logs/exports.test.ts
+++ b/packages/core/test/lib/logs/exports.test.ts
@@ -136,8 +136,8 @@ describe('_INTERNAL_captureLog', () => {
     const logAttributes = _INTERNAL_getLogBuffer(client)?.[0]?.attributes;
     expect(logAttributes).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ key: 'release', value: { stringValue: '1.0.0' } }),
-        expect.objectContaining({ key: 'environment', value: { stringValue: 'test' } }),
+        expect.objectContaining({ key: 'sentry.release', value: { stringValue: '1.0.0' } }),
+        expect.objectContaining({ key: 'sentry.environment', value: { stringValue: 'test' } }),
       ]),
     );
   });


### PR DESCRIPTION
fixes https://linear.app/getsentry/issue/LOGS-5

previously I wasn't matching the spec, this fixes that.