### PR TITLE
ci: Ensure CI uses correct node version & bump pnpm to latest v9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,8 +415,6 @@ jobs:
     if: needs.job_build.outputs.changed_bun == 'true' || github.event_name != 'pull_request'
     timeout-minutes: 10
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -442,8 +440,6 @@ jobs:
     if: needs.job_build.outputs.changed_deno == 'true' || github.event_name != 'pull_request'
     timeout-minutes: 10
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -475,7 +471,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, '^24.0.1']
+        node: [18, 20, 22, 24]
     steps:
       - name: Check out base commit (${{ github.event.pull_request.base.sha }})
         uses: actions/checkout@v4
@@ -885,18 +881,11 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.4.0
-      # TODO: Remove this once the repo is bumped to 20.19.2 or higher
-      - name: Set up Node for Angular 20
-        if: matrix.test-application == 'angular-20'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.19.2'
+          version: 9.15.9
       - name: Set up Node
-        if: matrix.test-application != 'angular-20'
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'dev-packages/e2e-tests/package.json'
+          node-version-file: 'dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}/package.json'
       - name: Set up Bun
         if: matrix.test-application == 'node-exports-test-app'
         uses: oven-sh/setup-bun@v2
@@ -1012,11 +1001,11 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.4.0
+          version: 9.15.9
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'dev-packages/e2e-tests/package.json'
+          node-version-file: 'dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}/package.json'
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -125,18 +125,12 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.4.0
-      # TODO: Remove this once the repo is bumped to 20.19.2 or higher
-      - name: Set up Node for Angular 20
-        if: matrix.test-application == 'angular-20'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.19.2'
+          version: 9.15.9
       - name: Set up Node
         if: matrix.test-application != 'angular-20'
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'dev-packages/e2e-tests/package.json'
+          node-version-file: 'dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}/package.json'
 
       - name: Restore canary cache
         uses: actions/cache/restore@v4

--- a/dev-packages/e2e-tests/test-applications/angular-20/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-20/package.json
@@ -46,6 +46,7 @@
     "typescript": "~5.8.3"
   },
   "volta": {
-    "extends": "../../package.json"
+    "extends": "../../package.json",
+    "node": "20.19.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "volta": {
     "node": "20.18.2",
     "yarn": "1.22.22",
-    "pnpm": "9.15.0"
+    "pnpm": "9.15.9"
   },
   "workspaces": [
     "packages/angular",


### PR DESCRIPTION
Extracted this out of https://github.com/getsentry/sentry-javascript/pull/16644, for clarity