### PR TITLE
feat(nextjs): Export server-side launchdarkly integration shims

### DIFF
--- a/packages/integration-shims/src/index.ts
+++ b/packages/integration-shims/src/index.ts
@@ -1,3 +1,4 @@
 export { feedbackIntegrationShim } from './Feedback';
 export { replayIntegrationShim } from './Replay';
 export { browserTracingIntegrationShim } from './BrowserTracing';
+export { launchDarklyIntegrationShim, buildLaunchDarklyFlagUsedHandlerShim } from './launchdarkly';

--- a/packages/integration-shims/src/launchDarkly.ts
+++ b/packages/integration-shims/src/launchDarkly.ts
@@ -1,0 +1,38 @@
+import { consoleSandbox, defineIntegration, isBrowser } from '@sentry/core';
+import { FAKE_FUNCTION } from './common';
+
+/**
+ * This is a shim for the LaunchDarkly integration.
+ * We need this in order to not throw runtime errors when accidentally importing this on the server through a meta framework like Next.js.
+ */
+export const launchDarklyIntegrationShim = defineIntegration((_options?: unknown) => {
+  if (!isBrowser()) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn('The launchDarklyIntegration() can only be used in the browser.');
+    });
+  }
+
+  return {
+    name: 'LaunchDarkly',
+  };
+});
+
+/**
+ * This is a shim for the LaunchDarkly flag used handler.
+ */
+export function buildLaunchDarklyFlagUsedHandlerShim(): unknown {
+  if (!isBrowser()) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn('The buildLaunchDarklyFlagUsedHandler() should only be used in the browser.');
+    });
+  }
+
+  return {
+    name: 'sentry-flag-auditor',
+    type: 'flag-used',
+    synchronous: true,
+    method: FAKE_FUNCTION,
+  };
+}

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -94,7 +94,8 @@
   "devDependencies": {
     "@types/resolve": "1.20.3",
     "eslint-plugin-react": "^7.31.11",
-    "next": "13.2.0"
+    "next": "13.2.0",
+    "@sentry-internal/integration-shims": "9.31.0"
   },
   "peerDependencies": {
     "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0"

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -138,3 +138,6 @@ export declare function wrapApiHandlerWithSentryVercelCrons<F extends (...args: 
 export declare function wrapPageComponentWithSentry<C>(WrappingTarget: C): C;
 
 export { captureRequestError } from './common/captureRequestError';
+
+export declare const launchDarklyIntegration: typeof clientSdk.launchDarklyIntegration;
+export declare const buildLaunchDarklyFlagUsedHandler: typeof clientSdk.buildLaunchDarklyFlagUsedHandler;

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -389,3 +389,8 @@ function sdkAlreadyInitialized(): boolean {
 export * from '../common';
 
 export { wrapApiHandlerWithSentry } from '../common/pages-router-instrumentation/wrapApiHandlerWithSentry';
+
+export {
+  launchDarklyIntegrationShim as launchDarklyIntegration,
+  buildLaunchDarklyFlagUsedHandlerShim as buildLaunchDarklyFlagUsedHandler,
+} from '@sentry-internal/integration-shims';

--- a/yarn.lock
+++ b/yarn.lock
@@ -24560,16 +24560,6 @@ quick-format-unescaped@^4.0.3:
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
   integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
 
-quick-format-unescaped@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
-  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
-
-quick-format-unescaped@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
-  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
-
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
@@ -29289,7 +29279,7 @@ vite@^5.0.0, vite@^5.4.11, vite@^5.4.5:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitefu@^0.2.2, vitefu@^0.2.4, vitefu@^0.2.5:
+vitefu@^0.2.2, vitefu@^0.2.4:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/vitefu/-/vitefu-0.2.5.tgz#c1b93c377fbdd3e5ddd69840ea3aa70b40d90969"
   integrity sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==


### PR DESCRIPTION
Shim LaunchDarkly functions on the server 

[Linear issue](https://linear.app/getsentry/issue/FE-512/investigate-missing-buildlaunchdarklyflagusedhandler-in-sentrynextjs)

ref https://github.com/getsentry/sentry-javascript/pull/16680