### PR TITLE
fix(sveltekit): Ensure server errors from streamed responses are sent

### DIFF
--- a/packages/sveltekit/src/server-common/handleError.ts
+++ b/packages/sveltekit/src/server-common/handleError.ts
@@ -44,7 +44,7 @@ export function handleErrorWithSentry(handleError: HandleServerError = defaultEr
 
     const platform = input.event.platform as {
       context?: {
-        waitUntil?: (fn: () => Promise<void>) => void;
+        waitUntil?: (p: Promise<void>) => void;
       };
     };
 

--- a/packages/sveltekit/test/server-common/handleError.test.ts
+++ b/packages/sveltekit/test/server-common/handleError.test.ts
@@ -91,5 +91,29 @@ describe('handleError', () => {
       // Check that the default handler wasn't invoked
       expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
     });
+
+    it('calls waitUntil if available', async () => {
+      const wrappedHandleError = handleErrorWithSentry();
+      const mockError = new Error('test');
+      const waitUntilSpy = vi.fn();
+
+      await wrappedHandleError({
+        error: mockError,
+        event: {
+          ...requestEvent,
+          platform: {
+            context: {
+              waitUntil: waitUntilSpy,
+            },
+          },
+        },
+        status: 500,
+        message: 'Internal Error',
+      });
+
+      expect(waitUntilSpy).toHaveBeenCalledTimes(1);
+      // flush() returns a promise, this is what we expect here
+      expect(waitUntilSpy).toHaveBeenCalledWith(expect.any(Promise));
+    });
   });
 });


### PR DESCRIPTION
In SvelteKit, users can return a `Promise` from a `load` function which causes a streamed http respnse to be sent. If the promise rejects after it is returned and the initial response is sent, an error is thrown server-side. This error will not be captured by our request handler wrappers because at this time, they already finished.

However, the error will be caught via our `handleErrorWithSentry` hook. This means we actually still catch the error but because the cloudflare function already terminated directly after the rejection, it is not sent successfully (i.e. the good old flush problem). 

This PR makes sure we use of Cloudflare's `waitUntil` function which fortunately is available within the error handler hook. 

closes https://github.com/getsentry/sentry-javascript/issues/17009