### PR TITLE
feat(nuxt): Add alias for `@opentelemetry/resources`

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import type { SentryNuxtModuleOptions } from './common/types';
 import { addDynamicImportEntryFileWrapper, addSentryTopImport, addServerConfigToBuild } from './vite/addServerConfig';
 import { setupSourceMaps } from './vite/sourceMaps';
-import { findDefaultSdkInitFile } from './vite/utils';
+import { addOTelCommonJSImportAlias, findDefaultSdkInitFile } from './vite/utils';
 
 export type ModuleOptions = SentryNuxtModuleOptions;
 
@@ -68,6 +68,8 @@ export default defineNuxtModule<ModuleOptions>({
     if (clientConfigFile || serverConfigFile) {
       setupSourceMaps(moduleOptions, nuxt);
     }
+
+    addOTelCommonJSImportAlias(nuxt);
 
     nuxt.hooks.hook('nitro:init', nitro => {
       if (serverConfigFile?.includes('.server.config')) {

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -179,3 +179,21 @@ export function constructFunctionReExport(pathWithQuery: string, entryId: string
       ),
     );
 }
+
+/**
+ * Sets up alias to work around OpenTelemetry's incomplete ESM imports.
+ * https://github.com/getsentry/sentry-javascript/issues/15204
+ *
+ * OpenTelemetry's @opentelemetry/resources package has incomplete imports missing
+ * the .js file extensions (like execAsync for machine-id detection). This causes module resolution
+ * errors in certain Nuxt configurations, particularly when local Nuxt modules in Nuxt 4 are present.
+ *
+ * @see https://nuxt.com/docs/guide/concepts/esm#aliasing-libraries
+ */
+export function addOTelCommonJSImportAlias(nuxt: Nuxt): void {
+  if (!nuxt.options.alias) {
+    nuxt.options.alias = {};
+  }
+
+  nuxt.options.alias['@opentelemetry/resources'] = '@opentelemetry/resources/build/src/index.js';
+}

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import type { Nuxt } from 'nuxt/schema';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  addOTelCommonJSImportAlias,
   constructFunctionReExport,
   constructWrappedFunctionExportQuery,
   extractFunctionReexportQueryParameters,
@@ -364,5 +365,52 @@ export { foo_sentryWrapped as foo };
     const entryId = './module';
     const result = constructFunctionReExport(query, entryId);
     expect(result).toBe('');
+  });
+});
+
+describe('addOTelCommonJSImportAlias', () => {
+  it('adds alias for @opentelemetry/resources when options.alias does not exist', () => {
+    const nuxtMock: Nuxt = {
+      options: {},
+    } as unknown as Nuxt;
+
+    addOTelCommonJSImportAlias(nuxtMock);
+
+    expect(nuxtMock.options.alias).toEqual({
+      '@opentelemetry/resources': '@opentelemetry/resources/build/src/index.js',
+    });
+  });
+
+  it('adds alias for @opentelemetry/resources when options.alias already exists', () => {
+    const nuxtMock: Nuxt = {
+      options: {
+        alias: {
+          'existing-alias': 'some-path',
+        },
+      },
+    } as unknown as Nuxt;
+
+    addOTelCommonJSImportAlias(nuxtMock);
+
+    expect(nuxtMock.options.alias).toEqual({
+      'existing-alias': 'some-path',
+      '@opentelemetry/resources': '@opentelemetry/resources/build/src/index.js',
+    });
+  });
+
+  it('overwrites existing alias for @opentelemetry/resources if already present', () => {
+    const nuxtMock: Nuxt = {
+      options: {
+        alias: {
+          '@opentelemetry/resources': 'some-other-path',
+        },
+      },
+    } as unknown as Nuxt;
+
+    addOTelCommonJSImportAlias(nuxtMock);
+
+    expect(nuxtMock.options.alias).toEqual({
+      '@opentelemetry/resources': '@opentelemetry/resources/build/src/index.js',
+    });
   });
 });


### PR DESCRIPTION
Under certain circumstances, you'll get a "Cannot find module" error in Nuxt dev mode. This is because ESM requires the .js file extensions to make the imports work and there is a tracking issue in OTel to support the ESM spec (which also means adding the file extensions): https://github.com/open-telemetry/opentelemetry-js/issues/4898



Fixes https://github.com/getsentry/sentry-javascript/issues/15204
As the issue is very long, here are some relevant comments:
- [ESM and OTel explanation](https://github.com/getsentry/sentry-javascript/issues/15204#issuecomment-2678498189)
- [Potential Workarounds](https://github.com/getsentry/sentry-javascript/issues/15204#issuecomment-3000889008)