### PR TITLE
chore: Document `process.env.DEBUG` in node integration tests README

### DIFF
--- a/dev-packages/node-integration-tests/README.md
+++ b/dev-packages/node-integration-tests/README.md
@@ -47,3 +47,19 @@ To run tests with Vitest's watch mode:
 To filter tests by their title:
 
 `yarn test -t "set different properties of a scope"`
+
+## Debugging Tests
+
+To enable verbose logging during test execution, set the `DEBUG` environment variable:
+
+`DEBUG=1 yarn test`
+
+When `DEBUG` is enabled, the test runner will output:
+- Test scenario startup information (path, flags, DSN)
+- Docker Compose output when using `withDockerCompose`
+- Child process stdout and stderr output
+- HTTP requests made during tests
+- Process errors and exceptions
+- Line-by-line output from test scenarios
+
+This is particularly useful when debugging failing tests or understanding the test execution flow.


### PR DESCRIPTION
A new "Debugging Tests" section was added to `dev-packages/node-integration-tests/README.md`.

This section documents the `DEBUG` environment variable, which enables verbose logging for the integration test suite.

When `DEBUG=1` is set (e.g., `DEBUG=1 yarn test`), the test runner provides detailed output, including:
*   Test scenario startup information (path, flags, DSN).
*   Docker Compose output when tests use `withDockerCompose`.
*   Child process stdout and stderr.
*   HTTP requests made during tests.
*   Process errors and exceptions.
*   Line-by-line output from test scenarios.

This addition improves discoverability and understanding of the debugging capabilities, aiding in troubleshooting failing tests and analyzing test execution flow.