### PR TITLE
fix(aws): Resolve all Sentry packages to local versions in layer build

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -79,7 +79,6 @@
   },
   "scripts": {
     "build": "run-p build:transpile build:types",
-    "build:bundle": "yarn build:layer",
     "build:layer": "yarn ts-node scripts/buildLambdaLayer.ts",
     "build:dev": "run-p build:transpile build:types",
     "build:transpile": "rollup -c rollup.npm.config.mjs && yarn build:layer",
@@ -103,18 +102,5 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false,
-  "nx": {
-    "targets": {
-      "build:bundle": {
-        "dependsOn": [
-          "build:transpile",
-          "build:types"
-        ],
-        "outputs": [
-          "{projectRoot}/build/aws"
-        ]
-      }
-    }
-  }
+  "sideEffects": false
 }


### PR DESCRIPTION
This fixes the AWS Layer release build which tried to fetch the new package versions from the NPM registry, which don't exist yet during the build. We now build a new `package.json` that uses `resolutions` to point all Sentry packages to their local version.
