### PR TITLE
chore: Add cursor rule for publishing a release

### DIFF
--- a/.cursor/rules/publishing_release.mdc
+++ b/.cursor/rules/publishing_release.mdc
@@ -1,0 +1,32 @@
+---
+description: Use this rule if you are looking to publish a release for the Sentry JavaScript SDKs
+globs:
+alwaysApply: false
+---
+# Publishing a Release
+
+Use these guidelines when publishing a new Sentry JavaScript SDK release.
+
+## Standard Release Process (from develop to master)
+
+The release process is outlined in [publishing-a-release.md](mdc:docs/publishing-a-release.md).
+
+1. Make sure you are on the latest version of the `develop` branch. To confirm this, run `git pull origin develop` to get the latest changes from the repo.
+2. Run `yarn changelog` on the `develop` branch and copy the output. You can use `yarn changelog | pbcopy` to copy the output of `yarn changelog` into your clipboard.
+3. Decide on a version for the release based on [semver](mdc:https:/semver.org). The version should be decided based on what is in included in the release. For example, if the release includes a new feature, we should increment the minor version. If it includes only bug fixes, we should increment the patch version.
+4. Create a branch `prepare-release/VERSION`, eg. `prepare-release/8.1.0`, off `develop`.
+5. Update [CHANGELOG.md](mdc:CHANGELOG.md) to add an entry for the next release number and a list of changes since the last release from the output of `yarn changelog`. See the `Updating the Changelog` section in [publishing-a-release.md](mdc:docs/publishing-a-release.md) for more details. If you remove changelog entries because they are not applicable, please let the user know.
+6. Commit the changes to [CHANGELOG.md](mdc:CHANGELOG.md) with `meta(changelog): Update changelog for VERSION` where `VERSION` is the version of the release
+7. Push the `prepare-release/VERSION` to origin and remind the user that the release PR needs to be opened from the `master` branch.
+
+## Key Commands
+
+- `yarn changelog` - Generate changelog entries
+- `yarn lint` - Ensure code quality
+- `yarn test` - Run test suite
+- `yarn build:dev` - Verify build
+
+## Important Notes
+
+- This repository uses **Git Flow** - target `develop` for feature PRs, not `master`. See [gitflow.md](mdc:docs/gitflow.md) for more details.
+- For first-time SDK releases, follow the New SDK Release Checklist [new-sdk-release-checklist.md](mdc:docs/new-sdk-release-checklist.md). If you notice there is something not following the new SDK release checklist, please remind the user.

