### PR TITLE
feat: Avoid usage of `any`

### DIFF
--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -109,11 +109,10 @@ export function instrumentFetchRequest(
   spans[span.spanContext().spanId] = span;
 
   if (shouldAttachHeaders(handlerData.fetchData.url)) {
-    const request: string | Request = handlerData.args[0];
-
     // Shallow clone the options object to avoid mutating the original user-provided object
     // Examples: users re-using same options object for multiple fetch calls, frozen objects
-    const options: { [key: string]: unknown } = { ...(handlerData.args[1] || {}) };
+    const request = handlerData.args[0] as string | Request;
+    const options: Record<string, unknown> = { ...((handlerData.args[1] || {}) as Record<string, unknown>) };
 
     const headers = _addTracingHeadersToFetchRequest(
       request,

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -11,6 +11,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '
 import { setHttpStatus, SPAN_STATUS_ERROR, SPAN_STATUS_OK, startSpan } from '../tracing';
 import type { IntegrationFn } from '../types-hoist/integration';
 import { debug } from '../utils/debug-logger';
+import type { SpanAttributes } from '../types-hoist/span';
 import { isPlainObject } from '../utils/is';
 import { addExceptionMechanism } from '../utils/misc';
 
@@ -66,7 +67,8 @@ export const FILTER_MAPPINGS = {
   not: 'not',
 };
 
-export const DB_OPERATIONS_TO_INSTRUMENT = ['select', 'insert', 'upsert', 'update', 'delete'];
+export const DB_OPERATIONS_TO_INSTRUMENT = ['select', 'insert', 'upsert', 'update', 'delete'] as const;
+type DBOperation = (typeof DB_OPERATIONS_TO_INSTRUMENT)[number];
 
 type AuthOperationFn = (...args: unknown[]) => Promise<unknown>;
 type AuthOperationName = (typeof AUTH_OPERATIONS_TO_INSTRUMENT)[number];
@@ -88,7 +90,7 @@ export interface PostgRESTFilterBuilder {
   headers: Record<string, string>;
   url: URL;
   schema: string;
-  body: any;
+  body: unknown;
 }
 
 export interface SupabaseResponse {
@@ -124,7 +126,7 @@ export interface SupabaseClientConstructor {
 export interface PostgRESTProtoThenable {
   then: <T>(
     onfulfilled?: ((value: T) => T | PromiseLike<T>) | null,
-    onrejected?: ((reason: any) => T | PromiseLike<T>) | null,
+    onrejected?: ((reason: unknown) => T | PromiseLike<T>) | null,
   ) => Promise<T>;
 }
 
@@ -154,7 +156,7 @@ function isInstrumented<T>(fn: T): boolean | undefined {
  * @param headers - The request headers
  * @returns The database operation type ('select', 'insert', 'upsert', 'update', or 'delete')
  */
-export function extractOperation(method: string, headers: Record<string, string> = {}): string {
+export function extractOperation(method: string, headers: Record<string, string> = {}): DBOperation | '<unknown-op>' {
   switch (method) {
     case 'GET': {
       return 'select';
@@ -337,7 +339,7 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
         const typedThis = thisArg as PostgRESTFilterBuilder;
         const operation = extractOperation(typedThis.method, typedThis.headers);
 
-        if (!operations.includes(operation)) {
+        if (!operations.includes(operation as DBOperation)) {
           return Reflect.apply(target, thisArg, argumentsList);
         }
 
@@ -368,7 +370,7 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
           ' ',
         )} from(${table})`;
 
-        const attributes: Record<string, any> = {
+        const attributes: SpanAttributes = {
           'db.table': table,
           'db.schema': typedThis.schema,
           'db.url': typedThis.url.origin,
@@ -384,7 +386,11 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
         }
 
         if (Object.keys(body).length) {
-          attributes['db.body'] = body;
+          try {
+            attributes['db.body'] = JSON.stringify(body);
+          } catch {
+            // could not stringify body
+          }
         }
 
         return startSpan(
@@ -479,17 +485,19 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
   markAsInstrumented((PostgRESTFilterBuilder.prototype as unknown as PostgRESTProtoThenable).then);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type BuilderPrototype = Record<DBOperation, (...args: any[]) => any>;
+
 function instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder: new () => PostgRESTQueryBuilder): void {
   // We need to wrap _all_ operations despite them sharing the same `PostgRESTFilterBuilder`
   // constructor, as we don't know which method will be called first, and we don't want to miss any calls.
   for (const operation of DB_OPERATIONS_TO_INSTRUMENT) {
-    if (isInstrumented((PostgRESTQueryBuilder.prototype as Record<string, any>)[operation])) {
+    if (isInstrumented((PostgRESTQueryBuilder.prototype as BuilderPrototype)[operation])) {
       continue;
     }
 
-    type PostgRESTOperation = keyof Pick<PostgRESTQueryBuilder, 'select' | 'insert' | 'upsert' | 'update' | 'delete'>;
-    (PostgRESTQueryBuilder.prototype as Record<string, any>)[operation as PostgRESTOperation] = new Proxy(
-      (PostgRESTQueryBuilder.prototype as Record<string, any>)[operation as PostgRESTOperation],
+    (PostgRESTQueryBuilder.prototype as BuilderPrototype)[operation] = new Proxy(
+      (PostgRESTQueryBuilder.prototype as BuilderPrototype)[operation],
       {
         apply(target, thisArg, argumentsList) {
           const rv = Reflect.apply(target, thisArg, argumentsList);
@@ -504,7 +512,7 @@ function instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder: new () => PostgR
       },
     );
 
-    markAsInstrumented((PostgRESTQueryBuilder.prototype as Record<string, any>)[operation]);
+    markAsInstrumented((PostgRESTQueryBuilder.prototype as BuilderPrototype)[operation]);
   }
 }
 
@@ -531,6 +539,7 @@ const _supabaseIntegration = ((supabaseClient: unknown) => {
   };
 }) satisfies IntegrationFn;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const supabaseIntegration = defineIntegration((options: { supabaseClient: any }) => {
   return _supabaseIntegration(options.supabaseClient);
 }) satisfies IntegrationFn;

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -10,8 +10,8 @@ import { defineIntegration } from '../integration';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../semanticAttributes';
 import { setHttpStatus, SPAN_STATUS_ERROR, SPAN_STATUS_OK, startSpan } from '../tracing';
 import type { IntegrationFn } from '../types-hoist/integration';
-import { debug } from '../utils/debug-logger';
 import type { SpanAttributes } from '../types-hoist/span';
+import { debug } from '../utils/debug-logger';
 import { isPlainObject } from '../utils/is';
 import { addExceptionMechanism } from '../utils/misc';
 

--- a/packages/core/src/profiling.ts
+++ b/packages/core/src/profiling.ts
@@ -1,3 +1,4 @@
+import type { Client } from './client';
 import { getClient } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { Profiler, ProfilingIntegration } from './types-hoist/profiling';

--- a/packages/core/src/types-hoist/breadcrumb.ts
+++ b/packages/core/src/types-hoist/breadcrumb.ts
@@ -52,8 +52,10 @@ export interface Breadcrumb {
    *
    * @summary Arbitrary data associated with this breadcrumb.
    */
+  // Note: we cannot use Record<string, unknown> here because it's not compatible with interface data types
+  // See: https://github.com/microsoft/TypeScript/issues/15300
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: { [key: string]: any };
+  data?: Record<string, any>;
 
   /**
    * The format is a numeric (integer or float) value representing
@@ -71,6 +73,8 @@ export interface Breadcrumb {
 
 /** JSDoc */
 export interface BreadcrumbHint {
+  // Note: we cannot use unknown here because it's not compatible with interface data types
+  // See: https://github.com/microsoft/TypeScript/issues/15300
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -92,8 +96,7 @@ export interface XhrBreadcrumbData {
 }
 
 export interface FetchBreadcrumbHint {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  input: any[];
+  input: unknown[];
   data?: unknown;
   response?: unknown;
   startTimestamp: number;

--- a/packages/core/src/types-hoist/context.ts
+++ b/packages/core/src/types-hoist/context.ts
@@ -1,7 +1,7 @@
 import type { FeatureFlag } from '../utils/featureFlags';
 import type { SpanLinkJSON } from './link';
 import type { Primitive } from './misc';
-import type { SpanOrigin } from './span';
+import type { SpanAttributes, SpanOrigin } from './span';
 
 export type Context = Record<string, unknown>;
 
@@ -99,8 +99,7 @@ export interface ResponseContext extends Record<string, unknown> {
 }
 
 export interface TraceContext extends Record<string, unknown> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: { [key: string]: any };
+  data?: SpanAttributes;
   op?: string;
   parent_span_id?: string;
   span_id: string;

--- a/packages/core/src/types-hoist/error.ts
+++ b/packages/core/src/types-hoist/error.ts
@@ -2,7 +2,5 @@
  * Just an Error object with arbitrary attributes attached to it.
  */
 export interface ExtendedError extends Error {
-  // TODO: fix in v11, convert any to unknown
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: unknown;
 }

--- a/packages/core/src/types-hoist/event.ts
+++ b/packages/core/src/types-hoist/event.ts
@@ -83,7 +83,6 @@ export interface EventHint {
   syntheticException?: Error | null;
   originalException?: unknown;
   attachments?: Attachment[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: any;
+  data?: unknown;
   integrations?: string[];
 }

--- a/packages/core/src/types-hoist/feedback/config.ts
+++ b/packages/core/src/types-hoist/feedback/config.ts
@@ -1,4 +1,5 @@
 import type { Primitive } from '../misc';
+import type { User } from '../user';
 import type { FeedbackFormData } from './form';
 import type { FeedbackTheme } from './theme';
 
@@ -53,8 +54,8 @@ export interface FeedbackGeneralConfiguration {
    * The value of the email/name keys represent the properties of your user context.
    */
   useSentryUser: {
-    email: string;
-    name: string;
+    email: keyof User;
+    name: keyof User;
   };
 
   /**

--- a/packages/core/src/types-hoist/instrument.ts
+++ b/packages/core/src/types-hoist/instrument.ts
@@ -47,8 +47,7 @@ interface SentryFetchData {
 }
 
 export interface HandlerDataFetch {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: any[];
+  args: unknown[];
   fetchData: SentryFetchData; // This data is among other things dumped directly onto the fetch breadcrumb data
   startTimestamp: number;
   endTimestamp?: number;
@@ -75,8 +74,7 @@ export interface HandlerDataDom {
 
 export interface HandlerDataConsole {
   level: ConsoleLevel;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  args: any[];
+  args: unknown[];
 }
 
 export interface HandlerDataHistory {

--- a/packages/core/src/types-hoist/misc.ts
+++ b/packages/core/src/types-hoist/misc.ts
@@ -4,9 +4,7 @@ import type { QueryParams } from './request';
  * Data extracted from an incoming request to a node server
  */
 export interface ExtractedNodeRequestData {
-  // TODO: fix in v11, convert any to unknown
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: unknown;
 
   /** Specific headers from the request */
   headers?: { [key: string]: string };

--- a/packages/core/src/types-hoist/polymorphics.ts
+++ b/packages/core/src/types-hoist/polymorphics.ts
@@ -50,15 +50,13 @@ type NextjsRequest = NodeRequest & {
     [key: string]: string;
   };
   query?: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
+    [key: string]: unknown;
   };
 };
 
 type ExpressRequest = NodeRequest & {
   baseUrl?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  body?: string | { [key: string]: any };
+  body?: string | { [key: string]: unknown };
   host?: string;
   hostname?: string;
   ip?: string;
@@ -72,12 +70,10 @@ type ExpressRequest = NodeRequest & {
     ];
   };
   query?: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
+    [key: string]: unknown;
   };
   user?: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
+    [key: string]: unknown;
   };
   _reconstructedRoute?: string;
 };

--- a/packages/core/src/types-hoist/samplingcontext.ts
+++ b/packages/core/src/types-hoist/samplingcontext.ts
@@ -6,9 +6,7 @@ import type { SpanAttributes } from './span';
  * Context data passed by the user when starting a transaction, to be used by the tracesSampler method.
  */
 export interface CustomSamplingContext {
-  // TODO: fix in v11, convert any to unknown
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**

--- a/packages/core/src/types-hoist/stackframe.ts
+++ b/packages/core/src/types-hoist/stackframe.ts
@@ -13,11 +13,7 @@ export interface StackFrame {
   in_app?: boolean;
   instruction_addr?: string;
   addr_mode?: string;
-  // TODO: fix in v11, convert any to unknown
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  vars?: { [key: string]: any };
+  vars?: { [key: string]: unknown };
   debug_id?: string;
-  // TODO: fix in v11, convert any to unknown
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  module_metadata?: any;
+  module_metadata?: unknown;
 }

--- a/packages/core/src/types-hoist/user.ts
+++ b/packages/core/src/types-hoist/user.ts
@@ -2,9 +2,7 @@
  * An interface describing a user of an application or a handled request.
  */
 export interface User {
-  // TODO: fix in v11, convert any to unknown
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: unknown;
   id?: string | number;
   ip_address?: string | null;
   email?: string;

--- a/packages/core/src/utils/aggregate-errors.ts
+++ b/packages/core/src/utils/aggregate-errors.ts
@@ -55,16 +55,17 @@ function aggregateExceptionsFromError(
   let newExceptions = [...prevExceptions];
 
   // Recursively call this function in order to walk down a chain of errors
-  if (isInstanceOf(error[key], Error)) {
+  const errorValue = error[key];
+  if (isInstanceOf(errorValue, Error)) {
     applyExceptionGroupFieldsForParentException(exception, exceptionId);
-    const newException = exceptionFromErrorImplementation(parser, error[key] as Error);
+    const newException = exceptionFromErrorImplementation(parser, errorValue);
     const newExceptionId = newExceptions.length;
     applyExceptionGroupFieldsForChildException(newException, key, newExceptionId, exceptionId);
     newExceptions = aggregateExceptionsFromError(
       exceptionFromErrorImplementation,
       parser,
       limit,
-      error[key] as ExtendedError,
+      errorValue as ExtendedError,
       key,
       [newException, ...newExceptions],
       newException,
@@ -75,7 +76,7 @@ function aggregateExceptionsFromError(
   // This will create exception grouping for AggregateErrors
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
   if (Array.isArray(error.errors)) {
-    error.errors.forEach((childError, i) => {
+    error.errors.forEach((childError: unknown, i) => {
       if (isInstanceOf(childError, Error)) {
         applyExceptionGroupFieldsForParentException(exception, exceptionId);
         const newException = exceptionFromErrorImplementation(parser, childError as Error);

--- a/packages/core/src/utils/eventbuilder.ts
+++ b/packages/core/src/utils/eventbuilder.ts
@@ -156,7 +156,7 @@ export function eventFromUnknownInput(
   exception: unknown,
   hint?: EventHint,
 ): Event {
-  const providedMechanism: Mechanism | undefined = hint?.data && (hint.data as { mechanism: Mechanism }).mechanism;
+  const providedMechanism = (hint?.data as { mechanism?: Mechanism })?.mechanism;
   const mechanism: Mechanism = providedMechanism || {
     handled: true,
     type: 'generic',

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -180,9 +180,7 @@ export function isSyntheticEvent(wat: unknown): boolean {
  * @param base A constructor to be used in a check.
  * @returns A boolean representing the result.
  */
-// TODO: fix in v11, convert any to unknown
-// export function isInstanceOf<T>(wat: unknown, base: { new (...args: any[]): T }): wat is T {
-export function isInstanceOf<T>(wat: any, base: any): wat is T {
+export function isInstanceOf<T extends new (...args: any) => any>(wat: any, base: T): wat is InstanceType<T> {
   try {
     return wat instanceof base;
   } catch {

--- a/packages/eslint-config-sdk/src/base.js
+++ b/packages/eslint-config-sdk/src/base.js
@@ -113,6 +113,9 @@ module.exports = {
 
         // We do not care about empty functions
         '@typescript-eslint/no-empty-function': 'off',
+
+        // Disallow (instead of warn) for usage of any.
+        '@typescript-eslint/no-explicit-any': 'error',
       },
     },
     {

--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -63,14 +63,17 @@ export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
       const screenshotInput = screenshotIntegration?.createInput({ h, hooks, dialog, options });
 
       const renderContent = (open: boolean): void => {
+        const defaultName = user?.[userKey.name];
+        const defaultEmail = user?.[userKey.email];
+
         render(
           <Dialog
             options={options}
             screenshotInput={screenshotInput}
             showName={options.showName || options.isNameRequired}
             showEmail={options.showEmail || options.isEmailRequired}
-            defaultName={String((userKey && user?.[userKey.name]) || '')}
-            defaultEmail={String((userKey && user?.[userKey.email]) || '')}
+            defaultName={typeof defaultName === 'string' ? defaultName : ''}
+            defaultEmail={typeof defaultEmail === 'string' ? defaultEmail : ''}
             onFormClose={() => {
               renderContent(false);
               options.onFormClose?.();

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -157,7 +157,7 @@ export function init(options: VercelEdgeOptions = {}): void {
     if (
       event.type === 'transaction' &&
       event.contexts?.trace?.data?.['next.span_type'] === 'Middleware.execute' &&
-      event.contexts?.trace?.data?.['next.span_name']
+      typeof event.contexts?.trace?.data?.['next.span_name'] === 'string'
     ) {
       if (event.transaction) {
         // Older nextjs versions pass the full url appended to the middleware name, which results in high cardinality transaction names.

--- a/packages/node/src/integrations/tracing/fastify/types.ts
+++ b/packages/node/src/integrations/tracing/fastify/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 export type HandlerOriginal =
   | ((request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) => Promise<void>)
   | ((request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) => void);

--- a/packages/node/src/integrations/tracing/fastify/v3/types.ts
+++ b/packages/node/src/integrations/tracing/fastify/v3/types.ts
@@ -20,6 +20,7 @@ import type { Span } from '@opentelemetry/api';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
 export interface FastifyRequestInfo {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   request: any; // FastifyRequest object from fastify package
 }
 

--- a/packages/node/src/integrations/tracing/fastify/v3/utils.ts
+++ b/packages/node/src/integrations/tracing/fastify/v3/utils.ts
@@ -56,7 +56,7 @@ export function startSpan(
  * @param reply - reply function
  * @param err - error
  */
-export function endSpan(reply: PluginFastifyReply, err?: any) {
+export function endSpan(reply: PluginFastifyReply, err?: Error) {
   const spans = reply[spanRequestSymbol] || [];
   // there is no active span, or it has already ended
   if (!spans.length) {

--- a/packages/node/src/integrations/tracing/postgresjs.ts
+++ b/packages/node/src/integrations/tracing/postgresjs.ts
@@ -35,6 +35,9 @@ const INTEGRATION_NAME = 'PostgresJs';
 const SUPPORTED_VERSIONS = ['>=3.0.0 <4'];
 const SQL_OPERATION_REGEX = /^(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)/i;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ResolveRejectFunction = (...args: any[]) => any;
+
 type PostgresConnectionContext = {
   ATTR_DB_NAMESPACE?: string; // Database name
   ATTR_SERVER_ADDRESS?: string; // Hostname or IP address of the database server

--- a/packages/remix/src/utils/types.ts
+++ b/packages/remix/src/utils/types.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type SentryMetaArgs<MetaFN extends (...args: any[]) => any> = Parameters<MetaFN>[0] & {
+export type SentryMetaArgs<MetaFN extends (...args: any) => any> = Parameters<MetaFN>[0] & {
   data: {
     sentryTrace: string;
     sentryBaggage: string;

--- a/packages/remix/src/vendor/instrumentation.ts
+++ b/packages/remix/src/vendor/instrumentation.ts
@@ -1,8 +1,6 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable import/no-named-as-default-member */
-/* eslint-disable import/no-duplicates */
 
 // Vendored and modified from:
 // https://github.com/justindsmith/opentelemetry-instrumentations-js/blob/3b1e8c3e566e5cc3389e9c28cafce6a5ebb39600/packages/instrumentation-remix/src/instrumentation.ts

--- a/packages/replay-internal/src/coreHandlers/handleBreadcrumbs.ts
+++ b/packages/replay-internal/src/coreHandlers/handleBreadcrumbs.ts
@@ -33,9 +33,8 @@ function beforeAddBreadcrumb(replay: ReplayContainer, breadcrumb: Breadcrumb): v
 }
 
 /** Exported only for tests. */
-export function normalizeBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb | null {
+export function normalizeBreadcrumb(breadcrumb: Required<Pick<Breadcrumb, 'category'>>): Breadcrumb | null {
   if (
-    !isBreadcrumbWithCategory(breadcrumb) ||
     [
       // fetch & xhr are handled separately,in handleNetworkBreadcrumbs
       'fetch',

--- a/packages/replay-internal/src/coreHandlers/handleNetworkBreadcrumbs.ts
+++ b/packages/replay-internal/src/coreHandlers/handleNetworkBreadcrumbs.ts
@@ -92,9 +92,9 @@ function _isFetchBreadcrumb(breadcrumb: Breadcrumb): breadcrumb is Breadcrumb & 
 }
 
 function _isXhrHint(hint?: BreadcrumbHint): hint is XhrHint {
-  return hint?.xhr;
+  return !!hint?.xhr;
 }
 
 function _isFetchHint(hint?: BreadcrumbHint): hint is FetchHint {
-  return hint?.response;
+  return !!hint?.response;
 }

--- a/packages/replay-internal/test/unit/coreHandlers/handleBreadcrumbs.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleBreadcrumbs.test.ts
@@ -4,7 +4,7 @@ import { normalizeBreadcrumb, normalizeConsoleBreadcrumb } from '../../../src/co
 
 describe('Unit | coreHandlers | handleBreadcrumbs', () => {
   describe('normalizeBreadcrumb', () => {
-    it.each([undefined, 'ui.click', 'ui.scroll', 'fetch', 'xhr', 'sentry.event', 'sentry.transaction'])(
+    it.each(['ui.click', 'ui.scroll', 'fetch', 'xhr', 'sentry.event', 'sentry.transaction'])(
       'returns null if breadcrumb has category=%j',
       category => {
         const actual = normalizeBreadcrumb({ category });

--- a/packages/vue/src/pinia.ts
+++ b/packages/vue/src/pinia.ts
@@ -17,8 +17,7 @@ type SentryPiniaPluginOptions = {
   addBreadcrumbs: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   actionTransformer: (action: string) => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stateTransformer: (state: Record<string, unknown>) => any;
+  stateTransformer: (state: Record<string, unknown>) => Record<string, unknown>;
 };
 
 const DEFAULT_PINIA_PLUGIN_OPTIONS: SentryPiniaPluginOptions = {


### PR DESCRIPTION
This makes the lint rule error, instead of warn, and gets rid of some more any usage. Some of that may technically be breaking because the types can be exposed, but this should be very unlikely to affect any users.

In a future version of eslint, this is on by default, but IMHO it makes sense for us anyhow - any should only be used when absolutely necessary and when we make a conscious choice to do so.