### PR TITLE
feat(node): Adds isolation scope forking to tRPC middleware

### DIFF
--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -1,4 +1,4 @@
-import { getClient, withScope } from './currentScopes';
+import { getClient, withIsolationScope } from './currentScopes';
 import { captureException } from './exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from './semanticAttributes';
 import { startSpanManual } from './tracing';
@@ -76,7 +76,7 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
       }
     }
 
-    return withScope(scope => {
+    return withIsolationScope(scope => {
       scope.setContext('trpc', trpcContext);
       return startSpanManual(
         {

--- a/packages/core/test/lib/trpc.test.ts
+++ b/packages/core/test/lib/trpc.test.ts
@@ -26,7 +26,7 @@ describe('trpcMiddleware', () => {
     setExtra: vi.fn(),
   };
 
-  const withScope = vi.fn(callback => {
+  const withIsolationScope = vi.fn(callback => {
     return callback(mockScope);
   });
 
@@ -38,7 +38,7 @@ describe('trpcMiddleware', () => {
     client.init();
     vi.spyOn(currentScopes, 'getClient').mockReturnValue(mockClient);
     vi.spyOn(tracing, 'startSpanManual').mockImplementation((name, callback) => callback(mockSpan, () => {}));
-    vi.spyOn(currentScopes, 'withScope').mockImplementation(withScope);
+    vi.spyOn(currentScopes, 'withIsolationScope').mockImplementation(withIsolationScope);
     vi.spyOn(exports, 'captureException').mockImplementation(() => 'mock-event-id');
   });
 


### PR DESCRIPTION
Writing tRPC handlers today and using top-level methods like `Sentry.setTag` isn't very intuitive as the isolations scope is not forked per procedure in our middleware.

This PR changes the middleware to fork the isolation scope, while this is not 100% correct, as it breaks the one isolation scope per process/request model, it should be more intuitive and work better for most users.

Resolves: #16262
