### PR TITLE
chore: Add @sentry/opentelemetry resolution back to remix integration tests

### DIFF
--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -27,6 +27,7 @@
     "@sentry/browser": "file:../../../browser",
     "@sentry/core": "file:../../../core",
     "@sentry/node": "file:../../../node",
+    "@sentry/opentelemetry": "file:../../../opentelemetry",
     "@sentry/react": "file:../../../react",
     "@sentry-internal/browser-utils": "file:../../../browser-utils",
     "@sentry-internal/replay": "file:../../../replay-internal",


### PR DESCRIPTION
While the remix package does not directly depend on @sentry/opentelemetry, we still need this resolution override for the integration tests.

It was removed in: https://github.com/getsentry/sentry-javascript/pull/16677