### PR TITLE
deps(nuxt): Add explicit peer dependencies & bump nitropack

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -63,7 +63,9 @@
   "devDependencies": {
     "@nuxt/module-builder": "^0.8.4",
     "@sentry/cloudflare": "9.36.0",
-    "nuxt": "^3.13.2"
+    "nuxt": "^3.13.2",
+    "nuxi": "^3.25.1",
+    "vite": "^5.4.11"
   },
   "scripts": {
     "build": "run-s build:types build:transpile",

--- a/packages/nuxt/src/runtime/hooks/captureErrorHook.ts
+++ b/packages/nuxt/src/runtime/hooks/captureErrorHook.ts
@@ -1,7 +1,7 @@
 import { captureException, getClient, getCurrentScope } from '@sentry/core';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { H3Error } from 'h3';
-import type { CapturedErrorContext } from 'nitropack';
+import type { CapturedErrorContext } from 'nitropack/types';
 import { extractErrorContext, flushIfServerless } from '../utils';
 
 /**

--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -9,7 +9,7 @@ import {
   vercelWaitUntil,
 } from '@sentry/core';
 import type { VueOptions } from '@sentry/vue/src/types';
-import type { CapturedErrorContext } from 'nitropack';
+import type { CapturedErrorContext } from 'nitropack/types';
 import type { NuxtRenderHTMLContext } from 'nuxt/app';
 import type { ComponentPublicInstance } from 'vue';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22352,10 +22352,10 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-nuxi@^3.13.2:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/nuxi/-/nuxi-3.14.0.tgz#697a1e8b4f0d92fb8b30aa355af9295fa8c2cb4e"
-  integrity sha512-MhG4QR6D95jQxhnwKfdKXulZ8Yqy1nbpwbotbxY5IcabOzpEeTB8hYn2BFkmYdMUB0no81qpv2ldZmVCT9UsnQ==
+nuxi@^3.13.2, nuxi@^3.25.1:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/nuxi/-/nuxi-3.25.1.tgz#8baea8c41a916e418728cba0cdbc135e795f86bd"
+  integrity sha512-NeZDRVdn58QF3+clrkKRXE3PtfhE4hkmj8/Wqf6th707SDqmdBb/KZV2BE4lwL+FhgEDgtN7AMF8WZCkicudXg==
 
 nuxt@^3.13.2:
   version "3.13.2"
@@ -27468,7 +27468,6 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
-  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"


### PR DESCRIPTION
This just bumps the underlying transitive dependency on nitropack, which apparently changes some type imports.

Extracted out of https://github.com/getsentry/sentry-javascript/pull/16751