### PR TITLE
test(e2e): Pin `@shopify/mini-oxygen` to 3.2.0 to fix build error

### DIFF
--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/package.json
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/package.json
@@ -36,7 +36,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@shopify/cli": "^3.74.1",
     "@shopify/hydrogen-codegen": "^0.3.1",
-    "@shopify/mini-oxygen": "^3.1.1",
+    "@shopify/mini-oxygen": "3.2.0",
     "@shopify/oxygen-workers-types": "^4.1.2",
     "@shopify/prettier-config": "^1.1.2",
     "@tailwindcss/vite": "4.0.0-alpha.17",

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -6,8 +6,8 @@ import {
 } from './semanticAttributes';
 import { startSpan, withActiveSpan } from './tracing';
 import type { Span } from './types-hoist/span';
-import { logger } from './utils-hoist/logger';
 import { getActiveSpan } from './utils/spanUtils';
+import { logger } from './utils-hoist/logger';
 
 interface MCPTransport {
   // The first argument is a JSON RPC message


### PR DESCRIPTION
Seems like `@shopify/mini-oxygen@3.2.1` breaks something. I somewhat suspect that they bumped a vite version but I didn't find a changelog yet

This should unblock the PRs we want to include in Today's release

Update: https://github.com/Shopify/hydrogen/pull/2863 likely caused this