### PR TITLE
fix(nextjs): Don't show turbopack warning for newer Next.js canaries

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -178,7 +178,8 @@ function getFinalConfigObject(
       patch !== undefined &&
       (major > 15 ||
         (major === 15 && minor > 3) ||
-        (major === 15 && minor === 3 && patch >= 0 && prerelease === undefined));
+        (major === 15 && minor === 3 && patch === 0 && prerelease === undefined) ||
+        (major === 15 && minor === 3 && patch > 0));
     const isSupportedCanary =
       major !== undefined &&
       minor !== undefined &&


### PR DESCRIPTION
We don't want to log for `15.3.1-canary.3`

Maybe ref https://github.com/getsentry/sentry-javascript/issues/16060 ???