### PR TITLE
test(node): Add test demonstrating `withIsolationScope` data loss on uncaught errors

### DIFF
--- a/dev-packages/node-integration-tests/suites/express-v5/handle-error-scope-data-loss/server.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/handle-error-scope-data-loss/server.ts
@@ -25,6 +25,13 @@ app.get('/test/isolationScope', () => {
   throw new Error('isolation_test_error');
 });
 
+app.get('/test/withIsolationScope', () => {
+  Sentry.withIsolationScope(iScope => {
+    iScope.setTag('with-isolation-scope', 'tag');
+    throw new Error('with_isolation_scope_test_error');
+  });
+});
+
 Sentry.setupExpressErrorHandler(app);
 
 startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express-v5/handle-error-scope-data-loss/test.ts
+++ b/dev-packages/node-integration-tests/suites/express-v5/handle-error-scope-data-loss/test.ts
@@ -86,3 +86,49 @@ test('isolation scope is applied to thrown error caught by global handler', asyn
   runner.makeRequest('get', '/test/isolationScope', { expectError: true });
   await runner.completed();
 });
+
+/**
+ * This test shows that an inner isolation scope, created via `withIsolationScope`, is not applied to the error.
+ *
+ * This behaviour occurs because, just like in the test above where we use `getIsolationScope().setTag`,
+ * this isolation scope again is only valid as long as we're in the callback.
+ *
+ * So why _does_ the http isolation scope get applied then? Because express' error handler applies on
+ * a per-request basis, meaning, it's called while we're inside the isolation scope of the http request,
+ * created from our `httpIntegration`.
+ */
+test('withIsolationScope scope is NOT applied to thrown error caught by global handler', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
+    .expect({
+      event: {
+        exception: {
+          values: [
+            {
+              mechanism: {
+                type: 'middleware',
+                handled: false,
+              },
+              type: 'Error',
+              value: 'with_isolation_scope_test_error',
+              stacktrace: {
+                frames: expect.arrayContaining([
+                  expect.objectContaining({
+                    function: expect.any(String),
+                    lineno: expect.any(Number),
+                    colno: expect.any(Number),
+                  }),
+                ]),
+              },
+            },
+          ],
+        },
+        // 'with-isolation-scope' tag is not applied to the event
+        tags: expect.not.objectContaining({ 'with-isolation-scope': expect.anything() }),
+      },
+    })
+    .start();
+
+  runner.makeRequest('get', '/test/withIsolationScope', { expectError: true });
+
+  await runner.completed();
+});

--- a/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/server.ts
@@ -28,7 +28,7 @@ app.get('/test/isolationScope', () => {
 app.get('/test/withIsolationScope', () => {
   Sentry.withIsolationScope(iScope => {
     iScope.setTag('with-isolation-scope', 'tag');
-    throw new Error('isolation_test_error');
+    throw new Error('with_isolation_scope_test_error');
   });
 });
 

--- a/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/server.ts
@@ -25,6 +25,13 @@ app.get('/test/isolationScope', () => {
   throw new Error('isolation_test_error');
 });
 
+app.get('/test/withIsolationScope', () => {
+  Sentry.withIsolationScope(iScope => {
+    iScope.setTag('with-isolation-scope', 'tag');
+    throw new Error('isolation_test_error');
+  });
+});
+
 Sentry.setupExpressErrorHandler(app);
 
 startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/test.ts
@@ -113,7 +113,7 @@ test('withIsolationScope scope is NOT applied to thrown error caught by global h
                 handled: false,
               },
               type: 'Error',
-              value: 'test_error',
+              value: 'with_isolation_scope_test_error',
               stacktrace: {
                 frames: expect.arrayContaining([
                   expect.objectContaining({
@@ -132,7 +132,7 @@ test('withIsolationScope scope is NOT applied to thrown error caught by global h
     })
     .start();
 
-  runner.makeRequest('get', '/test/withScope', { expectError: true });
+  runner.makeRequest('get', '/test/withIsolationScope', { expectError: true });
 
   await runner.completed();
 });

--- a/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-scope-data-loss/test.ts
@@ -53,7 +53,7 @@ test('withScope scope is NOT applied to thrown error caught by global handler', 
 /**
  * This test shows that the isolation scope set tags are applied correctly to the error.
  */
-test('isolation scope is applied to thrown error caught by global handler', async () => {
+test('http requestisolation scope is applied to thrown error caught by global handler', async () => {
   const runner = createRunner(__dirname, 'server.ts')
     .expect({
       event: {
@@ -87,6 +87,52 @@ test('isolation scope is applied to thrown error caught by global handler', asyn
     .start();
 
   runner.makeRequest('get', '/test/isolationScope', { expectError: true });
+
+  await runner.completed();
+});
+
+/**
+ * This test shows that an inner isolation scope, created via `withIsolationScope`, is not applied to the error.
+ *
+ * This behaviour occurs because, just like in the test above where we use `getIsolationScope().setTag`,
+ * this isolation scope again is only valid as long as we're in the callback.
+ *
+ * So why _does_ the http isolation scope get applied then? Because express' error handler applies on
+ * a per-request basis, meaning, it's called while we're inside the isolation scope of the http request,
+ * created from our `httpIntegration`.
+ */
+test('withIsolationScope scope is NOT applied to thrown error caught by global handler', async () => {
+  const runner = createRunner(__dirname, 'server.ts')
+    .expect({
+      event: {
+        exception: {
+          values: [
+            {
+              mechanism: {
+                type: 'middleware',
+                handled: false,
+              },
+              type: 'Error',
+              value: 'test_error',
+              stacktrace: {
+                frames: expect.arrayContaining([
+                  expect.objectContaining({
+                    function: expect.any(String),
+                    lineno: expect.any(Number),
+                    colno: expect.any(Number),
+                  }),
+                ]),
+              },
+            },
+          ],
+        },
+        // 'with-isolation-scope' tag is not applied to the event
+        tags: expect.not.objectContaining({ 'with-isolation-scope': expect.anything() }),
+      },
+    })
+    .start();
+
+  runner.makeRequest('get', '/test/withScope', { expectError: true });
 
   await runner.completed();
 });


### PR DESCRIPTION
This PR adds a test demonstrating the unintuitive but expected behaviour reported in https://github.com/getsentry/sentry-javascript/issues/16460

see comment for more details