### PR TITLE
ref(react): Use `debug` instead of `logger`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -166,7 +166,7 @@ export {
 } from './utils/is';
 export { isBrowser } from './utils/isBrowser';
 export { CONSOLE_LEVELS, consoleSandbox, debug, logger, originalConsoleMethods } from './utils/logger';
-export type { Logger } from './utils/logger';
+export type { Logger, SentryDebugLogger } from './utils/logger';
 export {
   addContextToFrame,
   addExceptionMechanism,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -166,7 +166,7 @@ export {
 } from './utils/is';
 export { isBrowser } from './utils/isBrowser';
 export { CONSOLE_LEVELS, consoleSandbox, debug, logger, originalConsoleMethods } from './utils/logger';
-export type { Logger, SentryDebugLogger } from './utils/logger';
+export type { Logger } from './utils/logger';
 export {
   addContextToFrame,
   addExceptionMechanism,

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -1,7 +1,7 @@
 import type { ReportDialogOptions } from '@sentry/browser';
 import { getClient, showReportDialog, withScope } from '@sentry/browser';
 import type { Scope } from '@sentry/core';
-import { logger } from '@sentry/core';
+import { debug } from '@sentry/core';
 import * as React from 'react';
 import { DEBUG_BUILD } from './debug-build';
 import { captureReactException } from './error';
@@ -207,7 +207,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     }
 
     if (fallback) {
-      DEBUG_BUILD && logger.warn('fallback did not produce a valid ReactElement');
+      DEBUG_BUILD && debug.warn('fallback did not produce a valid ReactElement');
     }
 
     // Fail gracefully if no fallback provided or is not valid

--- a/packages/react/src/reactrouterv6-compat-utils.tsx
+++ b/packages/react/src/reactrouterv6-compat-utils.tsx
@@ -10,11 +10,11 @@ import {
 } from '@sentry/browser';
 import type { Client, Integration, Span, TransactionSource } from '@sentry/core';
 import {
+  debug,
   getActiveSpan,
   getClient,
   getCurrentScope,
   getRootSpan,
-  logger,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -75,7 +75,7 @@ export function createV6CompatibleWrapCreateBrowserRouter<
 ): CreateRouterFunction<TState, TRouter> {
   if (!_useEffect || !_useLocation || !_useNavigationType || !_matchRoutes) {
     DEBUG_BUILD &&
-      logger.warn(
+      debug.warn(
         `reactRouterV${version}Instrumentation was unable to wrap the \`createRouter\` function because of one or more missing parameters.`,
       );
 
@@ -147,7 +147,7 @@ export function createV6CompatibleWrapCreateMemoryRouter<
 ): CreateRouterFunction<TState, TRouter> {
   if (!_useEffect || !_useLocation || !_useNavigationType || !_matchRoutes) {
     DEBUG_BUILD &&
-      logger.warn(
+      debug.warn(
         `reactRouterV${version}Instrumentation was unable to wrap the \`createMemoryRouter\` function because of one or more missing parameters.`,
       );
 
@@ -271,7 +271,7 @@ export function createReactRouterV6CompatibleTracingIntegration(
 export function createV6CompatibleWrapUseRoutes(origUseRoutes: UseRoutes, version: V6CompatibleVersion): UseRoutes {
   if (!_useEffect || !_useLocation || !_useNavigationType || !_matchRoutes) {
     DEBUG_BUILD &&
-      logger.warn(
+      debug.warn(
         'reactRouterV6Instrumentation was unable to wrap `useRoutes` because of one or more missing parameters.',
       );
 
@@ -632,7 +632,7 @@ export function createV6CompatibleWithSentryReactRouterRouting<P extends Record<
 ): R {
   if (!_useEffect || !_useLocation || !_useNavigationType || !_createRoutesFromChildren || !_matchRoutes) {
     DEBUG_BUILD &&
-      logger.warn(`reactRouterV6Instrumentation was unable to wrap Routes because of one or more missing parameters.
+      debug.warn(`reactRouterV6Instrumentation was unable to wrap Routes because of one or more missing parameters.
       useEffect: ${_useEffect}. useLocation: ${_useLocation}. useNavigationType: ${_useNavigationType}.
       createRoutesFromChildren: ${_createRoutesFromChildren}. matchRoutes: ${_matchRoutes}.`);
 


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/16940

Migrates `@sentry/react` to use the `debug` utility instead of `logger` from `@sentry/core`.

This change aligns with the ongoing effort to streamline logging utilities within the SDK, moving towards a more focused `debug` function.

---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).