### PR TITLE
fix(sveltekit): Align error status filtering and mechanism in `handleErrorWithSentry`

### DIFF
--- a/packages/sveltekit/src/client/handleError.ts
+++ b/packages/sveltekit/src/client/handleError.ts
@@ -28,20 +28,35 @@ type SafeHandleServerErrorInput = Omit<HandleClientErrorInput, 'status' | 'messa
  *
  * @param handleError The original SvelteKit error handler.
  */
-export function handleErrorWithSentry(handleError: HandleClientError = defaultErrorHandler): HandleClientError {
-  return (input: SafeHandleServerErrorInput): ReturnType<HandleClientError> => {
-    // SvelteKit 2.0 offers a reliable way to check for a 404 error:
-    if (input.status !== 404) {
-      captureException(input.error, {
-        mechanism: {
-          type: 'sveltekit',
-          handled: false,
-        },
-      });
+export function handleErrorWithSentry(handleError?: HandleClientError): HandleClientError {
+  const errorHandler = handleError ?? defaultErrorHandler;
+
+  return (input: HandleClientErrorInput): ReturnType<HandleClientError> => {
+    if (is4xxError(input)) {
+      return errorHandler(input);
     }
 
-    // We're extra cautious with SafeHandleServerErrorInput - this type is not compatible with HandleServerErrorInput
-    // @ts-expect-error - we're still passing the same object, just with a different (backwards-compatible) type
-    return handleError(input);
+    captureException(input.error, {
+      mechanism: {
+        type: 'sveltekit',
+        handled: !!handleError,
+      },
+    });
+
+    return errorHandler(input);
   };
+}
+
+// 4xx are expected errors and thus we don't want to capture them
+function is4xxError(input: SafeHandleServerErrorInput): boolean {
+  const { status } = input;
+
+  // Pre-SvelteKit 2.x, the status is not available,
+  // so we don't know if this is a 4xx error
+  if (!status) {
+    return false;
+  }
+
+  // SvelteKit 2.0 offers a reliable way to check for a Not Found error:
+  return status >= 400 && status < 500;
 }


### PR DESCRIPTION
Our `handleErrorWithSentry` logic was diverging a bit from the rest of the SvelteKit SDK and more general SDK patterns. Specifically, which errors would be ignored and when we set an error mechanism to `handled: true|false`.

This PR now aligns two behaviours:
- Ignore all 4xx errors (previously, we only ignored 404 errors)
- Set `handled: true` if a custom error handler was defined by users and `handled: false` otherwise.

Reported via Support, so no GH issue.