### PR TITLE
feat(browser): Add debugId sync APIs between web worker and main thread

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/assets/worker.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/assets/worker.js
@@ -1,0 +1,14 @@
+self._sentryDebugIds = {
+  'Error at http://sentry-test.io/worker.js': 'worker-debug-id-789',
+};
+
+self.postMessage({
+  _sentryMessage: true,
+  _sentryDebugIds: self._sentryDebugIds,
+});
+
+self.addEventListener('message', event => {
+  if (event.data.type === 'throw-error') {
+    throw new Error('Worker error for testing');
+  }
+});

--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/init.js
@@ -3,18 +3,9 @@ import * as Sentry from '@sentry/browser';
 // Initialize Sentry with webWorker integration
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  debug: true,
-  beforeSend(event) {
-    console.log('xx beforeSend', JSON.stringify(event.exception.values[0].stacktrace.frames, null, 2));
-    return event;
-  },
 });
 
 const worker = new Worker('/worker.js');
-
-worker.addEventListener('message', event => {
-  console.log('xx message', event);
-});
 
 Sentry.addIntegration(Sentry.webWorkerIntegration({ worker }));
 

--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/init.js
@@ -1,0 +1,27 @@
+import * as Sentry from '@sentry/browser';
+
+// Initialize Sentry with webWorker integration
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  debug: true,
+  beforeSend(event) {
+    console.log('xx beforeSend', JSON.stringify(event.exception.values[0].stacktrace.frames, null, 2));
+    return event;
+  },
+});
+
+const worker = new Worker('/worker.js');
+
+worker.addEventListener('message', event => {
+  console.log('xx message', event);
+});
+
+Sentry.addIntegration(Sentry.webWorkerIntegration({ worker }));
+
+const btn = document.getElementById('errWorker');
+
+btn.addEventListener('click', () => {
+  worker.postMessage({
+    type: 'throw-error',
+  });
+});

--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/template.html
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/template.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <button id="errWorker">Throw error in worker</button>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/test.ts
@@ -1,0 +1,38 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/core';
+import { sentryTest } from '../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+
+sentryTest('Assigns web worker debug IDs when using webWorkerIntegration', async ({ getLocalTestUrl, page }) => {
+  const bundle = process.env.PW_BUNDLE as string | undefined;
+  if (bundle != null && !bundle.includes('esm') && !bundle.includes('cjs')) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  page.route('**/worker.js', route => {
+    route.fulfill({
+      path: `${__dirname}/assets/worker.js`,
+    });
+  });
+
+  const button = page.locator('#errWorker');
+  await button.click();
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.debug_meta?.images).toBeDefined();
+
+  const debugImages = errorEvent.debug_meta?.images || [];
+
+  expect(debugImages.length).toBe(1);
+
+  debugImages.forEach(image => {
+    expect(image.type).toBe('sourcemap');
+    expect(image.debug_id).toEqual('worker-debug-id-789');
+    expect(image.code_file).toEqual('http://sentry-test.io/worker.js');
+  });
+});

