### PR TITLE
test(nextjs): Make next-orpc test optional

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/package.json
@@ -41,5 +41,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "sentryTest": {
+    "optional": true
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/playwright.config.mjs
@@ -5,15 +5,9 @@ if (!testEnv) {
   throw new Error('No test env defined');
 }
 
-const config = getPlaywrightConfig(
-  {
-    startCommand: testEnv === 'development' ? 'pnpm next dev -p 3030' : 'pnpm next start -p 3030',
-    port: 3030,
-  },
-  {
-    // This comes with the risk of tests leaking into each other but the tests run quite slow so we should parallelize
-    workers: '100%',
-  },
-);
+const config = getPlaywrightConfig({
+  startCommand: testEnv === 'development' ? 'pnpm next dev -p 3030' : 'pnpm next start -p 3030',
+  port: 3030,
+});
 
 export default config;


### PR DESCRIPTION
- Makes ORPC test optional for now as this will receive some updates soon
- Runs the tests in one worker