### PR TITLE
feat(nextjs): Automatically skip middleware requests for tunnel route

### DIFF
--- a/packages/nextjs/rollup.npm.config.mjs
+++ b/packages/nextjs/rollup.npm.config.mjs
@@ -17,7 +17,7 @@ export default [
       // prevent this internal nextjs code from ending up in our built package (this doesn't happen automatically because
       // the name doesn't match an SDK dependency)
       packageSpecificConfig: {
-        external: ['next/router', 'next/constants', 'next/headers', 'next/server', 'stacktrace-parser'],
+        external: ['next/router', 'next/constants', 'next/headers', 'stacktrace-parser'],
 
         // Next.js and our users are more happy when our client code has the "use client" directive
         plugins: [

--- a/packages/nextjs/rollup.npm.config.mjs
+++ b/packages/nextjs/rollup.npm.config.mjs
@@ -17,7 +17,7 @@ export default [
       // prevent this internal nextjs code from ending up in our built package (this doesn't happen automatically because
       // the name doesn't match an SDK dependency)
       packageSpecificConfig: {
-        external: ['next/router', 'next/constants', 'next/headers', 'stacktrace-parser'],
+        external: ['next/router', 'next/constants', 'next/headers', 'next/server', 'stacktrace-parser'],
 
         // Next.js and our users are more happy when our client code has the "use client" directive
         plugins: [

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -112,9 +112,7 @@ function getFinalConfigObject(
       }
     } else {
       const resolvedTunnelRoute =
-       userSentryOptions.tunnelRoute === true
-          ? generateRandomTunnelRoute()
-          : userSentryOptions.tunnelRoute;
+        userSentryOptions.tunnelRoute === true ? generateRandomTunnelRoute() : userSentryOptions.tunnelRoute;
 
       // Update the global options object to use the resolved value everywhere
       userSentryOptions.tunnelRoute = resolvedTunnelRoute || undefined;

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -112,7 +112,7 @@ function getFinalConfigObject(
       }
     } else {
       const resolvedTunnelRoute =
-        typeof userSentryOptions.tunnelRoute === 'boolean' && userSentryOptions.tunnelRoute === true
+       userSentryOptions.tunnelRoute === true
           ? generateRandomTunnelRoute()
           : userSentryOptions.tunnelRoute;
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -107,17 +107,17 @@ function getFinalConfigObject(
         showedExportModeTunnelWarning = true;
         // eslint-disable-next-line no-console
         console.warn(
-          '[@sentry/nextjs] The Sentry Next.js SDK `tunnelRoute` option will not work in combination with Next.js static exports. The `tunnelRoute` option uses serverside features that cannot be accessed in export mode. If you still want to tunnel Sentry events, set up your own tunnel: https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option',
+          '[@sentry/nextjs] The Sentry Next.js SDK `tunnelRoute` option will not work in combination with Next.js static exports. The `tunnelRoute` option uses server-side features that cannot be accessed in export mode. If you still want to tunnel Sentry events, set up your own tunnel: https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option',
         );
       }
     } else {
       const resolvedTunnelRoute =
-        typeof userSentryOptions.tunnelRoute === 'boolean'
+        typeof userSentryOptions.tunnelRoute === 'boolean' && userSentryOptions.tunnelRoute === true
           ? generateRandomTunnelRoute()
           : userSentryOptions.tunnelRoute;
 
       // Update the global options object to use the resolved value everywhere
-      userSentryOptions.tunnelRoute = resolvedTunnelRoute;
+      userSentryOptions.tunnelRoute = resolvedTunnelRoute || undefined;
       setUpTunnelRewriteRules(incomingUserNextConfigObject, resolvedTunnelRoute);
     }
   }

--- a/packages/nextjs/test/config/wrappers.test.ts
+++ b/packages/nextjs/test/config/wrappers.test.ts
@@ -2,7 +2,12 @@ import type { Client } from '@sentry/core';
 import * as SentryCore from '@sentry/core';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { wrapGetInitialPropsWithSentry, wrapGetServerSidePropsWithSentry } from '../../src/common';
+import {
+  wrapGetInitialPropsWithSentry,
+  wrapGetServerSidePropsWithSentry,
+  wrapMiddlewareWithSentry,
+} from '../../src/common';
+import type { EdgeRouteHandler } from '../../src/edge/types';
 
 const startSpanManualSpy = vi.spyOn(SentryCore, 'startSpanManual');
 
@@ -82,5 +87,104 @@ describe('data-fetching function wrappers should not create manual spans', () =>
     expect(mockGetActiveSpan).toHaveBeenCalled();
     expect(mockGetRootSpan).not.toHaveBeenCalled();
     expect(mockSetAttribute).not.toHaveBeenCalled();
+  });
+});
+
+describe('wrapMiddlewareWithSentry', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    if ('_sentryRewritesTunnelPath' in globalThis) {
+      delete (globalThis as any)._sentryRewritesTunnelPath;
+    }
+  });
+
+  test('should skip processing and return NextResponse.next() for tunnel route requests', async () => {
+    // Set up tunnel route in global
+    (globalThis as any)._sentryRewritesTunnelPath = '/monitoring/tunnel';
+
+    const origFunction: EdgeRouteHandler = vi.fn(async () => ({ status: 200 }));
+    const wrappedOriginal = wrapMiddlewareWithSentry(origFunction);
+
+    // Create a mock Request that matches the tunnel route
+    const mockRequest = new Request('https://example.com/monitoring/tunnel?o=123');
+
+    const result = await wrappedOriginal(mockRequest);
+
+    // Should skip calling the original function
+    expect(origFunction).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+
+  test('should process normal request and call original function', async () => {
+    const mockReturnValue = { status: 200 };
+    const origFunction: EdgeRouteHandler = vi.fn(async (..._args) => mockReturnValue);
+    const wrappedOriginal = wrapMiddlewareWithSentry(origFunction);
+
+    const mockRequest = new Request('https://example.com/api/users', { method: 'GET' });
+
+    const result = await wrappedOriginal(mockRequest);
+
+    expect(origFunction).toHaveBeenCalledWith(mockRequest);
+    expect(result).toBe(mockReturnValue);
+  });
+
+  test('should handle non-Request arguments', async () => {
+    const mockReturnValue = { status: 200 };
+    const origFunction: EdgeRouteHandler = vi.fn(async (..._args) => mockReturnValue);
+    const wrappedOriginal = wrapMiddlewareWithSentry(origFunction);
+
+    const mockArgs = { someProperty: 'value' };
+
+    const result = await wrappedOriginal(mockArgs);
+
+    expect(origFunction).toHaveBeenCalledWith(mockArgs);
+    expect(result).toBe(mockReturnValue);
+  });
+
+  test('should handle errors in middleware function', async () => {
+    const testError = new Error('Test middleware error');
+    const origFunction: EdgeRouteHandler = vi.fn(async (..._args) => {
+      throw testError;
+    });
+    const wrappedOriginal = wrapMiddlewareWithSentry(origFunction);
+
+    const mockRequest = new Request('https://example.com/api/users');
+
+    await expect(wrappedOriginal(mockRequest)).rejects.toThrow('Test middleware error');
+    expect(origFunction).toHaveBeenCalledWith(mockRequest);
+  });
+
+  test('should not process tunnel route when no tunnel path is set', async () => {
+    if ('_sentryRewritesTunnelPath' in globalThis) {
+      delete (globalThis as any)._sentryRewritesTunnelPath;
+    }
+
+    const mockReturnValue = { status: 200 };
+    const origFunction: EdgeRouteHandler = vi.fn(async (..._args) => mockReturnValue);
+    const wrappedOriginal = wrapMiddlewareWithSentry(origFunction);
+
+    const mockRequest = new Request('https://example.com/monitoring/tunnel/sentry?o=123');
+
+    const result = await wrappedOriginal(mockRequest);
+
+    // Should process normally since no tunnel path is configured
+    expect(origFunction).toHaveBeenCalledWith(mockRequest);
+    expect(result).toBe(mockReturnValue);
+  });
+
+  test('should process request when tunnel path is set but request does not match', async () => {
+    (globalThis as any)._sentryRewritesTunnelPath = '/monitoring/tunnel';
+
+    const mockReturnValue = { status: 200 };
+    const origFunction: EdgeRouteHandler = vi.fn(async (..._args) => mockReturnValue);
+    const wrappedOriginal = wrapMiddlewareWithSentry(origFunction);
+
+    const mockRequest = new Request('https://example.com/api/users', { method: 'GET' });
+
+    const result = await wrappedOriginal(mockRequest);
+
+    // Should process normally since request doesn't match tunnel path
+    expect(origFunction).toHaveBeenCalledWith(mockRequest);
+    expect(result).toBe(mockReturnValue);
   });
 });


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/16626 added the option to generate a randomly generated tunnel route per build. This PR adds functionality for automatically skipping tunnel route requests in the nextjs middleware, as this had to be set up manually by the user until now.

