### PR TITLE
ref: Avoid try-catch with unused parameter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     es2017: true,
   },
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
   },
   extends: ['@sentry-internal/sdk'],
   ignorePatterns: [

--- a/dev-packages/browser-integration-tests/scripts/detectFlakyTests.ts
+++ b/dev-packages/browser-integration-tests/scripts/detectFlakyTests.ts
@@ -131,7 +131,7 @@ function getApproximateNumberOfTests(testPath: string): number {
     const content = fs.readFileSync(path.join(process.cwd(), testPath, 'test.ts'), 'utf-8');
     const matches = content.match(/sentryTest\(/g);
     return Math.max(matches ? matches.length : 1, 1);
-  } catch (e) {
+  } catch {
     console.error(`Could not read file ${testPath}`);
     return 1;
   }

--- a/dev-packages/browser-integration-tests/suites/feedback/attachTo/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/attachTo/test.ts
@@ -17,7 +17,7 @@ sentryTest('should capture feedback with custom button', async ({ getLocalTestUr
 
     try {
       return getEnvelopeType(req) === 'feedback';
-    } catch (err) {
+    } catch {
       return false;
     }
   });

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/test.ts
@@ -17,7 +17,7 @@ sentryTest('should capture feedback', async ({ getLocalTestUrl, page }) => {
 
     try {
       return getEnvelopeType(req) === 'feedback';
-    } catch (err) {
+    } catch {
       return false;
     }
   });

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackAndReplay/hasSampling/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackAndReplay/hasSampling/test.ts
@@ -25,7 +25,7 @@ sentryTest('should capture feedback', async ({ forceFlushReplay, getLocalTestUrl
 
     try {
       return getEnvelopeType(req) === 'feedback';
-    } catch (err) {
+    } catch {
       return false;
     }
   });

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackCsp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackCsp/test.ts
@@ -17,7 +17,7 @@ sentryTest('should capture feedback', async ({ getLocalTestUrl, page }) => {
 
     try {
       return getEnvelopeType(req) === 'feedback';
-    } catch (err) {
+    } catch {
       return false;
     }
   });

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/init.js
@@ -14,7 +14,7 @@ Sentry.init({
             moduleMetadataEntries.push(frame.module_metadata);
           });
         });
-      } catch (e) {
+      } catch {
         // noop
       }
     }

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/init.js
@@ -28,7 +28,7 @@ Sentry.init({
             moduleMetadataEntries.push(frame.module_metadata);
           });
         });
-      } catch (e) {
+      } catch {
         // noop
       }
     }

--- a/dev-packages/browser-integration-tests/utils/helpers.ts
+++ b/dev-packages/browser-integration-tests/utils/helpers.ts
@@ -23,7 +23,7 @@ export const envelopeParser = (request: Request | null): unknown[] => {
   return envelope.split('\n').map(line => {
     try {
       return JSON.parse(line);
-    } catch (error) {
+    } catch {
       return line;
     }
   });
@@ -172,7 +172,7 @@ export async function runScriptInSandbox(
 ): Promise<void> {
   try {
     await page.addScriptTag({ path: impl.path, content: impl.content });
-  } catch (e) {
+  } catch {
     // no-op
   }
 }

--- a/dev-packages/e2e-tests/test-applications/ember-classic/app/controllers/index.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/app/controllers/index.ts
@@ -22,7 +22,7 @@ export default class IndexController extends Controller {
   public createCaughtEmberError(): void {
     try {
       throw new Error('Looks like you have a caught EmberError');
-    } catch (e) {
+    } catch {
       // do nothing
     }
   }

--- a/dev-packages/e2e-tests/test-applications/nextjs-13/pages/crashed-session-page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-13/pages/crashed-session-page.tsx
@@ -6,7 +6,7 @@ export default function CrashedPage() {
       // @ts-expect-error
       window.onerror(null, null, null, null, new Error('Crashed'));
     }
-  } catch (_e) {
+  } catch {
     // no-empty
   }
   return <h1>Crashed</h1>;

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/assert-build.ts
@@ -13,7 +13,7 @@ const getLatestNextVersion = async () => {
     const response = await fetch('https://registry.npmjs.org/next/latest');
     const data = await response.json();
     return data.version as string;
-  } catch (error) {
+  } catch {
     return '0.0.0';
   }
 };

--- a/dev-packages/node-core-integration-tests/scripts/clean.js
+++ b/dev-packages/node-core-integration-tests/scripts/clean.js
@@ -13,7 +13,7 @@ for (const path of paths) {
     // eslint-disable-next-line no-console
     console.log(`docker compose down @ ${path}`);
     execSync('docker compose down --volumes', { stdio: 'inherit', cwd: path });
-  } catch (_) {
+  } catch {
     //
   }
 }

--- a/dev-packages/node-core-integration-tests/utils/runner.ts
+++ b/dev-packages/node-core-integration-tests/utils/runner.ts
@@ -497,7 +497,7 @@ export function createRunner(...paths: string[]) {
             try {
               const envelope = JSON.parse(cleanedLine) as Envelope;
               newEnvelope(envelope);
-            } catch (_) {
+            } catch {
               //
             }
           }

--- a/dev-packages/node-integration-tests/scripts/clean.js
+++ b/dev-packages/node-integration-tests/scripts/clean.js
@@ -13,7 +13,7 @@ for (const path of paths) {
     // eslint-disable-next-line no-console
     console.log(`docker compose down @ ${path}`);
     execSync('docker compose down --volumes', { stdio: 'inherit', cwd: path });
-  } catch (_) {
+  } catch {
     //
   }
 }

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -506,7 +506,7 @@ export function createRunner(...paths: string[]) {
             try {
               const envelope = JSON.parse(cleanedLine) as Envelope;
               newEnvelope(envelope);
-            } catch (_) {
+            } catch {
               //
             }
           }

--- a/packages/angular/patch-vitest.ts
+++ b/packages/angular/patch-vitest.ts
@@ -85,7 +85,7 @@ function wrapTestInZone(testBody: string | any[] | undefined) {
       enumerable: false,
     });
     wrappedFunc.length = testBody.length;
