### PR TITLE
test(sveltekit): Pin `@sveltejs/kit@2.21.2` to unblock CI

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/package.json
@@ -23,7 +23,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "latest || *",
     "@sveltejs/adapter-auto": "^3.0.0",
-    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/kit": "2.21.2",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^5.0.0-next.115",
     "svelte-check": "^3.6.0",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
@@ -23,7 +23,7 @@
     "@sentry/core": "latest || *",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/adapter-node": "^2.0.0",
-    "@sveltejs/kit": "^2.16.0",
+    "@sveltejs/kit": "2.21.2",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^4.2.8",
     "svelte-check": "^3.6.0",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@playwright/test": "^1.45.3",
     "@sveltejs/adapter-cloudflare": "^5.0.3",
-    "@sveltejs/kit": "^2.17.2",
+    "@sveltejs/kit": "2.21.2",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "svelte": "^5.20.2",
     "svelte-check": "^4.1.4",


### PR DESCRIPTION
While we're investigating https://github.com/sveltejs/kit/issues/13869 and https://github.com/getsentry/sentry-javascript/issues/16507, let's pin to the last working SvelteKit version for now so the repo CI is unblocked.

I saw https://github.com/getsentry/sentry-javascript/pull/16528 but unfortunately, it's still failing with an error in our SvelteKit<>cloudflare e2e test app. Taking a look at this as well.