### PR TITLE
feat(core): Add `orgId` option to `init` and DSC (`sentry-org_id` in baggage)

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -8,7 +8,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/index.js',
     import: createImport('init'),
     gzip: true,
-    limit: '24 KB',
+    limit: '25 KB',
   },
   {
     name: '@sentry/browser - with treeshaking flags',

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-explicit-org-id.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-explicit-org-id.ts
@@ -1,0 +1,34 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
+
+export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
+
+Sentry.init({
+  dsn: 'https://public@o01234987.ingest.sentry.io/1337',
+  release: '1.0',
+  environment: 'prod',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});
+
+import cors from 'cors';
+import express from 'express';
+import * as http from 'http';
+
+const app = express();
+
+app.use(cors());
+
+app.get('/test/express', (_req, res) => {
+  const headers = http
+    .get({
+      hostname: 'example.com',
+    })
+    .getHeaders();
+
+  res.send({ test_data: headers });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-org-id.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-org-id.ts
@@ -1,0 +1,34 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
+
+export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
+
+Sentry.init({
+  dsn: 'https://public@public.ingest.sentry.io/1337',
+  release: '1.0',
+  environment: 'prod',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});
+
+import cors from 'cors';
+import express from 'express';
+import * as http from 'http';
+
+const app = express();
+
+app.use(cors());
+
+app.get('/test/express', (_req, res) => {
+  const headers = http
+    .get({
+      hostname: 'example.com',
+    })
+    .getHeaders();
+
+  res.send({ test_data: headers });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server.ts
@@ -1,0 +1,35 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
+
+export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
+
+Sentry.init({
+  dsn: 'https://public@o0000987.ingest.sentry.io/1337',
+  release: '1.0',
+  environment: 'prod',
+  orgId: '01234987',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});
+
+import cors from 'cors';
+import express from 'express';
+import * as http from 'http';
+
+const app = express();
+
+app.use(cors());
+
+app.get('/test/express', (_req, res) => {
+  const headers = http
+    .get({
+      hostname: 'example.com',
+    })
+    .getHeaders();
+
+  res.send({ test_data: headers });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/test.ts
@@ -1,0 +1,32 @@
+import { afterAll, expect, test } from 'vitest';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
+import type { TestAPIResponse } from './server';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+test('should include explicitly set org_id in the baggage header', async () => {
+  const runner = createRunner(__dirname, 'server.ts').start();
+
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
+
+  expect(response).toBeDefined();
+
+  const baggage = response?.test_data.baggage?.split(',').sort();
+
+  expect(baggage).toContain('sentry-org_id=01234987');
+});
+
+test('should extract org_id from DSN host when not explicitly set', async () => {
+  // This test requires a new server with different configuration
+  const runner = createRunner(__dirname, 'server-no-explicit-org-id.ts').start();
+
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
+
+  expect(response).toBeDefined();
+
+  const baggage = response?.test_data.baggage?.split(',').sort();
+
+  expect(baggage).toContain('sentry-org_id=01234987');
+});

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/test.ts
@@ -10,23 +10,28 @@ test('should include explicitly set org_id in the baggage header', async () => {
   const runner = createRunner(__dirname, 'server.ts').start();
 
   const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
-
   expect(response).toBeDefined();
 
-  const baggage = response?.test_data.baggage?.split(',').sort();
-
+  const baggage = response?.test_data.baggage;
   expect(baggage).toContain('sentry-org_id=01234987');
 });
 
 test('should extract org_id from DSN host when not explicitly set', async () => {
-  // This test requires a new server with different configuration
   const runner = createRunner(__dirname, 'server-no-explicit-org-id.ts').start();
 
   const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
-
   expect(response).toBeDefined();
 
-  const baggage = response?.test_data.baggage?.split(',').sort();
-
+  const baggage = response?.test_data.baggage;
   expect(baggage).toContain('sentry-org_id=01234987');
+});
+
+test('should set undefined org_id when it cannot be extracted', async () => {
+  const runner = createRunner(__dirname, 'server-no-org-id.ts').start();
+
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
+  expect(response).toBeDefined();
+
+  const baggage = response?.test_data.baggage;
+  expect(baggage).not.toContain('sentry-org_id');
 });

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -732,6 +732,7 @@ describe('browserTracingIntegration', () => {
         sampleRand: expect.any(Number),
         dsc: {
           release: undefined,
+          org_id: undefined,
           environment: 'production',
           public_key: 'examplePublicKey',
           sample_rate: '1',
@@ -773,6 +774,7 @@ describe('browserTracingIntegration', () => {
         sampleRand: expect.any(Number),
         dsc: {
           release: undefined,
+          org_id: undefined,
           environment: 'production',
           public_key: 'examplePublicKey',
           sample_rate: '0',
@@ -898,6 +900,7 @@ describe('browserTracingIntegration', () => {
       expect(dynamicSamplingContext).toBeDefined();
       expect(dynamicSamplingContext).toStrictEqual({
         release: undefined,
+        org_id: undefined,
         environment: 'production',
         public_key: 'examplePublicKey',
         sample_rate: '1',

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -49,7 +49,7 @@ export function getDynamicSamplingContextFromClient(trace_id: string, client: Cl
 
   let org_id: string | undefined;
   if (options.orgId) {
-    org_id = options.orgId;
+    org_id = String(options.orgId);
   } else if (host) {
     org_id = extractOrgIdFromDsnHost(host);
   }

--- a/packages/core/src/types-hoist/envelope.ts
+++ b/packages/core/src/types-hoist/envelope.ts
@@ -25,6 +25,7 @@ export type DynamicSamplingContext = {
   replay_id?: string;
   sampled?: string;
   sample_rand?: string;
+  org_id?: string;
 };
 
 // https://github.com/getsentry/relay/blob/311b237cd4471042352fa45e7a0824b8995f216f/relay-server/src/envelope.rs#L154

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -321,6 +321,13 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   tracePropagationTargets?: TracePropagationTargets;
 
   /**
+   * The organization ID of the current SDK.
+   *
+   * The SDK automatically extracts the organization ID from the DSN, if needed. With this option, you can override it.
+   */
+  orgId?: string;
+
+  /**
    * Function to compute tracing sample rate dynamically and filter unwanted traces.
    *
    * Tracing is enabled if either this or `tracesSampleRate` is defined. If both are defined, `tracesSampleRate` is

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -321,11 +321,12 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   tracePropagationTargets?: TracePropagationTargets;
 
   /**
-   * The organization ID of the current SDK.
+   * The organization ID of the current SDK. The organization ID is a string containing only numbers. This ID is used to
+   * propagate traces to other Sentry services.
    *
-   * The SDK automatically extracts the organization ID from the DSN, if needed. With this option, you can override it.
+   * The SDK tries to automatically extract the organization ID from the DSN. With this option, you can override it.
    */
-  orgId?: string;
+  orgId?: `${number}`;
 
   /**
    * Function to compute tracing sample rate dynamically and filter unwanted traces.

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -326,7 +326,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    *
    * The SDK tries to automatically extract the organization ID from the DSN. With this option, you can override it.
    */
-  orgId?: `${number}`;
+  orgId?: `${number}` | number;
 
   /**
    * Function to compute tracing sample rate dynamically and filter unwanted traces.

--- a/packages/core/src/utils-hoist/dsn.ts
+++ b/packages/core/src/utils-hoist/dsn.ts
@@ -2,6 +2,9 @@ import type { DsnComponents, DsnLike, DsnProtocol } from '../types-hoist/dsn';
 import { DEBUG_BUILD } from './../debug-build';
 import { consoleSandbox, logger } from './logger';
 
+/** Regular expression used to extract org ID from a DSN host. */
+const ORG_ID_REGEX = /^o(\d+)\./;
+
 /** Regular expression used to parse a Dsn. */
 const DSN_REGEX = /^(?:(\w+):)\/\/(?:(\w+)(?::(\w+)?)?@)([\w.-]+)(?::(\d+))?\/(.+)/;
 
@@ -112,6 +115,21 @@ function validateDsn(dsn: DsnComponents): boolean {
   }
 
   return true;
+}
+
+/**
+ * Extract the org ID from a DSN host.
+ *
+ * @param host The host from a DSN
+ * @returns The org ID if found, undefined otherwise
+ */
+export function extractOrgIdFromDsnHost(host: string): string | undefined {
+  const match = host.match(ORG_ID_REGEX);
+
+  if (match?.[1]) {
+    return match[1];
+  }
+  return undefined;
 }
 
 /**

--- a/packages/core/src/utils-hoist/dsn.ts
+++ b/packages/core/src/utils-hoist/dsn.ts
@@ -126,10 +126,7 @@ function validateDsn(dsn: DsnComponents): boolean {
 export function extractOrgIdFromDsnHost(host: string): string | undefined {
   const match = host.match(ORG_ID_REGEX);
 
-  if (match?.[1]) {
-    return match[1];
-  }
-  return undefined;
+  return match?.[1];
 }
 
 /**

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -228,14 +228,14 @@ describe('getDynamicSamplingContextFromClient', () => {
   it('uses orgId from options when specified', () => {
     client = new TestClient(
       getDefaultTestClientOptions({
-        orgId: 'explicit-org-id',
+        orgId: '00222111',
         dsn: 'https://public@sentry.example.com/1',
       }),
     );
 
     const dsc = getDynamicSamplingContextFromClient(TRACE_ID, client);
 
-    expect(dsc.org_id).toBe('explicit-org-id');
+    expect(dsc.org_id).toBe('00222111');
   });
 
   it('infers orgId from DSN host when not explicitly provided', () => {
@@ -253,14 +253,14 @@ describe('getDynamicSamplingContextFromClient', () => {
   it('prioritizes explicit orgId over inferred from DSN', () => {
     client = new TestClient(
       getDefaultTestClientOptions({
-        orgId: 'explicit-org-id',
+        orgId: '1234560',
         dsn: 'https://public@my-org.sentry.io/1',
       }),
     );
 
     const dsc = getDynamicSamplingContextFromClient(TRACE_ID, client);
 
-    expect(dsc.org_id).toBe('explicit-org-id');
+    expect(dsc.org_id).toBe('1234560');
   });
 
   it('handles missing DSN gracefully', () => {

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -73,6 +73,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
 
     expect(dynamicSamplingContext).toStrictEqual({
       public_key: undefined,
+      org_id: undefined,
       release: '1.0.1',
       environment: 'production',
       sampled: 'true',
@@ -92,6 +93,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
 
     expect(dynamicSamplingContext).toStrictEqual({
       public_key: undefined,
+      org_id: undefined,
       release: '1.0.1',
       environment: 'production',
       sampled: 'true',
@@ -116,6 +118,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
 
     expect(dynamicSamplingContext).toStrictEqual({
       public_key: undefined,
+      org_id: undefined,
       release: '1.0.1',
       environment: 'production',
       sampled: 'true',
@@ -172,6 +175,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
 
     expect(dynamicSamplingContext).toStrictEqual({
       public_key: undefined,
+      org_id: undefined,
       release: '1.0.1',
       environment: 'production',
       trace_id: expect.stringMatching(/^[a-f0-9]{32}$/),

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -263,6 +263,19 @@ describe('getDynamicSamplingContextFromClient', () => {
     expect(dsc.org_id).toBe('1234560');
   });
 
+  it('handles orgId passed as number', () => {
+    client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://public@my-org.sentry.io/1',
+        orgId: 123456,
+      }),
+    );
+
+    const dsc = getDynamicSamplingContextFromClient(TRACE_ID, client);
+
+    expect(dsc.org_id).toBe('123456');
+  });
+
   it('handles missing DSN gracefully', () => {
     client = new TestClient(
       getDefaultTestClientOptions({


### PR DESCRIPTION
Adds the organization ID to the DSC (dynamic sampling context). This will add the org ID as `sentry-org_id` to the baggage.

This org ID is parsed from the DSN. With the `orgId` option it's possible to overwrite the automatically parsed organization ID.

closes https://github.com/getsentry/sentry-javascript/issues/16290
