### PR TITLE
feat(core): Introduce `debug` to replace `logger`

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -37,7 +37,7 @@ import { dsnToString, makeDsn } from './utils/dsn';
 import { addItemToEnvelope, createAttachmentEnvelopeItem } from './utils/envelope';
 import { getPossibleEventMessages } from './utils/eventUtils';
 import { isParameterizedString, isPlainObject, isPrimitive, isThenable } from './utils/is';
-import { logger } from './utils/logger';
+import { debug } from './utils/logger';
 import { merge } from './utils/merge';
 import { checkOrSetAlreadyCaught, uuid4 } from './utils/misc';
 import { parseSampleRate } from './utils/parseSampleRate';
@@ -154,7 +154,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     if (options.dsn) {
       this._dsn = makeDsn(options.dsn);
     } else {
-      DEBUG_BUILD && logger.warn('No DSN provided, client will not send events.');
+      DEBUG_BUILD && debug.warn('No DSN provided, client will not send events.');
     }
 
     if (this._dsn) {
@@ -182,7 +182,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
     // ensure we haven't captured this very object before
     if (checkOrSetAlreadyCaught(exception)) {
-      DEBUG_BUILD && logger.log(ALREADY_SEEN_ERROR);
+      DEBUG_BUILD && debug.log(ALREADY_SEEN_ERROR);
       return eventId;
     }
 
@@ -237,7 +237,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
     // ensure we haven't captured this very object before
     if (hint?.originalException && checkOrSetAlreadyCaught(hint.originalException)) {
-      DEBUG_BUILD && logger.log(ALREADY_SEEN_ERROR);
+      DEBUG_BUILD && debug.log(ALREADY_SEEN_ERROR);
       return eventId;
     }
 
@@ -429,7 +429,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     if ('aggregates' in session) {
       const sessionAttrs = session.attrs || {};
       if (!sessionAttrs.release && !clientReleaseOption) {
-        DEBUG_BUILD && logger.warn(MISSING_RELEASE_FOR_SESSION_ERROR);
+        DEBUG_BUILD && debug.warn(MISSING_RELEASE_FOR_SESSION_ERROR);
         return;
       }
       sessionAttrs.release = sessionAttrs.release || clientReleaseOption;
@@ -437,7 +437,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
       session.attrs = sessionAttrs;
     } else {
       if (!session.release && !clientReleaseOption) {
-        DEBUG_BUILD && logger.warn(MISSING_RELEASE_FOR_SESSION_ERROR);
+        DEBUG_BUILD && debug.warn(MISSING_RELEASE_FOR_SESSION_ERROR);
         return;
       }
       session.release = session.release || clientReleaseOption;
@@ -465,7 +465,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
       // would be `Partial<Record<SentryRequestType, Partial<Record<Outcome, number>>>>`
       // With typescript 4.1 we could even use template literal types
       const key = `${reason}:${category}`;
-      DEBUG_BUILD && logger.log(`Recording outcome: "${key}"${count > 1 ? ` (${count} times)` : ''}`);
+      DEBUG_BUILD && debug.log(`Recording outcome: "${key}"${count > 1 ? ` (${count} times)` : ''}`);
       this._outcomes[key] = (this._outcomes[key] || 0) + count;
     }
   }
@@ -866,12 +866,12 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
     if (this._isEnabled() && this._transport) {
       return this._transport.send(envelope).then(null, reason => {
-        DEBUG_BUILD && logger.error('Error while sending envelope:', reason);
+        DEBUG_BUILD && debug.error('Error while sending envelope:', reason);
         return reason;
       });
     }
 
-    DEBUG_BUILD && logger.error('Transport disabled');
+    DEBUG_BUILD && debug.error('Transport disabled');
 
     return resolvedSyncPromise({});
   }
