### PR TITLE
fix(core): Prevent unhandled promise rejection in withMonitor

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -179,9 +179,8 @@ export function withMonitor<T>(
         () => {
           finishCheckIn('ok');
         },
-        e => {
+        () => {
           finishCheckIn('error');
-          throw e;
         },
       );
     } else {


### PR DESCRIPTION
### Problem
`withMonitor` function was causing unhandled promise rejections when wrapping async callbacks that throw errors. This could crash servers when monitoring async operations.

When a promise returned by the callback rejected, the error was being thrown inside the promise rejection handler:
```typescript
Promise.resolve(maybePromiseResult).then(
  () => { finishCheckIn('ok'); },
  e => {
    finishCheckIn('error');
    throw e;  // This causes unhandled rejection
  },
);
```

### Solution
Simply remove the `throw e;` line. The original promise is already returned to the caller, so they can handle the rejection appropriately. 

Fixes [#JS-620](https://linear.app/getsentry/issue/JS-362/nextjs-153-shows-warning-after-adding-sentry#comment-593d7419)