### PR TITLE
test(remix): Fix integration test flakes

### DIFF
--- a/packages/remix/test/integration/app/root.tsx
+++ b/packages/remix/test/integration/app/root.tsx
@@ -48,9 +48,9 @@ export const loader: LoaderFunction = async ({ request }) => {
     case 'returnRedirect':
       return redirect('/?type=plain');
     case 'throwRedirectToExternal':
-      throw redirect('https://example.com');
+      throw redirect(`https://docs.sentry.io`);
     case 'returnRedirectToExternal':
-      return redirect('https://example.com');
+      return redirect('https://docs.sentry.io');
     default: {
       return {};
     }

--- a/packages/remix/test/integration/test/client/root-loader.test.ts
+++ b/packages/remix/test/integration/test/client/root-loader.test.ts
@@ -20,6 +20,17 @@ async function extractTraceAndBaggageFromMeta(
   return { sentryTrace: sentryTraceContent, sentryBaggage: sentryBaggageContent };
 }
 
+async function mockExampleRoute(page: Page): Promise<void> {
+  await page.route('https://example.com/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      body: JSON.stringify({
+        foo: 'bar',
+      }),
+    });
+  });
+}
+
 test('should inject `sentry-trace` and `baggage` into root loader returning an empty object.', async ({ page }) => {
   await page.goto('/?type=empty');
 
@@ -123,6 +134,7 @@ test('should inject `sentry-trace` and `baggage` into root loader returning `und
 test('should inject `sentry-trace` and `baggage` into root loader throwing a redirection to a plain object.', async ({
   page,
 }) => {
+  await mockExampleRoute(page);
   await page.goto('/?type=throwRedirect');
 
   const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
@@ -144,6 +156,7 @@ test('should inject `sentry-trace` and `baggage` into root loader throwing a red
 test('should inject `sentry-trace` and `baggage` into root loader returning a redirection to valid path.', async ({
   page,
 }) => {
+  await mockExampleRoute(page);
   await page.goto('/?type=returnRedirect');
 
   const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
@@ -163,6 +176,7 @@ test('should inject `sentry-trace` and `baggage` into root loader returning a re
 });
 
 test('should return redirect to an external path with no baggage and trace injected.', async ({ page }) => {
+  await mockExampleRoute(page);
   await page.goto('/?type=returnRedirectToExternal');
 
   const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
@@ -175,6 +189,7 @@ test('should return redirect to an external path with no baggage and trace injec
 });
 
 test('should throw redirect to an external path with no baggage and trace injected.', async ({ page }) => {
+  await mockExampleRoute(page);
   await page.goto('/?type=throwRedirectToExternal');
 
   const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);

--- a/packages/remix/test/integration/test/client/root-loader.test.ts
+++ b/packages/remix/test/integration/test/client/root-loader.test.ts
@@ -155,7 +155,7 @@ test('should inject `sentry-trace` and `baggage` into root loader returning a re
   });
 });
 
-test('should return redirect to an external path with no baggage and trace injected.', async ({ page,baseURL }) => {
+test('should return redirect to an external path with no baggage and trace injected.', async ({ page, baseURL }) => {
   await page.goto(`${baseURL}/?type=returnRedirectToExternal`);
 
   expect(page.url()).toEqual(expect.stringContaining('docs.sentry.io'));

--- a/packages/remix/test/integration/test/client/root-loader.test.ts
+++ b/packages/remix/test/integration/test/client/root-loader.test.ts
@@ -125,10 +125,10 @@ test('should inject `sentry-trace` and `baggage` into root loader throwing a red
 }) => {
   await page.goto('/?type=throwRedirect');
 
+  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
+
   // We should be successfully redirected to the path.
   expect(page.url()).toEqual(expect.stringContaining('/?type=plain'));
-
-  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
 
   expect(sentryTrace).toMatch(/.+/);
   expect(sentryBaggage).toMatch(/.+/);
@@ -146,10 +146,10 @@ test('should inject `sentry-trace` and `baggage` into root loader returning a re
 }) => {
   await page.goto('/?type=returnRedirect');
 
+  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
+
   // We should be successfully redirected to the path.
   expect(page.url()).toEqual(expect.stringContaining('/?type=plain'));
-
-  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
 
   expect(sentryTrace).toMatch(/.+/);
   expect(sentryBaggage).toMatch(/.+/);
@@ -165,10 +165,10 @@ test('should inject `sentry-trace` and `baggage` into root loader returning a re
 test('should return redirect to an external path with no baggage and trace injected.', async ({ page }) => {
   await page.goto('/?type=returnRedirectToExternal');
 
+  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
+
   // We should be successfully redirected to the external path.
   expect(page.url()).toEqual(expect.stringContaining('https://example.com'));
-
-  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
 
   expect(sentryTrace).toBeUndefined();
   expect(sentryBaggage).toBeUndefined();
@@ -177,10 +177,10 @@ test('should return redirect to an external path with no baggage and trace injec
 test('should throw redirect to an external path with no baggage and trace injected.', async ({ page }) => {
   await page.goto('/?type=throwRedirectToExternal');
 
+  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
+
   // We should be successfully redirected to the external path.
   expect(page.url()).toEqual(expect.stringContaining('https://example.com'));
-
-  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
 
   expect(sentryTrace).toBeUndefined();
   expect(sentryBaggage).toBeUndefined();


### PR DESCRIPTION
Looks like `example.com` has some kind of rate limit or random unavailability. Switching to `docs.sentry.io` resolved the flakes. Maybe we can replace all `example.com` uses in the codebase with a Sentry domain 🤔 Wdyt?