### PR TITLE
Simplify error handling in finishCheckIn callback.

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -179,9 +179,8 @@ export function withMonitor<T>(
         () => {
           finishCheckIn('ok');
         },
-        e => {
+        () => {
           finishCheckIn('error');
-          throw e;
         },
       );
     } else {


### PR DESCRIPTION
Throwing an error inside catch block will produce unhandled exception and, as a result - crash.
fixes #16749

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
