### PR TITLE
docs(aws-serverless): Fix package homepage link

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -3,7 +3,7 @@
   "version": "9.38.0",
   "description": "Official Sentry SDK for AWS Lambda and AWS Serverless Environments",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
-  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/serverless",
+  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/aws-serverless",
   "author": "Sentry",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Link "homepage" on https://www.npmjs.com/package/@sentry/aws-serverless links to a 404 page, as it targets the old `serverless` URL.

Is: https://github.com/getsentry/sentry-javascript/tree/master/packages/serverless
Should be: https://github.com/getsentry/sentry-javascript/tree/master/packages/aws-serverless

This is the fix.

Not sure about the commit message, feel free to pick this up and adjust.

This PR is similar to the one for GCP: https://github.com/getsentry/sentry-javascript/pull/14411