### PR TITLE
Fix/nestjs cron issues

### DIFF
--- a/dev-packages/e2e-tests/run.ts
+++ b/dev-packages/e2e-tests/run.ts
@@ -66,6 +66,7 @@ async function run(): Promise<void> {
     }
 
     await asyncExec('pnpm clean:test-applications', { env, cwd: __dirname });
+    await asyncExec('pnpm cache delete "@sentry/*"', { env, cwd: __dirname });
 
     const testAppPaths = appName ? [appName.trim()] : globSync('*', { cwd: `${__dirname}/test-applications/` });
 

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/app.service.ts
@@ -85,10 +85,21 @@ export class AppService {
   only supports minute granularity, but we don't want to wait (worst case) a
   full minute for the tests to finish.
   */
-  @Cron('*/5 * * * * *', { name: 'test-cron-error' })
-  @SentryCron('test-cron-error-slug', monitorConfig)
+  @Cron('*/5 * * * * *', { name: 'test-async-cron-error' })
+  @SentryCron('test-async-cron-error-slug', monitorConfig)
   async testCronError() {
-    throw new Error('Test error from cron job');
+    throw new Error('Test error from cron async job');
+  }
+
+  /*
+ Actual cron schedule differs from schedule defined in config because Sentry
+ only supports minute granularity, but we don't want to wait (worst case) a
+ full minute for the tests to finish.
+ */
+  @Cron('*/5 * * * * *', { name: 'test-sync-cron-error' })
+  @SentryCron('test-sync-cron-error-slug', monitorConfig)
+  testSyncCronError() {
+    throw new Error('Test error from cron sync job');
   }
 
   async killTestCron(job: string) {

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/cron-decorator.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/cron-decorator.test.ts
@@ -62,20 +62,36 @@ test('Cron job triggers send of in_progress envelope', async ({ baseURL }) => {
   await fetch(`${baseURL}/kill-test-cron/test-cron-job`);
 });
 
-test('Sends exceptions to Sentry on error in cron job', async ({ baseURL }) => {
+test('Sends exceptions to Sentry on error in async cron job', async ({ baseURL }) => {
   const errorEventPromise = waitForError('nestjs-basic', event => {
-    return !event.type && event.exception?.values?.[0]?.value === 'Test error from cron job';
+    return !event.type && event.exception?.values?.[0]?.value === 'Test error from cron async job';
   });
 
   const errorEvent = await errorEventPromise;
 
   expect(errorEvent.exception?.values).toHaveLength(1);
-  expect(errorEvent.exception?.values?.[0]?.value).toBe('Test error from cron job');
   expect(errorEvent.contexts?.trace).toEqual({
     trace_id: expect.stringMatching(/[a-f0-9]{32}/),
     span_id: expect.stringMatching(/[a-f0-9]{16}/),
   });
 
   // kill cron so tests don't get stuck
-  await fetch(`${baseURL}/kill-test-cron/test-cron-error`);
+  await fetch(`${baseURL}/kill-test-cron/test-async-cron-error`);
+});
+
+test('Sends exceptions to Sentry on error in sync cron job', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('nestjs-basic', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'Test error from cron sync job';
+  });
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+  });
+
+  // kill cron so tests don't get stuck
+  await fetch(`${baseURL}/kill-test-cron/test-sync-cron-error`);
 });

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -175,15 +175,16 @@ export function withMonitor<T>(
     }
 
     if (isThenable(maybePromiseResult)) {
-      Promise.resolve(maybePromiseResult).then(
-        () => {
+      return maybePromiseResult.then(
+        r => {
           finishCheckIn('ok');
+          return r;
         },
         e => {
           finishCheckIn('error');
           throw e;
         },
-      );
+      ) as T;
     } else {
       finishCheckIn('ok');
     }

--- a/packages/nestjs/src/decorators.ts
+++ b/packages/nestjs/src/decorators.ts
@@ -1,5 +1,5 @@
 import type { MonitorConfig } from '@sentry/core';
-import { captureException } from '@sentry/core';
+import { captureException, isThenable } from '@sentry/core';
 import * as Sentry from '@sentry/node';
 import { startSpan } from '@sentry/node';
 import { isExpectedError } from './helpers';
@@ -15,7 +15,20 @@ export const SentryCron = (monitorSlug: string, monitorConfig?: MonitorConfig): 
       return Sentry.withMonitor(
         monitorSlug,
         () => {
-          return originalMethod.apply(this, args);
+          let result;
+          try {
+            result = originalMethod.apply(this, args);
+          } catch (e) {
+            captureException(e);
+            throw e;
+          }
+          if (isThenable(result)) {
+            return result.then(undefined, e => {
+              captureException(e);
+              throw e;
+            });
+          }
+          return result;
         },
         monitorConfig,
       );


### PR DESCRIPTION
Nestjs sync task has the same issue as async tasks - they don't care about exceptions because nestjs `@Cron()` decorator automatically wraps it to `try-catch` block and logs an error. That's why we should capture exception in our `@SentryCron()` decorator.
P.S. I didn't test, but, most probably, fixes also #16749

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
