### PR TITLE
ref(replay-internal): Use `debug` instead of `logger`

### DIFF
--- a/packages/browser-utils/src/networkUtils.ts
+++ b/packages/browser-utils/src/networkUtils.ts
@@ -1,5 +1,4 @@
-import type { Logger } from '@sentry/core';
-import { logger } from '@sentry/core';
+import { debug } from '@sentry/core';
 import { DEBUG_BUILD } from './debug-build';
 import type { NetworkMetaWarning } from './types';
 
@@ -16,7 +15,7 @@ export function serializeFormData(formData: FormData): string {
 }
 
 /** Get the string representation of a body. */
-export function getBodyString(body: unknown, _logger: Logger = logger): [string | undefined, NetworkMetaWarning?] {
+export function getBodyString(body: unknown, _debug: typeof debug = debug): [string | undefined, NetworkMetaWarning?] {
   try {
     if (typeof body === 'string') {
       return [body];
@@ -34,11 +33,11 @@ export function getBodyString(body: unknown, _logger: Logger = logger): [string 
       return [undefined];
     }
   } catch (error) {
-    DEBUG_BUILD && _logger.error(error, 'Failed to serialize body', body);
+    DEBUG_BUILD && _debug.error(error, 'Failed to serialize body', body);
     return [undefined, 'BODY_PARSE_ERROR'];
   }
 
-  DEBUG_BUILD && _logger.info('Skipping network body because of body type', body);
+  DEBUG_BUILD && _debug.log('Skipping network body because of body type', body);
 
   return [undefined, 'UNPARSEABLE_BODY_TYPE'];
 }

--- a/packages/replay-internal/src/coreHandlers/handleGlobalEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleGlobalEvent.ts
@@ -3,7 +3,7 @@ import { DEBUG_BUILD } from '../debug-build';
 import type { ReplayContainer } from '../types';
 import { isErrorEvent, isFeedbackEvent, isReplayEvent, isTransactionEvent } from '../util/eventUtils';
 import { isRrwebError } from '../util/isRrwebError';
-import { logger } from '../util/logger';
+import { debug } from '../util/logger';
 import { resetReplayIdOnDynamicSamplingContext } from '../util/resetReplayIdOnDynamicSamplingContext';
 import { addFeedbackBreadcrumb } from './util/addFeedbackBreadcrumb';
 import { shouldSampleForBufferEvent } from './util/shouldSampleForBufferEvent';
@@ -52,7 +52,7 @@ export function handleGlobalEventListener(replay: ReplayContainer): (event: Even
       // Unless `captureExceptions` is enabled, we want to ignore errors coming from rrweb
       // As there can be a bunch of stuff going wrong in internals there, that we don't want to bubble up to users
       if (isRrwebError(event, hint) && !replay.getOptions()._experiments.captureExceptions) {
-        DEBUG_BUILD && logger.log('Ignoring error from rrweb internals', event);
+        DEBUG_BUILD && debug.log('Ignoring error from rrweb internals', event);
         return null;
       }
 

--- a/packages/replay-internal/src/coreHandlers/handleNetworkBreadcrumbs.ts
+++ b/packages/replay-internal/src/coreHandlers/handleNetworkBreadcrumbs.ts
@@ -3,7 +3,7 @@ import { getClient } from '@sentry/core';
 import type { FetchHint, XhrHint } from '@sentry-internal/browser-utils';
 import { DEBUG_BUILD } from '../debug-build';
 import type { ReplayContainer, ReplayNetworkOptions } from '../types';
-import { logger } from '../util/logger';
+import { debug } from '../util/logger';
 import { captureFetchBreadcrumbToReplay, enrichFetchBreadcrumb } from './util/fetchUtils';
 import { captureXhrBreadcrumbToReplay, enrichXhrBreadcrumb } from './util/xhrUtils';
 
@@ -79,7 +79,7 @@ export function beforeAddNetworkBreadcrumb(
       captureFetchBreadcrumbToReplay(breadcrumb, hint, options);
     }
   } catch (e) {
-    DEBUG_BUILD && logger.exception(e, 'Error when enriching network breadcrumb');
+    DEBUG_BUILD && debug.exception(e, 'Error when enriching network breadcrumb');
   }
 }
 

--- a/packages/replay-internal/src/coreHandlers/util/fetchUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/fetchUtils.ts
@@ -8,7 +8,7 @@ import type {
   ReplayNetworkRequestData,
   ReplayNetworkRequestOrResponse,
 } from '../../types';
-import { logger } from '../../util/logger';
+import { debug } from '../../util/logger';
 import { addNetworkBreadcrumb } from './addNetworkBreadcrumb';
 import {
   buildNetworkRequestOrResponse,
@@ -39,7 +39,7 @@ export async function captureFetchBreadcrumbToReplay(
     const result = makeNetworkReplayBreadcrumb('resource.fetch', data);
     addNetworkBreadcrumb(options.replay, result);
   } catch (error) {
-    DEBUG_BUILD && logger.exception(error, 'Failed to capture fetch breadcrumb');
+    DEBUG_BUILD && debug.exception(error, 'Failed to capture fetch breadcrumb');
   }
 }
 
@@ -115,7 +115,7 @@ function _getRequestInfo(
 
   // We only want to transmit string or string-like bodies
   const requestBody = getFetchRequestArgBody(input);
-  const [bodyStr, warning] = getBodyString(requestBody, logger);
+  const [bodyStr, warning] = getBodyString(requestBody, debug);
   const data = buildNetworkRequestOrResponse(headers, requestBodySize, bodyStr);
 
   if (warning) {
@@ -188,7 +188,7 @@ function getResponseData(
 
     return buildNetworkRequestOrResponse(headers, size, undefined);
   } catch (error) {
-    DEBUG_BUILD && logger.exception(error, 'Failed to serialize response body');
+    DEBUG_BUILD && debug.exception(error, 'Failed to serialize response body');
     // fallback
     return buildNetworkRequestOrResponse(headers, responseBodySize, undefined);
   }
@@ -206,11 +206,11 @@ async function _parseFetchResponseBody(response: Response): Promise<[string | un
     return [text];
   } catch (error) {
     if (error instanceof Error && error.message.indexOf('Timeout') > -1) {
-      DEBUG_BUILD && logger.warn('Parsing text body from response timed out');
+      DEBUG_BUILD && debug.warn('Parsing text body from response timed out');
       return [undefined, 'BODY_PARSE_TIMEOUT'];
     }
 
-    DEBUG_BUILD && logger.exception(error, 'Failed to get text body from response');
+    DEBUG_BUILD && debug.exception(error, 'Failed to get text body from response');
     return [undefined, 'BODY_PARSE_ERROR'];
   }
 }
@@ -271,7 +271,7 @@ function _tryCloneResponse(response: Response): Response | void {
     return response.clone();
   } catch (error) {
     // this can throw if the response was already consumed before
-    DEBUG_BUILD && logger.exception(error, 'Failed to clone response body');
+    DEBUG_BUILD && debug.exception(error, 'Failed to clone response body');
   }
 }
 

--- a/packages/replay-internal/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/xhrUtils.ts
@@ -3,7 +3,7 @@ import type { NetworkMetaWarning, XhrHint } from '@sentry-internal/browser-utils
 import { getBodyString, SENTRY_XHR_DATA_KEY } from '@sentry-internal/browser-utils';
 import { DEBUG_BUILD } from '../../debug-build';
 import type { ReplayContainer, ReplayNetworkOptions, ReplayNetworkRequestData } from '../../types';
-import { logger } from '../../util/logger';
+import { debug } from '../../util/logger';
 import { addNetworkBreadcrumb } from './addNetworkBreadcrumb';
 import {
   buildNetworkRequestOrResponse,
@@ -32,7 +32,7 @@ export async function captureXhrBreadcrumbToReplay(
     const result = makeNetworkReplayBreadcrumb('resource.xhr', data);
     addNetworkBreadcrumb(options.replay, result);
   } catch (error) {
-    DEBUG_BUILD && logger.exception(error, 'Failed to capture xhr breadcrumb');
+    DEBUG_BUILD && debug.exception(error, 'Failed to capture xhr breadcrumb');
   }
 }
 
@@ -106,7 +106,7 @@ function _prepareXhrData(
     : {};
   const networkResponseHeaders = getAllowedHeaders(getResponseHeaders(xhr), options.networkResponseHeaders);
 
-  const [requestBody, requestWarning] = options.networkCaptureBodies ? getBodyString(input, logger) : [undefined];
+  const [requestBody, requestWarning] = options.networkCaptureBodies ? getBodyString(input, debug) : [undefined];
   const [responseBody, responseWarning] = options.networkCaptureBodies ? _getXhrResponseBody(xhr) : [undefined];
 
   const request = buildNetworkRequestOrResponse(networkRequestHeaders, requestBodySize, requestBody);
@@ -156,7 +156,7 @@ function _getXhrResponseBody(xhr: XMLHttpRequest): [string | undefined, NetworkM
     errors.push(e);
   }
 
-  DEBUG_BUILD && logger.warn('Failed to get xhr response body', ...errors);
+  DEBUG_BUILD && debug.warn('Failed to get xhr response body', ...errors);
 
   return [undefined];
 }
@@ -193,11 +193,11 @@ export function _parseXhrResponse(
       return [undefined];
     }
   } catch (error) {
-    DEBUG_BUILD && logger.exception(error, 'Failed to serialize body', body);
+    DEBUG_BUILD && debug.exception(error, 'Failed to serialize body', body);
     return [undefined, 'BODY_PARSE_ERROR'];
   }
 
