### PR TITLE
test(node): Test vercelai errors are properly linked to parent span

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error.mjs
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 async function run() {
   // Create a manual outer span (simulating the root span)
-  await Sentry.startSpan({ op: 'http.server', name: 'GET /api/test', description: 'HTTP server request' }, async () => {
+  await Sentry.startSpan({ op: 'outer', name: 'outer span', description: 'outer span' }, async () => {
     // It is expected that the error will bubble up naturally to the outer span
     await generateText({
       model: new MockLanguageModelV1({

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error.mjs
@@ -1,0 +1,53 @@
+import * as Sentry from '@sentry/node';
+import { generateText, tool } from 'ai';
+import { MockLanguageModelV1 } from 'ai/test';
+import { z } from 'zod';
+
+async function run() {
+  // Create a manual outer span (simulating the root span)
+  await Sentry.startSpan({ op: 'http.server', name: 'GET /api/test', description: 'HTTP server request' }, async () => {
+    // It is expected that the error will bubble up naturally to the outer span
+    await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { promptTokens: 10, completionTokens: 20 },
+          text: 'First span here!',
+          toolCalls: [
+            {
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'calculateTool',
+              args: '{ "a": 1, "b": 2 }',
+            },
+          ],
+        }),
+      }),
+      experimental_telemetry: {
+        functionId: 'Simple Agent',
+        recordInputs: true,
+        recordOutputs: true,
+        isEnabled: true,
+      },
+      tools: {
+        calculateTool: tool({
+          description: 'Calculate the result of a math problem. Returns a number.',
+          parameters: z.object({
+            a: z.number().describe('First number'),
+            b: z.number().describe('Second number'),
+          }),
+          type: 'function',
+          execute: async () => {
+            throw new Error('Not implemented');
+          },
+        }),
+      },
+      maxSteps: 2,
+      system: 'You help users with their math problems.',
+      prompt: 'What is 1 + 1?',
+    });
+  });
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-express-error.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-express-error.mjs
@@ -62,23 +62,19 @@ async function run() {
   const server = createServer(app);
 
   // Start server and make request
-  server.listen(0, async () => {
+  server.listen(0, () => {
     const port = server.address()?.port;
     // eslint-disable-next-line no-console
     console.log(JSON.stringify({ port }));
 
-    try {
-      // Make the request that will trigger the error
-      const response = await fetch(`http://localhost:${port}/api/chat`);
-      await response.json(); // Consume the response
-    } catch (error) {
-      // Expected to fail due to the tool error, but we still want to capture it
-    }
-
-    // Give time for Sentry to process and send the error
-    setTimeout(() => {
-      server.close();
-    }, 1000);
+    // Make the request that will trigger the error
+    fetch(`http://localhost:${port}/api/chat`)
+      .then(() => {
+        server.close();
+      })
+      .catch(() => {
+        server.close();
+      });
   });
 }
 

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-express-error.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-express-error.mjs
@@ -62,19 +62,23 @@ async function run() {
   const server = createServer(app);
 
   // Start server and make request
-  server.listen(0, () => {
+  server.listen(0, async () => {
     const port = server.address()?.port;
     // eslint-disable-next-line no-console
     console.log(JSON.stringify({ port }));
 
-    // Make the request that will trigger the error
-    fetch(`http://localhost:${port}/api/chat`)
-      .then(() => {
-        server.close();
-      })
-      .catch(() => {
-        server.close();
-      });
+    try {
+      // Make the request that will trigger the error
+      const response = await fetch(`http://localhost:${port}/api/chat`);
+      await response.json(); // Consume the response
+    } catch (error) {
+      // Expected to fail due to the tool error, but we still want to capture it
+    }
+
+    // Give time for Sentry to process and send the error
+    setTimeout(() => {
+      server.close();
+    }, 1000);
   });
 }
 

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-express-error.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-express-error.mjs
@@ -1,0 +1,81 @@
+import * as Sentry from '@sentry/node';
+import { generateText, tool } from 'ai';
+import { MockLanguageModelV1 } from 'ai/test';
+import express from 'express';
+import { createServer } from 'http';
+import { z } from 'zod';
+
+async function run() {
+  const app = express();
+
+  app.get('/api/chat', async (req, res) => {
+    try {
+      await generateText({
+        model: new MockLanguageModelV1({
+          doGenerate: async () => ({
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'stop',
+            usage: { promptTokens: 10, completionTokens: 20 },
+            text: 'Processing your request...',
+            toolCalls: [
+              {
+                toolCallType: 'function',
+                toolCallId: 'call-1',
+                toolName: 'calculateTool',
+                args: '{ "a": 1, "b": 2 }',
+              },
+            ],
+          }),
+        }),
+        experimental_telemetry: {
+          functionId: 'Chat Assistant',
+          recordInputs: true,
+          recordOutputs: true,
+          isEnabled: true,
+        },
+        tools: {
+          calculateTool: tool({
+            description: 'Calculate the result of a math problem. Returns a number.',
+            parameters: z.object({
+              a: z.number().describe('First number'),
+              b: z.number().describe('Second number'),
+            }),
+            type: 'function',
+            execute: async () => {
+              throw new Error('Calculation service unavailable');
+            },
+          }),
+        },
+        maxSteps: 2,
+        system: 'You are a helpful chat assistant.',
+        prompt: 'What is 1 + 1?',
+      });
+
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  Sentry.setupExpressErrorHandler(app);
+
+  const server = createServer(app);
+
+  // Start server and make request
+  server.listen(0, () => {
+    const port = server.address()?.port;
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify({ port }));
+
+    // Make the request that will trigger the error
+    fetch(`http://localhost:${port}/api/chat`)
+      .then(() => {
+        server.close();
+      })
+      .catch(() => {
+        server.close();
+      });
+  });
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -458,7 +458,7 @@ describe('Vercel AI integration', () => {
       expect(errorTraceId).toMatch(/^[a-f0-9]{32}$/);
 
       expect(errorTraceId).toBe(transactionTraceId);
-    }, 30000);
+    });
   });
 
   createEsmAndCjsTests(__dirname, 'scenario-express-error.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
@@ -504,6 +504,6 @@ describe('Vercel AI integration', () => {
       expect(errorTraceId).toMatch(/^[a-f0-9]{32}$/);
 
       expect(errorTraceId).toBe(transactionTraceId);
-    }, 30000);
+    });
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -426,7 +426,7 @@ describe('Vercel AI integration', () => {
         .expect({
           transaction: (transaction: any) => {
             capturedTransaction = transaction;
-            expect(transaction.transaction).toBe('GET /api/test');
+            expect(transaction.transaction).toBe('outer span');
           },
         })
         .expect({

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -458,7 +458,7 @@ describe('Vercel AI integration', () => {
       expect(errorTraceId).toMatch(/^[a-f0-9]{32}$/);
 
       expect(errorTraceId).toBe(transactionTraceId);
-    });
+    }, 30000);
   });
 
   createEsmAndCjsTests(__dirname, 'scenario-express-error.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
@@ -504,6 +504,6 @@ describe('Vercel AI integration', () => {
       expect(errorTraceId).toMatch(/^[a-f0-9]{32}$/);
 
       expect(errorTraceId).toBe(transactionTraceId);
-    });
+    }, 30000);
   });
 });


### PR DESCRIPTION
This adds tests to ensure Vercel AI errors properly inherit parent trace context.

Test Scenarios Added:
- Manual span creation test (This is for non server environment where we don't already have an http server span the error could bubble up to)
- Express HTTP request test (Tests realistic production scenario with Express server)