### PR TITLE
fix(remix): Use generic types for `ServerBuild` argument and return

### DIFF
--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -1,4 +1,3 @@
-import type { ServerBuild } from '@remix-run/server-runtime';
 import {
   instrumentBuild as instrumentRemixBuild,
   makeWrappedCreateRequestHandler,
@@ -15,14 +14,11 @@ export { makeWrappedCreateRequestHandler, sentryHandleError };
  * Instruments a Remix build to capture errors and performance data.
  * @param build The Remix build to instrument.
  * @returns The instrumented Remix build.
- *
- * Note: CreateRequestHandlerFunction from @shopify/remix-oxygen accepts a ServerBuild, not a function unlike the rest of the Remix ecosystem
- * That's why we accept and return a ServerBuild type here.
  */
-export const instrumentBuild = (build: ServerBuild): ServerBuild => {
+export const instrumentBuild: typeof instrumentRemixBuild = build => {
   return instrumentRemixBuild(build, {
     instrumentTracing: true,
-  }) as ServerBuild;
+  });
 };
 
 export type {

--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -1,3 +1,4 @@
+import type { ServerBuild } from '@remix-run/server-runtime';
 import {
   instrumentBuild as instrumentRemixBuild,
   makeWrappedCreateRequestHandler,
@@ -14,11 +15,14 @@ export { makeWrappedCreateRequestHandler, sentryHandleError };
  * Instruments a Remix build to capture errors and performance data.
  * @param build The Remix build to instrument.
  * @returns The instrumented Remix build.
+ *
+ * Note: CreateRequestHandlerFunction from @shopify/remix-oxygen accepts a ServerBuild, not a function unlike the rest of the Remix ecosystem
+ * That's why we accept and return a ServerBuild type here.
  */
-export const instrumentBuild: typeof instrumentRemixBuild = build => {
+export const instrumentBuild = (build: ServerBuild): ServerBuild => {
   return instrumentRemixBuild(build, {
     instrumentTracing: true,
-  });
+  }) as ServerBuild;
 };
 
 export type {

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -432,11 +432,7 @@ export function instrumentBuild(
 
 export const makeWrappedCreateRequestHandler = (options?: { instrumentTracing?: boolean }) =>
   function (origCreateRequestHandler: CreateRequestHandlerFunction): CreateRequestHandlerFunction {
-    return function (
-      this: unknown,
-      build: ServerBuild | (() => ServerBuild | Promise<ServerBuild>),
-      ...args: unknown[]
-    ): RequestHandler {
+    return function (this: unknown, build, ...args: unknown[]): RequestHandler {
       const newBuild = instrumentBuild(build, options);
       const requestHandler = origCreateRequestHandler.call(this, newBuild, ...args);
 


### PR DESCRIPTION
Closes: #15615 
Ref: https://github.com/getsentry/sentry-javascript/issues/15615#issuecomment-2887533896

Looks like `createRequestHandler` exported from `@shopify/remix-oxygen` does not accept a function that returns/resolves a `ServerBuild`. [It only accepts a plain `ServerBuild`](https://github.com/Shopify/hydrogen/blob/a7e33c1dd45e3c7c27ab2e1125851468051cee0b/packages/remix-oxygen/src/server.ts#L20).