### PR TITLE
chore: Revert AWS Lambda Layer build disabling

### DIFF
--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/package.json
@@ -18,8 +18,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "sentryTest": {
-    "skip": true
   }
 }

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-esm/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-esm/package.json
@@ -19,8 +19,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "sentryTest": {
-    "skip": true
   }
 }

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -79,9 +79,10 @@
   },
   "scripts": {
     "build": "run-p build:transpile build:types",
+    "build:bundle": "yarn build:layer",
     "build:layer": "yarn ts-node scripts/buildLambdaLayer.ts",
     "build:dev": "run-p build:transpile build:types",
-    "build:transpile": "rollup -c rollup.npm.config.mjs",
+    "build:transpile": "rollup -c rollup.npm.config.mjs && yarn build:layer",
     "build:types": "run-s build:types:core build:types:downlevel",
     "build:types:core": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "yarn downlevel-dts build/npm/types build/npm/types-ts3.8 --to ts3.8",


### PR DESCRIPTION
We removed this in order to release a v10 alpha but the release process still expcets a built layer, thus failing. We'll wait for a proper layer build fix.