### PR TITLE
test(angular): Add Angular `next` canary tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -886,6 +886,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9.4.0
+      # TODO: Remove this once the repo is bumped to 20.19.2 or higher
       - name: Set up Node for Angular 20
         if: matrix.test-application == 'angular-20'
         uses: actions/setup-node@v4

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -69,6 +69,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - test-application: 'angular-20'
+            build-command: 'test:build-canary'
+            label: 'angular-20 (next)'
           - test-application: 'create-react-app'
             build-command: 'test:build-canary'
             label: 'create-react-app (canary)'
@@ -123,8 +126,14 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9.4.0
-
+      # TODO: Remove this once the repo is bumped to 20.19.2 or higher
+      - name: Set up Node for Angular 20
+        if: matrix.test-application == 'angular-20'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.2'
       - name: Set up Node
+        if: matrix.test-application != 'angular-20'
         uses: actions/setup-node@v4
         with:
           node-version-file: 'dev-packages/e2e-tests/package.json'

--- a/dev-packages/e2e-tests/test-applications/angular-20/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-20/package.json
@@ -10,6 +10,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "playwright test",
     "test:build": "pnpm install && pnpm build",
+    "test:build-canary": "pnpm install && pnpm add @angular/animations@next @angular/common@next @angular/compiler@next @angular/core@next @angular/forms@next @angular/platform-browser@next @angular/platform-browser-dynamic@next @angular/router@next && pnpm add -D @angular-devkit/build-angular@next @angular/cli@next @angular/compiler-cli@next && pnpm build",
     "test:assert": "playwright test",
     "clean": "npx rimraf .angular node_modules pnpm-lock.yaml dist"
   },


### PR DESCRIPTION
This PR adds canary tests for the `@angular/*@next` packages. The tests are based on our `angular-20` e2e test app just like in our other canary tests, we manually install the preview versions of the packages and the run the app and the tests.

closes #16379 
closes #16365 