@@ -1021,7 +1021,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     isolationScope = getIsolationScope(),
   ): PromiseLike<string | undefined> {
     if (DEBUG_BUILD && isErrorEvent(event)) {
-      logger.log(`Captured error event \`${getPossibleEventMessages(event)[0] || '<unknown>'}\``);
+      debug.log(`Captured error event \`${getPossibleEventMessages(event)[0] || '<unknown>'}\``);
     }
 
     return this._processEvent(event, hint, currentScope, isolationScope).then(
@@ -1031,11 +1031,11 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
       reason => {
         if (DEBUG_BUILD) {
           if (_isDoNotSendEventError(reason)) {
-            logger.log(reason.message);
+            debug.log(reason.message);
           } else if (_isInternalError(reason)) {
-            logger.warn(reason.message);
+            debug.warn(reason.message);
           } else {
-            logger.warn(reason);
+            debug.warn(reason);
           }
         }
         return undefined;
@@ -1196,22 +1196,22 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
    * Sends client reports as an envelope.
    */
   protected _flushOutcomes(): void {
-    DEBUG_BUILD && logger.log('Flushing outcomes...');
+    DEBUG_BUILD && debug.log('Flushing outcomes...');
 
     const outcomes = this._clearOutcomes();
 
     if (outcomes.length === 0) {
-      DEBUG_BUILD && logger.log('No outcomes to send');
+      DEBUG_BUILD && debug.log('No outcomes to send');
       return;
     }
 
     // This is really the only place where we want to check for a DSN and only send outcomes then
     if (!this._dsn) {
-      DEBUG_BUILD && logger.log('No dsn provided, will not send outcomes');
+      DEBUG_BUILD && debug.log('No dsn provided, will not send outcomes');
       return;
     }
 
-    DEBUG_BUILD && logger.log('Sending outcomes:', outcomes);
+    DEBUG_BUILD && debug.log('Sending outcomes:', outcomes);
 
     const envelope = createClientReportEnvelope(outcomes, this._options.tunnel && dsnToString(this._dsn));
 

--- a/packages/core/src/eventProcessors.ts
+++ b/packages/core/src/eventProcessors.ts
@@ -2,7 +2,7 @@ import { DEBUG_BUILD } from './debug-build';
 import type { Event, EventHint } from './types-hoist/event';
 import type { EventProcessor } from './types-hoist/eventprocessor';
 import { isThenable } from './utils/is';
-import { logger } from './utils/logger';
+import { debug } from './utils/logger';
 import { SyncPromise } from './utils/syncpromise';
 
 /**
@@ -21,7 +21,7 @@ export function notifyEventProcessors(
     } else {
       const result = processor({ ...event }, hint) as Event | null;
 
-      DEBUG_BUILD && processor.id && result === null && logger.log(`Event processor "${processor.id}" dropped event`);
+      DEBUG_BUILD && processor.id && result === null && debug.log(`Event processor "${processor.id}" dropped event`);
 
       if (isThenable(result)) {
         void result

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -11,7 +11,7 @@ import type { Session, SessionContext } from './types-hoist/session';
 import type { SeverityLevel } from './types-hoist/severity';
 import type { User } from './types-hoist/user';
 import { isThenable } from './utils/is';
-import { logger } from './utils/logger';
+import { debug } from './utils/logger';
 import { uuid4 } from './utils/misc';
 import type { ExclusiveEventHintOrCaptureContext } from './utils/prepareEvent';
 import { parseEventHintOrCaptureContext } from './utils/prepareEvent';
@@ -136,9 +136,9 @@ export function captureCheckIn(checkIn: CheckIn, upsertMonitorConfig?: MonitorCo
   const scope = getCurrentScope();
   const client = getClient();
   if (!client) {
-    DEBUG_BUILD && logger.warn('Cannot capture check-in. No client defined.');
+    DEBUG_BUILD && debug.warn('Cannot capture check-in. No client defined.');
   } else if (!client.captureCheckIn) {
-    DEBUG_BUILD && logger.warn('Cannot capture check-in. Client does not support sending check-ins.');
+    DEBUG_BUILD && debug.warn('Cannot capture check-in. Client does not support sending check-ins.');
   } else {
     return client.captureCheckIn(checkIn, upsertMonitorConfig, scope);
   }
@@ -206,7 +206,7 @@ export async function flush(timeout?: number): Promise<boolean> {
   if (client) {
     return client.flush(timeout);
   }
-  DEBUG_BUILD && logger.warn('Cannot flush events. No client defined.');
+  DEBUG_BUILD && debug.warn('Cannot flush events. No client defined.');
   return Promise.resolve(false);
 }
 
@@ -223,7 +223,7 @@ export async function close(timeout?: number): Promise<boolean> {
   if (client) {
     return client.close(timeout);
   }
-  DEBUG_BUILD && logger.warn('Cannot flush events and disable SDK. No client defined.');
+  DEBUG_BUILD && debug.warn('Cannot flush events and disable SDK. No client defined.');
   return Promise.resolve(false);
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,7 +165,7 @@ export {
   isVueViewModel,
 } from './utils/is';
 export { isBrowser } from './utils/isBrowser';
-export { CONSOLE_LEVELS, consoleSandbox, logger, originalConsoleMethods } from './utils/logger';
+export { CONSOLE_LEVELS, consoleSandbox, debug, logger, originalConsoleMethods } from './utils/logger';
 export type { Logger } from './utils/logger';
 export {
   addContextToFrame,

--- a/packages/core/src/instrument/handlers.ts
+++ b/packages/core/src/instrument/handlers.ts
@@ -1,5 +1,5 @@
 import { DEBUG_BUILD } from '../debug-build';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { getFunctionName } from '../utils/stacktrace';
 
 export type InstrumentHandlerType =
@@ -41,7 +41,7 @@ export function maybeInstrument(type: InstrumentHandlerType, instrumentFn: () =>
     try {
       instrumentFn();
     } catch (e) {
-      DEBUG_BUILD && logger.error(`Error while instrumenting ${type}`, e);
+      DEBUG_BUILD && debug.error(`Error while instrumenting ${type}`, e);
     }
   }
 }
@@ -58,7 +58,7 @@ export function triggerHandlers(type: InstrumentHandlerType, data: unknown): voi
       handler(data);
     } catch (e) {
       DEBUG_BUILD &&
-        logger.error(
+        debug.error(
           `Error while triggering instrumentation handler.\nType: ${type}\nName: ${getFunctionName(handler)}\nError:`,
           e,
         );

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -4,7 +4,7 @@ import { DEBUG_BUILD } from './debug-build';
 import type { Event, EventHint } from './types-hoist/event';
 import type { Integration, IntegrationFn } from './types-hoist/integration';
 import type { Options } from './types-hoist/options';
-import { logger } from './utils/logger';
+import { debug } from './utils/logger';
 
 export const installedIntegrations: string[] = [];
 
@@ -99,7 +99,7 @@ export function afterSetupIntegrations(client: Client, integrations: Integration
 /** Setup a single integration.  */
 export function setupIntegration(client: Client, integration: Integration, integrationIndex: IntegrationIndex): void {
   if (integrationIndex[integration.name]) {
-    DEBUG_BUILD && logger.log(`Integration skipped because it was already installed: ${integration.name}`);
+    DEBUG_BUILD && debug.log(`Integration skipped because it was already installed: ${integration.name}`);
     return;
   }
   integrationIndex[integration.name] = integration;
@@ -130,7 +130,7 @@ export function setupIntegration(client: Client, integration: Integration, integ
     client.addEventProcessor(processor);
   }
 
-  DEBUG_BUILD && logger.log(`Integration installed: ${integration.name}`);
+  DEBUG_BUILD && debug.log(`Integration installed: ${integration.name}`);
 }
 
 /** Add an integration to the current scope's client. */
@@ -138,7 +138,7 @@ export function addIntegration(integration: Integration): void {
   const client = getClient();
 
   if (!client) {
-    DEBUG_BUILD && logger.warn(`Cannot add integration "${integration.name}" because no SDK Client is available.`);
+    DEBUG_BUILD && debug.warn(`Cannot add integration "${integration.name}" because no SDK Client is available.`);
     return;
   }
 

--- a/packages/core/src/integrations/dedupe.ts
+++ b/packages/core/src/integrations/dedupe.ts
@@ -4,7 +4,7 @@ import type { Event } from '../types-hoist/event';
 import type { Exception } from '../types-hoist/exception';
 import type { IntegrationFn } from '../types-hoist/integration';
 import type { StackFrame } from '../types-hoist/stackframe';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { getFramesFromEvent } from '../utils/stacktrace';
 
 const INTEGRATION_NAME = 'Dedupe';
@@ -24,7 +24,7 @@ const _dedupeIntegration = (() => {
       // Juuust in case something goes wrong
       try {
         if (_shouldDropEvent(currentEvent, previousEvent)) {
-          DEBUG_BUILD && logger.warn('Event dropped due to being a duplicate of previously captured event.');
+          DEBUG_BUILD && debug.warn('Event dropped due to being a duplicate of previously captured event.');
           return null;
         }
       } catch (_oO) {} // eslint-disable-line no-empty

--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -4,7 +4,7 @@ import type { Event } from '../types-hoist/event';
 import type { IntegrationFn } from '../types-hoist/integration';
 import type { StackFrame } from '../types-hoist/stackframe';
 import { getPossibleEventMessages } from '../utils/eventUtils';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { getEventDescription } from '../utils/misc';
 import { stringMatchesSomePattern } from '../utils/string';
 
@@ -111,14 +111,14 @@ function _shouldDropEvent(event: Event, options: Partial<EventFiltersOptions>): 
     // Filter errors
     if (_isIgnoredError(event, options.ignoreErrors)) {
       DEBUG_BUILD &&
-        logger.warn(
+        debug.warn(
           `Event dropped due to being matched by \`ignoreErrors\` option.\nEvent: ${getEventDescription(event)}`,
         );
       return true;
     }
     if (_isUselessError(event)) {
       DEBUG_BUILD &&
-        logger.warn(
+        debug.warn(
           `Event dropped due to not having an error message, error type or stacktrace.\nEvent: ${getEventDescription(
             event,
           )}`,
@@ -127,7 +127,7 @@ function _shouldDropEvent(event: Event, options: Partial<EventFiltersOptions>): 
     }
     if (_isDeniedUrl(event, options.denyUrls)) {
       DEBUG_BUILD &&
-        logger.warn(
+        debug.warn(
           `Event dropped due to being matched by \`denyUrls\` option.\nEvent: ${getEventDescription(
             event,
           )}.\nUrl: ${_getEventFilterUrl(event)}`,
@@ -136,7 +136,7 @@ function _shouldDropEvent(event: Event, options: Partial<EventFiltersOptions>): 
     }
     if (!_isAllowedUrl(event, options.allowUrls)) {
       DEBUG_BUILD &&
-        logger.warn(
+        debug.warn(
           `Event dropped due to not being matched by \`allowUrls\` option.\nEvent: ${getEventDescription(
             event,
           )}.\nUrl: ${_getEventFilterUrl(event)}`,
@@ -148,7 +148,7 @@ function _shouldDropEvent(event: Event, options: Partial<EventFiltersOptions>): 
 
     if (_isIgnoredTransaction(event, options.ignoreTransactions)) {
       DEBUG_BUILD &&
-        logger.warn(
+        debug.warn(
           `Event dropped due to being matched by \`ignoreTransactions\` option.\nEvent: ${getEventDescription(event)}`,
         );
       return true;
@@ -212,7 +212,7 @@ function _getEventFilterUrl(event: Event): string | null {
     const frames = rootException?.stacktrace?.frames;
     return frames ? _getLastValidUrl(frames) : null;
   } catch (oO) {
-    DEBUG_BUILD && logger.error(`Cannot extract url for event ${getEventDescription(event)}`);
+    DEBUG_BUILD && debug.error(`Cannot extract url for event ${getEventDescription(event)}`);
     return null;
   }
 }

--- a/packages/core/src/integrations/extraerrordata.ts
+++ b/packages/core/src/integrations/extraerrordata.ts
@@ -5,7 +5,7 @@ import type { ExtendedError } from '../types-hoist/error';
 import type { Event, EventHint } from '../types-hoist/event';
 import type { IntegrationFn } from '../types-hoist/integration';
 import { isError, isPlainObject } from '../utils/is';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { normalize } from '../utils/normalize';
 import { addNonEnumerableProperty } from '../utils/object';
 import { truncate } from '../utils/string';
@@ -130,7 +130,7 @@ function _extractErrorData(
 
     return extraErrorInfo;
   } catch (oO) {
-    DEBUG_BUILD && logger.error('Unable to extract extra data from the Error object:', oO);
+    DEBUG_BUILD && debug.error('Unable to extract extra data from the Error object:', oO);
   }
 
   return null;

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -10,7 +10,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '
 import { setHttpStatus, SPAN_STATUS_ERROR, SPAN_STATUS_OK, startSpan } from '../tracing';
 import type { IntegrationFn } from '../types-hoist/integration';
 import { isPlainObject } from '../utils/is';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 
 const AUTH_OPERATIONS_TO_INSTRUMENT = [
   'reauthenticate',
@@ -481,7 +481,7 @@ function instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder: new () => PostgR
           const rv = Reflect.apply(target, thisArg, argumentsList);
           const PostgRESTFilterBuilder = (rv as PostgRESTFilterBuilder).constructor;
 
-          DEBUG_BUILD && logger.log(`Instrumenting ${operation} operation's PostgRESTFilterBuilder`);
+          DEBUG_BUILD && debug.log(`Instrumenting ${operation} operation's PostgRESTFilterBuilder`);
 
           instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder);
 
@@ -496,7 +496,7 @@ function instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder: new () => PostgR
 
 export const instrumentSupabaseClient = (supabaseClient: unknown): void => {
   if (!supabaseClient) {
-    DEBUG_BUILD && logger.warn('Supabase integration was not installed because no Supabase client was provided.');
+    DEBUG_BUILD && debug.warn('Supabase integration was not installed because no Supabase client was provided.');
     return;
   }
   const SupabaseClientConstructor =

--- a/packages/core/src/logs/console-integration.ts
+++ b/packages/core/src/logs/console-integration.ts
@@ -6,7 +6,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../semanticAttributes';
 import type { ConsoleLevel } from '../types-hoist/instrument';
 import type { IntegrationFn } from '../types-hoist/integration';
 import { isPrimitive } from '../utils/is';
-import { CONSOLE_LEVELS, logger } from '../utils/logger';
+import { CONSOLE_LEVELS, debug } from '../utils/logger';
 import { normalize } from '../utils/normalize';
 import { GLOBAL_OBJ } from '../utils/worldwide';
 import { _INTERNAL_captureLog } from './exports';
@@ -35,7 +35,7 @@ const _consoleLoggingIntegration = ((options: Partial<CaptureConsoleOptions> = {
     setup(client) {
       const { _experiments, normalizeDepth = 3, normalizeMaxBreadth = 1_000 } = client.getOptions();
       if (!_experiments?.enableLogs) {
-        DEBUG_BUILD && logger.warn('`_experiments.enableLogs` is not enabled, ConsoleLogs integration disabled');
+        DEBUG_BUILD && debug.warn('`_experiments.enableLogs` is not enabled, ConsoleLogs integration disabled');
         return;
       }
 

--- a/packages/core/src/logs/exports.ts
+++ b/packages/core/src/logs/exports.ts
@@ -6,7 +6,7 @@ import type { Scope, ScopeData } from '../scope';
 import type { Log, SerializedLog, SerializedLogAttributeValue } from '../types-hoist/log';
 import { mergeScopeData } from '../utils/applyScopeDataToEvent';
 import { isParameterizedString } from '../utils/is';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { _getSpanForScope } from '../utils/spanOnScope';
 import { timestampInSeconds } from '../utils/time';
 import { GLOBAL_OBJ } from '../utils/worldwide';
@@ -121,14 +121,14 @@ export function _INTERNAL_captureLog(
   captureSerializedLog: (client: Client, log: SerializedLog) => void = _INTERNAL_captureSerializedLog,
 ): void {
   if (!client) {
-    DEBUG_BUILD && logger.warn('No client available to capture log.');
+    DEBUG_BUILD && debug.warn('No client available to capture log.');
     return;
   }
 
   const { _experiments, release, environment } = client.getOptions();
   const { enableLogs = false, beforeSendLog } = _experiments ?? {};
   if (!enableLogs) {
-    DEBUG_BUILD && logger.warn('logging option not enabled, log will not be captured.');
+    DEBUG_BUILD && debug.warn('logging option not enabled, log will not be captured.');
     return;
   }
 
@@ -172,7 +172,7 @@ export function _INTERNAL_captureLog(
   const log = beforeSendLog ? beforeSendLog(processedLog) : processedLog;
   if (!log) {
     client.recordDroppedEvent('before_send', 'log_item', 1);
-    DEBUG_BUILD && logger.warn('beforeSendLog returned null, log will not be captured.');
+    DEBUG_BUILD && debug.warn('beforeSendLog returned null, log will not be captured.');
     return;
   }
 

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -6,7 +6,7 @@ import {
 } from './semanticAttributes';
 import { startSpan, withActiveSpan } from './tracing';
 import type { Span } from './types-hoist/span';
-import { logger } from './utils/logger';
+import { debug } from './utils/logger';
 import { getActiveSpan } from './utils/spanUtils';
 
 interface MCPTransport {
@@ -41,7 +41,7 @@ export function wrapMcpServerWithSentry<S extends object>(mcpServerInstance: S):
   }
 
   if (!isMcpServerInstance(mcpServerInstance)) {
-    DEBUG_BUILD && logger.warn('Did not patch MCP server. Interface is incompatible.');
+    DEBUG_BUILD && debug.warn('Did not patch MCP server. Interface is incompatible.');
     return mcpServerInstance;
   }
 

--- a/packages/core/src/profiling.ts
+++ b/packages/core/src/profiling.ts
@@ -1,7 +1,7 @@
 import { getClient } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { Profiler, ProfilingIntegration } from './types-hoist/profiling';
-import { logger } from './utils/logger';
+import { debug } from './utils/logger';
 
 function isProfilingIntegrationWithProfiler(
   integration: ProfilingIntegration<any> | undefined,
@@ -21,19 +21,19 @@ function isProfilingIntegrationWithProfiler(
 function startProfiler(): void {
   const client = getClient();
   if (!client) {
-    DEBUG_BUILD && logger.warn('No Sentry client available, profiling is not started');
+    DEBUG_BUILD && debug.warn('No Sentry client available, profiling is not started');
     return;
   }
 
   const integration = client.getIntegrationByName<ProfilingIntegration<any>>('ProfilingIntegration');
 
   if (!integration) {
-    DEBUG_BUILD && logger.warn('ProfilingIntegration is not available');
+    DEBUG_BUILD && debug.warn('ProfilingIntegration is not available');
     return;
   }
 
   if (!isProfilingIntegrationWithProfiler(integration)) {
-    DEBUG_BUILD && logger.warn('Profiler is not available on profiling integration.');
+    DEBUG_BUILD && debug.warn('Profiler is not available on profiling integration.');
     return;
   }
 
@@ -47,18 +47,18 @@ function startProfiler(): void {
 function stopProfiler(): void {
   const client = getClient();
   if (!client) {
-    DEBUG_BUILD && logger.warn('No Sentry client available, profiling is not started');
+    DEBUG_BUILD && debug.warn('No Sentry client available, profiling is not started');
     return;
   }
 
   const integration = client.getIntegrationByName<ProfilingIntegration<any>>('ProfilingIntegration');
   if (!integration) {
-    DEBUG_BUILD && logger.warn('ProfilingIntegration is not available');
+    DEBUG_BUILD && debug.warn('ProfilingIntegration is not available');
     return;
   }
 
   if (!isProfilingIntegrationWithProfiler(integration)) {
-    DEBUG_BUILD && logger.warn('Profiler is not available on profiling integration.');
+    DEBUG_BUILD && debug.warn('Profiler is not available on profiling integration.');
     return;
   }
 

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import type { Client } from './client';
+import { DEBUG_BUILD } from './debug-build';
 import { updateSession } from './session';
 import type { Attachment } from './types-hoist/attachment';
 import type { Breadcrumb } from './types-hoist/breadcrumb';
@@ -16,7 +17,7 @@ import type { Span } from './types-hoist/span';
 import type { PropagationContext } from './types-hoist/tracing';
 import type { User } from './types-hoist/user';
 import { isPlainObject } from './utils/is';
-import { logger } from './utils/logger';
+import { debug } from './utils/logger';
 import { merge } from './utils/merge';
 import { uuid4 } from './utils/misc';
 import { generateTraceId } from './utils/propagationContext';
@@ -573,7 +574,7 @@ export class Scope {
     const eventId = hint?.event_id || uuid4();
 
     if (!this._client) {
-      logger.warn('No client configured on scope - will not capture exception!');
+      DEBUG_BUILD && debug.warn('No client configured on scope - will not capture exception!');
       return eventId;
     }
 
@@ -602,7 +603,7 @@ export class Scope {
     const eventId = hint?.event_id || uuid4();
 
     if (!this._client) {
-      logger.warn('No client configured on scope - will not capture message!');
+      DEBUG_BUILD && debug.warn('No client configured on scope - will not capture message!');
       return eventId;
     }
 
@@ -632,7 +633,7 @@ export class Scope {
     const eventId = hint?.event_id || uuid4();
 
     if (!this._client) {
-      logger.warn('No client configured on scope - will not capture event!');
+      DEBUG_BUILD && debug.warn('No client configured on scope - will not capture event!');
       return eventId;
     }
 

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -2,7 +2,7 @@ import type { Client } from './client';
 import { getCurrentScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { ClientOptions } from './types-hoist/options';
-import { consoleSandbox, logger } from './utils/logger';
+import { consoleSandbox, debug } from './utils/logger';
 
 /** A class object that can instantiate Client objects. */
 export type ClientClass<F extends Client, O extends ClientOptions> = new (options: O) => F;
@@ -20,9 +20,9 @@ export function initAndBind<F extends Client, O extends ClientOptions>(
 ): Client {
   if (options.debug === true) {
     if (DEBUG_BUILD) {
-      logger.enable();
+      debug.enable();
     } else {
-      // use `console.warn` rather than `logger.warn` since by non-debug bundles have all `logger.x` statements stripped
+      // use `console.warn` rather than `debug.warn` since by non-debug bundles have all `debug.x` statements stripped
       consoleSandbox(() => {
         // eslint-disable-next-line no-console
         console.warn('[Sentry] Cannot initialize SDK with `debug` option using a non-debug bundle.');

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -15,7 +15,7 @@ import type { SeverityLevel } from './types-hoist/severity';
 import type { BaseTransportOptions } from './types-hoist/transport';
 import { eventFromMessage, eventFromUnknownInput } from './utils/eventbuilder';
 import { isPrimitive } from './utils/is';
-import { logger } from './utils/logger';
+import { debug } from './utils/logger';
 import { uuid4 } from './utils/misc';
 import { resolvedSyncPromise } from './utils/syncpromise';
 
@@ -134,7 +134,7 @@ export class ServerRuntimeClient<
   public captureCheckIn(checkIn: CheckIn, monitorConfig?: MonitorConfig, scope?: Scope): string {
     const id = 'checkInId' in checkIn && checkIn.checkInId ? checkIn.checkInId : uuid4();
     if (!this._isEnabled()) {
-      DEBUG_BUILD && logger.warn('SDK not enabled, will not capture check-in.');
+      DEBUG_BUILD && debug.warn('SDK not enabled, will not capture check-in.');
       return id;
     }
 
@@ -179,7 +179,7 @@ export class ServerRuntimeClient<
       this.getDsn(),
     );
 
-    DEBUG_BUILD && logger.info('Sending checkin:', checkIn.monitorSlug, checkIn.status);
+    DEBUG_BUILD && debug.log('Sending checkin:', checkIn.monitorSlug, checkIn.status);
 
     // sendEnvelope should not throw
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/core/src/tracing/errors.ts
+++ b/packages/core/src/tracing/errors.ts
@@ -1,7 +1,7 @@
 import { DEBUG_BUILD } from '../debug-build';
 import { addGlobalErrorInstrumentationHandler } from '../instrument/globalError';
 import { addGlobalUnhandledRejectionInstrumentationHandler } from '../instrument/globalUnhandledRejection';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { getActiveSpan, getRootSpan } from '../utils/spanUtils';
 import { SPAN_STATUS_ERROR } from './spanstatus';
 
@@ -33,7 +33,7 @@ function errorCallback(): void {
   const rootSpan = activeSpan && getRootSpan(activeSpan);
   if (rootSpan) {
     const message = 'internal_error';
-    DEBUG_BUILD && logger.log(`[Tracing] Root span: ${message} -> Global error occurred`);
+    DEBUG_BUILD && debug.log(`[Tracing] Root span: ${message} -> Global error occurred`);
     rootSpan.setStatus({ code: SPAN_STATUS_ERROR, message });
   }
 }

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -5,7 +5,7 @@ import type { DynamicSamplingContext } from '../types-hoist/envelope';
 import type { Span } from '../types-hoist/span';
 import type { StartSpanOptions } from '../types-hoist/startSpanOptions';
 import { hasSpansEnabled } from '../utils/hasSpansEnabled';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { _setSpanForScope } from '../utils/spanOnScope';
 import {
   getActiveSpan,
@@ -277,7 +277,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON, _finishReason);
     }
 
-    logger.log(`[Tracing] Idle span "${spanJSON.op}" finished`);
+    debug.log(`[Tracing] Idle span "${spanJSON.op}" finished`);
 
     const childSpans = getSpanDescendants(span).filter(child => child !== span);
 
@@ -288,7 +288,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
         childSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'cancelled' });
         childSpan.end(endTimestamp);
         DEBUG_BUILD &&
-          logger.log('[Tracing] Cancelling span since span ended early', JSON.stringify(childSpan, undefined, 2));
+          debug.log('[Tracing] Cancelling span since span ended early', JSON.stringify(childSpan, undefined, 2));
       }
 
       const childSpanJSON = spanToJSON(childSpan);
@@ -303,9 +303,9 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       if (DEBUG_BUILD) {
         const stringifiedSpan = JSON.stringify(childSpan, undefined, 2);
         if (!spanStartedBeforeIdleSpanEnd) {
-          logger.log('[Tracing] Discarding span since it happened after idle span was finished', stringifiedSpan);
+          debug.log('[Tracing] Discarding span since it happened after idle span was finished', stringifiedSpan);
         } else if (!spanEndedBeforeFinalTimeout) {
-          logger.log('[Tracing] Discarding span since it finished after idle span final timeout', stringifiedSpan);
+          debug.log('[Tracing] Discarding span since it finished after idle span final timeout', stringifiedSpan);
         }
       }
 
@@ -383,7 +383,7 @@ function _startIdleSpan(options: StartSpanOptions): Span {
 
   _setSpanForScope(getCurrentScope(), span);
 
-  DEBUG_BUILD && logger.log('[Tracing] Started span is an idle span');
+  DEBUG_BUILD && debug.log('[Tracing] Started span is an idle span');
 
   return span;
 }

--- a/packages/core/src/tracing/logSpans.ts
+++ b/packages/core/src/tracing/logSpans.ts
@@ -1,6 +1,6 @@
 import { DEBUG_BUILD } from '../debug-build';
 import type { Span } from '../types-hoist/span';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { getRootSpan, spanIsSampled, spanToJSON } from '../utils/spanUtils';
 
 /**
@@ -35,7 +35,7 @@ export function logSpanStart(span: Span): void {
     }
   }
 
-  logger.log(`${header}
+  debug.log(`${header}
   ${infoParts.join('\n  ')}`);
 }
 
@@ -51,5 +51,5 @@ export function logSpanEnd(span: Span): void {
   const isRootSpan = rootSpan === span;
 
   const msg = `[Tracing] Finishing "${op}" ${isRootSpan ? 'root ' : ''}span "${description}" with ID ${spanId}`;
-  logger.log(msg);
+  debug.log(msg);
 }

--- a/packages/core/src/tracing/measurement.ts
+++ b/packages/core/src/tracing/measurement.ts
@@ -5,7 +5,7 @@ import {
 } from '../semanticAttributes';
 import type { Measurements, MeasurementUnit } from '../types-hoist/measurement';
 import type { TimedEvent } from '../types-hoist/timedEvent';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { getActiveSpan, getRootSpan } from '../utils/spanUtils';
 
 /**
@@ -16,7 +16,7 @@ export function setMeasurement(name: string, value: number, unit: MeasurementUni
   const rootSpan = activeSpan && getRootSpan(activeSpan);
 
   if (rootSpan) {
-    DEBUG_BUILD && logger.log(`[Measurement] Setting measurement on root span: ${name} = ${value} ${unit}`);
+    DEBUG_BUILD && debug.log(`[Measurement] Setting measurement on root span: ${name} = ${value} ${unit}`);
     rootSpan.addEvent(name, {
       [SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_VALUE]: value,
       [SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_UNIT]: unit as string,

--- a/packages/core/src/tracing/sampling.ts
+++ b/packages/core/src/tracing/sampling.ts
@@ -2,7 +2,7 @@ import { DEBUG_BUILD } from '../debug-build';
 import type { Options } from '../types-hoist/options';
 import type { SamplingContext } from '../types-hoist/samplingcontext';
 import { hasSpansEnabled } from '../utils/hasSpansEnabled';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { parseSampleRate } from '../utils/parseSampleRate';
 
 /**
@@ -59,7 +59,7 @@ export function sampleSpan(
 
   if (parsedSampleRate === undefined) {
     DEBUG_BUILD &&
-      logger.warn(
+      debug.warn(
         `[Tracing] Discarding root span because of invalid sample rate. Sample rate must be a boolean or a number between 0 and 1. Got ${JSON.stringify(
           sampleRate,
         )} of type ${JSON.stringify(typeof sampleRate)}.`,
@@ -70,7 +70,7 @@ export function sampleSpan(
   // if the function returned 0 (or false), or if `tracesSampleRate` is 0, it's a sign the transaction should be dropped
   if (!parsedSampleRate) {
     DEBUG_BUILD &&
-      logger.log(
+      debug.log(
         `[Tracing] Discarding transaction because ${
           typeof options.tracesSampler === 'function'
             ? 'tracesSampler returned 0 or false'
@@ -87,7 +87,7 @@ export function sampleSpan(
   // if we're not going to keep it, we're done
   if (!shouldSample) {
     DEBUG_BUILD &&
-      logger.log(
+      debug.log(
         `[Tracing] Discarding transaction because it's not included in the random sample (sampling rate = ${Number(
           sampleRate,
         )})`,

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -25,7 +25,7 @@ import type {
 import type { SpanStatus } from '../types-hoist/spanStatus';
 import type { TimedEvent } from '../types-hoist/timedEvent';
 import type { TransactionSource } from '../types-hoist/transaction';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { generateSpanId, generateTraceId } from '../utils/propagationContext';
 import {
   convertSpanLinksForEnvelope,
@@ -255,7 +255,7 @@ export class SentrySpan implements Span {
     attributesOrStartTime?: SpanAttributes | SpanTimeInput,
     startTime?: SpanTimeInput,
   ): this {
-    DEBUG_BUILD && logger.log('[Tracing] Adding an event to span:', name);
+    DEBUG_BUILD && debug.log('[Tracing] Adding an event to span:', name);
 
     const time = isSpanTimeInput(attributesOrStartTime) ? attributesOrStartTime : startTime || timestampInSeconds();
     const attributes = isSpanTimeInput(attributesOrStartTime) ? {} : attributesOrStartTime || {};
@@ -305,7 +305,7 @@ export class SentrySpan implements Span {
         sendSpanEnvelope(createSpanEnvelope([this], client));
       } else {
         DEBUG_BUILD &&
-          logger.log('[Tracing] Discarding standalone span because its trace was not chosen to be sampled.');
+          debug.log('[Tracing] Discarding standalone span because its trace was not chosen to be sampled.');
         if (client) {
           client.recordDroppedEvent('sample_rate', 'span');
         }
@@ -330,7 +330,7 @@ export class SentrySpan implements Span {
     }
 
     if (!this._name) {
-      DEBUG_BUILD && logger.warn('Transaction has no name, falling back to `<unlabeled transaction>`.');
+      DEBUG_BUILD && debug.warn('Transaction has no name, falling back to `<unlabeled transaction>`.');
       this._name = '<unlabeled transaction>';
     }
 
@@ -389,7 +389,7 @@ export class SentrySpan implements Span {
 
     if (hasMeasurements) {
       DEBUG_BUILD &&
-        logger.log(
+        debug.log(
           '[Measurements] Adding measurements to transaction event',
           JSON.stringify(measurements, undefined, 2),
         );

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -13,7 +13,7 @@ import type { SentrySpanArguments, Span, SpanTimeInput } from '../types-hoist/sp
 import type { StartSpanOptions } from '../types-hoist/startSpanOptions';
 import { handleCallbackErrors } from '../utils/handleCallbackErrors';
 import { hasSpansEnabled } from '../utils/hasSpansEnabled';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { parseSampleRate } from '../utils/parseSampleRate';
 import { generateTraceId } from '../utils/propagationContext';
 import { _getSpanForScope, _setSpanForScope } from '../utils/spanOnScope';
@@ -287,7 +287,7 @@ export function startNewTrace<T>(callback: () => T): T {
       traceId: generateTraceId(),
       sampleRand: Math.random(),
     });
-    DEBUG_BUILD && logger.info(`Starting a new trace with id ${scope.getPropagationContext().traceId}`);
+    DEBUG_BUILD && debug.log(`Starting a new trace with id ${scope.getPropagationContext().traceId}`);
     return withActiveSpan(null, callback);
   });
 }
@@ -447,7 +447,7 @@ function _startRootSpan(spanArguments: SentrySpanArguments, scope: Scope, parent
   });
 
   if (!sampled && client) {
-    DEBUG_BUILD && logger.log('[Tracing] Discarding root span because its trace was not chosen to be sampled.');
+    DEBUG_BUILD && debug.log('[Tracing] Discarding root span because its trace was not chosen to be sampled.');
     client.recordDroppedEvent('sample_rate', 'transaction');
   }
 

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -13,7 +13,7 @@ import {
   forEachEnvelopeItem,
   serializeEnvelope,
 } from '../utils/envelope';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { type PromiseBuffer, makePromiseBuffer, SENTRY_BUFFER_FULL_ERROR } from '../utils/promisebuffer';
 import { type RateLimits, isRateLimited, updateRateLimits } from '../utils/ratelimit';
 import { resolvedSyncPromise } from '../utils/syncpromise';
@@ -68,7 +68,7 @@ export function createTransport(
         response => {
           // We don't want to throw on NOK responses, but we want to at least log them
           if (response.statusCode !== undefined && (response.statusCode < 200 || response.statusCode >= 300)) {
-            DEBUG_BUILD && logger.warn(`Sentry responded with status code ${response.statusCode} to sent event.`);
+            DEBUG_BUILD && debug.warn(`Sentry responded with status code ${response.statusCode} to sent event.`);
           }
 
           rateLimits = updateRateLimits(rateLimits, response);
@@ -76,7 +76,7 @@ export function createTransport(
         },
         error => {
           recordEnvelopeLoss('network_error');
-          DEBUG_BUILD && logger.error('Encountered error running transport request:', error);
+          DEBUG_BUILD && debug.error('Encountered error running transport request:', error);
           throw error;
         },
       );
@@ -85,7 +85,7 @@ export function createTransport(
       result => result,
       error => {
         if (error === SENTRY_BUFFER_FULL_ERROR) {
-          DEBUG_BUILD && logger.error('Skipped sending event because buffer is full.');
+          DEBUG_BUILD && debug.error('Skipped sending event because buffer is full.');
           recordEnvelopeLoss('queue_overflow');
           return resolvedSyncPromise({});
         } else {

--- a/packages/core/src/transports/offline.ts
+++ b/packages/core/src/transports/offline.ts
@@ -2,7 +2,7 @@ import { DEBUG_BUILD } from '../debug-build';
 import type { Envelope } from '../types-hoist/envelope';
 import type { InternalBaseTransportOptions, Transport, TransportMakeRequestResponse } from '../types-hoist/transport';
 import { envelopeContainsItemType } from '../utils/envelope';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { parseRetryAfterHeader } from '../utils/ratelimit';
 
 export const MIN_DELAY = 100; // 100 ms
@@ -64,7 +64,7 @@ export function makeOfflineTransport<TO>(
   createTransport: (options: TO) => Transport,
 ): (options: TO & OfflineTransportOptions) => Transport {
   function log(...args: unknown[]): void {
-    DEBUG_BUILD && logger.info('[Offline]:', ...args);
+    DEBUG_BUILD && debug.log('[Offline]:', ...args);
   }
 
   return options => {

--- a/packages/core/src/utils/baggage.ts
+++ b/packages/core/src/utils/baggage.ts
@@ -1,7 +1,7 @@
 import { DEBUG_BUILD } from '../debug-build';
 import type { DynamicSamplingContext } from '../types-hoist/envelope';
 import { isString } from './is';
-import { logger } from './logger';
+import { debug } from './logger';
 
 export const SENTRY_BAGGAGE_KEY_PREFIX = 'sentry-';
 
@@ -150,7 +150,7 @@ export function objectToBaggageHeader(object: Record<string, string>): string | 
     const newBaggageHeader = currentIndex === 0 ? baggageEntry : `${baggageHeader},${baggageEntry}`;
     if (newBaggageHeader.length > MAX_BAGGAGE_STRING_LENGTH) {
       DEBUG_BUILD &&
-        logger.warn(
+        debug.warn(
           `Not adding key: ${objectKey} with val: ${objectValue} to baggage header due to exceeding baggage size limits.`,
         );
       return baggageHeader;

--- a/packages/core/src/utils/dsn.ts
+++ b/packages/core/src/utils/dsn.ts
@@ -1,6 +1,6 @@
 import { DEBUG_BUILD } from '../debug-build';
 import type { DsnComponents, DsnLike, DsnProtocol } from '../types-hoist/dsn';
-import { consoleSandbox, logger } from './logger';
+import { consoleSandbox, debug } from './logger';
 
 /** Regular expression used to extract org ID from a DSN host. */
 const ORG_ID_REGEX = /^o(\d+)\./;
@@ -89,7 +89,7 @@ function validateDsn(dsn: DsnComponents): boolean {
   const requiredComponents: ReadonlyArray<keyof DsnComponents> = ['protocol', 'publicKey', 'host', 'projectId'];
   const hasMissingRequiredComponent = requiredComponents.find(component => {
     if (!dsn[component]) {
-      logger.error(`Invalid Sentry Dsn: ${component} missing`);
+      debug.error(`Invalid Sentry Dsn: ${component} missing`);
       return true;
     }
     return false;
@@ -100,17 +100,17 @@ function validateDsn(dsn: DsnComponents): boolean {
   }
 
   if (!projectId.match(/^\d+$/)) {
-    logger.error(`Invalid Sentry Dsn: Invalid projectId ${projectId}`);
+    debug.error(`Invalid Sentry Dsn: Invalid projectId ${projectId}`);
     return false;
   }
 
   if (!isValidProtocol(protocol)) {
-    logger.error(`Invalid Sentry Dsn: Invalid protocol ${protocol}`);
+    debug.error(`Invalid Sentry Dsn: Invalid protocol ${protocol}`);
     return false;
   }
 
   if (port && isNaN(parseInt(port, 10))) {
-    logger.error(`Invalid Sentry Dsn: Invalid port ${port}`);
+    debug.error(`Invalid Sentry Dsn: Invalid port ${port}`);
     return false;
   }
 

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -3,7 +3,7 @@
  * constants, which can be overridden during build. By guarding certain pieces of code with functions that return these
  * constants, we can control whether or not they appear in the final bundle. (Any code guarded by a false condition will
  * never run, and will hence be dropped during treeshaking.) The two primary uses for this are stripping out calls to
- * `logger` and preventing node-related code from appearing in browser bundles.
+ * `debug` and preventing node-related code from appearing in browser bundles.
  *
  * Attention:
  * This file should not be used to define constants/flags that are intended to be used for tree-shaking conducted by

--- a/packages/core/src/utils/featureFlags.ts
+++ b/packages/core/src/utils/featureFlags.ts
@@ -2,7 +2,7 @@ import { getCurrentScope } from '../currentScopes';
 import { DEBUG_BUILD } from '../debug-build';
 import { type Event } from '../types-hoist/event';
 import { type Span } from '../types-hoist/span';
-import { logger } from '../utils/logger';
+import { debug } from '../utils/logger';
 import { GLOBAL_OBJ } from '../utils/worldwide';
 import { getActiveSpan } from './spanUtils';
 
@@ -95,7 +95,7 @@ export function _INTERNAL_insertToFlagBuffer(
   }
 
   if (flags.length > maxSize) {
-    DEBUG_BUILD && logger.error(`[Feature Flags] insertToFlagBuffer called on a buffer larger than maxSize=${maxSize}`);
+    DEBUG_BUILD && debug.error(`[Feature Flags] insertToFlagBuffer called on a buffer larger than maxSize=${maxSize}`);
     return;
   }
 

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -17,6 +17,15 @@ export interface Logger {
   trace(...args: Parameters<typeof console.trace>): void;
 }
 
+export interface SentryDebugLogger {
+  disable(): void;
+  enable(): void;
+  isEnabled(): boolean;
+  log(...args: Parameters<typeof console.log>): void;
+  warn(...args: Parameters<typeof console.warn>): void;
+  error(...args: Parameters<typeof console.error>): void;
+}
+
 export const CONSOLE_LEVELS: readonly ConsoleLevel[] = [
   'debug',
   'info',
@@ -102,7 +111,7 @@ function error(...args: Parameters<typeof console.error>): void {
   _maybeLog('error', ...args);
 }
 
-function debug(...args: Parameters<typeof console.debug>): void {
+function _debug(...args: Parameters<typeof console.debug>): void {
   _maybeLog('debug', ...args);
 }
 
@@ -154,9 +163,27 @@ export const logger = {
   /** Log an error. */
   error,
   /** Log a debug message. */
-  debug,
+  debug: _debug,
   /** Log an assertion. */
   assert,
   /** Log a trace. */
   trace,
 } satisfies Logger;
+
+/**
+ * This is a logger singleton which either logs things or no-ops if logging is not enabled.
+ */
+export const debug = {
+  /** Enable logging. */
+  enable,
+  /** Disable logging. */
+  disable,
+  /** Check if logging is enabled. */
+  isEnabled,
+  /** Log a message. */
+  log,
+  /** Log a warning. */
+  warn,
+  /** Log an error. */
+  error,
+} satisfies SentryDebugLogger;

--- a/packages/core/src/utils/node.ts
+++ b/packages/core/src/utils/node.ts
@@ -1,6 +1,6 @@
 /**
  * NOTE: In order to avoid circular dependencies, if you add a function to this module and it needs to print something,
- * you must either a) use `console.log` rather than the logger, or b) put your function elsewhere.
+ * you must either a) use `console.log` rather than the `debug` singleton, or b) put your function elsewhere.
  */
 
 import { isBrowserBundle } from './env';

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -3,7 +3,7 @@ import { DEBUG_BUILD } from '../debug-build';
 import type { WrappedFunction } from '../types-hoist/wrappedfunction';
 import { htmlTreeAsString } from './browser';
 import { isElement, isError, isEvent, isInstanceOf, isPrimitive } from './is';
-import { logger } from './logger';
+import { debug } from './logger';
 import { truncate } from './string';
 
 /**
@@ -42,7 +42,7 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
   try {
     source[name] = wrapped;
   } catch {
-    DEBUG_BUILD && logger.log(`Failed to replace method "${name}" in object`, source);
+    DEBUG_BUILD && debug.log(`Failed to replace method "${name}" in object`, source);
   }
 }
 
@@ -62,7 +62,7 @@ export function addNonEnumerableProperty(obj: object, name: string, value: unkno
       configurable: true,
     });
   } catch (o_O) {
-    DEBUG_BUILD && logger.log(`Failed to add non-enumerable property "${name}" to object`, obj);
+    DEBUG_BUILD && debug.log(`Failed to add non-enumerable property "${name}" to object`, obj);
   }
 }
 

--- a/packages/core/src/utils/supports.ts
+++ b/packages/core/src/utils/supports.ts
@@ -1,5 +1,5 @@
 import { DEBUG_BUILD } from '../debug-build';
-import { logger } from './logger';
+import { debug } from './logger';
 import { GLOBAL_OBJ } from './worldwide';
 
 const WINDOW = GLOBAL_OBJ as unknown as Window;
@@ -133,8 +133,7 @@ export function supportsNativeFetch(): boolean {
       }
       doc.head.removeChild(sandbox);
     } catch (err) {
-      DEBUG_BUILD &&
-        logger.warn('Could not create sandbox iframe for pure fetch check, bailing to window.fetch: ', err);
+      DEBUG_BUILD && debug.warn('Could not create sandbox iframe for pure fetch check, bailing to window.fetch: ', err);
     }
   }
 

--- a/packages/core/src/utils/traceData.ts
+++ b/packages/core/src/utils/traceData.ts
@@ -8,7 +8,7 @@ import { getDynamicSamplingContextFromScope, getDynamicSamplingContextFromSpan }
 import type { Span } from '../types-hoist/span';
 import type { SerializedTraceData } from '../types-hoist/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from './baggage';
-import { logger } from './logger';
+import { debug } from './logger';
 import { getActiveSpan, spanToTraceHeader } from './spanUtils';
 import { generateSentryTraceHeader, TRACEPARENT_REGEXP } from './tracing';
 
@@ -43,7 +43,7 @@ export function getTraceData(options: { span?: Span; scope?: Scope; client?: Cli
 
   const isValidSentryTraceHeader = TRACEPARENT_REGEXP.test(sentryTrace);
   if (!isValidSentryTraceHeader) {
-    logger.warn('Invalid sentry-trace data. Cannot generate trace data');
+    debug.warn('Invalid sentry-trace data. Cannot generate trace data');
     return {};
   }
 

--- a/packages/core/src/utils/worldwide.ts
+++ b/packages/core/src/utils/worldwide.ts
@@ -1,6 +1,6 @@
 /**
  * NOTE: In order to avoid circular dependencies, if you add a function to this module and it needs to print something,
- * you must either a) use `console.log` rather than the logger, or b) put your function elsewhere.
+ * you must either a) use `console.log` rather than the `debug` singleton, or b) put your function elsewhere.
  *
  * Note: This file was originally called `global.ts`, but was changed to unblock users which might be doing
  * string replaces with bundlers like Vite for `global` (would break imports that rely on importing from utils/src/global).

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -348,8 +348,8 @@ describe('Client', () => {
       expect(clientEventFromException).toHaveBeenCalledTimes(1);
     });
 
-    test('captures logger message', () => {
-      const logSpy = vi.spyOn(loggerModule.logger, 'log').mockImplementation(() => undefined);
+    test('captures debug message', () => {
+      const logSpy = vi.spyOn(loggerModule.debug, 'log').mockImplementation(() => undefined);
 
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
@@ -440,8 +440,8 @@ describe('Client', () => {
       );
     });
 
-    test('captures logger message', () => {
-      const logSpy = vi.spyOn(loggerModule.logger, 'log').mockImplementation(() => undefined);
+    test('captures debug message', () => {
+      const logSpy = vi.spyOn(loggerModule.debug, 'log').mockImplementation(() => undefined);
 
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
@@ -1207,7 +1207,7 @@ describe('Client', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSend });
       const client = new TestClient(options);
       const captureExceptionSpy = vi.spyOn(client, 'captureException');
-      const loggerLogSpy = vi.spyOn(loggerModule.logger, 'log');
+      const loggerLogSpy = vi.spyOn(loggerModule.debug, 'log');
 
       client.captureEvent({ message: 'hello' });
 
@@ -1226,7 +1226,7 @@ describe('Client', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSendTransaction });
       const client = new TestClient(options);
       const captureExceptionSpy = vi.spyOn(client, 'captureException');
-      const loggerLogSpy = vi.spyOn(loggerModule.logger, 'log');
+      const loggerLogSpy = vi.spyOn(loggerModule.debug, 'log');
 
       client.captureEvent({ transaction: '/dogs/are/great', type: 'transaction' });
 
@@ -1288,7 +1288,7 @@ describe('Client', () => {
         // @ts-expect-error we need to test regular-js behavior
         const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSend });
         const client = new TestClient(options);
-        const loggerWarnSpy = vi.spyOn(loggerModule.logger, 'warn');
+        const loggerWarnSpy = vi.spyOn(loggerModule.debug, 'warn');
 
         client.captureEvent({ message: 'hello' });
 
@@ -1307,7 +1307,7 @@ describe('Client', () => {
         // @ts-expect-error we need to test regular-js behavior
         const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSendTransaction });
         const client = new TestClient(options);
-        const loggerWarnSpy = vi.spyOn(loggerModule.logger, 'warn');
+        const loggerWarnSpy = vi.spyOn(loggerModule.debug, 'warn');
 
         client.captureEvent({ transaction: '/dogs/are/great', type: 'transaction' });
 
@@ -1551,7 +1551,7 @@ describe('Client', () => {
 
       const client = new TestClient(getDefaultTestClientOptions({ dsn: PUBLIC_DSN }));
       const captureExceptionSpy = vi.spyOn(client, 'captureException');
-      const loggerLogSpy = vi.spyOn(loggerModule.logger, 'log');
+      const loggerLogSpy = vi.spyOn(loggerModule.debug, 'log');
       const scope = new Scope();
       scope.addEventProcessor(() => null);
 
@@ -1569,7 +1569,7 @@ describe('Client', () => {
 
       const client = new TestClient(getDefaultTestClientOptions({ dsn: PUBLIC_DSN }));
       const captureExceptionSpy = vi.spyOn(client, 'captureException');
-      const loggerLogSpy = vi.spyOn(loggerModule.logger, 'log');
+      const loggerLogSpy = vi.spyOn(loggerModule.debug, 'log');
       const scope = new Scope();
       scope.addEventProcessor(() => null);
 
@@ -1668,7 +1668,7 @@ describe('Client', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const captureExceptionSpy = vi.spyOn(client, 'captureException');
-      const loggerWarnSpy = vi.spyOn(loggerModule.logger, 'warn');
+      const loggerWarnSpy = vi.spyOn(loggerModule.debug, 'warn');
       const scope = new Scope();
       const exception = new Error('sorry');
       scope.addEventProcessor(() => {
@@ -1701,8 +1701,8 @@ describe('Client', () => {
       expect(recordLostEventSpy).toHaveBeenCalledWith('sample_rate', 'error');
     });
 
-    test('captures logger message', () => {
-      const logSpy = vi.spyOn(loggerModule.logger, 'log').mockImplementation(() => undefined);
+    test('captures debug message', () => {
+      const logSpy = vi.spyOn(loggerModule.debug, 'log').mockImplementation(() => undefined);
 
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -4,7 +4,7 @@ import { addIntegration, getIntegrationsToSetup, installedIntegrations, setupInt
 import { setCurrentClient } from '../../src/sdk';
 import type { Integration } from '../../src/types-hoist/integration';
 import type { Options } from '../../src/types-hoist/options';
-import { logger } from '../../src/utils/logger';
+import { debug } from '../../src/utils/logger';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 
 function getTestClient(): TestClient {
@@ -594,7 +594,7 @@ describe('addIntegration', () => {
   });
 
   it('works with a client setup', () => {
-    const warnings = vi.spyOn(logger, 'warn');
+    const warnings = vi.spyOn(debug, 'warn');
 
     class CustomIntegration implements Integration {
       name = 'test';
@@ -612,7 +612,7 @@ describe('addIntegration', () => {
   });
 
   it('works without a client setup', () => {
-    const warnings = vi.spyOn(logger, 'warn');
+    const warnings = vi.spyOn(debug, 'warn');
     class CustomIntegration implements Integration {
       name = 'test';
       setupOnce = vi.fn();
@@ -653,7 +653,7 @@ describe('addIntegration', () => {
   });
 
   it('does not trigger hooks if already installed', () => {
-    const logs = vi.spyOn(logger, 'log');
+    const logs = vi.spyOn(debug, 'log');
 
     class CustomIntegration implements Integration {
       name = 'test';

--- a/packages/core/test/lib/integrations/captureconsole.test.ts
+++ b/packages/core/test/lib/integrations/captureconsole.test.ts
@@ -125,7 +125,7 @@ describe('CaptureConsole setup', () => {
     expect(captureMessage).toHaveBeenCalledWith('', { extra: { arguments: [] }, level: 'log' });
   });
 
-  it('should add an event processor that sets the `logger` field of events', () => {
+  it('should add an event processor that sets the `debug` field of events', () => {
     const captureConsole = captureConsoleIntegration({ levels: ['log'] });
     captureConsole.setup?.(mockClient);
 

--- a/packages/core/test/lib/logs/exports.test.ts
+++ b/packages/core/test/lib/logs/exports.test.ts
@@ -100,7 +100,7 @@ describe('_INTERNAL_captureLog', () => {
   });
 
   it('does not capture logs when enableLogs experiment is not enabled', () => {
-    const logWarnSpy = vi.spyOn(loggerModule.logger, 'warn').mockImplementation(() => undefined);
+    const logWarnSpy = vi.spyOn(loggerModule.debug, 'warn').mockImplementation(() => undefined);
     const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);
 
@@ -332,7 +332,7 @@ describe('_INTERNAL_captureLog', () => {
   it('drops logs when beforeSendLog returns null', () => {
     const beforeSendLog = vi.fn().mockReturnValue(null);
     const recordDroppedEventSpy = vi.spyOn(TestClient.prototype, 'recordDroppedEvent');
-    const loggerWarnSpy = vi.spyOn(loggerModule.logger, 'warn').mockImplementation(() => undefined);
+    const loggerWarnSpy = vi.spyOn(loggerModule.debug, 'warn').mockImplementation(() => undefined);
 
     const options = getDefaultTestClientOptions({
       dsn: PUBLIC_DSN,

--- a/packages/core/test/lib/utils/dsn.test.ts
+++ b/packages/core/test/lib/utils/dsn.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { DEBUG_BUILD } from '../../../src/debug-build';
 import { dsnToString, extractOrgIdFromDsnHost, makeDsn } from '../../../src/utils/dsn';
-import { logger } from '../../../src/utils/logger';
+import { debug } from '../../../src/utils/logger';
 
 function testIf(condition: boolean) {
   return condition ? test : test.skip;
 }
 
-const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+const loggerErrorSpy = vi.spyOn(debug, 'error').mockImplementation(() => {});
 const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
 describe('Dsn', () => {

--- a/packages/core/test/lib/utils/featureFlags.test.ts
+++ b/packages/core/test/lib/utils/featureFlags.test.ts
@@ -5,7 +5,7 @@ import {
   _INTERNAL_insertFlagToScope,
   _INTERNAL_insertToFlagBuffer,
 } from '../../../src/utils/featureFlags';
-import { logger } from '../../../src/utils/logger';
+import { debug } from '../../../src/utils/logger';
 
 describe('flags', () => {
   describe('insertFlagToScope()', () => {
@@ -26,7 +26,7 @@ describe('flags', () => {
   });
 
   describe('insertToFlagBuffer()', () => {
-    const loggerSpy = vi.spyOn(logger, 'error');
+    const loggerSpy = vi.spyOn(debug, 'error');
 
     afterEach(() => {
       loggerSpy.mockClear();

--- a/packages/core/test/lib/utils/logger.test.ts
+++ b/packages/core/test/lib/utils/logger.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { logger } from '../../../src';
+import { debug, logger } from '../../../src';
 import { getMainCarrier, getSentryCarrier } from '../../../src/carrier';
 
 describe('logger', () => {
@@ -53,5 +53,59 @@ describe('logger', () => {
     logger.log('test');
     expect(consoleLogSpy).toHaveBeenCalledTimes(0);
     expect(logger.isEnabled()).toBe(false);
+  });
+});
+
+describe('debug', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSentryCarrier(getMainCarrier()).loggerSettings = undefined;
+  });
+
+  it('works with defaults', () => {
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    debug.log('test');
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+    expect(debug.isEnabled()).toBe(false);
+  });
+
+  it('allows to enable and disable logging', () => {
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    debug.log('test');
+    expect(debug.isEnabled()).toBe(false);
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+
+    debug.enable();
+    debug.log('test');
+    expect(debug.isEnabled()).toBe(true);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+
+    debug.log('test2');
+    expect(consoleLogSpy).toHaveBeenCalledTimes(2);
+
+    debug.disable();
+
+    debug.log('test3');
+    expect(debug.isEnabled()).toBe(false);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('picks up enabled logger settings from carrier', () => {
+    getSentryCarrier(getMainCarrier()).loggerSettings = { enabled: true };
+
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    debug.log('test');
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+    expect(debug.isEnabled()).toBe(true);
+  });
+
+  it('picks up disabled logger settings from carrier', () => {
+    getSentryCarrier(getMainCarrier()).loggerSettings = { enabled: false };
+
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    debug.log('test');
+    expect(consoleLogSpy).toHaveBeenCalledTimes(0);
+    expect(debug.isEnabled()).toBe(false);
   });
 });

--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -1,5 +1,5 @@
 import type { Integration } from '@sentry/core';
-import { getGlobalScope, getIsolationScope, logger } from '@sentry/core';
+import { debug, getGlobalScope, getIsolationScope } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { getClient, getCurrentScope, WINDOW } from '@sentry/react';
 import { JSDOM } from 'jsdom';
@@ -7,7 +7,7 @@ import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { breadcrumbsIntegration, browserTracingIntegration, init } from '../src/client';
 
 const reactInit = vi.spyOn(SentryReact, 'init');
-const loggerLogSpy = vi.spyOn(logger, 'log');
+const debugLogSpy = vi.spyOn(debug, 'log');
 
 // We're setting up JSDom here because the Next.js routing instrumentations requires a few things to be present on pageload:
 // 1. Access to window.document API for `window.document.getElementById`
@@ -90,7 +90,7 @@ describe('Client init()', () => {
     });
 
     expect(transportSend).not.toHaveBeenCalled();
-    expect(loggerLogSpy).toHaveBeenCalledWith('An event processor returned `null`, will not send event.');
+    expect(debugLogSpy).toHaveBeenCalledWith('An event processor returned `null`, will not send event.');
   });
 
   describe('integrations', () => {


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/16903

ref https://github.com/getsentry/sentry-javascript/issues/16901

This PR introduces a `debug` function that aims to replace `logger`.

This gives us a couple of benefits:
1. communicates intent of the export much better
1. avoids collision with `logger` exported from other sdks (which is used for sentry structured logging)
1. we can move structured logging `logger` code into `@sentry/core`, reducing duplication across our sdks

We don't deprecate `logger` just yet, we need to convert everything else in the other SDKs first.