### PR TITLE
test(browser): Add test showing behavior of capturing built-in class instances

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/builtInClassInstance/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/builtInClassInstance/subject.js
@@ -1,0 +1,1 @@
+Sentry.captureException(new Response('test body'));

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/builtInClassInstance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/builtInClassInstance/test.ts
@@ -3,7 +3,7 @@ import type { Event } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture an class instance', async ({ getLocalTestUrl, page }) => {
+sentryTest('should capture a class instance of a built-in class', async ({ getLocalTestUrl, page }) => {
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
@@ -11,7 +11,7 @@ sentryTest('should capture an class instance', async ({ getLocalTestUrl, page })
   expect(eventData.exception?.values).toHaveLength(1);
   expect(eventData.exception?.values?.[0]).toMatchObject({
     type: 'Error',
-    value: 'Object captured as exception with keys: prop1, prop2',
+    value: '[object Response]',
     mechanism: {
       type: 'generic',
       handled: true,


### PR DESCRIPTION
This is not really ideal, but there is no great alternative for this that I can think of to handle this generically 😬 

Now at least we have a test showing the current behavior!