--- a/dev-packages/e2e-tests/lib/copyToTemp.ts
+++ b/dev-packages/e2e-tests/lib/copyToTemp.ts
@@ -28,7 +28,7 @@ function fixPackageJson(cwd: string): void {
 
   // 2. Fix volta extends
   if (!packageJson.volta) {
-    throw new Error('No volta config found, please provide one!');
+    throw new Error("No volta config found, please add one to the test app's package.json!");
   }
 
   if (typeof packageJson.volta.extends === 'string') {

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/.npmrc
@@ -1,0 +1,2 @@
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/index.html
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + TS</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+    <button id="trigger-error" type="button" style="background-color: #dc3545; color: white">
+      Trigger Worker Error
+    </button>
+  </body>
+</html>

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/index.html
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/index.html
@@ -11,5 +11,11 @@
     <button id="trigger-error" type="button" style="background-color: #dc3545; color: white">
       Trigger Worker Error
     </button>
+    <button id="trigger-error-2" type="button" style="background-color: #dc3545; color: white">
+      Trigger Worker 2 Error
+    </button>
+    <button id="trigger-error-3" type="button" style="background-color: #dc3545; color: white">
+      Trigger Worker 3 (lazily added) Error
+    </button>
   </body>
 </html>

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/package.json
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gh-sentry-javascript-bundler-plugins-755-vite-worker-bundles",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "rm -rf dist &&tsc && vite build",
+    "preview": "vite preview --port 3030",
+    "test:build": "pnpm install && pnpm build",
+    "test:assert": "pnpm test"
+  },
+  "devDependencies": {
+    "@playwright/test": "~1.53.2",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "typescript": "~5.8.3",
+    "vite": "^7.0.4"
+  },
+  "dependencies": {
+    "@sentry/browser": "^9.38.0",
+    "@sentry/vite-plugin": "^3.5.0"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/package.json
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "gh-sentry-javascript-bundler-plugins-755-vite-worker-bundles",
+  "name": "browser-webworker-vite",
   "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "rm -rf dist &&tsc && vite build",
+    "build": "rm -rf dist && tsc && vite build",
     "preview": "vite preview --port 3030",
+    "test": "playwright test",
     "test:build": "pnpm install && pnpm build",
     "test:assert": "pnpm test"
   },
@@ -17,7 +18,12 @@
     "vite": "^7.0.4"
   },
   "dependencies": {
-    "@sentry/browser": "^9.38.0",
+    "@sentry/browser": "latest || *",
     "@sentry/vite-plugin": "^3.5.0"
+  },
+  "volta": {
+    "node": "20.19.2",
+    "yarn": "1.22.22",
+    "pnpm": "9.15.9"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/playwright.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm preview`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/playwright.config.mjs
@@ -2,6 +2,9 @@ import { getPlaywrightConfig } from '@sentry-internal/test-utils';
 
 const config = getPlaywrightConfig({
   startCommand: `pnpm preview`,
+  eventProxyFile: 'start-event-proxy.mjs',
+  eventProxyPort: 3031,
+  port: 3030,
 });
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
@@ -1,13 +1,13 @@
-import './style.css';
 import MyWorker from './worker.ts?worker';
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
-  dsn: import.meta.env.E2E_TEST_DSN,
+  dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: import.meta.env.MODE || 'development',
   tracesSampleRate: 1.0,
   debug: true,
   integrations: [Sentry.browserTracingIntegration()],
+  tunnel: 'http://localhost:3031/', // proxy server
 });
 
 const worker = new MyWorker();
@@ -16,12 +16,11 @@ Sentry.addIntegration(Sentry.webWorkerIntegration({ worker }));
 
 worker.addEventListener('message', event => {
   // this is part of the test, do not delete
-  console.log('xx received message from worker', event);
+  console.log('received message from worker:', event.data.msg);
 });
 
 document.querySelector<HTMLButtonElement>('#trigger-error')!.addEventListener('click', () => {
   worker.postMessage({
-    type: 'TRIGGER_ERROR',
-    data: 'This message triggers an uncaught error!',
+    msg: 'TRIGGER_ERROR',
   });
 });

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
@@ -1,0 +1,27 @@
+import './style.css';
+import MyWorker from './worker.ts?worker';
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: import.meta.env.E2E_TEST_DSN,
+  environment: import.meta.env.MODE || 'development',
+  tracesSampleRate: 1.0,
+  debug: true,
+  integrations: [Sentry.browserTracingIntegration()],
+});
+
+const worker = new MyWorker();
+
+Sentry.addIntegration(Sentry.webWorkerIntegration({ worker }));
+
+worker.addEventListener('message', event => {
+  // this is part of the test, do not delete
+  console.log('xx received message from worker', event);
+});
+
+document.querySelector<HTMLButtonElement>('#trigger-error')!.addEventListener('click', () => {
+  worker.postMessage({
+    type: 'TRIGGER_ERROR',
+    data: 'This message triggers an uncaught error!',
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
@@ -1,4 +1,5 @@
 import MyWorker from './worker.ts?worker';
+import MyWorker2 from './worker2.ts?worker';
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
@@ -11,8 +12,10 @@ Sentry.init({
 });
 
 const worker = new MyWorker();
+const worker2 = new MyWorker2();
 
-Sentry.addIntegration(Sentry.webWorkerIntegration({ worker }));
+const webWorkerIntegration = Sentry.webWorkerIntegration({ worker: [worker, worker2] });
+Sentry.addIntegration(webWorkerIntegration);
 
 worker.addEventListener('message', event => {
   // this is part of the test, do not delete
@@ -21,6 +24,21 @@ worker.addEventListener('message', event => {
 
 document.querySelector<HTMLButtonElement>('#trigger-error')!.addEventListener('click', () => {
   worker.postMessage({
+    msg: 'TRIGGER_ERROR',
+  });
+});
+
+document.querySelector<HTMLButtonElement>('#trigger-error-2')!.addEventListener('click', () => {
+  worker2.postMessage({
+    msg: 'TRIGGER_ERROR',
+  });
+});
+
+document.querySelector<HTMLButtonElement>('#trigger-error-3')!.addEventListener('click', async () => {
+  const Worker3 = await import('./worker3.ts?worker');
+  const worker3 = new Worker3.default();
+  webWorkerIntegration.addWorker(worker3);
+  worker3.postMessage({
     msg: 'TRIGGER_ERROR',
   });
 });

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/vite-env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/worker.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/worker.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/browser';
+
+// type cast necessary because TS thinks this file is part of the main
+// thread where self is of type `Window` instead of `Worker`
+Sentry.registerWebWorker({ self: self as unknown as Worker });
+
+// Let the main thread know the worker is ready
+self.postMessage({
+  msg: 'WORKER_READY',
+});
+
+self.addEventListener('message', event => {
+  if (event.data.msg === 'TRIGGER_ERROR') {
+    // This will throw an uncaught error in the worker
+    throw new Error(`Uncaught error in worker`);
+  }
+});

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/worker2.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/worker2.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/browser';
+
+// type cast necessary because TS thinks this file is part of the main
+// thread where self is of type `Window` instead of `Worker`
+Sentry.registerWebWorker({ self: self as unknown as Worker });
+
+// Let the main thread know the worker is ready
+self.postMessage({
+  msg: 'WORKER_2_READY',
+});
+
+self.addEventListener('message', event => {
+  if (event.data.msg === 'TRIGGER_ERROR') {
+    // This will throw an uncaught error in the worker
+    throw new Error(`Uncaught error in worker 2`);
+  }
+});

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/worker3.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/worker3.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/browser';
+
+// type cast necessary because TS thinks this file is part of the main
+// thread where self is of type `Window` instead of `Worker`
+Sentry.registerWebWorker({ self: self as unknown as Worker });
+
+// Let the main thread know the worker is ready
+self.postMessage({
+  msg: 'WORKER_3_READY',
+});
+
+self.addEventListener('message', event => {
+  if (event.data.msg === 'TRIGGER_ERROR') {
+    // This will throw an uncaught error in the worker
+    throw new Error(`Uncaught error in worker 3`);
+  }
+});

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'browser-webworker-vite',
+});

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/tests/errors.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+
+const E2E_TEST_APP_NAME = 'browser-webworker-vite';
+
+test('captures an error with debug ids and pageload trace context', async ({ page }) => {
+  const errorEventPromise = waitForError(E2E_TEST_APP_NAME, event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'Uncaught error in worker';
+  });
+
+  const transactionPromise = waitForTransaction(E2E_TEST_APP_NAME, transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  });
+
+  await page.goto('/');
+
+  await page.locator('id=trigger-error').click();
+
+  const errorEvent = await errorEventPromise;
+  const transactionEvent = await transactionPromise;
+
+  const pageloadTraceId = transactionEvent.contexts?.trace?.trace_id;
+  const pageloadSpanId = transactionEvent.contexts?.trace?.span_id;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('Uncaught error in worker');
+  expect(errorEvent.exception?.values?.[0]?.stacktrace?.frames).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toContain('worker.js');
+
+  expect(errorEvent.transaction).toBe('/');
+  expect(transactionEvent.transaction).toBe('/');
+
+  expect(errorEvent.request).toEqual({
+    url: 'http://localhost:4173/',
+    headers: expect.any(Object),
+  });
+
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: pageloadTraceId,
+    span_id: pageloadSpanId,
+  });
+
+  expect(errorEvent.debug_meta).toEqual({
+    sourcemaps: {
+      'worker.js': {
+        version: expect.any(String),
+        url: expect.any(String),
+      },
+    },
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   build: {
     sourcemap: 'hidden',
+    envPrefix: ['PUBLIC_'],
   },
 
   plugins: [
@@ -23,4 +24,6 @@ export default defineConfig({
       }),
     ],
   },
+
+  envPrefix: ['PUBLIC_'],
 });

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/vite.config.ts
@@ -1,0 +1,26 @@
+import { sentryVitePlugin } from '@sentry/vite-plugin';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    sourcemap: 'hidden',
+  },
+
+  plugins: [
+    sentryVitePlugin({
+      org: process.env.E2E_TEST_SENTRY_ORG_SLUG,
+      project: process.env.E2E_TEST_SENTRY_PROJECT,
+      authToken: process.env.E2E_TEST_AUTH_TOKEN,
+    }),
+  ],
+
+  worker: {
+    plugins: () => [
+      ...sentryVitePlugin({
+        org: process.env.E2E_TEST_SENTRY_ORG_SLUG,
+        project: process.env.E2E_TEST_SENTRY_PROJECT,
+        authToken: process.env.E2E_TEST_AUTH_TOKEN,
+      }),
+    ],
+  },
+});

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -73,3 +73,4 @@ export { openFeatureIntegration, OpenFeatureIntegrationHook } from './integratio
 export { unleashIntegration } from './integrations/featureFlags/unleash';
 export { statsigIntegration } from './integrations/featureFlags/statsig';
 export { diagnoseSdkConnectivity } from './diagnose-sdk';
+export { webWorkerIntegration } from './integrations/webWorker';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -73,4 +73,4 @@ export { openFeatureIntegration, OpenFeatureIntegrationHook } from './integratio
 export { unleashIntegration } from './integrations/featureFlags/unleash';
 export { statsigIntegration } from './integrations/featureFlags/statsig';
 export { diagnoseSdkConnectivity } from './diagnose-sdk';
-export { webWorkerIntegration } from './integrations/webWorker';
+export { webWorkerIntegration, registerWebWorker } from './integrations/webWorker';

--- a/packages/browser/src/integrations/webWorker.ts
+++ b/packages/browser/src/integrations/webWorker.ts
@@ -6,7 +6,7 @@ export const INTEGRATION_NAME = 'WebWorker';
 
 interface WebWorkerMessage {
   _sentryMessage: boolean;
-  _sentryDebugIds: Record<string, string>;
+  _sentryDebugIds?: Record<string, string>;
 }
 
 interface WebWorkerIntegrationOptions {
@@ -111,5 +111,10 @@ export function registerWebWorker({ self }: RegisterWebWorkerOptions): void {
 }
 
 function isWebWorkerMessage(eventData: unknown): eventData is WebWorkerMessage {
-  return isPlainObject(eventData) && eventData._sentryMessage === true && typeof eventData._sentryDebugIds === 'object';
+  return (
+    isPlainObject(eventData) &&
+    eventData._sentryMessage === true &&
+    '_sentryDebugIds' in eventData &&
+    (isPlainObject(eventData._sentryDebugIds) || eventData._sentryDebugIds === undefined)
+  );
 }

--- a/packages/browser/src/integrations/webWorker.ts
+++ b/packages/browser/src/integrations/webWorker.ts
@@ -70,7 +70,7 @@ export const webWorkerIntegration = defineIntegration(({ worker }: WebWorkerInte
   name: INTEGRATION_NAME,
   setupOnce: () => {
     worker.addEventListener('message', event => {
-      if (isWebWorkerMessage(event.data)) {
+      if (isSentryDebugIdMessage(event.data)) {
         event.stopImmediatePropagation(); // other listeners should not receive this message
         DEBUG_BUILD && debug.log('Sentry debugId web worker message received', event.data);
         WINDOW._sentryDebugIds = {
@@ -110,7 +110,7 @@ export function registerWebWorker({ self }: RegisterWebWorkerOptions): void {
   });
 }
 
-function isWebWorkerMessage(eventData: unknown): eventData is WebWorkerMessage {
+function isSentryDebugIdMessage(eventData: unknown): eventData is WebWorkerMessage {
   return (
     isPlainObject(eventData) &&
     eventData._sentryMessage === true &&

--- a/packages/browser/src/integrations/webWorker.ts
+++ b/packages/browser/src/integrations/webWorker.ts
@@ -1,0 +1,107 @@
+import { debug, defineIntegration, isPlainObject } from '@sentry/core';
+import { DEBUG_BUILD } from '../debug-build';
+import { WINDOW } from '../helpers';
+
+export const INTEGRATION_NAME = 'WebWorker';
+
+interface WebWorkerMessage {
+  _sentryMessage: boolean;
+  _sentryDebugIds: Record<string, string>;
+}
+
+interface WebWorkerIntegrationOptions {
+  worker: Worker;
+}
+
+/**
+ * Use this integration to set up Sentry with web workers.
+ *
+ * IMPORTANT: This integration must be added **before** you start listening to
+ * any messages from the worker. Otherwise, your message handlers will receive
+ * messages from Sentry which you need to ignore.
+ *
+ * This integration only has an effect, if you call `Sentry.registerWorker(self)`
+ * from within the worker you're adding to the integration.
+ *
+ * Given that you want to initialize the SDK as early as possible, you most likely
+ * want to add the integration after initializing the SDK:
+ *
+ * @example:
+ * ```ts filename={main.js}
+ * import * as Sentry from '@sentry/<your-sdk>';
+ *
+ * // some time earlier:
+ * Sentry.init(...)
+ *
+ * // 1. Initialize the worker
+ * const worker = new Worker(new URL('./worker.ts', import.meta.url));
+ *
+ * // 2. Add the integration
+ * Sentry.addIntegration(Sentry.webWorkerIntegration({ worker }));
+ *
+ * // 3. Register message listeners on the worker
+ * worker.addEventListener('message', event => {
+ *  // ...
+ * });
+ * ```
+ *
+ * Of course, you can also directly add the integration in Sentry.init:
+ * ```ts filename={main.js}
+ * import * as Sentry from '@sentry/<your-sdk>';
+ *
+ * // 1. Initialize the worker
+ * const worker = new Worker(new URL('./worker.ts', import.meta.url));
+ *
+ * // 2. Initialize the SDK
+ * Sentry.init({
+ *  integrations: [Sentry.webWorkerIntegration({ worker })]
+ * });
+ *
+ * // 3. Register message listeners on the worker
+ * worker.addEventListener('message', event => {
+ *  // ...
+ * });
+ * ```
+ */
+export const webWorkerIntegration = defineIntegration(({ worker }: WebWorkerIntegrationOptions) => ({
+  name: INTEGRATION_NAME,
+  setupOnce: () => {
+    worker.addEventListener('message', event => {
+      if (isWebWorkerMessage(event.data)) {
+        event.stopImmediatePropagation(); // other listeners should not receive this message
+        DEBUG_BUILD && debug.log('Sentry debugId web worker message received', event.data);
+        WINDOW._sentryDebugIds = {
+          ...event.data._sentryDebugIds,
+          // debugIds of the main thread have precedence over the worker's in case of a collision.
+          ...WINDOW._sentryDebugIds,
+        };
+      }
+    });
+  },
+}));
+
+/**
+ * Use this function to register the worker with the Sentry SDK.
+ *
+ * @example
+ * ```ts filename={worker.js}
+ * import * as Sentry from '@sentry/<your-sdk>';
+ *
+ * // Do this as early as possible in your worker.
+ * Sentry.registerWorker(self);
+ *
+ * // continue setting up your worker
+ * self.postMessage(...)
+ * ```
+ * @param self The worker instance.
+ */
+export function registerWebWorker(self: Worker & { _sentryDebugIds: Record<string, string> }): void {
+  self.postMessage({
+    _sentryMessage: true,
+    _sentryDebugIds: self._sentryDebugIds ?? undefined,
+  });
+}
+
+function isWebWorkerMessage(eventData: unknown): eventData is WebWorkerMessage {
+  return isPlainObject(eventData) && eventData._sentryMessage === true && typeof eventData._sentry === 'object';
+}

--- a/packages/browser/src/integrations/webWorker.ts
+++ b/packages/browser/src/integrations/webWorker.ts
@@ -62,6 +62,9 @@ interface WebWorkerIntegrationOptions {
  *  // ...
  * });
  * ```
+ *
+ * @param options {WebWorkerIntegrationOptions} Integration options:
+ *   - `worker`: The worker instance.
  */
 export const webWorkerIntegration = defineIntegration(({ worker }: WebWorkerIntegrationOptions) => ({
   name: INTEGRATION_NAME,
@@ -80,6 +83,10 @@ export const webWorkerIntegration = defineIntegration(({ worker }: WebWorkerInte
   },
 }));
 
+interface RegisterWebWorkerOptions {
+  self: Worker & { _sentryDebugIds?: Record<string, string> };
+}
+
 /**
  * Use this function to register the worker with the Sentry SDK.
  *
@@ -88,14 +95,15 @@ export const webWorkerIntegration = defineIntegration(({ worker }: WebWorkerInte
  * import * as Sentry from '@sentry/<your-sdk>';
  *
  * // Do this as early as possible in your worker.
- * Sentry.registerWorker(self);
+ * Sentry.registerWorker({ self });
  *
  * // continue setting up your worker
  * self.postMessage(...)
  * ```
- * @param self The worker instance.
+ * @param options {RegisterWebWorkerOptions} Integration options:
+ *   - `self`: The worker instance you're calling this function from (self).
  */
-export function registerWebWorker(self: Worker & { _sentryDebugIds: Record<string, string> }): void {
+export function registerWebWorker({ self }: RegisterWebWorkerOptions): void {
   self.postMessage({
     _sentryMessage: true,
     _sentryDebugIds: self._sentryDebugIds ?? undefined,

--- a/packages/browser/src/integrations/webWorker.ts
+++ b/packages/browser/src/integrations/webWorker.ts
@@ -103,5 +103,5 @@ export function registerWebWorker(self: Worker & { _sentryDebugIds: Record<strin
 }
 
 function isWebWorkerMessage(eventData: unknown): eventData is WebWorkerMessage {
-  return isPlainObject(eventData) && eventData._sentryMessage === true && typeof eventData._sentry === 'object';
+  return isPlainObject(eventData) && eventData._sentryMessage === true && typeof eventData._sentryDebugIds === 'object';
 }

--- a/packages/browser/test/integrations/webWorker.test.ts
+++ b/packages/browser/test/integrations/webWorker.test.ts
@@ -203,7 +203,7 @@ describe('registerWebWorker', () => {
   });
 
   it('posts message with _sentryMessage flag', () => {
-    registerWebWorker(mockWorkerSelf as any);
+    registerWebWorker({ self: mockWorkerSelf as any });
 
     expect(mockWorkerSelf.postMessage).toHaveBeenCalledTimes(1);
     expect(mockWorkerSelf.postMessage).toHaveBeenCalledWith({
@@ -218,7 +218,7 @@ describe('registerWebWorker', () => {
       'worker-file2.js': 'debug-id-2',
     };
 
-    registerWebWorker(mockWorkerSelf as any);
+    registerWebWorker({ self: mockWorkerSelf as any });
 
     expect(mockWorkerSelf.postMessage).toHaveBeenCalledTimes(1);
     expect(mockWorkerSelf.postMessage).toHaveBeenCalledWith({
@@ -233,7 +233,7 @@ describe('registerWebWorker', () => {
   it('handles undefined debug IDs', () => {
     mockWorkerSelf._sentryDebugIds = undefined;
 
-    registerWebWorker(mockWorkerSelf as any);
+    registerWebWorker({ self: mockWorkerSelf as any });
 
     expect(mockWorkerSelf.postMessage).toHaveBeenCalledTimes(1);
     expect(mockWorkerSelf.postMessage).toHaveBeenCalledWith({
@@ -272,7 +272,7 @@ describe('registerWebWorker and webWorkerIntegration', () => {
     const integration = webWorkerIntegration({ worker: mockWorker as any });
     integration.setupOnce!();
 
-    registerWebWorker(mockWorker as any);
+    registerWebWorker({ self: mockWorker as any });
 
     expect(mockWorker.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
     expect(mockWorker.postMessage).toHaveBeenCalledWith({

--- a/packages/browser/test/integrations/webWorker.test.ts
+++ b/packages/browser/test/integrations/webWorker.test.ts
@@ -248,9 +248,9 @@ describe('registerWebWorker and webWorkerIntegration', () => {
 
   it('works together', () => {
     (helpers.WINDOW as any)._sentryDebugIds = {
-      'main-file1.js': 'main-debug-1',
-      'main-file2.js': 'main-debug-2',
-      'shared-file.js': 'main-debug-id',
+      'Error at \n /main-file1.js': 'main-debug-1',
+      'Error at \n /main-file2.js': 'main-debug-2',
+      'Error at \n /shared-file.js': 'main-debug-id',
     };
 
     let cb: ((arg0: any) => any) | undefined = undefined;
@@ -258,9 +258,9 @@ describe('registerWebWorker and webWorkerIntegration', () => {
     // Setup mock worker
     const mockWorker = {
       _sentryDebugIds: {
-        'worker-file1.js': 'worker-debug-1',
-        'worker-file2.js': 'worker-debug-2',
-        'shared-file.js': 'worker-debug-id',
+        'Error at \n /worker-file1.js': 'worker-debug-1',
+        'Error at \n /worker-file2.js': 'worker-debug-2',
+        'Error at \n /shared-file.js': 'worker-debug-id',
       },
       addEventListener: vi.fn((_, l) => (cb = l)),
       postMessage: vi.fn(message => {
@@ -281,11 +281,11 @@ describe('registerWebWorker and webWorkerIntegration', () => {
     });
 
     expect((helpers.WINDOW as any)._sentryDebugIds).toEqual({
-      'main-file1.js': 'main-debug-1',
-      'main-file2.js': 'main-debug-2',
-      'shared-file.js': 'main-debug-id',
-      'worker-file1.js': 'worker-debug-1',
-      'worker-file2.js': 'worker-debug-2',
+      'Error at \n /main-file1.js': 'main-debug-1',
+      'Error at \n /main-file2.js': 'main-debug-2',
+      'Error at \n /shared-file.js': 'main-debug-id',
+      'Error at \n /worker-file1.js': 'worker-debug-1',
+      'Error at \n /worker-file2.js': 'worker-debug-2',
     });
   });
 });

--- a/packages/browser/test/integrations/webWorker.test.ts
+++ b/packages/browser/test/integrations/webWorker.test.ts
@@ -1,0 +1,332 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import * as SentryCore from '@sentry/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as helpers from '../../src/helpers';
+import { INTEGRATION_NAME, registerWebWorker, webWorkerIntegration } from '../../src/integrations/webWorker';
+
+// Mock @sentry/core
+vi.mock('@sentry/core', async importActual => {
+  return {
+    ...((await importActual()) as any),
+    debug: {
+      log: vi.fn(),
+    },
+  };
+});
+
+// Mock debug build
+vi.mock('../../src/debug-build', () => ({
+  DEBUG_BUILD: true,
+}));
+
+// Mock helpers
+vi.mock('../../src/helpers', () => ({
+  WINDOW: {
+    _sentryDebugIds: undefined,
+  },
+}));
+
+describe('webWorkerIntegration', () => {
+  const mockDebugLog = SentryCore.debug.log as any;
+
+  let mockWorker: {
+    addEventListener: ReturnType<typeof vi.fn>;
+    postMessage: ReturnType<typeof vi.fn>;
+    _sentryDebugIds?: Record<string, string>;
+  };
+
+  let mockEvent: {
+    data: any;
+    stopImmediatePropagation: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Reset WINDOW mock
+    (helpers.WINDOW as any)._sentryDebugIds = undefined;
+
+    // Setup mock worker
+    mockWorker = {
+      addEventListener: vi.fn(),
+      postMessage: vi.fn(),
+    };
+
+    // Setup mock event
+    mockEvent = {
+      data: {},
+      stopImmediatePropagation: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('integration creation', () => {
+    it('creates integration with correct name', () => {
+      const integration = webWorkerIntegration({ worker: mockWorker as any });
+
+      expect(integration.name).toBe(INTEGRATION_NAME);
+      expect(integration.name).toBe('WebWorker');
+    });
+
+    it('returns a properly structured integration object', () => {
+      const integration = webWorkerIntegration({ worker: mockWorker as any });
+
+      expect(typeof integration).toBe('object');
+      expect(integration.name).toBeDefined();
+      expect(integration.setupOnce).toBeDefined();
+    });
+
+    it('returns integration object with setupOnce function', () => {
+      const integration = webWorkerIntegration({ worker: mockWorker as any });
+
+      expect(integration).toMatchObject({
+        name: 'WebWorker',
+        setupOnce: expect.any(Function),
+      });
+    });
+  });
+
+  describe('setupOnce', () => {
+    it('adds message event listener to worker', () => {
+      const integration = webWorkerIntegration({ worker: mockWorker as any });
+
+      expect(integration.setupOnce).toBeDefined();
+      integration.setupOnce!();
+
+      expect(mockWorker.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    });
+
+    describe('message handler', () => {
+      let messageHandler: (event: any) => void;
+
+      beforeEach(() => {
+        const integration = webWorkerIntegration({ worker: mockWorker as any });
+        expect(integration.setupOnce).toBeDefined();
+        integration.setupOnce!();
+
+        // Extract the message handler from the addEventListener call
+        expect(mockWorker.addEventListener.mock.calls).toBeDefined();
+        messageHandler = mockWorker.addEventListener.mock.calls![0]![1];
+      });
+
+      it('ignores non-Sentry messages', () => {
+        mockEvent.data = { someData: 'value' };
+
+        messageHandler(mockEvent);
+
+        expect(mockEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+        expect(mockDebugLog).not.toHaveBeenCalled();
+      });
+
+      it('ignores plain objects without _sentryMessage flag', () => {
+        mockEvent.data = {
+          someData: 'value',
+          _sentry: {},
+        };
+
+        messageHandler(mockEvent);
+
+        expect(mockEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+        expect(mockDebugLog).not.toHaveBeenCalled();
+      });
+
+      it('ignores messages without _sentry object', () => {
+        mockEvent.data = {
+          _sentryMessage: true,
+          _sentryDebugIds: { 'file1.js': 'debug-id-1' },
+        };
+
+        messageHandler(mockEvent);
+
+        expect(mockEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+        expect(mockDebugLog).not.toHaveBeenCalled();
+      });
+
+      it('processes valid Sentry messages', () => {
+        mockEvent.data = {
+          _sentryMessage: true,
+          _sentryDebugIds: { 'file1.js': 'debug-id-1' },
+          _sentry: {},
+        };
+
+        messageHandler(mockEvent);
+
+        expect(mockEvent.stopImmediatePropagation).toHaveBeenCalled();
+        expect(mockDebugLog).toHaveBeenCalledWith('Sentry debugId web worker message received', mockEvent.data);
+      });
+
+      it('merges debug IDs with worker precedence for new IDs', () => {
+        (helpers.WINDOW as any)._sentryDebugIds = undefined;
+
+        mockEvent.data = {
+          _sentryMessage: true,
+          _sentryDebugIds: {
+            'worker-file1.js': 'worker-debug-1',
+            'worker-file2.js': 'worker-debug-2',
+          },
+          _sentry: {},
+        };
+
+        messageHandler(mockEvent);
+
+        expect((helpers.WINDOW as any)._sentryDebugIds).toEqual({
+          'worker-file1.js': 'worker-debug-1',
+          'worker-file2.js': 'worker-debug-2',
+        });
+      });
+
+      it('gives main thread precedence over worker for conflicting debug IDs', () => {
+        (helpers.WINDOW as any)._sentryDebugIds = {
+          'shared-file.js': 'main-debug-id',
+          'main-only.js': 'main-debug-2',
+        };
+
+        mockEvent.data = {
+          _sentryMessage: true,
+          _sentryDebugIds: {
+            'shared-file.js': 'worker-debug-id', // Should be overridden
+            'worker-only.js': 'worker-debug-3', // Should be kept
+          },
+          _sentry: {},
+        };
+
+        messageHandler(mockEvent);
+
+        expect((helpers.WINDOW as any)._sentryDebugIds).toEqual({
+          'shared-file.js': 'main-debug-id', // Main thread wins
+          'main-only.js': 'main-debug-2', // Main thread preserved
+          'worker-only.js': 'worker-debug-3', // Worker added
+        });
+      });
+
+      it('handles empty debug IDs from worker', () => {
+        (helpers.WINDOW as any)._sentryDebugIds = { 'main.js': 'main-debug' };
+
+        mockEvent.data = {
+          _sentryMessage: true,
+          _sentryDebugIds: {},
+          _sentry: {},
+        };
+
+        messageHandler(mockEvent);
+
+        expect((helpers.WINDOW as any)._sentryDebugIds).toEqual({
+          'main.js': 'main-debug',
+        });
+      });
+    });
+  });
+});
+
+describe('registerWebWorker', () => {
+  let mockWorkerSelf: {
+    postMessage: ReturnType<typeof vi.fn>;
+    _sentryDebugIds?: Record<string, string>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockWorkerSelf = {
+      postMessage: vi.fn(),
+    };
+  });
+
+  it('posts message with _sentryMessage flag', () => {
+    registerWebWorker(mockWorkerSelf as any);
+
+    expect(mockWorkerSelf.postMessage).toHaveBeenCalledWith({
+      _sentryMessage: true,
+      _sentryDebugIds: undefined,
+    });
+  });
+
+  it('includes debug IDs when available', () => {
+    mockWorkerSelf._sentryDebugIds = {
+      'worker-file1.js': 'debug-id-1',
+      'worker-file2.js': 'debug-id-2',
+    };
+
+    registerWebWorker(mockWorkerSelf as any);
+
+    expect(mockWorkerSelf.postMessage).toHaveBeenCalledWith({
+      _sentryMessage: true,
+      _sentryDebugIds: {
+        'worker-file1.js': 'debug-id-1',
+        'worker-file2.js': 'debug-id-2',
+      },
+    });
+  });
+
+  it('handles undefined debug IDs', () => {
+    mockWorkerSelf._sentryDebugIds = undefined;
+
+    registerWebWorker(mockWorkerSelf as any);
+
+    expect(mockWorkerSelf.postMessage).toHaveBeenCalledWith({
+      _sentryMessage: true,
+      _sentryDebugIds: undefined,
+    });
+  });
+
+  it('handles empty debug IDs object', () => {
+    mockWorkerSelf._sentryDebugIds = {};
+
+    registerWebWorker(mockWorkerSelf as any);
+
+    expect(mockWorkerSelf.postMessage).toHaveBeenCalledWith({
+      _sentryMessage: true,
+      _sentryDebugIds: {},
+    });
+  });
+
+  it('calls postMessage exactly once', () => {
+    registerWebWorker(mockWorkerSelf as any);
+
+    expect(mockWorkerSelf.postMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('event propagation ', () => {
+  // Since isWebWorkerMessage is not exported, we test it indirectly through the integration
+  let messageHandler: (event: any) => void;
+  let mockWorker: { addEventListener: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockWorker = { addEventListener: vi.fn() };
+    const integration = webWorkerIntegration({ worker: mockWorker as any });
+    integration.setupOnce!();
+    expect(mockWorker.addEventListener).toHaveBeenCalled();
+    expect(mockWorker.addEventListener.mock.calls).toBeDefined();
+    messageHandler = mockWorker.addEventListener.mock.calls![0]![1];
+  });
+
+  it.each([
+    ['plain object but missing _sentryMessage: { _sentry: {} }', { _sentry: {} }],
+    [
+      'plain object but _sentryMessage is false: { _sentryMessage: false, _sentry: {} }',
+      { _sentryMessage: false, _sentry: {} },
+    ],
+    ['plain object but missing _sentry: { _sentryMessage: true }', { _sentryMessage: true }],
+    [
+      'plain object but _sentry is not an object: { _sentryMessage: true, _sentry: "not-object" }',
+      { _sentryMessage: true, _sentry: 'not-object' },
+    ],
+  ])("doesn't stop propagation for %s", (_desc, data) => {
+    const mockEvent = { stopImmediatePropagation: vi.fn(), data };
+    messageHandler(mockEvent);
+    expect(mockEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+
+  it('stops propagation for sentry message', () => {
+    const mockEvent = { stopImmediatePropagation: vi.fn(), data: { _sentryMessage: true, _sentryDebugIds: {} } };
+    messageHandler(mockEvent);
+    expect(mockEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
This PR adds two Browser SDK APIs to let the main thread know about debugIds of worker files:

- `webWorkerIntegration({worker})` to be used in the main thread
- `registerWebWorker(self)` to be used in the web worker

The communication between workers and main thread is established between both APIs and they have to be used both for the sync to work correctly. Another limitation around this approach is that users must set up `webWorkerInegration` before they register their own message listeners. This ensures that the message from `registerWebWorker` is not propagated to user-created message listeners. We'll document this thoroughly in docs and I already added a section about this in the JSDoc.

Because of the strict co-dependence of both APIs, I decided to add them in one PR (also makes testing easier).

## Usage

```js
// main.js
Sentry.init({...})

const worker = new MyWorker(...);

Sentry.addIntegration(Sentry.webWorkerIntegration({ worker }));

worker.addEventListener('message', e => {...});
```

```js
// worker.js
Sentry.registerWebWorker({ self });

self.postMessage(...);
```

### Multiple Workers

Multiple workers are also supported:

```js
// main.js
Sentry.init({...})

const worker = new MyWorker(...);
const worker2 = new MyWorker2(...);

Sentry.addIntegration(Sentry.webWorkerIntegration({ worker: [worker, worker2] }));

worker.addEventListener('message', e => {...});
```

A worker can also be passed to the integration after it was initialized. This is helpful if workers are initialized lazily or at different times:

```js
// main.js
Sentry.init({...})

const worker = new MyWorker(...);

const webWorkerIntegration = Sentry.webWorkerIntegration({ worker });

Sentry.addIntegration(webWorkerIntegration);

worker.addEventListener('message', e => {...});

// sometime later

const lazyWorker = new MyLazyWorker(...);
webWorkerIntegration.addWorker(lazyWorker);
lazyWorker.addEventListener('message', e => {...});

```



I decided to keep both APIs very general around web workers because I think there could be other use cases in which we can sync data by using the worker's message channels. This should be as easy as listening for other messages.

also added 
- unit tests for the two APIs
- integration test testing the `webWorkerIntegration`
- e2e test demonstrating correct usage of both APIs together

closes #16975 
closes #16976 