### PR TITLE
feat(cloudflare): Add console integration

### DIFF
--- a/packages/cloudflare/src/integrations/console.ts
+++ b/packages/cloudflare/src/integrations/console.ts
@@ -1,0 +1,38 @@
+import {
+  addBreadcrumb,
+  addConsoleInstrumentationHandler,
+  defineIntegration,
+  getClient,
+  safeJoin,
+  severityLevelFromString,
+} from '@sentry/core';
+
+const INTEGRATION_NAME = 'Console';
+
+/**
+ * Capture console logs as breadcrumbs. Enabled by default in the Cloudflare SDK.
+ */
+export const consoleIntegration = defineIntegration(() => {
+  return {
+    name: INTEGRATION_NAME,
+    setup(client) {
+      addConsoleInstrumentationHandler(({ args, level }) => {
+        if (getClient() !== client) {
+          return;
+        }
+
+        addBreadcrumb(
+          {
+            category: 'console',
+            level: severityLevelFromString(level),
+            message: safeJoin(args, ' '),
+          },
+          {
+            input: [...args],
+            level,
+          },
+        );
+      });
+    },
+  };
+});

--- a/packages/cloudflare/src/sdk.ts
+++ b/packages/cloudflare/src/sdk.ts
@@ -14,6 +14,7 @@ import { CloudflareClient } from './client';
 import { fetchIntegration } from './integrations/fetch';
 import { makeCloudflareTransport } from './transport';
 import { defaultStackParser } from './vendor/stacktrace';
+import { consoleIntegration } from './integrations/console';
 
 /** Get the default integrations for the Cloudflare SDK. */
 export function getDefaultIntegrations(options: CloudflareOptions): Integration[] {
@@ -27,6 +28,7 @@ export function getDefaultIntegrations(options: CloudflareOptions): Integration[
     linkedErrorsIntegration(),
     fetchIntegration(),
     requestDataIntegration(sendDefaultPii ? undefined : { include: { cookies: false } }),
+    consoleIntegration(),
   ];
 }
 


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/15439

resolves https://linear.app/getsentry/issue/JSC-192

Add console integration to cloudflare SDK. Unfortunately can't access Node.js APIs, so we have to use `safeJoin` over `util.format` from `node:util` when creating the console message.