-  DEBUG_BUILD && logger.info('Skipping network body because of body type', body);
+  DEBUG_BUILD && debug.log('Skipping network body because of body type', body);
 
   return [undefined, 'UNPARSEABLE_BODY_TYPE'];
 }

--- a/packages/replay-internal/src/eventBuffer/EventBufferCompressionWorker.ts
+++ b/packages/replay-internal/src/eventBuffer/EventBufferCompressionWorker.ts
@@ -2,7 +2,7 @@ import type { ReplayRecordingData } from '@sentry/core';
 import { REPLAY_MAX_EVENT_BUFFER_SIZE } from '../constants';
 import { DEBUG_BUILD } from '../debug-build';
 import type { AddEventResult, EventBuffer, EventBufferType, RecordingEvent } from '../types';
-import { logger } from '../util/logger';
+import { debug } from '../util/logger';
 import { timestampToMs } from '../util/timestamp';
 import { EventBufferSizeExceededError } from './error';
 import { WorkerHandler } from './WorkerHandler';
@@ -91,7 +91,7 @@ export class EventBufferCompressionWorker implements EventBuffer {
 
     // We do not wait on this, as we assume the order of messages is consistent for the worker
     this._worker.postMessage('clear').then(null, e => {
-      DEBUG_BUILD && logger.exception(e, 'Sending "clear" message to worker failed', e);
+      DEBUG_BUILD && debug.exception(e, 'Sending "clear" message to worker failed', e);
     });
   }
 