-  } catch (e) {
+  } catch {
     return testBody.length === 0
       ? () => testProxyZone.run(testBody, null)
       : (done: any) => testProxyZone.run(testBody, null, [done]);

--- a/packages/aws-serverless/test/sdk.test.ts
+++ b/packages/aws-serverless/test/sdk.test.ts
@@ -265,7 +265,7 @@ describe('AWSLambda', () => {
 
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
-      } catch (e) {
+      } catch {
         const fakeTransactionContext = {
           name: 'functionName',
           op: 'function.aws.lambda',
@@ -376,7 +376,7 @@ describe('AWSLambda', () => {
 
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
-      } catch (e) {
+      } catch {
         const fakeTransactionContext = {
           name: 'functionName',
           op: 'function.aws.lambda',
@@ -458,7 +458,7 @@ describe('AWSLambda', () => {
 
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
-      } catch (e) {
+      } catch {
         const fakeTransactionContext = {
           name: 'functionName',
           op: 'function.aws.lambda',
@@ -489,7 +489,7 @@ describe('AWSLambda', () => {
 
     try {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
-    } catch (e) {
+    } catch {
       expect(mockCaptureException).toBeCalledWith(error, expect.any(Function));
 
       const scopeFunction = mockCaptureException.mock.calls[0][1];

--- a/packages/browser-utils/src/instrument/dom.ts
+++ b/packages/browser-utils/src/instrument/dom.ts
@@ -86,7 +86,7 @@ export function instrumentDOM(): void {
             }
 
             handlerForType.refCount++;
-          } catch (e) {
+          } catch {
             // Accessing dom properties is always fragile.
             // Also allows us to skip `addEventListeners` calls with no proper `this` context.
           }
@@ -120,7 +120,7 @@ export function instrumentDOM(): void {
                   delete this.__sentry_instrumentation_handlers__;
                 }
               }
-            } catch (e) {
+            } catch {
               // Accessing dom properties is always fragile.
               // Also allows us to skip `addEventListeners` calls with no proper `this` context.
             }
@@ -148,7 +148,7 @@ function isSimilarToLastCapturedEvent(event: Event): boolean {
     if (!event.target || (event.target as SentryWrappedTarget)._sentryId !== lastCapturedEventTargetId) {
       return false;
     }
-  } catch (e) {
+  } catch {
     // just accessing `target` property can throw an exception in some rare circumstances
     // see: https://github.com/getsentry/sentry-javascript/issues/838
   }
@@ -236,7 +236,7 @@ function makeDOMEventHandler(
 function getEventTarget(event: Event): SentryWrappedTarget | null {
   try {
     return event.target as SentryWrappedTarget | null;
-  } catch (e) {
+  } catch {
     // just accessing `target` property can throw an exception in some rare circumstances
     // see: https://github.com/getsentry/sentry-javascript/issues/838
     return null;

--- a/packages/browser-utils/src/instrument/xhr.ts
+++ b/packages/browser-utils/src/instrument/xhr.ts
@@ -79,7 +79,7 @@ export function instrumentXHR(): void {
             // touching statusCode in some platforms throws
             // an exception
             xhrInfo.status_code = xhrOpenThisArg.status;
-          } catch (e) {
+          } catch {
             /* do nothing */
           }
 

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -120,7 +120,7 @@ function parseStackFrames(
 
   try {
     return stackParser(stacktrace, skipLines, framesToPop);
-  } catch (e) {
+  } catch {
     // no-empty
   }
 
@@ -392,7 +392,7 @@ function getObjectClassName(obj: unknown): string | undefined | void {
   try {
     const prototype: Prototype | null = Object.getPrototypeOf(obj);
     return prototype ? prototype.constructor.name : undefined;
-  } catch (e) {
+  } catch {
     // ignore errors here
   }
 }

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -96,7 +96,7 @@ export function wrap<T extends WrappableFunction, NonFunction>(
     if (getOriginalFunction(fn)) {
       return fn;
     }
-  } catch (e) {
+  } catch {
     // Just accessing custom props in some Selenium environments
     // can cause a "Permission denied" exception (see raven-js#495).
     // Bail on wrapping and return the function as-is (defers to window.onerror).

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -159,7 +159,7 @@ function _getDomBreadcrumbHandler(
 
       target = htmlTreeAsString(element, { keyAttrs, maxStringLength });
       componentName = getComponentName(element);
-    } catch (e) {
+    } catch {
       target = '<unknown>';
     }
 

--- a/packages/browser/src/integrations/browserapierrors.ts
+++ b/packages/browser/src/integrations/browserapierrors.ts
@@ -256,7 +256,7 @@ function _wrapEventTarget(target: string, integrationOptions: BrowserApiErrorsOp
         if (originalEventHandler) {
           originalRemoveEventListener.call(this, eventName, originalEventHandler, options);
         }
-      } catch (e) {
+      } catch {
         // ignore, accessing __sentry_wrapped__ will throw in some Selenium environments
       }
       return originalRemoveEventListener.call(this, eventName, fn, options);

--- a/packages/browser/src/tracing/linkedTraces.ts
+++ b/packages/browser/src/tracing/linkedTraces.ts
@@ -226,7 +226,7 @@ export function getPreviousTraceFromSessionStorage(): PreviousTraceInfo | undefi
     const previousTraceInfo = WINDOW.sessionStorage?.getItem(PREVIOUS_TRACE_KEY);
     // @ts-expect-error - intentionally risking JSON.parse throwing when previousTraceInfo is null to save bundle size
     return JSON.parse(previousTraceInfo);
-  } catch (e) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -277,7 +277,7 @@ export function shouldAttachHeaders(
     try {
       resolvedUrl = new URL(targetUrl, href);
       currentOrigin = new URL(href).origin;
-    } catch (e) {
+    } catch {
       return false;
     }
 
@@ -413,7 +413,7 @@ function setHeaderOnXhr(
         xhr.setRequestHeader!('baggage', sentryBaggageHeader);
       }
     }
-  } catch (_) {
+  } catch {
     // Error: InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
   }
 }

--- a/packages/browser/src/transports/offline.ts
+++ b/packages/browser/src/transports/offline.ts
@@ -129,7 +129,7 @@ function createIndexedDbStore(options: BrowserOfflineTransportOptions): OfflineS
       try {
         const serialized = await serializeEnvelope(env);
         await push(getStore(), serialized, options.maxQueueSize || 30);
-      } catch (_) {
+      } catch {
         //
       }
     },
@@ -137,7 +137,7 @@ function createIndexedDbStore(options: BrowserOfflineTransportOptions): OfflineS
       try {
         const serialized = await serializeEnvelope(env);
         await unshift(getStore(), serialized, options.maxQueueSize || 30);
-      } catch (_) {
+      } catch {
         //
       }
     },
@@ -147,7 +147,7 @@ function createIndexedDbStore(options: BrowserOfflineTransportOptions): OfflineS
         if (deserialized) {
           return parseEnvelope(deserialized);
         }
-      } catch (_) {
+      } catch {
         //
       }
 

--- a/packages/cloudflare/src/handler.ts
+++ b/packages/cloudflare/src/handler.ts
@@ -233,7 +233,7 @@ export function withSentry<Env = unknown, QueueHandlerMessage = unknown, CfHostM
     }
 
     // This is here because Miniflare sometimes cannot get instrumented
-  } catch (e) {
+  } catch {
     // Do not console anything here, we don't want to spam the console with errors
   }
 

--- a/packages/core/src/instrument/fetch.ts
+++ b/packages/core/src/instrument/fetch.ts
@@ -172,7 +172,7 @@ async function resolveResponse(res: Response | undefined, onFinishedResolving: (
           onFinishedResolving();
           readingActive = false;
         }
-      } catch (error) {
+      } catch {
         readingActive = false;
       } finally {
         clearTimeout(chunkTimeout);

--- a/packages/core/src/integrations/dedupe.ts
+++ b/packages/core/src/integrations/dedupe.ts
@@ -27,7 +27,7 @@ const _dedupeIntegration = (() => {
           DEBUG_BUILD && debug.warn('Event dropped due to being a duplicate of previously captured event.');
           return null;
         }
-      } catch (_oO) {} // eslint-disable-line no-empty
+      } catch {} // eslint-disable-line no-empty
 
       return (previousEvent = currentEvent);
     },
@@ -170,7 +170,7 @@ function _isSameFingerprint(currentEvent: Event, previousEvent: Event): boolean 
   // Otherwise, compare the two
   try {
     return !!(currentFingerprint.join('') === previousFingerprint.join(''));
-  } catch (_oO) {
+  } catch {
     return false;
   }
 }

--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -211,7 +211,7 @@ function _getEventFilterUrl(event: Event): string | null {
       .find(value => value.mechanism?.parent_id === undefined && value.stacktrace?.frames?.length);
     const frames = rootException?.stacktrace?.frames;
     return frames ? _getLastValidUrl(frames) : null;
-  } catch (oO) {
+  } catch {
     DEBUG_BUILD && debug.error(`Cannot extract url for event ${getEventDescription(event)}`);
     return null;
   }

--- a/packages/core/src/integrations/rewriteframes.ts
+++ b/packages/core/src/integrations/rewriteframes.ts
@@ -75,7 +75,7 @@ export const rewriteFramesIntegration = defineIntegration((options: RewriteFrame
           })),
         },
       };
-    } catch (_oO) {
+    } catch {
       return event;
     }
   }

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -72,7 +72,7 @@ export function addMetadataToStackFrames(parser: StackParser, event: Event): voi
         }
       }
     });