--- a/.cursor/rules/publishing_release.mdc
+++ b/.cursor/rules/publishing_release.mdc
@@ -13,11 +13,11 @@ The release process is outlined in [publishing-a-release.md](mdc:docs/publishing
 
 1. Make sure you are on the latest version of the `develop` branch. To confirm this, run `git pull origin develop` to get the latest changes from the repo.
 2. Run `yarn changelog` on the `develop` branch and copy the output. You can use `yarn changelog | pbcopy` to copy the output of `yarn changelog` into your clipboard.
-3. Decide on a version for the release based on [semver](mdc:https:/semver.org). The version should be decided based on what is in included in the release. For example, if the release includes a new feature, we should increment the minor version. If it includes only bug fixes, we should increment the patch version.
+3. Decide on a version for the release based on [semver](mdc:https://semver.org). The version should be decided based on what is in included in the release. For example, if the release includes a new feature, we should increment the minor version. If it includes only bug fixes, we should increment the patch version.
 4. Create a branch `prepare-release/VERSION`, eg. `prepare-release/8.1.0`, off `develop`.
 5. Update [CHANGELOG.md](mdc:CHANGELOG.md) to add an entry for the next release number and a list of changes since the last release from the output of `yarn changelog`. See the `Updating the Changelog` section in [publishing-a-release.md](mdc:docs/publishing-a-release.md) for more details. If you remove changelog entries because they are not applicable, please let the user know.
-6. Commit the changes to [CHANGELOG.md](mdc:CHANGELOG.md) with `meta(changelog): Update changelog for VERSION` where `VERSION` is the version of the release
-7. Push the `prepare-release/VERSION` to origin and remind the user that the release PR needs to be opened from the `master` branch.
+6. Commit the changes to [CHANGELOG.md](mdc:CHANGELOG.md) with `meta(changelog): Update changelog for VERSION` where `VERSION` is the version of the release, e.g. `meta(changelog): Update changelog for 8.1.0`
+7. Push the `prepare-release/VERSION` branch to origin and remind the user that the release PR needs to be opened from the `master` branch.
 
 ## Key Commands
 

--- a/docs/publishing-a-release.md
+++ b/docs/publishing-a-release.md
@@ -2,11 +2,13 @@
 
 _These steps are only relevant to Sentry employees when preparing and publishing a new SDK release._
 
+These have also been documented via [Cursor Rules](../.cursor/rules/publishing-release.mdc).
+
 **If you want to release a new SDK for the first time, be sure to follow the
 [New SDK Release Checklist](./new-sdk-release-checklist.md)**
 
 1. Run `yarn changelog` on the `develop` branch and determine what version will be released (we use
-   [semver](https://semver.org))
+   [semver](https://semver.org)). The semvar version should be decided based on what is in included in the release. For example, if the release includes a new feature, we should increment the minor version. If it includes only bug fixes, we should increment the patch version.
 2. Create a branch `prepare-release/VERSION`, eg. `prepare-release/8.1.0`, off develop
 3. Update [`CHANGELOG.md`](https://github.com/getsentry/sentry-javascript/edit/master/CHANGELOG.md) to add an entry for
    the next release number and a list of changes since the last release. (See details below.)
@@ -43,8 +45,9 @@ _These steps are only relevant to Sentry employees when preparing and publishing
 2. Create a new section in the changelog with the previously determined version number.
 3. Paste in the logs you copied earlier.
 4. Delete any which aren't user-facing changes (such as docs or tests).
-5. Highlight any important changes with subheadings.
-6. If any of the PRs are from external contributors, include underneath the commits
+5. If there are any important features or fixes, highlight them under the `Important Changes` subheading. If there are no important changes, don't include this section. If the `Important Changes` subheading is used, put all other changes under the `Other Changes` subheading.
+6. Make sure the changelog entries are ordered alphabetically.
+7. If any of the PRs are from external contributors, include underneath the commits
    `Work in this release contributed by <list of external contributors' GitHub usernames>. Thank you for your contributions!`.
    If there's only one external PR, don't forget to remove the final `s`. If there are three or more, use an Oxford
    comma. (It's in the Sentry styleguide!)
@@ -52,4 +55,28 @@ _These steps are only relevant to Sentry employees when preparing and publishing
      "Unreleased". The GitHub Action creates a PR with this change every time a PR of an external contributor is merged.
      You can safely cut and paste this line to the new release section of the changelog (but a sanity check is never
      wrong).
-7. Commit, push, and continue with step 4 from the previous section with the general instructions (above).
+8. Commit, push, and continue with step 4 from the previous section with the general instructions (above).
+
+### Example Changelog Entry
+
+This is an example of a changelog entry for a release.
+
+```md
+## 9.28.0
+
+### Important Changes
+
+- **feat(nestjs): Stop creating spans for `TracingInterceptor` ([#16501](https://github.com/getsentry/sentry-javascript/pull/16501))**
+
+With this change we stop creating spans for `TracingInterceptor` as this interceptor only serves as an internal helper and adds noise for the user.
+
+- **feat(node): Update vercel ai spans as per new conventions ([#16497](https://github.com/getsentry/sentry-javascript/pull/16497))**
+
+This feature ships updates to the span names and ops to better match OpenTelemetry. This should make them more easily accessible to the new agents module view we are building.
+
+### Other Changes
+
+- fix(sveltekit): Export `vercelAIIntegration` from `@sentry/node` ([#16496](https://github.com/getsentry/sentry-javascript/pull/16496))
+
+Work in this release was contributed by @agrattan0820. Thank you for your contribution!
+```

--- a/docs/publishing-a-release.md
+++ b/docs/publishing-a-release.md
@@ -8,7 +8,7 @@ These have also been documented via [Cursor Rules](../.cursor/rules/publishing-r
 [New SDK Release Checklist](./new-sdk-release-checklist.md)**
 
 1. Run `yarn changelog` on the `develop` branch and determine what version will be released (we use
-   [semver](https://semver.org)). The semvar version should be decided based on what is in included in the release. For example, if the release includes a new feature, we should increment the minor version. If it includes only bug fixes, we should increment the patch version.
+   [semver](https://semver.org)). The semver version should be decided based on what is in included in the release. For example, if the release includes a new feature, we should increment the minor version. If it includes only bug fixes, we should increment the patch version.
 2. Create a branch `prepare-release/VERSION`, eg. `prepare-release/8.1.0`, off develop
 3. Update [`CHANGELOG.md`](https://github.com/getsentry/sentry-javascript/edit/master/CHANGELOG.md) to add an entry for
    the next release number and a list of changes since the last release. (See details below.)


### PR DESCRIPTION
We should give this a try next time we want to publish a release (ideally just kick off a background agent that does it).