### PR TITLE
feat(react-router): Add server action instrumentation

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes.ts
@@ -16,5 +16,6 @@ export default [
     route('with/:param', 'routes/performance/dynamic-param.tsx'),
     route('static', 'routes/performance/static.tsx'),
     route('server-loader', 'routes/performance/server-loader.tsx'),
+    route('server-action', 'routes/performance/server-action.tsx'),
   ]),
 ] satisfies RouteConfig;

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/server-action.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/server-action.tsx
@@ -1,0 +1,24 @@
+import { Form } from 'react-router';
+import type { Route } from './+types/server-action';
+
+export async function action({ request }: Route.ActionArgs) {
+  let formData = await request.formData();
+  let name = formData.get('name');
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  return {
+    greeting: `Hola ${name}`,
+  };
+}
+
+export default function Project({ actionData }: Route.ComponentProps) {
+  return (
+    <div>
+      <h1>Server action page</h1>
+      <Form method="post">
+        <input type="text" name="name" />
+        <button type="submit">Submit</button>
+      </Form>
+      {actionData ? <p>{actionData.greeting}</p> : null}
+    </div>
+  );
+}

--- a/packages/react-router/src/server/sdk.ts
+++ b/packages/react-router/src/server/sdk.ts
@@ -45,7 +45,7 @@ export function init(options: NodeOptions): NodeClient | undefined {
         const overwrite = event.contexts?.trace?.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OVERWRITE];
         if (
           event.type === 'transaction' &&
-          event.transaction === 'GET *' &&
+          (event.transaction === 'GET *' || event.transaction === 'POST *') &&
           event.contexts?.trace?.data?.[ATTR_HTTP_ROUTE] === '*' &&
           overwrite
         ) {


### PR DESCRIPTION
Work for this was basically already done in https://github.com/getsentry/sentry-javascript/pull/16147

This PR just adds a check for POST requests in the event processor + an e2e test


closes https://github.com/getsentry/sentry-javascript/issues/15195