### PR TITLE
feat(astro): Deprecate passing runtime config to astro integration

### DIFF
--- a/packages/astro/src/integration/snippets.ts
+++ b/packages/astro/src/integration/snippets.ts
@@ -13,7 +13,6 @@ export function buildSdkInitFileImportSnippet(filePath: string): string {
  * default options.
  */
 export function buildClientSnippet(options: SentryOptions): string {
-  /* eslint-disable deprecation/deprecation */
   return `import * as Sentry from "@sentry/astro";
 
 Sentry.init({
@@ -22,7 +21,6 @@ Sentry.init({
   replaysSessionSampleRate: ${options.replaysSessionSampleRate ?? 0.1},
   replaysOnErrorSampleRate: ${options.replaysOnErrorSampleRate ?? 1.0},
 });`;
-  /* eslint-enable deprecation/deprecation */
 }
 
 /**
@@ -37,7 +35,6 @@ Sentry.init({
 });`;
 }
 
-/* eslint-disable deprecation/deprecation */
 const buildCommonInitOptions = (options: SentryOptions): string => `dsn: ${
   options.dsn ? JSON.stringify(options.dsn) : 'import.meta.env.PUBLIC_SENTRY_DSN'
 },
@@ -47,7 +44,6 @@ const buildCommonInitOptions = (options: SentryOptions): string => `dsn: ${
   tracesSampleRate: ${options.tracesSampleRate ?? 1.0},${
     options.sampleRate ? `\n  sampleRate: ${options.sampleRate},` : ''
   }`;
-/* eslint-enable deprecation/deprecation */
 
 /**
  * We don't include the `BrowserTracing` integration if `bundleSizeOptimizations.excludeTracing` is falsy.
@@ -64,13 +60,9 @@ const buildClientIntegrations = (options: SentryOptions): string => {
   }
 
   if (
-    // eslint-disable-next-line deprecation/deprecation
     options.replaysSessionSampleRate == null ||
-    // eslint-disable-next-line deprecation/deprecation
     options.replaysSessionSampleRate ||
-    // eslint-disable-next-line deprecation/deprecation
     options.replaysOnErrorSampleRate == null ||
-    // eslint-disable-next-line deprecation/deprecation
     options.replaysOnErrorSampleRate
   ) {
     integrations.push('Sentry.replayIntegration()');

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -1,5 +1,3 @@
-import type { BrowserOptions } from '@sentry/browser';
-import type { Options } from '@sentry/core';
 import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 
 type SdkInitPaths = {
@@ -185,40 +183,14 @@ type SdkEnabledOptions = {
       };
 };
 
-type DeprecatedRuntimeOptions = Pick<
-  Options,
-  'environment' | 'release' | 'dsn' | 'debug' | 'sampleRate' | 'tracesSampleRate'
-> &
-  Pick<BrowserOptions, 'replaysSessionSampleRate' | 'replaysOnErrorSampleRate'> & {
-    /**
-     * @deprecated Use the `environment` option in your runtime-specific Sentry.init() call in sentry.client.config.(js|ts) or sentry.server.config.(js|ts) instead.
-     */
-    environment?: string;
-    /**
-     * @deprecated Use the `release` option in your runtime-specific Sentry.init() call in sentry.client.config.(js|ts) or sentry.server.config.(js|ts) instead.
-     */
-    release?: string;
-    /**
-     * @deprecated Use the `dsn` option in your runtime-specific Sentry.init() call in sentry.client.config.(js|ts) or sentry.server.config.(js|ts) instead.
-     */
-    dsn?: string;
-    /**
-     * @deprecated Use the `sampleRate` option in your runtime-specific Sentry.init() call in sentry.client.config.(js|ts) or sentry.server.config.(js|ts) instead.
-     */
-    sampleRate?: number;
-    /**
-     * @deprecated Use the `tracesSampleRate` option in your runtime-specific Sentry.init() call in sentry.client.config.(js|ts) or sentry.server.config.(js|ts) instead.
-     */
-    tracesSampleRate?: number;
-    /**
-     * @deprecated Use the `replaysSessionSampleRate` option in your Sentry.init() call in sentry.client.config.(js|ts) instead.
-     */
-    replaysSessionSampleRate?: number;
-    /**
-     * @deprecated Use the `replaysOnErrorSampleRate` option in your Sentry.init() call in sentry.client.config.(js|ts) instead.
-     */
-    replaysOnErrorSampleRate?: number;
-  };
+/**
+ * We accept aribtrary options that are passed through to the Sentry SDK.
+ * This is not recommended and will stop working in a future version.
+ * Note: Not all options are actually passed through, only a select subset:
+ * release, environment, dsn, debug, sampleRate, tracesSampleRate, replaysSessionSampleRate, replaysOnErrorSampleRate
+ * @deprecated This will be removed in a future major.
+ **/
+type DeprecatedRuntimeOptions = Record<string, unknown>;
 
 /**
  * A subset of Sentry SDK options that can be set via the `sentryAstro` integration.
@@ -230,7 +202,6 @@ type DeprecatedRuntimeOptions = Pick<
  * If you specify a dedicated init file, the SDK options passed to `sentryAstro` will be ignored.
  */
 export type SentryOptions = SdkInitPaths &
-  DeprecatedRuntimeOptions &
   InstrumentationOptions &
   SdkEnabledOptions & {
     /**
@@ -251,4 +222,5 @@ export type SentryOptions = SdkInitPaths &
      * If enabled, prints debug logs during the build process.
      */
     debug?: boolean;
-  };
+    // eslint-disable-next-line deprecation/deprecation
+  } & DeprecatedRuntimeOptions;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/16837

This should not break anything, I actually added a test to verify injecting this works as expected. We now simply console.warn when some runtime config is passed in the astro integration. Also, no more type completion exists for these, but they are still accepted via `Record<string, unknown>`.