### PR TITLE
ci: Use generic node 18 for node-integration-tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -709,7 +709,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['18.20.5', 20, 22, 24]
+        node: [18, 20, 22, 24]
         typescript:
           - false
         include:


### PR DESCRIPTION
No need to overwrite to a specific version here anymore, I believe.