### PR TITLE
fix(nextjs): Include patch version 0 for min supported 15.3.0

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -178,7 +178,7 @@ function getFinalConfigObject(
       patch !== undefined &&
       (major > 15 ||
         (major === 15 && minor > 3) ||
-        (major === 15 && minor === 3 && patch > 0 && prerelease === undefined));
+        (major === 15 && minor === 3 && patch >= 0 && prerelease === undefined));
     const isSupportedCanary =
       major !== undefined &&
       minor !== undefined &&


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/16025