### PR TITLE
chore: Add node-core craft entry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -8,10 +8,15 @@ targets:
   - name: npm
     id: '@sentry/types'
     includeNames: /^sentry-types-\d.*\.tgz$/
-  ## 1.2 Core SDK
+  ## 1.2 Core SDKs
   - name: npm
     id: '@sentry/core'
     includeNames: /^sentry-core-\d.*\.tgz$/
+  # This SDK does not exist yet on `develop` but we need an entry
+  # here to be able to publish a pre-release
+  - name: npm
+    id: '@sentry/node-core'
+    includeNames: /^sentry-node-core-\d.*\.tgz$/
   ## 1.3 Browser Utils package
   - name: npm
     id: '@sentry-internal/browser-utils'


### PR DESCRIPTION
In order to be able to publish an alpha release of `@sentry/node-core`, we need a craft target on the default branch (develop). This should not do anything on develop because the package doesn't exist so craft will skip it.