### PR TITLE
feat(cloudflare): Read `SENTRY_RELEASE` from `env`

### DIFF
--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -15,6 +15,7 @@ import type { CloudflareOptions } from './client';
 import { isInstrumented, markAsInstrumented } from './instrument';
 import { wrapRequestHandler } from './request';
 import { init } from './sdk';
+import { getFinalOptions } from './options';
 
 type MethodWrapperOptions = {
   spanName?: string;
@@ -140,7 +141,7 @@ export function instrumentDurableObjectWithSentry<E, T extends DurableObject<E>>
     construct(target, [context, env]) {
       setAsyncLocalStorageAsyncContextStrategy();
 
-      const options = optionsCallback(env);
+      const options = getFinalOptions(optionsCallback(env), env);
 
       const obj = new target(context, env);
 

--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -13,9 +13,9 @@ import type { DurableObject } from 'cloudflare:workers';
 import { setAsyncLocalStorageAsyncContextStrategy } from './async';
 import type { CloudflareOptions } from './client';
 import { isInstrumented, markAsInstrumented } from './instrument';
+import { getFinalOptions } from './options';
 import { wrapRequestHandler } from './request';
 import { init } from './sdk';
-import { getFinalOptions } from './options';
 
 type MethodWrapperOptions = {
   spanName?: string;

--- a/packages/cloudflare/src/handler.ts
+++ b/packages/cloudflare/src/handler.ts
@@ -9,6 +9,7 @@ import {
 import { setAsyncLocalStorageAsyncContextStrategy } from './async';
 import type { CloudflareOptions } from './client';
 import { isInstrumented, markAsInstrumented } from './instrument';
+import { getFinalOptions } from './options';
 import { wrapRequestHandler } from './request';
 import { addCloudResourceContext } from './scope-utils';
 import { init } from './sdk';
@@ -35,9 +36,8 @@ export function withSentry<Env = unknown, QueueHandlerMessage = unknown, CfHostM
       handler.fetch = new Proxy(handler.fetch, {
         apply(target, thisArg, args: Parameters<ExportedHandlerFetchHandler<Env, CfHostMetadata>>) {
           const [request, env, context] = args;
-          const callbackOptions = optionsCallback(env);
 
-          const options = { ...getOptionsFromEnv(env), ...callbackOptions };
+          const options = getFinalOptions(optionsCallback(env), env);
 
           return wrapRequestHandler({ options, request, context }, () => target.apply(thisArg, args));
         },
@@ -51,9 +51,7 @@ export function withSentry<Env = unknown, QueueHandlerMessage = unknown, CfHostM
         apply(target, thisArg, args: Parameters<ExportedHandlerScheduledHandler<Env>>) {
           const [event, env, context] = args;
           return withIsolationScope(isolationScope => {
-            const callbackOptions = optionsCallback(env);
-
-            const options = { ...getOptionsFromEnv(env), ...callbackOptions };
+            const options = getFinalOptions(optionsCallback(env), env);
 
             const client = init(options);
             isolationScope.setClient(client);
@@ -96,14 +94,4 @@ export function withSentry<Env = unknown, QueueHandlerMessage = unknown, CfHostM
   }
 
   return handler;
-}
-
-function getOptionsFromEnv(env: unknown): CloudflareOptions {
-  if (typeof env !== 'object' || env === null) {
-    return {};
-  }
-
-  return {
-    release: 'SENTRY_RELEASE' in env && typeof env.SENTRY_RELEASE === 'string' ? env.SENTRY_RELEASE : undefined,
-  };
 }

--- a/packages/cloudflare/src/options.ts
+++ b/packages/cloudflare/src/options.ts
@@ -1,0 +1,23 @@
+import type { CloudflareOptions } from './client';
+
+/**
+ * Merges the options passed in from the user with the options we read from
+ * the Cloudflare `env` environment variable object.
+ *
+ * @param userOptions - The options passed in from the user.
+ * @param env - The environment variables.
+ *
+ * @returns The final options.
+ */
+export function getFinalOptions(userOptions: CloudflareOptions, env: unknown): CloudflareOptions {
+  function getOptionsFromEnv(env: unknown): CloudflareOptions {
+    if (typeof env !== 'object' || env === null) {
+      return {};
+    }
+
+    return {
+      release: 'SENTRY_RELEASE' in env && typeof env.SENTRY_RELEASE === 'string' ? env.SENTRY_RELEASE : undefined,
+    };
+  }
+  return { ...getOptionsFromEnv(env), ...userOptions };
+}

--- a/packages/cloudflare/src/options.ts
+++ b/packages/cloudflare/src/options.ts
@@ -10,14 +10,11 @@ import type { CloudflareOptions } from './client';
  * @returns The final options.
  */
 export function getFinalOptions(userOptions: CloudflareOptions, env: unknown): CloudflareOptions {
-  function getOptionsFromEnv(env: unknown): CloudflareOptions {
-    if (typeof env !== 'object' || env === null) {
-      return {};
-    }
-
-    return {
-      release: 'SENTRY_RELEASE' in env && typeof env.SENTRY_RELEASE === 'string' ? env.SENTRY_RELEASE : undefined,
-    };
+  if (typeof env !== 'object' || env === null) {
+    return userOptions;
   }
-  return { ...getOptionsFromEnv(env), ...userOptions };
+
+  const release = 'SENTRY_RELEASE' in env && typeof env.SENTRY_RELEASE === 'string' ? env.SENTRY_RELEASE : undefined;
+
+  return { release, ...userOptions };
 }

--- a/packages/cloudflare/test/options.test.ts
+++ b/packages/cloudflare/test/options.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { getFinalOptions } from '../src/options';
+
+describe('getFinalOptions', () => {
+  it('returns user options when env is not an object', () => {
+    const userOptions = { dsn: 'test-dsn', release: 'test-release' };
+    const env = 'not-an-object';
+
+    const result = getFinalOptions(userOptions, env);
+
+    expect(result).toEqual(userOptions);
+  });
+
+  it('returns user options when env is null', () => {
+    const userOptions = { dsn: 'test-dsn', release: 'test-release' };
+    const env = null;
+
+    const result = getFinalOptions(userOptions, env);
+
+    expect(result).toEqual(userOptions);
+  });
+
+  it('merges options from env with user options', () => {
+    const userOptions = { dsn: 'test-dsn', release: 'user-release' };
+    const env = { SENTRY_RELEASE: 'env-release' };
+
+    const result = getFinalOptions(userOptions, env);
+
+    expect(result).toEqual({ dsn: 'test-dsn', release: 'user-release' });
+  });
+
+  it('uses user options when SENTRY_RELEASE exists but is not a string', () => {
+    const userOptions = { dsn: 'test-dsn', release: 'user-release' };
+    const env = { SENTRY_RELEASE: 123 };
+
+    const result = getFinalOptions(userOptions, env);
+
+    expect(result).toEqual(userOptions);
+  });
+
+  it('uses user options when SENTRY_RELEASE does not exist', () => {
+    const userOptions = { dsn: 'test-dsn', release: 'user-release' };
+    const env = { OTHER_VAR: 'some-value' };
+
+    const result = getFinalOptions(userOptions, env);
+
+    expect(result).toEqual(userOptions);
+  });
+
+  it('takes user options over env options', () => {
+    const userOptions = { dsn: 'test-dsn', release: 'user-release' };
+    const env = { SENTRY_RELEASE: 'env-release' };
+
+    const result = getFinalOptions(userOptions, env);
+
+    expect(result).toEqual(userOptions);
+  });
+});

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
 
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test/options.test.ts"],
 
   "compilerOptions": {
     "module": "esnext",

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
 
-  "include": ["src/**/*", "test/options.test.ts"],
+  "include": ["src/**/*"],
 
   "compilerOptions": {
     "module": "esnext",


### PR DESCRIPTION
This PR enables reading the `SENTRY_RELEASE` variable from the CF `env` that users should pass to their `withSentry` worker wrapper. This is quite similar to how we'd usually access env variables in Node-based SDKs.

We need this for uploading release-based source maps for CF worker functions being bundled and deployed by wrangler.

see https://github.com/getsentry/sentry-wizard/issues/824#issuecomment-2851533722
ref https://linear.app/getsentry/issue/WIZARD-36/improve-sentrywizard-i-sourcemaps-for-cloudflarewrangler
