### PR TITLE
doc(node): Fix `ignoreIncomingRequestBody` JSDoc

### DIFF
--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -77,8 +77,8 @@ export type SentryHttpInstrumentationOptions = InstrumentationConfig & {
    * Do not capture the request body for incoming HTTP requests to URLs where the given callback returns `true`.
    * This can be useful for long running requests where the body is not needed and we want to avoid capturing it.
    *
-   * @param url Contains the entire URL, including query string (if any), protocol, host, etc. of the outgoing request.
-   * @param request Contains the {@type RequestOptions} object used to make the outgoing request.
+   * @param url Contains the entire URL, including query string (if any), protocol, host, etc. of the incoming request.
+   * @param request Contains the {@type RequestOptions} object used to make the incoming request.
    */
   ignoreIncomingRequestBody?: (url: string, request: http.RequestOptions) => boolean;
 

--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -85,8 +85,8 @@ interface HttpOptions {
    * Do not capture the request body for incoming HTTP requests to URLs where the given callback returns `true`.
    * This can be useful for long running requests where the body is not needed and we want to avoid capturing it.
    *
-   * @param url Contains the entire URL, including query string (if any), protocol, host, etc. of the outgoing request.
-   * @param request Contains the {@type RequestOptions} object used to make the outgoing request.
+   * @param url Contains the entire URL, including query string (if any), protocol, host, etc. of the incoming request.
+   * @param request Contains the {@type RequestOptions} object used to make the incoming request.
    */
   ignoreIncomingRequestBody?: (url: string, request: RequestOptions) => boolean;
 


### PR DESCRIPTION
This PR just fixes incorrect JSDoc where I missed a mix-up of incoming and outgoing requests for the `ignoreIncomingRequestBody` option while reviewing. Raised in https://github.com/getsentry/sentry-docs/pull/13698/files#r2088760944