### PR TITLE
ref: Avoid `enum` usage

### DIFF
--- a/packages/browser/src/integrations/featureFlags/openfeature/types.ts
+++ b/packages/browser/src/integrations/featureFlags/openfeature/types.ts
@@ -17,16 +17,17 @@ export const StandardResolutionReasons = {
   STALE: 'STALE',
   ERROR: 'ERROR',
 } as const;
-export enum ErrorCode {
-  PROVIDER_NOT_READY = 'PROVIDER_NOT_READY',
-  PROVIDER_FATAL = 'PROVIDER_FATAL',
-  FLAG_NOT_FOUND = 'FLAG_NOT_FOUND',
-  PARSE_ERROR = 'PARSE_ERROR',
-  TYPE_MISMATCH = 'TYPE_MISMATCH',
-  TARGETING_KEY_MISSING = 'TARGETING_KEY_MISSING',
-  INVALID_CONTEXT = 'INVALID_CONTEXT',
-  GENERAL = 'GENERAL',
-}
+
+type ErrorCode =
+  | 'PROVIDER_NOT_READY'
+  | 'PROVIDER_FATAL'
+  | 'FLAG_NOT_FOUND'
+  | 'PARSE_ERROR'
+  | 'TYPE_MISMATCH'
+  | 'TARGETING_KEY_MISSING'
+  | 'INVALID_CONTEXT'
+  | 'GENERAL';
+
 export interface Logger {
   error(...args: unknown[]): void;
   warn(...args: unknown[]): void;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -197,11 +197,7 @@ export type Navigation = NavigationStates[keyof NavigationStates];
 export type RouteData = any;
 export type Fetcher = any;
 
-export declare enum HistoryAction {
-  Pop = 'POP',
-  Push = 'PUSH',
-  Replace = 'REPLACE',
-}
+type HistoryAction = 'POP' | 'PUSH' | 'REPLACE';
 
 export interface RouterState {
   historyAction: Action | HistoryAction | any;


### PR DESCRIPTION
Apart of directly vendored code, we should avoid `enum`, as it has bundle size impact.

Also somehow part of https://github.com/getsentry/sentry-javascript/issues/16846