### PR TITLE
fix(browser): Ensure standalone CLS and LCP spans have traceId of pageload span

### DIFF
--- a/packages/browser-utils/src/metrics/cls.ts
+++ b/packages/browser-utils/src/metrics/cls.ts
@@ -72,7 +72,7 @@ export function trackClsAsStandaloneSpan(): void {
       return;
     }
 
-    const unsubscribeStartNavigation = client.on('startNavigationSpan', (_, options) => {
+    const unsubscribeStartNavigation = client.on('beforeStartNavigationSpan', (_, options) => {
       // we only want to collect LCP if we actually navigate. Redirects should be ignored.
       if (!options?.isRedirect) {
         _collectClsOnce();

--- a/packages/browser-utils/src/metrics/lcp.ts
+++ b/packages/browser-utils/src/metrics/lcp.ts
@@ -72,7 +72,7 @@ export function trackLcpAsStandaloneSpan(): void {
       return;
     }
 
-    const unsubscribeStartNavigation = client.on('startNavigationSpan', (_, options) => {
+    const unsubscribeStartNavigation = client.on('beforeStartNavigationSpan', (_, options) => {
       // we only want to collect LCP if we actually navigate. Redirects should be ignored.
       if (!options?.isRedirect) {
         _collectLcpOnce();


### PR DESCRIPTION
builds on top of #16863 

this PR fixes a bug in standalone web vital spans where, if they were sent because of a navigation, they would incorrectly be added to the `navigation` span's trace instead of the initial `pageload` span's trace. This surfaced while dogfooding these spans on sentry and inspecting them in the EAP traceview. 

To fix this, I added a lifecycle hook in #16863 that triggers right before we start preparing the navigation span and hence, right before we recycle the propagation context to the new traceId. This PR now makes use of the new hook for CLS and LCP spans and it also makes the integration tests stricter to check for the correct trace ids.