### PR TITLE
fix(test): Make Remix integration tests Node 24 compatible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -760,7 +760,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22]
+        node: [18, 20, 22, 24]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4

--- a/packages/remix/test/integration/test/client/capture-exception.test.ts
+++ b/packages/remix/test/integration/test/client/capture-exception.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 import { getMultipleSentryEnvelopeRequests } from './utils/helpers';
 
 test('should report a manually captured error.', async ({ page }) => {

--- a/packages/remix/test/integration/test/client/capture-message.test.ts
+++ b/packages/remix/test/integration/test/client/capture-message.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 import { getMultipleSentryEnvelopeRequests } from './utils/helpers';
 
 test('should report a manually captured message.', async ({ page }) => {

--- a/packages/remix/test/integration/test/client/click-error.test.ts
+++ b/packages/remix/test/integration/test/client/click-error.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 import { getMultipleSentryEnvelopeRequests } from './utils/helpers';
 
 test('should report a manually captured message on click with the correct stacktrace.', async ({ page }) => {

--- a/packages/remix/test/integration/test/client/errorboundary.test.ts
+++ b/packages/remix/test/integration/test/client/errorboundary.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 import { getMultipleSentryEnvelopeRequests } from './utils/helpers';
 
 test('should capture React component errors.', async ({ page }) => {

--- a/packages/remix/test/integration/test/client/manualtracing.test.ts
+++ b/packages/remix/test/integration/test/client/manualtracing.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 import { getMultipleSentryEnvelopeRequests } from './utils/helpers';
 
 test('should report a manually created / finished transaction.', async ({ page }) => {

--- a/packages/remix/test/integration/test/client/meta-tags.test.ts
+++ b/packages/remix/test/integration/test/client/meta-tags.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 import { getFirstSentryEnvelopeRequest } from './utils/helpers';
 
 test('should inject `sentry-trace` and `baggage` meta tags inside the root page.', async ({ page }) => {

--- a/packages/remix/test/integration/test/client/pageload.test.ts
+++ b/packages/remix/test/integration/test/client/pageload.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 import { getFirstSentryEnvelopeRequest } from './utils/helpers';
 
 test('should add `pageload` transaction on load.', async ({ page }) => {

--- a/packages/remix/test/integration/test/client/root-loader.test.ts
+++ b/packages/remix/test/integration/test/client/root-loader.test.ts
@@ -1,4 +1,4 @@
-import { Page, expect, test } from '@playwright/test';
+import { type Page, expect, test } from '@playwright/test';
 
 async function getRouteData(page: Page): Promise<any> {
   return page.evaluate('window.__remixContext.state.loaderData').catch(err => {

--- a/packages/remix/test/integration/test/server/instrumentation/loader.test.ts
+++ b/packages/remix/test/integration/test/server/instrumentation/loader.test.ts
@@ -1,4 +1,4 @@
-import { Event } from '@sentry/core';
+import type { Event } from '@sentry/core';
 import { describe, expect, it } from 'vitest';
 import { RemixTestEnv, assertSentryEvent, assertSentryTransaction } from '../utils/helpers';
 


### PR DESCRIPTION
Resolves: #16239 

Looks like importing types without `type` fails on Node 24.