### PR TITLE
test(node): Fix nestjs-11 E2E test by pinning version

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-11/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-11/package.json
@@ -44,5 +44,10 @@
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
     "typescript": "~5.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "minimatch": "10.0.1"
+    }
   }
 }


### PR DESCRIPTION
See https://github.com/nestjs/nest/issues/15273

We can drop this when we bump node to 20.19.0, but for now this should be fine.