### PR TITLE
fix(sveltekit): Avoid capturing `redirect()` calls as errors in Cloudflare

### DIFF
--- a/packages/sveltekit/src/worker/cloudflare.ts
+++ b/packages/sveltekit/src/worker/cloudflare.ts
@@ -37,6 +37,9 @@ export function initCloudflareSentryHandle(options: CloudflareOptions): Handle {
           request: event.request as Request<unknown, IncomingRequestCfProperties<unknown>>,
           // @ts-expect-error This will exist in Cloudflare
           context: event.platform.context,
+          // We don't want to capture errors here, as we want to capture them in the `sentryHandle` handler
+          // where we can distinguish between redirects and actual errors.
+          captureErrors: false,
         },
         () => resolve(event),
       );

--- a/packages/sveltekit/test/worker/cloudflare.test.ts
+++ b/packages/sveltekit/test/worker/cloudflare.test.ts
@@ -45,7 +45,7 @@ describe('initCloudflareSentryHandle', () => {
 
     expect(SentryCloudflare.wrapRequestHandler).toHaveBeenCalledTimes(1);
     expect(SentryCloudflare.wrapRequestHandler).toHaveBeenCalledWith(
-      { options: expect.objectContaining({ dsn: options.dsn }), request, context },
+      { options: expect.objectContaining({ dsn: options.dsn }), request, context, captureErrors: false },
       expect.any(Function),
     );
 


### PR DESCRIPTION
This PR builds on top of #16852 to avoid capturing errors too early and too generally via the `initCloudflareSentryHandle` request handler. Internally, this handler used a wrapper from `@sentry/cloudflare` to capture errors but prior to #16852 it captured everything that was thrown. This included thrown `redirect()` objects from SvelteKit which serve as control flow mechanisms but should not be captured as errors.

This PR opts out of capturing errors in the Cloudflare wrapper. Instead, we rely on our already existing error capturing mechanisms in SvelteKit, which already ignore `redirect()` and a few other error classes. 

closes https://github.com/getsentry/sentry-javascript/issues/16847