### PR TITLE
ref(browser): Streamline browser `init()` checks

### DIFF
--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/test.ts
@@ -23,7 +23,7 @@ sentryTest(
     if (hasDebugLogs()) {
       expect(errorLogs.length).toEqual(1);
       expect(errorLogs[0]).toEqual(
-        '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
+        '[Sentry] You cannot use Sentry.init() in a browser extension, see: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
       );
     } else {
       expect(errorLogs.length).toEqual(0);

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/test.ts
@@ -21,7 +21,7 @@ sentryTest('should not initialize when inside a Chrome browser extension', async
   if (hasDebugLogs()) {
     expect(errorLogs.length).toEqual(1);
     expect(errorLogs[0]).toEqual(
-      '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
+      '[Sentry] You cannot use Sentry.init() in a browser extension, see: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
     );
   } else {
     expect(errorLogs.length).toEqual(0);

--- a/packages/browser/test/sdk.test.ts
+++ b/packages/browser/test/sdk.test.ts
@@ -149,7 +149,7 @@ describe('init', () => {
 
       expect(consoleErrorSpy).toBeCalledTimes(1);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
+        '[Sentry] You cannot use Sentry.init() in a browser extension, see: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
       );
 
       consoleErrorSpy.mockRestore();
@@ -164,7 +164,7 @@ describe('init', () => {
 
       expect(consoleErrorSpy).toBeCalledTimes(1);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[Sentry] You cannot run Sentry this way in a browser extension, check: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
+        '[Sentry] You cannot use Sentry.init() in a browser extension, see: https://docs.sentry.io/platforms/javascript/best-practices/browser-extensions/',
       );
 
       consoleErrorSpy.mockRestore();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -203,9 +203,11 @@ export {
   supportsDOMError,
   supportsDOMException,
   supportsErrorEvent,
+  // eslint-disable-next-line deprecation/deprecation
   supportsFetch,
   supportsHistory,
   supportsNativeFetch,
+  // eslint-disable-next-line deprecation/deprecation
   supportsReferrerPolicy,
   supportsReportingObserver,
 } from './utils-hoist/supports';

--- a/packages/core/src/utils-hoist/supports.ts
+++ b/packages/core/src/utils-hoist/supports.ts
@@ -69,8 +69,11 @@ export function supportsHistory(): boolean {
  * {@link supportsFetch}.
  *
  * @returns Answer to the given question.
+ * @deprecated This is no longer used and will be removed in a future major version.
  */
-export function supportsFetch(): boolean {
+export const supportsFetch = _isFetchSupported;
+
+function _isFetchSupported(): boolean {
   if (!('fetch' in WINDOW)) {
     return false;
   }
@@ -104,7 +107,7 @@ export function supportsNativeFetch(): boolean {
     return true;
   }
 
-  if (!supportsFetch()) {
+  if (!_isFetchSupported()) {
     return false;
   }
 
@@ -153,6 +156,7 @@ export function supportsReportingObserver(): boolean {
  * {@link supportsReferrerPolicy}.
  *
  * @returns Answer to the given question.
+ * @deprecated This is no longer used and will be removed in a future major version.
  */
 export function supportsReferrerPolicy(): boolean {
   // Despite all stars in the sky saying that Edge supports old draft syntax, aka 'never', 'always', 'origin' and 'default'
@@ -160,7 +164,7 @@ export function supportsReferrerPolicy(): boolean {
   // it doesn't. And it throws an exception instead of ignoring this parameter...
   // REF: https://github.com/getsentry/raven-js/issues/1233
 
-  if (!supportsFetch()) {
+  if (!_isFetchSupported()) {
     return false;
   }
 


### PR DESCRIPTION
Extracted this out of https://github.com/getsentry/sentry-javascript/pull/15307

This PR:

1. Moves things around in the `sdk.ts` file a bit, moving types & consts to the top of the file
2. Removes an "unecessary" log around fetch not being supported: This log has two problems. First, it is not actually logged, because we do `logger.log()` before running `init()`, which would actually set the logger up. So the log would never show up. Second, the log is superfluous, if the (default) fetch transport fails to send because fetch is not available, you get a warning anyhow for this.
3. Streamlines the browser extension check code slightly.

Closes https://github.com/getsentry/sentry-javascript/issues/16284