### PR TITLE
feat(node): Drop 3xx status code spans by default

### DIFF
--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -79,7 +79,7 @@ interface HttpOptions {
    * By default, spans with 404 status code are ignored.
    * Expects an array of status codes or a range of status codes, e.g. [[300,399], 404] would ignore 3xx and 404 status codes.
    *
-   * @default `[404]`
+   * @default `[404, [300, 399]]`
    */
   dropSpansForIncomingRequestStatusCodes?: (number | [number, number])[];
 
@@ -184,7 +184,7 @@ export function _shouldInstrumentSpans(options: HttpOptions, clientOptions: Part
  * It creates breadcrumbs and spans for outgoing HTTP requests which will be attached to the currently active span.
  */
 export const httpIntegration = defineIntegration((options: HttpOptions = {}) => {
-  const dropSpansForIncomingRequestStatusCodes = options.dropSpansForIncomingRequestStatusCodes ?? [404];
+  const dropSpansForIncomingRequestStatusCodes = options.dropSpansForIncomingRequestStatusCodes ?? [404, [300, 399]];
 
   return {
     name: INTEGRATION_NAME,


### PR DESCRIPTION
In addition to 404, we now also drop 3xx (e.g. 301 MOVED_PERMANTENTLY) spans by default.

These are usually not helpful.

Noticed this in some react-router E2E test where 301 spans were messing with the test, but these should not even be captured really.