### PR TITLE
deps(node): Bump `import-in-the-middle` to `1.13.1`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-turbo/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-turbo/package.json
@@ -35,11 +35,7 @@
     "@sentry/opentelemetry": "latest || *",
     "@sentry/react": "latest || *",
     "@sentry-internal/replay": "latest || *",
-    "@sentry/vercel-edge": "latest || *",
-    "import-in-the-middle": "1.12.0"
-  },
-  "overrides": {
-    "import-in-the-middle": "1.12.0"
+    "@sentry/vercel-edge": "latest || *"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -98,7 +98,7 @@
     "@prisma/instrumentation": "6.7.0",
     "@sentry/core": "9.17.0",
     "@sentry/opentelemetry": "9.17.0",
-    "import-in-the-middle": "^1.13.0"
+    "import-in-the-middle": "^1.13.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17685,10 +17685,10 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^1.13.0, import-in-the-middle@^1.8.1:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.13.0.tgz#e592583c3f53ff29c6079c0af31feab592ac6b2a"
-  integrity sha512-YG86SYDtrL/Yu8JgfWb7kjQ0myLeT1whw6fs/ZHFkXFcbk9zJU9lOCsSJHpvaPumU11nN3US7NW6x1YTk+HrUA==
+import-in-the-middle@^1.13.1, import-in-the-middle@^1.8.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz#789651f9e93dd902a5a306f499ab51eb72b03a12"
+  integrity sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==
   dependencies:
     acorn "^8.14.0"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
See https://github.com/nodejs/import-in-the-middle/releases/tag/import-in-the-middle-v1.13.1

### Bug Fixes

* handling of circular dependencies ([#181](https://github.com/nodejs/import-in-the-middle/issues/181)) ([b58092e](https://github.com/nodejs/import-in-the-middle/commit/b58092ec9becf4a14f541da4cf5bfb190f2a9a9b))
* importing JSON files ([#182](https://github.com/nodejs/import-in-the-middle/issues/182)) ([8c52014](https://github.com/nodejs/import-in-the-middle/commit/8c52014658fcf698cc340d032b441d9e7a65be36))
* warning from use of context.importAssertions ([#179](https://github.com/nodejs/import-in-the-middle/issues/179)) ([8e56cf1](https://github.com/nodejs/import-in-the-middle/commit/8e56cf1e89752e6c8768d648c10c12fb3178e2ae))

This version is already allowed by our range, but in order to ensure everybody gets this, bumping it here.