### PR TITLE
feat: Export `isEnabled` from all SDKs

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -63,6 +63,7 @@ export {
   eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,
+  isEnabled,
   kafkaIntegration,
   koaIntegration,
   knexIntegration,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -14,6 +14,7 @@ export {
   createTransport,
   getClient,
   isInitialized,
+  isEnabled,
   generateInstrumentOnce,
   getCurrentScope,
   getGlobalScope,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -32,6 +32,7 @@ export {
   flush,
   getClient,
   isInitialized,
+  isEnabled,
   getCurrentScope,
   getIsolationScope,
   getGlobalScope,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -33,6 +33,7 @@ export {
   createTransport,
   getClient,
   isInitialized,
+  isEnabled,
   generateInstrumentOnce,
   getCurrentScope,
   getGlobalScope,

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -33,6 +33,7 @@ export {
   flush,
   getClient,
   isInitialized,
+  isEnabled,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -33,6 +33,7 @@ export {
   flush,
   getClient,
   isInitialized,
+  isEnabled,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -14,6 +14,7 @@ export {
   createTransport,
   getClient,
   isInitialized,
+  isEnabled,
   generateInstrumentOnce,
   getCurrentScope,
   getGlobalScope,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -65,6 +65,7 @@ export {
 export {
   addBreadcrumb,
   isInitialized,
+  isEnabled,
   getGlobalScope,
   lastEventId,
   close,

--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -55,6 +55,7 @@ export {
   flush,
   getClient,
   isInitialized,
+  isEnabled,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -52,6 +52,7 @@ export {
   eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,
+  isEnabled,
   knexIntegration,
   kafkaIntegration,
   koaIntegration,

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -55,6 +55,7 @@ export {
   eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,
+  isEnabled,
   knexIntegration,
   kafkaIntegration,
   koaIntegration,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -57,6 +57,7 @@ export {
   eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,
+  isEnabled,
   knexIntegration,
   kafkaIntegration,
   koaIntegration,

--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -46,6 +46,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   inboundFiltersIntegration,
   isInitialized,
+  isEnabled,
   lastEventId,
   linkedErrorsIntegration,
   requestDataIntegration,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -33,6 +33,7 @@ export {
   flush,
   getClient,
   isInitialized,
+  isEnabled,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,


### PR DESCRIPTION
This was forgotten to re-export. We actually document this, but have not exported it, oops.