### PR TITLE
feat(node): Allow to force activate `vercelAiIntegration`

### DIFF
--- a/packages/node/src/integrations/tracing/vercelai/index.ts
+++ b/packages/node/src/integrations/tracing/vercelai/index.ts
@@ -33,7 +33,7 @@ const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
       instrumentation = instrumentVercelAi();
     },
     setup(client) {
-      instrumentation?.callWhenPatched(() => {
+      function registerProcessors(): void {
         client.on('spanStart', span => {
           const { data: attributes, description: name } = spanToJSON(span);
 
@@ -188,7 +188,13 @@ const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
 
           return event;
         });
-      });
+      }
+
+      if (options.force) {
+        registerProcessors();
+      } else {
+        instrumentation?.callWhenPatched(registerProcessors);
+      }
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/node/src/integrations/tracing/vercelai/types.ts
+++ b/packages/node/src/integrations/tracing/vercelai/types.ts
@@ -56,6 +56,12 @@ export interface VercelAiOptions {
    * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings
    */
   recordOutputs?: boolean;
+
+  /**
+   * By default, the instrumentation will register span processors only when the ai package is used.
+   * If you want to register the span processors even when the ai package usage cannot be detected, you can set `force` to `true`.
+   */
+  force?: boolean;
 }
 
 export interface VercelAiIntegration extends Integration {


### PR DESCRIPTION
By default, the instrumentation will register span processors only when the ai package is used. This is done to avoid overhead of span processing for users that do not even use this package.

However, it seems that in some environments, esp. in Next.js, the instrumentation is not added correctly, thus never running this, and not converting spans correctly. For now, this PR adds an escape hatch to manually opt-in to this to still get correct spans:

```js
vercelAiIntegration({ force: true })
```
