### PR TITLE
fix(nextjs): Stop injecting release value when create release options is set to `false`

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -689,6 +689,10 @@ function addValueInjectionLoader(
 ): void {
   const assetPrefix = userNextConfig.assetPrefix || userNextConfig.basePath || '';
 
+  // Check if release creation is disabled to prevent injection that breaks build determinism
+  const shouldCreateRelease = userSentryOptions.release?.create !== false;
+  const releaseToInject = releaseName && shouldCreateRelease ? releaseName : undefined;
+
   const isomorphicValues = {
     // `rewritesTunnel` set by the user in Next.js config
     _sentryRewritesTunnelPath:
@@ -700,7 +704,8 @@ function addValueInjectionLoader(
 
     // The webpack plugin's release injection breaks the `app` directory so we inject the release manually here instead.
     // Having a release defined in dev-mode spams releases in Sentry so we only set one in non-dev mode
-    SENTRY_RELEASE: releaseName && !buildContext.dev ? { id: releaseName } : undefined,
+    // Only inject if release creation is not explicitly disabled (to maintain build determinism)
+    SENTRY_RELEASE: releaseToInject && !buildContext.dev ? { id: releaseToInject } : undefined,
     _sentryBasePath: buildContext.dev ? userNextConfig.basePath : undefined,
   };
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -90,7 +90,12 @@ function getFinalConfigObject(
   incomingUserNextConfigObject: NextConfigObject,
   userSentryOptions: SentryBuildOptions,
 ): NextConfigObject {
-  const releaseName = userSentryOptions.release?.name ?? getSentryRelease() ?? getGitRevision();
+  // Only determine a release name if release creation is not explicitly disabled
+  // This prevents injection of Git commit hashes that break build determinism
+  const shouldCreateRelease = userSentryOptions.release?.create !== false;
+  const releaseName = shouldCreateRelease
+    ? userSentryOptions.release?.name ?? getSentryRelease() ?? getGitRevision()
+    : userSentryOptions.release?.name;
 
   if (userSentryOptions?.tunnelRoute) {
     if (incomingUserNextConfigObject.output === 'export') {
@@ -126,8 +131,8 @@ function getFinalConfigObject(
       // 1. compile: Code compilation
       // 2. generate: Environment variable inlining and prerendering (We don't instrument this phase, we inline in the compile phase)
       //
-      // We assume a single “full” build and reruns Webpack instrumentation in both phases.
-      // During the generate step it collides with Next.js’s inliner
+      // We assume a single "full" build and reruns Webpack instrumentation in both phases.
+      // During the generate step it collides with Next.js's inliner
       // producing malformed JS and build failures.
       // We skip Sentry processing during generate to avoid this issue.
       return incomingUserNextConfigObject;


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/16593