### PR TITLE
Sergical/fix nextjs console check

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -2,19 +2,19 @@
 /* eslint-disable complexity */
 import { isThenable, parseSemver } from '@sentry/core';
 
-import { getSentryRelease } from '@sentry/node';
 import * as childProcess from 'child_process';
+import { getSentryRelease } from '@sentry/node';
 
-import * as fs from 'fs';
-import * as path from 'path';
 import type {
   ExportedNextConfig as NextConfig,
   NextConfigFunction,
   NextConfigObject,
   SentryBuildOptions,
 } from './types';
-import { getNextjsVersion } from './util';
 import { constructWebpackConfigFunction } from './webpack';
+import { getNextjsVersion } from './util';
+import * as fs from 'fs';
+import * as path from 'path';
 
 let showedExportModeTunnelWarning = false;
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -2,19 +2,19 @@
 /* eslint-disable complexity */
 import { isThenable, parseSemver } from '@sentry/core';
 
-import * as childProcess from 'child_process';
 import { getSentryRelease } from '@sentry/node';
+import * as childProcess from 'child_process';
 
+import * as fs from 'fs';
+import * as path from 'path';
 import type {
   ExportedNextConfig as NextConfig,
   NextConfigFunction,
   NextConfigObject,
   SentryBuildOptions,
 } from './types';
-import { constructWebpackConfigFunction } from './webpack';
 import { getNextjsVersion } from './util';
-import * as fs from 'fs';
-import * as path from 'path';
+import { constructWebpackConfigFunction } from './webpack';
 
 let showedExportModeTunnelWarning = false;
 
@@ -178,7 +178,7 @@ function getFinalConfigObject(
       patch !== undefined &&
       (major > 15 ||
         (major === 15 && minor > 3) ||
-        (major === 15 && minor === 3 && patch >= 0 && prerelease === undefined));
+        (major === 15 && minor === 3 && patch >= 0));
     const isSupportedCanary =
       major !== undefined &&
       minor !== undefined &&


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Would like to avoid 

```
> next dev --turbopack

[@sentry/nextjs] WARNING: You are using the Sentry SDK with Turbopack (`next dev --turbo`). The Sentry SDK is compatible with Turbopack on Next.js version 15.3.0 or later. You are currently on 15.3.0. Please upgrade to a newer Next.js version to use the Sentry SDK with Turbopack. Note that the SDK will continue to work for non-Turbopack production builds. This warning is only about dev-mode.
   ▲ Next.js 15.3.0 (Turbopack)
```