--- a/packages/replay-internal/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay-internal/src/eventBuffer/EventBufferProxy.ts
@@ -1,7 +1,7 @@
 import type { ReplayRecordingData } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 import type { AddEventResult, EventBuffer, EventBufferType, RecordingEvent } from '../types';
-import { logger } from '../util/logger';
+import { debug } from '../util/logger';
 import { EventBufferArray } from './EventBufferArray';
 import { EventBufferCompressionWorker } from './EventBufferCompressionWorker';
 
@@ -99,7 +99,7 @@ export class EventBufferProxy implements EventBuffer {
     } catch (error) {
       // If the worker fails to load, we fall back to the simple buffer.
       // Nothing more to do from our side here
-      DEBUG_BUILD && logger.exception(error, 'Failed to load the compression worker, falling back to simple buffer');
+      DEBUG_BUILD && debug.exception(error, 'Failed to load the compression worker, falling back to simple buffer');
       return;
     }
 
@@ -130,7 +130,7 @@ export class EventBufferProxy implements EventBuffer {
       // Can now clear fallback buffer as it's no longer necessary
       this._fallback.clear();
     } catch (error) {
-      DEBUG_BUILD && logger.exception(error, 'Failed to add events when switching buffers.');
+      DEBUG_BUILD && debug.exception(error, 'Failed to add events when switching buffers.');
     }
   }
 }

