### PR TITLE
feat(core)!: Remove deprecated logger

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -41,6 +41,7 @@ Updates and fixes for version 9 will be published as `SentryNodeServerlessSDKv9`
 
 - `BaseClient` was removed, use `Client` as a direct replacement.
 - `hasTracingEnabled` was removed, use `hasSpansEnabled` as a direct replacement.
+- `logger` and type `Logger` were removed, use `debug` and type `SentryDebugLogger` instead.
 
 ## No Version Support Timeline
 

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/server/plugins/customNitroErrorHandler.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/server/plugins/customNitroErrorHandler.ts
@@ -1,4 +1,4 @@
-import { Context, GLOBAL_OBJ, flush, logger, vercelWaitUntil } from '@sentry/core';
+import { Context, GLOBAL_OBJ, flush, debug, vercelWaitUntil } from '@sentry/core';
 import * as SentryNode from '@sentry/node';
 import { H3Error } from 'h3';
 import type { CapturedErrorContext } from 'nitropack';
@@ -74,10 +74,10 @@ async function flushWithTimeout(): Promise<void> {
   const isDebug = sentryClient ? sentryClient.getOptions().debug : false;
 
   try {
-    isDebug && logger.log('Flushing events...');
+    isDebug && debug.log('Flushing events...');
     await flush(2000);
-    isDebug && logger.log('Done flushing events');
+    isDebug && debug.log('Done flushing events');
   } catch (e) {
-    isDebug && logger.log('Error while flushing events:\n', e);
+    isDebug && debug.log('Error while flushing events:\n', e);
   }
 }

--- a/packages/core/src/carrier.ts
+++ b/packages/core/src/carrier.ts
@@ -3,7 +3,6 @@ import type { AsyncContextStrategy } from './asyncContext/types';
 import type { Client } from './client';
 import type { Scope } from './scope';
 import type { SerializedLog } from './types-hoist/log';
-import type { Logger } from './utils/debug-logger';
 import { SDK_VERSION } from './utils/version';
 import { GLOBAL_OBJ } from './utils/worldwide';
 
@@ -26,9 +25,6 @@ export interface SentryCarrier {
   globalScope?: Scope;
   defaultIsolationScope?: Scope;
   defaultCurrentScope?: Scope;
-  /** @deprecated Logger is no longer set. Instead, we keep enabled state in loggerSettings. */
-  // eslint-disable-next-line deprecation/deprecation
-  logger?: Logger;
   loggerSettings?: { enabled: boolean };
   /**
    * A map of Sentry clients to their log buffers.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,10 +161,8 @@ export {
   isVueViewModel,
 } from './utils/is';
 export { isBrowser } from './utils/isBrowser';
-// eslint-disable-next-line deprecation/deprecation
-export { CONSOLE_LEVELS, consoleSandbox, debug, logger, originalConsoleMethods } from './utils/debug-logger';
-// eslint-disable-next-line deprecation/deprecation
-export type { Logger, SentryDebugLogger } from './utils/debug-logger';
+export { CONSOLE_LEVELS, consoleSandbox, debug, originalConsoleMethods } from './utils/debug-logger';
+export type { SentryDebugLogger } from './utils/debug-logger';
 export {
   addContextToFrame,
   addExceptionMechanism,

--- a/packages/core/src/utils/debug-logger.ts
+++ b/packages/core/src/utils/debug-logger.ts
@@ -3,24 +3,6 @@ import { DEBUG_BUILD } from '../debug-build';
 import type { ConsoleLevel } from '../types-hoist/instrument';
 import { GLOBAL_OBJ } from './worldwide';
 
-/**
- * A Sentry Logger instance.
- *
- * @deprecated Use {@link debug} instead with the {@link SentryDebugLogger} type.
- */
-export interface Logger {
-  disable(): void;
-  enable(): void;
-  isEnabled(): boolean;
-  log(...args: Parameters<typeof console.log>): void;
-  info(...args: Parameters<typeof console.info>): void;
-  warn(...args: Parameters<typeof console.warn>): void;
-  error(...args: Parameters<typeof console.error>): void;
-  debug(...args: Parameters<typeof console.debug>): void;
-  assert(...args: Parameters<typeof console.assert>): void;
-  trace(...args: Parameters<typeof console.trace>): void;
-}
-
 export interface SentryDebugLogger {
   disable(): void;
   enable(): void;
@@ -115,18 +97,6 @@ function error(...args: Parameters<typeof console.error>): void {
   _maybeLog('error', ...args);
 }
 
-function _debug(...args: Parameters<typeof console.debug>): void {
-  _maybeLog('debug', ...args);
-}
-
-function assert(...args: Parameters<typeof console.assert>): void {
-  _maybeLog('assert', ...args);
-}
-
-function trace(...args: Parameters<typeof console.trace>): void {
-  _maybeLog('trace', ...args);
-}
-
 function _maybeLog(level: ConsoleLevel, ...args: Parameters<(typeof console)[typeof level]>): void {
   if (!DEBUG_BUILD) {
     return;
@@ -146,36 +116,6 @@ function _getLoggerSettings(): { enabled: boolean } {
 
   return getGlobalSingleton('loggerSettings', () => ({ enabled: false }));
 }
-
-/**
- * This is a logger singleton which either logs things or no-ops if logging is not enabled.
- * The logger is a singleton on the carrier, to ensure that a consistent logger is used throughout the SDK.
- *
- * @deprecated Use {@link debug} instead.
- */
-export const logger = {
-  /** Enable logging. */
-  enable,
-  /** Disable logging. */
-  disable,
-  /** Check if logging is enabled. */
-  isEnabled,
-  /** Log a message. */
-  log,
-  /** Log level info */
-  info,
-  /** Log a warning. */
-  warn,
-  /** Log an error. */
-  error,
-  /** Log a debug message. */
-  debug: _debug,
-  /** Log an assertion. */
-  assert,
-  /** Log a trace. */
-  trace,
-  // eslint-disable-next-line deprecation/deprecation
-} satisfies Logger;
 
 /**
  * This is a logger singleton which either logs things or no-ops if logging is not enabled.


### PR DESCRIPTION
BREAKING CHANGE

In https://github.com/getsentry/sentry-javascript/issues/16901 we deprecated the `logger` export from `@sentry/core`.

This PR removes it for the v10 release.