### PR TITLE
feat(nuxt): Log when adding HTML trace meta tags

### DIFF
--- a/packages/nuxt/src/runtime/plugins/sentry.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry.server.ts
@@ -57,8 +57,7 @@ export default defineNitroPlugin(nitroApp => {
 
   // @ts-expect-error - 'render:html' is a valid hook name in the Nuxt context
   nitroApp.hooks.hook('render:html', (html: NuxtRenderHTMLContext) => {
-    const sentryClient = SentryNode.getClient();
-    addSentryTracingMetaTags(html.head, sentryClient?.getOptions().debug);
+    addSentryTracingMetaTags(html.head);
   });
 });
 

--- a/packages/nuxt/src/runtime/plugins/sentry.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry.server.ts
@@ -57,7 +57,8 @@ export default defineNitroPlugin(nitroApp => {
 
   // @ts-expect-error - 'render:html' is a valid hook name in the Nuxt context
   nitroApp.hooks.hook('render:html', (html: NuxtRenderHTMLContext) => {
-    addSentryTracingMetaTags(html.head);
+    const sentryClient = SentryNode.getClient();
+    addSentryTracingMetaTags(html.head, sentryClient?.getOptions().debug);
   });
 });
 

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -1,5 +1,5 @@
 import type { ClientOptions, Context } from '@sentry/core';
-import { consoleSandbox } from '@sentry/core';
+import { logger } from '@sentry/core';
 import { captureException, getClient, getTraceMetaTags } from '@sentry/core';
 import type { VueOptions } from '@sentry/vue/src/types';
 import type { CapturedErrorContext } from 'nitropack';
@@ -39,10 +39,7 @@ export function addSentryTracingMetaTags(head: NuxtRenderHTMLContext['head'], de
 
   if (metaTags) {
     if (debug) {
-      consoleSandbox(() => {
-        // eslint-disable-next-line no-console
-        console.log('[Sentry] Adding Sentry tracing meta tags to HTML page:', metaTags);
-      });
+      logger.log('[Sentry] Adding Sentry tracing meta tags to HTML page:', metaTags);
     }
     head.push(metaTags);
   }

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -39,7 +39,7 @@ export function addSentryTracingMetaTags(head: NuxtRenderHTMLContext['head'], de
 
   if (metaTags) {
     if (debug) {
-      logger.log('[Sentry] Adding Sentry tracing meta tags to HTML page:', metaTags);
+      logger.log('Adding Sentry tracing meta tags to HTML page:', metaTags);
     }
     head.push(metaTags);
   }

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -34,13 +34,11 @@ export function extractErrorContext(errorContext: CapturedErrorContext | undefin
  *
  * Exported only for testing
  */
-export function addSentryTracingMetaTags(head: NuxtRenderHTMLContext['head'], debug?: boolean): void {
+export function addSentryTracingMetaTags(head: NuxtRenderHTMLContext['head']): void {
   const metaTags = getTraceMetaTags();
 
   if (metaTags) {
-    if (debug) {
-      logger.log('Adding Sentry tracing meta tags to HTML page:', metaTags);
-    }
+    logger.log('Adding Sentry tracing meta tags to HTML page:', metaTags);
     head.push(metaTags);
   }
 }

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -1,4 +1,5 @@
 import type { ClientOptions, Context } from '@sentry/core';
+import { consoleSandbox } from '@sentry/core';
 import { captureException, getClient, getTraceMetaTags } from '@sentry/core';
 import type { VueOptions } from '@sentry/vue/src/types';
 import type { CapturedErrorContext } from 'nitropack';
@@ -33,10 +34,16 @@ export function extractErrorContext(errorContext: CapturedErrorContext | undefin
  *
  * Exported only for testing
  */
-export function addSentryTracingMetaTags(head: NuxtRenderHTMLContext['head']): void {
+export function addSentryTracingMetaTags(head: NuxtRenderHTMLContext['head'], debug?: boolean): void {
   const metaTags = getTraceMetaTags();
 
   if (metaTags) {
+    if (debug) {
+      consoleSandbox(() => {
+        // eslint-disable-next-line no-console
+        console.log('[Sentry] Adding Sentry tracing meta tags to HTML page:', metaTags);
+      });
+    }
     head.push(metaTags);
   }
 }

--- a/packages/nuxt/test/runtime/plugins/server.test.ts
+++ b/packages/nuxt/test/runtime/plugins/server.test.ts
@@ -2,9 +2,13 @@ import { getTraceMetaTags } from '@sentry/core';
 import { type Mock, afterEach, describe, expect, it, vi } from 'vitest';
 import { addSentryTracingMetaTags } from '../../../src/runtime/utils';
 
-vi.mock('@sentry/core', () => ({
-  getTraceMetaTags: vi.fn(),
-}));
+vi.mock(import('@sentry/core'), async importOriginal => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    getTraceMetaTags: vi.fn(),
+  };
+});
 
 describe('addSentryTracingMetaTags', () => {
   afterEach(() => {


### PR DESCRIPTION
Logging the tracing meta tags makes debugging [things like this](https://github.com/getsentry/sentry-javascript/issues/16039) easier.
