### PR TITLE
feat(node): Introduce `ignoreLayersType` option to koa integration

### DIFF
--- a/packages/node/test/integrations/tracing/koa.test.ts
+++ b/packages/node/test/integrations/tracing/koa.test.ts
@@ -1,6 +1,6 @@
 import { KoaInstrumentation } from '@opentelemetry/instrumentation-koa';
 import { type MockInstance, beforeEach, describe, expect, it, vi } from 'vitest';
-import { koaIntegration, instrumentKoa } from '../../../src/integrations/tracing/koa';
+import { instrumentKoa, koaIntegration } from '../../../src/integrations/tracing/koa';
 import { INSTRUMENTED } from '../../../src/otel/instrument';
 
 vi.mock('@opentelemetry/instrumentation-koa');


### PR DESCRIPTION
ref https://linear.app/getsentry/issue/FE-503/investigate-nested-middleware-spans-in-webfx-koa-application

The Koa integration in `@sentry/node` was updated to expose the `ignoreLayersType` option from `@opentelemetry/instrumentation-koa`, aligning its configuration with the GraphQL integration.

https://www.npmjs.com/package/@opentelemetry/instrumentation-koa

<span><div class="markdown-heading"><h3 class="heading-element">Koa Instrumentation Options</h3><a id="user-content-koa-instrumentation-options" class="anchor" aria-label="Permalink: Koa Instrumentation Options" href="https://www.npmjs.com/package/@opentelemetry/instrumentation-koa#koa-instrumentation-options"></a></div></span><span>
Options | Type | Example | Description
-- | -- | -- | --
ignoreLayersType | KoaLayerType[] | ['middleware'] | Ignore layers of specified type.
requestHook | KoaRequestCustomAttributeFunction | (span, info) => {} | Function for adding custom attributes to Koa middleware layers. Receives params: Span, KoaRequestInfo.

<p><code>ignoreLayersType</code> accepts an array of <code>KoaLayerType</code> which can take the following string values:</p>
<ul>
<li>
<code>router</code>,</li>
<li>
<code>middleware</code>.</li>
</ul></span>