### PR TITLE
ref(google-cloud-serverless): Use `debug` instead of `logger`

### DIFF
--- a/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
@@ -1,6 +1,6 @@
 import {
+  debug,
   handleCallbackErrors,
-  logger,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
@@ -56,7 +56,7 @@ function _wrapCloudEventFunction(
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           flush(options.flushTimeout)
             .then(null, e => {
-              DEBUG_BUILD && logger.error(e);
+              DEBUG_BUILD && debug.error(e);
             })
             .then(() => {
               if (typeof callback === 'function') {

--- a/packages/google-cloud-serverless/src/gcpfunction/events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/events.ts
@@ -1,6 +1,6 @@
 import {
+  debug,
   handleCallbackErrors,
-  logger,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
@@ -59,7 +59,7 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           flush(options.flushTimeout)
             .then(null, e => {
-              DEBUG_BUILD && logger.error(e);
+              DEBUG_BUILD && debug.error(e);
             })
             .then(() => {
               if (typeof callback === 'function') {

--- a/packages/google-cloud-serverless/src/gcpfunction/http.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/http.ts
@@ -1,8 +1,8 @@
 import {
+  debug,
   handleCallbackErrors,
   httpRequestToRequestData,
   isString,
-  logger,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setHttpStatus,
@@ -68,7 +68,7 @@ function _wrapHttpFunction(fn: HttpFunction, options: Partial<WrapperOptions>): 
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             flush(flushTimeout)
               .then(null, e => {
-                DEBUG_BUILD && logger.error(e);
+                DEBUG_BUILD && debug.error(e);
               })
               .then(() => {
                 _end.call(this, chunk, encoding, cb);


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/16948