### PR TITLE
fix(node): Fix vercel flushing logic & add test for it

### DIFF
--- a/dev-packages/node-integration-tests/suites/vercel/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/vercel/instrument.mjs
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+process.env.VERCEL = 'true';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  // We look at debug logs in this test
+  debug: true,
+});

--- a/dev-packages/node-integration-tests/suites/vercel/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/vercel/scenario.mjs
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/node';
+import { startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
+import express from 'express';
+
+const app = express();
+
+app.get('/test/express', (_req, res) => {
+  res.send({ response: 'response 1' });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/vercel/test.ts
+++ b/dev-packages/node-integration-tests/suites/vercel/test.ts
@@ -1,0 +1,53 @@
+import { afterAll, describe, expect } from 'vitest';
+import { cleanupChildProcesses, createEsmAndCjsTests } from '../../utils/runner';
+
+describe('vercel xxx', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('should flush events correctly on Vercel', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'GET /test/express',
+          },
+        })
+        .start();
+      runner.makeRequest('get', '/test/express');
+      await runner.completed();
+
+      const actualLogs = runner.getLogs();
+
+      // We want to test that the following logs are present in this order
+      // other logs may be in between
+      const expectedLogs = [
+        'Sentry Logger [log]: @sentry/instrumentation-http Patching server.emit',
+        'Sentry Logger [log]: @sentry/instrumentation-http Handling incoming request',
+        'Sentry Logger [log]: @sentry/instrumentation-http Patching request.on',
+        'Sentry Logger [debug]: @opentelemetry_sentry-patched/instrumentation-http http instrumentation incomingRequest',
+        'Sentry Logger [log]: [Tracing] Starting sampled root span',
+        // later...
+        'Sentry Logger [log]: Patching response to flush on Vercel',
+        'Sentry Logger [log]: Patching res.end()',
+        // later...
+        'Sentry Logger [log]: Flushing events before Vercel Lambda freeze',
+        'Sentry Logger [log]: SpanExporter exported 4 spans, 0 spans are waiting for their parent spans to finish',
+      ];
+
+      // Test that the order of logs is correct
+      for (const log of actualLogs) {
+        if (expectedLogs.length === 0) {
+          break;
+        }
+
+        if (log === expectedLogs[0]) {
+          expectedLogs.shift();
+        }
+      }
+
+      expect(expectedLogs).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
As pre-work for https://github.com/getsentry/sentry-javascript/pull/16178, actually add a test for this (kind of). This showed that there was actually a fundamental flaw here, as we looked as the `req` not the `res`, oops.