### PR TITLE
fix(node): Avoid using dynamic `require` for fastify integration

### DIFF
--- a/packages/node/src/integrations/tracing/fastify/fastify-otel/index.js
+++ b/packages/node/src/integrations/tracing/fastify/fastify-otel/index.js
@@ -43,7 +43,7 @@ import {
   ATTR_HTTP_ROUTE,
   ATTR_SERVICE_NAME,
 } from '@opentelemetry/semantic-conventions';
-import { minimatch } from 'minimatch';
+import * as minimatch from 'minimatch';
 
 // SENTRY VENDOR NOTE
 // Instead of using the package.json file, we hard code the package name and version here.
@@ -97,7 +97,7 @@ export class FastifyOtelInstrumentation extends InstrumentationBase {
         throw new TypeError('ignorePaths must be a string or a function');
       }
 
-      const globMatcher = minimatch;
+      const globMatcher = minimatch.minimatch;
 
       this[kIgnorePaths] = routeOptions => {
         if (typeof ignorePaths === 'function') {


### PR DESCRIPTION
Not sure why we even have this, but this somehow breaks cloudflare-pages E2E tests in some scenarios. It also seems simply unnecessary - or is there a reason we have this? 🤔 

Extracted this out from https://github.com/getsentry/sentry-javascript/pull/16783