-  } catch (_) {
+  } catch {
     // To save bundle size we're just try catching here instead of checking for the existence of all the different objects.
   }
 }
@@ -92,7 +92,7 @@ export function stripMetadataFromStackFrames(event: Event): void {
         delete frame.module_metadata;
       }
     });
-  } catch (_) {
+  } catch {
     // To save bundle size we're just try catching here instead of checking for the existence of all the different objects.
   }
 }

--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -70,7 +70,7 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
           const rawRes = await getRawInput();
 
           trpcContext.input = normalize(rawRes);
-        } catch (err) {
+        } catch {
           // noop
         }
       }

--- a/packages/core/src/utils/browser.ts
+++ b/packages/core/src/utils/browser.ts
@@ -56,7 +56,7 @@ export function htmlTreeAsString(
     }
 
     return out.reverse().join(separator);
-  } catch (_oO) {
+  } catch {
     return '<unknown>';
   }
 }
@@ -134,7 +134,7 @@ function _htmlElementAsString(el: unknown, keyAttrs?: string[]): string {
 export function getLocationHref(): string {
   try {
     return WINDOW.document.location.href;
-  } catch (oO) {
+  } catch {
     return '';
   }
 }

--- a/packages/core/src/utils/cookie.ts
+++ b/packages/core/src/utils/cookie.ts
@@ -66,7 +66,7 @@ export function parseCookie(str: string): Record<string, string> {
 
       try {
         obj[key] = val.indexOf('%') !== -1 ? decodeURIComponent(val) : val;
-      } catch (e) {
+      } catch {
         obj[key] = val;
       }
     }

--- a/packages/core/src/utils/envelope.ts
+++ b/packages/core/src/utils/envelope.ts
@@ -112,7 +112,7 @@ export function serializeEnvelope(envelope: Envelope): string | Uint8Array {
       let stringifiedPayload: string;
       try {
         stringifiedPayload = JSON.stringify(payload);
-      } catch (e) {
+      } catch {
         // In case, despite all our efforts to keep `payload` circular-dependency-free, `JSON.stringify()` still
         // fails, we try again after normalizing it again with infinite normalization depth. This of course has a
         // performance impact but in this case a performance hit is better than throwing.

--- a/packages/core/src/utils/eventUtils.ts
+++ b/packages/core/src/utils/eventUtils.ts
@@ -19,7 +19,7 @@ export function getPossibleEventMessages(event: Event): string[] {
         possibleMessages.push(`${lastException.type}: ${lastException.value}`);
       }
     }
-  } catch (e) {
+  } catch {
     // ignore errors here
   }
 

--- a/packages/core/src/utils/eventbuilder.ts
+++ b/packages/core/src/utils/eventbuilder.ts
@@ -82,7 +82,7 @@ function getObjectClassName(obj: unknown): string | undefined | void {
   try {
     const prototype: unknown | null = Object.getPrototypeOf(obj);
     return prototype ? prototype.constructor.name : undefined;
-  } catch (e) {
+  } catch {
     // ignore errors here
   }
 }

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -182,7 +182,7 @@ export function isSyntheticEvent(wat: unknown): boolean {
 export function isInstanceOf(wat: any, base: any): boolean {
   try {
     return wat instanceof base;
-  } catch (_e) {
+  } catch {
     return false;
   }
 }

--- a/packages/core/src/utils/misc.ts
+++ b/packages/core/src/utils/misc.ts
@@ -222,7 +222,7 @@ export function checkOrSetAlreadyCaught(exception: unknown): boolean {
     // set it this way rather than by assignment so that it's not ennumerable and therefore isn't recorded by the
     // `ExtraErrorData` integration
     addNonEnumerableProperty(exception as { [key: string]: unknown }, '__sentry_captured__', true);
-  } catch (err) {
+  } catch {
     // `exception` is a primitive, so we can't mark it seen
   }
 

--- a/packages/core/src/utils/misc.ts
+++ b/packages/core/src/utils/misc.ts
@@ -45,7 +45,7 @@ export function uuid4(crypto = getCrypto()): string {
         return typedArray[0]!;
       };
     }
-  } catch (_) {
+  } catch {
     // some runtimes can crash invoking crypto
     // https://github.com/getsentry/sentry-javascript/issues/8935
   }

