### PR TITLE
chore: Skip Lambda layer tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/package.json
@@ -18,5 +18,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "sentryTest": {
+    "skip": true
   }
 }

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/tests/basic.test.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/tests/basic.test.ts
@@ -18,7 +18,7 @@ test('Lambda layer SDK bundle sends events', async ({ request }) => {
   );
 
   child_process.execSync('pnpm start', {
-    stdio: 'pipe',
+    stdio: 'inherit',
   });
 
   const transactionEvent = await transactionEventPromise;

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/tests/basic.test.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-cjs/tests/basic.test.ts
@@ -18,7 +18,7 @@ test('Lambda layer SDK bundle sends events', async ({ request }) => {
   );
 
   child_process.execSync('pnpm start', {
-    stdio: 'ignore',
+    stdio: 'pipe',
   });
 
   const transactionEvent = await transactionEventPromise;

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-esm/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-esm/package.json
@@ -19,5 +19,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "sentryTest": {
+    "skip": true
   }
 }

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-esm/tests/basic.test.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-esm/tests/basic.test.ts
@@ -18,7 +18,7 @@ test('Lambda layer SDK bundle sends events', async ({ request }) => {
   );
 
   child_process.execSync('pnpm start', {
-    stdio: 'pipe',
+    stdio: 'inherit',
   });
 
   const transactionEvent = await transactionEventPromise;

--- a/dev-packages/e2e-tests/test-applications/aws-lambda-layer-esm/tests/basic.test.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-lambda-layer-esm/tests/basic.test.ts
@@ -18,7 +18,7 @@ test('Lambda layer SDK bundle sends events', async ({ request }) => {
   );
 
   child_process.execSync('pnpm start', {
-    stdio: 'ignore',
+    stdio: 'pipe',
   });
 
   const transactionEvent = await transactionEventPromise;


### PR DESCRIPTION
skip until we figure out why they are failing on CI.
