### PR TITLE
fix(cloudflare): Account for static fields in wrapper type

### DIFF
--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -133,10 +133,11 @@ function wrapMethodWithSentry<T extends (...args: any[]) => any>(
  * );
  * ```
  */
-export function instrumentDurableObjectWithSentry<E, T extends DurableObject<E>>(
-  optionsCallback: (env: E) => CloudflareOptions,
-  DurableObjectClass: new (state: DurableObjectState, env: E) => T,
-): new (state: DurableObjectState, env: E) => T {
+export function instrumentDurableObjectWithSentry<
+  E,
+  T extends DurableObject<E>,
+  C extends new (state: DurableObjectState, env: E) => T,
+>(optionsCallback: (env: E) => CloudflareOptions, DurableObjectClass: C): C {
   return new Proxy(DurableObjectClass, {
     construct(target, [context, env]) {
       setAsyncLocalStorageAsyncContextStrategy();


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/16247

By adjusting the generic, we'll make sure that we don't erase static fields with the `instrumentDurableObjectWithSentry` function. See an example below:

```js
class MyDurableObjectBase extends DurableObject {
  public static readonly VERSION = '1.0.0';
}

const MyDurableObject = instrumentDurableObjectWithSentry(
  () => ({
    dsn: 'https://example.com/sentry',
    tracesSampleRate: 1.0,
  }),
  MyDurableObjectBase,
);

console.log(MyDurableObject.VERSION); // This will now work correctly
```

By moving the `DurableObjectClass` into it's own generic (`new (state: DurableObjectState, env: E) => T`), which we named `C`, it helps preserve the exact constructor type of the input class, including all its static properties and methods.

This was previously being lost by not aligning the `DurableObjectClass` with the function return value.
