### PR TITLE
feat(ember): Stop warning for `onError` usage

### DIFF
--- a/packages/ember/README.md
+++ b/packages/ember/README.md
@@ -70,9 +70,6 @@ following Ember specific configuration:
 
 ```javascript
 ENV['@sentry/ember'] = {
-  // Will silence Ember.onError warning without the need of using Ember debugging tools.
-  ignoreEmberOnErrorWarning: false,
-
   // Will disable automatic instrumentation of performance.
   // Manual instrumentation will still be sent.
   disablePerformance: true,

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -1,7 +1,6 @@
-import { assert, warn } from '@ember/debug';
+import { assert } from '@ember/debug';
 import type Route from '@ember/routing/route';
-import { next } from '@ember/runloop';
-import { getOwnConfig, isDevelopingApp, macroCondition } from '@embroider/macros';
+import { getOwnConfig } from '@embroider/macros';
 import type { BrowserOptions } from '@sentry/browser';
 import { startSpan } from '@sentry/browser';
 import * as Sentry from '@sentry/browser';
@@ -12,7 +11,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
-import Ember from 'ember';
 import type { EmberSentryConfig, GlobalConfig, OwnConfig } from './types';
 
 function _getSentryInitConfig(): EmberSentryConfig['sentry'] {
@@ -45,24 +43,7 @@ export function init(_runtimeConfig?: BrowserOptions): Client | undefined {
   const sentryInitConfig = _getSentryInitConfig();
   Object.assign(sentryInitConfig, initConfig);
 
-  const client = Sentry.init(initConfig);
-
-  if (macroCondition(isDevelopingApp())) {
-    if (environmentConfig.ignoreEmberOnErrorWarning) {
-      return client;
-    }
-    next(null, function () {
-      warn(
-        'Ember.onerror found. Using Ember.onerror can hide some errors (such as flushed runloop errors) from Sentry. Use Sentry.captureException to capture errors within Ember.onError or remove it to have errors caught by Sentry directly. This error can be silenced via addon configuration.',
-        !Ember.onerror,
-        {
-          id: '@sentry/ember.ember-onerror-detected',
-        },
-      );
-    });
-  }
-
-  return client;
+  return Sentry.init(initConfig);
 }
 
 type RouteConstructor = new (...args: ConstructorParameters<typeof Route>) => Route;

--- a/packages/ember/addon/types.ts
+++ b/packages/ember/addon/types.ts
@@ -5,7 +5,9 @@ type BrowserTracingOptions = Parameters<typeof browserTracingIntegration>[0];
 export type EmberSentryConfig = {
   sentry: BrowserOptions & { browserTracingOptions?: BrowserTracingOptions };
   transitionTimeout: number;
-  // @deprecated This option is no longer used and will be removed in the next major version.
+  /**
+   * @deprecated This option is no longer used and will be removed in the next major version.
+   */
   ignoreEmberOnErrorWarning: boolean;
   disableInstrumentComponents: boolean;
   disablePerformance: boolean;

--- a/packages/ember/addon/types.ts
+++ b/packages/ember/addon/types.ts
@@ -5,6 +5,7 @@ type BrowserTracingOptions = Parameters<typeof browserTracingIntegration>[0];
 export type EmberSentryConfig = {
   sentry: BrowserOptions & { browserTracingOptions?: BrowserTracingOptions };
   transitionTimeout: number;
+  // @deprecated This option is no longer used and will be removed in the next major version.
   ignoreEmberOnErrorWarning: boolean;
   disableInstrumentComponents: boolean;
   disablePerformance: boolean;

--- a/packages/ember/tests/dummy/config/environment.js
+++ b/packages/ember/tests/dummy/config/environment.js
@@ -32,7 +32,6 @@ module.exports = function (environment) {
         },
       },
     },
-    ignoreEmberOnErrorWarning: true,
     minimumRunloopQueueDuration: 0,
     minimumComponentRenderDuration: 0,
   };


### PR DESCRIPTION
This deprecates the `ignoreEmberOnErrorWarning` option, as it is no longer used. Previously, we logged a warnining if we detected that this was used. But the option is now deprecated/will be removed, and since there is no real logic attached to this we can simply remove this (as well as the usage of the global `Ember` namespace) to avoid deprecations.

Closes https://github.com/getsentry/sentry-javascript/issues/16504