### PR TITLE
ref(browser): Streamline `showReportDialog` code

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -84,7 +84,8 @@ export {
 } from './stack-parsers';
 export { eventFromException, eventFromMessage, exceptionFromError } from './eventbuilder';
 export { createUserFeedbackEnvelope } from './userfeedback';
-export { getDefaultIntegrations, forceLoad, init, onLoad, showReportDialog } from './sdk';
+export { getDefaultIntegrations, forceLoad, init, onLoad } from './sdk';
+export { showReportDialog } from './report-dialog';
 
 export { breadcrumbsIntegration } from './integrations/breadcrumbs';
 export { globalHandlersIntegration } from './integrations/globalhandlers';

--- a/packages/browser/src/report-dialog.ts
+++ b/packages/browser/src/report-dialog.ts
@@ -1,0 +1,64 @@
+import type { ReportDialogOptions } from '@sentry/core';
+import { getClient, getCurrentScope, getReportDialogEndpoint, lastEventId, logger } from '@sentry/core';
+import { DEBUG_BUILD } from './debug-build';
+import { WINDOW } from './helpers';
+
+/**
+ * Present the user with a report dialog.
+ *
+ * @param options Everything is optional, we try to fetch all info need from the current scope.
+ */
+export function showReportDialog(options: ReportDialogOptions = {}): void {
+  const optionalDocument = WINDOW.document as Document | undefined;
+  const injectionPoint = optionalDocument?.head || optionalDocument?.body;
+
+  // doesn't work without a document (React Native)
+  if (!injectionPoint) {
+    DEBUG_BUILD && logger.error('[showReportDialog] Global document not defined');
+    return;
+  }
+
+  const scope = getCurrentScope();
+  const client = getClient();
+  const dsn = client?.getDsn();
+
+  if (!dsn) {
+    DEBUG_BUILD && logger.error('[showReportDialog] DSN not configured');
+    return;
+  }
+
+  const mergedOptions = {
+    ...options,
+    user: {
+      ...scope.getUser(),
+      ...options.user,
+    },
+    eventId: options.eventId || lastEventId(),
+  };
+
+  const script = WINDOW.document.createElement('script');
+  script.async = true;
+  script.crossOrigin = 'anonymous';
+  script.src = getReportDialogEndpoint(dsn, mergedOptions);
+
+  const { onLoad, onClose } = mergedOptions;
+
+  if (onLoad) {
+    script.onload = onLoad;
+  }
+
+  if (onClose) {
+    const reportDialogClosedMessageHandler = (event: MessageEvent): void => {
+      if (event.data === '__sentry_reportdialog_closed__') {
+        try {
+          onClose();
+        } finally {
+          WINDOW.removeEventListener('message', reportDialogClosedMessageHandler);
+        }
+      }
+    };
+    WINDOW.addEventListener('message', reportDialogClosedMessageHandler);
+  }
+
+  injectionPoint.appendChild(script);
+}

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -71,6 +71,9 @@ describe('browserTracingIntegration', () => {
     getIsolationScope().clear();
     getCurrentScope().setClient(undefined);
     document.head.innerHTML = '';
+
+    // We want to suppress the "Multiple browserTracingIntegration instances are not supported." warnings
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {


### PR DESCRIPTION
Just a small refactor, noticed this while working on other browser sdk stuff. Moving this into a dedicated file decouples this from the core SDK functionality, which this IMHO is not (anymore). Also, we can streamline the code slightly for efficiency.