### PR TITLE
fix(google-cloud-serverless): Make `CloudEventsContext` compatible with `CloudEvent`

### DIFF
--- a/packages/google-cloud-serverless/src/gcpfunction/general.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/general.ts
@@ -31,8 +31,8 @@ export interface CloudEventsContext {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
   id: string;
   specversion: string;
-  type?: string;
-  source?: string;
+  type: string;
+  source: string;
   time?: string;
   schemaurl?: string;
   contenttype?: string;


### PR DESCRIPTION
Update CloudEventsContext interface types

Make `type` and `source` required properties

- Closes: #16653
- Refs: https://github.com/getsentry/sentry-javascript/issues/16653#issuecomment-2997811924
- Refs: #16661
