### PR TITLE
feat(core)!: Remove `BaseClient`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,7 +36,7 @@ Updates and fixes for version 9 will be published as `SentryNodeServerlessSDKv9`
 
 ### `@sentry/core` / All SDKs
 
-- TODO: fill in removed APIs
+- `BaseClient` was removed, use `Client` as a direct replacement.
 
 ## No Version Support Timeline
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1247,18 +1247,6 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 }
 
 /**
- * @deprecated Use `Client` instead. This alias may be removed in a future major version.
- */
-// TODO(v10): Remove
-export type BaseClient = Client;
-
-/**
- * @deprecated Use `Client` instead. This alias may be removed in a future major version.
- */
-// TODO(v10): Remove
-export const BaseClient = Client;
-
-/**
  * Verifies that return value of configured `beforeSend` or `beforeSendTransaction` is of expected type, and returns the value if so.
  */
 function _validateBeforeSendResult(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,11 +49,7 @@ export { Scope } from './scope';
 export type { CaptureContext, ScopeContext, ScopeData } from './scope';
 export { notifyEventProcessors } from './eventProcessors';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
-export {
-  Client,
-  // eslint-disable-next-line deprecation/deprecation
-  BaseClient,
-} from './client';
+export { Client } from './client';
 export { ServerRuntimeClient } from './server-runtime-client';
 export { initAndBind, setCurrentClient } from './sdk';
 export { createTransport } from './transports/base';

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -11,7 +11,6 @@ import {
   SyncPromise,
   withMonitor,
 } from '../../src';
-import type { BaseClient, Client } from '../../src/client';
 import * as integrationModule from '../../src/integration';
 import type { Envelope } from '../../src/types-hoist/envelope';
 import type { ErrorEvent, Event, TransactionEvent } from '../../src/types-hoist/event';
@@ -2107,30 +2106,22 @@ describe('Client', () => {
   describe('hooks', () => {
     const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
 
-    // Make sure types work for both Client & BaseClient
-    const scenarios = [
-      // eslint-disable-next-line deprecation/deprecation
-      ['BaseClient', new TestClient(options) as BaseClient],
-      ['Client', new TestClient(options) as Client],
-    ] as const;
+    it('should call a beforeEnvelope hook', () => {
+      const client = new TestClient(options);
+      expect.assertions(1);
 
-    describe.each(scenarios)('with client %s', (_, client) => {
-      it('should call a beforeEnvelope hook', () => {
-        expect.assertions(1);
+      const mockEnvelope = [
+        {
+          event_id: '12345',
+        },
+        {},
+      ] as Envelope;
 
-        const mockEnvelope = [
-          {
-            event_id: '12345',
-          },
-          {},
-        ] as Envelope;
-
-        client.on('beforeEnvelope', envelope => {
-          expect(envelope).toEqual(mockEnvelope);
-        });
-
-        client.emit('beforeEnvelope', mockEnvelope);
+      client.on('beforeEnvelope', envelope => {
+        expect(envelope).toEqual(mockEnvelope);
       });
+
+      client.emit('beforeEnvelope', mockEnvelope);
     });
   });
 


### PR DESCRIPTION
`BaseClient` was deprecated in v9, use `Client` as a direct replacement.