### PR TITLE
fix(nestjs): Handle multiple `OnEvent` decorators

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/events.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/events.controller.ts
@@ -11,4 +11,11 @@ export class EventsController {
 
     return { message: 'Events emitted' };
   }
+
+  @Get('emit-multiple')
+  async emitMultipleEvents() {
+    await this.eventsService.emitMultipleEvents();
+
+    return { message: 'Events emitted' };
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/events.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/events.service.ts
@@ -11,4 +11,11 @@ export class EventsService {
 
     return { message: 'Events emitted' };
   }
+
+  async emitMultipleEvents() {
+    this.eventEmitter.emit('multiple.first', { data: 'test-first' });
+    this.eventEmitter.emit('multiple.second', { data: 'test-second' });
+
+    return { message: 'Events emitted' };
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/listeners/test-event.listener.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/listeners/test-event.listener.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import * as Sentry from '@sentry/nestjs';
 
 @Injectable()
 export class TestEventListener {
@@ -17,6 +18,7 @@ export class TestEventListener {
   @OnEvent('multiple.first')
   @OnEvent('multiple.second')
   async handleMultipleEvents(payload: any): Promise<void> {
+    Sentry.setTag('payload', payload);
     await new Promise(resolve => setTimeout(resolve, 100));
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/listeners/test-event.listener.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/listeners/test-event.listener.ts
@@ -18,7 +18,7 @@ export class TestEventListener {
   @OnEvent('multiple.first')
   @OnEvent('multiple.second')
   async handleMultipleEvents(payload: any): Promise<void> {
-    Sentry.setTag('payload', payload);
+    Sentry.setTag(payload.data, true);
     await new Promise(resolve => setTimeout(resolve, 100));
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/listeners/test-event.listener.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/listeners/test-event.listener.ts
@@ -13,4 +13,10 @@ export class TestEventListener {
     await new Promise(resolve => setTimeout(resolve, 100));
     throw new Error('Test error from event handler');
   }
+
+  @OnEvent('multiple.first')
+  @OnEvent('multiple.second')
+  async handleMultipleEvents(payload: any): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/tests/events.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/tests/events.test.ts
@@ -43,10 +43,13 @@ test('Event emitter', async () => {
 
 test('Multiple OnEvent decorators', async () => {
   const firstTxPromise = waitForTransaction('nestjs-distributed-tracing', transactionEvent => {
-    return transactionEvent.transaction === 'event multiple.first';
+    return transactionEvent.transaction === 'event multiple.first|multiple.second';
   });
   const secondTxPromise = waitForTransaction('nestjs-distributed-tracing', transactionEvent => {
-    return transactionEvent.transaction === 'event multiple.second';
+    return transactionEvent.transaction === 'event multiple.first|multiple.second';
+  });
+  const rootPromise = waitForTransaction('nestjs-distributed-tracing', transactionEvent => {
+    return transactionEvent.transaction === 'GET /events/emit-multiple';
   });
 
   const eventsUrl = `http://localhost:3050/events/emit-multiple`;
@@ -54,7 +57,10 @@ test('Multiple OnEvent decorators', async () => {
 
   const firstTx = await firstTxPromise;
   const secondTx = await secondTxPromise;
+  const rootTx = await rootPromise;
 
-  expect(firstTx.tags).toMatchObject({ payload: { data: 'test-first' } });
-  expect(secondTx.tags).toMatchObject({ payload: { data: 'test-second' } });
+  expect(firstTx).toBeDefined();
+  expect(secondTx).toBeDefined();
+  // assert that the correct payloads were added
+  expect(rootTx.tags).toMatchObject({ 'test-first': true, 'test-second': true });
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/tests/events.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/tests/events.test.ts
@@ -55,6 +55,6 @@ test('Multiple OnEvent decorators', async () => {
   const firstTx = await firstTxPromise;
   const secondTx = await secondTxPromise;
 
-  expect(firstTx).toBeDefined();
-  expect(secondTx).toBeDefined();
+  expect(firstTx.tags).toMatchObject({ payload: { data: 'test-first' } });
+  expect(secondTx.tags).toMatchObject({ payload: { data: 'test-second' } });
 });

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/tests/events.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/tests/events.test.ts
@@ -40,3 +40,21 @@ test('Event emitter', async () => {
     status: 'ok',
   });
 });
+
+test('Multiple OnEvent decorators', async () => {
+  const firstTxPromise = waitForTransaction('nestjs-distributed-tracing', transactionEvent => {
+    return transactionEvent.transaction === 'event multiple.first';
+  });
+  const secondTxPromise = waitForTransaction('nestjs-distributed-tracing', transactionEvent => {
+    return transactionEvent.transaction === 'event multiple.second';
+  });
+
+  const eventsUrl = `http://localhost:3050/events/emit-multiple`;
+  await fetch(eventsUrl);
+
+  const firstTx = await firstTxPromise;
+  const secondTx = await secondTxPromise;
+
+  expect(firstTx).toBeDefined();
+  expect(secondTx).toBeDefined();
+});

--- a/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
@@ -58,31 +58,46 @@ export class SentryNestEventInstrumentation extends InstrumentationBase {
   private _createWrapOnEvent() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return function wrapOnEvent(original: any) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return function wrappedOnEvent(event: any, options?: any) {
-        const eventName = Array.isArray(event)
-          ? event.join(',')
-          : typeof event === 'string' || typeof event === 'symbol'
-            ? event.toString()
-            : '<unknown_event>';
-
+      return function wrappedOnEvent(event: unknown, options?: unknown) {
         // Get the original decorator result
         const decoratorResult = original(event, options);
 
         // Return a new decorator function that wraps the handler
-        return function (target: OnEventTarget, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
-          if (!descriptor.value || typeof descriptor.value !== 'function' || target.__SENTRY_INTERNAL__) {
+        return (target: OnEventTarget, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
+          if (
+            !descriptor.value ||
+            typeof descriptor.value !== 'function' ||
+            target.__SENTRY_INTERNAL__ ||
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            descriptor.value.__SENTRY_INSTRUMENTED__
+          ) {
             return decoratorResult(target, propertyKey, descriptor);
           }
 
-          // Get the original handler
           const originalHandler = descriptor.value;
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           const handlerName = originalHandler.name || propertyKey;
+          let eventName = typeof event === 'string' ? event : String(event);
 
-          // Instrument the handler
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          descriptor.value = async function (...args: any[]) {
+          // Instrument the actual handler
+          descriptor.value = async function (...args: unknown[]) {
+            // When multiple @OnEvent decorators are used on a single method, we need to get all event names
+            // from the reflector metadata as there is no information during execution which event triggered it
+            if (Reflect.getMetadataKeys(descriptor.value).includes('EVENT_LISTENER_METADATA')) {
+              const eventData = Reflect.getMetadata('EVENT_LISTENER_METADATA', descriptor.value);
+              if (Array.isArray(eventData) && eventData.length > 0) {
+                eventName = eventData
+                  .map((data: unknown) => {
+                    if (data && typeof data === 'object' && 'event' in data && data.event) {
+                      return data.event;
+                    }
+                    return '';
+                  })
+                  .reverse() // decorators are evaluated bottom to top
+                  .join('|');
+              }
+            }
+
             return startSpan(getEventSpanOptions(eventName), async () => {
               try {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -95,6 +110,9 @@ export class SentryNestEventInstrumentation extends InstrumentationBase {
               }
             });
           };
+
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          descriptor.value.__SENTRY_INSTRUMENTED__ = true;
 
           // Preserve the original function name
           Object.defineProperty(descriptor.value, 'name', {

--- a/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
@@ -85,7 +85,7 @@ export class SentryNestEventInstrumentation extends InstrumentationBase {
             // from the reflector metadata as there is no information during execution which event triggered it
             if (Reflect.getMetadataKeys(descriptor.value).includes('EVENT_LISTENER_METADATA')) {
               const eventData = Reflect.getMetadata('EVENT_LISTENER_METADATA', descriptor.value);
-              if (Array.isArray(eventData) && eventData.length > 0) {
+              if (Array.isArray(eventData)) {
                 eventName = eventData
                   .map((data: unknown) => {
                     if (data && typeof data === 'object' && 'event' in data && data.event) {

--- a/packages/nestjs/test/integrations/nest.test.ts
+++ b/packages/nestjs/test/integrations/nest.test.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import * as core from '@sentry/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isPatched } from '../../src/integrations/helpers';


### PR DESCRIPTION
Problem is that within the execution there is no way of detecting the triggering event.

- Because of this we now emit a merged transaction name of all applied events – but will add a note on docs that we recommend just putting one decorator per function. We do this by reading the metadata applied on the function by nestjs.
- Adds a flag to avoid double wrapping of the descriptor value (this way we get the correct payload per event and make sure the handler is executed for each event) 

closes https://github.com/getsentry/sentry-javascript/issues/15218