### PR TITLE
fix(node): Update version range for `module.register`

### DIFF
--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -42,7 +42,7 @@ export function maybeInitializeEsmLoader(): void {
   const [nodeMajor = 0, nodeMinor = 0] = process.versions.node.split('.').map(Number);
 
   // Register hook was added in v20.6.0 and v18.19.0
-  if (nodeMajor >= 22 || (nodeMajor === 20 && nodeMinor >= 6) || (nodeMajor === 18 && nodeMinor >= 19)) {
+  if (nodeMajor >= 21 || (nodeMajor === 20 && nodeMinor >= 6) || (nodeMajor === 18 && nodeMinor >= 19)) {
     if (!GLOBAL_OBJ._sentryEsmLoaderHookRegistered) {
       try {
         const { addHookMessagePort } = createAddHookMessageChannel();


### PR DESCRIPTION
Adding Node 21 to the accepted version range for `module.register` as it is already supported (https://nodejs.org/docs/v21.0.0/api/module.html).

This also causes the customization hook not to call register (maybe a reason why some packages in issue https://github.com/getsentry/sentry-javascript/issues/14202 are not instrumented): https://github.com/getsentry/sentry-javascript/blob/59094afb6ab53ac33b87b83f70eea9d13e4c2291/packages/node/src/sdk/initOtel.ts#L45-L65


--- 
Additionally, the above mentioned issue https://github.com/getsentry/sentry-javascript/issues/14202 shows the following warning although it's using v21:
```
[Sentry] You are using Node.js in ESM mode ("import syntax"). The Sentry Node.js SDK is not compatible with ESM in Node.js versions before 18.19.0 or before 20.6.0. Please either build your application with CommonJS ("require() syntax"), or upgrade your Node.js version.
```
