### PR TITLE
fix(node): Ensure late init works with all integrations

### DIFF
--- a/packages/aws-serverless/src/integration/awslambda.ts
+++ b/packages/aws-serverless/src/integration/awslambda.ts
@@ -15,22 +15,19 @@ interface AwsLambdaOptions {
   disableAwsContextPropagation?: boolean;
 }
 
-export const instrumentAwsLambda = generateInstrumentOnce<AwsLambdaOptions>(
+export const instrumentAwsLambda = generateInstrumentOnce(
   'AwsLambda',
-  (_options: AwsLambdaOptions = {}) => {
-    const options = {
+  AwsLambdaInstrumentation,
+  (options: AwsLambdaOptions) => {
+    return {
       disableAwsContextPropagation: true,
-      ..._options,
-    };
-
-    return new AwsLambdaInstrumentation({
       ...options,
       eventContextExtractor,
       requestHook(span) {
         span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.otel.aws-lambda');
         span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'function.aws.lambda');
       },
-    });
+    };
   },
 );
 

--- a/packages/node/src/integrations/tracing/graphql.ts
+++ b/packages/node/src/integrations/tracing/graphql.ts
@@ -37,12 +37,13 @@ interface GraphqlOptions {
 
 const INTEGRATION_NAME = 'Graphql';
 
-export const instrumentGraphql = generateInstrumentOnce<GraphqlOptions>(
+export const instrumentGraphql = generateInstrumentOnce(
   INTEGRATION_NAME,
-  (_options: GraphqlOptions = {}) => {
+  GraphQLInstrumentation,
+  (_options: GraphqlOptions) => {
     const options = getOptionsWithDefaults(_options);
 
-    return new GraphQLInstrumentation({
+    return {
       ...options,
       responseHook(span) {
         addOriginToSpan(span, 'auto.graphql.otel.graphql');
@@ -73,7 +74,7 @@ export const instrumentGraphql = generateInstrumentOnce<GraphqlOptions>(
           }
         }
       },
-    });
+    };
   },
 );
 

--- a/packages/remix/src/server/integrations/opentelemetry.ts
+++ b/packages/remix/src/server/integrations/opentelemetry.ts
@@ -7,22 +7,24 @@ import type { RemixOptions } from '../../utils/remixOptions';
 
 const INTEGRATION_NAME = 'Remix';
 
-const instrumentRemix = generateInstrumentOnce<RemixOptions>(
-  INTEGRATION_NAME,
-  (_options?: RemixOptions) =>
-    new RemixInstrumentation({
-      actionFormDataAttributes: _options?.sendDefaultPii ? _options?.captureActionFormDataKeys : undefined,
-    }),
-);
+interface RemixInstrumentationOptions {
+  actionFormDataAttributes?: Record<string, string | boolean>;
+}
+
+const instrumentRemix = generateInstrumentOnce(INTEGRATION_NAME, (options?: RemixInstrumentationOptions) => {
+  return new RemixInstrumentation(options);
+});
 
 const _remixIntegration = (() => {
   return {
     name: 'Remix',
     setupOnce() {
       const client = getClient();
-      const options = client?.getOptions();
+      const options = client?.getOptions() as RemixOptions | undefined;
 
-      instrumentRemix(options);
+      instrumentRemix({
+        actionFormDataAttributes: options?.sendDefaultPii ? options?.captureActionFormDataKeys : undefined,
+      });
     },
 
     setup(client: Client) {


### PR DESCRIPTION
In cases where we tweak the options we pass to the instrumentation, our code did not handle this very well. This could lead to certain options missing when init is called again later, as we updated the config with incomplete/wrong options.

To fix this properly, I added a new variant to `generateInstrumentOnce` which accepts a class and an options transformer, which ensures that the options are always correctly transformed, no matter if called the first or second time.

(The code to make this overloaded `generateInstrumentOnce` function work with TS was pretty tricky, but I think it is good now - type inferral etc. works nicely now!)

Fixes https://github.com/getsentry/sentry-javascript/issues/16004