### PR TITLE
chore: Avoid building aws layer for now

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -82,7 +82,7 @@
     "build:bundle": "yarn build:layer",
     "build:layer": "yarn ts-node scripts/buildLambdaLayer.ts",
     "build:dev": "run-p build:transpile build:types",
-    "build:transpile": "rollup -c rollup.npm.config.mjs && yarn build:layer",
+    "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "run-s build:types:core build:types:downlevel",
     "build:types:core": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "yarn downlevel-dts build/npm/types build/npm/types-ts3.8 --to ts3.8",


### PR DESCRIPTION
The current way of building the AWS Lambda Layer is not working during releases because it tries to install @sentry/aws-serverless from the registry instead of the workspace.

Temporarily disable it until we figure out how to fix it.