### PR TITLE
feat(core): Associate resource/tool/prompt invocations with request span instead of response span

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express/package.json
@@ -11,6 +11,7 @@
     "test:assert": "pnpm test"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.10.2",
     "@sentry/core": "latest || *",
     "@sentry/node": "latest || *",
     "@trpc/server": "10.45.2",
@@ -19,7 +20,7 @@
     "@types/node": "^18.19.1",
     "express": "^4.21.2",
     "typescript": "~5.0.0",
-    "zod": "~3.22.4"
+    "zod": "~3.24.3"
   },
   "devDependencies": {
     "@playwright/test": "~1.50.0",

--- a/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
@@ -19,9 +19,12 @@ import { TRPCError, initTRPC } from '@trpc/server';
 import * as trpcExpress from '@trpc/server/adapters/express';
 import express from 'express';
 import { z } from 'zod';
+import { mcpRouter } from './mcp';
 
 const app = express();
 const port = 3030;
+
+app.use(mcpRouter);
 
 app.get('/test-success', function (req, res) {
   res.send({ version: 'v1' });

--- a/dev-packages/e2e-tests/test-applications/node-express/src/mcp.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/mcp.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { z } from 'zod';
+import { wrapMcpServerWithSentry } from '@sentry/core';
+
+const mcpRouter = express.Router();
+
+const server = wrapMcpServerWithSentry(
+  new McpServer({
+    name: 'Echo',
+    version: '1.0.0',
+  }),
+);
+
+server.resource('echo', new ResourceTemplate('echo://{message}', { list: undefined }), async (uri, { message }) => ({
+  contents: [
+    {
+      uri: uri.href,
+      text: `Resource echo: ${message}`,
+    },
+  ],
+}));
+
+server.tool('echo', { message: z.string() }, async ({ message }, rest) => {
+  return {
+    content: [{ type: 'text', text: `Tool echo: ${message}` }],
+  };
+});
+
+server.prompt('echo', { message: z.string() }, ({ message }, extra) => ({
+  messages: [
+    {
+      role: 'user',
+      content: {
+        type: 'text',
+        text: `Please process this message: ${message}`,
+      },
+    },
+  ],
+}));
+
+const transports: Record<string, SSEServerTransport> = {};
+
+mcpRouter.get('/sse', async (_, res) => {
+  const transport = new SSEServerTransport('/messages', res);
+  transports[transport.sessionId] = transport;
+  res.on('close', () => {
+    delete transports[transport.sessionId];
+  });
+  await server.connect(transport);
+});
+
+mcpRouter.post('/messages', async (req, res) => {
+  const sessionId = req.query.sessionId;
+  const transport = transports[sessionId as string];
+  if (transport) {
+    await transport.handlePostMessage(req, res);
+  } else {
+    res.status(400).send('No transport found for sessionId');
+  }
+});
+
+export { mcpRouter };

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/mcp.test.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+
+test.only('Should record transactions for mcp handlers', async ({ baseURL }) => {
+  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
+
+  const client = new Client({
+    name: 'test-client',
+    version: '1.0.0',
+  });
+
+  await client.connect(transport);
+
+  await test.step('tool handler', async () => {
+    const postTransactionPromise = waitForTransaction('node-express', transactionEvent => {
+      return transactionEvent.transaction === 'POST /messages';
+    });
+    const toolTransactionPromise = waitForTransaction('node-express', transactionEvent => {
+      return transactionEvent.transaction === 'mcp-server/tool:echo';
+    });
+
+    const toolResult = await client.callTool({
+      name: 'echo',
+      arguments: {
+        message: 'foobar',
+      },
+    });
+
+    expect(toolResult).toMatchObject({
+      content: [
+        {
+          text: 'Tool echo: foobar',
+          type: 'text',
+        },
+      ],
+    });
+
+    const postTransaction = await postTransactionPromise;
+    expect(postTransaction).toBeDefined();
+
+    const toolTransaction = await toolTransactionPromise;
+    expect(toolTransaction).toBeDefined();
+
+    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+  });
+
+  await test.step('resource handler', async () => {
+    const postTransactionPromise = waitForTransaction('node-express', transactionEvent => {
+      return transactionEvent.transaction === 'POST /messages';
+    });
+    const resourceTransactionPromise = waitForTransaction('node-express', transactionEvent => {
+      return transactionEvent.transaction === 'mcp-server/resource:echo';
+    });
+
+    const resourceResult = await client.readResource({
+      uri: 'echo://foobar',
+    });
+
+    expect(resourceResult).toMatchObject({
+      contents: [{ text: 'Resource echo: foobar', uri: 'echo://foobar' }],
+    });
+
+    const postTransaction = await postTransactionPromise;
+    expect(postTransaction).toBeDefined();
+
+    const resourceTransaction = await resourceTransactionPromise;
+    expect(resourceTransaction).toBeDefined();
+
+    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+  });
+
+  await test.step('prompt handler', async () => {
+    const postTransactionPromise = waitForTransaction('node-express', transactionEvent => {
+      return transactionEvent.transaction === 'POST /messages';
+    });
+    const promptTransactionPromise = waitForTransaction('node-express', transactionEvent => {
+      return transactionEvent.transaction === 'mcp-server/prompt:echo';
+    });
+
+    const promptResult = await client.getPrompt({
+      name: 'echo',
+      arguments: {
+        message: 'foobar',
+      },
+    });
+
+    expect(promptResult).toMatchObject({
+      messages: [
+        {
+          content: {
+            text: 'Please process this message: foobar',
+            type: 'text',
+          },
+          role: 'user',
+        },
+      ],
+    });
+
+    const postTransaction = await postTransactionPromise;
+    expect(postTransaction).toBeDefined();
+
+    const promptTransaction = await promptTransactionPromise;
+    expect(promptTransaction).toBeDefined();
+
+    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/mcp.test.ts
@@ -3,7 +3,7 @@ import { waitForTransaction } from '@sentry-internal/test-utils';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 
-test.only('Should record transactions for mcp handlers', async ({ baseURL }) => {
+test('Should record transactions for mcp handlers', async ({ baseURL }) => {
   const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
 
   const client = new Client({

--- a/dev-packages/e2e-tests/test-applications/node-express/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/node-express/tsconfig.json
@@ -4,7 +4,8 @@
     "esModuleInterop": true,
     "lib": ["es2020"],
     "strict": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -4,8 +4,17 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from './semanticAttributes';
-import { startSpan } from './tracing';
+import { startSpan, withActiveSpan } from './tracing';
+import type { Span } from './types-hoist/span';
 import { logger } from './utils-hoist/logger';
+import { getActiveSpan } from './utils/spanUtils';
+
+interface MCPTransport {
+  // The first argument is a JSON RPC message
+  onmessage?: (...args: unknown[]) => void;
+  onclose?: (...args: unknown[]) => void;
+  sessionId?: string;
+}
 
 interface MCPServerInstance {
   // The first arg is always a name, the last arg should always be a callback function (ie a handler).
@@ -15,6 +24,7 @@ interface MCPServerInstance {
   tool: (name: string, ...args: unknown[]) => void;
   // The first arg is always a name, the last arg should always be a callback function (ie a handler).
   prompt: (name: string, ...args: unknown[]) => void;
+  connect(transport: MCPTransport): Promise<void>;
 }
 
 const wrappedMcpServerInstances = new WeakSet();
@@ -35,6 +45,59 @@ export function wrapMcpServerWithSentry<S extends object>(mcpServerInstance: S):
     return mcpServerInstance;
   }
 
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  mcpServerInstance.connect = new Proxy(mcpServerInstance.connect, {
+    apply(target, thisArg, argArray) {
+      const [transport, ...restArgs] = argArray as [MCPTransport, ...unknown[]];
+
+      if (!transport.onclose) {
+        transport.onclose = () => {
+          if (transport.sessionId) {
+            handleTransportOnClose(transport.sessionId);
+          }
+        };
+      }
+
+      if (!transport.onmessage) {
+        transport.onmessage = jsonRpcMessage => {
+          if (transport.sessionId && isJsonRPCMessageWithRequestId(jsonRpcMessage)) {
+            handleTransportOnMessage(transport.sessionId, jsonRpcMessage.id);
+          }
+        };
+      }
+
+      const patchedTransport = new Proxy(transport, {
+        set(target, key, value) {
+          if (key === 'onmessage') {
+            target[key] = new Proxy(value, {
+              apply(onMessageTarget, onMessageThisArg, onMessageArgArray) {
+                const [jsonRpcMessage] = onMessageArgArray;
+                if (transport.sessionId && isJsonRPCMessageWithRequestId(jsonRpcMessage)) {
+                  handleTransportOnMessage(transport.sessionId, jsonRpcMessage.id);
+                }
+                return Reflect.apply(onMessageTarget, onMessageThisArg, onMessageArgArray);
+              },
+            });
+          } else if (key === 'onclose') {
+            target[key] = new Proxy(value, {
+              apply(onCloseTarget, onCloseThisArg, onCloseArgArray) {
+                if (transport.sessionId) {
+                  handleTransportOnClose(transport.sessionId);
+                }
+                return Reflect.apply(onCloseTarget, onCloseThisArg, onCloseArgArray);
+              },
+            });
+          } else {
+            target[key as keyof MCPTransport] = value;
+          }
+          return true;
+        },
+      });
+
+      return Reflect.apply(target, thisArg, [patchedTransport, ...restArgs]);
+    },
+  });
+
   mcpServerInstance.resource = new Proxy(mcpServerInstance.resource, {
     apply(target, thisArg, argArray) {
       const resourceName: unknown = argArray[0];
@@ -44,19 +107,28 @@ export function wrapMcpServerWithSentry<S extends object>(mcpServerInstance: S):
         return target.apply(thisArg, argArray);
       }
 
-      return startSpan(
-        {
-          name: `mcp-server/resource:${resourceName}`,
-          forceTransaction: true,
-          attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'auto.function.mcp-server',
-            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.mcp-server',
-            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
-            'mcp_server.resource': resourceName,
-          },
+      const wrappedResourceHandler = new Proxy(resourceHandler, {
+        apply(resourceHandlerTarget, resourceHandlerThisArg, resourceHandlerArgArray) {
+          const extraHandlerDataWithRequestId = resourceHandlerArgArray.find(isExtraHandlerDataWithRequestId);
+          return associateContextWithRequestSpan(extraHandlerDataWithRequestId, () => {
+            return startSpan(
+              {
+                name: `mcp-server/resource:${resourceName}`,
+                forceTransaction: true,
+                attributes: {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'auto.function.mcp-server',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.mcp-server',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+                  'mcp_server.resource': resourceName,
+                },
+              },
+              () => resourceHandlerTarget.apply(resourceHandlerThisArg, resourceHandlerArgArray),
+            );
+          });
         },
-        () => target.apply(thisArg, argArray),
-      );
+      });
+
+      return Reflect.apply(target, thisArg, [...argArray.slice(0, -1), wrappedResourceHandler]);
     },
   });
 
@@ -69,19 +141,28 @@ export function wrapMcpServerWithSentry<S extends object>(mcpServerInstance: S):
         return target.apply(thisArg, argArray);
       }
 
-      return startSpan(
-        {
-          name: `mcp-server/tool:${toolName}`,
-          forceTransaction: true,
-          attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'auto.function.mcp-server',
-            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.mcp-server',
-            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
-            'mcp_server.tool': toolName,
-          },
+      const wrappedToolHandler = new Proxy(toolHandler, {
+        apply(toolHandlerTarget, toolHandlerThisArg, toolHandlerArgArray) {
+          const extraHandlerDataWithRequestId = toolHandlerArgArray.find(isExtraHandlerDataWithRequestId);
+          return associateContextWithRequestSpan(extraHandlerDataWithRequestId, () => {
+            return startSpan(
+              {
+                name: `mcp-server/tool:${toolName}`,
+                forceTransaction: true,
+                attributes: {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'auto.function.mcp-server',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.mcp-server',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+                  'mcp_server.tool': toolName,
+                },
+              },
+              () => toolHandlerTarget.apply(toolHandlerThisArg, toolHandlerArgArray),
+            );
+          });
         },
-        () => target.apply(thisArg, argArray),
-      );
+      });
+
+      return Reflect.apply(target, thisArg, [...argArray.slice(0, -1), wrappedToolHandler]);
     },
   });
 
@@ -94,19 +175,28 @@ export function wrapMcpServerWithSentry<S extends object>(mcpServerInstance: S):
         return target.apply(thisArg, argArray);
       }
 
-      return startSpan(
-        {
-          name: `mcp-server/resource:${promptName}`,
-          forceTransaction: true,
-          attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'auto.function.mcp-server',
-            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.mcp-server',
-            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
-            'mcp_server.prompt': promptName,
-          },
+      const wrappedPromptHandler = new Proxy(promptHandler, {
+        apply(promptHandlerTarget, promptHandlerThisArg, promptHandlerArgArray) {
+          const extraHandlerDataWithRequestId = promptHandlerArgArray.find(isExtraHandlerDataWithRequestId);
+          return associateContextWithRequestSpan(extraHandlerDataWithRequestId, () => {
+            return startSpan(
+              {
+                name: `mcp-server/prompt:${promptName}`,
+                forceTransaction: true,
+                attributes: {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'auto.function.mcp-server',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.mcp-server',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+                  'mcp_server.prompt': promptName,
+                },
+              },
+              () => promptHandlerTarget.apply(promptHandlerThisArg, promptHandlerArgArray),
+            );
+          });
         },
-        () => target.apply(thisArg, argArray),
-      );
+      });
+
+      return Reflect.apply(target, thisArg, [...argArray.slice(0, -1), wrappedPromptHandler]);
     },
   });
 
@@ -124,6 +214,79 @@ function isMcpServerInstance(mcpServerInstance: unknown): mcpServerInstance is M
     'tool' in mcpServerInstance &&
     typeof mcpServerInstance.tool === 'function' &&
     'prompt' in mcpServerInstance &&
-    typeof mcpServerInstance.prompt === 'function'
+    typeof mcpServerInstance.prompt === 'function' &&
+    'connect' in mcpServerInstance &&
+    typeof mcpServerInstance.connect === 'function'
   );
+}
+
+function isJsonRPCMessageWithRequestId(target: unknown): target is { id: RequestId } {
+  return (
+    typeof target === 'object' &&
+    target !== null &&
+    'id' in target &&
+    (typeof target.id === 'number' || typeof target.id === 'string')
+  );
+}
+
+interface ExtraHandlerDataWithRequestId {
+  sessionId: SessionId;
+  requestId: RequestId;
+}
+
+// Note that not all versions of the MCP library have `requestId` as a field on the extra data.
+function isExtraHandlerDataWithRequestId(target: unknown): target is ExtraHandlerDataWithRequestId {
+  return (
+    typeof target === 'object' &&
+    target !== null &&
+    'sessionId' in target &&
+    typeof target.sessionId === 'string' &&
+    'requestId' in target &&
+    (typeof target.requestId === 'number' || typeof target.requestId === 'string')
+  );
+}
+
+type SessionId = string;
+type RequestId = string | number;
+
+const sessionAndRequestToRequestParentSpanMap = new Map<SessionId, Map<RequestId, Span>>();
+
+function handleTransportOnClose(sessionId: SessionId): void {
+  sessionAndRequestToRequestParentSpanMap.delete(sessionId);
+}
+
+function handleTransportOnMessage(sessionId: SessionId, requestId: RequestId): void {
+  const activeSpan = getActiveSpan();
+  if (activeSpan) {
+    const requestIdToSpanMap = sessionAndRequestToRequestParentSpanMap.get(sessionId) ?? new Map();
+    requestIdToSpanMap.set(requestId, activeSpan);
+    sessionAndRequestToRequestParentSpanMap.set(sessionId, requestIdToSpanMap);
+  }
+}
+
+function associateContextWithRequestSpan<T>(
+  extraHandlerData: ExtraHandlerDataWithRequestId | undefined,
+  cb: () => T,
+): T {
+  if (extraHandlerData) {
+    const { sessionId, requestId } = extraHandlerData;
+    const requestIdSpanMap = sessionAndRequestToRequestParentSpanMap.get(sessionId);
+
+    if (!requestIdSpanMap) {
+      return cb();
+    }
+
+    const span = requestIdSpanMap.get(requestId);
+    if (!span) {
+      return cb();
+    }
+
+    // remove the span from the map so it can be garbage collected
+    requestIdSpanMap.delete(requestId);
+    return withActiveSpan(span, () => {
+      return cb();
+    });
+  }
+
+  return cb();
 }


### PR DESCRIPTION
This PR adds a best effor mechanism to associate handler spans for `resource`, `tool` and `prompt` with the incoming message requests instead of the outgoing SSE response.

The work is based on the upstream PR which exposes the request id on the handler metadata: https://github.com/modelcontextprotocol/typescript-sdk/pull/358

This PR actually also fixes a bug where we were instrumenting the registering of the handler instead of the actual handler 🤦‍♂️.

One thing to note in this PR is that it has a risk of being slightly memory leaky. We are storing away spans by session and request id and cleaning them up when they are used. In the case of long lived sessions the span will not be garbage collected for a long time. There is unfortunately no way of doing a weak reference because session id and request ids are primitives and the framework doesn't give us any identity objects to cross-reference stuff with.