### PR TITLE
chore(browser): Update comment for fetch transport

### DIFF
--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -45,7 +45,7 @@ export function makeFetchTransport(
     }
 
     try {
-      // TODO: This may need a `suppressTracing` call in the future when we switch the browser SDK to OTEL
+      // Note: We do not need to suppress tracing here, becasue we are using the native fetch, instead of our wrapped one.
       return nativeFetch(options.url, requestOptions).then(response => {
         pendingBodySize -= requestSize;
         pendingCount--;


### PR DESCRIPTION
Replaces https://github.com/getsentry/sentry-javascript/pull/16532

Updates the comment in the browser fetch transport to explain why we do not need to suppress tracing there.