### PR TITLE
test(core): Add explicit tests for `tracesSampler` returning negative sampling decisions

### DIFF
--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  ClientOptions,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
@@ -660,30 +661,60 @@ describe('startSpan', () => {
     });
   });
 
-  it('samples with a tracesSampler', () => {
-    const tracesSampler = vi.fn(() => {
+  describe('uses tracesSampler if defined', () => {
+    const tracesSampler = vi.fn<() => boolean | number>(() => {
       return true;
     });
 
-    const options = getDefaultTestClientOptions({ tracesSampler });
-    client = new TestClient(options);
-    setCurrentClient(client);
-    client.init();
+    it.each([true, 1])('returns a positive sampling decision if tracesSampler returns %s', tracesSamplerResult => {
+      tracesSampler.mockReturnValueOnce(tracesSamplerResult);
 
-    startSpan({ name: 'outer', attributes: { test1: 'aa', test2: 'aa', test3: 'bb' } }, outerSpan => {
-      expect(outerSpan).toBeDefined();
+      const options = getDefaultTestClientOptions({ tracesSampler });
+      client = new TestClient(options);
+      setCurrentClient(client);
+      client.init();
+
+      startSpan({ name: 'outer', attributes: { test1: 'aa', test2: 'aa', test3: 'bb' } }, outerSpan => {
+        expect(outerSpan).toBeDefined();
+        expect(spanIsSampled(outerSpan)).toBe(true);
+      });
+
+      expect(tracesSampler).toBeCalledTimes(1);
+      expect(tracesSampler).toHaveBeenLastCalledWith({
+        parentSampled: undefined,
+        name: 'outer',
+        attributes: {
+          test1: 'aa',
+          test2: 'aa',
+          test3: 'bb',
+        },
+        inheritOrSampleWith: expect.any(Function),
+      });
     });
 
-    expect(tracesSampler).toBeCalledTimes(1);
-    expect(tracesSampler).toHaveBeenLastCalledWith({
-      parentSampled: undefined,
-      name: 'outer',
-      attributes: {
-        test1: 'aa',
-        test2: 'aa',
-        test3: 'bb',
-      },
-      inheritOrSampleWith: expect.any(Function),
+    it.each([false, 0])('returns a negative sampling decision if tracesSampler returns %s', tracesSamplerResult => {
+      tracesSampler.mockReturnValueOnce(tracesSamplerResult);
+
+      const options = getDefaultTestClientOptions({ tracesSampler });
+      client = new TestClient(options);
+      setCurrentClient(client);
+
+      startSpan({ name: 'outer', attributes: { test1: 'aa', test2: 'aa', test3: 'bb' } }, outerSpan => {
+        expect(outerSpan).toBeDefined();
+        expect(spanIsSampled(outerSpan)).toBe(false);
+      });
+
+      expect(tracesSampler).toBeCalledTimes(1);
+      expect(tracesSampler).toHaveBeenLastCalledWith({
+        parentSampled: undefined,
+        name: 'outer',
+        attributes: {
+          test1: 'aa',
+          test2: 'aa',
+          test3: 'bb',
+        },
+        inheritOrSampleWith: expect.any(Function),
+      });
     });
   });
 

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -699,7 +699,7 @@ describe('startSpan', () => {
       client = new TestClient(options);
       setCurrentClient(client);
 
-      startSpan({ name: 'outer', attributes: { test1: 'aa', test2: 'aa', test3: 'bb' } }, outerSpan => {
+      startSpan({ name: 'outer' }, outerSpan => {
         expect(outerSpan).toBeDefined();
         expect(spanIsSampled(outerSpan)).toBe(false);
       });
@@ -707,12 +707,8 @@ describe('startSpan', () => {
       expect(tracesSampler).toBeCalledTimes(1);
       expect(tracesSampler).toHaveBeenLastCalledWith({
         parentSampled: undefined,
+        attributes: {},
         name: 'outer',
-        attributes: {
-          test1: 'aa',
-          test2: 'aa',
-          test3: 'bb',
-        },
         inheritOrSampleWith: expect.any(Function),
       });
     });

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  ClientOptions,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -698,6 +698,7 @@ describe('startSpan', () => {
       const options = getDefaultTestClientOptions({ tracesSampler });
       client = new TestClient(options);
       setCurrentClient(client);
+      client.init();
 
       startSpan({ name: 'outer' }, outerSpan => {
         expect(outerSpan).toBeDefined();


### PR DESCRIPTION
This PR adds a couple of unit tests to explicitly test sampling behaviour of the core SDK's sampling logic when users pass in a `tracesSampler` function returning negative sampling values (i.e. `0`, `false`). 

According to coverage, this is tested implicitly already but I couldn't find specific explicit tests that assert on this expected outcome. Decided to add some while investigating https://github.com/getsentry/sentry-javascript/issues/16849.