### PR TITLE
fix(browser): Ensure pageload & navigation spans have correct data

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/history/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/history/navigation/test.ts
@@ -29,14 +29,14 @@ sentryTest('should record history changes as navigation breadcrumbs', async ({ g
       category: 'navigation',
       data: {
         from: '/bar?a=1#fragment',
-        to: '[object Object]',
+        to: '/[object%20Object]',
       },
       timestamp: expect.any(Number),
     },
     {
       category: 'navigation',
       data: {
-        from: '[object Object]',
+        from: '/[object%20Object]',
         to: '/bar?a=1#fragment',
       },
       timestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -210,7 +210,7 @@ sentryTest(
     expect(replayEvent6).toEqual(
       getExpectedReplayEvent({
         segment_id: 6,
-        urls: ['/spa'],
+        urls: [`${TEST_HOST}/spa`],
         request: {
           url: `${TEST_HOST}/spa`,
           headers: {

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-aborting-pageload/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-aborting-pageload/init.js
@@ -9,4 +9,4 @@ Sentry.init({
 });
 
 // Immediately navigate to a new page to abort the pageload
-window.location.href = '#foo';
+window.history.pushState({}, '', '/sub-page');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-aborting-pageload/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-aborting-pageload/test.ts
@@ -40,6 +40,9 @@ sentryTest(
     expect(navigationTraceId).toBeDefined();
     expect(pageloadTraceId).not.toEqual(navigationTraceId);
 
+    expect(pageloadRequest.transaction).toEqual('/index.html');
+    expect(navigationRequest.transaction).toEqual('/sub-page');
+
     expect(pageloadRequest.contexts?.trace?.data).toMatchObject({
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
       [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -53,6 +56,18 @@ sentryTest(
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
       ['sentry.idle_span_finish_reason']: 'idleTimeout',
+    });
+    expect(pageloadRequest.request).toEqual({
+      headers: {
+        'User-Agent': expect.any(String),
+      },
+      url: 'http://sentry-test.io/index.html',
+    });
+    expect(navigationRequest.request).toEqual({
+      headers: {
+        'User-Agent': expect.any(String),
+      },
+      url: 'http://sentry-test.io/sub-page',
     });
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation/test.ts
@@ -7,7 +7,12 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
+import {
+  envelopeRequestParser,
+  getFirstSentryEnvelopeRequest,
+  shouldSkipTracingTest,
+  waitForTransactionRequest,
+} from '../../../../utils/helpers';
 
 sentryTest('should create a navigation transaction on page navigation', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
@@ -84,4 +89,66 @@ sentryTest('should create a navigation transaction on page navigation', async ({
   );
 
   expect(pageloadSpanId).not.toEqual(navigationSpanId);
+});
+
+//
+sentryTest('should handle pushState with full URL', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+  const navigationRequestPromise = waitForTransactionRequest(
+    page,
+    event => event.contexts?.trace?.op === 'navigation' && event.transaction === '/sub-page',
+  );
+  const navigationRequestPromise2 = waitForTransactionRequest(
+    page,
+    event => event.contexts?.trace?.op === 'navigation' && event.transaction === '/sub-page-2',
+  );
+
+  await page.goto(url);
+  await pageloadRequestPromise;
+
+  await page.evaluate("window.history.pushState({}, '', `${window.location.origin}/sub-page`);");
+
+  const navigationRequest = envelopeRequestParser(await navigationRequestPromise);
+
+  expect(navigationRequest.transaction).toEqual('/sub-page');
+
+  expect(navigationRequest.contexts?.trace?.data).toMatchObject({
+    [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
+    [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
+    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+    ['sentry.idle_span_finish_reason']: 'idleTimeout',
+  });
+  expect(navigationRequest.request).toEqual({
+    headers: {
+      'User-Agent': expect.any(String),
+    },
+    url: 'http://sentry-test.io/sub-page',
+  });
+
+  await page.evaluate("window.history.pushState({}, '', `${window.location.origin}/sub-page-2`);");
+
+  const navigationRequest2 = envelopeRequestParser(await navigationRequestPromise2);
+
+  expect(navigationRequest2.transaction).toEqual('/sub-page-2');
+
+  expect(navigationRequest2.contexts?.trace?.data).toMatchObject({
+    [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
+    [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
+    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+    ['sentry.idle_span_finish_reason']: 'idleTimeout',
+  });
+  expect(navigationRequest2.request).toEqual({
+    headers: {
+      'User-Agent': expect.any(String),
+    },
+    url: 'http://sentry-test.io/sub-page-2',
+  });
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation/test.ts
@@ -31,6 +31,10 @@ sentryTest('should create a navigation transaction on page navigation', async ({
   expect(navigationTraceId).toBeDefined();
   expect(pageloadTraceId).not.toEqual(navigationTraceId);
 
+  expect(pageloadRequest.transaction).toEqual('/index.html');
+  // Fragment is not in transaction name
+  expect(navigationRequest.transaction).toEqual('/index.html');
+
   expect(pageloadRequest.contexts?.trace?.data).toMatchObject({
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
     [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -44,6 +48,18 @@ sentryTest('should create a navigation transaction on page navigation', async ({
     [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
     ['sentry.idle_span_finish_reason']: 'idleTimeout',
+  });
+  expect(pageloadRequest.request).toEqual({
+    headers: {
+      'User-Agent': expect.any(String),
+    },
+    url: 'http://sentry-test.io/index.html',
+  });
+  expect(navigationRequest.request).toEqual({
+    headers: {
+      'User-Agent': expect.any(String),
+    },
+    url: 'http://sentry-test.io/index.html#foo',
   });
 
   const pageloadSpans = pageloadRequest.spans;

--- a/packages/browser-utils/src/instrument/history.ts
+++ b/packages/browser-utils/src/instrument/history.ts
@@ -47,9 +47,15 @@ export function instrumentHistory(): void {
     return function (this: History, ...args: unknown[]): void {
       const url = args.length > 2 ? args[2] : undefined;
       if (url) {
-        // coerce to string (this is what pushState does)
         const from = lastHref;
-        const to = String(url);
+
+        // Ensure the URL is absolute
+        // this can be either a path, then it is relative to the current origin
+        // or a full URL of the current origin - other origins are not allowed
+        // See: https://developer.mozilla.org/en-US/docs/Web/API/History/pushState#url
+        // coerce to string (this is what pushState does)
+        const to = getAbsoluteUrl(String(url));
+
         // keep track of the current URL state, as we always receive only the updated state
         lastHref = to;
 
@@ -66,4 +72,14 @@ export function instrumentHistory(): void {
 
   fill(WINDOW.history, 'pushState', historyReplacementFunction);
   fill(WINDOW.history, 'replaceState', historyReplacementFunction);
+}
+
+function getAbsoluteUrl(urlOrPath: string): string {
+  try {
+    const url = new URL(urlOrPath, WINDOW.location.origin);
+    return url.toString();
+  } catch {
+    // fallback, just do nothing
+    return urlOrPath;
+  }
 }

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -4,6 +4,7 @@ import {
   addExceptionTypeValue,
   addNonEnumerableProperty,
   captureException,
+  getLocationHref,
   getOriginalFunction,
   GLOBAL_OBJ,
   markFunctionWrapped,
@@ -174,4 +175,25 @@ export function wrap<T extends WrappableFunction, NonFunction>(
   }
 
   return sentryWrapped;
+}
+
+/**
+ * Get HTTP request data from the current page.
+ */
+export function getHttpRequestData(): { url: string; headers: Record<string, string> } {
+  // grab as much info as exists and add it to the event
+  const url = getLocationHref();
+  const { referrer } = WINDOW.document || {};
+  const { userAgent } = WINDOW.navigator || {};
+
+  const headers = {
+    ...(referrer && { Referer: referrer }),
+    ...(userAgent && { 'User-Agent': userAgent }),
+  };
+  const request = {
+    url,
+    headers,
+  };
+
+  return request;
 }

--- a/packages/browser/src/integrations/httpcontext.ts
+++ b/packages/browser/src/integrations/httpcontext.ts
@@ -1,5 +1,5 @@
-import { defineIntegration, getLocationHref } from '@sentry/core';
-import { WINDOW } from '../helpers';
+import { defineIntegration } from '@sentry/core';
+import { getHttpRequestData, WINDOW } from '../helpers';
 
 /**
  * Collects information about HTTP request headers and
@@ -14,23 +14,17 @@ export const httpContextIntegration = defineIntegration(() => {
         return;
       }
 
-      // grab as much info as exists and add it to the event
-      const url = event.request?.url || getLocationHref();
-      const { referrer } = WINDOW.document || {};
-      const { userAgent } = WINDOW.navigator || {};
-
+      const reqData = getHttpRequestData();
       const headers = {
+        ...reqData.headers,
         ...event.request?.headers,
-        ...(referrer && { Referer: referrer }),
-        ...(userAgent && { 'User-Agent': userAgent }),
       };
-      const request = {
+
+      event.request = {
+        ...reqData,
         ...event.request,
-        ...(url && { url }),
         headers,
       };
-
-      event.request = request;
     },
   };
 });

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -355,6 +355,10 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
           sampled: spanIsSampled(idleSpan),
           dsc: getDynamicSamplingContextFromSpan(span),
         });
+
+        scope.setSDKProcessingMetadata({
+          normalizedRequest: undefined,
+        });
       },
     });
 

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -152,7 +152,7 @@ describe('browserTracingIntegration', () => {
     expect(spanIsSampled(span!)).toBe(false);
   });
 
-  it('starts navigation when URL changes', async () => {
+  it('starts navigation when URL changes', () => {
     const client = new BrowserClient(
       getDefaultBrowserClientOptions({
         tracesSampleRate: 1,
@@ -186,9 +186,6 @@ describe('browserTracingIntegration', () => {
     Object.defineProperty(global, 'location', { value: dom.window.document.location, writable: true });
 
     WINDOW.history.pushState({}, '', '/test');
-
-    // wait a tick to ensure everything settled
-    await new Promise(resolve => setTimeout(resolve, 1));
 
     expect(span!.isRecording()).toBe(false);
 
@@ -227,9 +224,6 @@ describe('browserTracingIntegration', () => {
     Object.defineProperty(global, 'location', { value: dom2.window.document.location, writable: true });
 
     WINDOW.history.pushState({}, '', '/test2');
-
-    // wait a tick to ensure everything settled
-    await new Promise(resolve => setTimeout(resolve, 1));
 
     expect(span2!.isRecording()).toBe(false);
 
@@ -867,7 +861,7 @@ describe('browserTracingIntegration', () => {
       expect(propagationContext.parentSpanId).toEqual('1121201211212012');
     });
 
-    it('ignores the meta tag data for navigation spans', async () => {
+    it('ignores the meta tag data for navigation spans', () => {
       document.head.innerHTML =
         '<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">' +
         '<meta name="baggage" content="sentry-release=2.1.14">';
@@ -888,9 +882,6 @@ describe('browserTracingIntegration', () => {
       Object.defineProperty(global, 'location', { value: dom.window.document.location, writable: true });
 
       WINDOW.history.pushState({}, '', '/navigation-test');
-
-      // wait a tick to ensure everything settled
-      await new Promise(resolve => setTimeout(resolve, 1));
 
       const idleSpan = getActiveSpan()!;
       expect(idleSpan).toBeDefined();

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -152,7 +152,7 @@ describe('browserTracingIntegration', () => {
     expect(spanIsSampled(span!)).toBe(false);
   });
 
-  it('starts navigation when URL changes', () => {
+  it('starts navigation when URL changes', async () => {
     const client = new BrowserClient(
       getDefaultBrowserClientOptions({
         tracesSampleRate: 1,
@@ -186,6 +186,9 @@ describe('browserTracingIntegration', () => {
     Object.defineProperty(global, 'location', { value: dom.window.document.location, writable: true });
 
     WINDOW.history.pushState({}, '', '/test');
+
+    // wait a tick to ensure everything settled
+    await new Promise(resolve => setTimeout(resolve, 1));
 
     expect(span!.isRecording()).toBe(false);
 
@@ -224,6 +227,9 @@ describe('browserTracingIntegration', () => {
     Object.defineProperty(global, 'location', { value: dom2.window.document.location, writable: true });
 
     WINDOW.history.pushState({}, '', '/test2');
+
+    // wait a tick to ensure everything settled
+    await new Promise(resolve => setTimeout(resolve, 1));
 
     expect(span2!.isRecording()).toBe(false);
 
@@ -861,7 +867,7 @@ describe('browserTracingIntegration', () => {
       expect(propagationContext.parentSpanId).toEqual('1121201211212012');
     });
 
-    it('ignores the meta tag data for navigation spans', () => {
+    it('ignores the meta tag data for navigation spans', async () => {
       document.head.innerHTML =
         '<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">' +
         '<meta name="baggage" content="sentry-release=2.1.14">';
@@ -882,6 +888,9 @@ describe('browserTracingIntegration', () => {
       Object.defineProperty(global, 'location', { value: dom.window.document.location, writable: true });
 
       WINDOW.history.pushState({}, '', '/navigation-test');
+
+      // wait a tick to ensure everything settled
+      await new Promise(resolve => setTimeout(resolve, 1));
 
       const idleSpan = getActiveSpan()!;
       expect(idleSpan).toBeDefined();

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -336,6 +336,8 @@ export class SentrySpan implements Span {
 
     const { scope: capturedSpanScope, isolationScope: capturedSpanIsolationScope } = getCapturedScopesOnSpan(this);
 
+    const normalizedRequest = capturedSpanScope?.getScopeData().sdkProcessingMetadata?.normalizedRequest;
+
     if (this._sampled !== true) {
       return undefined;
     }
@@ -374,6 +376,7 @@ export class SentrySpan implements Span {
         capturedSpanIsolationScope,
         dynamicSamplingContext: getDynamicSamplingContextFromSpan(this),
       },
+      request: normalizedRequest,
       ...(source && {
         transaction_info: {
           source,

--- a/packages/core/src/types-hoist/instrument.ts
+++ b/packages/core/src/types-hoist/instrument.ts
@@ -78,7 +78,9 @@ export interface HandlerDataConsole {
 }
 
 export interface HandlerDataHistory {
+  /** The full URL of the previous page */
   from: string | undefined;
+  /** The full URL of the new page */
   to: string;
 }
 


### PR DESCRIPTION
This PR fixes two things about our idle spans emitted from `browserTracingIntegration`:

1. The navigation name was sometimes incorrect. This is because we look at `window.location.pathname` at the time when the `popstate` event is emitted - but at this point, this may not be updated yet. So a `navigation` transaction would possibly have the pathname of the previous page as transaction name.
2. The request data is also possibly incorrect - this is set by `HttpContext` integration at event processing time. However, at this time the `window.location` data is also usually already of the following navigation, so the pageload would often have wrong request data associated to it. Now, we store this on the current scope at span creation time to ensure it is actually correct.
