### PR TITLE
feat(browser): Add option to ignore `mark` and `measure` spans

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
@@ -1,0 +1,19 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    Sentry.browserTracingIntegration({
+      ignoreMeasureSpans: ['measure-ignore', 'mark-i'],
+      idleTimeout: 9000,
+    }),
+  ],
+  tracesSampleRate: 1,
+});
+
+performance.mark('mark-pass');
+performance.mark('mark-ignore');
+performance.measure('measure-pass');
+performance.measure('measure-ignore');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
@@ -6,7 +6,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      ignoreMeasureSpans: ['measure-ignore', 'mark-i'],
+      ignoreMeasureSpans: ['measure-ignore', /mark-i/],
       idleTimeout: 9000,
     }),
   ],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
@@ -6,7 +6,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      ignoreMeasureSpans: ['measure-ignore', /mark-i/],
+      ignorePerformanceApiSpans: ['measure-ignore', /mark-i/],
       idleTimeout: 9000,
     }),
   ],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/test.ts
@@ -4,7 +4,7 @@ import { sentryTest } from '../../../../utils/fixtures';
 import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../utils/helpers';
 
 sentryTest(
-  'should ignore mark and measure spans that match `ignoreMeasureSpans`',
+  'should ignore mark and measure spans that match `ignorePerformanceApiSpans`',
   async ({ getLocalTestUrl, page }) => {
     if (shouldSkipTracingTest()) {
       sentryTest.skip();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/test.ts
@@ -1,0 +1,47 @@
+import type { Route } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../utils/helpers';
+
+sentryTest(
+  'should ignore mark and measure spans that match `ignoreMeasureSpans`',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    await page.route('**/path/to/script.js', (route: Route) =>
+      route.fulfill({ path: `${__dirname}/assets/script.js` }),
+    );
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const transactionRequestPromise = waitForTransactionRequest(
+      page,
+      evt => evt.type === 'transaction' && evt.contexts?.trace?.op === 'pageload',
+    );
+
+    await page.goto(url);
+
+    const transactionEvent = envelopeRequestParser(await transactionRequestPromise);
+    const markAndMeasureSpans = transactionEvent.spans?.filter(({ op }) => op && ['mark', 'measure'].includes(op));
+
+    expect(markAndMeasureSpans?.length).toBe(3);
+    expect(markAndMeasureSpans).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          description: 'mark-pass',
+          op: 'mark',
+        }),
+        expect.objectContaining({
+          description: 'measure-pass',
+          op: 'measure',
+        }),
+        expect.objectContaining({
+          description: 'sentry-tracing-init',
+          op: 'mark',
+        }),
+      ]),
+    );
+  },
+);

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -315,7 +315,7 @@ interface AddPerformanceEntriesOptions {
    *
    * Default: []
    */
-  ignoreMeasureSpans: Array<string>;
+  ignoreMeasureSpans: Array<string | RegExp>;
 }
 
 /** Add performance related spans to a transaction */
