### PR TITLE
ref(flags): rewrite span flag tracking to not use global map

### DIFF
--- a/packages/core/src/utils/featureFlags.ts
+++ b/packages/core/src/utils/featureFlags.ts
@@ -1,10 +1,8 @@
 import { getCurrentScope } from '../currentScopes';
 import { DEBUG_BUILD } from '../debug-build';
 import { type Event } from '../types-hoist/event';
-import { type Span } from '../types-hoist/span';
 import { logger } from '../utils/logger';
-import { GLOBAL_OBJ } from '../utils/worldwide';
-import { getActiveSpan } from './spanUtils';
+import { getActiveSpan, spanToJSON } from './spanUtils';
 
 /**
  * Ordered LRU cache for storing feature flags in the scope context. The name
@@ -23,9 +21,6 @@ export const _INTERNAL_FLAG_BUFFER_SIZE = 100;
  * Max number of flag evaluations to record per span.
  */
 export const _INTERNAL_MAX_FLAGS_PER_SPAN = 10;
-
-// Global map of spans to feature flag buffers. Populated by feature flag integrations.
-GLOBAL_OBJ._spanToFlagBufferMap = new WeakMap<Span, Set<string>>();
 
 const SPAN_FLAG_ATTRIBUTE_PREFIX = 'flag.evaluation.';
 
@@ -133,20 +128,16 @@ export function _INTERNAL_addFeatureFlagToActiveSpan(
   value: unknown,
   maxFlagsPerSpan: number = _INTERNAL_MAX_FLAGS_PER_SPAN,
 ): void {
-  const spanFlagMap = GLOBAL_OBJ._spanToFlagBufferMap;
-  if (!spanFlagMap || typeof value !== 'boolean') {
+  if (typeof value !== 'boolean') {
     return;
   }
 
   const span = getActiveSpan();
   if (span) {
-    const flags = spanFlagMap.get(span) || new Set<string>();
-    if (flags.has(name)) {
-      span.setAttribute(`${SPAN_FLAG_ATTRIBUTE_PREFIX}${name}`, value);
-    } else if (flags.size < maxFlagsPerSpan) {
-      flags.add(name);
+    const attributes = spanToJSON(span).data;
+    const flags = Object.keys(attributes).filter(key => key.startsWith(SPAN_FLAG_ATTRIBUTE_PREFIX));
+    if (flags.length < maxFlagsPerSpan || flags.find(flag => flag === `${SPAN_FLAG_ATTRIBUTE_PREFIX}${name}`)) {
       span.setAttribute(`${SPAN_FLAG_ATTRIBUTE_PREFIX}${name}`, value);
     }
-    spanFlagMap.set(span, flags);
   }
 }

--- a/packages/core/src/utils/worldwide.ts
+++ b/packages/core/src/utils/worldwide.ts
@@ -15,7 +15,6 @@
 import type { Carrier } from '../carrier';
 import type { Client } from '../client';
 import type { SerializedLog } from '../types-hoist/log';
-import type { Span } from '../types-hoist/span';
 import type { SdkSource } from './env';
 
 /** Internal global with common properties and Sentry extensions  */
@@ -57,10 +56,6 @@ export type InternalGlobal = {
    */
   _sentryModuleMetadata?: Record<string, any>;
   _sentryEsmLoaderHookRegistered?: boolean;
-  /**
-   * A map of spans to evaluated feature flags. Populated by feature flag integrations.
-   */
-  _spanToFlagBufferMap?: WeakMap<Span, Set<string>>;
 } & Carrier;
 
 /** Get's the global object for the current JavaScript runtime */


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry-javascript/pull/16485#pullrequestreview-2931118348

Instead of tracking the evaluated feature flags in a global weakmap, we can directly check the span attributes by converting to JSON. This should save bundle size but I'm curious if the team has concerns on performance? If a customer is repeatedly evaluating 100s of flags and calling `addFeatureFlag` each time, should we worry about `spanToJSON` being too expensive?