--- a/packages/core/src/utils/node.ts
+++ b/packages/core/src/utils/node.ts
@@ -50,7 +50,7 @@ export function loadModule<T>(moduleName: string, existingModule: any = module):
 
   try {
     mod = dynamicRequire(existingModule, moduleName);
-  } catch (e) {
+  } catch {
     // no-empty
   }
 
@@ -58,7 +58,7 @@ export function loadModule<T>(moduleName: string, existingModule: any = module):
     try {
       const { cwd } = dynamicRequire(existingModule, 'process');
       mod = dynamicRequire(existingModule, `${cwd()}/node_modules/${moduleName}`) as T;
-    } catch (e) {
+    } catch {
       // no-empty
     }
   }

--- a/packages/core/src/utils/normalize.ts
+++ b/packages/core/src/utils/normalize.ts
@@ -134,7 +134,7 @@ function visit(
       const jsonValue = valueWithToJSON.toJSON();
       // We need to normalize the return value of `.toJSON()` in case it has circular references
       return visit('', jsonValue, remainingDepth - 1, maxProperties, memo);
-    } catch (err) {
+    } catch {
       // pass (The built-in `toJSON` failed, but we can still try to do it ourselves)
     }
   }
@@ -296,7 +296,7 @@ export function normalizeUrlToBase(url: string, basePath: string): string {
   let newUrl = url;
   try {
     newUrl = decodeURI(url);
-  } catch (_Oo) {
+  } catch {
     // Sometime this breaks
   }
   return (

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -61,7 +61,7 @@ export function addNonEnumerableProperty(obj: object, name: string, value: unkno
       writable: true,
       configurable: true,
     });
-  } catch (o_O) {
+  } catch {
     DEBUG_BUILD && debug.log(`Failed to add non-enumerable property "${name}" to object`, obj);
   }
 }
