### PR TITLE
fix(browser): guard `nextHopProtocol` when adding resource spans

### DIFF
--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -717,7 +717,7 @@ export function _addResourceSpans(
 
   // Checking for only `undefined` and `null` is intentional because it's
   // valid for `nextHopProtocol` to be an empty string.
-  if (entry.nextHopProtocol != undefined) {
+  if (entry.nextHopProtocol != null) {
     const { name, version } = extractNetworkProtocol(entry.nextHopProtocol);
     attributes['network.protocol.name'] = name;
     attributes['network.protocol.version'] = version;


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/16804

This was addressed with https://github.com/getsentry/sentry-javascript/pull/16806, but we didn't guard every location that uses `entry.nextHopProtocol`.

Will backport to v9 after merge.