### PR TITLE
fix: Wait for the correct clientWidth/clientHeight when showing Feedback Screenshot previews

### DIFF
--- a/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
+++ b/packages/feedback/src/screenshot/components/ScreenshotEditor.tsx
@@ -166,6 +166,11 @@ export function ScreenshotEditorFactory({
           );
           setScaleFactor(scale);
         });
+
+        // For Firefox, the canvas is not yet measured, so we need to wait for it to get the correct size
+        if (measurementDiv.clientHeight === 0 || measurementDiv.clientWidth === 0) {
+          setTimeout(handleResize, 0);
+        }
       };
 
       handleResize();


### PR DESCRIPTION
Before we would see a blank screenshot in the feedback modal when using firefox. After resizing the screenshot would appear.

I debugged and foundout that the clientWidth/clientHeight wasn't being set right away, therefore the elements were on the page properly, and contained the correct pixel information drawn into the canvas, but the canvas wasn't sized correctly on the page, so you couldn't see anything.

This triggers a resize after a tick, giving the browser a chance first set the width/height before we measure it and set the scale factor.

**Before:**
<img width="1282" alt="SCR-20250618-kgwr" src="https://github.com/user-attachments/assets/c95f82f1-8468-4640-86ec-ca30874ce841" />

After:

<img width="1282" alt="SCR-20250618-kgrm" src="https://github.com/user-attachments/assets/e79e62df-ed53-4933-b42c-abd2ce520dd1" />

Fixes REPLAY-420