--- a/packages/replay-internal/src/eventBuffer/WorkerHandler.ts
+++ b/packages/replay-internal/src/eventBuffer/WorkerHandler.ts
@@ -1,6 +1,6 @@
 import { DEBUG_BUILD } from '../debug-build';
 import type { WorkerRequest, WorkerResponse } from '../types';
-import { logger } from '../util/logger';
+import { debug } from '../util/logger';
 
 /**
  * Event buffer that uses a web worker to compress events.
@@ -55,7 +55,7 @@ export class WorkerHandler {
    * Destroy the worker.
    */
   public destroy(): void {
-    DEBUG_BUILD && logger.info('Destroying compression worker');
+    DEBUG_BUILD && debug.log('Destroying compression worker');
     this._worker.terminate();
   }
 
@@ -83,7 +83,7 @@ export class WorkerHandler {
 
         if (!response.success) {
           // TODO: Do some error handling, not sure what
-          DEBUG_BUILD && logger.error('Error in compression worker: ', response.response);
+          DEBUG_BUILD && debug.error('Error in compression worker: ', response.response);
 
           reject(new Error('Error in compression worker'));
           return;

--- a/packages/replay-internal/src/eventBuffer/index.ts
+++ b/packages/replay-internal/src/eventBuffer/index.ts
@@ -1,7 +1,7 @@
 import { getWorkerURL } from '@sentry-internal/replay-worker';
 import { DEBUG_BUILD } from '../debug-build';
 import type { EventBuffer, ReplayWorkerURL } from '../types';
-import { logger } from '../util/logger';
+import { debug } from '../util/logger';
 import { EventBufferArray } from './EventBufferArray';
 import { EventBufferProxy } from './EventBufferProxy';
 
@@ -32,7 +32,7 @@ export function createEventBuffer({
     }
   }
 
-  DEBUG_BUILD && logger.info('Using simple buffer');
+  DEBUG_BUILD && debug.log('Using simple buffer');
   return new EventBufferArray();
 }
 
@@ -44,11 +44,11 @@ function _loadWorker(customWorkerUrl?: ReplayWorkerURL): EventBufferProxy | void
       return;
     }
 
-    DEBUG_BUILD && logger.info(`Using compression worker${customWorkerUrl ? ` from ${customWorkerUrl}` : ''}`);
+    DEBUG_BUILD && debug.log(`Using compression worker${customWorkerUrl ? ` from ${customWorkerUrl}` : ''}`);
     const worker = new Worker(workerUrl);
     return new EventBufferProxy(worker);
   } catch (error) {
-    DEBUG_BUILD && logger.exception(error, 'Failed to create compression worker');
+    DEBUG_BUILD && debug.exception(error, 'Failed to create compression worker');
     // Fall back to use simple event buffer array
   }
 }

--- a/packages/replay-internal/src/session/fetchSession.ts
+++ b/packages/replay-internal/src/session/fetchSession.ts
@@ -2,7 +2,7 @@ import { REPLAY_SESSION_KEY, WINDOW } from '../constants';
 import { DEBUG_BUILD } from '../debug-build';
 import type { Session } from '../types';
 import { hasSessionStorage } from '../util/hasSessionStorage';
