### PR TITLE
ref(core): Avoid side-effect of & streamline `timestampInSeconds` method

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta-precedence/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta-precedence/test.ts
@@ -25,9 +25,6 @@ sentryTest.describe('When `consistentTraceSampling` is `true` and page contains 
         sentryTest.skip();
       }
 
-
-
-
       const url = await getLocalTestUrl({ testDir: __dirname });
 
       const clientReportPromise = waitForClientReportRequest(page);


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-javascript/issues/16846

This rewrites `timestampInSeconds` to avoid side effects.

As a part of this, I also streamlined this a bit to remove special handling for missing `timeOrigin`. If that is missing, we just fall back to using `dateTimestampInSeconds`, instead of doing some custom handling of `timeOrigin` - IMHO that should not be any less accurate, as otherwise we are currently mixing `performance.now` with `Date.now()` which is likely not necessarily accurate either.