### PR TITLE
build: Fix command injection possibility in playwright GHA

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -34,7 +34,9 @@ runs:
       working-directory: ${{ inputs.cwd }}
 
     - name: Install Playwright system dependencies only (cached)
-      run: npx playwright install-deps ${{ inputs.browsers || 'chromium webkit firefox' }}
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ inputs.browsers || 'chromium webkit firefox' }}
+      run: npx playwright install-deps "$PLAYWRIGHT_BROWSERS"
       if: steps.playwright-cache.outputs.cache-hit == 'true'
       shell: bash
       working-directory: ${{ inputs.cwd }}


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/FE-484

> Using variable interpolation ${{...}} with github context data in a run: step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. github context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with env: to store the data and use the environment variable in the run: script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".