### PR TITLE
ref(core): Avoid side-effect of `vercelAiEventProcessor`

### DIFF
--- a/packages/core/src/utils/vercel-ai.ts
+++ b/packages/core/src/utils/vercel-ai.ts
@@ -57,19 +57,15 @@ function onVercelAiSpanStart(span: Span): void {
   processGenerateSpan(span, name, attributes);
 }
 
-const vercelAiEventProcessor = Object.assign(
-  (event: Event): Event => {
-    if (event.type === 'transaction' && event.spans) {
-      for (const span of event.spans) {
-        // this mutates spans in-place
-        processEndedVercelAiSpan(span);
-      }
+function vercelAiEventProcessor(event: Event): Event {
+  if (event.type === 'transaction' && event.spans) {
+    for (const span of event.spans) {
+      // this mutates spans in-place
+      processEndedVercelAiSpan(span);
     }
-    return event;
-  },
-  { id: 'VercelAiEventProcessor' },
-);
-
+  }
+  return event;
+}
 /**
  * Post-process spans emitted by the Vercel AI SDK.
  */
@@ -229,5 +225,5 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
 export function addVercelAiProcessors(client: Client): void {
   client.on('spanStart', onVercelAiSpanStart);
   // Note: We cannot do this on `spanEnd`, because the span cannot be mutated anymore at this point
-  client.addEventProcessor(vercelAiEventProcessor);
+  client.addEventProcessor(Object.assign(vercelAiEventProcessor, { id: 'VercelAiEventProcessor' }));
 }


### PR DESCRIPTION
This is pretty small, but apparently `Object.assign()` also counts as side effect.

Part of https://github.com/getsentry/sentry-javascript/issues/16846