### PR TITLE
fix(feedback): Prevent `removeFromDom()` from throwing

### DIFF
--- a/packages/feedback/src/core/components/Actor.ts
+++ b/packages/feedback/src/core/components/Actor.ts
@@ -56,7 +56,6 @@ export function Actor({ triggerLabel, triggerAriaLabel, shadow, styleNonce }: Ac
         logger.error(
           '[Feedback] Error when trying to remove Actor from the DOM. It is not appended to the DOM yet!',
         );
-        throw new Error('[Feedback] Actor is not appended to DOM, nothing to remove.');
       }
     },
     show(): void {

--- a/packages/feedback/src/core/components/Actor.ts
+++ b/packages/feedback/src/core/components/Actor.ts
@@ -1,4 +1,4 @@
-import { DEBUG_BUILD } from 'src/util/debug-build';
+import { DEBUG_BUILD } from '../../util/debug-build';
 import { DOCUMENT, TRIGGER_LABEL } from '../../constants';
 import { createActorStyles } from './Actor.css';
 import { FeedbackIcon } from './FeedbackIcon';

--- a/packages/feedback/src/core/components/Actor.ts
+++ b/packages/feedback/src/core/components/Actor.ts
@@ -1,8 +1,6 @@
-import { DEBUG_BUILD } from '../../util/debug-build';
 import { DOCUMENT, TRIGGER_LABEL } from '../../constants';
 import { createActorStyles } from './Actor.css';
 import { FeedbackIcon } from './FeedbackIcon';
-import { logger } from '@sentry/core';
 
 export interface ActorProps {
   triggerLabel: string;
@@ -48,15 +46,8 @@ export function Actor({ triggerLabel, triggerAriaLabel, shadow, styleNonce }: Ac
       shadow.appendChild(el);
     },
     removeFromDom(): void {
-      try {
-        el.remove();
-        style.remove();
-      } catch {
-        DEBUG_BUILD &&
-        logger.error(
-          '[Feedback] Error when trying to remove Actor from the DOM. It is not appended to the DOM yet!',
-        );
-      }
+      el.remove();
+      style.remove();
     },
     show(): void {
       el.ariaHidden = 'false';

--- a/packages/feedback/src/core/components/Actor.ts
+++ b/packages/feedback/src/core/components/Actor.ts
@@ -1,6 +1,8 @@
+import { DEBUG_BUILD } from 'src/util/debug-build';
 import { DOCUMENT, TRIGGER_LABEL } from '../../constants';
 import { createActorStyles } from './Actor.css';
 import { FeedbackIcon } from './FeedbackIcon';
+import { logger } from '@sentry/core';
 
 export interface ActorProps {
   triggerLabel: string;
@@ -46,8 +48,16 @@ export function Actor({ triggerLabel, triggerAriaLabel, shadow, styleNonce }: Ac
       shadow.appendChild(el);
     },
     removeFromDom(): void {
-      shadow.removeChild(el);
-      shadow.removeChild(style);
+      try {
+        el.remove();
+        style.remove();
+      } catch {
+        DEBUG_BUILD &&
+        logger.error(
+          '[Feedback] Error when trying to remove Actor from the DOM. It is not appended to the DOM yet!',
+        );
+        throw new Error('[Feedback] Actor is not appended to DOM, nothing to remove.');
+      }
     },
     show(): void {
       el.ariaHidden = 'false';

--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -5,8 +5,6 @@ import * as hooks from 'preact/hooks';
 import { DOCUMENT } from '../constants';
 import { Dialog } from './components/Dialog';
 import { createDialogStyles } from './components/Dialog.css';
-import { DEBUG_BUILD } from 'src/util/debug-build';
-import { logger } from '@sentry/core';
 
 function getUser(): User | undefined {
   const currentUser = getCurrentScope().getUser();
@@ -46,14 +44,8 @@ export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
           }
         },
         removeFromDom(): void {
-          try {
-            el.remove();
-            style.remove();
-          } catch {
-            DEBUG_BUILD &&
-              logger.error('[Feedback] Error when trying to remove Modal from the DOM. It is not appended to the DOM yet!');
-            throw new Error('[Feedback] Modal is not appended to DOM, nothing to remove.');
-          }
+          el.remove();
+          style.remove();
           DOCUMENT.body.style.overflow = originalOverflow;
         },
         open() {

--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -5,6 +5,8 @@ import * as hooks from 'preact/hooks';
 import { DOCUMENT } from '../constants';
 import { Dialog } from './components/Dialog';
 import { createDialogStyles } from './components/Dialog.css';
+import { DEBUG_BUILD } from 'src/util/debug-build';
+import { logger } from '@sentry/core';
 
 function getUser(): User | undefined {
   const currentUser = getCurrentScope().getUser();
@@ -44,8 +46,14 @@ export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
           }
         },
         removeFromDom(): void {
-          shadowRoot.removeChild(el);
-          shadowRoot.removeChild(style);
+          try {
+            el.remove();
+            style.remove();
+          } catch {
+            DEBUG_BUILD &&
+              logger.error('[Feedback] Error when trying to remove Modal from the DOM. It is not appended to the DOM yet!');
+            throw new Error('[Feedback] Modal is not appended to DOM, nothing to remove.');
+          }
           DOCUMENT.body.style.overflow = originalOverflow;
         },
         open() {

--- a/packages/feedback/test/core/components/Actor.test.ts
+++ b/packages/feedback/test/core/components/Actor.test.ts
@@ -63,4 +63,24 @@ describe('Actor', () => {
     expect(actorAria.el.textContent).toBe('Button');
     expect(actorAria.el.ariaLabel).toBe('Aria');
   });
+
+  it('does not throw if removeFromDom() is called when it is not mounted', () => {
+    const feedbackIntegration = buildFeedbackIntegration({
+      lazyLoadIntegration: vi.fn(),
+    });
+
+    const configuredIntegration = feedbackIntegration({});
+    mockSdk({
+      sentryOptions: {
+        integrations: [configuredIntegration],
+      },
+    });
+
+    const feedback = getFeedback();
+
+    const actorComponent = feedback!.createWidget();
+
+    expect(() => actorComponent.removeFromDom()).not.toThrowError();
+    expect(() => actorComponent.removeFromDom()).not.toThrowError();
+  });
 });


### PR DESCRIPTION
An internal user reported seeing "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node." and the replay of their session confirms it: https://sentry.sentry.io/explore/replays/127444034ae84099a84b524458b6dd90/

However, there is no matching JS error to give more clues.

What I think happened is that after interacting with the Feedback SDK the widget got into a state where it was no longer mounted into the page, but we called `removeFromDom()` anyway. 

Looking at the replay i saw the moment when the feedback dom was aded to the page, but it wasn't visible, only this got added at 18:51:
<img width="265" alt="SCR-20250411-lsav" src="https://github.com/user-attachments/assets/1f65a174-1a8a-405c-8ce4-be0a10d09a64" />

So something prevented it from opening all the way up.

Fixes https://github.com/getsentry/sentry/issues/89424