### PR TITLE
test(node): Increase timeout of anr tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -107,7 +107,7 @@ const ANR_EVENT_WITH_DEBUG_META: Event = {
   },
 };
 
-describe('should report ANR when event loop blocked', () => {
+describe('should report ANR when event loop blocked', { timeout: 60_000 }, () => {
   afterAll(() => {
     cleanupChildProcesses();
   });


### PR DESCRIPTION
Noticed this flaking sometimes, not 100% sure if this is due to the timeout, but it does not hurt I guess..