### PR TITLE
feat(browser): Warn on duplicate `browserTracingIntegration`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/multiple-integrations/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/multiple-integrations/init.js
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration(), Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/multiple-integrations/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/multiple-integrations/test.ts
@@ -1,0 +1,22 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
+
+sentryTest('warns if multiple integrations are used', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const msgs: string[] = [];
+
+  page.on('console', msg => {
+    msgs.push(msg.text());
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.goto(url);
+
+  expect(msgs).toEqual(['Multiple browserTracingIntegration instances are not supported.']);
+});

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -9,7 +9,16 @@ import {
   startTrackingLongTasks,
   startTrackingWebVitals,
 } from '@sentry-internal/browser-utils';
-import type { Client, IntegrationFn, Span, StartSpanOptions, TransactionSource, WebFetchHeaders } from '@sentry/core';
+import {
+  Client,
+  IntegrationFn,
+  Span,
+  StartSpanOptions,
+  TransactionSource,
+  WebFetchHeaders,
+  consoleSandbox,
+  isBrowser,
+} from '@sentry/core';
 import {
   GLOBAL_OBJ,
   SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON,
@@ -217,6 +226,8 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   ...defaultRequestInstrumentationOptions,
 };
 
+let _hasBeenInitialized = false;
+
 /**
  * The Browser Tracing integration automatically instruments browser pageload/navigation
  * actions as transactions, and captures requests, metrics and errors as spans.
@@ -227,6 +238,15 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
  * We explicitly export the proper type here, as this has to be extended in some cases.
  */
 export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptions> = {}) => {
+  if (_hasBeenInitialized && isBrowser()) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn('Multiple browserTracingIntegration instances are not supported.');
+    });
+  }
+
+  _hasBeenInitialized = true;
+
   /**
    * This is just a small wrapper that makes `document` optional.
    * We want to be extra-safe and always check that this exists, to ensure weird environments do not blow up.


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/16040

this logs a warning if a user adds multiple instances of `browserTracingIntegration`. If this is done, this can lead to potentially weird things (e.g. we add multiple handlers etc).

This is especially relevant for react, as there are multiple different integrations there that users may add.