### PR TITLE
chore(remix): Cleanup unused error args in sourcemaps script

### DIFF
--- a/packages/remix/scripts/createRelease.js
+++ b/packages/remix/scripts/createRelease.js
@@ -34,13 +34,13 @@ async function createRelease(argv, URL_PREFIX, BUILD_PATH) {
       useArtifactBundle: !argv.disableDebugIds,
       live: 'rejectOnError',
     });
-  } catch (error) {
+  } catch {
     console.warn('[sentry] Failed to upload sourcemaps.');
   }
 
   try {
     await sentry.releases.finalize(release);
-  } catch (error) {
+  } catch {
     console.warn('[sentry] Failed to finalize release.');
   }
 


### PR DESCRIPTION
Small cleanup forward-port to `develop` (see  https://github.com/getsentry/sentry-javascript/pull/17095#discussion_r2218413532.)