@@ -449,7 +449,7 @@ export function _addMeasureSpans(
   startTime: number,
   duration: number,
   timeOrigin: number,
-  ignoreMeasureSpans: Array<string>,
+  ignoreMeasureSpans: AddPerformanceEntriesOptions['ignoreMeasureSpans'],
 ): void {
   if (['mark', 'measure'].includes(entry.entryType) && stringMatchesSomePattern(entry.name, ignoreMeasureSpans)) {
     return;

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -310,12 +310,13 @@ interface AddPerformanceEntriesOptions {
   ignoreResourceSpans: Array<'resouce.script' | 'resource.css' | 'resource.img' | 'resource.other' | string>;
 
   /**
-   * Performance spans created from `performance.mark(...)` or `performance.measure(...)`
+   * Performance spans created from browser Performance APIs,
+   * `performance.mark(...)` nand `performance.measure(...)`
    * with `name`s matching strings in the array will not be emitted.
    *
    * Default: []
    */
-  ignoreMeasureSpans: Array<string | RegExp>;
+  ignorePerformanceApiSpans: Array<string | RegExp>;
 }
 
 /** Add performance related spans to a transaction */
@@ -355,7 +356,7 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
       case 'mark':
       case 'paint':
       case 'measure': {
-        _addMeasureSpans(span, entry, startTime, duration, timeOrigin, options.ignoreMeasureSpans);
+        _addMeasureSpans(span, entry, startTime, duration, timeOrigin, options.ignorePerformanceApiSpans);
 
         // capture web vitals
         const firstHidden = getVisibilityWatcher();
@@ -449,9 +450,12 @@ export function _addMeasureSpans(
   startTime: number,
   duration: number,
   timeOrigin: number,
-  ignoreMeasureSpans: AddPerformanceEntriesOptions['ignoreMeasureSpans'],
+  ignorePerformanceApiSpans: AddPerformanceEntriesOptions['ignorePerformanceApiSpans'],
 ): void {
-  if (['mark', 'measure'].includes(entry.entryType) && stringMatchesSomePattern(entry.name, ignoreMeasureSpans)) {
+  if (
+    ['mark', 'measure'].includes(entry.entryType) &&
+    stringMatchesSomePattern(entry.name, ignorePerformanceApiSpans)
+  ) {
     return;
   }
 

--- a/packages/browser-utils/test/browser/browserMetrics.test.ts
+++ b/packages/browser-utils/test/browser/browserMetrics.test.ts
@@ -173,8 +173,7 @@ describe('_addMeasureSpans', () => {
     const duration = 356;
 
     entries.forEach(e => {
-      // full match ('measure-ignore') and partial match ('mark-i') cause the span to be ignored
-      _addMeasureSpans(pageloadSpan, e, startTime, duration, timeOrigin, ['measure-ignore', 'mark-i']);
+      _addMeasureSpans(pageloadSpan, e, startTime, duration, timeOrigin, ['measure-i', /mark-ign/]);
     });
 
     expect(spans).toHaveLength(3);

--- a/packages/browser-utils/test/browser/browserMetrics.test.ts
+++ b/packages/browser-utils/test/browser/browserMetrics.test.ts
@@ -117,7 +117,7 @@ describe('_addMeasureSpans', () => {
     expect(spans).toHaveLength(0);
   });
 
-  it('ignores performance spans that match ignoreMeasureSpans', () => {
+  it('ignores performance spans that match ignorePerformanceApiSpans', () => {
     const pageloadSpan = new SentrySpan({ op: 'pageload', name: '/', sampled: true });
     const spans: Span[] = [];
 

--- a/packages/browser-utils/test/browser/browserMetrics.test.ts
+++ b/packages/browser-utils/test/browser/browserMetrics.test.ts
@@ -10,12 +10,7 @@ import {
   spanToJSON,
 } from '@sentry/core';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import {
-  _addMeasureSpans,
-  _addNavigationSpans,
-  _addResourceSpans,
-  addPerformanceEntries,
-} from '../../src/metrics/browserMetrics';
+import { _addMeasureSpans, _addNavigationSpans, _addResourceSpans } from '../../src/metrics/browserMetrics';
 import { WINDOW } from '../../src/types';
 import { getDefaultClientOptions, TestClient } from '../utils/TestClient';
 

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -164,7 +164,7 @@ export interface BrowserTracingOptions {
    *
    * Default: [] - By default, all `mark` and `measure` entries are sent as spans.
    */
-  ignoreMeasureSpans: Array<string>;
+  ignoreMeasureSpans: Array<string | RegExp>;
 
   /**
    * Link the currently started trace to a previous trace (e.g. a prior pageload, navigation or

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -152,19 +152,39 @@ export interface BrowserTracingOptions {
   ignoreResourceSpans: Array<'resouce.script' | 'resource.css' | 'resource.img' | 'resource.other' | string>;
 
   /**
-   * Spans created from
-   * [`performance.mark(...)`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)
-   * and
-   * [`performance.measure(...)`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)
-   * calls will not be emitted if their names match strings in this array.
+   * Spans created from the following browser Performance APIs,
+   *
+   * - [`performance.mark(...)`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark)
+   * - [`performance.measure(...)`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure)
+   *
+   * will not be emitted if their names match strings in this array.
    *
    * This is useful, if you come across `mark` or `measure` spans in your Sentry traces
    * that you want to ignore. For example, sometimes, browser extensions or libraries
    * emit these entries on their own, which might not be relevant to your application.
    *
+   * * @example
+   * ```ts
+   * Sentry.init({
+   *   integrations: [
+   *     Sentry.browserTracingIntegration({
+   *      ignorePerformanceApiSpans: ['myMeasurement', /myMark/],
+   *     }),
+   *   ],
+   * });
+   *
+   * // no spans will be created for these:
+   * performance.mark('myMark');
+   * performance.measure('myMeasurement');
+   *
+   * // spans will be created for these:
+   * performance.mark('authenticated');
+   * performance.measure('input-duration', ...);
+   * ```
+   *
    * Default: [] - By default, all `mark` and `measure` entries are sent as spans.
    */
-  ignoreMeasureSpans: Array<string | RegExp>;
+  ignorePerformanceApiSpans: Array<string | RegExp>;
 
   /**
    * Link the currently started trace to a previous trace (e.g. a prior pageload, navigation or
@@ -249,7 +269,7 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   enableLongAnimationFrame: true,
   enableInp: true,
   ignoreResourceSpans: [],
-  ignoreMeasureSpans: [],
+  ignorePerformanceApiSpans: [],
   linkPreviousTrace: 'in-memory',
   consistentTraceSampling: false,
   _experiments: {},
@@ -293,7 +313,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
     shouldCreateSpanForRequest,
     enableHTTPTimings,
     ignoreResourceSpans,
-    ignoreMeasureSpans,
+    ignorePerformanceApiSpans,
     instrumentPageLoad,
     instrumentNavigation,
     linkPreviousTrace,
@@ -339,7 +359,7 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         addPerformanceEntries(span, {
           recordClsOnPageloadSpan: !enableStandaloneClsSpans,
           ignoreResourceSpans,
-          ignoreMeasureSpans,
+          ignorePerformanceApiSpans,
         });
         setActiveIdleSpan(client, undefined);
 


### PR DESCRIPTION
- Adds `ignorePerformanceApiSpans` option that matches span names of `mark` and `measure` spans to a given array or RegExp
- Adds unit tests
- Adds integration test

Usage:

```js
Sentry.init({
  dsn: '...',
  integrations: [
    Sentry.browserTracingIntegration({
      ignorePerformanceApiSpans: ['measure-ignore', /mark-to-ignore/],
    }),
  ],
  tracesSampleRate: 1,
});
```

closes #16441 