### PR TITLE
fix(core): Avoid prolonging idle span when starting standalone span

### DIFF
--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -17,6 +17,7 @@ import {
 import { timestampInSeconds } from '../utils/time';
 import { freezeDscOnSpan, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { SentryNonRecordingSpan } from './sentryNonRecordingSpan';
+import { SentrySpan } from './sentrySpan';
 import { SPAN_STATUS_ERROR } from './spanstatus';
 import { startInactiveSpan } from './trace';
 
@@ -326,7 +327,12 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       // or if this is the idle span itself being started,
       // or if the started span has already been closed,
       // we don't care about it for activity
-      if (_finished || startedSpan === span || !!spanToJSON(startedSpan).timestamp) {
+      if (
+        _finished ||
+        startedSpan === span ||
+        !!spanToJSON(startedSpan).timestamp ||
+        (startedSpan instanceof SentrySpan && startedSpan.isStandaloneSpan())
+      ) {
         return;
       }
 


### PR DESCRIPTION
While working on #16893 I realized that if we reported a web vital standalone span while an idlespan (e.g. pageload) was still running, we'd restart the idle span's child span timeout (i.e. prolong its duration potentially). Is is unintended because by definition the standalone span should not be associated with a potentially ongoing idle span and its tree.

This can happen, for example when users hide the page while the pageload span is still active, causing web vitals to be reported. 