### PR TITLE
ref(profiling): Improve generic profiling type

### DIFF
--- a/packages/core/src/profiling.ts
+++ b/packages/core/src/profiling.ts
@@ -4,8 +4,8 @@ import type { Profiler, ProfilingIntegration } from './types-hoist/profiling';
 import { debug } from './utils/debug-logger';
 
 function isProfilingIntegrationWithProfiler(
-  integration: ProfilingIntegration<any> | undefined,
-): integration is ProfilingIntegration<any> {
+  integration: ProfilingIntegration | undefined,
+): integration is ProfilingIntegration {
   return (
     !!integration &&
     typeof integration['_profiler'] !== 'undefined' &&
@@ -25,7 +25,7 @@ function startProfiler(): void {
     return;
   }
 
-  const integration = client.getIntegrationByName<ProfilingIntegration<any>>('ProfilingIntegration');
+  const integration = client.getIntegrationByName<ProfilingIntegration>('ProfilingIntegration');
 
   if (!integration) {
     DEBUG_BUILD && debug.warn('ProfilingIntegration is not available');
@@ -51,7 +51,7 @@ function stopProfiler(): void {
     return;
   }
 
-  const integration = client.getIntegrationByName<ProfilingIntegration<any>>('ProfilingIntegration');
+  const integration = client.getIntegrationByName<ProfilingIntegration>('ProfilingIntegration');
   if (!integration) {
     DEBUG_BUILD && debug.warn('ProfilingIntegration is not available');
     return;

--- a/packages/core/src/types-hoist/profiling.ts
+++ b/packages/core/src/types-hoist/profiling.ts
@@ -9,7 +9,7 @@ export interface ContinuousProfiler<T extends Client> {
   stop(): void;
 }
 
-export interface ProfilingIntegration<T extends Client> extends Integration {
+export interface ProfilingIntegration<T extends Client = Client> extends Integration {
   _profiler: ContinuousProfiler<T>;
 }
 


### PR DESCRIPTION
This allows us to avoid `any` here, and makes more sense overall IMHO.