### PR TITLE
test(astro): Add E2E test case for catch-all routes

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-5/src/pages/catchAll/[...path].astro
+++ b/dev-packages/e2e-tests/test-applications/astro-5/src/pages/catchAll/[...path].astro
@@ -1,0 +1,12 @@
+---
+import Layout from '../../layouts/Layout.astro';
+
+export const prerender = false;
+
+const params = Astro.params;
+
+---
+
+<Layout title="CatchAll SSR page">
+  <p>params: {params}</p>
+</Layout>

--- a/dev-packages/e2e-tests/test-applications/astro-5/tests/tracing.dynamic.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-5/tests/tracing.dynamic.test.ts
@@ -233,7 +233,7 @@ test.describe('nested SSR routes (client, server, server request)', () => {
     expect(serverRequestHTTPClientSpan).toMatchObject({
       op: 'http.client',
       origin: 'auto.http.otel.node_fetch',
-      description: 'GET http://localhost:3030/api/user/myUsername123.json', // todo: parametrize (this is just a span though - no transaction)
+      description: 'GET http://localhost:3030/api/user/myUsername123.json', // http.client does not need to be parametrized
       data: {
         'sentry.op': 'http.client',
         'sentry.origin': 'auto.http.otel.node_fetch',


### PR DESCRIPTION
Extracting a test case in a new PR while working on route parametrization.

Continuation of https://github.com/getsentry/sentry-javascript/pull/17054

Part of https://github.com/getsentry/sentry-javascript/issues/16686
