### PR TITLE
test(node): Remove `axios` in favor of using `fetch`

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -39,7 +39,6 @@
     "ai": "^4.0.6",
     "amqplib": "^0.10.7",
     "apollo-server": "^3.11.1",
-    "axios": "^1.7.7",
     "body-parser": "^1.20.3",
     "connect": "^3.7.0",
     "cors": "^2.8.5",

--- a/dev-packages/node-integration-tests/suites/express-v5/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/tracing/test.ts
@@ -161,7 +161,12 @@ describe('express tracing', () => {
           })
           .start();
 
-        runner.makeRequest('post', '/test-post', { data: { foo: 'bar', other: 1 } });
+        runner.makeRequest('post', '/test-post', {
+          data: JSON.stringify({ foo: 'bar', other: 1 }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
         await runner.completed();
       });
 

--- a/dev-packages/node-integration-tests/suites/express-v5/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/tracing/test.ts
@@ -79,8 +79,8 @@ describe('express tracing', () => {
 
     test.each([['array1'], ['array5']])(
       'should set a correct transaction name for routes consisting of arrays of routes for %p',
-      ((segment: string, done: () => void) => {
-        createRunner(__dirname, 'server.js')
+      async (segment: string) => {
+        const runner = await createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
               transaction: 'GET /test/array1,/\\/test\\/array[2-9]/',
@@ -101,9 +101,10 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done)
-          .makeRequest('get', `/test/${segment}`);
-      }) as any,
+          .start();
+        await runner.makeRequest('get', `/test/${segment}`);
+        await runner.completed();
+      },
     );
 
     test.each([
@@ -113,8 +114,8 @@ describe('express tracing', () => {
       ['arr/requiredPath'],
       ['arr/required/lastParam'],
       ['arr55/required/lastParam'],
-    ])('should handle more complex regexes in route arrays correctly for %p', ((segment: string, done: () => void) => {
-      createRunner(__dirname, 'server.js')
+    ])('should handle more complex regexes in route arrays correctly for %p', async (segment: string) => {
+      const runner = await createRunner(__dirname, 'server.js')
         .expect({
           transaction: {
             transaction: 'GET /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?/',
@@ -135,9 +136,10 @@ describe('express tracing', () => {
             },
           },
         })
-        .start(done)
-        .makeRequest('get', `/test/${segment}`);
-    }) as any);
+        .start();
+      await runner.makeRequest('get', `/test/${segment}`);
+      await runner.completed();
+    });
 
     describe('request data', () => {
       test('correctly captures JSON request data', async () => {

--- a/dev-packages/node-integration-tests/suites/express-v5/without-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/without-tracing/test.ts
@@ -54,7 +54,12 @@ describe('express without tracing', () => {
         })
         .start();
 
-      runner.makeRequest('post', '/test-post', { data: { foo: 'bar', other: 1 } });
+      runner.makeRequest('post', '/test-post', {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: JSON.stringify({ foo: 'bar', other: 1 }),
+      });
       await runner.completed();
     });
 

--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -80,8 +80,8 @@ describe('express tracing', () => {
 
     test.each([['array1'], ['array5']])(
       'should set a correct transaction name for routes consisting of arrays of routes for %p',
-      ((segment: string, done: () => void) => {
-        createRunner(__dirname, 'server.js')
+      async (segment: string) => {
+        const runner = await createRunner(__dirname, 'server.js')
           .expect({
             transaction: {
               transaction: 'GET /test/array1,/\\/test\\/array[2-9]/',
@@ -102,9 +102,10 @@ describe('express tracing', () => {
               },
             },
           })
-          .start(done)
-          .makeRequest('get', `/test/${segment}`);
-      }) as any,
+          .start();
+        await runner.makeRequest('get', `/test/${segment}`);
+        await runner.completed();
+      },
     );
 
     test.each([
@@ -116,8 +117,8 @@ describe('express tracing', () => {
       ['arr55/required/lastParam'],
       ['arr/requiredPath/optionalPath/'],
       ['arr/requiredPath/optionalPath/lastParam'],
-    ])('should handle more complex regexes in route arrays correctly for %p', ((segment: string, done: () => void) => {
-      createRunner(__dirname, 'server.js')
+    ])('should handle more complex regexes in route arrays correctly for %p', async (segment: string) => {
+      const runner = await createRunner(__dirname, 'server.js')
         .expect({
           transaction: {
             transaction: 'GET /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?/',
@@ -138,9 +139,10 @@ describe('express tracing', () => {
             },
           },
         })
-        .start(done)
-        .makeRequest('get', `/test/${segment}`);
-    }) as any);
+        .start();
+      await runner.makeRequest('get', `/test/${segment}`);
+      await runner.completed();
+    });
 
     describe('request data', () => {
       test('correctly captures JSON request data', async () => {

--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -164,7 +164,12 @@ describe('express tracing', () => {
           })
           .start();
 
-        runner.makeRequest('post', '/test-post', { data: { foo: 'bar', other: 1 } });
+        runner.makeRequest('post', '/test-post', {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: JSON.stringify({ foo: 'bar', other: 1 }),
+        });
         await runner.completed();
       });
 

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/test.ts
@@ -54,7 +54,12 @@ describe('express without tracing', () => {
         })
         .start();
 
-      runner.makeRequest('post', '/test-post', { data: { foo: 'bar', other: 1 } });
+      runner.makeRequest('post', '/test-post', {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: JSON.stringify({ foo: 'bar', other: 1 }),
+      });
       await runner.completed();
     });
 

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/test.ts
@@ -12,15 +12,14 @@ describe('getTraceMetaTags', () => {
 
     const runner = createRunner(__dirname, 'server.js').start();
 
-    const response = await runner.makeRequest('get', '/test', {
+    const response = await runner.makeRequest<{ response: string }>('get', '/test', {
       headers: {
         'sentry-trace': `${traceId}-${parentSpanId}-1`,
         baggage: 'sentry-environment=production,sentry-sample_rand=0.42',
       },
     });
 
-    // @ts-ignore - response is defined, types just don't reflect it
-    const html = response?.response as unknown as string;
+    const html = response?.response;
 
     expect(html).toMatch(/<meta name="sentry-trace" content="cd7ee7a6fe3ebe7ab9c3271559bc203c-[a-z0-9]{16}-1"\/>/);
     expect(html).toContain('<meta name="baggage" content="sentry-environment=production,sentry-sample_rand=0.42"/>');
@@ -29,12 +28,11 @@ describe('getTraceMetaTags', () => {
   test('injects <meta> tags with new trace if no incoming headers', async () => {
     const runner = createRunner(__dirname, 'server.js').start();
 
-    const response = await runner.makeRequest('get', '/test');
+    const response = await runner.makeRequest<{ response: string }>('get', '/test');
 
-    // @ts-ignore - response is defined, types just don't reflect it
-    const html = response?.response as unknown as string;
+    const html = response?.response;
 
-    const traceId = html.match(/<meta name="sentry-trace" content="([a-z0-9]{32})-[a-z0-9]{16}-1"\/>/)?.[1];
+    const traceId = html?.match(/<meta name="sentry-trace" content="([a-z0-9]{32})-[a-z0-9]{16}-1"\/>/)?.[1];
     expect(traceId).not.toBeUndefined();
 
     expect(html).toContain('<meta name="baggage"');
@@ -44,12 +42,11 @@ describe('getTraceMetaTags', () => {
   test('injects <meta> tags with negative sampling decision if tracesSampleRate is 0', async () => {
     const runner = createRunner(__dirname, 'server-tracesSampleRate-zero.js').start();
 
-    const response = await runner.makeRequest('get', '/test');
+    const response = await runner.makeRequest<{ response: string }>('get', '/test');
 
-    // @ts-ignore - response is defined, types just don't reflect it
-    const html = response?.response as unknown as string;
+    const html = response?.response;
 
-    const traceId = html.match(/<meta name="sentry-trace" content="([a-z0-9]{32})-[a-z0-9]{16}-0"\/>/)?.[1];
+    const traceId = html?.match(/<meta name="sentry-trace" content="([a-z0-9]{32})-[a-z0-9]{16}-0"\/>/)?.[1];
     expect(traceId).not.toBeUndefined();
 
     expect(html).toContain('<meta name="baggage"');
@@ -63,15 +60,14 @@ describe('getTraceMetaTags', () => {
 
     const runner = createRunner(__dirname, 'server-sdk-disabled.js').start();
 
-    const response = await runner.makeRequest('get', '/test', {
+    const response = await runner.makeRequest<{ response: string }>('get', '/test', {
       headers: {
         'sentry-trace': `${traceId}-${parentSpanId}-1`,
         baggage: 'sentry-environment=production',
       },
     });
 
-    // @ts-ignore - response is defined, types just don't reflect it
-    const html = response?.response as unknown as string;
+    const html = response?.response;
 
     expect(html).not.toContain('"sentry-trace"');
     expect(html).not.toContain('"baggage"');

--- a/yarn.lock
+++ b/yarn.lock
@@ -10168,7 +10168,7 @@ aws-ssl-profiles@^1.1.1:
   resolved "https://registry.yarnpkg.com/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz#157dd77e9f19b1d123678e93f120e6f193022641"
   integrity sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==
 
-axios@1.8.2, axios@^1.0.0, axios@^1.7.7:
+axios@1.8.2, axios@^1.0.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.2.tgz#fabe06e241dfe83071d4edfbcaa7b1c3a40f7979"
   integrity sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==


### PR DESCRIPTION
This removes usage of `axios` in our node-integration-test runner, in favor of just using `fetch`.