### PR TITLE
fix(vue): Make pageload span handling more reliable

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/tests/tracing.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/tests/tracing.client.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
-import type { Span } from '@sentry/nuxt';
 
 test('sends a pageload root span with a parameterized URL', async ({ page }) => {
   const transactionPromise = waitForTransaction('nuxt-3-min', async transactionEvent => {
-    return transactionEvent.transaction === '/test-param/:param()';
+    return (
+      transactionEvent.contexts?.trace?.op === 'pageload' && transactionEvent.transaction === '/test-param/:param()'
+    );
   });
 
   await page.goto(`/test-param/1234`);
@@ -39,7 +40,7 @@ test('sends component tracking spans when `trackComponents` is enabled', async (
   await page.goto(`/client-error`);
 
   const rootSpan = await transactionPromise;
-  const errorButtonSpan = rootSpan.spans.find((span: Span) => span.description === 'Vue <ErrorButton>');
+  const errorButtonSpan = rootSpan.spans.find(span => span.description === 'Vue <ErrorButton>');
 
   const expected = {
     data: { 'sentry.origin': 'auto.ui.vue', 'sentry.op': 'ui.vue.mount' },

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -121,8 +121,8 @@ describe('instrumentVueRouter()', () => {
       beforeEachCallback(to, testRoutes['initialPageloadRoute']!, mockNext); // fake initial pageload
       beforeEachCallback(to, from, mockNext);
 
-      expect(mockStartSpan).toHaveBeenCalledTimes(1);
-      expect(mockStartSpan).toHaveBeenCalledWith({
+      expect(mockStartSpan).toHaveBeenCalledTimes(2);
+      expect(mockStartSpan).toHaveBeenLastCalledWith({
         name: transactionName,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.vue',


### PR DESCRIPTION
We used to rely on a somewhat complex heuristic to determine if a router change is a pageload or not. This somehow did not work anymore here: https://github.com/getsentry/sentry-javascript/pull/16783 in nuxt-3-min. Likely some vue router difference... However, I think this can be simplified anyhow, by just checking if we have an active pageload span. That seems to work reliably enough.