-import { logger } from '../util/logger';
+import { debug } from '../util/logger';
 import { makeSession } from './Session';
 
 /**
@@ -23,7 +23,7 @@ export function fetchSession(): Session | null {
 
     const sessionObj = JSON.parse(sessionStringFromStorage) as Session;
 
-    DEBUG_BUILD && logger.infoTick('Loading existing session');
+    DEBUG_BUILD && debug.infoTick('Loading existing session');
 
     return makeSession(sessionObj);
   } catch {

--- a/packages/replay-internal/src/session/loadOrCreateSession.ts
+++ b/packages/replay-internal/src/session/loadOrCreateSession.ts
@@ -1,6 +1,6 @@
 import { DEBUG_BUILD } from '../debug-build';
 import type { Session, SessionOptions } from '../types';
-import { logger } from '../util/logger';
+import { debug } from '../util/logger';
 import { createSession } from './createSession';
 import { fetchSession } from './fetchSession';
 import { shouldRefreshSession } from './shouldRefreshSession';
@@ -25,7 +25,7 @@ export function loadOrCreateSession(
 
   // No session exists yet, just create a new one
   if (!existingSession) {
-    DEBUG_BUILD && logger.infoTick('Creating new session');
+    DEBUG_BUILD && debug.infoTick('Creating new session');
     return createSession(sessionOptions, { previousSessionId });
   }
 
@@ -33,6 +33,6 @@ export function loadOrCreateSession(
     return existingSession;
   }
 
-  DEBUG_BUILD && logger.infoTick('Session in sessionStorage is expired, creating new one...');
+  DEBUG_BUILD && debug.infoTick('Session in sessionStorage is expired, creating new one...');
   return createSession(sessionOptions, { previousSessionId: existingSession.id });
 }

--- a/packages/replay-internal/src/util/addEvent.ts
+++ b/packages/replay-internal/src/util/addEvent.ts
@@ -3,7 +3,7 @@ import { EventType } from '@sentry-internal/rrweb';
 import { DEBUG_BUILD } from '../debug-build';
 import { EventBufferSizeExceededError } from '../eventBuffer/error';
 import type { AddEventResult, RecordingEvent, ReplayContainer, ReplayFrameEvent, ReplayPluginOptions } from '../types';
-import { logger } from './logger';
+import { debug } from './logger';
 import { timestampToMs } from './timestamp';
 
 function isCustomEvent(event: RecordingEvent): event is ReplayFrameEvent {
@@ -123,7 +123,7 @@ export function shouldAddEvent(replay: ReplayContainer, event: RecordingEvent): 
   // Throw out events that are +60min from the initial timestamp
   if (timestampInMs > replay.getContext().initialTimestamp + replay.getOptions().maxReplayDuration) {
     DEBUG_BUILD &&
-      logger.infoTick(`Skipping event with timestamp ${timestampInMs} because it is after maxReplayDuration`);
+      debug.infoTick(`Skipping event with timestamp ${timestampInMs} because it is after maxReplayDuration`);
     return false;
   }
 
@@ -140,7 +140,7 @@ function maybeApplyCallback(
     }
   } catch (error) {
     DEBUG_BUILD &&
-      logger.exception(error, 'An error occurred in the `beforeAddRecordingEvent` callback, skipping the event...');
+      debug.exception(error, 'An error occurred in the `beforeAddRecordingEvent` callback, skipping the event...');
     return null;
   }
 

--- a/packages/replay-internal/src/util/handleRecordingEmit.ts
+++ b/packages/replay-internal/src/util/handleRecordingEmit.ts
@@ -4,7 +4,7 @@ import { DEBUG_BUILD } from '../debug-build';
 import { saveSession } from '../session/saveSession';
 import type { RecordingEvent, ReplayContainer, ReplayOptionFrameEvent } from '../types';
 import { addEventSync } from './addEvent';
-import { logger } from './logger';
+import { debug } from './logger';
 
 type RecordingEmitCallback = (event: RecordingEvent, isCheckout?: boolean) => void;
 
@@ -19,7 +19,7 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
   return (event: RecordingEvent, _isCheckout?: boolean) => {
     // If this is false, it means session is expired, create and a new session and wait for checkout
     if (!replay.checkAndHandleExpiredSession()) {
-      DEBUG_BUILD && logger.warn('Received replay event after session expired.');
+      DEBUG_BUILD && debug.warn('Received replay event after session expired.');
 
       return;
     }
@@ -76,7 +76,7 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
         const earliestEvent = replay.eventBuffer.getEarliestTimestamp();
         if (earliestEvent) {
           DEBUG_BUILD &&
-            logger.info(`Updating session start time to earliest event in buffer to ${new Date(earliestEvent)}`);
+            debug.log(`Updating session start time to earliest event in buffer to ${new Date(earliestEvent)}`);
 
           session.started = earliestEvent;
 

--- a/packages/replay-internal/src/util/logger.ts
+++ b/packages/replay-internal/src/util/logger.ts
@@ -1,28 +1,28 @@
-import type { ConsoleLevel, Logger, SeverityLevel } from '@sentry/core';
-import { addBreadcrumb, captureException, logger as coreLogger, severityLevelFromString } from '@sentry/core';
+import type { ConsoleLevel, SeverityLevel } from '@sentry/core';
+import { addBreadcrumb, captureException, debug as coreDebug, severityLevelFromString } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 
-type ReplayConsoleLevels = Extract<ConsoleLevel, 'info' | 'warn' | 'error' | 'log'>;
-const CONSOLE_LEVELS: readonly ReplayConsoleLevels[] = ['info', 'warn', 'error', 'log'] as const;
+type ReplayConsoleLevels = Extract<ConsoleLevel, 'log' | 'warn' | 'error'>;
+const CONSOLE_LEVELS: readonly ReplayConsoleLevels[] = ['log', 'warn', 'error'] as const;
 const PREFIX = '[Replay] ';
-
-type LoggerMethod = (...args: unknown[]) => void;
 
 interface LoggerConfig {
   captureExceptions: boolean;
   traceInternals: boolean;
 }
 
-interface ReplayLogger extends Logger {
+type CoreDebugLogger = typeof coreDebug;
+
+interface ReplayDebugLogger extends CoreDebugLogger {
   /**
-   * Calls `logger.info` but saves breadcrumb in the next tick due to race
+   * Calls `debug.log` but saves breadcrumb in the next tick due to race
    * conditions before replay is initialized.
    */
