### PR TITLE
build: Pin node unit tests to ^24.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,7 +475,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 24]
+        node: [18, 20, 22, '^24.0.1']
     steps:
       - name: Check out base commit (${{ github.event.pull_request.base.sha }})
         uses: actions/checkout@v4


### PR DESCRIPTION
Node [`24.0.1`](https://github.com/nodejs/node/releases/tag/v24.0.1) fixed a bug with our google cloud serverless tests that we were running into in https://github.com/getsentry/sentry-javascript/issues/16238

For some reason CI doesn't want to use it? So pinning to `^24.0.1`.