### PR TITLE
fix(react-router): Ensure source map upload fails silently if Sentry CLI fails

### DIFF
--- a/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
+++ b/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
@@ -59,7 +59,12 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
   if (sourceMapsUploadOptions?.enabled ?? (true && viteConfig.build.sourcemap !== false)) {
     // inject debugIds
     try {
-      await cliInstance.execute(['sourcemaps', 'inject', reactRouterConfig.buildDirectory], debug);
+      await cliInstance.execute(
+        ['sourcemaps', 'inject', reactRouterConfig.buildDirectory],
+        // @ts-expect-error - 'rejectOnError' is not yet exported as a type from @sentry/cli. It is valid though.
+        // TODO: update to @sentry/cli@2.50.0 once the fix is released: https://github.com/getsentry/sentry-cli/pull/2628
+        debug ? 'rejectOnError' : false,
+      );
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('[Sentry] Could not inject debug ids', error);
@@ -73,6 +78,7 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
             paths: [reactRouterConfig.buildDirectory],
           },
         ],
+        live: 'rejectOnError',
       });
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
+++ b/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
@@ -61,8 +61,6 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
     try {
       await cliInstance.execute(
         ['sourcemaps', 'inject', reactRouterConfig.buildDirectory],
-        // @ts-expect-error - 'rejectOnError' is not yet exported as a type from @sentry/cli. It is valid though.
-        // TODO: update to @sentry/cli@2.50.0 once the fix is released: https://github.com/getsentry/sentry-cli/pull/2628
         debug ? 'rejectOnError' : false,
       );
     } catch (error) {

--- a/packages/react-router/test/vite/buildEnd/handleOnBuildEnd.test.ts
+++ b/packages/react-router/test/vite/buildEnd/handleOnBuildEnd.test.ts
@@ -147,8 +147,10 @@ describe('sentryOnBuildEnd', () => {
 
     await sentryOnBuildEnd(config);
 
+    expect(mockSentryCliInstance.releases.uploadSourceMaps).toHaveBeenCalledTimes(1);
     expect(mockSentryCliInstance.releases.uploadSourceMaps).toHaveBeenCalledWith('undefined', {
       include: [{ paths: ['/build'] }],
+      live: 'rejectOnError',
     });
   });
 
@@ -249,6 +251,8 @@ describe('sentryOnBuildEnd', () => {
     mockSentryCliInstance.execute.mockRejectedValueOnce(new Error('Injection failed'));
 
     await sentryOnBuildEnd(defaultConfig);
+    expect(mockSentryCliInstance.execute).toHaveBeenCalledTimes(1);
+    expect(mockSentryCliInstance.execute).toHaveBeenCalledWith(['sourcemaps', 'inject', '/build'], false);
 
     expect(consoleSpy).toHaveBeenCalledWith('[Sentry] Could not inject debug ids', expect.any(Error));
     consoleSpy.mockRestore();
@@ -282,6 +286,9 @@ describe('sentryOnBuildEnd', () => {
 
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[Sentry] Automatically setting'));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Deleting asset after upload:'));
+    // rejectOnError is used in debug mode to pipe debug id injection output from the CLI to this process's stdout
+    expect(mockSentryCliInstance.execute).toHaveBeenCalledWith(['sourcemaps', 'inject', '/build'], 'rejectOnError');
+
     consoleSpy.mockRestore();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7046,27 +7046,7 @@
   resolved "https://registry.yarnpkg.com/@sentry/cli-win32-x64/-/cli-win32-x64-2.50.2.tgz#1d0c106125b6dc87f3a598ac02519c699f17a6c0"
   integrity sha512-tE27pu1sRRub1Jpmemykv3QHddBcyUk39Fsvv+n4NDpQyMgsyVPcboxBZyby44F0jkpI/q3bUH2tfCB1TYDNLg==
 
-"@sentry/cli@^2.49.0":
-  version "2.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.49.0.tgz#a8332ae38e9f92a0da3d939bdbce119e63450e99"
-  integrity sha512-99IKax3yjOaPlWJh3rAJC/R6hdmZZJ2B3ACVP8CpOYE+JzGGLyir1fvTzrdFKFLPLOq2lGC3RqWuKqU7PJUTZQ==
-  dependencies:
-    https-proxy-agent "^5.0.0"
-    node-fetch "^2.6.7"
-    progress "^2.0.3"
-    proxy-from-env "^1.1.0"
-    which "^2.0.2"
-  optionalDependencies:
-    "@sentry/cli-darwin" "2.49.0"
-    "@sentry/cli-linux-arm" "2.49.0"
-    "@sentry/cli-linux-arm64" "2.49.0"
-    "@sentry/cli-linux-i686" "2.49.0"
-    "@sentry/cli-linux-x64" "2.49.0"
-    "@sentry/cli-win32-arm64" "2.49.0"
-    "@sentry/cli-win32-i686" "2.49.0"
-    "@sentry/cli-win32-x64" "2.49.0"
-
-"@sentry/cli@^2.50.2":
+"@sentry/cli@^2.49.0", "@sentry/cli@^2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.50.2.tgz#9fb90f2ae6648fc0104f0ca7f528d2e19ee0ecae"
   integrity sha512-m1L9shxutF3WHSyNld6Y1vMPoXfEyQhoRh1V3SYSdl+4AB40U+zr2sRzFa2OPm7XP4zYNaWuuuHLkY/iHITs8Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6924,7 +6924,7 @@
     mitt "^3.0.0"
 
 "@sentry-internal/test-utils@link:dev-packages/test-utils":
-  version "10.1.0"
+  version "10.2.0"
   dependencies:
     express "^4.21.1"
 
@@ -6966,47 +6966,107 @@
     magic-string "0.30.8"
     unplugin "1.0.1"
 
+"@sentry/cli-darwin@2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-darwin/-/cli-darwin-2.49.0.tgz#290657e5840b360cb8ca25c8a78f8c0f15c66b03"
+  integrity sha512-bgowyDeFuXbjkGq1ZKqcWhmzgfBe7oKIXYWJOOps4+32QfG+YsrdNnottHS01td3bzrJq0QnHj8H12fA81DqrA==
+
 "@sentry/cli-darwin@2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli-darwin/-/cli-darwin-2.50.2.tgz#fcf924fcc02cfa54748ff07a380334e533635c74"
   integrity sha512-0Pjpl0vQqKhwuZm19z6AlEF+ds3fJg1KWabv8WzGaSc/fwxMEwjFwOZj+IxWBJPV578cXXNvB39vYjjpCH8j7A==
+
+"@sentry/cli-linux-arm64@2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.49.0.tgz#a732004d7131f7e7b44f6a64abdccc36efb35d52"
+  integrity sha512-dqxsDUd76aDm03fUwUOs5BR7RHLpSb2EH/B1hlWm0mFvo9uY907XxW9wDFx/qDpCdmpC0aF+lF/lOBOrG9B5Fg==
 
 "@sentry/cli-linux-arm64@2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.50.2.tgz#ac9e6dba42095832bac8084abab4b86fdd2956f3"
   integrity sha512-03Cj215M3IdoHAwevCxm5oOm9WICFpuLR05DQnODFCeIUsGvE1pZsc+Gm0Ky/ZArq2PlShBJTpbHvXbCUka+0w==
 
+"@sentry/cli-linux-arm@2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm/-/cli-linux-arm-2.49.0.tgz#73719561510df3369e05e9a4898b4e43b8753e4c"
+  integrity sha512-RBDIjIGmNsFw+a6vAt6m3D7ROKsMEB9i3u+UuIRxk0/DyHTcfVWxnK/ScPXGILM6PxQ2XOBfOKad0mmiDHBzZA==
+
 "@sentry/cli-linux-arm@2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm/-/cli-linux-arm-2.50.2.tgz#835acd53ca83f6be9fc0d3d85a3cd4c694051bce"
   integrity sha512-jzFwg9AeeuFAFtoCcyaDEPG05TU02uOy1nAX09c1g7FtsyQlPcbhI94JQGmnPzdRjjDmORtwIUiVZQrVTkDM7w==
+
+"@sentry/cli-linux-i686@2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-i686/-/cli-linux-i686-2.49.0.tgz#8d1bb1378251a3aa995cc4b56bd352fa12a84b66"
+  integrity sha512-gDAd5/vJbEhd4Waud0Cd8ZRqLEagDlOvWwNH3KB694EiHJUwzRSiTA1YUVMYGI8Z9UyEA1sKxARwm2Trv99BxA==
 
 "@sentry/cli-linux-i686@2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli-linux-i686/-/cli-linux-i686-2.50.2.tgz#72f0e4bc1c515754aa11225efce711a24fb53524"
   integrity sha512-J+POvB34uVyHbIYF++Bc/OCLw+gqKW0H/y/mY7rRZCiocgpk266M4NtsOBl6bEaurMx1D+BCIEjr4nc01I/rqA==
 
+"@sentry/cli-linux-x64@2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-x64/-/cli-linux-x64-2.49.0.tgz#7bf58fb7005c89fdde4e1262d5ed35e23065aceb"
+  integrity sha512-mbohGvPNhHjUciYNXzkt9TYUebTmxeAp9v9JfLSb/Soz6fubKwEHhpRJuz1zASxVWIR4PuqkePchqN5zhcLC0A==
+
 "@sentry/cli-linux-x64@2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli-linux-x64/-/cli-linux-x64-2.50.2.tgz#d06f8ffd65871b1373a0d2228ab254d9456a615c"
   integrity sha512-81yQVRLj8rnuHoYcrM7QbOw8ubA3weiMdPtTxTim1s6WExmPgnPTKxLCr9xzxGJxFdYo3xIOhtf5JFpUX/3j4A==
+
+"@sentry/cli-win32-arm64@2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.49.0.tgz#2bf6dd911acbe3ddb02eec0afb4301bb8fb25b53"
+  integrity sha512-3zwvsp61EPpSuGpGdXY4JelVJmNEjoj4vn5m6EFoOtk7OUI5/VFqqR4wchjy9Hjm3Eh6MB5K+KTKXs4W2p18ng==
 
 "@sentry/cli-win32-arm64@2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.50.2.tgz#4bd7a140367c17f77d621903cfe0914232108657"
   integrity sha512-QjentLGvpibgiZlmlV9ifZyxV73lnGH6pFZWU5wLeRiaYKxWtNrrHpVs+HiWlRhkwQ0mG1/S40PGNgJ20DJ3gA==
 
+"@sentry/cli-win32-i686@2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-i686/-/cli-win32-i686-2.49.0.tgz#32e31472ae6c5f69e538a4061d651937fcb8f14a"
+  integrity sha512-2oWaNl6z0BaOCAjM1Jxequfgjod3XO6wothxow4kA8e9+43JLhgarSdpwJPgQjcVyxjygwQ3/jKPdUFh0qNOmg==
+
 "@sentry/cli-win32-i686@2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli-win32-i686/-/cli-win32-i686-2.50.2.tgz#1eb997cf780c396446cdd8e63c6d4309894465e8"
   integrity sha512-UkBIIzkQkQ1UkjQX8kHm/+e7IxnEhK6CdgSjFyNlxkwALjDWHJjMztevqAPz3kv4LdM6q1MxpQ/mOqXICNhEGg==
+
+"@sentry/cli-win32-x64@2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-x64/-/cli-win32-x64-2.49.0.tgz#86aab38cb41f885914d7c99ceaab7b6ce52c72c6"
+  integrity sha512-dR4ulyrA6ZT7x7cg4Rwm0tcHf4TZz5QO6t1W1jX6uJ9n/U0bOSqSFZHNf/RryiUzQE1g8LBthOYyKGMkET6T8w==
 
 "@sentry/cli-win32-x64@2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli-win32-x64/-/cli-win32-x64-2.50.2.tgz#1d0c106125b6dc87f3a598ac02519c699f17a6c0"
   integrity sha512-tE27pu1sRRub1Jpmemykv3QHddBcyUk39Fsvv+n4NDpQyMgsyVPcboxBZyby44F0jkpI/q3bUH2tfCB1TYDNLg==
 
-"@sentry/cli@^2.49.0", "@sentry/cli@^2.50.2":
+"@sentry/cli@^2.49.0":
+  version "2.49.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.49.0.tgz#a8332ae38e9f92a0da3d939bdbce119e63450e99"
+  integrity sha512-99IKax3yjOaPlWJh3rAJC/R6hdmZZJ2B3ACVP8CpOYE+JzGGLyir1fvTzrdFKFLPLOq2lGC3RqWuKqU7PJUTZQ==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.7"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
+  optionalDependencies:
+    "@sentry/cli-darwin" "2.49.0"
+    "@sentry/cli-linux-arm" "2.49.0"
+    "@sentry/cli-linux-arm64" "2.49.0"
+    "@sentry/cli-linux-i686" "2.49.0"
+    "@sentry/cli-linux-x64" "2.49.0"
+    "@sentry/cli-win32-arm64" "2.49.0"
+    "@sentry/cli-win32-i686" "2.49.0"
+    "@sentry/cli-win32-x64" "2.49.0"
+
+"@sentry/cli@^2.50.2":
   version "2.50.2"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.50.2.tgz#9fb90f2ae6648fc0104f0ca7f528d2e19ee0ecae"
   integrity sha512-m1L9shxutF3WHSyNld6Y1vMPoXfEyQhoRh1V3SYSdl+4AB40U+zr2sRzFa2OPm7XP4zYNaWuuuHLkY/iHITs8Q==
@@ -28567,7 +28627,6 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
-  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"


### PR DESCRIPTION
Sentry CLI's `cli.releases.uploadSourceMaps` method previously never rejected when the actual CLI binary execution exited with an error code. In CLI 2.49.0 and 2.50.0 I added a new execution mode variant (`rejectOnError`) which continues to pipe stdio to the process (the RR SDKs' upload script) but now also rejects on error.

This PR bumps Sentry CLI and configures it to actually reject now. We already catch the rejection and fail silently. Nothing changed here.