### PR TITLE
test(nuxt): Remove `external` config

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/nuxt.config.ts
@@ -11,12 +11,6 @@ export default defineNuxtConfig({
       },
     },
   },
-  nitro: {
-    rollupConfig: {
-      // @sentry/... is set external to prevent bundling all of Sentry into the `runtime.mjs` file in the build output
-      external: [/@sentry\/.*/],
-    },
-  },
   sentry: {
     autoInjectServerSentry: 'experimental_dynamic-import',
   },

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/nuxt.config.ts
@@ -11,10 +11,4 @@ export default defineNuxtConfig({
       },
     },
   },
-  nitro: {
-    rollupConfig: {
-      // @sentry/... is set external to prevent bundling all of Sentry into the `runtime.mjs` file in the build output
-      external: [/@sentry\/.*/],
-    },
-  },
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/nuxt.config.ts
@@ -11,12 +11,6 @@ export default defineNuxtConfig({
       },
     },
   },
-  nitro: {
-    rollupConfig: {
-      // @sentry/... is set external to prevent bundling all of Sentry into the `runtime.mjs` file in the build output
-      external: [/@sentry\/.*/],
-    },
-  },
   sentry: {
     autoInjectServerSentry: 'top-level-import',
   },

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/nuxt.config.ts
@@ -11,10 +11,4 @@ export default defineNuxtConfig({
       },
     },
   },
-  nitro: {
-    rollupConfig: {
-      // @sentry/... is set external to prevent bundling all of Sentry into the `runtime.mjs` file in the build output
-      external: [/@sentry\/.*/],
-    },
-  },
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt.config.ts
@@ -13,10 +13,4 @@ export default defineNuxtConfig({
       },
     },
   },
-  nitro: {
-    rollupConfig: {
-      // @sentry/... is set external to prevent bundling all of Sentry into the `runtime.mjs` file in the build output
-      external: [/@sentry\/.*/],
-    },
-  },
 });


### PR DESCRIPTION
Removing the externals fixes the following runtime error: `Cannot find module: import '/Users/[...long-file-path...]/node_modules/@sentry/nuxt/build/module/runtime/plugins/sentry.server';`

The problem is that usually (also when I tested this in an external app), the `server/index.mjs` file includes two imports:

```js
import '@sentry/core';
import '@sentry/node';
```

However, when `@sentry/...` is set external, it adds a very long import path (see above in the error message).

More about this in this comment: https://github.com/getsentry/sentry-javascript/issues/16762#issuecomment-3018361824

The behavior changed with this PR in Nuxt: https://github.com/nuxt/nuxt/pull/32354
