### PR TITLE
fix(node): Revert to using upstream `@fastify/otel` instrumentation

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@fastify/otel": "https://codeload.github.com/getsentry/fastify-otel/tar.gz/ae3088d65e286bdc94ac5d722573537d6a6671bb",
+    "@fastify/otel": "0.6.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^1.30.1",
     "@opentelemetry/core": "^1.30.1",


### PR DESCRIPTION
With #16256 we switched from upstream `@fastify/otel` to a Otel v1 downgraded fork to ensure dependencies are aligned with our node sdk.

This PR will re-introduce a warning about unmet dependencies #16245 for the time being.