### PR TITLE
feat(nextjs): Expose top level buildTime `errorHandler` option

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -446,6 +446,23 @@ export type SentryBuildOptions = {
   automaticVercelMonitors?: boolean;
 
   /**
+   * When an error occurs during release creation or sourcemaps upload, the plugin will call this function.
+   *
+   * By default, the plugin will simply throw an error, thereby stopping the bundling process.
+   * If an `errorHandler` callback is provided, compilation will continue, unless an error is
+   * thrown in the provided callback.
+   *
+   * To allow compilation to continue but still emit a warning, set this option to the following:
+   *
+   * ```js
+   * (err) => {
+   *   console.warn(err);
+   * }
+   * ```
+   */
+  errorHandler?: (err: Error) => void;
+
+  /**
    * Contains a set of experimental flags that might change in future releases. These flags enable
    * features that are still in development and may be modified, renamed, or removed without notice.
    * Use with caution in production environments.

--- a/packages/nextjs/src/config/webpackPluginOptions.ts
+++ b/packages/nextjs/src/config/webpackPluginOptions.ts
@@ -62,6 +62,7 @@ export function getWebpackPluginOptions(
     project: sentryBuildOptions.project,
     telemetry: sentryBuildOptions.telemetry,
     debug: sentryBuildOptions.debug,
+    errorHandler: sentryBuildOptions.errorHandler,
     reactComponentAnnotation: {
       ...sentryBuildOptions.reactComponentAnnotation,
       ...sentryBuildOptions.unstable_sentryWebpackPluginOptions?.reactComponentAnnotation,

--- a/packages/nextjs/test/config/webpack/webpackPluginOptions.test.ts
+++ b/packages/nextjs/test/config/webpack/webpackPluginOptions.test.ts
@@ -138,6 +138,23 @@ describe('getWebpackPluginOptions()', () => {
     });
   });
 
+  it('forwards errorHandler option', () => {
+    const buildContext = generateBuildContext({ isServer: false });
+    const mockErrorHandler = (err: Error) => {
+      throw err;
+    };
+
+    const generatedPluginOptions = getWebpackPluginOptions(
+      buildContext,
+      {
+        errorHandler: mockErrorHandler,
+      },
+      undefined,
+    );
+
+    expect(generatedPluginOptions.errorHandler).toBe(mockErrorHandler);
+  });
+
   it('returns the right `assets` and `ignore` values during the server build', () => {
     const buildContext = generateBuildContext({ isServer: true });
     const generatedPluginOptions = getWebpackPluginOptions(buildContext, {}, undefined);


### PR DESCRIPTION
Exposes a `errorHandler` option in `withSentryConfig` for handling built-time errors.

closes https://github.com/getsentry/sentry-javascript/issues/16195