### PR TITLE
feat(react-router): Filter manifest requests

### DIFF
--- a/packages/react-router/src/server/integration/lowQualityTransactionsFilterIntegration.ts
+++ b/packages/react-router/src/server/integration/lowQualityTransactionsFilterIntegration.ts
@@ -10,7 +10,7 @@ function _lowQualityTransactionsFilterIntegration(options: NodeOptions): {
   name: string;
   processEvent: (event: Event, hint: EventHint, client: Client) => Event | null;
 } {
-  const matchedRegexes = [/GET \/node_modules\//, /GET \/favicon\.ico/, /GET \/@id\//];
+  const matchedRegexes = [/GET \/node_modules\//, /GET \/favicon\.ico/, /GET \/@id\//, /GET \/__manifest\?/];
 
   return {
     name: 'LowQualityTransactionsFilter',

--- a/packages/react-router/src/server/sdk.ts
+++ b/packages/react-router/src/server/sdk.ts
@@ -5,8 +5,8 @@ import type { NodeClient, NodeOptions } from '@sentry/node';
 import { getDefaultIntegrations as getNodeDefaultIntegrations, init as initNodeSdk } from '@sentry/node';
 import { DEBUG_BUILD } from '../common/debug-build';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OVERWRITE } from './instrumentation/util';
+import { lowQualityTransactionsFilterIntegration } from './integration/lowQualityTransactionsFilterIntegration';
 import { reactRouterServerIntegration } from './integration/reactRouterServer';
-import { lowQualityTransactionsFilterIntegration } from './lowQualityTransactionsFilterIntegration';
 
 /**
  * Returns the default integrations for the React Router SDK.

--- a/packages/react-router/test/server/lowQualityTransactionsFilterIntegration.test.ts
+++ b/packages/react-router/test/server/lowQualityTransactionsFilterIntegration.test.ts
@@ -2,7 +2,7 @@ import type { Event, EventType, Integration } from '@sentry/core';
 import * as SentryCore from '@sentry/core';
 import * as SentryNode from '@sentry/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { lowQualityTransactionsFilterIntegration } from '../../src/server/lowQualityTransactionsFilterIntegration';
+import { lowQualityTransactionsFilterIntegration } from '../../src/server/integration/lowQualityTransactionsFilterIntegration';
 
 const loggerLog = vi.spyOn(SentryCore.logger, 'log').mockImplementation(() => {});
 
@@ -18,6 +18,7 @@ describe('Low Quality Transactions Filter Integration', () => {
         ['node_modules requests', 'GET /node_modules/some-package/index.js'],
         ['favicon.ico requests', 'GET /favicon.ico'],
         ['@id/ requests', 'GET /@id/some-id'],
+        ['manifest requests', 'GET /__manifest?p=%2Fperformance%2Fserver-action'],
       ])('%s', (description, transaction) => {
         const integration = lowQualityTransactionsFilterIntegration({ debug: true }) as Integration;
         const event = {

--- a/packages/react-router/test/server/sdk.test.ts
+++ b/packages/react-router/test/server/sdk.test.ts
@@ -3,7 +3,7 @@ import type { NodeClient } from '@sentry/node';
 import * as SentryNode from '@sentry/node';
 import { SDK_VERSION } from '@sentry/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import * as LowQualityModule from '../../src/server/lowQualityTransactionsFilterIntegration';
+import * as LowQualityModule from '../../src/server/integration/lowQualityTransactionsFilterIntegration';
 import { init as reactRouterInit } from '../../src/server/sdk';
 
 const nodeInit = vi.spyOn(SentryNode, 'init');


### PR DESCRIPTION
- Adds a regex for `GET /__manifest` requests to  to the low quality tx filter
- Moves the integration into the integration folder

