### PR TITLE
feat(node): Ensure `modulesIntegration` works in more environments

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/server-components.test.ts
@@ -123,4 +123,12 @@ test('Should capture an error and transaction for a app router page', async ({ p
   expect(errorEvent.tags?.['my-global-scope-isolated-tag']).not.toBeDefined();
   expect(transactionEvent.tags?.['my-isolated-tag']).toBe(true);
   expect(transactionEvent.tags?.['my-global-scope-isolated-tag']).not.toBeDefined();
+
+  // Modules are set for Next.js
+  expect(errorEvent.modules).toEqual(
+    expect.objectContaining({
+      '@sentry/nextjs': expect.any(String),
+      '@playwright/test': expect.any(String),
+    }),
+  );
 });

--- a/dev-packages/node-integration-tests/suites/modules/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/modules/instrument.mjs
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+});

--- a/dev-packages/node-integration-tests/suites/modules/server.js
+++ b/dev-packages/node-integration-tests/suites/modules/server.js
@@ -13,7 +13,7 @@ const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node
 
 const app = express();
 
-app.get('/test1', (_req, _res) => {
+app.get('/test1', () => {
   throw new Error('error_1');
 });
 

--- a/dev-packages/node-integration-tests/suites/modules/server.js
+++ b/dev-packages/node-integration-tests/suites/modules/server.js
@@ -1,0 +1,22 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+const { startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+
+const app = express();
+
+app.get('/test1', (_req, _res) => {
+  throw new Error('error_1');
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/modules/server.mjs
+++ b/dev-packages/node-integration-tests/suites/modules/server.mjs
@@ -4,7 +4,7 @@ import express from 'express';
 
 const app = express();
 
-app.get('/test1', (_req, _res) => {
+app.get('/test1', () => {
   throw new Error('error_1');
 });
 

--- a/dev-packages/node-integration-tests/suites/modules/server.mjs
+++ b/dev-packages/node-integration-tests/suites/modules/server.mjs
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/node';
+import { startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
+import express from 'express';
+
+const app = express();
+
+app.get('/test1', (_req, _res) => {
+  throw new Error('error_1');
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/modules/test.ts
+++ b/dev-packages/node-integration-tests/suites/modules/test.ts
@@ -1,0 +1,48 @@
+import { SDK_VERSION } from '@sentry/core';
+import { join } from 'path';
+import { afterAll, describe, expect, test } from 'vitest';
+import { cleanupChildProcesses, createRunner } from '../../utils/runner';
+
+describe('modulesIntegration', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  test('CJS', async () => {
+    const runner = createRunner(__dirname, 'server.js')
+      .withMockSentryServer()
+      .expect({
+        event: {
+          modules: {
+            // exact version comes from require.caches
+            express: '4.21.1',
+            // this comes from package.json
+            '@sentry/node': SDK_VERSION,
+            yargs: '^16.2.0',
+          },
+        },
+      })
+      .start();
+    runner.makeRequest('get', '/test1', { expectError: true });
+    await runner.completed();
+  });
+
+  test('ESM', async () => {
+    const runner = createRunner(__dirname, 'server.mjs')
+      .withInstrument(join(__dirname, 'instrument.mjs'))
+      .withMockSentryServer()
+      .expect({
+        event: {
+          modules: {
+            // this comes from package.json
+            express: '^4.21.1',
+            '@sentry/node': SDK_VERSION,
+            yargs: '^16.2.0',
+          },
+        },
+      })
+      .start();
+    runner.makeRequest('get', '/test1', { expectError: true });
+    await runner.completed();
+  });
+});

--- a/dev-packages/node-integration-tests/suites/modules/test.ts
+++ b/dev-packages/node-integration-tests/suites/modules/test.ts
@@ -1,6 +1,6 @@
 import { SDK_VERSION } from '@sentry/core';
 import { join } from 'path';
-import { afterAll, describe, expect, test } from 'vitest';
+import { afterAll, describe, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
 describe('modulesIntegration', () => {

--- a/packages/node/src/integrations/modules.ts
+++ b/packages/node/src/integrations/modules.ts
@@ -13,7 +13,8 @@ const INTEGRATION_NAME = 'Modules';
 declare const __SENTRY_SERVER_MODULES__: Record<string, string>;
 
 /**
- * This is replaced at build time with the modules loaded by the server.
+ * `__SENTRY_SERVER_MODULES__` can be replaced at build time with the modules loaded by the server.
+ * Right now, we leverage this in Next.js to circumvent the problem that we do not get access to these things at runtime.
  */
 const SERVER_MODULES = typeof __SENTRY_SERVER_MODULES__ === 'undefined' ? {} : __SENTRY_SERVER_MODULES__;
 

--- a/packages/node/src/integrations/modules.ts
+++ b/packages/node/src/integrations/modules.ts
@@ -1,26 +1,23 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { IntegrationFn } from '@sentry/core';
-import { defineIntegration, logger } from '@sentry/core';
-import { DEBUG_BUILD } from '../debug-build';
+import { defineIntegration } from '@sentry/core';
 import { isCjs } from '../utils/commonjs';
 
-let moduleCache: { [key: string]: string };
+type ModuleInfo = Record<string, string>;
+
+let moduleCache: ModuleInfo | undefined;
 
 const INTEGRATION_NAME = 'Modules';
 
-const _modulesIntegration = (() => {
-  // This integration only works in CJS contexts
-  if (!isCjs()) {
-    DEBUG_BUILD &&
-      logger.warn(
-        'modulesIntegration only works in CommonJS (CJS) environments. Remove this integration if you are using ESM.',
-      );
-    return {
-      name: INTEGRATION_NAME,
-    };
-  }
+declare const __SENTRY_SERVER_MODULES__: Record<string, string>;
 
+/**
+ * This is replaced at build time with the modules loaded by the server.
+ */
+const SERVER_MODULES = typeof __SENTRY_SERVER_MODULES__ === 'undefined' ? {} : __SENTRY_SERVER_MODULES__;
+
+const _modulesIntegration = (() => {
   return {
     name: INTEGRATION_NAME,
     processEvent(event) {
@@ -36,13 +33,14 @@ const _modulesIntegration = (() => {
 
 /**
  * Add node modules / packages to the event.
- *
- * Only works in CommonJS (CJS) environments.
+ * For this, multiple sources are used:
+ * - They can be injected at build time into the __SENTRY_SERVER_MODULES__ variable (e.g. in Next.js)
+ * - They are extracted from the dependencies & devDependencies in the package.json file
+ * - They are extracted from the require.cache (CJS only)
  */
 export const modulesIntegration = defineIntegration(_modulesIntegration);
 
-/** Extract information about paths */
-function getPaths(): string[] {
+function getRequireCachePaths(): string[] {
   try {
     return require.cache ? Object.keys(require.cache as Record<string, unknown>) : [];
   } catch (e) {
@@ -51,17 +49,23 @@ function getPaths(): string[] {
 }
 
 /** Extract information about package.json modules */
-function collectModules(): {
-  [name: string]: string;
-} {
+function collectModules(): ModuleInfo {
+  return {
+    ...SERVER_MODULES,
+    ...getModulesFromPackageJson(),
+    ...(isCjs() ? collectRequireModules() : {}),
+  };
+}
+
+/** Extract information about package.json modules from require.cache */
+function collectRequireModules(): ModuleInfo {
   const mainPaths = require.main?.paths || [];
-  const paths = getPaths();
-  const infos: {
-    [name: string]: string;
-  } = {};
-  const seen: {
-    [path: string]: boolean;
-  } = {};
+  const paths = getRequireCachePaths();
+
+  // We start with the modules from package.json (if possible)
+  // These may be overwritten by more specific versions from the require.cache
+  const infos: ModuleInfo = {};
+  const seen = new Set<string>();
 
   paths.forEach(path => {
     let dir = path;
@@ -71,7 +75,7 @@ function collectModules(): {
       const orig = dir;
       dir = dirname(orig);
 
-      if (!dir || orig === dir || seen[orig]) {
+      if (!dir || orig === dir || seen.has(orig)) {
         return undefined;
       }
       if (mainPaths.indexOf(dir) < 0) {
@@ -79,7 +83,7 @@ function collectModules(): {
       }
 
       const pkgfile = join(orig, 'package.json');
-      seen[orig] = true;
+      seen.add(orig);
 
       if (!existsSync(pkgfile)) {
         return updir();
@@ -103,9 +107,34 @@ function collectModules(): {
 }
 
 /** Fetches the list of modules and the versions loaded by the entry file for your node.js app. */
-function _getModules(): { [key: string]: string } {
+function _getModules(): ModuleInfo {
   if (!moduleCache) {
     moduleCache = collectModules();
   }
   return moduleCache;
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+function getPackageJson(): PackageJson {
+  try {
+    const filePath = join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(readFileSync(filePath, 'utf8')) as PackageJson;
+
+    return packageJson;
+  } catch (e) {
+    return {};
+  }
+}
+
+function getModulesFromPackageJson(): ModuleInfo {
+  const packageJson = getPackageJson();
+
+  return {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  };
 }

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -40,10 +40,6 @@ import { defaultStackParser, getSentryRelease } from './api';
 import { NodeClient } from './client';
 import { initOpenTelemetry, maybeInitializeEsmLoader } from './initOtel';
 
-function getCjsOnlyIntegrations(): Integration[] {
-  return isCjs() ? [modulesIntegration()] : [];
-}
-
 /**
  * Get default integrations, excluding performance.
  */
@@ -69,7 +65,7 @@ export function getDefaultIntegrationsWithoutPerformance(): Integration[] {
     nodeContextIntegration(),
     childProcessIntegration(),
     processSessionIntegration(),
-    ...getCjsOnlyIntegrations(),
+    modulesIntegration(),
   ];
 }
 


### PR DESCRIPTION
Extracted out from https://github.com/getsentry/sentry-javascript/pull/16565

I noticed that our `modulesIntegration` is pretty limited:

1. It does nothing on EMS
2. It does not work on Next.js (even though that is CJS)

This PR makes this a bit more robust (not perfect):

1. It generally now also tries to look at `process.cwd() + 'package.json'` and take the dependencies and devDependencies from there. this should generally work in esm apps now as well, at least at a basic level. You do not get all dependencies and versions may be ranges, but better than nothing.
2. For Next.js, we inject a modules list based off the package.json at build time, as we do not have proper access to this at runtime.

