### PR TITLE
fix(sveltekit): Export `vercelAIIntegration` from `@sentry/node`

### DIFF
--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -123,6 +123,7 @@ export {
   logger,
   consoleLoggingIntegration,
   createSentryWinstonTransport,
+  vercelAIIntegration,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports


### PR DESCRIPTION
Closes #16494 

Was wondering if the order of the exports should be updated since some seem to be grouped logically (the two Supabase ones are next to each other) and others seem to be ordered alphabetically, but just placed this export at the end to be safe 🙂