@@ -78,7 +78,7 @@ export function markFunctionWrapped(wrapped: WrappedFunction, original: WrappedF
     const proto = original.prototype || {};
     wrapped.prototype = original.prototype = proto;
     addNonEnumerableProperty(wrapped, '__sentry_original__', original);
-  } catch (o_O) {} // eslint-disable-line no-empty
+  } catch {} // eslint-disable-line no-empty
 }
 
 /**
@@ -151,7 +151,7 @@ export function convertToPlainObject<V>(value: V):
 function serializeEventTarget(target: unknown): string {
   try {
     return isElement(target) ? htmlTreeAsString(target) : Object.prototype.toString.call(target);
-  } catch (_oO) {
+  } catch {
     return '<unknown>';
   }
 }

--- a/packages/core/src/utils/stacktrace.ts
+++ b/packages/core/src/utils/stacktrace.ts
@@ -133,7 +133,7 @@ export function getFunctionName(fn: unknown): string {
       return defaultFunctionName;
     }
     return fn.name || defaultFunctionName;
-  } catch (e) {
+  } catch {
     // Just accessing custom props in some Selenium environments
     // can cause a "Permission denied" exception (see raven-js#495).
     return defaultFunctionName;
@@ -158,7 +158,7 @@ export function getFramesFromEvent(event: Event): StackFrame[] | undefined {
         }
       });
       return frames;
-    } catch (_oO) {
+    } catch {
       return undefined;
     }
   }

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -85,7 +85,7 @@ export function safeJoin(input: unknown[], delimiter?: string): string {
       } else {
         output.push(String(value));
       }
-    } catch (e) {
+    } catch {
       output.push('[value cannot be serialized]');
     }
   }

--- a/packages/core/src/utils/supports.ts
+++ b/packages/core/src/utils/supports.ts
@@ -16,7 +16,7 @@ export function supportsErrorEvent(): boolean {
   try {
     new ErrorEvent('');
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }
@@ -34,7 +34,7 @@ export function supportsDOMError(): boolean {
     // @ts-expect-error It really needs 1 argument, not 0.
     new DOMError('');
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }
@@ -49,7 +49,7 @@ export function supportsDOMException(): boolean {
   try {
     new DOMException('');
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }
@@ -83,7 +83,7 @@ function _isFetchSupported(): boolean {
     new Request('http://www.example.com');
     new Response();
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }
@@ -172,7 +172,7 @@ export function supportsReferrerPolicy(): boolean {
       referrerPolicy: 'origin' as ReferrerPolicy,
     });
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -94,7 +94,7 @@ describe('startSpan', () => {
         await startSpan({ name: 'GET users/[id]' }, () => {
           return callback();
         });
-      } catch (e) {
+      } catch {
         //
       }
       expect(_span).toBeDefined();
@@ -113,7 +113,7 @@ describe('startSpan', () => {
           span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'http.server');
           return callback();
         });
-      } catch (e) {
+      } catch {
         //
       }
 
@@ -133,7 +133,7 @@ describe('startSpan', () => {
             return callback();
           });
         });
-      } catch (e) {
+      } catch {
         //
       }
 
@@ -160,7 +160,7 @@ describe('startSpan', () => {
             return callback();
           });
         });
-      } catch (e) {
+      } catch {
         //
       }
 
@@ -186,7 +186,7 @@ describe('startSpan', () => {
             return callback();
           },
         );
-      } catch (e) {
+      } catch {
         //
       }
 

--- a/packages/core/test/lib/utils/promisebuffer.test.ts
+++ b/packages/core/test/lib/utils/promisebuffer.test.ts
@@ -74,7 +74,7 @@ describe('PromiseBuffer', () => {
     expect(buffer.$.length).toEqual(1);
     try {
       await task;
-    } catch (_) {
+    } catch {
       // no-empty
     }
     expect(buffer.$.length).toEqual(0);

--- a/packages/core/test/testutils.ts
+++ b/packages/core/test/testutils.ts
@@ -10,7 +10,7 @@ export const testOnlyIfNodeVersionAtLeast = (minVersion: number): Function => {
     if (Number(currentNodeVersion?.split('.')[0]) < minVersion) {
       return it.skip;
     }
-  } catch (oO) {
+  } catch {
     // we can't tell, so err on the side of running the test
   }
 

--- a/packages/deno/scripts/install-deno.mjs
+++ b/packages/deno/scripts/install-deno.mjs
@@ -4,7 +4,7 @@ import { download } from './download.mjs';
 
 try {
   execSync('deno --version', { stdio: 'inherit' });
-} catch (_) {
+} catch {
   // eslint-disable-next-line no-console
   console.error('Deno is not installed. Installing...');
   if (process.platform === 'win32') {

--- a/packages/deno/src/integrations/contextlines.ts
+++ b/packages/deno/src/integrations/contextlines.ts
@@ -28,7 +28,7 @@ async function readSourceFile(filename: string): Promise<string | null> {
   let content: string | null = null;
   try {
     content = await Deno.readTextFile(filename);
-  } catch (_) {
+  } catch {
     //
   }
 
@@ -102,7 +102,7 @@ async function addSourceContextToFrames(frames: StackFrame[], contextLines: numb
           try {
             const lines = sourceFile.split('\n');
             addContextToFrame(lines, frame, contextLines);
-          } catch (_) {
+          } catch {
             // anomaly, being defensive in case
             // unlikely to ever happen in practice but can definitely happen in theory
           }

--- a/packages/deno/src/integrations/globalhandlers.ts
+++ b/packages/deno/src/integrations/globalhandlers.ts
@@ -96,7 +96,7 @@ function installGlobalUnhandledRejectionHandler(client: Client): void {
       if ('reason' in e) {
         error = e.reason;
       }
-    } catch (_oO) {
+    } catch {
       // no-empty
     }
 

--- a/packages/deno/src/integrations/normalizepaths.ts
+++ b/packages/deno/src/integrations/normalizepaths.ts
@@ -54,7 +54,7 @@ function getCwd(): string | undefined {
     if (permission.state == 'granted') {
       return Deno.cwd();
     }
-  } catch (_) {
+  } catch {
     //
   }
 

--- a/packages/ember/tests/dummy/app/controllers/index.ts
+++ b/packages/ember/tests/dummy/app/controllers/index.ts
@@ -22,7 +22,7 @@ export default class IndexController extends Controller {
   public createCaughtEmberError(): void {
     try {
       throw new Error('Looks like you have a caught EmberError');
-    } catch (e) {
+    } catch {
       // do nothing
     }
   }

--- a/packages/eslint-config-sdk/src/base.js
+++ b/packages/eslint-config-sdk/src/base.js
@@ -11,6 +11,10 @@ module.exports = {
       rules: {
         'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       },
+      parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 2020,
+      },
     },
     {
       // Configuration for typescript files
@@ -185,7 +189,7 @@ module.exports = {
       files: ['*.config.js', '*.config.mjs'],
       parserOptions: {
         sourceType: 'module',
-        ecmaVersion: 2018,
+        ecmaVersion: 2020,
       },
     },
     {

--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -68,7 +68,7 @@ exports.onCreateWebpackConfig = ({ getConfig, actions }, options) => {
   let configFile = null;
   try {
     configFile = SENTRY_USER_CONFIG.find(file => fs.existsSync(file));
-  } catch (error) {
+  } catch {
     // Some node versions (like v11) throw an exception on `existsSync` instead of
     // returning false. See https://github.com/tschaub/mock-fs/issues/256
   }

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -39,7 +39,7 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
               if (frameOrigin === windowOrigin) {
                 frame.filename = frame.filename?.replace(frameOrigin, 'app://').replace(basePath, '');
               }
-            } catch (err) {
+            } catch {
               // Filename wasn't a properly formed URL, so there's nothing we can do
             }
           }
@@ -47,7 +47,7 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
           try {
             const { origin } = new URL(frame.filename as string);
             frame.filename = frame.filename?.replace(origin, 'app://').replace(rewriteFramesAssetPrefixPath, '');
-          } catch (err) {
+          } catch {
             // Filename wasn't a properly formed URL, so there's nothing we can do
           }
         }

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -81,7 +81,7 @@ export function init(options: BrowserOptions): Client | undefined {
     if (process.turbopack) {
       getGlobalScope().setTag('turbopack', true);
     }
-  } catch (e) {
+  } catch {
     // Noop
     // The statement above can throw because process is not defined on the client
   }

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -69,7 +69,7 @@ function extractNextDataTagInformation(): NextDataTagInfo {
   if (nextDataTag?.innerHTML) {
     try {
       nextData = JSON.parse(nextDataTag.innerHTML);
-    } catch (e) {
+    } catch {
       DEBUG_BUILD && logger.warn('Could not extract __NEXT_DATA__');
     }
   }

--- a/packages/nextjs/src/client/routing/parameterization.ts
+++ b/packages/nextjs/src/client/routing/parameterization.ts
@@ -98,7 +98,7 @@ function getManifest(): RouteManifest | null {
     cachedManifest = manifest;
     cachedManifestString = currentManifestString;
     return manifest;
-  } catch (error) {
+  } catch {
     // Something went wrong while parsing the manifest, so we'll fallback to no parameterization
     DEBUG_BUILD && logger.warn('Could not extract route manifest');
     return null;

--- a/packages/nextjs/src/common/devErrorSymbolicationEventProcessor.ts
+++ b/packages/nextjs/src/common/devErrorSymbolicationEventProcessor.ts
@@ -91,7 +91,7 @@ export async function devErrorSymbolicationEventProcessor(event: Event, hint: Ev
         );
       }
     }
-  } catch (e) {
+  } catch {
     return event;
   }
 

--- a/packages/nextjs/src/common/utils/urls.ts
+++ b/packages/nextjs/src/common/utils/urls.ts
@@ -91,7 +91,7 @@ export function extractSanitizedUrlFromRefererHeader(headersDict?: HeadersDict):
   try {
     const refererUrl = new URL(referer);
     return getSanitizedUrlStringFromUrlObject(refererUrl);
-  } catch (error) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -82,7 +82,7 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
       awaitedHeaders?.forEach((value, key) => {
         fullHeadersObject[key] = value;
       });
-    } catch (e) {
+    } catch {
       DEBUG_BUILD &&
         logger.warn(
           "Sentry wasn't able to extract the tracing headers for a server action. Will not trace this request.",

--- a/packages/nextjs/src/common/wrapGenerationFunctionWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGenerationFunctionWithSentry.ts
@@ -40,7 +40,7 @@ export function wrapGenerationFunctionWithSentry<F extends (...args: any[]) => a
       // We try-catch here just in case anything goes wrong with the async storage here goes wrong since it is Next.js internal API
       try {
         headers = requestAsyncStorage?.getStore()?.headers;
-      } catch (e) {
+      } catch {
         /** empty */
       }
 

