### PR TITLE
fix(logs): Ensure logs can be flushed correctly

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
@@ -13,6 +13,9 @@ Sentry.init({
   debug: !!process.env.DEBUG,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,
+  _experiments: {
+    enableLogs: true,
+  },
 });
 
 import { TRPCError, initTRPC } from '@trpc/server';
@@ -28,6 +31,11 @@ app.use(mcpRouter);
 
 app.get('/test-success', function (req, res) {
   res.send({ version: 'v1' });
+});
+
+app.get('/test-log', function (req, res) {
+  Sentry.logger.debug('Accessed /test-log route');
+  res.send({ message: 'Log sent' });
 });
 
 app.get('/test-param/:param', function (req, res) {

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/logs.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/logs.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+import { waitForEnvelopeItem } from '@sentry-internal/test-utils';
+import type { SerializedLog, SerializedLogContainer } from '@sentry/core';
+
+test('should send logs', async ({ baseURL }) => {
+  const logEnvelopePromise = waitForEnvelopeItem('node-express', envelope => {
+    return envelope[0].type === 'log' && (envelope[1] as SerializedLogContainer).items[0]?.level === 'debug';
+  });
+
+  await fetch(`${baseURL}/test-log`);
+
+  const logEnvelope = await logEnvelopePromise;
+  const log = (logEnvelope[1] as SerializedLogContainer).items[0];
+  expect(log?.level).toBe('debug');
+  expect(log?.body).toBe('Accessed /test-log route');
+});

--- a/packages/core/src/utils-hoist/worldwide.ts
+++ b/packages/core/src/utils-hoist/worldwide.ts
@@ -13,6 +13,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Carrier } from '../carrier';
+import type { Client } from '../client';
+import type { SerializedLog } from '../types-hoist/log';
 import type { SdkSource } from './env';
 
 /** Internal global with common properties and Sentry extensions  */
@@ -35,6 +37,12 @@ export type InternalGlobal = {
     id?: string;
   };
   SENTRY_SDK_SOURCE?: SdkSource;
+  /**
+   * A map of Sentry clients to their log buffers.
+   *
+   * This is used to store logs that are sent to Sentry.
+   */
+  _sentryClientToLogBufferMap?: WeakMap<Client, Array<SerializedLog>>;
   /**
    * Debug IDs are indirectly injected by Sentry CLI or bundler plugins to directly reference a particular source map
    * for resolving of a source file. The injected code will place an entry into the record for each loaded bundle/JS


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/16110

Stores the Client to LogBuffer WeakMap onto the global object so logs can be retrieved correctly during flushing. Previously, the WeakMap reference would be different at flush time, causing no logs to be found for any given client.

Adds an express e2e tests to ensure logs are flushed correctly.