### PR TITLE
ref(bun): Ensure bun is latest for local tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/esm/warn-esm/test.ts
+++ b/dev-packages/node-integration-tests/suites/esm/warn-esm/test.ts
@@ -5,8 +5,7 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-const esmWarning =
-  '[Sentry] You are using Node.js in ESM mode ("import syntax"). The Sentry Node.js SDK is not compatible with ESM in Node.js versions before 18.19.0 or before 20.6.0. Please either build your application with CommonJS ("require() syntax"), or upgrade your Node.js version.';
+const esmWarning = `[Sentry] You are using Node.js v${process.versions.node} in ESM mode ("import syntax"). The Sentry Node.js SDK is not compatible with ESM in Node.js versions before 18.19.0 or before 20.6.0. Please either build your application with CommonJS ("require() syntax"), or upgrade your Node.js version.`;
 
 test("warns if using ESM on Node.js versions that don't support `register()`", async () => {
   const nodeMajorVersion = Number(process.versions.node.split('.')[0]);

--- a/packages/bun/scripts/install-bun.js
+++ b/packages/bun/scripts/install-bun.js
@@ -10,40 +10,58 @@ const https = require('https');
 const installScriptUrl = 'https://bun.sh/install';
 
 // Check if bun is installed
-exec('bun -version', error => {
+exec('bun -version', (error, version) => {
   if (error) {
     console.error('bun is not installed. Installing...');
-    // Download and execute the installation script
-    https
-      .get(installScriptUrl, res => {
-        if (res.statusCode !== 200) {
-          console.error(`Failed to download the installation script (HTTP ${res.statusCode})`);
-          process.exit(1);
-        }
-
-        res.setEncoding('utf8');
-        let scriptData = '';
-
-        res.on('data', chunk => {
-          scriptData += chunk;
-        });
-
-        res.on('end', () => {
-          // Execute the downloaded script
-          exec(scriptData, installError => {
-            if (installError) {
-              console.error('Failed to install bun:', installError);
-              process.exit(1);
-            }
-            console.log('bun has been successfully installed.');
-          });
-        });
-      })
-      .on('error', e => {
-        console.error('Failed to download the installation script:', e);
-        process.exit(1);
-      });
+    installLatestBun();
   } else {
-    // Bun is installed
+    const versionBefore = version.trim();
+
+    exec('bun upgrade', (error, stdout, stderr) => {
+      if (error) {
+        console.error('Failed to upgrade bun:', error);
+        process.exit(1);
+      }
+
+      const out = [stdout, stderr].join('\n');
+
+      if (out.includes("You're already on the latest version of Bun")) {
+        return;
+      }
+
+      console.log(out);
+    });
   }
 });
+
+function installLatestBun() {
+  https
+    .get(installScriptUrl, res => {
+      if (res.statusCode !== 200) {
+        console.error(`Failed to download the installation script (HTTP ${res.statusCode})`);
+        process.exit(1);
+      }
+
+      res.setEncoding('utf8');
+      let scriptData = '';
+
+      res.on('data', chunk => {
+        scriptData += chunk;
+      });
+
+      res.on('end', () => {
+        // Execute the downloaded script
+        exec(scriptData, installError => {
+          if (installError) {
+            console.error('Failed to install bun:', installError);
+            process.exit(1);
+          }
+          console.log('bun has been successfully installed.');
+        });
+      });
+    })
+    .on('error', e => {
+      console.error('Failed to download the installation script:', e);
+      process.exit(1);
+    });
+}

--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -59,7 +59,7 @@ export function maybeInitializeEsmLoader(): void {
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
       console.warn(
-        '[Sentry] You are using Node.js in ESM mode ("import syntax"). The Sentry Node.js SDK is not compatible with ESM in Node.js versions before 18.19.0 or before 20.6.0. Please either build your application with CommonJS ("require() syntax"), or upgrade your Node.js version.',
+        `[Sentry] You are using Node.js v${process.versions.node} in ESM mode ("import syntax"). The Sentry Node.js SDK is not compatible with ESM in Node.js versions before 18.19.0 or before 20.6.0. Please either build your application with CommonJS ("require() syntax"), or upgrade your Node.js version.`,
       );
     });
   }


### PR DESCRIPTION
I noticed that my bun version locally was old, leading to weird test issues.
Now, our install script will ensure this is the latest version. On CI, we already test against the latest version.

(Noticed this because bun 1.0.2 which I had installed reports itself as Node 18.5.0 which lead to ESM warnings)