### PR TITLE
ref(node): Add `sentry.parent_span_already_sent` attribute

### DIFF
--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -195,7 +195,7 @@ export class SentrySpanExporter {
       if (root.parentNode && this._sentSpans.has(root.parentNode.id)) {
         const traceData = transactionEvent.contexts?.trace?.data;
         if (traceData) {
-          traceData['sentry.transaction.parent_span_already_sent'] = true;
+          traceData['sentry.parent_span_already_sent'] = true;
         }
       }
 

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -621,7 +621,7 @@ describe('Integration | Transactions', () => {
 
     expect(transactions[1]?.transaction).toBe('inner span 2');
     expect(transactions[1]?.contexts?.trace?.data).toEqual({
-      'sentry.transaction.parent_span_already_sent': true,
+      'sentry.parent_span_already_sent': true,
       'sentry.origin': 'manual',
       'sentry.source': 'custom',
     });


### PR DESCRIPTION
This adds a new attribute to spans that we send from the Node SDK because their parent span was already sent. This can be used by us or customers to debug why certain things show up as transactions/root spans in product. We could possibly also use this in the trace view to give users helpful pointers.