### PR TITLE
chore(ci): re-enable Node 24 tests for google-cloud-serverless

### DIFF
--- a/scripts/ci-unit-tests.ts
+++ b/scripts/ci-unit-tests.ts
@@ -29,8 +29,6 @@ const BROWSER_TEST_PACKAGES = [
 // Packages that cannot run in Node 18
 const SKIP_NODE_18_PACKAGES = ['@sentry/react-router'];
 
-const SKIP_NODE_24_PACKAGES = ['@sentry/google-cloud-serverless'];
-
 function getAllPackages(): string[] {
   const { workspaces }: { workspaces: string[] } = JSON.parse(
     fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'),
@@ -64,10 +62,6 @@ function runTests(): void {
 
     if (NODE_VERSION === '18') {
       SKIP_NODE_18_PACKAGES.forEach(pkg => ignores.add(pkg));
-    }
-
-    if (NODE_VERSION === '24') {
-      SKIP_NODE_24_PACKAGES.forEach(pkg => ignores.add(pkg));
     }
   }
 


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/16238

The error with the google cloud serverless tests in Node 24 was only happening in Node `24.0.0`, which was fixed in [`24.0.1`](https://github.com/nodejs/node/releases/tag/v24.0.1), so we can safely re-enable everything.