### PR TITLE
ci: Stop caching utils src files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,6 @@ env:
     ${{ github.workspace }}/packages/*/lib
     ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/gatsby/*.d.ts
-    ${{ github.workspace }}/packages/utils/cjs
-    ${{ github.workspace }}/packages/utils/esm
 
   BUILD_CACHE_TARBALL_KEY: tarball-${{ github.event.inputs.commit || github.sha }}
 


### PR DESCRIPTION
This used to be necessary due to polyfills, I believe, but since they are gone this hopefully is not needed anymore.