### PR TITLE
ref(feedback) set submission timeout to 30 seconds

### DIFF
--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -34,8 +34,8 @@ export const sendFeedback: SendFeedback = (
 
   // We want to wait for the feedback to be sent (or not)
   return new Promise<string>((resolve, reject) => {
-    // After 5s, we want to clear anyhow
-    const timeout = setTimeout(() => reject('Unable to determine if Feedback was correctly sent.'), 5_000);
+    // After 30s, we want to clear anyhow
+    const timeout = setTimeout(() => reject('Unable to determine if Feedback was correctly sent.'), 30_000);
 
     const cleanup = client.on('afterSendEvent', (event: Event, response: TransportMakeRequestResponse) => {
       if (event.event_id !== eventId) {

--- a/packages/feedback/test/core/sendFeedback.test.ts
+++ b/packages/feedback/test/core/sendFeedback.test.ts
@@ -321,7 +321,7 @@ describe('sendFeedback', () => {
 
     mockSdk();
     vi.spyOn(getClient()!.getTransport()!, 'send').mockImplementation(() => {
-      return new Promise(resolve => setTimeout(resolve, 10_000));
+      return new Promise(resolve => setTimeout(resolve, 40_000));
     });
 
     const promise = sendFeedback({
@@ -330,7 +330,7 @@ describe('sendFeedback', () => {
       message: 'mi',
     });
 
-    vi.advanceTimersByTime(5_000);
+    vi.advanceTimersByTime(30_000);
 
     await expect(promise).rejects.toMatch('Unable to determine if Feedback was correctly sent.');
 


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

This PR increases the feedback widget's submission timeout from 5 seconds to 30 seconds.

**Why?**
The previous 5-second timeout was too aggressive, leading to premature errors and a poor user experience, especially in slow network conditions. Increasing the timeout provides more time for feedback to be sent successfully, improving reliability.

---

[Slack Thread](https://sentry.slack.com/archives/C05J714QPRR/p1752188409093349?thread_ts=1752188409.093349&cid=C05J714QPRR)