### PR TITLE
fix(v7/cdn): Stop using `Object.assign` to be ES5 compatible

### DIFF
--- a/packages/eslint-plugin-sdk/src/rules/no-unsupported-es6-methods.js
+++ b/packages/eslint-plugin-sdk/src/rules/no-unsupported-es6-methods.js
@@ -20,9 +20,10 @@ module.exports = {
         const functionName = node.callee.property.name;
 
         const es6ArrayFunctions = ['copyWithin', 'values', 'fill'];
+        const es6ObjectFunctions = ['assign'];
         const es6StringFunctions = ['repeat'];
 
-        const es6Functions = [].concat(es6ArrayFunctions, es6StringFunctions);
+        const es6Functions = [].concat(es6ArrayFunctions, es6StringFunctions, es6ObjectFunctions);
         if (es6Functions.indexOf(functionName) > -1) {
           context.report({
             node: node.callee.property,

--- a/packages/tracing-internal/src/browser/web-vitals/lib/observe.ts
+++ b/packages/tracing-internal/src/browser/web-vitals/lib/observe.ts
@@ -49,15 +49,11 @@ export const observe = <K extends keyof PerformanceEntryMap>(
       const po = new PerformanceObserver(list => {
         callback(list.getEntries() as PerformanceEntryMap[K]);
       });
-      po.observe(
-        Object.assign(
-          {
-            type,
-            buffered: true,
-          },
-          opts || {},
-        ) as PerformanceObserverInit,
-      );
+      po.observe({
+        type,
+        buffered: true,
+        ...opts,
+      } as PerformanceObserverInit);
       return po;
     }
   } catch (e) {


### PR DESCRIPTION
This adds a lint rule to avoid usage of `Object.assign` (we already have similar rules for other things that are not polyfilled). We can just use object spread instead, which _is_ polyfilled.

Fixes https://github.com/getsentry/sentry-javascript/issues/16970

Replacing https://github.com/getsentry/sentry-javascript/pull/17053 as that stalled on CI somehow...