### PR TITLE
ci(e2e): Only run changed E2E tests

### DIFF
--- a/dev-packages/e2e-tests/lib/getTestMatrix.ts
+++ b/dev-packages/e2e-tests/lib/getTestMatrix.ts
@@ -178,11 +178,13 @@ function getAffectedTestApplications(
         return testApplications.filter(testApp => changedTestApps.has(testApp));
       }
     } catch (error) {
-      // Fall back to running all tests
       // eslint-disable-next-line no-console
       console.error('Failed to get changed files, running all tests:', error);
       return testApplications;
     }
+
+    // Fall back to running all tests
+    return testApplications;
   }
 
   return testApplications.filter(testApp => {


### PR DESCRIPTION
This pr changes the detection logic for the e2e tests directory.

Before we always ran every test whenever something changed in this dir.
With this change we check for changed files in the test apps and only run all tests if shared code has been changed.