### PR TITLE
ci: Improve size limit tree shaking handling

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -18,7 +18,6 @@ module.exports = [
     limit: '24.1 KB',
     modifyWebpackConfig: function (config) {
       const webpack = require('webpack');
-      const TerserPlugin = require('terser-webpack-plugin');
 
       config.plugins.push(
         new webpack.DefinePlugin({
@@ -30,7 +29,6 @@ module.exports = [
       );
 
       config.optimization.minimize = true;
-      config.optimization.minimizer = [new TerserPlugin()];
 
       return config;
     },
@@ -57,7 +55,6 @@ module.exports = [
     limit: '70.1 KB',
     modifyWebpackConfig: function (config) {
       const webpack = require('webpack');
-      const TerserPlugin = require('terser-webpack-plugin');
 
       config.plugins.push(
         new webpack.DefinePlugin({
@@ -69,7 +66,6 @@ module.exports = [
       );
 
       config.optimization.minimize = true;
-      config.optimization.minimizer = [new TerserPlugin()];
 
       return config;
     },
@@ -239,7 +235,6 @@ module.exports = [
     ignore: [...builtinModules, ...nodePrefixedBuiltinModules],
     modifyWebpackConfig: function (config) {
       const webpack = require('webpack');
-      const TerserPlugin = require('terser-webpack-plugin');
 
       config.plugins.push(
         new webpack.DefinePlugin({
@@ -248,7 +243,6 @@ module.exports = [
       );
 
       config.optimization.minimize = true;
-      config.optimization.minimizer = [new TerserPlugin()];
 
       return config;
     },

--- a/dev-packages/size-limit-gh-action/package.json
+++ b/dev-packages/size-limit-gh-action/package.json
@@ -20,7 +20,7 @@
     "@actions/github": "^5.0.0",
     "@actions/glob": "0.4.0",
     "@actions/io": "1.1.3",
-    "bytes": "3.1.2",
+    "bytes-iec": "3.1.1",
     "markdown-table": "3.0.3"
   },
   "volta": {

--- a/dev-packages/size-limit-gh-action/utils/SizeLimitFormatter.mjs
+++ b/dev-packages/size-limit-gh-action/utils/SizeLimitFormatter.mjs
@@ -1,5 +1,5 @@
 import * as core from '@actions/core';
-import bytes from 'bytes';
+import bytes from 'bytes-iec';
 
 const SIZE_RESULTS_HEADER = ['Path', 'Size', '% Change', 'Change'];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11367,7 +11367,7 @@ byte-size@8.1.1:
   resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-8.1.1.tgz#3424608c62d59de5bfda05d31e0313c6174842ae"
   integrity sha512-tUkzZWK0M/qdoLEqikxBWe4kumyuwjl3HO6zHTr4yEI23EojPtLYXdG1+AQY7MN0cGyNDvEaJ8wiYQm6P2bPxg==
 
-bytes-iec@^3.1.1:
+bytes-iec@3.1.1, bytes-iec@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bytes-iec/-/bytes-iec-3.1.1.tgz#94cd36bf95c2c22a82002c247df8772d1d591083"
   integrity sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==


### PR DESCRIPTION
By us providing an empty terser plugin we actually get weird results (the browser variant with tree shaking was actually larger then the default one :O). We can just use the defaults here.

I also updated the GH action to use `bytes-iec` instead of `bytes` package for rendering the sizes - this is also what size-limit itself uses, so this should be better aligned now. Values may _look_ larger now because it formats as `kB` now (so factors of 1000) instead of `KiB` (factors of 1024).