### PR TITLE
feat(browser): Export `Context` and `Contexts` types

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -1,6 +1,8 @@
 export type {
   Breadcrumb,
   BreadcrumbHint,
+  Context,
+  Contexts,
   RequestEventData,
   SdkInfo,
   Event,


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/16764