### PR TITLE
feat(node): Add `shouldHandleError` option to `fastifyIntegration`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/package.json
@@ -4,11 +4,13 @@
   "private": true,
   "scripts": {
     "start": "ts-node src/app.ts",
+    "start:override": "ts-node src/app-handle-error-override.ts",
     "test": "playwright test",
+    "test:override": "playwright test --config playwright.override.config.mjs",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "typecheck": "tsc",
     "test:build": "pnpm install && pnpm run typecheck",
-    "test:assert": "pnpm test"
+    "test:assert": "pnpm test && pnpm test:override"
   },
   "dependencies": {
     "@sentry/node": "latest || *",

--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/playwright.override.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/playwright.override.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm start:override`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app.ts
@@ -17,7 +17,19 @@ console.warn = new Proxy(console.warn, {
 Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
-  integrations: [],
+  integrations: [
+    Sentry.fastifyIntegration({
+      shouldHandleError: (error, _request, _reply) => {
+        // @ts-ignore // Fastify V3 is not typed correctly
+        if (_request.url?.includes('/test-error-not-captured')) {
+          // Errors from this path will not be captured by Sentry
+          return false;
+        }
+
+        return true;
+      },
+    }),
+  ],
   tracesSampleRate: 1,
   tunnel: 'http://localhost:3031/', // proxy server
   tracePropagationTargets: ['http://localhost:3030', '/external-allowed'],
@@ -79,6 +91,11 @@ app.get('/test-error', async function (req, res) {
   await Sentry.flush(2000);
 
   res.send({ exceptionId });
+});
+
+app.get('/test-error-not-captured', async function () {
+  // This error will not be captured by Sentry
+  throw new Error('This is an error that will not be captured');
 });
 
 app.get<{ Params: { id: string } }>('/test-exception/:id', async function (req, res) {

--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/tests/errors.test.ts
@@ -28,3 +28,18 @@ test('Sends correct error event', async ({ baseURL }) => {
     parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
   });
 });
+
+test('Does not send error when shouldHandleError returns false', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('node-fastify-3', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'This is an error that will not be captured';
+  });
+
+  errorEventPromise.then(() => {
+    throw new Error('This error should not be captured');
+  });
+
+  await fetch(`${baseURL}/test-error-not-captured`);
+
+  // wait for a short time to ensure the error is not captured
+  await new Promise(resolve => setTimeout(resolve, 1000));
+});

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/package.json
@@ -4,11 +4,13 @@
   "private": true,
   "scripts": {
     "start": "ts-node src/app.ts",
+    "start:override": "ts-node src/app-handle-error-override.ts",
     "test": "playwright test",
+    "test:override": "playwright test --config playwright.override.config.mjs",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "typecheck": "tsc",
     "test:build": "pnpm install && pnpm run typecheck",
-    "test:assert": "pnpm test"
+    "test:assert": "pnpm test && pnpm test:override"
   },
   "dependencies": {
     "@sentry/node": "latest || *",

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/playwright.override.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/playwright.override.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm start:override`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app-handle-error-override.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app-handle-error-override.ts
@@ -20,11 +20,6 @@ Sentry.init({
   integrations: [
     Sentry.fastifyIntegration({
       shouldHandleError: (error, _request, _reply) => {
-        if (_request.routeOptions?.url?.includes('/test-error-not-captured')) {
-          // Errors from this path will not be captured by Sentry
-          return false;
-        }
-
         return true;
       },
     }),
@@ -45,7 +40,16 @@ const app = fastify();
 const port = 3030;
 const port2 = 3040;
 
-Sentry.setupFastifyErrorHandler(app);
+Sentry.setupFastifyErrorHandler(app, {
+  shouldHandleError: (error, _request, _reply) => {
+    if (_request.routeOptions?.url?.includes('/test-error-not-captured')) {
+      // Errors from this path will not be captured by Sentry
+      return false;
+    }
+
+    return true;
+  },
+});
 
 app.get('/test-success', function (_req, res) {
   res.send({ version: 'v1' });

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/tests/errors.test.ts
@@ -50,3 +50,18 @@ test('Does not send 4xx errors by default', async ({ baseURL }) => {
   const errorEvent = await serverErrorPromise;
   expect(errorEvent.exception?.values?.[0]?.value).toContain('This is a 5xx error');
 });
+
+test('Does not send error when shouldHandleError returns false', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('node-fastify-4', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'This is an error that will not be captured';
+  });
+
+  errorEventPromise.then(() => {
+    throw new Error('This error should not be captured');
+  });
+
+  await fetch(`${baseURL}/test-error-not-captured`);
+
+  // wait for a short time to ensure the error is not captured
+  await new Promise(resolve => setTimeout(resolve, 1000));
+});

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/package.json
@@ -4,11 +4,13 @@
   "private": true,
   "scripts": {
     "start": "ts-node src/app.ts",
+    "start:override": "ts-node src/app-handle-error-override.ts",
     "test": "playwright test",
+    "test:override": "playwright test --config playwright.override.config.mjs",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "typecheck": "tsc",
     "test:build": "pnpm install && pnpm run typecheck",
-    "test:assert": "pnpm test"
+    "test:assert": "pnpm test && pnpm test:override"
   },
   "dependencies": {
     "@sentry/node": "latest || *",

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/playwright.override.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/playwright.override.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm start`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app-handle-error-override.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app-handle-error-override.ts
@@ -20,11 +20,6 @@ Sentry.init({
   integrations: [
     Sentry.fastifyIntegration({
       shouldHandleError: (error, _request, _reply) => {
-        if (_request.routeOptions?.url?.includes('/test-error-not-captured')) {
-          // Errors from this path will not be captured by Sentry
-          return false;
-        }
-
         return true;
       },
     }),
@@ -45,7 +40,17 @@ const app = fastify();
 const port = 3030;
 const port2 = 3040;
 
-Sentry.setupFastifyErrorHandler(app);
+Sentry.setupFastifyErrorHandler(app, {
+  shouldHandleError: (error, _request, _reply) => {
+    // @ts-ignore // Fastify V5 is not typed correctly
+    if (_request.routeOptions?.url?.includes('/test-error-not-captured')) {
+      // Errors from this path will not be captured by Sentry
+      return false;
+    }
+
+    return true;
+  },
+});
 
 app.get('/test-success', function (_req, res) {
   res.send({ version: 'v1' });
@@ -95,16 +100,6 @@ app.get('/test-error', async function (req, res) {
 app.get('/test-error-not-captured', async function () {
   // This error will not be captured by Sentry
   throw new Error('This is an error that will not be captured');
-});
-
-app.get('/test-4xx-error', async function (req, res) {
-  res.code(400);
-  throw new Error('This is a 4xx error');
-});
-
-app.get('/test-5xx-error', async function (req, res) {
-  res.code(500);
-  throw new Error('This is a 5xx error');
 });
 
 app.get<{ Params: { id: string } }>('/test-exception/:id', async function (req, res) {

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
@@ -19,7 +19,7 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   integrations: [
     Sentry.fastifyIntegration({
-      shouldHandleError: (error, _request, _reply) => {
+      shouldHandleDiagnosticsChannelError: (error, _request, _reply) => {
         if (_request.routeOptions?.url?.includes('/test-error-not-captured')) {
           // Errors from this path will not be captured by Sentry
           return false;

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
@@ -19,7 +19,7 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   integrations: [
     Sentry.fastifyIntegration({
-      shouldHandleDiagnosticsChannelError: (error, _request, _reply) => {
+      shouldHandleError: (error, _request, _reply) => {
         if (_request.routeOptions?.url?.includes('/test-error-not-captured')) {
           // Errors from this path will not be captured by Sentry
           return false;

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/errors.test.ts
@@ -39,5 +39,5 @@ test('Does not send error when shouldHandleError returns false', async ({ baseUR
   // Wait for a short time to ensure no error is sent
   await new Promise(resolve => setTimeout(resolve, 1000));
 
-  expect(errorEventPromise).rejects.toBeDefined();
+  await expect(errorEventPromise).rejects.toBeDefined();
 });

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/errors.test.ts
@@ -28,3 +28,16 @@ test('Sends correct error event', async ({ baseURL }) => {
     parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
   });
 });
+
+test('Does not send error when shouldHandleError returns false', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('node-fastify-5', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'This is an error that will not be captured';
+  });
+
+  await fetch(`${baseURL}/test-error-not-captured`);
+
+  // Wait for a short time to ensure no error is sent
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  expect(errorEventPromise).rejects.toBeDefined();
+});

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/errors.test.ts
@@ -34,10 +34,12 @@ test('Does not send error when shouldHandleError returns false', async ({ baseUR
     return !event.type && event.exception?.values?.[0]?.value === 'This is an error that will not be captured';
   });
 
+  errorEventPromise.then(() => {
+    test.fail();
+  });
+
   await fetch(`${baseURL}/test-error-not-captured`);
 
-  // Wait for a short time to ensure no error is sent
+  // wait for a short time to ensure the error is not captured
   await new Promise(resolve => setTimeout(resolve, 1000));
-
-  await expect(errorEventPromise).rejects.toBeDefined();
 });

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/errors.test.ts
@@ -35,7 +35,7 @@ test('Does not send error when shouldHandleError returns false', async ({ baseUR
   });
 
   errorEventPromise.then(() => {
-    test.fail();
+    throw new Error('This error should not be captured');
   });
 
   await fetch(`${baseURL}/test-error-not-captured`);

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -105,11 +105,7 @@ function handleFastifyError(
 
 export const instrumentFastify = generateInstrumentOnce(
   INTEGRATION_NAME,
-  (
-    options: Partial<FastifyHandlerOptions> = {
-      shouldHandleError: defaultShouldHandleError,
-    },
-  ) => {
+  (options: Partial<FastifyHandlerOptions> = {}) => {
     const fastifyOtelInstrumentationInstance = new FastifyOtelInstrumentation();
     const plugin = fastifyOtelInstrumentationInstance.plugin();
 
@@ -144,7 +140,7 @@ export const instrumentFastify = generateInstrumentOnce(
         error,
         request,
         reply,
-        options.shouldHandleError,
+        options?.shouldHandleError || defaultShouldHandleError,
         'diagnostics-channel',
       );
     });


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-javascript/issues/16819

This requires the Fastify integration to be manually added while initialising Sentry. 

```typescript
Sentry.init({
  integrations: [
    Sentry.fastifyIntegration({
      shouldHandleError(_error, _request, reply) {
        return reply.statusCode >= 500;
      },
    });
  },
});
```

If `shouldHandleError` is provided in `setupFastifyErrorHandler`, it overrides `shouldHandleError` provided from `fastifyIntegration`. So this should not break any existing (pre-DC) usage.

In summary: 
- When `setupFastifyErrorHandler` is not used, `shouldHandleError` at `Sentry.init` will be used.
- When `setupFastifyErrorHandler` is used but without `shouldHandleError`, `shouldHandleError` at `Sentry.init` will be used.
- When in both `setupFastifyErrorHandler` and `Sentry.init`  are used with `shouldHandleError`, the one in `setupFastifyErrorHandler` is used.

Works for all Fastify versions supported (v3, v4, v5)

Note: E2E tests for this now requires to test overrides, so they need to be run twice with both overriden and non-overriden applications. Not the prettiest solution, but I could not figure out an alternative.