--- a/packages/nextjs/src/config/templates/routeHandlerWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/routeHandlerWrapperTemplate.ts
@@ -43,7 +43,7 @@ function wrapHandler<T>(handler: T, method: 'GET' | 'POST' | 'PUT' | 'PATCH' | '
       try {
         const requestAsyncStore = requestAsyncStorage?.getStore() as ReturnType<RequestAsyncStorage['getStore']>;
         headers = requestAsyncStore?.headers;
-      } catch (e) {
+      } catch {
         /** empty */
       }
 

--- a/packages/nextjs/src/config/templates/serverComponentWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/serverComponentWrapperTemplate.ts
@@ -50,7 +50,7 @@ if (typeof serverComponent === 'function') {
         sentryTraceHeader = requestAsyncStore?.headers.get('sentry-trace') ?? undefined;
         baggageHeader = requestAsyncStore?.headers.get('baggage') ?? undefined;
         headers = requestAsyncStore?.headers;
-      } catch (e) {
+      } catch {
         /** empty */
       }
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -487,7 +487,7 @@ function getInstrumentationFile(projectDir: string, dotPrefixedExtensions: strin
   for (const pathSegments of paths) {
     try {
       return fs.readFileSync(path.resolve(projectDir, ...pathSegments), { encoding: 'utf-8' });
-    } catch (e) {
+    } catch {
       // no-op
     }
   }

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -470,7 +470,7 @@ function getGitRevision(): string | undefined {
       .execSync('git rev-parse HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
       .toString()
       .trim();
-  } catch (e) {
+  } catch {
     // noop
   }
   return gitRevision;

--- a/packages/node-core/src/integrations/anr/index.ts
+++ b/packages/node-core/src/integrations/anr/index.ts
@@ -231,7 +231,7 @@ async function _startWorker(
       const session = currentSession ? { ...currentSession, toJSON: undefined } : undefined;
       // message the worker to tell it the main event loop is still running
       worker.postMessage({ session, debugImages: getFilenameToDebugIdMap(initOptions.stackParser) });
-    } catch (_) {
+    } catch {
       //
     }
   }, options.pollInterval);

--- a/packages/node-core/src/integrations/anr/worker.ts
+++ b/packages/node-core/src/integrations/anr/worker.ts
@@ -62,7 +62,7 @@ async function sendAbnormalSession(): Promise<void> {
     try {
       // Notify the main process that the session has ended so the session can be cleared from the scope
       parentPort?.postMessage('session-ended');
-    } catch (_) {
+    } catch {
       // ignore
     }
   }
@@ -280,7 +280,7 @@ if (options.captureStackTrace) {
       session.post('Debugger.enable', () => {
         session.post('Debugger.pause');
       });
-    } catch (_) {
+    } catch {
       //
     }
   };

--- a/packages/node-core/src/integrations/context.ts
+++ b/packages/node-core/src/integrations/context.ts
@@ -192,7 +192,7 @@ function getCultureContext(): CultureContext | undefined {
         timezone: options.timeZone,
       };
     }
-  } catch (err) {
+  } catch {
     //
   }
 
@@ -228,7 +228,7 @@ export function getDeviceContext(deviceOpt: DeviceContextOptions | true): Device
   let uptime;
   try {
     uptime = os.uptime();
-  } catch (e) {
+  } catch {
     // noop
   }
 
@@ -347,7 +347,7 @@ async function getDarwinInfo(): Promise<OsContext> {
     darwinInfo.name = matchFirst(/^ProductName:\s+(.*)$/m, output);
     darwinInfo.version = matchFirst(/^ProductVersion:\s+(.*)$/m, output);
     darwinInfo.build = matchFirst(/^BuildVersion:\s+(.*)$/m, output);
-  } catch (e) {
+  } catch {
     // ignore
   }
 
@@ -402,7 +402,7 @@ async function getLinuxInfo(): Promise<OsContext> {
     // are computed in `LINUX_VERSIONS`.
     const id = getLinuxDistroId(linuxInfo.name);
     linuxInfo.version = LINUX_VERSIONS[id]?.(contents);
-  } catch (e) {
+  } catch {
     // ignore
   }
 

