### PR TITLE
fix(remix): Add missing `client` exports to `server` and `cloudflare` entries

### DIFF
--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -8,6 +8,7 @@ export * from '@sentry/react';
 
 export { captureRemixErrorBoundaryError } from '../client/errors';
 export { withSentry } from '../client/performance';
+export { ErrorBoundary, browserTracingIntegration } from '../client';
 export { makeWrappedCreateRequestHandler, sentryHandleError };
 
 /**

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -1,4 +1,4 @@
 export * from './server';
-export { captureRemixErrorBoundaryError, withSentry } from './client';
+export { captureRemixErrorBoundaryError, withSentry, ErrorBoundary, browserTracingIntegration } from './client';
 
 export type { SentryMetaArgs } from './utils/types';


### PR DESCRIPTION
Resolves: #16298 

Also exported `ErrorBoundary` and `browserTracingIntegration` from `cloudflare` entry. 