### PR TITLE
fix(nuxt): Only add OTel alias in dev mode

### DIFF
--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -191,9 +191,15 @@ export function constructFunctionReExport(pathWithQuery: string, entryId: string
  * @see https://nuxt.com/docs/guide/concepts/esm#aliasing-libraries
  */
 export function addOTelCommonJSImportAlias(nuxt: Nuxt): void {
+  if (nuxt.options.dev) {
+    return;
+  }
+
   if (!nuxt.options.alias) {
     nuxt.options.alias = {};
   }
 
-  nuxt.options.alias['@opentelemetry/resources'] = '@opentelemetry/resources/build/src/index.js';
+  if (!nuxt.options.alias['@opentelemetry/resources']) {
+    nuxt.options.alias['@opentelemetry/resources'] = '@opentelemetry/resources/build/src/index.js';
+  }
 }

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -191,7 +191,7 @@ export function constructFunctionReExport(pathWithQuery: string, entryId: string
  * @see https://nuxt.com/docs/guide/concepts/esm#aliasing-libraries
  */
 export function addOTelCommonJSImportAlias(nuxt: Nuxt): void {
-  if (nuxt.options.dev) {
+  if (!nuxt.options.dev) {
     return;
   }
 

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -398,7 +398,7 @@ describe('addOTelCommonJSImportAlias', () => {
     });
   });
 
-  it('overwrites existing alias for @opentelemetry/resources if already present', () => {
+  it('does not override existing alias for @opentelemetry/resources', () => {
     const nuxtMock: Nuxt = {
       options: {
         alias: {
@@ -410,7 +410,19 @@ describe('addOTelCommonJSImportAlias', () => {
     addOTelCommonJSImportAlias(nuxtMock);
 
     expect(nuxtMock.options.alias).toEqual({
-      '@opentelemetry/resources': '@opentelemetry/resources/build/src/index.js',
+      '@opentelemetry/resources': 'some-other-path',
     });
+  });
+
+  it('does not add alias in development mode', () => {
+    const nuxtMock: Nuxt = {
+      options: {
+        dev: true,
+      },
+    } as unknown as Nuxt;
+
+    addOTelCommonJSImportAlias(nuxtMock);
+
+    expect(nuxtMock.options.alias).toBeUndefined();
   });
 });

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -371,7 +371,7 @@ export { foo_sentryWrapped as foo };
 describe('addOTelCommonJSImportAlias', () => {
   it('adds alias for @opentelemetry/resources when options.alias does not exist', () => {
     const nuxtMock: Nuxt = {
-      options: {},
+      options: { dev: true },
     } as unknown as Nuxt;
 
     addOTelCommonJSImportAlias(nuxtMock);
@@ -384,6 +384,7 @@ describe('addOTelCommonJSImportAlias', () => {
   it('adds alias for @opentelemetry/resources when options.alias already exists', () => {
     const nuxtMock: Nuxt = {
       options: {
+        dev: true,
         alias: {
           'existing-alias': 'some-path',
         },
@@ -401,6 +402,7 @@ describe('addOTelCommonJSImportAlias', () => {
   it('does not override existing alias for @opentelemetry/resources', () => {
     const nuxtMock: Nuxt = {
       options: {
+        dev: true,
         alias: {
           '@opentelemetry/resources': 'some-other-path',
         },
@@ -414,11 +416,9 @@ describe('addOTelCommonJSImportAlias', () => {
     });
   });
 
-  it('does not add alias in development mode', () => {
+  it('does not add alias when not development mode', () => {
     const nuxtMock: Nuxt = {
-      options: {
-        dev: true,
-      },
+      options: {},
     } as unknown as Nuxt;
 
     addOTelCommonJSImportAlias(nuxtMock);


### PR DESCRIPTION
Only add alias in dev mode and don't override an existing one so people can still add their own alias.

fixes https://github.com/getsentry/sentry-javascript/issues/16742
reference: https://github.com/getsentry/sentry-javascript/issues/15204
