### PR TITLE
test: Use `%j` instead of `%p` placeholder for vitest

### DIFF
--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -183,7 +183,7 @@ describe('shouldAttachHeaders', () => {
       ['https://my-origin.com?my-query', 'my-query', true],
       ['https://not-my-origin.com?my-query', 'my-query', true],
     ])(
-      'for url %p and tracePropagationTarget %p on page "https://my-origin.com/api/my-route" should return %p',
+      'for url %j and tracePropagationTarget %j on page "https://my-origin.com/api/my-route" should return %j',
       (url, matcher, result) => {
         expect(shouldAttachHeaders(url, [matcher])).toBe(result);
       },
@@ -234,7 +234,7 @@ describe('shouldAttachHeaders', () => {
     'https://not-my-origin.com/api',
     'https://my-origin.com?my-query',
     'https://not-my-origin.com?my-query',
-  ])('should return false for everything if tracePropagationTargets are empty (%p)', url => {
+  ])('should return false for everything if tracePropagationTargets are empty (%j)', url => {
     expect(shouldAttachHeaders(url, [])).toBe(false);
   });
 
@@ -266,7 +266,7 @@ describe('shouldAttachHeaders', () => {
         ['http://localhost:3000', false],
         ['https://somewhere.com/test/localhost/123', false],
         ['https://somewhere.com/test?url=https://my-origin.com', false],
-      ])('for URL %p should return %p', (url, expectedResult) => {
+      ])('for URL %j should return %j', (url, expectedResult) => {
         expect(shouldAttachHeaders(url, undefined)).toBe(expectedResult);
       });
     });
@@ -327,7 +327,7 @@ describe('shouldAttachHeaders', () => {
       ['https://not-my-origin.com/api', 'api', true],
       ['https://my-origin.com?my-query', 'my-query', true],
       ['https://not-my-origin.com?my-query', 'my-query', true],
-    ])('for url %p and tracePropagationTarget %p should return %p', (url, matcher, result) => {
+    ])('for url %j and tracePropagationTarget %j should return %j', (url, matcher, result) => {
       expect(shouldAttachHeaders(url, [matcher])).toBe(result);
     });
   });

--- a/packages/core/test/lib/utils/merge.test.ts
+++ b/packages/core/test/lib/utils/merge.test.ts
@@ -69,7 +69,7 @@ describe('merge', () => {
         a0a: 'a0a',
       },
     ],
-  ])('works with %p and %p', (oldData, newData, expected) => {
+  ])('works with %j and %j', (oldData, newData, expected) => {
     const actual = merge(oldData, newData as any);
     expect(actual).toEqual(expected);
   });

--- a/packages/core/test/lib/utils/parseSampleRate.test.ts
+++ b/packages/core/test/lib/utils/parseSampleRate.test.ts
@@ -17,7 +17,7 @@ describe('parseSampleRate', () => {
     ['1.5', undefined],
     ['0.555', 0.555],
     ['0', 0],
-  ])('works with %p', (input, sampleRate) => {
+  ])('works with %j', (input, sampleRate) => {
     const actual = parseSampleRate(input);
     expect(actual).toBe(sampleRate);
   });

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -11,7 +11,7 @@ describe('httpIntegration', () => {
       [{ spans: false }, { skipOpenTelemetrySetup: true }, false],
       [{}, { skipOpenTelemetrySetup: true }, false],
       [{}, { skipOpenTelemetrySetup: false }, true],
-    ])('returns the correct value for options=%p and clientOptions=%p', (options, clientOptions, expected) => {
+    ])('returns the correct value for options=%j and clientOptions=%j', (options, clientOptions, expected) => {
       const actual = _shouldInstrumentSpans(options, clientOptions);
       expect(actual).toBe(expected);
     });

