### PR TITLE
ref(v9/browser): Remove unnecessary CLS web vital check 

### DIFF
--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -430,10 +430,8 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
       delete _measurements['mark.fid'];
     }
 
-    // If FCP is not recorded we should not record the cls value
-    // according to the new definition of CLS.
-    // TODO: Check if the first condition is still necessary: `onCLS` already only fires once `onFCP` was called.
-    if (!('fcp' in _measurements) || !options.recordClsOnPageloadSpan) {
+    // If CLS standalone spans are enabled, don't record CLS as a measurement
+    if (!options.recordClsOnPageloadSpan) {
       delete _measurements.cls;
     }
 


### PR DESCRIPTION
Backport of #17090:

Just a minor cleanup from a TODO I left a while ago. We can safely
remove this check because CLS isn't reported before FCP is reported.