### PR TITLE
Fix GitHub actions module import error

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/vite.config.ts
@@ -9,4 +9,10 @@ export default defineConfig({
     }),
     sveltekit(),
   ],
+  ssr: {
+    external: [
+      '@prisma/instrumentation',
+      /^@opentelemetry\/instrumentation/
+    ]
+  }
 });


### PR DESCRIPTION
The GitHub Actions failure, specifically a `SyntaxError: The requested module '@prisma/instrumentation' does not provide an export named 'default'`, was addressed by modifying the Vite configuration in the SvelteKit test application.

The error occurred because SvelteKit's build process, powered by Vite, was incorrectly transforming the import statement for `@prisma/instrumentation`. This package uses named exports, but the bundler attempted to import a non-existent default export.

The fix involved updating `dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/vite.config.ts` to externalize specific modules during the server-side rendering (SSR) build:

*   The `ssr.external` option was added to `vite.config.ts`.
*   `@prisma/instrumentation` was explicitly added to the `external` array.
*   A regular expression `^@opentelemetry\/instrumentation/` was added to externalize all OpenTelemetry instrumentation packages, anticipating similar issues.

This change instructs Vite/SvelteKit to not bundle these modules, preserving their original import statements and allowing Node.js to handle their resolution at runtime, thereby preventing the incorrect CommonJS-to-ESM transformation that caused the build error.