### PR TITLE
fix(tests): Set `vite` versions in Remix e2e tests.

### DIFF
--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "tsx": "4.7.2",
     "typescript": "^5.1.6",
+    "vite": "^5.4.11",
     "vite-tsconfig-paths": "^4.2.1"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/package.json
@@ -30,7 +30,8 @@
     "@types/react-dom": "^18.2.34",
     "@types/prop-types": "15.7.7",
     "eslint": "^8.38.0",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "vite": "^5.4.11"
   },
   "resolutions": {
     "@types/react": "18.2.22"


### PR DESCRIPTION
This will fix the [failing e2e tests](https://github.com/getsentry/sentry-javascript/actions/runs/15852381250) on CI