### PR TITLE
fix(node): Ensure tool errors for `vercelAiIntegration` have correct trace connected

### DIFF
--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "node-express-app",
+  "name": "aws-lambda-layer-cjs",
   "version": "1.0.0",
   "private": true,
+  "type": "commonjs",
   "scripts": {
     "start": "node src/run.js",
     "test": "playwright test",

--- a/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-0/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error-tracesSampleRate-0/server.ts
@@ -5,7 +5,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,
-  tracesSampleRate: 0
+  tracesSampleRate: 0,
 });
 
 import express from 'express';

--- a/dev-packages/node-integration-tests/suites/express/handle-error/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/server.ts
@@ -4,8 +4,8 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  tracesSampleRate: 1,
   transport: loggingTransport,
-  tracesSampleRate: 0
 });
 
 import express from 'express';

--- a/dev-packages/node-integration-tests/suites/express/handle-error/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/test.ts
@@ -5,8 +5,13 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('should capture and send Express controller error with txn name if tracesSampleRate is 0', async () => {
+test('should capture and send Express controller error with txn name if tracesSampleRate is 1', async () => {
   const runner = createRunner(__dirname, 'server.ts')
+    .expect({
+      transaction: {
+        transaction: 'GET /test/express/:id',
+      },
+    })
     .expect({
       event: {
         exception: {

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span-ended.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span-ended.ts
@@ -8,21 +8,25 @@ Sentry.init({
   transport: loggingTransport,
 });
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 recordSpan(async () => {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   doSomething();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   doSomethingWithError();
 });
 
-async function doSomething() {
+async function doSomething(): Promise<void> {
   return Promise.resolve();
 }
 
-async function doSomethingWithError() {
+async function doSomethingWithError(): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, 100));
   throw new Error('test error');
 }
 
-function recordSpan(fn: (span: unknown) => Promise<void>) {
+// Duplicating some code from vercel-ai to verify how things work in more complex/weird scenarios
+function recordSpan(fn: (span: unknown) => Promise<void>): Promise<void> {
   return Sentry.startSpanManual({ name: 'test-span' }, async span => {
     try {
       const result = await fn(span);

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span-ended.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span-ended.ts
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1,
+  transport: loggingTransport,
+});
+
+recordSpan(async () => {
+  doSomething();
+  doSomethingWithError();
+});
+
+async function doSomething() {
+  return Promise.resolve();
+}
+
+async function doSomethingWithError() {
+  await new Promise(resolve => setTimeout(resolve, 100));
+  throw new Error('test error');
+}
+
+function recordSpan(fn: (span: unknown) => Promise<void>) {
+  return Sentry.startSpanManual({ name: 'test-span' }, async span => {
+    try {
+      const result = await fn(span);
+      span.end();
+      return result;
+    } catch (error) {
+      try {
+        span.setStatus({ code: 2 });
+      } finally {
+        // always stop the span when there is an error:
+        span.end();
+      }
+
+      throw error;
+    }
+  });
+}

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1,
+  transport: loggingTransport,
+});
+
+Sentry.startSpan({ name: 'test-span' }, async () => {
+  throw new Error('test error');
+});

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span.ts
@@ -8,6 +8,7 @@ Sentry.init({
   transport: loggingTransport,
 });
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 Sentry.startSpan({ name: 'test-span' }, async () => {
   throw new Error('test error');
 });

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
@@ -1,8 +1,8 @@
+import type { Event } from '@sentry/node';
 import * as childProcess from 'child_process';
 import * as path from 'path';
 import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
-import type { Event } from '@sentry/node';
 
 describe('onUnhandledRejectionIntegration', () => {
   afterAll(() => {

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
@@ -2,6 +2,7 @@ import * as childProcess from 'child_process';
 import * as path from 'path';
 import { afterAll, describe, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+import type { Event } from '@sentry/node';
 
 describe('onUnhandledRejectionIntegration', () => {
   afterAll(() => {
@@ -122,5 +123,59 @@ test rejection`);
       })
       .start()
       .completed();
+  });
+
+  test('handles unhandled rejection in spans', async () => {
+    let transactionEvent: Event | undefined;
+    let errorEvent: Event | undefined;
+
+    await createRunner(__dirname, 'scenario-with-span.ts')
+      .expect({
+        transaction: transaction => {
+          transactionEvent = transaction;
+        },
+      })
+      .expect({
+        event: event => {
+          errorEvent = event;
+        },
+      })
+      .start()
+      .completed();
+
+    expect(transactionEvent).toBeDefined();
+    expect(errorEvent).toBeDefined();
+
+    expect(transactionEvent!.transaction).toBe('test-span');
+
+    expect(transactionEvent!.contexts!.trace!.trace_id).toBe(errorEvent!.contexts!.trace!.trace_id);
+    expect(transactionEvent!.contexts!.trace!.span_id).toBe(errorEvent!.contexts!.trace!.span_id);
+  });
+
+  test('handles unhandled rejection in spans that are ended early', async () => {
+    let transactionEvent: Event | undefined;
+    let errorEvent: Event | undefined;
+
+    await createRunner(__dirname, 'scenario-with-span-ended.ts')
+      .expect({
+        transaction: transaction => {
+          transactionEvent = transaction;
+        },
+      })
+      .expect({
+        event: event => {
+          errorEvent = event;
+        },
+      })
+      .start()
+      .completed();
+
+    expect(transactionEvent).toBeDefined();
+    expect(errorEvent).toBeDefined();
+
+    expect(transactionEvent!.transaction).toBe('test-span');
+
+    expect(transactionEvent!.contexts!.trace!.trace_id).toBe(errorEvent!.contexts!.trace!.trace_id);
+    expect(transactionEvent!.contexts!.trace!.span_id).toBe(errorEvent!.contexts!.trace!.span_id);
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-pii.mjs
@@ -7,5 +7,5 @@ Sentry.init({
   tracesSampleRate: 1.0,
   sendDefaultPii: true,
   transport: loggingTransport,
-  integrations: [Sentry.vercelAIIntegration({ force: true })],
+  integrations: [Sentry.vercelAIIntegration()],
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument.mjs
@@ -6,5 +6,5 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  integrations: [Sentry.vercelAIIntegration({ force: true })],
+  integrations: [Sentry.vercelAIIntegration()],
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error-in-tool-express.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error-in-tool-express.mjs
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/node';
+import { startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import { generateText } from 'ai';
 import { MockLanguageModelV1 } from 'ai/test';
-import { z } from 'zod';
-import { startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import express from 'express';
+import { z } from 'zod';
 
 const app = express();
 

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error-in-tool.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error-in-tool.mjs
@@ -1,0 +1,38 @@
+import * as Sentry from '@sentry/node';
+import { generateText } from 'ai';
+import { MockLanguageModelV1 } from 'ai/test';
+import { z } from 'zod';
+
+async function run() {
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    await generateText({
+      model: new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'tool-calls',
+          usage: { promptTokens: 15, completionTokens: 25 },
+          text: 'Tool call completed!',
+          toolCalls: [
+            {
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+              args: '{ "location": "San Francisco" }',
+            },
+          ],
+        }),
+      }),
+      tools: {
+        getWeather: {
+          parameters: z.object({ location: z.string() }),
+          execute: async args => {
+            throw new Error('Error in tool');
+          },
+        },
+      },
+      prompt: 'What is the weather in San Francisco?',
+    });
+  });
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error-in-tool.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-error-in-tool.mjs
@@ -25,7 +25,7 @@ async function run() {
       tools: {
         getWeather: {
           parameters: z.object({ location: z.string() }),
-          execute: async args => {
+          execute: async () => {
             throw new Error('Error in tool');
           },
         },

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -1,7 +1,6 @@
 import { afterAll, describe, expect } from 'vitest';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
-// `ai` SDK only support Node 18+
 describe('Vercel AI integration', () => {
   afterAll(() => {
     cleanupChildProcesses();
@@ -414,6 +413,117 @@ describe('Vercel AI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates ai related spans with sendDefaultPii: true', async () => {
       await createRunner().expect({ transaction: EXPECTED_TRANSACTION_DEFAULT_PII_TRUE }).start().completed();
+    });
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario-error-in-tool.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('captures error in tool', async () => {
+      const expectedTransaction = {
+        transaction: 'main',
+        spans: expect.arrayContaining([
+          expect.objectContaining({
+            data: {
+              'vercel.ai.model.id': 'mock-model-id',
+              'vercel.ai.model.provider': 'mock-provider',
+              'vercel.ai.operationId': 'ai.generateText',
+              'vercel.ai.pipeline.name': 'generateText',
+              'vercel.ai.settings.maxRetries': 2,
+              'vercel.ai.settings.maxSteps': 1,
+              'vercel.ai.streaming': false,
+              'gen_ai.response.model': 'mock-model-id',
+              'operation.name': 'ai.generateText',
+              'sentry.op': 'gen_ai.invoke_agent',
+              'sentry.origin': 'auto.vercelai.otel',
+            },
+            description: 'generateText',
+            op: 'gen_ai.invoke_agent',
+            origin: 'auto.vercelai.otel',
+            status: 'unknown_error',
+          }),
+          expect.objectContaining({
+            data: {
+              'vercel.ai.model.id': 'mock-model-id',
+              'vercel.ai.model.provider': 'mock-provider',
+              'vercel.ai.operationId': 'ai.generateText.doGenerate',
+              'vercel.ai.pipeline.name': 'generateText.doGenerate',
+              'vercel.ai.response.finishReason': 'tool-calls',
+              'vercel.ai.response.id': expect.any(String),
+              'vercel.ai.response.model': 'mock-model-id',
+              'vercel.ai.response.timestamp': expect.any(String),
+              'vercel.ai.settings.maxRetries': 2,
+              'vercel.ai.streaming': false,
+              'gen_ai.request.model': 'mock-model-id',
+              'gen_ai.response.finish_reasons': ['tool-calls'],
+              'gen_ai.response.id': expect.any(String),
+              'gen_ai.response.model': 'mock-model-id',
+              'gen_ai.system': 'mock-provider',
+              'gen_ai.usage.input_tokens': 15,
+              'gen_ai.usage.output_tokens': 25,
+              'gen_ai.usage.total_tokens': 40,
+              'operation.name': 'ai.generateText.doGenerate',
+              'sentry.op': 'gen_ai.generate_text',
+              'sentry.origin': 'auto.vercelai.otel',
+            },
+            description: 'generate_text mock-model-id',
+            op: 'gen_ai.generate_text',
+            origin: 'auto.vercelai.otel',
+            status: 'ok',
+          }),
+          expect.objectContaining({
+            data: {
+              'vercel.ai.operationId': 'ai.toolCall',
+              'gen_ai.tool.call.id': 'call-1',
+              'gen_ai.tool.name': 'getWeather',
+              'gen_ai.tool.type': 'function',
+              'operation.name': 'ai.toolCall',
+              'sentry.op': 'gen_ai.execute_tool',
+              'sentry.origin': 'auto.vercelai.otel',
+            },
+            description: 'execute_tool getWeather',
+            op: 'gen_ai.execute_tool',
+            origin: 'auto.vercelai.otel',
+            status: 'unknown_error',
+          }),
+        ]),
+      };
+
+      let traceId: string = 'unset-trace-id';
+      let spanId: string = 'unset-span-id';
+
+      const expectedError = {
+        contexts: {
+          trace: {
+            span_id: expect.any(String),
+            trace_id: expect.any(String),
+          },
+        },
+        exception: {
+          values: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'AI_ToolExecutionError',
+              value: 'Error executing tool getWeather: Error in tool',
+            }),
+          ]),
+        },
+      };
+
+      await createRunner()
+        .expect({
+          transaction: transaction => {
+            expect(transaction).toMatchObject(expectedTransaction);
+            traceId = transaction.contexts!.trace!.trace_id;
+            spanId = transaction.contexts!.trace!.span_id;
+          },
+        })
+        .expect({
+          event: event => {
+            expect(event).toMatchObject(expectedError);
+            expect(event.contexts!.trace!.trace_id).toBe(traceId);
+            expect(event.contexts!.trace!.span_id).toBe(spanId);
+          },
+        })
+        .start()
+        .completed();
     });
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -1,6 +1,6 @@
+import type { Event } from '@sentry/node';
 import { afterAll, describe, expect } from 'vitest';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
-import { Event } from '@sentry/node';
 
 describe('Vercel AI integration', () => {
   afterAll(() => {

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect } from 'vitest';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+import { Event } from '@sentry/node';
 
 describe('Vercel AI integration', () => {
   afterAll(() => {
@@ -485,6 +486,10 @@ describe('Vercel AI integration', () => {
             status: 'unknown_error',
           }),
         ]),
+
+        tags: {
+          'test-tag': 'test-value',
+        },
       };
 
       let traceId: string = 'unset-trace-id';
@@ -505,6 +510,9 @@ describe('Vercel AI integration', () => {
             }),
           ]),
         },
+        tags: {
+          'test-tag': 'test-value',
+        },
       };
 
       await createRunner()
@@ -524,6 +532,131 @@ describe('Vercel AI integration', () => {
         })
         .start()
         .completed();
+    });
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario-error-in-tool-express.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('captures error in tool in express server', async () => {
+      const expectedTransaction = {
+        transaction: 'GET /test/error-in-tool',
+        spans: expect.arrayContaining([
+          expect.objectContaining({
+            data: {
+              'vercel.ai.model.id': 'mock-model-id',
+              'vercel.ai.model.provider': 'mock-provider',
+              'vercel.ai.operationId': 'ai.generateText',
+              'vercel.ai.pipeline.name': 'generateText',
+              'vercel.ai.settings.maxRetries': 2,
+              'vercel.ai.settings.maxSteps': 1,
+              'vercel.ai.streaming': false,
+              'gen_ai.response.model': 'mock-model-id',
+              'operation.name': 'ai.generateText',
+              'sentry.op': 'gen_ai.invoke_agent',
+              'sentry.origin': 'auto.vercelai.otel',
+            },
+            description: 'generateText',
+            op: 'gen_ai.invoke_agent',
+            origin: 'auto.vercelai.otel',
+            status: 'unknown_error',
+          }),
+          expect.objectContaining({
+            data: {
+              'vercel.ai.model.id': 'mock-model-id',
+              'vercel.ai.model.provider': 'mock-provider',
+              'vercel.ai.operationId': 'ai.generateText.doGenerate',
+              'vercel.ai.pipeline.name': 'generateText.doGenerate',
+              'vercel.ai.response.finishReason': 'tool-calls',
+              'vercel.ai.response.id': expect.any(String),
+              'vercel.ai.response.model': 'mock-model-id',
+              'vercel.ai.response.timestamp': expect.any(String),
+              'vercel.ai.settings.maxRetries': 2,
+              'vercel.ai.streaming': false,
+              'gen_ai.request.model': 'mock-model-id',
+              'gen_ai.response.finish_reasons': ['tool-calls'],
+              'gen_ai.response.id': expect.any(String),
+              'gen_ai.response.model': 'mock-model-id',
+              'gen_ai.system': 'mock-provider',
+              'gen_ai.usage.input_tokens': 15,
+              'gen_ai.usage.output_tokens': 25,
+              'gen_ai.usage.total_tokens': 40,
+              'operation.name': 'ai.generateText.doGenerate',
+              'sentry.op': 'gen_ai.generate_text',
+              'sentry.origin': 'auto.vercelai.otel',
+            },
+            description: 'generate_text mock-model-id',
+            op: 'gen_ai.generate_text',
+            origin: 'auto.vercelai.otel',
+            status: 'ok',
+          }),
+          expect.objectContaining({
+            data: {
+              'vercel.ai.operationId': 'ai.toolCall',
+              'gen_ai.tool.call.id': 'call-1',
+              'gen_ai.tool.name': 'getWeather',
+              'gen_ai.tool.type': 'function',
+              'operation.name': 'ai.toolCall',
+              'sentry.op': 'gen_ai.execute_tool',
+              'sentry.origin': 'auto.vercelai.otel',
+            },
+            description: 'execute_tool getWeather',
+            op: 'gen_ai.execute_tool',
+            origin: 'auto.vercelai.otel',
+            status: 'unknown_error',
+          }),
+        ]),
+
+        tags: {
+          'test-tag': 'test-value',
+        },
+      };
+
+      const expectedError = {
+        contexts: {
+          trace: {
+            span_id: expect.any(String),
+            trace_id: expect.any(String),
+          },
+        },
+        exception: {
+          values: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'AI_ToolExecutionError',
+              value: 'Error executing tool getWeather: Error in tool',
+            }),
+          ]),
+        },
+        tags: {
+          'test-tag': 'test-value',
+        },
+      };
+
+      let transactionEvent: Event | undefined;
+      let errorEvent: Event | undefined;
+
+      const runner = await createRunner()
+        .expect({
+          transaction: transaction => {
+            transactionEvent = transaction;
+          },
+        })
+        .expect({
+          event: event => {
+            errorEvent = event;
+          },
+        })
+        .start();
+
+      await runner.makeRequest('get', '/test/error-in-tool', { expectError: true });
+      await runner.completed();
+
+      expect(transactionEvent).toBeDefined();
+      expect(errorEvent).toBeDefined();
+
+      expect(transactionEvent).toMatchObject(expectedTransaction);
+
+      expect(errorEvent).toMatchObject(expectedError);
+      expect(errorEvent!.contexts!.trace!.trace_id).toBe(transactionEvent!.contexts!.trace!.trace_id);
+      expect(errorEvent!.contexts!.trace!.span_id).toBe(transactionEvent!.contexts!.trace!.span_id);
     });
   });
 });

--- a/packages/node-core/src/integrations/onunhandledrejection.ts
+++ b/packages/node-core/src/integrations/onunhandledrejection.ts
@@ -53,7 +53,8 @@ export function makeUnhandledPromiseHandler(
 
     // this can be set in places where we cannot reliably get access to the active span/error
     // when the error bubbles up to this handler, we can use this to set the active span
-    const activeSpanForError = (reason as { _sentry_active_span?: Span })._sentry_active_span;
+    const activeSpanForError =
+      reason && typeof reason === 'object' ? (reason as { _sentry_active_span?: Span })._sentry_active_span : undefined;
 
     const activeSpanWrapper = activeSpanForError
       ? (fn: () => void) => withActiveSpan(activeSpanForError, fn)


### PR DESCRIPTION
This fixes the problem that for tool errors triggered from vercel-ai integration, traces were not connected.
This seemed to happen because errors bubble up to the global unhandled rejection handler, where the span is no longer active and thus the trace cannot be connected.

This PR fixes this by attaching the active span to the error and using this in the unhandled rejection handler, if it exists. 

Closes https://github.com/getsentry/sentry-javascript/issues/17108