### PR TITLE
ref(core): Keep client-logger map on carrier & avoid side-effect

### DIFF
--- a/packages/core/src/carrier.ts
+++ b/packages/core/src/carrier.ts
@@ -1,6 +1,8 @@
 import type { AsyncContextStack } from './asyncContext/stackStrategy';
 import type { AsyncContextStrategy } from './asyncContext/types';
+import type { Client } from './client';
 import type { Scope } from './scope';
+import type { SerializedLog } from './types-hoist/log';
 import type { Logger } from './utils/logger';
 import { SDK_VERSION } from './utils/version';
 import { GLOBAL_OBJ } from './utils/worldwide';
@@ -27,6 +29,11 @@ export interface SentryCarrier {
   /** @deprecated Logger is no longer set. Instead, we keep enabled state in loggerSettings. */
   logger?: Logger;
   loggerSettings?: { enabled: boolean };
+  /**
+   * A map of Sentry clients to their log buffers.
+   * This is used to store logs that are sent to Sentry.
+   */
+  clientToLogBufferMap?: WeakMap<Client, Array<SerializedLog>>;
 
   /** Overwrites TextEncoder used in `@sentry/core`, need for `react-native@0.73` and older */
   encodePolyfill?: (input: string) => Uint8Array;

--- a/packages/core/src/utils/worldwide.ts
+++ b/packages/core/src/utils/worldwide.ts
@@ -13,8 +13,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Carrier } from '../carrier';
-import type { Client } from '../client';
-import type { SerializedLog } from '../types-hoist/log';
 import type { Span } from '../types-hoist/span';
 import type { SdkSource } from './env';
 
@@ -38,12 +36,6 @@ export type InternalGlobal = {
     id?: string;
   };
   SENTRY_SDK_SOURCE?: SdkSource;
-  /**
-   * A map of Sentry clients to their log buffers.
-   *
-   * This is used to store logs that are sent to Sentry.
-   */
-  _sentryClientToLogBufferMap?: WeakMap<Client, Array<SerializedLog>>;
   /**
    * Debug IDs are indirectly injected by Sentry CLI or bundler plugins to directly reference a particular source map
    * for resolving of a source file. The injected code will place an entry into the record for each loaded bundle/JS


### PR DESCRIPTION
Instead of having a side effect of writing on the GLOBAL_OBJ, we can use a global singleton instead.

Part of https://github.com/getsentry/sentry-javascript/issues/16846