### PR TITLE
ref(nextjs): Prefer `esm/index.server.js` over CJS version

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -43,8 +43,8 @@
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"
       },
-      "node": "./build/cjs/index.server.js",
-      "import": "./build/esm/index.server.js"
+      "import": "./build/esm/index.server.js",
+      "node": "./build/cjs/index.server.js"
     },
     "./async-storage-shim": {
       "import": {


### PR DESCRIPTION
This makes bundlers prefer the ESM version of `index.server.js`, for better tree shaking.

The ESM versions are already listed first for the edge versions