### PR TITLE
feat(core): Export `_INTERNAL_captureSerializedLog`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,7 +119,7 @@ export { trpcMiddleware } from './trpc';
 export { wrapMcpServerWithSentry } from './mcp-server';
 export { captureFeedback } from './feedback';
 export type { ReportDialogOptions } from './report-dialog';
-export { _INTERNAL_captureLog, _INTERNAL_flushLogsBuffer } from './logs/exports';
+export { _INTERNAL_captureLog, _INTERNAL_flushLogsBuffer, _INTERNAL_captureSerializedLog } from './logs/exports';
 export { consoleLoggingIntegration } from './logs/console-integration';
 
 export type { FeatureFlag } from './featureFlags';

--- a/packages/core/src/logs/exports.ts
+++ b/packages/core/src/logs/exports.ts
@@ -61,7 +61,16 @@ export function logAttributeToSerializedLogAttribute(value: unknown): Serialized
   }
 }
 
-function defaultCaptureSerializedLog(client: Client, serializedLog: SerializedLog): void {
+/**
+ * Captures a serialized log event and adds it to the log buffer for the given client.
+ *
+ * @param client - A client. Uses the current client if not provided.
+ * @param serializedLog - The serialized log event to capture.
+ *
+ * @experimental This method will experience breaking changes. This is not yet part of
+ * the stable Sentry SDK API and can be changed or removed without warning.
+ */
+export function _INTERNAL_captureSerializedLog(client: Client, serializedLog: SerializedLog): void {
   const logBuffer = _INTERNAL_getLogBuffer(client);
   if (logBuffer === undefined) {
     GLOBAL_OBJ._sentryClientToLogBufferMap?.set(client, [serializedLog]);
@@ -88,7 +97,7 @@ export function _INTERNAL_captureLog(
   beforeLog: Log,
   client: Client | undefined = getClient(),
   scope = getCurrentScope(),
-  captureSerializedLog: (client: Client, log: SerializedLog) => void = defaultCaptureSerializedLog,
+  captureSerializedLog: (client: Client, log: SerializedLog) => void = _INTERNAL_captureSerializedLog,
 ): void {
   if (!client) {
     DEBUG_BUILD && logger.warn('No client available to capture log.');


### PR DESCRIPTION
I renamed `defaultCaptureSerializedLog` to `_INTERNAL_captureSerializedLog` and exported it so it can be accessed from other SDKs.

I will use this in the Electron SDK in the root main process to add logs passed by IPC from other processes to the queue.
