### PR TITLE
feat(nextjs): Ensure all packages we auto-instrument are externalized

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -45,11 +45,12 @@ export type NextConfigObject = {
   experimental?: {
     instrumentationHook?: boolean;
     clientTraceMetadata?: string[];
+    serverComponentsExternalPackages?: string[]; // next < v15.0.0
   };
   productionBrowserSourceMaps?: boolean;
   // https://nextjs.org/docs/pages/api-reference/next-config-js/env
   env?: Record<string, string>;
-  serverExternalPackages?: string[];
+  serverExternalPackages?: string[]; // next >= v15.0.0
 };
 
 export type SentryBuildOptions = {


### PR DESCRIPTION
So they can be instrumented by us.

I think this should be fine and not really affect users, hopefully, since Next.js itself also does this already for common packages.

Closes https://github.com/getsentry/sentry-javascript/issues/16550