--- a/packages/node-core/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node-core/src/integrations/local-variables/local-variables-sync.ts
@@ -76,7 +76,7 @@ export function createCallbackList<T>(complete: Next<T>): CallbackWrapper<T> {
 
     try {
       popped(result);
-    } catch (_) {
+    } catch {
       // If there is an error, we still want to call the complete callback
       checkedComplete(result);
     }

--- a/packages/node-core/src/integrations/modules.ts
+++ b/packages/node-core/src/integrations/modules.ts
@@ -44,7 +44,7 @@ export const modulesIntegration = _modulesIntegration;
 function getRequireCachePaths(): string[] {
   try {
     return require.cache ? Object.keys(require.cache as Record<string, unknown>) : [];
-  } catch (e) {
+  } catch {
     return [];
   }
 }
@@ -96,7 +96,7 @@ function collectRequireModules(): ModuleInfo {
           version: string;
         };
         infos[info.name] = info.version;
-      } catch (_oO) {
+      } catch {
         // no-empty
       }
     };
@@ -126,7 +126,7 @@ function getPackageJson(): PackageJson {
     const packageJson = JSON.parse(readFileSync(filePath, 'utf8')) as PackageJson;
 
     return packageJson;
-  } catch (e) {
+  } catch {
     return {};
   }
 }

--- a/packages/node-core/src/utils/debug.ts
+++ b/packages/node-core/src/utils/debug.ts
@@ -9,7 +9,7 @@ export async function isDebuggerEnabled(): Promise<boolean> {
       // Node can be built without inspector support
       const inspector = await import('node:inspector');
       cachedDebuggerEnabled = !!inspector.url();
-    } catch (_) {
+    } catch {
       cachedDebuggerEnabled = false;
     }
   }

--- a/packages/node-native/src/event-loop-block-integration.ts
+++ b/packages/node-native/src/event-loop-block-integration.ts
@@ -48,7 +48,7 @@ function poll(enabled: boolean, clientOptions: ClientOptions): void {
     const session = currentSession ? { ...currentSession, toJSON: undefined } : undefined;
     // message the worker to tell it the main event loop is still running
     threadPoll({ session, debugImages: getFilenameToDebugIdMap(clientOptions.stackParser) }, !enabled);
-  } catch (_) {
+  } catch {
     // we ignore all errors
   }
 }

--- a/packages/node/src/integrations/tracing/express-v5/utils.ts
+++ b/packages/node/src/integrations/tracing/express-v5/utils.ts
@@ -146,7 +146,7 @@ export const isLayerIgnored = (
         return true;
       }
     }
-  } catch (e) {
+  } catch {
     /* catch block */
   }
 

--- a/packages/node/src/utils/redisCache.ts
+++ b/packages/node/src/utils/redisCache.ts
@@ -53,7 +53,7 @@ export function getCacheKeySafely(redisCommand: string, cmdArgs: IORedisCommandA
     }
 
     return flatten(cmdArgs.map(arg => processArg(arg)));
-  } catch (e) {
+  } catch {
     return undefined;
   }
 }
@@ -82,7 +82,7 @@ export function calculateCacheItemSize(response: unknown): number | undefined {
       else if (typeof value === 'number') return value.toString().length;
       else if (value === null || value === undefined) return 0;
       return JSON.stringify(value).length;
-    } catch (e) {
+    } catch {
       return undefined;
     }
   };

--- a/packages/react-router/src/server/instrumentation/reactRouter.ts
+++ b/packages/react-router/src/server/instrumentation/reactRouter.ts
@@ -67,7 +67,7 @@ export class ReactRouterInstrumentation extends InstrumentationBase<Instrumentat
               let url: URL;
               try {
                 url = new URL(request.url);
-              } catch (error) {
+              } catch {
                 return originalRequestHandler(request, initialContext);
               }
 

--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -106,7 +106,7 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
                 { filename: 'redux_state.json', data: JSON.stringify(event.contexts.state.state.value) },
               ];
             }
-          } catch (_) {
+          } catch {
             // empty
           }
           return event;

