### PR TITLE
ref(node): Improve span flushing

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,7 @@ export { parseSampleRate } from './utils/parseSampleRate';
 export { applySdkMetadata } from './utils/sdkMetadata';
 export { getTraceData } from './utils/traceData';
 export { getTraceMetaTags } from './utils/meta';
+export { debounce } from './utils/debounce';
 export {
   winterCGHeadersToDict,
   winterCGRequestToRequestData,

--- a/packages/core/test/lib/utils/debounce.test.ts
+++ b/packages/core/test/lib/utils/debounce.test.ts
@@ -1,0 +1,276 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { debounce } from '../../../src/utils/debounce';
+
+describe('Unit | util | debounce', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
+  it('delay the execution of the passed callback function by the passed minDelay', () => {
+    const callback = vi.fn();
+    const debouncedCallback = debounce(callback, 100);
+    debouncedCallback();
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(99);
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should invoke the callback at latest by maxWait, if the option is specified', () => {
+    const callback = vi.fn();
+    const debouncedCallback = debounce(callback, 100, { maxWait: 150 });
+    debouncedCallback();
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(98);
+    expect(callback).not.toHaveBeenCalled();
+
+    debouncedCallback();
+
+    vi.advanceTimersByTime(1);
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(49);
+    // at this time, the callback shouldn't be invoked and with a new call, it should be debounced further.
+    debouncedCallback();
+    expect(callback).not.toHaveBeenCalled();
+
+    // But because the maxWait is reached, the callback should nevertheless be invoked.
+    vi.advanceTimersByTime(10);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should not invoke the callback as long as it is debounced and no maxWait option is specified', () => {
+    const callback = vi.fn();
+    const debouncedCallback = debounce(callback, 100);
+    debouncedCallback();
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(99);
+    expect(callback).not.toHaveBeenCalled();
+
+    debouncedCallback();
+
+    vi.advanceTimersByTime(1);
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(98);
+    debouncedCallback();
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(99);
+    expect(callback).not.toHaveBeenCalled();
+    debouncedCallback();
+
+    vi.advanceTimersByTime(100);
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should invoke the callback as soon as callback.flush() is called', () => {
+    const callback = vi.fn();
+    const debouncedCallback = debounce(callback, 100, { maxWait: 200 });
+    debouncedCallback();
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(10);
+    expect(callback).not.toHaveBeenCalled();
+
+    debouncedCallback.flush();
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should not invoke the callback, if  callback.cancel() is called', () => {
+    const callback = vi.fn();
+    const debouncedCallback = debounce(callback, 100, { maxWait: 200 });
+    debouncedCallback();
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(99);
+    expect(callback).not.toHaveBeenCalled();
+
+    // If the callback is canceled, it should not be invoked after the minwait
+    debouncedCallback.cancel();
+    vi.advanceTimersByTime(1);
+    expect(callback).not.toHaveBeenCalled();
+
+    // And it should also not be invoked after the maxWait
+    vi.advanceTimersByTime(500);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("should return the callback's return value when calling callback.flush()", () => {
+    const callback = vi.fn().mockReturnValue('foo');
+    const debouncedCallback = debounce(callback, 100);
+
+    debouncedCallback();
+
+    const returnValue = debouncedCallback.flush();
+    expect(returnValue).toBe('foo');
+  });
+
+  it('should return the callbacks return value on subsequent calls of the debounced function', () => {
+    const callback = vi.fn().mockReturnValue('foo');
+    const debouncedCallback = debounce(callback, 100);
+
+    const returnValue1 = debouncedCallback();
+    expect(returnValue1).toBe(undefined);
+    expect(callback).not.toHaveBeenCalled();
+
+    // now we expect the callback to have been invoked
+    vi.advanceTimersByTime(200);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // calling the debounced function now should return the return value of the callback execution
+    const returnValue2 = debouncedCallback();
+    expect(returnValue2).toBe('foo');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // and the callback should also be invoked again
+    vi.advanceTimersByTime(200);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle return values of consecutive invocations without maxWait', () => {
+    let i = 0;
+    const callback = vi.fn().mockImplementation(() => {
+      return `foo-${++i}`;
+    });
+    const debouncedCallback = debounce(callback, 100);
+
+    const returnValue0 = debouncedCallback();
+    expect(returnValue0).toBe(undefined);
+    expect(callback).not.toHaveBeenCalled();
+
+    // now we expect the callback to have been invoked
+    vi.advanceTimersByTime(200);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // calling the debounced function now should return the return value of the callback execution
+    const returnValue1 = debouncedCallback();
+    expect(returnValue1).toBe('foo-1');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    const returnValue2 = debouncedCallback();
+    expect(returnValue2).toBe('foo-1');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // and the callback should also be invoked again
+    vi.advanceTimersByTime(200);
+    const returnValue3 = debouncedCallback();
+    expect(returnValue3).toBe('foo-2');
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle return values of consecutive invocations with maxWait', () => {
+    let i = 0;
+    const callback = vi.fn().mockImplementation(() => {
+      return `foo-${++i}`;
+    });
+    const debouncedCallback = debounce(callback, 150, { maxWait: 200 });
+
+    const returnValue0 = debouncedCallback();
+    expect(returnValue0).toBe(undefined);
+    expect(callback).not.toHaveBeenCalled();
+
+    // now we expect the callback to have been invoked
+    vi.advanceTimersByTime(149);
+    const returnValue1 = debouncedCallback();
+    expect(returnValue1).toBe(undefined);
+    expect(callback).not.toHaveBeenCalled();
+
+    // calling the debounced function now should return the return value of the callback execution
+    // as it was executed because of maxWait
+    vi.advanceTimersByTime(51);
+    const returnValue2 = debouncedCallback();
+    expect(returnValue2).toBe('foo-1');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // at this point (100ms after the last debounce call), nothing should have happened
+    vi.advanceTimersByTime(100);
+    const returnValue3 = debouncedCallback();
+    expect(returnValue3).toBe('foo-1');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // and the callback should now have been invoked again
+    vi.advanceTimersByTime(150);
+    const returnValue4 = debouncedCallback();
+    expect(returnValue4).toBe('foo-2');
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle return values of consecutive invocations after a cancellation', () => {
+    let i = 0;
+    const callback = vi.fn().mockImplementation(() => {
+      return `foo-${++i}`;
+    });
+    const debouncedCallback = debounce(callback, 150, { maxWait: 200 });
+
+    const returnValue0 = debouncedCallback();
+    expect(returnValue0).toBe(undefined);
+    expect(callback).not.toHaveBeenCalled();
+
+    // now we expect the callback to have been invoked
+    vi.advanceTimersByTime(149);
+    const returnValue1 = debouncedCallback();
+    expect(returnValue1).toBe(undefined);
+    expect(callback).not.toHaveBeenCalled();
+
+    debouncedCallback.cancel();
+
+    // calling the debounced function now still return undefined because we cancelled the invocation
+    vi.advanceTimersByTime(51);
+    const returnValue2 = debouncedCallback();
+    expect(returnValue2).toBe(undefined);
+    expect(callback).not.toHaveBeenCalled();
+
+    // and the callback should also be invoked again
+    vi.advanceTimersByTime(150);
+    const returnValue3 = debouncedCallback();
+    expect(returnValue3).toBe('foo-1');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle the return value of calling flush after cancelling', () => {
+    const callback = vi.fn().mockReturnValue('foo');
+    const debouncedCallback = debounce(callback, 100);
+
+    debouncedCallback();
+    debouncedCallback.cancel();
+
+    const returnValue = debouncedCallback.flush();
+    expect(returnValue).toBe(undefined);
+  });
+
+  it('should handle equal wait and maxWait values and only invoke func once', () => {
+    const callback = vi.fn().mockReturnValue('foo');
+    const debouncedCallback = debounce(callback, 100, { maxWait: 100 });
+
+    debouncedCallback();
+    vi.advanceTimersByTime(25);
+    debouncedCallback();
+    vi.advanceTimersByTime(25);
+    debouncedCallback();
+    vi.advanceTimersByTime(25);
+    debouncedCallback();
+    vi.advanceTimersByTime(25);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    const retval = debouncedCallback();
+    expect(retval).toBe('foo');
+
+    vi.advanceTimersByTime(25);
+    debouncedCallback();
+    vi.advanceTimersByTime(25);
+    debouncedCallback();
+    vi.advanceTimersByTime(25);
+    debouncedCallback();
+    vi.advanceTimersByTime(25);
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -14,6 +14,7 @@ import type {
 import {
   captureEvent,
   convertSpanLinksForEnvelope,
+  debounce,
   getCapturedScopesOnSpan,
   getDynamicSamplingContextFromSpan,
   getStatusMessage,
@@ -49,8 +50,6 @@ interface FinishedSpanBucket {
  * A Sentry-specific exporter that converts OpenTelemetry Spans to Sentry Spans & Transactions.
  */
 export class SentrySpanExporter {
-  private _flushTimeout: ReturnType<typeof setTimeout> | undefined;
-
   /*
    * A quick explanation on the buckets: We do bucketing of finished spans for efficiency. This span exporter is
    * accumulating spans until a root span is encountered and then it flushes all the spans that are descendants of that
@@ -74,6 +73,7 @@ export class SentrySpanExporter {
   // Essentially a a set of span ids that are already sent. The values are expiration
   // times in this cache so we don't hold onto them indefinitely.
   private _sentSpans: Map<string, number>;
+  private _debouncedFlush: ReturnType<typeof debounce>;
 
   public constructor(options?: {
     /** Lower bound of time in seconds until spans that are buffered but have not been sent as part of a transaction get cleared from memory. */
@@ -84,47 +84,7 @@ export class SentrySpanExporter {
     this._lastCleanupTimestampInS = Math.floor(Date.now() / 1000);
     this._spansToBucketEntry = new WeakMap();
     this._sentSpans = new Map<string, number>();
-  }
-
-  /**
-   * Check if a span with the given ID has already been sent using the `_sentSpans` as a cache.
-   * Purges "expired" spans from the cache upon checking.
-   * @param spanId The span id to check.
-   * @returns Whether the span is already sent in the past X seconds.
-   */
-  public isSpanAlreadySent(spanId: string): boolean {
-    const expirationTime = this._sentSpans.get(spanId);
-    if (expirationTime) {
-      if (Date.now() >= expirationTime) {
-        this._sentSpans.delete(spanId); // Remove expired span
-      } else {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /** Remove "expired" span id entries from the _sentSpans cache. */
-  public flushSentSpanCache(): void {
-    const currentTimestamp = Date.now();
-    // Note, it is safe to delete items from the map as we go: https://stackoverflow.com/a/35943995/90297
-    for (const [spanId, expirationTime] of this._sentSpans.entries()) {
-      if (expirationTime <= currentTimestamp) {
-        this._sentSpans.delete(spanId);
-      }
-    }
-  }
-
-  /** Check if a node is a completed root node or a node whose parent has already been sent */
-  public nodeIsCompletedRootNode(node: SpanNode): node is SpanNodeCompleted {
-    return !!node.span && (!node.parentNode || this.isSpanAlreadySent(node.parentNode.id));
-  }
-
-  /** Get all completed root nodes from a list of nodes */
-  public getCompletedRootNodes(nodes: SpanNode[]): SpanNodeCompleted[] {
-    // TODO: We should be able to remove the explicit `node is SpanNodeCompleted` type guard
-    //       once we stop supporting TS < 5.5
-    return nodes.filter((node): node is SpanNodeCompleted => this.nodeIsCompletedRootNode(node));
+    this._debouncedFlush = debounce(this.flush.bind(this), 1, { maxWait: 100 });
   }
 
   /** Export a single span. */
@@ -159,26 +119,18 @@ export class SentrySpanExporter {
 
     // If the span doesn't have a local parent ID (it's a root span), we're gonna flush all the ended spans
     const localParentId = getLocalParentId(span);
-    if (!localParentId || this.isSpanAlreadySent(localParentId)) {
-      this._clearTimeout();
-
-      // If we got a parent span, we try to send the span tree
-      // Wait a tick for this, to ensure we avoid race conditions
-      this._flushTimeout = setTimeout(() => {
-        this.flush();
-      }, 1);
+    if (!localParentId || this._sentSpans.has(localParentId)) {
+      this._debouncedFlush();
     }
   }
 
   /** Try to flush any pending spans immediately. */
   public flush(): void {
-    this._clearTimeout();
-
     const finishedSpans: ReadableSpan[] = this._finishedSpanBuckets.flatMap(bucket =>
       bucket ? Array.from(bucket.spans) : [],
     );
 
-    this.flushSentSpanCache();
+    this._flushSentSpanCache();
     const sentSpans = this._maybeSend(finishedSpans);
     for (const span of finishedSpans) {
       this._sentSpans.set(span.spanContext().spanId, Date.now() + DEFAULT_TIMEOUT * 1000);
@@ -197,20 +149,15 @@ export class SentrySpanExporter {
         bucketEntry.spans.delete(span);
       }
     }
+    // Cancel a pending debounced flush, if there is one
+    this._debouncedFlush.cancel();
   }
 
   /** Clear the exporter. */
   public clear(): void {
     this._finishedSpanBuckets = this._finishedSpanBuckets.fill(undefined);
-    this._clearTimeout();
-  }
-
-  /** Clear the flush timeout. */
-  private _clearTimeout(): void {
-    if (this._flushTimeout) {
-      clearTimeout(this._flushTimeout);
-      this._flushTimeout = undefined;
-    }
+    this._sentSpans.clear();
+    this._debouncedFlush.cancel();
   }
 
   /**
@@ -226,7 +173,7 @@ export class SentrySpanExporter {
     const grouped = groupSpansWithParents(spans);
     const sentSpans = new Set<ReadableSpan>();
 
-    const rootNodes = this.getCompletedRootNodes(grouped);
+    const rootNodes = this._getCompletedRootNodes(grouped);
 
     for (const root of rootNodes) {
       const span = root.span;
@@ -256,6 +203,29 @@ export class SentrySpanExporter {
     }
 
     return sentSpans;
+  }
+
+  /** Remove "expired" span id entries from the _sentSpans cache. */
+  private _flushSentSpanCache(): void {
+    const currentTimestamp = Date.now();
+    // Note, it is safe to delete items from the map as we go: https://stackoverflow.com/a/35943995/90297
+    for (const [spanId, expirationTime] of this._sentSpans.entries()) {
+      if (expirationTime <= currentTimestamp) {
+        this._sentSpans.delete(spanId);
+      }
+    }
+  }
+
+  /** Check if a node is a completed root node or a node whose parent has already been sent */
+  private _nodeIsCompletedRootNode(node: SpanNode): node is SpanNodeCompleted {
+    return !!node.span && (!node.parentNode || this._sentSpans.has(node.parentNode.id));
+  }
+
+  /** Get all completed root nodes from a list of nodes */
+  private _getCompletedRootNodes(nodes: SpanNode[]): SpanNodeCompleted[] {
+    // TODO: We should be able to remove the explicit `node is SpanNodeCompleted` type guard
+    //       once we stop supporting TS < 5.5
+    return nodes.filter((node): node is SpanNodeCompleted => this._nodeIsCompletedRootNode(node));
   }
 }
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-javascript/pull/16416, slightly moving things around and making some small improvements to performance and logic (some not related to that PR but another improvement we noticed when BYK looked int this):

1. Actually debounce the flushing properly, including a maxWait of 100ms. Previously, it was technically possible to debounce flushing forever, if a span was flushed every ms. Now, at least after 100ms it should _always_ flush.
2. Simplify overhead by avoid checking for the 5min timeout of sent spans. As this check `isSpanAlreadySent` has been called for every single span that ended, it is quite high impact, and meant a little bit of additional work (although it should not necessarily run _too_ often, but still). Instead, we now simply check for `map.has(id)` which should be good enough for what we want to achieve, IMHO. We still clean up the sent spans when flushing, so old stuff should still go away eventually.
3. Made stuff that is not needed as public API private on the span exporter class. this is technically breaking but I think it is OK, this should not be public API surface as it does not need to be called from outside.

For this I moved the already existing `debounce` function from replay to core. We re-implement this in replay with a different setTimeout impl. which is needed for some angular stuff.