### PR TITLE
fix(node): Pin `@fastify/otel` fork to direct url to allow installing without git

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@fastify/otel": "getsentry/fastify-otel#otel-v1",
+    "@fastify/otel": "https://codeload.github.com/getsentry/fastify-otel/tar.gz/d6bb1756c3db3d00d4d82c39c93ee3316e06d305",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^1.30.1",
     "@opentelemetry/core": "^1.30.1",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@fastify/otel": "https://codeload.github.com/getsentry/fastify-otel/tar.gz/d6bb1756c3db3d00d4d82c39c93ee3316e06d305",
+    "@fastify/otel": "https://codeload.github.com/getsentry/fastify-otel/tar.gz/ae3088d65e286bdc94ac5d722573537d6a6671bb",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^1.30.1",
     "@opentelemetry/core": "^1.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,9 +3912,9 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.0.0.tgz#f22824caff3ae506b18207bad4126dbc6ccdb6b8"
   integrity sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==
 
-"@fastify/otel@https://codeload.github.com/getsentry/fastify-otel/tar.gz/d6bb1756c3db3d00d4d82c39c93ee3316e06d305":
+"@fastify/otel@https://codeload.github.com/getsentry/fastify-otel/tar.gz/ae3088d65e286bdc94ac5d722573537d6a6671bb":
   version "0.8.0"
-  resolved "https://codeload.github.com/getsentry/fastify-otel/tar.gz/d6bb1756c3db3d00d4d82c39c93ee3316e06d305#d56518a165ba728247aa9d66fd020d58ebfce136"
+  resolved "https://codeload.github.com/getsentry/fastify-otel/tar.gz/ae3088d65e286bdc94ac5d722573537d6a6671bb#1632d3df7ebf8cd86996a50e9e42721aea05b39c"
   dependencies:
     "@opentelemetry/core" "^1.30.1"
     "@opentelemetry/instrumentation" "^0.57.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,9 +3912,9 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.0.0.tgz#f22824caff3ae506b18207bad4126dbc6ccdb6b8"
   integrity sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==
 
-"@fastify/otel@getsentry/fastify-otel#otel-v1":
+"@fastify/otel@https://codeload.github.com/getsentry/fastify-otel/tar.gz/d6bb1756c3db3d00d4d82c39c93ee3316e06d305":
   version "0.8.0"
-  resolved "https://codeload.github.com/getsentry/fastify-otel/tar.gz/d6bb1756c3db3d00d4d82c39c93ee3316e06d305"
+  resolved "https://codeload.github.com/getsentry/fastify-otel/tar.gz/d6bb1756c3db3d00d4d82c39c93ee3316e06d305#d56518a165ba728247aa9d66fd020d58ebfce136"
   dependencies:
     "@opentelemetry/core" "^1.30.1"
     "@opentelemetry/instrumentation" "^0.57.2"


### PR DESCRIPTION
The previous approach of specifying the git repo directly breaks systems that don't have git installed (e.g. slim linux distros). I tested this works on a ubuntu vm without git.

**Important:** When making changes to the fork, the linked commit sha in `packages/node/package.json` has to be updated and the yarn lockfile regenerated.

Resolves: #16281