### PR TITLE
fix(aws): Use file link in dependency version

### DIFF
--- a/packages/aws-serverless/scripts/buildLambdaLayer.ts
+++ b/packages/aws-serverless/scripts/buildLambdaLayer.ts
@@ -169,7 +169,7 @@ function buildPackageJson(): void {
 
   const packageJson = {
     dependencies: {
-      '@sentry/aws-serverless': version,
+      '@sentry/aws-serverless': 'file:../../../../../../packages/aws-serverless',
     },
     resolutions,
   };


### PR DESCRIPTION
Next try. Use local file link here too to skip registry fetch
