### PR TITLE
fix(cloudflare): calculate retries not attempts

### DIFF
--- a/packages/cloudflare/src/handler.ts
+++ b/packages/cloudflare/src/handler.ts
@@ -175,7 +175,7 @@ export function withSentry<Env = unknown, QueueHandlerMessage = unknown, CfHostM
                   'messaging.destination.name': batch.queue,
                   'messaging.system': 'cloudflare',
                   'messaging.batch.message_count': batch.messages.length,
-                  'messaging.message.retry.count': batch.messages.reduce((acc, message) => acc + message.attempts, 0),
+                  'messaging.message.retry.count': batch.messages.reduce((acc, message) => acc + message.attempts - 1, 0),
                   [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'queue.process',
                   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.faas.cloudflare.queue',
                   [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',

--- a/packages/cloudflare/test/handler.test.ts
+++ b/packages/cloudflare/test/handler.test.ts
@@ -843,7 +843,7 @@ describe('withSentry', () => {
             'messaging.destination.name': batch.queue,
             'messaging.system': 'cloudflare',
             'messaging.batch.message_count': batch.messages.length,
-            'messaging.message.retry.count': batch.messages.reduce((acc, message) => acc + message.attempts, 0),
+            'messaging.message.retry.count': batch.messages.reduce((acc, message) => acc + message.attempts - 1, 0),
             'sentry.sample_rate': 1,
             'sentry.source': 'task',
           },


### PR DESCRIPTION
The `message.attempts` property starts at 1 so we were calculating the number of attempts not the number of retries. Attempt 2 is the first retry not attempt 1.

Currently the retry count is the same as the number of messages in the batch this way:

![Screenshot 2025-07-07 at 23 40 48](https://github.com/user-attachments/assets/69ee5947-4677-4bd4-b0e1-33c1b62c0a10)

Additionally this causes the error rate to be quite nice and I have been assured my code is not THAT bad:

![Screenshot 2025-07-07 at 23 41 43](https://github.com/user-attachments/assets/738cbd9b-f4fe-4213-a40c-820fe402befc)

See: https://developers.cloudflare.com/queues/configuration/javascript-apis/