-  infoTick: LoggerMethod;
+  infoTick: CoreDebugLogger['log'];
   /**
    * Captures exceptions (`Error`) if "capture internal exceptions" is enabled
    */
-  exception: LoggerMethod;
+  exception: CoreDebugLogger['error'];
   /**
    * Configures the logger with additional debugging behavior
    */
@@ -43,11 +43,11 @@ function _addBreadcrumb(message: unknown, level: SeverityLevel = 'info'): void {
   );
 }
 
-function makeReplayLogger(): ReplayLogger {
+function makeReplayDebugLogger(): ReplayDebugLogger {
   let _capture = false;
   let _trace = false;
 
-  const _logger: Partial<ReplayLogger> = {
+  const _debug: Partial<ReplayDebugLogger> = {
     exception: () => undefined,
     infoTick: () => undefined,
     setConfig: (opts: Partial<LoggerConfig>) => {
@@ -58,20 +58,20 @@ function makeReplayLogger(): ReplayLogger {
 
   if (DEBUG_BUILD) {
     CONSOLE_LEVELS.forEach(name => {
-      _logger[name] = (...args: unknown[]) => {
-        coreLogger[name](PREFIX, ...args);
+      _debug[name] = (...args: unknown[]) => {
+        coreDebug[name](PREFIX, ...args);
         if (_trace) {
           _addBreadcrumb(args.join(''), severityLevelFromString(name));
         }
       };
     });
 
-    _logger.exception = (error: unknown, ...message: unknown[]) => {
-      if (message.length && _logger.error) {
-        _logger.error(...message);
+    _debug.exception = (error: unknown, ...message: unknown[]) => {
+      if (message.length && _debug.error) {
+        _debug.error(...message);
       }
 
-      coreLogger.error(PREFIX, error);
+      coreDebug.error(PREFIX, error);
 
       if (_capture) {
         captureException(error);
@@ -82,8 +82,8 @@ function makeReplayLogger(): ReplayLogger {
       }
     };
 
-    _logger.infoTick = (...args: unknown[]) => {
-      coreLogger.info(PREFIX, ...args);
+    _debug.infoTick = (...args: unknown[]) => {
+      coreDebug.log(PREFIX, ...args);
       if (_trace) {
         // Wait a tick here to avoid race conditions for some initial logs
         // which may be added before replay is initialized
@@ -92,11 +92,11 @@ function makeReplayLogger(): ReplayLogger {
     };
   } else {
     CONSOLE_LEVELS.forEach(name => {
-      _logger[name] = () => undefined;
+      _debug[name] = () => undefined;
     });
   }
 
-  return _logger as ReplayLogger;
+  return _debug as ReplayDebugLogger;
 }
 
-export const logger = makeReplayLogger();
+export const debug = makeReplayDebugLogger();

--- a/packages/replay-internal/src/util/sendReplayRequest.ts
+++ b/packages/replay-internal/src/util/sendReplayRequest.ts
@@ -4,7 +4,7 @@ import { REPLAY_EVENT_NAME, UNABLE_TO_SEND_REPLAY } from '../constants';
 import { DEBUG_BUILD } from '../debug-build';
 import type { SendReplayData } from '../types';
 import { createReplayEnvelope } from './createReplayEnvelope';
-import { logger } from './logger';
+import { debug } from './logger';
 import { prepareRecordingData } from './prepareRecordingData';
 import { prepareReplayEvent } from './prepareReplayEvent';
 
@@ -54,7 +54,7 @@ export async function sendReplayRequest({
   if (!replayEvent) {
     // Taken from baseclient's `_processEvent` method, where this is handled for errors/transactions
     client.recordDroppedEvent('event_processor', 'replay');
-    DEBUG_BUILD && logger.info('An event processor returned `null`, will not send event.');
+    DEBUG_BUILD && debug.log('An event processor returned `null`, will not send event.');
     return resolvedSyncPromise({});
   }
 

--- a/packages/replay-internal/test/integration/flush.test.ts
+++ b/packages/replay-internal/test/integration/flush.test.ts
@@ -14,7 +14,7 @@ import { clearSession } from '../../src/session/clearSession';
 import type { EventBuffer } from '../../src/types';
 import { createPerformanceEntries } from '../../src/util/createPerformanceEntries';
 import { createPerformanceSpans } from '../../src/util/createPerformanceSpans';
-import { logger } from '../../src/util/logger';
+import { debug } from '../../src/util/logger';
 import * as SendReplay from '../../src/util/sendReplay';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '../index';
 import type { DomHandler } from '../types';
@@ -332,7 +332,7 @@ describe('Integration | flush', () => {
   });
 
   it('logs warning if flushing initial segment without checkout', async () => {
-    logger.setConfig({ traceInternals: true });
+    debug.setConfig({ traceInternals: true });
 
     sessionStorage.clear();
     clearSession(replay);
@@ -405,13 +405,13 @@ describe('Integration | flush', () => {
       },
     ]);
 
-    logger.setConfig({ traceInternals: false });
+    debug.setConfig({ traceInternals: false });
   });
 
   it('logs warning if adding event that is after maxReplayDuration', async () => {
-    logger.setConfig({ traceInternals: true });
+    debug.setConfig({ traceInternals: true });
 
-    const spyLogger = vi.spyOn(SentryUtils.logger, 'info');
+    const spyDebugLogger = vi.spyOn(SentryUtils.debug, 'log');
 
     sessionStorage.clear();
     clearSession(replay);
@@ -436,15 +436,15 @@ describe('Integration | flush', () => {
     expect(mockFlush).toHaveBeenCalledTimes(0);
     expect(mockSendReplay).toHaveBeenCalledTimes(0);
 
-    expect(spyLogger).toHaveBeenLastCalledWith(
+    expect(spyDebugLogger).toHaveBeenLastCalledWith(
       '[Replay] ',
       `Skipping event with timestamp ${
         BASE_TIMESTAMP + MAX_REPLAY_DURATION + 100
       } because it is after maxReplayDuration`,
     );
 
-    logger.setConfig({ traceInternals: false });
-    spyLogger.mockRestore();
+    debug.setConfig({ traceInternals: false });
+    spyDebugLogger.mockRestore();
   });
 
   /**

--- a/packages/replay-internal/test/unit/util/logger.test.ts
+++ b/packages/replay-internal/test/unit/util/logger.test.ts
@@ -1,14 +1,13 @@
 import * as SentryCore from '@sentry/core';
-import { logger as coreLogger } from '@sentry/core';
+import { debug as coreDebugLogger } from '@sentry/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { logger } from '../../../src/util/logger';
+import { debug } from '../../../src/util/logger';
 
 const mockCaptureException = vi.spyOn(SentryCore, 'captureException');
 const mockAddBreadcrumb = vi.spyOn(SentryCore, 'addBreadcrumb');
-const mockLogError = vi.spyOn(coreLogger, 'error');
-vi.spyOn(coreLogger, 'info');
-vi.spyOn(coreLogger, 'log');
-vi.spyOn(coreLogger, 'warn');
+const mockLogError = vi.spyOn(coreDebugLogger, 'error');
+vi.spyOn(coreDebugLogger, 'log');
+vi.spyOn(coreDebugLogger, 'warn');
 
 describe('logger', () => {
   beforeEach(() => {
@@ -22,20 +21,19 @@ describe('logger', () => {
     [true, true],
   ])('with options: captureExceptions:%s, traceInternals:%s', (captureExceptions, traceInternals) => {
     beforeEach(() => {
-      logger.setConfig({
+      debug.setConfig({
         captureExceptions,
         traceInternals,
       });
     });
 
     it.each([
-      ['info', 'info', 'info message'],
       ['log', 'log', 'log message'],
       ['warn', 'warning', 'warn message'],
       ['error', 'error', 'error message'],
-    ])('%s', (fn, level, message) => {
-      logger[fn](message);
-      expect(coreLogger[fn]).toHaveBeenCalledWith('[Replay] ', message);
+    ] as const)('%s', (fn, level, message) => {
+      debug[fn](message);
+      expect(coreDebugLogger[fn]).toHaveBeenCalledWith('[Replay] ', message);
 
       if (traceInternals) {
         expect(mockAddBreadcrumb).toHaveBeenLastCalledWith(
@@ -52,7 +50,7 @@ describe('logger', () => {
 
     it('logs exceptions with a message', () => {
       const err = new Error('An error');
-      logger.exception(err, 'a message');
+      debug.exception(err, 'a message');
       if (captureExceptions) {
         expect(mockCaptureException).toHaveBeenCalledWith(err);
       }
@@ -75,7 +73,7 @@ describe('logger', () => {
 
     it('logs exceptions without a message', () => {
       const err = new Error('An error');
-      logger.exception(err);
+      debug.exception(err);
       if (captureExceptions) {
         expect(mockCaptureException).toHaveBeenCalledWith(err);
         expect(mockAddBreadcrumb).not.toHaveBeenCalled();


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/16937

Also reaches into `packages/browser-utils/src/networkUtils.ts` to make a quick change.