### PR TITLE
test(nuxt): Add fake module and composable to E2E test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-4/app/app.vue
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/app/app.vue
@@ -13,5 +13,8 @@
   </NuxtLayout>
 </template>
 
-<script setup>
+<script setup lang="ts">
+import { useSentryTestTag } from '#imports';
+
+useSentryTestTag();
 </script>

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/app/composables/use-sentry-test-tag.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/app/composables/use-sentry-test-tag.ts
@@ -1,7 +1,7 @@
-// fixme: this needs to be imported from @sentry/core, not @sentry/nuxt (import-in-the-middle error in dev mode)
+// fixme: this needs to be imported from @sentry/core, not @sentry/nuxt in dev mode (because of import-in-the-middle error)
 // This could also be a problem with the specific setup of the pnpm E2E test setup, because this could not be reproduced outside of the E2E test.
 // Related to this: https://github.com/getsentry/sentry-javascript/issues/15204#issuecomment-2948908130
-import { setTag } from '@sentry/core';
+import { setTag } from '@sentry/nuxt';
 
 export default function useSentryTestTag(): void {
   setTag('test-tag', null);

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/app/composables/use-sentry-test-tag.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/app/composables/use-sentry-test-tag.ts
@@ -1,0 +1,8 @@
+// fixme: this needs to be imported from @sentry/core, not @sentry/nuxt (import-in-the-middle error in dev mode)
+// This could also be a problem with the specific setup of the pnpm E2E test setup, because this could not be reproduced outside of the E2E test.
+// Related to this: https://github.com/getsentry/sentry-javascript/issues/15204#issuecomment-2948908130
+import { setTag } from '@sentry/core';
+
+export default function useSentryTestTag(): void {
+  setTag('test-tag', null);
+}

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/modules/another-module.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/modules/another-module.ts
@@ -1,0 +1,9 @@
+import { defineNuxtModule } from 'nuxt/kit';
+
+// Just a fake module to check if the SDK works alongside other local Nuxt modules without breaking the build
+export default defineNuxtModule({
+  meta: { name: 'another-module' },
+  setup() {
+    console.log('another-module setup called');
+  },
+});

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt.config.ts
@@ -1,7 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   future: { compatibilityVersion: 4 },
-  compatibilityDate: '2024-04-03',
+  compatibilityDate: '2025-06-06',
   imports: { autoImport: false },
 
   modules: ['@pinia/nuxt', '@sentry/nuxt/module'],

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@pinia/nuxt": "^0.5.5",
     "@sentry/nuxt": "latest || *",
-    "nuxt": "^3.13.2"
+    "nuxt": "^3.17.5"
   },
   "devDependencies": {
     "@playwright/test": "~1.50.0",


### PR DESCRIPTION
This adds a `modules` and `composables` folder to the Nuxt 4 E2E test. The main purpose is to check, that the build runs through without problems.

Additionally, the versions were updated (as this is the Nuxt 4 test and it should use the latest versions for the compatibility mode).

Related to this: https://github.com/getsentry/sentry-javascript/issues/15204#issuecomment-2948908130
