### PR TITLE
test(react): Pin react-router version for e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/package.json
@@ -9,7 +9,7 @@
     "express": "4.20.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^7.2.0",
+    "react-router-dom": "7.6.0",
     "react-scripts": "5.0.1",
     "typescript": "~5.0.0"
   },


### PR DESCRIPTION
This E2E is _probably_ failing due to https://github.com/remix-run/react-router/issues/14020

The PR just pins the react-router version to unblock us