### PR TITLE
fix(remix): Add ESM-compatible exports

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -24,11 +24,15 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./build/types/index.types.d.ts",
+      "default": "./build/esm/index.client.js",
       "browser": {
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"
       },
-      "node": "./build/cjs/index.server.js"
+      "node": {
+        "import": "./build/esm/index.server.js",
+        "require": "./build/cjs/index.server.js"
+      }
     },
     "./cloudflare": {
       "import": "./build/esm/cloudflare/index.js",


### PR DESCRIPTION
Vite 6 is more strict with exports. I changed the `exports` section a bit to make it compatible.

closes https://github.com/getsentry/sentry-javascript/issues/16120