--- a/packages/remix/src/server/errors.ts
+++ b/packages/remix/src/server/errors.ts
@@ -54,7 +54,7 @@ export async function captureRemixServerException(err: unknown, name: string, re
 
   try {
     normalizedRequest = winterCGRequestToRequestData(request);
-  } catch (e) {
+  } catch {
     DEBUG_BUILD && debug.warn('Failed to normalize Remix request');
   }
 

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -288,7 +288,7 @@ function wrapRequestHandler<T extends ServerBuild | (() => ServerBuild | Promise
 
       try {
         normalizedRequest = winterCGRequestToRequestData(request);
-      } catch (e) {
+      } catch {
         DEBUG_BUILD && debug.warn('Failed to normalize Remix request');
       }
 

--- a/packages/remix/test/integration/test/client/utils/helpers.ts
+++ b/packages/remix/test/integration/test/client/utils/helpers.ts
@@ -172,7 +172,7 @@ export async function runScriptInSandbox(
 ): Promise<void> {
   try {
     await page.addScriptTag({ path: impl.path, content: impl.content });
-  } catch (e) {
+  } catch {
     // no-op
   }
 }

--- a/packages/replay-canvas/src/canvas.ts
+++ b/packages/replay-canvas/src/canvas.ts
@@ -94,7 +94,7 @@ export const _replayCanvasIntegration = ((options: Partial<ReplayCanvasOptions> 
                 if (typeof err === 'object') {
                   (err as Error & { __rrweb__?: boolean }).__rrweb__ = true;
                 }
-              } catch (error) {
+              } catch {
                 // ignore errors here
                 // this can happen if the error is frozen or does not allow mutation for other reasons
               }

--- a/packages/replay-internal/src/coreHandlers/handleDom.ts
+++ b/packages/replay-internal/src/coreHandlers/handleDom.ts
@@ -98,7 +98,7 @@ function getDomTarget(handlerData: HandlerDataDom): { target: Node | null; messa
   try {
     target = isClick ? getClickTargetNode(handlerData.event as Event) : getTargetNode(handlerData.event as Event);
     message = htmlTreeAsString(target, { maxStringLength: 200 }) || '<unknown>';
-  } catch (e) {
+  } catch {
     message = '<unknown>';
   }
 

--- a/packages/replay-internal/src/coreHandlers/util/onWindowOpen.ts
+++ b/packages/replay-internal/src/coreHandlers/util/onWindowOpen.ts
@@ -32,7 +32,7 @@ function monkeyPatchWindowOpen(): void {
       if (handlers) {
         try {
           handlers.forEach(handler => handler());
-        } catch (e) {
+        } catch {
           // ignore errors in here
         }
       }

--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -145,7 +145,7 @@ export class Replay implements Integration {
       errorHandler: (err: Error & { __rrweb__?: boolean }) => {
         try {
           err.__rrweb__ = true;
-        } catch (error) {
+        } catch {
           // ignore errors here
           // this can happen if the error is frozen or does not allow mutation for other reasons
         }

--- a/packages/replay-internal/src/util/addMemoryEntry.ts
+++ b/packages/replay-internal/src/util/addMemoryEntry.ts
@@ -23,7 +23,7 @@ export async function addMemoryEntry(replay: ReplayContainer): Promise<Array<Add
         createMemoryEntry(WINDOW.performance.memory),
       ]),
     );
-  } catch (error) {
+  } catch {
     // Do nothing
     return [];
   }

--- a/packages/replay-internal/src/util/rrweb.ts
+++ b/packages/replay-internal/src/util/rrweb.ts
@@ -12,7 +12,7 @@ export function closestElementOfNode(node: Node | null): HTMLElement | null {
   try {
     const el: HTMLElement | null = node.nodeType === node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement;
     return el;
-  } catch (error) {
+  } catch {
     return null;
   }
 }

--- a/packages/replay-worker/examples/worker.js
+++ b/packages/replay-worker/examples/worker.js
@@ -729,7 +729,7 @@ var te = typeof TextEncoder != 'undefined' && /*#__PURE__*/ new TextEncoder();
 var td = typeof TextDecoder != 'undefined' && /*#__PURE__*/ new TextDecoder();
 try {
   td.decode(et, { stream: true });
-} catch (e) {}
+} catch {}
 /**
  * Streaming UTF-8 encoding
  */

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -330,7 +330,7 @@ export async function makeCustomSentryVitePlugins(options?: CustomSentryVitePlug
         // Not pretty but my testing shows that it works.
         // @ts-expect-error - this hook exists on the plugin!
         await sentryViteDebugIdUploadPlugin.writeBundle({ dir: outDir });
-      } catch (_) {
+      } catch {
         // eslint-disable-next-line no-console
         console.warn('[Source Maps Plugin] Failed to upload source maps!');
         // eslint-disable-next-line no-console
@@ -464,7 +464,7 @@ function detectSentryRelease(): string {
       .execSync('git rev-parse HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
       .toString()
       .trim();
-  } catch (_) {
+  } catch {
     // the command can throw for various reasons. Most importantly:
     // - git is not installed
     // - there is no git repo or no commit yet

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -107,7 +107,7 @@ async function getNodeAdapterOutputDir(svelteConfig: Config): Promise<string> {
 
   try {
     await nodeAdapter.adapt(adapterBuilder);
-  } catch (_) {
+  } catch {
     // We expect the adapter to throw in writeClient!
   }
 

--- a/packages/sveltekit/test/server-common/handle.test.ts
+++ b/packages/sveltekit/test/server-common/handle.test.ts
@@ -133,7 +133,7 @@ describe('sentryHandle', () => {
 
       try {
         await sentryHandle()({ event: mockEvent(), resolve: resolve(type, isError) });
-      } catch (e) {
+      } catch {
         //
       }
 
@@ -172,7 +172,7 @@ describe('sentryHandle', () => {
             return mockResponse;
           },
         });
-      } catch (e) {
+      } catch {
         //
       }
 
@@ -275,7 +275,7 @@ describe('sentryHandle', () => {
 
       try {
         await sentryHandle()({ event, resolve: resolve(type, isError) });
-      } catch (e) {
+      } catch {
         //
       }
 
@@ -305,7 +305,7 @@ describe('sentryHandle', () => {
     it("doesn't send redirects in a request handler to Sentry", async () => {
       try {
         await sentryHandle()({ event: mockEvent(), resolve: resolve(type, false, 'redirect') });
-      } catch (e) {
+      } catch {
         expect(mockCaptureException).toBeCalledTimes(0);
       }
     });
@@ -313,7 +313,7 @@ describe('sentryHandle', () => {
     it("doesn't send Http 4xx errors in a request handler to Sentry", async () => {
       try {
         await sentryHandle()({ event: mockEvent(), resolve: resolve(type, false, 'http') });
-      } catch (e) {
+      } catch {
         expect(mockCaptureException).toBeCalledTimes(0);
       }
     });

--- a/packages/sveltekit/test/server-common/handle.test.ts
+++ b/packages/sveltekit/test/server-common/handle.test.ts
@@ -226,7 +226,7 @@ describe('sentryHandle', () => {
 
       try {
         await sentryHandle()({ event, resolve: resolve(type, isError) });
-      } catch (e) {
+      } catch {
         //
       }
 

--- a/packages/vue/src/pinia.ts
+++ b/packages/vue/src/pinia.ts
@@ -70,7 +70,7 @@ export const createSentryPiniaPlugin: (
               },
             ];
           }
-        } catch (_) {
+        } catch {
           // empty
         }
 

--- a/scripts/normalize-e2e-test-dump-transaction-events.js
+++ b/scripts/normalize-e2e-test-dump-transaction-events.js
@@ -25,7 +25,7 @@ glob.glob(
         let envelope;
         try {
           envelope = JSON.parse(serializedEnvelope);
-        } catch (e) {
+        } catch {
           return;
           // noop
         }


### PR DESCRIPTION
Instead, we can just use the parameter-less version of try-catch. In future versions of eslint, this will be disallowed, so extracting this out.