### PR TITLE
fix(browser): Remove usage of Array.at() method

### DIFF
--- a/packages/browser-utils/src/metrics/web-vitals/lib/LayoutShiftManager.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/lib/LayoutShiftManager.ts
@@ -30,7 +30,8 @@ export class LayoutShiftManager {
     if (entry.hadRecentInput) return;
 
     const firstSessionEntry = this._sessionEntries[0];
-    const lastSessionEntry = this._sessionEntries.at(-1);
+    // This previously used `this._sessionEntries.at(-1)` but that is ES2022. We support ES2021 and earlier.
+    const lastSessionEntry = this._sessionEntries[this._sessionEntries.length - 1];
 
     // If the entry occurred less than 1 second after the previous entry
     // and less than 5 seconds after the first entry in the session,


### PR DESCRIPTION
Sentry SDK supported browsers: https://docs.sentry.io/platforms/javascript/troubleshooting/supported-browsers/

<img width="1440" alt="Image" src="https://github.com/user-attachments/assets/9311db04-b3d1-4e7a-aac6-4f5c7f624875" />

`.at` is ES2022: https://blog.saeloun.com/2022/02/24/ecmascript2022-adds-add-method/

The browser SDK supports ES2021 at the current moment, so we need to change this.

Resolves https://github.com/getsentry/sentry-javascript/issues/16646