### PR TITLE
feat(core): Emit debug log when transport execution fails

### DIFF
--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -77,6 +77,7 @@ export function createTransport(
         },
         error => {
           recordEnvelopeLoss('network_error');
+          DEBUG_BUILD && logger.error('Encountered error running transport request:', error);
           throw error;
         },
       );


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/issues/15993 is incredibly annoying to debug because we don't log the actual error