### PR TITLE
fix(nuxt): Add `@sentry/nuxt` as external in Rollup

### DIFF
--- a/packages/nuxt/src/vite/addServerConfig.ts
+++ b/packages/nuxt/src/vite/addServerConfig.ts
@@ -8,6 +8,7 @@ import type { SentryNuxtModuleOptions } from '../common/types';
 import {
   constructFunctionReExport,
   constructWrappedFunctionExportQuery,
+  getExternalOptionsWithSentryNuxt,
   getFilenameFromNodeStartCommand,
   QUERY_END_INDICATOR,
   removeSentryQueryFromPath,
@@ -129,6 +130,13 @@ function injectServerConfigPlugin(nitro: Nitro, serverConfigFile: string, debug?
 
   return {
     name: 'rollup-plugin-inject-sentry-server-config',
+
+    options(opts) {
+      return {
+        ...opts,
+        external: getExternalOptionsWithSentryNuxt(opts.external),
+      };
+    },
 
     buildStart() {
       const configPath = createResolver(nitro.options.srcDir).resolve(`/${serverConfigFile}`);

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -5,6 +5,7 @@ import {
   constructWrappedFunctionExportQuery,
   extractFunctionReexportQueryParameters,
   findDefaultSdkInitFile,
+  getExternalOptionsWithSentryNuxt,
   getFilenameFromNodeStartCommand,
   QUERY_END_INDICATOR,
   removeSentryQueryFromPath,
@@ -294,5 +295,71 @@ export { foo_sentryWrapped as foo };
     const entryId = './module';
     const result = constructFunctionReExport(query, entryId);
     expect(result).toBe('');
+  });
+});
+
+describe('getExternalOptionsWithSentryNuxt', () => {
+  it('should return sentryExternals when previousExternal is undefined', () => {
+    const result = getExternalOptionsWithSentryNuxt(undefined);
+    expect(result).toEqual([/^@sentry\/nuxt$/]);
+  });
+
+  it('should merge sentryExternals with array previousExternal', () => {
+    const previousExternal = [/vue/, 'react'];
+    const result = getExternalOptionsWithSentryNuxt(previousExternal);
+    expect(result).toEqual([/^@sentry\/nuxt$/, /vue/, 'react']);
+  });
+
+  it('should create array with sentryExternals and non-array previousExternal', () => {
+    const previousExternal = 'vue';
+    const result = getExternalOptionsWithSentryNuxt(previousExternal);
+    expect(result).toEqual([/^@sentry\/nuxt$/, 'vue']);
+  });
+
+  it('should create a proxy when previousExternal is a function', () => {
+    const mockExternalFn = vi.fn().mockReturnValue(false);
+    const result = getExternalOptionsWithSentryNuxt(mockExternalFn);
+
+    expect(typeof result).toBe('function');
+    expect(result).toBeInstanceOf(Function);
+  });
+
+  it('should return true from proxied function when source is @sentry/nuxt', () => {
+    const mockExternalFn = vi.fn().mockReturnValue(false);
+    const result = getExternalOptionsWithSentryNuxt(mockExternalFn);
+
+    if (typeof result === 'function') {
+      const output = result('@sentry/nuxt', undefined, false);
+      expect(output).toBe(true);
+      expect(mockExternalFn).not.toHaveBeenCalled();
+    } else {
+      throw Error('Result should be a function');
+    }
+  });
+
+  it('should return false from proxied function and call function when source just includes @sentry/nuxt', () => {
+    const mockExternalFn = vi.fn().mockReturnValue(false);
+    const result = getExternalOptionsWithSentryNuxt(mockExternalFn);
+
+    if (typeof result === 'function') {
+      const output = result('@sentry/nuxt/dist/index.js', undefined, false);
+      expect(output).toBe(false);
+      expect(mockExternalFn).toHaveBeenCalledWith('@sentry/nuxt/dist/index.js', undefined, false);
+    } else {
+      throw Error('Result should be a function');
+    }
+  });
+
+  it('should call original function when source does not include @sentry/nuxt', () => {
+    const mockExternalFn = vi.fn().mockReturnValue(false);
+    const result = getExternalOptionsWithSentryNuxt(mockExternalFn);
+
+    if (typeof result === 'function') {
+      const output = result('vue', undefined, false);
+      expect(output).toBe(false);
+      expect(mockExternalFn).toHaveBeenCalledWith('vue', undefined, false);
+    } else {
+      throw Error('Result should be a function');
+    }
   });
 });


### PR DESCRIPTION
The Sentry Nuxt SDK emits the Sentry config file during the Rollup build. Users add this file to their application which includes an import from `@sentry/nuxt` and the init function. This file is then added as an `.mjs` file in the build output.

However, when building the application, this `.mjs` file included a bunch of OpenTelemetry imports and not only the init code as every dependency from `@sentry/nuxt` was traced back and bundled into the build output.

By adding `@sentry/nuxt` as external, the `.mjs` file really only contains the content like in the `.ts` file.
