### PR TITLE
feat: Export `wrapMcpServerWithSentry` from server packages

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -132,6 +132,7 @@ export {
   profiler,
   logger,
   consoleLoggingIntegration,
+  wrapMcpServerWithSentry,
 } from '@sentry/node';
 
 export { init } from './server/sdk';

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -118,6 +118,7 @@ export {
   vercelAIIntegration,
   logger,
   consoleLoggingIntegration,
+  wrapMcpServerWithSentry,
 } from '@sentry/node';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -137,6 +137,7 @@ export {
   logger,
   consoleLoggingIntegration,
   createSentryWinstonTransport,
+  wrapMcpServerWithSentry,
 } from '@sentry/node';
 
 export {

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -88,6 +88,7 @@ export {
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,
+  wrapMcpServerWithSentry,
 } from '@sentry/core';
 
 export { withSentry } from './handler';

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -85,6 +85,7 @@ export {
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,
+  wrapMcpServerWithSentry,
 } from '@sentry/core';
 
 export { DenoClient } from './client';

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -118,6 +118,7 @@ export {
   vercelAIIntegration,
   logger,
   consoleLoggingIntegration,
+  wrapMcpServerWithSentry,
 } from '@sentry/node';
 
 export {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -134,6 +134,7 @@ export {
   profiler,
   consoleLoggingIntegration,
   consoleIntegration,
+  wrapMcpServerWithSentry,
 } from '@sentry/core';
 
 export type {

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -87,6 +87,7 @@ export {
   spanToJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
+  wrapMcpServerWithSentry,
 } from '@sentry/core';
 
 export { VercelEdgeClient } from './client';


### PR DESCRIPTION
Exports the `wrapMcpServerWithSentry` which is our MCP server instrumentation from all the server packages.

Fixes https://github.com/getsentry/sentry-javascript/issues/16111