--- a/packages/opentelemetry/test/utils/spanTypes.test.ts
+++ b/packages/opentelemetry/test/utils/spanTypes.test.ts
@@ -8,7 +8,7 @@ describe('spanTypes', () => {
       [{}, false],
       [{ attributes: null }, false],
       [{ attributes: {} }, true],
-    ])('works with %p', (span, expected) => {
+    ])('works with %j', (span, expected) => {
       const castSpan = span as unknown as Span;
       const actual = spanHasAttributes(castSpan);
 
@@ -27,7 +27,7 @@ describe('spanTypes', () => {
       [{ kind: 0 }, true],
       [{ kind: 5 }, true],
       [{ kind: 'TEST_KIND' }, false],
-    ])('works with %p', (span, expected) => {
+    ])('works with %j', (span, expected) => {
       const castSpan = span as unknown as Span;
       const actual = spanHasKind(castSpan);
 
@@ -44,7 +44,7 @@ describe('spanTypes', () => {
       [{}, false],
       [{ parentSpanId: null }, false],
       [{ parentSpanId: 'TEST_PARENT_ID' }, true],
-    ])('works with %p', (span, expected) => {
+    ])('works with %j', (span, expected) => {
       const castSpan = span as unknown as Span;
       const actual = spanHasParentId(castSpan);
 
@@ -61,7 +61,7 @@ describe('spanTypes', () => {
       [{}, false],
       [{ events: null }, false],
       [{ events: [] }, true],
-    ])('works with %p', (span, expected) => {
+    ])('works with %j', (span, expected) => {
       const castSpan = span as unknown as Span;
       const actual = spanHasEvents(castSpan);
 

--- a/packages/replay-internal/test/unit/coreHandlers/handleBreadcrumbs.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleBreadcrumbs.test.ts
@@ -5,7 +5,7 @@ import { normalizeBreadcrumb, normalizeConsoleBreadcrumb } from '../../../src/co
 describe('Unit | coreHandlers | handleBreadcrumbs', () => {
   describe('normalizeBreadcrumb', () => {
     it.each([undefined, 'ui.click', 'ui.scroll', 'fetch', 'xhr', 'sentry.event', 'sentry.transaction'])(
-      'returns null if breadcrumb has category=%p',
+      'returns null if breadcrumb has category=%j',
       category => {
         const actual = normalizeBreadcrumb({ category });
         expect(actual).toBeNull();

--- a/packages/replay-internal/test/unit/coreHandlers/handleClick.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleClick.test.ts
@@ -509,7 +509,7 @@ describe('Unit | coreHandlers | handleClick', () => {
       ['a', { target: '_blank' }, true],
       ['a', { download: '' }, true],
       ['a', { href: 'xx' }, false],
-    ])('it works with <%s> & %p', (tagName, attributes, expected) => {
+    ])('it works with <%s> & %j', (tagName, attributes, expected) => {
       const node = document.createElement(tagName);
       Object.entries(attributes).forEach(([key, value]) => {
         node.setAttribute(key, value);

--- a/packages/replay-internal/test/unit/util/isSampled.test.ts
+++ b/packages/replay-internal/test/unit/util/isSampled.test.ts
@@ -18,7 +18,7 @@ describe('Unit | util | isSampled', () => {
   const mockRandom = vi.spyOn(Math, 'random');
 
   test.each(cases)(
-    'given sample rate of %p and RNG returns %p, result should be %p',
+    'given sample rate of %j and RNG returns %j, result should be %j',
     (sampleRate: number, mockRandomValue: number, expectedResult: boolean) => {
       mockRandom.mockImplementationOnce(() => mockRandomValue);
       const result = isSampled(sampleRate);

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -328,7 +328,7 @@ describe('instrumentVueRouter()', () => {
     [false, 0],
     [true, 1],
   ])(
-    'should return instrumentation that considers the instrumentPageLoad = %p',
+    'should return instrumentation that considers the instrumentPageLoad = %j',
     (instrumentPageLoad, expectedCallsAmount) => {
       const mockRootSpan = {
         ...MOCK_SPAN,
@@ -368,7 +368,7 @@ describe('instrumentVueRouter()', () => {
     [false, 0],
     [true, 1],
   ])(
-    'should return instrumentation that considers the instrumentNavigation = %p',
+    'should return instrumentation that considers the instrumentNavigation = %j',
     (instrumentNavigation, expectedCallsAmount) => {
       const mockStartSpan = vi.fn().mockReturnValue(MOCK_SPAN);
       instrumentVueRouter(


### PR DESCRIPTION
See https://vitest.dev/api/#test-each, `%p` does not exist there.