### PR TITLE
feat(core)!: Remove `logger` and type `Logger`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,7 +36,7 @@ Updates and fixes for version 9 will be published as `SentryNodeServerlessSDKv9`
 
 ### `@sentry/core` / All SDKs
 
-- TODO: fill in removed APIs
+- `logger` and type `Logger` were removed, use `debug` and type `SentryDebugLogger` instead.
 
 ## No Version Support Timeline
 

--- a/packages/core/src/carrier.ts
+++ b/packages/core/src/carrier.ts
@@ -3,7 +3,7 @@ import type { AsyncContextStrategy } from './asyncContext/types';
 import type { Client } from './client';
 import type { Scope } from './scope';
 import type { SerializedLog } from './types-hoist/log';
-import type { Logger } from './utils/debug-logger';
+import type { SentryDebugLogger } from './utils/debug-logger';
 import { SDK_VERSION } from './utils/version';
 import { GLOBAL_OBJ } from './utils/worldwide';
 
@@ -26,9 +26,7 @@ export interface SentryCarrier {
   globalScope?: Scope;
   defaultIsolationScope?: Scope;
   defaultCurrentScope?: Scope;
-  /** @deprecated Logger is no longer set. Instead, we keep enabled state in loggerSettings. */
-  // eslint-disable-next-line deprecation/deprecation
-  logger?: Logger;
+  logger?: SentryDebugLogger;
   loggerSettings?: { enabled: boolean };
   /**
    * A map of Sentry clients to their log buffers.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,10 +167,8 @@ export {
   isVueViewModel,
 } from './utils/is';
 export { isBrowser } from './utils/isBrowser';
-// eslint-disable-next-line deprecation/deprecation
-export { CONSOLE_LEVELS, consoleSandbox, debug, logger, originalConsoleMethods } from './utils/debug-logger';
-// eslint-disable-next-line deprecation/deprecation
-export type { Logger, SentryDebugLogger } from './utils/debug-logger';
+export { CONSOLE_LEVELS, consoleSandbox, debug, originalConsoleMethods } from './utils/debug-logger';
+export type { SentryDebugLogger } from './utils/debug-logger';
 export {
   addContextToFrame,
   addExceptionMechanism,

--- a/packages/core/src/utils/debug-logger.ts
+++ b/packages/core/src/utils/debug-logger.ts
@@ -3,24 +3,6 @@ import { DEBUG_BUILD } from '../debug-build';
 import type { ConsoleLevel } from '../types-hoist/instrument';
 import { GLOBAL_OBJ } from './worldwide';
 
-/**
- * A Sentry Logger instance.
- *
- * @deprecated Use {@link debug} instead with the {@link SentryDebugLogger} type.
- */
-export interface Logger {
-  disable(): void;
-  enable(): void;
-  isEnabled(): boolean;
-  log(...args: Parameters<typeof console.log>): void;
-  info(...args: Parameters<typeof console.info>): void;
-  warn(...args: Parameters<typeof console.warn>): void;
-  error(...args: Parameters<typeof console.error>): void;
-  debug(...args: Parameters<typeof console.debug>): void;
-  assert(...args: Parameters<typeof console.assert>): void;
-  trace(...args: Parameters<typeof console.trace>): void;
-}
-
 export interface SentryDebugLogger {
   disable(): void;
   enable(): void;
@@ -146,36 +128,6 @@ function _getLoggerSettings(): { enabled: boolean } {
 
   return getGlobalSingleton('loggerSettings', () => ({ enabled: false }));
 }
-
-/**
- * This is a logger singleton which either logs things or no-ops if logging is not enabled.
- * The logger is a singleton on the carrier, to ensure that a consistent logger is used throughout the SDK.
- *
- * @deprecated Use {@link debug} instead.
- */
-export const logger = {
-  /** Enable logging. */
-  enable,
-  /** Disable logging. */
-  disable,
-  /** Check if logging is enabled. */
-  isEnabled,
-  /** Log a message. */
-  log,
-  /** Log level info */
-  info,
-  /** Log a warning. */
-  warn,
-  /** Log an error. */
-  error,
-  /** Log a debug message. */
-  debug: _debug,
-  /** Log an assertion. */
-  assert,
-  /** Log a trace. */
-  trace,
-  // eslint-disable-next-line deprecation/deprecation
-} satisfies Logger;
 
 /**
  * This is a logger singleton which either logs things or no-ops if logging is not enabled.


### PR DESCRIPTION
`logger` and type `Logger` were deprecated in v9, use `debug` and type `SentryDebugLogger` instead.