### PR TITLE
fix(opentelemetry): Ensure `withScope` keeps span active & `_getTraceInfoFromScope` works

### DIFF
--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1781,6 +1781,19 @@ describe('getActiveSpan', () => {
     const result = getActiveSpan();
     expect(result).toBe(staticSpan);
   });
+
+  it('handles active span when passing scopes to withScope', () => {
+    const [scope, span] = startSpan({ name: 'outer' }, span => {
+      return [getCurrentScope(), span];
+    });
+
+    const spanOnScope = withScope(scope, () => {
+      return getActiveSpan();
+    });
+
+    expect(spanOnScope).toBeDefined();
+    expect(spanOnScope).toBe(span);
+  });
 });
 
 describe('withActiveSpan()', () => {

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -8,7 +8,7 @@ import {
 } from './constants';
 import { continueTrace, startInactiveSpan, startSpan, startSpanManual, withActiveSpan } from './trace';
 import type { CurrentScopes } from './types';
-import { getScopesFromContext } from './utils/contextData';
+import { getContextFromScope, getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
 import { getTraceData } from './utils/getTraceData';
 import { suppressTracing } from './utils/suppressTracing';
@@ -48,7 +48,7 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
   }
 
   function withSetScope<T>(scope: Scope, callback: (scope: Scope) => T): T {
-    const ctx = api.context.active();
+    const ctx = getContextFromScope(scope) || api.context.active();
 
     // We depend on the otelContextManager to handle the context/hub
     // We set the `SENTRY_FORK_SET_SCOPE_CONTEXT_KEY` context value, which is picked up by

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -1342,6 +1342,21 @@ describe('trace', () => {
       });
     });
   });
+
+  describe('scope passing', () => {
+    it('handles active span when passing scopes to withScope', () => {
+      const [scope, span] = startSpan({ name: 'outer' }, span => {
+        return [getCurrentScope(), span];
+      });
+
+      const spanOnScope = withScope(scope, () => {
+        return getActiveSpan();
+      });
+
+      expect(spanOnScope).toBeDefined();
+      expect(spanOnScope).toBe(span);
+    });
+  });
 });
 
 describe('trace (tracing disabled)', () => {


### PR DESCRIPTION
Also ensure that `withScope(scope, callback)` maintains the active span from the passed in scope.

Fixes https://github.com/getsentry/sentry-javascript/issues/16361

The problem here was that we used the `_getSpanForScope` method in core for this, but this only actually works for the core implementation, not the node one 😬 So I rewrote this to use more general utilities, which should work isomorphically. While doing this, I noticed an actual bug in the `withScope` implementation in otel, where we did not actually keep the active span correctly.