### PR TITLE
fix(react-router): Conditionally add `ReactRouterServer` integration

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -50,6 +50,7 @@ const DEPENDENTS: Dependent[] = [
     ignoreExports: [
       // not supported in bun:
       'NodeClient',
+      'NODE_VERSION',
       'childProcessIntegration',
     ],
   },

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -134,6 +134,7 @@ export {
   logger,
   consoleLoggingIntegration,
   wrapMcpServerWithSentry,
+  NODE_VERSION,
 } from '@sentry/node';
 
 export { init } from './server/sdk';

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -120,6 +120,7 @@ export {
   logger,
   consoleLoggingIntegration,
   wrapMcpServerWithSentry,
+  NODE_VERSION,
 } from '@sentry/node';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -139,7 +139,6 @@ export {
   consoleLoggingIntegration,
   createSentryWinstonTransport,
   wrapMcpServerWithSentry,
-  NODE_VERSION,
 } from '@sentry/node';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -139,6 +139,7 @@ export {
   consoleLoggingIntegration,
   createSentryWinstonTransport,
   wrapMcpServerWithSentry,
+  NODE_VERSION,
 } from '@sentry/node';
 
 export {

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -120,6 +120,7 @@ export {
   logger,
   consoleLoggingIntegration,
   wrapMcpServerWithSentry,
+  NODE_VERSION,
 } from '@sentry/node';
 
 export {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -54,6 +54,7 @@ export { createGetModuleFromFilename } from './utils/module';
 export { makeNodeTransport } from './transports';
 export { NodeClient } from './sdk/client';
 export { cron } from './cron';
+export { NODE_VERSION } from './nodeVersion';
 
 export type { NodeOptions } from './types';
 

--- a/packages/react-router/src/server/sdk.ts
+++ b/packages/react-router/src/server/sdk.ts
@@ -15,7 +15,10 @@ import { reactRouterServerIntegration } from './integration/reactRouterServer';
 export function getDefaultReactRouterServerIntegrations(options: NodeOptions): Integration[] {
   const integrations = [...getNodeDefaultIntegrations(options), lowQualityTransactionsFilterIntegration(options)];
 
-  if (NODE_VERSION.major === 20 && NODE_VERSION.minor < 19) {
+  if (
+    (NODE_VERSION.major === 20 && NODE_VERSION.minor < 19) || // https://nodejs.org/en/blog/release/v20.19.0
+    (NODE_VERSION.major === 22 && NODE_VERSION.minor < 12) // https://nodejs.org/en/blog/release/v22.12.0
+  ) {
     integrations.push(reactRouterServerIntegration());
   }
 

--- a/packages/react-router/src/server/sdk.ts
+++ b/packages/react-router/src/server/sdk.ts
@@ -2,7 +2,7 @@ import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import type { EventProcessor, Integration } from '@sentry/core';
 import { applySdkMetadata, getGlobalScope, logger, setTag } from '@sentry/core';
 import type { NodeClient, NodeOptions } from '@sentry/node';
-import { getDefaultIntegrations as getNodeDefaultIntegrations, init as initNodeSdk } from '@sentry/node';
+import { getDefaultIntegrations as getNodeDefaultIntegrations, init as initNodeSdk, NODE_VERSION } from '@sentry/node';
 import { DEBUG_BUILD } from '../common/debug-build';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OVERWRITE } from './instrumentation/util';
 import { lowQualityTransactionsFilterIntegration } from './integration/lowQualityTransactionsFilterIntegration';
@@ -13,11 +13,13 @@ import { reactRouterServerIntegration } from './integration/reactRouterServer';
  * @param options The options for the SDK.
  */
 export function getDefaultReactRouterServerIntegrations(options: NodeOptions): Integration[] {
-  return [
-    ...getNodeDefaultIntegrations(options),
-    lowQualityTransactionsFilterIntegration(options),
-    reactRouterServerIntegration(),
-  ];
+  const integrations = [...getNodeDefaultIntegrations(options), lowQualityTransactionsFilterIntegration(options)];
+
+  if (NODE_VERSION.major === 20 && NODE_VERSION.minor < 19) {
+    integrations.push(reactRouterServerIntegration());
+  }
+
+  return integrations;
 }
 
 /**

--- a/packages/react-router/test/server/sdk.test.ts
+++ b/packages/react-router/test/server/sdk.test.ts
@@ -71,5 +71,41 @@ describe('React Router server SDK', () => {
 
       expect(filterIntegration).toBeDefined();
     });
+
+    it('adds reactRouterServer integration for Node.js 20.18', () => {
+      vi.spyOn(SentryNode, 'NODE_VERSION', 'get').mockReturnValue({ major: 20, minor: 18, patch: 0 });
+
+      reactRouterInit({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      });
+
+      expect(nodeInit).toHaveBeenCalledTimes(1);
+      const initOptions = nodeInit.mock.calls[0]?.[0];
+      const defaultIntegrations = initOptions?.defaultIntegrations as Integration[];
+
+      const reactRouterServerIntegration = defaultIntegrations.find(
+        integration => integration.name === 'ReactRouterServer',
+      );
+
+      expect(reactRouterServerIntegration).toBeDefined();
+    });
+
+    it('does not add reactRouterServer integration for Node.js 20.19', () => {
+      vi.spyOn(SentryNode, 'NODE_VERSION', 'get').mockReturnValue({ major: 20, minor: 19, patch: 0 });
+
+      reactRouterInit({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      });
+
+      expect(nodeInit).toHaveBeenCalledTimes(1);
+      const initOptions = nodeInit.mock.calls[0]?.[0];
+      const defaultIntegrations = initOptions?.defaultIntegrations as Integration[];
+
+      const reactRouterServerIntegration = defaultIntegrations.find(
+        integration => integration.name === 'ReactRouterServer',
+      );
+
+      expect(reactRouterServerIntegration).toBeUndefined();
+    });
   });
 });

--- a/packages/react-router/test/server/sdk.test.ts
+++ b/packages/react-router/test/server/sdk.test.ts
@@ -90,8 +90,44 @@ describe('React Router server SDK', () => {
       expect(reactRouterServerIntegration).toBeDefined();
     });
 
+    it('adds reactRouterServer integration for Node.js 22.11', () => {
+      vi.spyOn(SentryNode, 'NODE_VERSION', 'get').mockReturnValue({ major: 22, minor: 11, patch: 0 });
+
+      reactRouterInit({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      });
+
+      expect(nodeInit).toHaveBeenCalledTimes(1);
+      const initOptions = nodeInit.mock.calls[0]?.[0];
+      const defaultIntegrations = initOptions?.defaultIntegrations as Integration[];
+
+      const reactRouterServerIntegration = defaultIntegrations.find(
+        integration => integration.name === 'ReactRouterServer',
+      );
+
+      expect(reactRouterServerIntegration).toBeDefined();
+    });
+
     it('does not add reactRouterServer integration for Node.js 20.19', () => {
       vi.spyOn(SentryNode, 'NODE_VERSION', 'get').mockReturnValue({ major: 20, minor: 19, patch: 0 });
+
+      reactRouterInit({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      });
+
+      expect(nodeInit).toHaveBeenCalledTimes(1);
+      const initOptions = nodeInit.mock.calls[0]?.[0];
+      const defaultIntegrations = initOptions?.defaultIntegrations as Integration[];
+
+      const reactRouterServerIntegration = defaultIntegrations.find(
+        integration => integration.name === 'ReactRouterServer',
+      );
+
+      expect(reactRouterServerIntegration).toBeUndefined();
+    });
+
+    it('does not add reactRouterServer integration for Node.js 22.12', () => {
+      vi.spyOn(SentryNode, 'NODE_VERSION', 'get').mockReturnValue({ major: 22, minor: 12, patch: 0 });
 
       reactRouterInit({
         dsn: 'https://public@dsn.ingest.sentry.io/1337',


### PR DESCRIPTION
This PR conditionally instruments the server runtime of react-router, as there have been [instrumentation issues](https://github.com/getsentry/sentry-javascript/issues/16327). 

- Only instruments RR for node 20 (min version for react router) up to 20.19 (where we started seeing issues).
- Exports the NODE_VERSION helper from `@sentry/node`