### PR TITLE
test(nuxt): Use official Nuxt 4 version for E2E test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt.config.ts
@@ -12,10 +12,4 @@ export default defineNuxtConfig({
       },
     },
   },
-  nitro: {
-    rollupConfig: {
-      // @sentry/... is set external to prevent bundling all of Sentry into the `runtime.mjs` file in the build output
-      external: [/@sentry\/.*/],
-    },
-  },
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt.config.ts
@@ -1,6 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  future: { compatibilityVersion: 4 },
   compatibilityDate: '2025-06-06',
   imports: { autoImport: false },
 

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@pinia/nuxt": "^0.5.5",
     "@sentry/nuxt": "latest || *",
-    "nuxt": "^3.17.5"
+    "nuxt": "^4.0.0-alpha.4"
   },
   "devDependencies": {
     "@playwright/test": "~1.50.0",


### PR DESCRIPTION
Nuxt starts releasing official Nuxt 4 versions which we can use for the E2E test.
