### PR TITLE
fix(node): Don't warn about Spotlight on empty NODE_ENV

### DIFF
--- a/packages/node/src/integrations/spotlight.ts
+++ b/packages/node/src/integrations/spotlight.ts
@@ -20,7 +20,12 @@ const _spotlightIntegration = ((options: Partial<SpotlightConnectionOptions> = {
   return {
     name: INTEGRATION_NAME,
     setup(client) {
-      if (typeof process === 'object' && process.env && process.env.NODE_ENV !== 'development') {
+      if (
+        typeof process === 'object' &&
+        process.env &&
+        process.env.NODE_ENV &&
+        process.env.NODE_ENV !== 'development'
+      ) {
         logger.warn("[Spotlight] It seems you're not in dev mode. Do you really want to have Spotlight enabled?");
       }
       connectToSpotlight(client, _options);


### PR DESCRIPTION
When running with `spotlight: true` I got a warning about not being in development mode when `NODE_ENV` was not set. This typically indicates dev mode so added a check for that.
