### PR TITLE
chore(test-registry): Add more descriptive error code for common error

### DIFF
--- a/dev-packages/e2e-tests/registrySetup.ts
+++ b/dev-packages/e2e-tests/registrySetup.ts
@@ -85,8 +85,15 @@ export function registrySetup(): void {
       },
     );
 
-    if (publishImageContainerRunProcess.status !== 0) {
-      throw new Error('Publish Image Container failed.');
+    const statusCode = publishImageContainerRunProcess.status;
+
+    if (statusCode !== 0) {
+      if (statusCode === 137) {
+        throw new Error(
+          `Publish Image Container failed with exit code ${statusCode}, possibly due to memory issues. Consider increasing the memory limit for the container.`,
+        );
+      }
+      throw new Error(`Publish Image Container failed with exit code ${statusCode}`);
     }
   });
 


### PR DESCRIPTION
The error code 137 is a very common error when running E2E tests. Starting colima only with `colima start` often results in too little memory and it makes sense to add a more descriptive message here. 

To make it work with Colima, it's better to start it with `colima start --cpu 10 --memory 12 --network-address`