### PR TITLE
test(node): Unflake feature flag test

### DIFF
--- a/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/withScope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/withScope/scenario.ts
@@ -1,22 +1,26 @@
-import type { Scope } from '@sentry/node';
 import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+const flagsIntegration = Sentry.featureFlagsIntegration();
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   transport: loggingTransport,
-  integrations: [Sentry.featureFlagsIntegration()],
+  integrations: [flagsIntegration],
 });
 
-const flagsIntegration = Sentry.getClient()?.getIntegrationByName<Sentry.FeatureFlagsIntegration>('FeatureFlags');
-flagsIntegration?.addFeatureFlag('shared', true);
+flagsIntegration.addFeatureFlag('shared', true);
 
-Sentry.withScope((_scope: Scope) => {
-  flagsIntegration?.addFeatureFlag('forked', true);
-  flagsIntegration?.addFeatureFlag('shared', false);
+Sentry.withScope(() => {
+  flagsIntegration.addFeatureFlag('forked', true);
+  flagsIntegration.addFeatureFlag('shared', false);
   Sentry.captureException(new Error('Error in forked scope'));
 });
 
-flagsIntegration?.addFeatureFlag('main', true);
-throw new Error('Error in main scope');
+flagsIntegration.addFeatureFlag('main', true);
+
+// To ensure order of sent events
+setTimeout(() => {
+  throw new Error('Error in main scope');
+}, 1);


### PR DESCRIPTION
This seems flaky (e.g. https://github.com/getsentry/sentry-javascript/actions/runs/15727905218/job/44322221132?pr=16633), likely because they may be flushed at the same time I suppose!