### PR TITLE
feat(browser): Detect redirects when emitting navigation spans

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/negatively-sampled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/negatively-sampled/init.js
@@ -4,7 +4,8 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [Sentry.browserTracingIntegration()],
+  // We want to ignore redirects for this test
+  integrations: [Sentry.browserTracingIntegration({ detectRedirects: false })],
   tracesSampler: ctx => {
     if (ctx.attributes['sentry.origin'] === 'auto.pageload.browser') {
       return 0;

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click-early/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click-early/init.js
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1,
+  debug: true,
+});
+
+document.getElementById('btn1').addEventListener('click', () => {
+  // Trigger navigation later than click, so the last click is more than 300ms ago
+  setTimeout(() => {
+    window.history.pushState({}, '', '/sub-page');
+
+    // then trigger redirect inside of this navigation, which should be detected as a redirect
+    // because the last click was more than 300ms ago
+    setTimeout(() => {
+      window.history.pushState({}, '', '/sub-page-redirect');
+    }, 100);
+  }, 400);
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click-early/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click-early/template.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <button id="btn1">Trigger navigation</button>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click-early/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click-early/test.ts
@@ -1,0 +1,41 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+
+sentryTest(
+  'should create a navigation.redirect span if a click happened more than 300ms before navigation',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+    const navigationRequestPromise = waitForTransactionRequest(
+      page,
+      event => event.contexts?.trace?.op === 'navigation',
+    );
+
+    await page.goto(url);
+
+    await pageloadRequestPromise;
+
+    // Now trigger navigation, and then a redirect in the navigation, with
+    await page.click('#btn1');
+
+    const navigationRequest = envelopeRequestParser(await navigationRequestPromise);
+
+    expect(navigationRequest.contexts?.trace?.op).toBe('navigation');
+    expect(navigationRequest.transaction).toEqual('/sub-page');
+
+    const spans = navigationRequest.spans || [];
+
+    expect(spans).toContainEqual(
+      expect.objectContaining({
+        op: 'navigation.redirect',
+        description: '/sub-page-redirect',
+      }),
+    );
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1,
+  debug: true,
+});
+
+document.getElementById('btn1').addEventListener('click', () => {
+  // trigger redirect immediately
+  window.history.pushState({}, '', '/sub-page');
+});
+
+// Now trigger click, whic should trigger navigation
+document.getElementById('btn1').click();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/init.js
@@ -8,11 +8,3 @@ Sentry.init({
   tracesSampleRate: 1,
   debug: true,
 });
-
-document.getElementById('btn1').addEventListener('click', () => {
-  // trigger redirect immediately
-  window.history.pushState({}, '', '/sub-page');
-});
-
-// Now trigger click, whic should trigger navigation
-document.getElementById('btn1').click();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/subject.js
@@ -1,0 +1,7 @@
+document.getElementById('btn1').addEventListener('click', () => {
+  // trigger redirect immediately
+  window.history.pushState({}, '', '/sub-page');
+});
+
+// Now trigger click, which should trigger navigation
+document.getElementById('btn1').click();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/template.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <button id="btn1">Trigger navigation</button>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/template.html
@@ -3,5 +3,5 @@
   <head>
     <meta charset="utf-8" />
   </head>
-  <button id="btn1">Trigger navigation</button>
+  <button id="btn1" type="button">Trigger navigation</button>
 </html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/click/test.ts
@@ -1,0 +1,34 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+
+sentryTest(
+  'should not create a navigation.redirect span if a click happened before navigation',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+    const navigationRequestPromise = waitForTransactionRequest(
+      page,
+      event => event.contexts?.trace?.op === 'navigation',
+    );
+
+    await page.goto(url);
+
+    const pageloadRequest = envelopeRequestParser(await pageloadRequestPromise);
+    // Ensure a navigation span is sent, too
+    await navigationRequestPromise;
+
+    const spans = pageloadRequest.spans || [];
+
+    expect(spans).not.toContainEqual(
+      expect.objectContaining({
+        op: 'navigation.redirect',
+      }),
+    );
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/immediately/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/immediately/init.js
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1,
+});
+
+// trigger redirect immediately
+window.history.pushState({}, '', '/sub-page');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/immediately/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/immediately/test.ts
@@ -1,0 +1,66 @@
+import { expect } from '@playwright/test';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+} from '@sentry/core';
+import { sentryTest } from '../../../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+
+sentryTest('should create a pageload transaction with navigation.redirect span', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+
+  await page.goto(url);
+
+  const pageloadRequest = envelopeRequestParser(await pageloadRequestPromise);
+
+  expect(pageloadRequest.contexts?.trace?.op).toBe('pageload');
+
+  expect(pageloadRequest.contexts?.trace?.data).toMatchObject({
+    [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
+    [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
+    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+    ['sentry.idle_span_finish_reason']: 'idleTimeout',
+  });
+
+  expect(pageloadRequest.request).toEqual({
+    headers: {
+      'User-Agent': expect.any(String),
+    },
+    url: 'http://sentry-test.io/index.html',
+  });
+
+  const spans = pageloadRequest.spans || [];
+
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'navigation.redirect',
+    }),
+  );
+
+  const navigationSpan = spans.find(span => span.op === 'navigation.redirect');
+  expect(navigationSpan?.timestamp).toEqual(navigationSpan?.start_timestamp);
+  expect(navigationSpan).toEqual({
+    data: {
+      'sentry.op': 'navigation.redirect',
+      'sentry.origin': 'auto.navigation.browser',
+      'sentry.source': 'url',
+    },
+    description: '/sub-page',
+    op: 'navigation.redirect',
+    origin: 'auto.navigation.browser',
+    parent_span_id: pageloadRequest.contexts!.trace!.span_id,
+    span_id: expect.any(String),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    trace_id: expect.any(String),
+  });
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress-early/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress-early/init.js
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1,
+  debug: true,
+});
+
+document.getElementById('btn1').addEventListener('click', () => {
+  // Trigger navigation later than click, so the last click is more than 300ms ago
+  setTimeout(() => {
+    window.history.pushState({}, '', '/sub-page');
+
+    // then trigger redirect inside of this navigation, which should be detected as a redirect
+    // because the last click was more than 300ms ago
+    setTimeout(() => {
+      window.history.pushState({}, '', '/sub-page-redirect');
+    }, 100);
+  }, 400);
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress-early/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress-early/template.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <button id="btn1">Trigger navigation</button>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress-early/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress-early/test.ts
@@ -1,0 +1,42 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+
+sentryTest(
+  'should create a navigation.redirect span if a keypress happened more than 300ms before navigation',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+    const navigationRequestPromise = waitForTransactionRequest(
+      page,
+      event => event.contexts?.trace?.op === 'navigation',
+    );
+
+    await page.goto(url);
+
+    await pageloadRequestPromise;
+
+    // Now trigger navigation, and then a redirect in the navigation
+    await page.focus('#btn1');
+    await page.keyboard.press('Enter');
+
+    const navigationRequest = envelopeRequestParser(await navigationRequestPromise);
+
+    expect(navigationRequest.contexts?.trace?.op).toBe('navigation');
+    expect(navigationRequest.transaction).toEqual('/sub-page');
+
+    const spans = navigationRequest.spans || [];
+
+    expect(spans).toContainEqual(
+      expect.objectContaining({
+        op: 'navigation.redirect',
+        description: '/sub-page-redirect',
+      }),
+    );
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress/init.js
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1,
+  debug: true,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress/subject.js
@@ -1,0 +1,4 @@
+document.getElementById('btn1').addEventListener('click', () => {
+  // trigger redirect immediately
+  window.history.pushState({}, '', '/sub-page');
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress/template.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <button id="btn1" type="button">Trigger navigation</button>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/keypress/test.ts
@@ -1,0 +1,36 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+
+sentryTest(
+  'should not create a navigation.redirect span if a keypress happened before navigation',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+    const navigationRequestPromise = waitForTransactionRequest(
+      page,
+      event => event.contexts?.trace?.op === 'navigation',
+    );
+
+    await page.goto(url);
+    await page.focus('#btn1');
+    await page.keyboard.press('Enter');
+
+    const pageloadRequest = envelopeRequestParser(await pageloadRequestPromise);
+    // Ensure a navigation span is sent, too
+    await navigationRequestPromise;
+
+    const spans = pageloadRequest.spans || [];
+
+    expect(spans).not.toContainEqual(
+      expect.objectContaining({
+        op: 'navigation.redirect',
+      }),
+    );
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/late/init.js
@@ -4,12 +4,11 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [Sentry.browserTracingIntegration({ idleTimeout: 2000 })],
+  integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,
 });
 
-// Navigate to a new page to abort the pageload
-// We have to wait >300ms to avoid the redirect handling
+// trigger redirect later
 setTimeout(() => {
   window.history.pushState({}, '', '/sub-page');
-}, 500);
+}, 400);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/late/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/late/test.ts
@@ -1,0 +1,34 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+
+sentryTest(
+  'should not create a navigation.redirect span if redirect happened more than 300ms after pageload',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+    const navigationRequestPromise = waitForTransactionRequest(
+      page,
+      event => event.contexts?.trace?.op === 'navigation',
+    );
+
+    await page.goto(url);
+
+    const pageloadRequest = envelopeRequestParser(await pageloadRequestPromise);
+    // Ensure a navigation span is sent, too
+    await navigationRequestPromise;
+
+    const spans = pageloadRequest.spans || [];
+
+    expect(spans).not.toContainEqual(
+      expect.objectContaining({
+        op: 'navigation.redirect',
+      }),
+    );
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/opt-out/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/opt-out/init.js
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    Sentry.browserTracingIntegration({
+      detectRedirects: false,
+    }),
+  ],
+  tracesSampleRate: 1,
+});
+
+// trigger redirect immediately
+window.history.pushState({}, '', '/sub-page');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/opt-out/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/opt-out/test.ts
@@ -1,0 +1,34 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+
+sentryTest(
+  'should not create a navigation.redirect span if `detectRedirects` is set to false',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+    const navigationRequestPromise = waitForTransactionRequest(
+      page,
+      event => event.contexts?.trace?.op === 'navigation',
+    );
+
+    await page.goto(url);
+
+    const pageloadRequest = envelopeRequestParser(await pageloadRequestPromise);
+    // Ensure a navigation span is sent, too
+    await navigationRequestPromise;
+
+    const spans = pageloadRequest.spans || [];
+
+    expect(spans).not.toContainEqual(
+      expect.objectContaining({
+        op: 'navigation.redirect',
+      }),
+    );
+  },
+);

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -490,7 +490,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         }
 
         if (navigationOptions?.isRedirect) {
-          DEBUG_BUILD && logger.warn('[Tracing] Detected redirect, navigation span will not be the root span.');
+          DEBUG_BUILD && logger.warn('[Tracing] Detected redirect, navigation span will not be the root span, but a child span.');
           _createRouteSpan(
             client,
             {

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -3,6 +3,7 @@ import type { Client, IntegrationFn, Span, StartSpanOptions, TransactionSource, 
 import {
   addNonEnumerableProperty,
   browserPerformanceTimeOrigin,
+  dateTimestampInSeconds,
   generateTraceId,
   getClient,
   getCurrentScope,
@@ -20,6 +21,8 @@ import {
   spanIsSampled,
   spanToJSON,
   startIdleSpan,
+  startInactiveSpan,
+  timestampInSeconds,
   TRACING_DEFAULTS,
 } from '@sentry/core';
 import {
@@ -196,6 +199,14 @@ export interface BrowserTracingOptions {
   ignorePerformanceApiSpans: Array<string | RegExp>;
 
   /**
+   * By default, the SDK will try to detect redirects and avoid creating separate spans for them.
+   * If you want to opt-out of this behavior, you can set this option to `false`.
+   *
+   * Default: true
+   */
+  detectRedirects: boolean;
+
+  /**
    * Link the currently started trace to a previous trace (e.g. a prior pageload, navigation or
    * manually started span). When enabled, this option will allow you to navigate between traces
    * in the Sentry UI.
@@ -281,6 +292,7 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   enableElementTiming: true,
   ignoreResourceSpans: [],
   ignorePerformanceApiSpans: [],
+  detectRedirects: true,
   linkPreviousTrace: 'in-memory',
   consistentTraceSampling: false,
   _experiments: {},
@@ -328,6 +340,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
     ignorePerformanceApiSpans,
     instrumentPageLoad,
     instrumentNavigation,
+    detectRedirects,
     linkPreviousTrace,
     consistentTraceSampling,
     onRequestSpanStart,
@@ -337,9 +350,10 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
   };
 
   let _collectWebVitals: undefined | (() => void);
+  let lastClickTimestamp: number | undefined;
 
   /** Create routing idle transaction. */
-  function _createRouteSpan(client: Client, startSpanOptions: StartSpanOptions): void {
+  function _createRouteSpan(client: Client, startSpanOptions: StartSpanOptions, makeActive = true): void {
     const isPageloadTransaction = startSpanOptions.op === 'pageload';
 
     const finalStartSpanOptions: StartSpanOptions = beforeStartSpan
@@ -353,6 +367,16 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
     if (startSpanOptions.name !== finalStartSpanOptions.name) {
       attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] = 'custom';
       finalStartSpanOptions.attributes = attributes;
+    }
+
+    if (!makeActive) {
+      // We want to ensure this has 0s duration
+      const now = dateTimestampInSeconds();
+      startInactiveSpan({
+        ...finalStartSpanOptions,
+        startTime: now,
+      }).end(now);
+      return;
     }
 
     latestRoute.name = finalStartSpanOptions.name;
@@ -441,6 +465,10 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         startTrackingInteractions();
       }
 
+      if (detectRedirects && optionalWindowDocument) {
+        addEventListener('click', () => (lastClickTimestamp = timestampInSeconds()), { capture: true, passive: true });
+      }
+
       function maybeEndActiveSpan(): void {
         const activeSpan = getActiveIdleSpan(client);
 
@@ -452,8 +480,21 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         }
       }
 
-      client.on('startNavigationSpan', startSpanOptions => {
+      client.on('startNavigationSpan', (startSpanOptions, navigationOptions) => {
         if (getClient() !== client) {
+          return;
+        }
+
+        if (navigationOptions?.isRedirect) {
+          DEBUG_BUILD && logger.warn('[Tracing] Detected redirect, navigation span will not be the root span.');
+          _createRouteSpan(
+            client,
+            {
+              op: 'navigation.redirect',
+              ...startSpanOptions,
+            },
+            false,
+          );
           return;
         }
 
@@ -540,23 +581,19 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
 
             startingUrl = undefined;
             const parsed = parseStringToURLObject(to);
-            startBrowserTracingNavigationSpan(client, {
-              name: parsed?.pathname || WINDOW.location.pathname,
-              attributes: {
-                [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
-                [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
+            const activeSpan = getActiveIdleSpan(client);
+            const navigationIsRedirect = activeSpan && detectRedirects && isRedirect(activeSpan, lastClickTimestamp);
+            startBrowserTracingNavigationSpan(
+              client,
+              {
+                name: parsed?.pathname || WINDOW.location.pathname,
+                attributes: {
+                  [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
+                },
               },
-            });
-
-            // We store the normalized request data on the scope, so we get the request data at time of span creation
-            // otherwise, the URL etc. may already be of the following navigation, and we'd report the wrong URL
-            getCurrentScope().setSDKProcessingMetadata({
-              normalizedRequest: {
-                ...getHttpRequestData(),
-                // Ensure to set this, so this matches the target route even if the URL has not yet been updated
-                url: to,
-              },
-            });
+              { url: to, isRedirect: navigationIsRedirect },
+            );
           });
         }
       }
@@ -608,10 +645,28 @@ export function startBrowserTracingPageLoadSpan(
  * Manually start a navigation span.
  * This will only do something if a browser tracing integration has been setup.
  */
-export function startBrowserTracingNavigationSpan(client: Client, spanOptions: StartSpanOptions): Span | undefined {
-  client.emit('startNavigationSpan', spanOptions);
+export function startBrowserTracingNavigationSpan(
+  client: Client,
+  spanOptions: StartSpanOptions,
+  options?: { url?: string; isRedirect?: boolean },
+): Span | undefined {
+  const { url, isRedirect } = options || {};
 
-  getCurrentScope().setTransactionName(spanOptions.name);
+  client.emit('startNavigationSpan', spanOptions, { isRedirect });
+
+  const scope = getCurrentScope();
+  scope.setTransactionName(spanOptions.name);
+
+  // We store the normalized request data on the scope, so we get the request data at time of span creation
+  // otherwise, the URL etc. may already be of the following navigation, and we'd report the wrong URL
+  if (url && !isRedirect) {
+    scope.setSDKProcessingMetadata({
+      normalizedRequest: {
+        ...getHttpRequestData(),
+        url,
+      },
+    });
+  }
 
   return getActiveIdleSpan(client);
 }
@@ -684,7 +739,7 @@ function registerInteractionListener(
   };
 
   if (optionalWindowDocument) {
-    addEventListener('click', registerInteractionTransaction, { once: false, capture: true });
+    addEventListener('click', registerInteractionTransaction, { capture: true });
   }
 }
 
@@ -696,4 +751,28 @@ function getActiveIdleSpan(client: Client): Span | undefined {
 
 function setActiveIdleSpan(client: Client, span: Span | undefined): void {
   addNonEnumerableProperty(client, ACTIVE_IDLE_SPAN_PROPERTY, span);
+}
+
+// The max. time in seconds between two pageload/navigation spans that makes us consider the second one a redirect
+const REDIRECT_THRESHOLD = 0.3;
+
+function isRedirect(activeSpan: Span, lastClickTimestamp: number | undefined): boolean {
+  const spanData = spanToJSON(activeSpan);
+
+  const now = dateTimestampInSeconds();
+
+  // More than 300ms since last navigation/pageload span?
+  // --> never consider this a redirect
+  const startTimestamp = spanData.start_timestamp;
+  if (now - startTimestamp > REDIRECT_THRESHOLD) {
+    return false;
+  }
+
+  // A click happened in the last 300ms?
+  // --> never consider this a redirect
+  if (lastClickTimestamp && now - lastClickTimestamp <= REDIRECT_THRESHOLD) {
+    return false;
+  }
+
+  return true;
 }

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -469,8 +469,8 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         const clickHandler = (): void => {
           lastInteractionTimestamp = timestampInSeconds();
         };
-        addEventListener('click', () => clickHandler, { capture: true, passive: true });
-        addEventListener('keypress', () => clickHandler, { capture: true, passive: true });
+        addEventListener('click', clickHandler, { capture: true });
+        addEventListener('keydown', clickHandler, { capture: true, passive: true });
       }
 
       function maybeEndActiveSpan(): void {

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -490,7 +490,8 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         }
 
         if (navigationOptions?.isRedirect) {
-          DEBUG_BUILD && logger.warn('[Tracing] Detected redirect, navigation span will not be the root span, but a child span.');
+          DEBUG_BUILD &&
+            logger.warn('[Tracing] Detected redirect, navigation span will not be the root span, but a child span.');
           _createRouteSpan(
             client,
             {
@@ -586,7 +587,8 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
             startingUrl = undefined;
             const parsed = parseStringToURLObject(to);
             const activeSpan = getActiveIdleSpan(client);
-            const navigationIsRedirect = activeSpan && detectRedirects && isRedirect(activeSpan, lastInteractionTimestamp);
+            const navigationIsRedirect =
+              activeSpan && detectRedirects && isRedirect(activeSpan, lastInteractionTimestamp);
             startBrowserTracingNavigationSpan(
               client,
               {

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -466,11 +466,11 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
       }
 
       if (detectRedirects && optionalWindowDocument) {
-        const clickHandler = (): void => {
+        const interactionHandler = (): void => {
           lastInteractionTimestamp = timestampInSeconds();
         };
-        addEventListener('click', clickHandler, { capture: true });
-        addEventListener('keydown', clickHandler, { capture: true, passive: true });
+        addEventListener('click', interactionHandler, { capture: true });
+        addEventListener('keydown', interactionHandler, { capture: true, passive: true });
       }
 
       function maybeEndActiveSpan(): void {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -607,7 +607,10 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
    * A hook for browser tracing integrations to trigger a span for a navigation.
    * @returns {() => void} A function that, when executed, removes the registered callback.
    */
-  public on(hook: 'startNavigationSpan', callback: (options: StartSpanOptions) => void): () => void;
+  public on(
+    hook: 'startNavigationSpan',
+    callback: (options: StartSpanOptions, navigationOptions?: { isRedirect?: boolean }) => void,
+  ): () => void;
 
   /**
    * A hook for GraphQL client integration to enhance a span with request data.
@@ -782,7 +785,11 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   /**
    * Emit a hook event for browser tracing integrations to trigger a span for a navigation.
    */
-  public emit(hook: 'startNavigationSpan', options: StartSpanOptions): void;
+  public emit(
+    hook: 'startNavigationSpan',
+    options: StartSpanOptions,
+    navigationOptions?: { isRedirect?: boolean },
+  ): void;
 
   /**
    * Emit a hook event for GraphQL client integration to enhance a span with request data.

--- a/packages/nextjs/test/performance/pagesRouterInstrumentation.test.ts
+++ b/packages/nextjs/test/performance/pagesRouterInstrumentation.test.ts
@@ -332,6 +332,7 @@ describe('pagesRouterInstrumentNavigation', () => {
             'sentry.source': expectedTransactionSource,
           },
         }),
+        { isRedirect: undefined },
       );
     },
   );


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/15286

This PR adds a new option to `browserTracingIntegration`, `detectRedirects`, which is enabled by default. If this is enabled, the integration will try to detect if a navigation is actually a redirect based on a simple heuristic, and in this case, will not end the ongoing pageload/navigation, but instead let it run and create a `navigation.redirect` zero-duration span instead.

An example trace for this would be: https://sentry-sdks.sentry.io/explore/discover/trace/95280de69dc844448d39de7458eab527/?dataset=transactions&eventId=8a1150fd1dc846e4ac8420ccf03ad0ee&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=4504956726345728&query=&queryDataset=transaction-like&sort=-timestamp&source=discover&statsPeriod=5m&timestamp=1747646096&yAxis=count%28%29
![image](https://github.com/user-attachments/assets/5f30210b-5ad0-44d9-ad49-bb00354b5fe5)

Where the respective index route that triggered this has this code:

```js
setTimeout(() => {
  window.history.pushState({}, "", "/test-sub-page");
  fetch('https://example.com')
}, 100);
```

The used heuristic is:

* If the ongoing pageload/navigation was started less than 300ms ago...
* ... and no click has happened in this time...
* ... then we consider the navigation a redirect

this limit was chosen somewhat arbitrarily, open for other suggestions too.

While this logic will not be 100% bullet proof, it should be reliable enough and likely better than what we have today. Users can opt-out of this logic via `browserTracingIntegration({ detectRedirects: false })`, if needed.