### PR TITLE
fix: Export logger from sveltekit worker

### DIFF
--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -49,6 +49,7 @@ export {
   isEnabled,
   lastEventId,
   linkedErrorsIntegration,
+  logger,
   requestDataIntegration,
   rewriteFramesIntegration,
   Scope,


### PR DESCRIPTION
### Issue

The `logger` was missing from SvelteKit's worker environment exports, causing `Sentry.logger` to be `null` when deploying to Cloudflare Pages. Users experienced:
- `Sentry.logger` is `null` in production 
- `logger.info()` throws access violations
- Works fine locally but fails in Cloudflare Pages deployment

Cloudflare Pages uses the **worker runtime environment** (not Node.js) when `@sveltejs/adapter-cloudflare` is configured which is why logger must be exported from there.

[official Cloudflare Pages Functions documentation](https://developers.cloudflare.com/pages/functions/)
https://developers.cloudflare.com/pages/framework-guides/deploy-a-svelte-kit-site/#functions-setup
