### PR TITLE
feat(deps): bump the npm_and_yarn group with 3 updates

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -48,7 +48,7 @@
     "babel-loader": "^8.2.2",
     "fflate": "0.8.2",
     "html-webpack-plugin": "^5.5.0",
-    "webpack": "^5.95.0"
+    "webpack": "^5.95.1"
   },
   "devDependencies": {
     "@types/glob": "8.0.0",


### PR DESCRIPTION
Bumps the npm_and_yarn group with 3 updates: [webpack](https://github.com/webpack/webpack), [node-fetch](https://github.com/node-fetch/node-fetch) and [esbuild](https://github.com/evanw/esbuild).

Updates `webpack` from 5.96.0 to 5.96.1
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/webpack/webpack/releases">webpack's releases</a>.</em></p> <blockquote>
<h2>v5.96.1</h2>
<h2>Bug Fixes</h2>
<ul>
<li><strong>[Types]</strong> Add <code>@types/eslint-scope</code> to dependencieS</li> <li><strong>[Types]</strong> Fixed regression in <code>validate</code></li> </ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/webpack/webpack/commit/d4ced7322229c7d72a7a0d2ca955bdde0c910a0b"><code>d4ced73</code></a> chore(release): 5.96.1</li>
<li><a href="https://github.com/webpack/webpack/commit/7d6dbea53c00c431fc19654a30aaa2511204bbd6"><code>7d6dbea</code></a> fix: types regression in validate</li>
<li><a href="https://github.com/webpack/webpack/commit/5c556e32c5021980e536c4ae50ee810bba227fcb"><code>5c556e3</code></a> fix: types regression in validate</li>
<li><a href="https://github.com/webpack/webpack/commit/2420eaebe2043a0aeeab642e1ec7ff1c299c01ed"><code>2420eae</code></a> fix: add <code>@types/eslint-scope</code> to dependencies due types regression</li>
<li><a href="https://github.com/webpack/webpack/commit/ec45d2d8d47f2804c4e5a29019688ebb02dee67a"><code>ec45d2d</code></a> fix: add <code>@types/eslint-scope</code> to dependencies</li>
<li>See full diff in <a href="https://github.com/webpack/webpack/compare/v5.96.0...v5.96.1">compare view</a></li> </ul>
</details>
<br />

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
