### PR TITLE
ref: Remove `@typescript-eslint/no-empty-function` eslint rule

### DIFF
--- a/packages/cloudflare/src/opentelemetry/tracer.ts
+++ b/packages/cloudflare/src/opentelemetry/tracer.ts
@@ -71,8 +71,7 @@ class SentryCloudflareTracer implements Tracer {
           ? context
           : typeof fn === 'function'
             ? fn
-            : // eslint-disable-next-line @typescript-eslint/no-empty-function
-              () => {}
+            : () => {}
     ) as F;
 
     // In OTEL the semantic matches `startSpanManual` because spans are not auto-ended

--- a/packages/core/src/tracing/sentryNonRecordingSpan.ts
+++ b/packages/core/src/tracing/sentryNonRecordingSpan.ts
@@ -32,7 +32,6 @@ export class SentryNonRecordingSpan implements Span {
   }
 
   /** @inheritdoc */
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public end(_timestamp?: SpanTimeInput): void {}
 
   /** @inheritdoc */

--- a/packages/core/src/utils/handleCallbackErrors.ts
+++ b/packages/core/src/utils/handleCallbackErrors.ts
@@ -14,11 +14,7 @@ import { isThenable } from '../utils/is';
 export function handleCallbackErrors<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Fn extends () => any,
->(
-  fn: Fn,
-  onError: (error: unknown) => void,
-  onFinally: () => void = () => {},
-): ReturnType<Fn> {
+>(fn: Fn, onError: (error: unknown) => void, onFinally: () => void = () => {}): ReturnType<Fn> {
   let maybePromiseResult: ReturnType<Fn>;
   try {
     maybePromiseResult = fn();

--- a/packages/core/src/utils/handleCallbackErrors.ts
+++ b/packages/core/src/utils/handleCallbackErrors.ts
@@ -17,7 +17,6 @@ export function handleCallbackErrors<
 >(
   fn: Fn,
   onError: (error: unknown) => void,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   onFinally: () => void = () => {},
 ): ReturnType<Fn> {
   let maybePromiseResult: ReturnType<Fn>;

--- a/packages/eslint-config-sdk/src/base.js
+++ b/packages/eslint-config-sdk/src/base.js
@@ -107,6 +107,9 @@ module.exports = {
         // Be explicit about class member accessibility (public, private, protected). Turned off
         // on tests for ease of use.
         '@typescript-eslint/explicit-member-accessibility': ['error'],
+
+        // We do not care about empty functions
+        '@typescript-eslint/no-empty-function': 'off',
       },
     },
     {

--- a/packages/eslint-config-sdk/src/base.js
+++ b/packages/eslint-config-sdk/src/base.js
@@ -178,7 +178,6 @@ module.exports = {
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
-        '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-floating-promises': 'off',
         '@sentry-internal/sdk/no-focused-tests': 'error',
         '@sentry-internal/sdk/no-skipped-tests': 'error',

--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -22,7 +22,6 @@ function getUser(): User | undefined {
 export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
   return {
     name: 'FeedbackModal',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     setupOnce() {},
     createDialog: ({ options, screenshotIntegration, sendFeedback, shadow }) => {
       const shadowRoot = shadow as unknown as ShadowRoot;

--- a/packages/feedback/src/screenshot/integration.ts
+++ b/packages/feedback/src/screenshot/integration.ts
@@ -7,7 +7,6 @@ import { ScreenshotEditorFactory } from './components/ScreenshotEditor';
 export const feedbackScreenshotIntegration = ((): FeedbackScreenshotIntegration => {
   return {
     name: 'FeedbackScreenshot',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     setupOnce() {},
     createInput: ({ h, hooks, dialog, options }) => {
       const outputBuffer = DOCUMENT.createElement('canvas');

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -86,13 +86,10 @@ async function getNodeAdapterOutputDir(svelteConfig: Config): Promise<string> {
     },
     // @ts-expect-error - No need to implement the other methods
     log: {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function -- this should be a noop
       minor() {},
     },
     getBuildDirectory: () => '',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function -- this should be a noop
     rimraf: () => {},
-    // eslint-disable-next-line @typescript-eslint/no-empty-function -- this should be a noop
     mkdirp: () => {},
 
     config: {


### PR DESCRIPTION
This is IMHO not super helpful, we constantly disable it or add a noop comment for no gain.