### PR TITLE
fix(vue): Ensure root component render span always ends

### DIFF
--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -31,7 +31,7 @@ const HOOKS: { [key in Operation]: Hook[] } = {
   update: ['beforeUpdate', 'updated'],
 };
 
-/** Finish top-level component span and activity with a debounce configured using `timeout` option */
+/** End the top-level component span and activity with a debounce configured using `timeout` option */
 function maybeEndRootComponentSpan(vm: VueSentry, timestamp: number, timeout: number): void {
   if (vm.$_sentryRootComponentSpanTimer) {
     clearTimeout(vm.$_sentryRootComponentSpanTimer);
@@ -125,7 +125,7 @@ export const createTracingMixins = (options: Partial<TracingOptions> = {}): Mixi
           if (activeSpan) {
             // Cancel any existing span for this operation (safety measure)
             // We're actually not sure if it will ever be the case that cleanup hooks were not called.
-            // However, we had users report that spans didn't get finished, so we finished the span before
+            // However, we had users report that spans didn't end, so we end the span before
             // starting a new one, just to be sure.
             const oldSpan = this.$_sentryComponentSpans[operation];
             if (oldSpan) {
@@ -150,8 +150,8 @@ export const createTracingMixins = (options: Partial<TracingOptions> = {}): Mixi
           if (!span) return; // Skip if no span was created in the "before" hook
           span.end();
 
-          // For any "after" hook, also schedule the root component span to finish
-          maybeEndRootComponentSpan(this, timestampInSeconds(), options.timeout || 2000);
+          // For any "after" hook, also schedule the root component span to end
+          maybeEndRootComponentSpan(this, timestampInSeconds(), rootComponentSpanFinalTimeout);
         }
       };
     }

--- a/packages/vue/test/tracing/tracingMixin.test.ts
+++ b/packages/vue/test/tracing/tracingMixin.test.ts
@@ -128,8 +128,8 @@ describe('Vue Tracing Mixins', () => {
 
     it.each([true, false])(
       'should finish root component span on timer after component spans end, if trackComponents is %s',
-      () => {
-        const mixins = createTracingMixins({ trackComponents: false, timeout: 1000 });
+      trackComponents => {
+        const mixins = createTracingMixins({ trackComponents, timeout: 1000 });
         const rootMockSpan = mockSpanFactory();
         mockRootInstance.$_sentryRootComponentSpan = rootMockSpan;
 


### PR DESCRIPTION
This PR fixes a bug discovered in https://github.com/getsentry/sentry-javascript/pull/16486#discussion_r2128214297 where the root component span would not end correctly if `trackComponents` was `false`.

Also added a comment to explain the purpose of the root component `ui.vue.render` span. We might want to look into renaming or removing this span in the future but for now, let's fix the behaviour. 