### PR TITLE
fix(nuxt): Ensure order of plugins is consistent

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -42,7 +42,7 @@ export default defineNuxtModule<ModuleOptions>({
       addPluginTemplate({
         mode: 'client',
         filename: 'sentry-client-config.mjs',
-        order: -20,
+        order: 0,
 
         // Dynamic import of config file to wrap it within a Nuxt context (here: defineNuxtPlugin)
         // Makes it possible to call useRuntimeConfig() in the user-defined sentry config file
@@ -62,7 +62,7 @@ export default defineNuxtModule<ModuleOptions>({
       addPlugin({
         src: moduleDirResolver.resolve('./runtime/plugins/sentry.client'),
         mode: 'client',
-        order: -10,
+        order: 1,
       });
     }
 


### PR DESCRIPTION
Noticed https://github.com/getsentry/sentry-javascript/pull/16783 in the nuxt-3-min test, that the plugins are not consistently run apparently. In that test, the client integrations plugin was run before the client config plugin, leading to the client not existing yet, and thus not adding the browser tracing integration.

This PR changes this to ensure we have a consistent order of these plugins.