### PR TITLE
feat(pino): Add initial package for `@sentry/pino-transport`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -50,6 +50,7 @@ body:
         - '@sentry/nestjs'
         - '@sentry/nextjs'
         - '@sentry/nuxt'
+        - '@sentry/pino-transport'
         - '@sentry/react'
         - '@sentry/react-router'
         - '@sentry/remix'

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ below:
   Provides the integration for Session Replay.
 - [`@sentry/core`](https://github.com/getsentry/sentry-javascript/tree/master/packages/core): The base for all
   JavaScript SDKs with interfaces, type definitions and base classes.
+- [`@sentry/pino-transport`](https://github.com/getsentry/sentry-javascript/tree/master/packages/pino-transport): Pino
+  transport for automatically sending log messages to Sentry.
 
 ## Bug Bounty Program
 

--- a/dev-packages/e2e-tests/verdaccio-config/config.yaml
+++ b/dev-packages/e2e-tests/verdaccio-config/config.yaml
@@ -110,6 +110,12 @@ packages:
     unpublish: $all
     # proxy: npmjs # Don't proxy for E2E tests!
 
+  '@sentry/pino-transport':
+    access: $all
+    publish: $all
+    unpublish: $all
+    # proxy: npmjs # Don't proxy for E2E tests!
+
   '@sentry/profiling-node':
     access: $all
     publish: $all

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "packages/node",
     "packages/nuxt",
     "packages/opentelemetry",
+    "packages/pino-transport",
     "packages/profiling-node",
     "packages/react",
     "packages/react-router",

--- a/packages/pino-transport/.eslintrc.js
+++ b/packages/pino-transport/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  env: {
+    node: true,
+  },
+  extends: ['../../.eslintrc.js'],
+  overrides: [
+    {
+      files: ['src/**/*.ts'],
+      rules: {},
+    },
+  ],
+};

--- a/packages/pino-transport/LICENSE
+++ b/packages/pino-transport/LICENSE
@@ -1,0 +1,16 @@
+MIT License
+
+Copyright (c) 2025 Functional Software, Inc. dba Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/pino-transport/README.md
+++ b/packages/pino-transport/README.md
@@ -1,0 +1,31 @@
+# @sentry/pino-transport
+
+[![npm version](https://img.shields.io/npm/v/@sentry/pino-transport.svg)](https://www.npmjs.com/package/@sentry/pino-transport)
+[![npm dm](https://img.shields.io/npm/dm/@sentry/pino-transport.svg)](https://www.npmjs.com/package/@sentry/pino-transport)
+[![npm dt](https://img.shields.io/npm/dt/@sentry/pino-transport.svg)](https://www.npmjs.com/package/@sentry/pino-transport)
+
+**This package is currently in alpha. Breaking changes may still occur.**
+
+A Pino transport for integrating [Pino](https://github.com/pinojs/pino) logging with [Sentry](https://sentry.io). This transport automatically captures log messages as Sentry events and breadcrumbs, making it easy to monitor your application's logs in Sentry.
+
+## Installation
+
+```bash
+npm install @sentry/node @sentry/pino-transport
+# or
+yarn add @sentry/node @sentry/pino-transport
+```
+
+## Usage
+
+TODO: Add usage instructions
+
+## Requirements
+
+- Node.js 18 or higher
+- Pino 8.0.0 or higher
+- @sentry/node must be configured in your application
+
+## License
+
+MIT

--- a/packages/pino-transport/package.json
+++ b/packages/pino-transport/package.json
@@ -39,8 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/core": "9.30.0",
-    "@sentry/node": "9.30.0"
+    "@sentry/core": "9.30.0"
   },
   "peerDependencies": {
     "pino": "^8.0.0 || ^9.0.0"

--- a/packages/pino-transport/package.json
+++ b/packages/pino-transport/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@sentry/pino-transport",
+  "version": "9.30.0",
+  "description": "Pino transport for Sentry SDK",
+  "repository": "git://github.com/getsentry/sentry-javascript.git",
+  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/pino-transport",
+  "author": "Sentry",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "/build"
+  ],
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
+  "types": "build/types/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
+      },
+      "require": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/cjs/index.js"
+      }
+    }
+  },
+  "typesVersions": {
+    "<5.0": {
+      "build/types/index.d.ts": [
+        "build/types-ts3.8/index.d.ts"
+      ]
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@sentry/core": "9.30.0",
+    "@sentry/node": "9.30.0"
+  },
+  "peerDependencies": {
+    "pino": "^8.0.0 || ^9.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.19.1",
+    "pino": "^9.0.0"
+  },
+  "scripts": {
+    "build": "run-p build:transpile build:types",
+    "build:dev": "yarn build",
+    "build:transpile": "rollup -c rollup.npm.config.mjs",
+    "build:types": "run-s build:types:core build:types:downlevel",
+    "build:types:core": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "yarn downlevel-dts build/types build/types-ts3.8 --to ts3.8",
+    "build:watch": "run-p build:transpile:watch build:types:watch",
+    "build:dev:watch": "yarn build:watch",
+    "build:transpile:watch": "rollup -c rollup.npm.config.mjs --watch",
+    "build:types:watch": "tsc -p tsconfig.types.json --watch",
+    "build:tarball": "npm pack",
+    "circularDepCheck": "madge --circular src/index.ts",
+    "clean": "rimraf build coverage sentry-pino-transport-*.tgz",
+    "fix": "eslint . --format stylish --fix",
+    "lint": "eslint . --format stylish",
+    "lint:es-compatibility": "es-check es2022 ./build/cjs/*.js && es-check es2022 ./build/esm/*.js --module",
+    "test": "yarn test:unit",
+    "test:unit": "vitest run",
+    "test:watch": "vitest --watch",
+    "yalc:publish": "yalc publish --push --sig"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "sideEffects": false
+}

--- a/packages/pino-transport/rollup.npm.config.mjs
+++ b/packages/pino-transport/rollup.npm.config.mjs
@@ -1,0 +1,3 @@
+import { makeBaseNPMConfig, makeNPMConfigVariants } from '@sentry-internal/rollup-utils';
+
+export default makeNPMConfigVariants(makeBaseNPMConfig());

--- a/packages/pino-transport/src/index.ts
+++ b/packages/pino-transport/src/index.ts
@@ -1,0 +1,2 @@
+// TODO: Implement this
+export {};

--- a/packages/pino-transport/test/index.test.ts
+++ b/packages/pino-transport/test/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import * as index from '../src';
+
+describe('pino-transport', () => {
+  it('should be defined', () => {
+    expect(index).toBeDefined();
+  });
+});

--- a/packages/pino-transport/tsconfig.json
+++ b/packages/pino-transport/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+
+  "include": ["src/**/*"],
+
+  "compilerOptions": {
+    "lib": ["es2018", "es2020.string"],
+    "module": "Node16"
+  }
+}

--- a/packages/pino-transport/tsconfig.test.json
+++ b/packages/pino-transport/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["test/**/*", "src/**/*", "vite.config.ts"],
+  "compilerOptions": {
+    "types": ["vitest/globals", "node"]
+  }
+}

--- a/packages/pino-transport/tsconfig.types.json
+++ b/packages/pino-transport/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/types",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "stripInternal": true
+  }
+}

--- a/packages/pino-transport/vite.config.ts
+++ b/packages/pino-transport/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/15952

resolves https://github.com/getsentry/sentry-javascript/issues/16621

We've gotten a lot of feedback about supporting pino. This PR kicks that off by creating a new pino package, specifically for the pino transport.

All pino transports need to use https://github.com/pinojs/pino-abstract-transport, which we don't want to add as a dep to `@sentry/node`. Hopefully keeping the versions in sync shouldn't be too bad, although I'll force a peer dep range.
