### PR TITLE
feat(nextjs): Add option for auto-generated random tunnel route

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -426,7 +426,7 @@ export type SentryBuildOptions = {
    * Tunnel Sentry requests through this route on the Next.js server, to circumvent ad-blockers blocking Sentry events
    * from being sent. This option should be a path (for example: '/error-monitoring').
    *
-   * - Pass `true` to auto-generate a random, ad-blocker-resistant route
+   * - Pass `true` to auto-generate a random, ad-blocker-resistant route for each build
    * - Pass a string path (e.g., '/monitoring') to use a custom route
    *
    * NOTE: This feature only works with Next.js 11+

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -426,9 +426,12 @@ export type SentryBuildOptions = {
    * Tunnel Sentry requests through this route on the Next.js server, to circumvent ad-blockers blocking Sentry events
    * from being sent. This option should be a path (for example: '/error-monitoring').
    *
+   * - Pass `true` to auto-generate a random, ad-blocker-resistant route
+   * - Pass a string path (e.g., '/monitoring') to use a custom route
+   *
    * NOTE: This feature only works with Next.js 11+
    */
-  tunnelRoute?: string;
+  tunnelRoute?: string | boolean;
 
   /**
    * Tree shakes Sentry SDK logger statements from the bundle.

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -692,7 +692,9 @@ function addValueInjectionLoader(
   const isomorphicValues = {
     // `rewritesTunnel` set by the user in Next.js config
     _sentryRewritesTunnelPath:
-      userSentryOptions.tunnelRoute !== undefined && userNextConfig.output !== 'export'
+      userSentryOptions.tunnelRoute !== undefined &&
+      userNextConfig.output !== 'export' &&
+      typeof userSentryOptions.tunnelRoute === 'string'
         ? `${userNextConfig.basePath ?? ''}${userSentryOptions.tunnelRoute}`
         : undefined,
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -107,6 +107,8 @@ function getFinalConfigObject(
           ? generateRandomTunnelRoute()
           : userSentryOptions.tunnelRoute;
 
+      // Update the global options object to use the resolved value everywhere
+      userSentryOptions.tunnelRoute = resolvedTunnelRoute;
       setUpTunnelRewriteRules(incomingUserNextConfigObject, resolvedTunnelRoute);
     }
   }
@@ -378,12 +380,12 @@ function setUpBuildTimeVariables(
   const assetPrefix = userNextConfig.assetPrefix || userNextConfig.basePath || '';
   const basePath = userNextConfig.basePath ?? '';
 
-  let rewritesTunnelPath: string | undefined;
-  if (userSentryOptions.tunnelRoute !== undefined && userNextConfig.output !== 'export') {
-    const resolvedTunnelRoute =
-      typeof userSentryOptions.tunnelRoute === 'boolean' ? generateRandomTunnelRoute() : userSentryOptions.tunnelRoute;
-    rewritesTunnelPath = `${basePath}${resolvedTunnelRoute}`;
-  }
+  const rewritesTunnelPath =
+    userSentryOptions.tunnelRoute !== undefined &&
+    userNextConfig.output !== 'export' &&
+    typeof userSentryOptions.tunnelRoute === 'string'
+      ? `${basePath}${userSentryOptions.tunnelRoute}`
+      : undefined;
 
   const buildTimeVariables: Record<string, string> = {
     // Make sure that if we have a windows path, the backslashes are interpreted as such (rather than as escape

--- a/packages/nextjs/test/utils/tunnelRoute.test.ts
+++ b/packages/nextjs/test/utils/tunnelRoute.test.ts
@@ -81,3 +81,28 @@ describe('applyTunnelRouteOption()', () => {
     expect(options.tunnel).toBe('/my-error-monitoring-route?o=2222222&p=3333333&r=us');
   });
 });
+
+describe('Random tunnel route generation', () => {
+  it('Generates random tunnel routes when tunnelRoute is true', () => {
+    globalWithInjectedValues._sentryRewritesTunnelPath = '/abc123def'; // Simulated random path
+    const options: any = {
+      dsn: 'https://11111111111111111111111111111111@o2222222.ingest.sentry.io/3333333',
+    } as BrowserOptions;
+
+    applyTunnelRouteOption(options);
+
+    expect(options.tunnel).toBe('/abc123def?o=2222222&p=3333333');
+    expect(options.tunnel).toMatch(/^\/[a-z0-9]+\?o=2222222&p=3333333$/);
+  });
+
+  it('Does not apply tunnel route when tunnelRoute is false', () => {
+    globalWithInjectedValues._sentryRewritesTunnelPath = undefined;
+    const options: any = {
+      dsn: 'https://11111111111111111111111111111111@o2222222.ingest.sentry.io/3333333',
+    } as BrowserOptions;
+
+    applyTunnelRouteOption(options);
+
+    expect(options.tunnel).toBeUndefined();
+  });
+});

--- a/packages/nextjs/test/utils/tunnelRoute.test.ts
+++ b/packages/nextjs/test/utils/tunnelRoute.test.ts
@@ -83,7 +83,7 @@ describe('applyTunnelRouteOption()', () => {
 });
 
 describe('Random tunnel route generation', () => {
-  it('Generates random tunnel routes when tunnelRoute is true', () => {
+  it('Works when tunnelRoute is true and generates random-looking paths', () => {
     globalWithInjectedValues._sentryRewritesTunnelPath = '/abc123def'; // Simulated random path
     const options: any = {
       dsn: 'https://11111111111111111111111111111111@o2222222.ingest.sentry.io/3333333',
@@ -95,7 +95,19 @@ describe('Random tunnel route generation', () => {
     expect(options.tunnel).toMatch(/^\/[a-z0-9]+\?o=2222222&p=3333333$/);
   });
 
-  it('Does not apply tunnel route when tunnelRoute is false', () => {
+  it('Works with region DSNs when tunnelRoute is true', () => {
+    globalWithInjectedValues._sentryRewritesTunnelPath = '/x7h9k2m'; // Simulated random path
+    const options: any = {
+      dsn: 'https://11111111111111111111111111111111@o2222222.ingest.eu.sentry.io/3333333',
+    } as BrowserOptions;
+
+    applyTunnelRouteOption(options);
+
+    expect(options.tunnel).toBe('/x7h9k2m?o=2222222&p=3333333&r=eu');
+    expect(options.tunnel).toMatch(/^\/[a-z0-9]+\?o=2222222&p=3333333&r=eu$/);
+  });
+
+  it('Does not apply tunnel when tunnelRoute is false', () => {
     globalWithInjectedValues._sentryRewritesTunnelPath = undefined;
     const options: any = {
       dsn: 'https://11111111111111111111111111111111@o2222222.ingest.sentry.io/3333333',


### PR DESCRIPTION
This PR adds support for auto-generated tunnel paths to avoid ad-blocker detection.

- Random paths are less likely to be blocked than `/monitoring`
- Users can just set `tunnelRoute: true` for an auto-generated route
- Existing configs will still work

**Note that every build will now create a different random path which should be quite unpredictable for ad-blockers**
