### PR TITLE
feat(core): Add experimental scopeValuesAppliedToLogs option

### DIFF
--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -200,6 +200,14 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
      * @returns A new log that will be sent | null.
      */
     beforeSendLog?: (log: Log) => Log | null;
+
+    /**
+     * Setting this field to an array of attribute keys will add the corresponding attributes
+     * from the Sentry Scope to to all outgoing logs as log attributes.
+     *
+     * The allowed keys are `user` and `tags`. Defaults to `[]`.
+     */
+    scopeValuesAppliedToLogs?: Array<'user' | 'tags'>;
   };
 
   /**


### PR DESCRIPTION
We've gotten some requests for being able to get user info (from the scope) onto logs. See: https://linear.app/getsentry/issue/LOGS-21

To experiment with how this feels, we're going to try adding a new option/api to the JS SDK, `scopeValuesAppliedToLogs`. This right now only works for `user` and `tags`, but we might open it up for more contexts in the future.

In browser JS `browser`/`os`/`device` and `request` are all parsed from relay, so there's no SDK changes to be made here.

Usage:

```js
Sentry.init({
  _experiments: {
    enableLogs: true,
    scopeValuesAppliedToLogs: ['user', 'tags'],
  },
});

Sentry.setTag("service", "omega_star");
Sentry.setTag("is_iso_compliant", "false");

Sentry.setUser({ id: "very_cool_developer" });

// gets attached:
// `sentry.tag.service="omega_star"`
// `sentry.tag.is_iso_compliant="false"`
// `sentry.user.id="very_cool_developer"`
Sentry.logger.info("test");
```

resolves https://linear.app/getsentry/issue/JSC-294