### PR TITLE
fix(node): Make body capturing more robust

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-fastify/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/src/app.ts
@@ -119,6 +119,10 @@ app.get('/test-outgoing-http-external-disallowed', async function (req, res) {
   res.send(data);
 });
 
+app.post('/test-post', function (req, res) {
+  res.send({ status: 'ok', body: req.body });
+});
+
 app.listen({ port: port });
 
 // A second app so we can test header propagation between external URLs

--- a/dev-packages/e2e-tests/test-applications/node-fastify/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify/tests/transactions.test.ts
@@ -124,3 +124,40 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     origin: 'manual',
   });
 });
+
+test('Captures request metadata', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('node-fastify', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' && transactionEvent?.transaction === 'POST /test-post'
+    );
+  });
+
+  const res = await fetch(`${baseURL}/test-post`, {
+    method: 'POST',
+    body: JSON.stringify({ foo: 'bar', other: 1 }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const resBody = await res.json();
+
+  expect(resBody).toEqual({ status: 'ok', body: { foo: 'bar', other: 1 } });
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent.request).toEqual({
+    cookies: {},
+    url: expect.stringMatching(/^http:\/\/localhost:(\d+)\/test-post$/),
+    method: 'POST',
+    headers: expect.objectContaining({
+      'user-agent': expect.stringContaining(''),
+      'content-type': 'application/json',
+    }),
+    data: JSON.stringify({
+      foo: 'bar',
+      other: 1,
+    }),
+  });
+
+  expect(transactionEvent.user).toEqual(undefined);
+});

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -389,7 +389,7 @@ function patchRequestToCaptureBody(req: IncomingMessage, isolationScope: Scope):
 
                 if (bodyByteLength < MAX_BODY_BYTE_LENGTH) {
                   chunks.push(bufferifiedChunk);
-                  bodyByteLength += bufferifiedChunk.length;
+                  bodyByteLength += bufferifiedChunk.byteLength;
                 } else if (DEBUG_BUILD) {
                   logger.log(
                     INSTRUMENTATION_NAME,

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -3,7 +3,7 @@ import { context, propagation } from '@opentelemetry/api';
 import { VERSION } from '@opentelemetry/core';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
-import type { AggregationCounts, Client, RequestEventData, SanitizedRequestData, Scope } from '@sentry/core';
+import type { AggregationCounts, Client, SanitizedRequestData, Scope } from '@sentry/core';
 import {
   addBreadcrumb,
   generateSpanId,

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -396,8 +396,8 @@ function patchRequestToCaptureBody(req: IncomingMessage, isolationScope: Scope):
                     `Dropping request body chunk because maximum body length of ${MAX_BODY_BYTE_LENGTH}b is exceeded.`,
                   );
                 }
-              } catch {
-                // noop
+              } catch (err) {
+                DEBUG_BUILD && logger.error(INSTRUMENTATION_NAME, 'Encountered error while storing body chunk.');
               }
 
               return Reflect.apply(target, thisArg, args);


### PR DESCRIPTION
I have a hunch that not all frameworks call `req.on('end')` but may only do `req.on('close')` or whatever else and this is why we are not reliably capturing bodies.

It should be safe to attach a `req.on('end')` handler, as that doesn't change any semantics AFAIK.

Fixes https://github.com/getsentry/sentry-javascript/issues/16090