### PR TITLE
Update deleteSourcemapsAfterUpload comment (defaults to true)

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -153,7 +153,7 @@ export type SentryBuildOptions = {
     /**
      * Toggle whether generated source maps within your Next.js build folder should be automatically deleted after being uploaded to Sentry.
      *
-     * Defaults to `false`.
+     * Defaults to `true`.
      */
     deleteSourcemapsAfterUpload?: boolean;
   };


### PR DESCRIPTION
The current behavior is that if `deleteSourcemapsAfterUpload` is undefined, then source maps _are_ deleted

https://github.com/getsentry/sentry-javascript/blob/68eef54eecd30554b2eae9086b1ed94b3de29d7c/packages/nextjs/src/config/webpack.ts#L382-L383