### PR TITLE
ref(node): Log when incoming request bodies are being captured

### DIFF
--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -30,6 +30,8 @@ import { getRequestInfo } from './vendor/getRequestInfo';
 type Http = typeof http;
 type Https = typeof https;
 
+const INSTRUMENTATION_NAME = '@sentry/instrumentation-http';
+
 export type SentryHttpInstrumentationOptions = InstrumentationConfig & {
   /**
    * Whether breadcrumbs should be recorded for requests.
@@ -101,7 +103,7 @@ const MAX_BODY_BYTE_LENGTH = 1024 * 1024;
  */
 export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpInstrumentationOptions> {
   public constructor(config: SentryHttpInstrumentationOptions = {}) {
-    super('@sentry/instrumentation-http', VERSION, config);
+    super(INSTRUMENTATION_NAME, VERSION, config);
   }
 
   /** @inheritdoc */
@@ -377,6 +379,10 @@ function patchRequestToCaptureBody(req: IncomingMessage, isolationScope: Scope):
       apply: (target, thisArg, args: Parameters<typeof req.on>) => {
         const [event, listener, ...restArgs] = args;
 
+        if (DEBUG_BUILD) {
+          logger.log(INSTRUMENTATION_NAME, 'Patching request.on', event);
+        }
+
         if (event === 'data') {
           const callback = new Proxy(listener, {
             apply: (target, thisArg, args: Parameters<typeof listener>) => {
@@ -387,6 +393,7 @@ function patchRequestToCaptureBody(req: IncomingMessage, isolationScope: Scope):
                 chunks.push(chunk);
               } else if (DEBUG_BUILD) {
                 logger.log(
+                  INSTRUMENTATION_NAME,
                   `Dropping request body chunk because it maximum body length of ${MAX_BODY_BYTE_LENGTH}b is exceeded.`,
                 );
               }
@@ -410,8 +417,10 @@ function patchRequestToCaptureBody(req: IncomingMessage, isolationScope: Scope):
                   const normalizedRequest = { data: body } satisfies RequestEventData;
                   isolationScope.setSDKProcessingMetadata({ normalizedRequest });
                 }
-              } catch {
-                // ignore errors here
+              } catch (error) {
+                if (DEBUG_BUILD) {
+                  logger.error(INSTRUMENTATION_NAME, 'Error building captured request body', error);
+                }
               }
 
               return Reflect.apply(target, thisArg, args);
@@ -445,8 +454,10 @@ function patchRequestToCaptureBody(req: IncomingMessage, isolationScope: Scope):
         return Reflect.apply(target, thisArg, args);
       },
     });
-  } catch {
-    // ignore errors if we can't patch stuff
+  } catch (error) {
+    if (DEBUG_BUILD) {
+      logger.error(INSTRUMENTATION_NAME, 'Error patching request to capture body', error);
+    }
   }
 }
 

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -394,7 +394,7 @@ function patchRequestToCaptureBody(req: IncomingMessage, isolationScope: Scope):
               } else if (DEBUG_BUILD) {
                 logger.log(
                   INSTRUMENTATION_NAME,
-                  `Dropping request body chunk because it maximum body length of ${MAX_BODY_BYTE_LENGTH}b is exceeded.`,
+                  `Dropping request body chunk because maximum body length of ${MAX_BODY_BYTE_LENGTH}b is exceeded.`,
                 );
               }
 


### PR DESCRIPTION
We used to swallow most things when we try to capture request bodies of incoming requests in node. This can make it hard to debug this.

This PR adds some log messages here:

1. Logs when we successfully patched `request.on`
2. Logs the errors that happen during patching

ref https://github.com/getsentry/sentry-javascript/issues/16090