### PR TITLE
fix(google-cloud-serverless): Make `CloudEvent` type compatible

### DIFF
--- a/packages/google-cloud-serverless/src/gcpfunction/general.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/general.ts
@@ -29,10 +29,10 @@ export interface CloudFunctionsContext {
 
 export interface CloudEventsContext {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  id: string;
+  specversion: string;
   type?: string;
-  specversion?: string;
   source?: string;
-  id?: string;
   time?: string;
   schemaurl?: string;
   contenttype?: string;

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -121,8 +121,6 @@ export {
   consoleLoggingIntegration,
   wrapMcpServerWithSentry,
   NODE_VERSION,
-  featureFlagsIntegration,
-  type FeatureFlagsIntegration,
 } from '@sentry/node';
 
 export {

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -121,6 +121,8 @@ export {
   consoleLoggingIntegration,
   wrapMcpServerWithSentry,
   NODE_VERSION,
+  featureFlagsIntegration,
+  type FeatureFlagsIntegration,
 } from '@sentry/node';
 
 export {

--- a/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
@@ -45,6 +45,8 @@ describe('wrapCloudEventFunction', () => {
   function handleCloudEvent(fn: CloudEventFunctionWithCallback): Promise<any> {
     return new Promise((resolve, reject) => {
       const context = {
+        id: 'test-event-id',
+        specversion: '1.0',
         type: 'event.type',
       };
 
@@ -232,6 +234,10 @@ describe('wrapCloudEventFunction', () => {
     const handler: CloudEventFunction = _context => 42;
     const wrappedHandler = wrapCloudEventFunction(handler);
     await handleCloudEvent(wrappedHandler);
-    expect(mockScope.setContext).toBeCalledWith('gcp.function.context', { type: 'event.type' });
+    expect(mockScope.setContext).toBeCalledWith('gcp.function.context', {
+      id: 'test-event-id',
+      specversion: '1.0',
+      type: 'event.type'
+    });
   });
 });

--- a/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
@@ -237,7 +237,7 @@ describe('wrapCloudEventFunction', () => {
     expect(mockScope.setContext).toBeCalledWith('gcp.function.context', {
       id: 'test-event-id',
       specversion: '1.0',
-      type: 'event.type'
+      type: 'event.type',
     });
   });
 });


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/16653

As per the google cloud SDK (https://github.com/cloudevents/sdk-javascript/blob/c07afa9b774deefa137a960d2d11adee0bf3674a/src/event/interfaces.ts#L10-L31), `id` and  `specversion` should be mandatory.