### PR TITLE
ref(core): Remove duplicate internal `DEBUG_BUILD` constant

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/test.ts
@@ -32,7 +32,6 @@ describe('outgoing http requests with tracing & spans disabled', () => {
 
         await createRunner()
           .withEnv({ SERVER_URL })
-          .ensureNoErrorOutput()
           .expect({
             event: {
               exception: {
@@ -131,7 +130,6 @@ describe('outgoing http requests with tracing & spans disabled', () => {
 
         await createRunner()
           .withEnv({ SERVER_URL })
-          .ensureNoErrorOutput()
           .expect({
             event: {
               exception: {

--- a/packages/core/src/utils-hoist/baggage.ts
+++ b/packages/core/src/utils-hoist/baggage.ts
@@ -1,5 +1,5 @@
 import type { DynamicSamplingContext } from '../types-hoist/envelope';
-import { DEBUG_BUILD } from './debug-build';
+import { DEBUG_BUILD } from './../debug-build';
 import { isString } from './is';
 import { logger } from './logger';
 

--- a/packages/core/src/utils-hoist/debug-build.ts
+++ b/packages/core/src/utils-hoist/debug-build.ts
@@ -1,8 +1,0 @@
-declare const __DEBUG_BUILD__: boolean;
-
-/**
- * This serves as a build time flag that will be true by default, but false in non-debug builds or if users replace `__SENTRY_DEBUG__` in their generated code.
- *
- * ATTENTION: This constant must never cross package boundaries (i.e. be exported) to guarantee that it can be used for tree shaking.
- */
-export const DEBUG_BUILD = __DEBUG_BUILD__;

--- a/packages/core/src/utils-hoist/dsn.ts
+++ b/packages/core/src/utils-hoist/dsn.ts
@@ -1,5 +1,5 @@
 import type { DsnComponents, DsnLike, DsnProtocol } from '../types-hoist/dsn';
-import { DEBUG_BUILD } from './debug-build';
+import { DEBUG_BUILD } from './../debug-build';
 import { consoleSandbox, logger } from './logger';
 
 /** Regular expression used to parse a Dsn. */

--- a/packages/core/src/utils-hoist/instrument/handlers.ts
+++ b/packages/core/src/utils-hoist/instrument/handlers.ts
@@ -1,4 +1,4 @@
-import { DEBUG_BUILD } from '../debug-build';
+import { DEBUG_BUILD } from '../../debug-build';
 import { logger } from '../logger';
 import { getFunctionName } from '../stacktrace';
 

--- a/packages/core/src/utils-hoist/logger.ts
+++ b/packages/core/src/utils-hoist/logger.ts
@@ -1,6 +1,6 @@
 import { getGlobalSingleton } from '../carrier';
 import type { ConsoleLevel } from '../types-hoist/instrument';
-import { DEBUG_BUILD } from './debug-build';
+import { DEBUG_BUILD } from './../debug-build';
 import { GLOBAL_OBJ } from './worldwide';
 
 /** Prefix for logging strings */

--- a/packages/core/src/utils-hoist/object.ts
+++ b/packages/core/src/utils-hoist/object.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { WrappedFunction } from '../types-hoist/wrappedfunction';
-import { htmlTreeAsString } from './browser';
 import { DEBUG_BUILD } from './../debug-build';
+import { htmlTreeAsString } from './browser';
 import { isElement, isError, isEvent, isInstanceOf, isPrimitive } from './is';
 import { logger } from './logger';
 import { truncate } from './string';

--- a/packages/core/src/utils-hoist/object.ts
+++ b/packages/core/src/utils-hoist/object.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { WrappedFunction } from '../types-hoist/wrappedfunction';
 import { htmlTreeAsString } from './browser';
-import { DEBUG_BUILD } from './debug-build';
+import { DEBUG_BUILD } from './../debug-build';
 import { isElement, isError, isEvent, isInstanceOf, isPrimitive } from './is';
 import { logger } from './logger';
 import { truncate } from './string';

--- a/packages/core/src/utils-hoist/supports.ts
+++ b/packages/core/src/utils-hoist/supports.ts
@@ -1,4 +1,4 @@
-import { DEBUG_BUILD } from './debug-build';
+import { DEBUG_BUILD } from './../debug-build';
 import { logger } from './logger';
 import { GLOBAL_OBJ } from './worldwide';
 

--- a/packages/core/test/utils-hoist/dsn.test.ts
+++ b/packages/core/test/utils-hoist/dsn.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { DEBUG_BUILD } from '../../src/utils-hoist/debug-build';
+import { DEBUG_BUILD } from '../../src/utils-hoist/../debug-build';
 import { dsnToString, makeDsn } from '../../src/utils-hoist/dsn';
 import { logger } from '../../src/utils-hoist/logger';
 

--- a/packages/core/test/utils-hoist/dsn.test.ts
+++ b/packages/core/test/utils-hoist/dsn.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { DEBUG_BUILD } from '../../src/utils-hoist/../debug-build';
+import { DEBUG_BUILD } from '../../src/debug-build';
 import { dsnToString, makeDsn } from '../../src/utils-hoist/dsn';
 import { logger } from '../../src/utils-hoist/logger';
 


### PR DESCRIPTION
Noticed we still have this twice from the utils-hoist folder.