### PR TITLE
fix(v9/nextjs): Update stackframe calls for next v15.5 (#17156)

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/devErrorSymbolification.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/devErrorSymbolification.test.ts
@@ -1,35 +1,30 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/test-utils';
 
-test.describe('dev mode error symbolification', () => {
-  if (process.env.TEST_ENV !== 'development') {
-    test.skip('should be skipped for non-dev mode', () => {});
-    return;
-  }
+test('should have symbolicated dev errors', async ({ page }) => {
+  test.skip(process.env.TEST_ENV !== 'development', 'should be skipped for non-dev mode');
 
-  test('should have symbolicated dev errors', async ({ page }) => {
-    await page.goto('/');
+  await page.goto('/');
 
-    const errorEventPromise = waitForError('nextjs-app-dir', errorEvent => {
-      return errorEvent?.exception?.values?.[0]?.value === 'Click Error';
-    });
-
-    await page.getByText('Throw error').click();
-
-    const errorEvent = await errorEventPromise;
-    const errorEventFrames = errorEvent.exception?.values?.[0]?.stacktrace?.frames;
-
-    expect(errorEventFrames?.[errorEventFrames?.length - 1]).toEqual(
-      expect.objectContaining({
-        function: 'onClick',
-        filename: 'components/client-error-debug-tools.tsx',
-        lineno: 54,
-        colno: expect.any(Number),
-        in_app: true,
-        pre_context: ['       <button', '         onClick={() => {'],
-        context_line: "           throw new Error('Click Error');",
-        post_context: ['         }}', '       >', '         Throw error'],
-      }),
-    );
+  const errorEventPromise = waitForError('nextjs-app-dir', errorEvent => {
+    return errorEvent?.exception?.values?.[0]?.value === 'Click Error';
   });
+
+  await page.getByText('Throw error').click();
+
+  const errorEvent = await errorEventPromise;
+  const errorEventFrames = errorEvent.exception?.values?.[0]?.stacktrace?.frames;
+
+  expect(errorEventFrames?.[errorEventFrames?.length - 1]).toEqual(
+    expect.objectContaining({
+      function: 'onClick',
+      filename: 'components/client-error-debug-tools.tsx',
+      lineno: 54,
+      colno: expect.any(Number),
+      in_app: true,
+      pre_context: ['       <button', '         onClick={() => {'],
+      context_line: "           throw new Error('Click Error');",
+      post_context: ['         }}', '       >', '         Throw error'],
+    }),
+  );
 });

--- a/packages/nextjs/src/common/devErrorSymbolicationEventProcessor.ts
+++ b/packages/nextjs/src/common/devErrorSymbolicationEventProcessor.ts
@@ -45,7 +45,7 @@ export async function devErrorSymbolicationEventProcessor(event: Event, hint: Ev
 
       let resolvedFrames: ({
         originalCodeFrame: string | null;
-        originalStackFrame: StackFrame | null;
+        originalStackFrame: (StackFrame & { line1?: number; column1?: number }) | null;
       } | null)[];
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -84,8 +84,9 @@ export async function devErrorSymbolicationEventProcessor(event: Event, hint: Ev
               post_context: postContextLines,
               function: resolvedFrame.originalStackFrame.methodName,
               filename: resolvedFrame.originalStackFrame.file || undefined,
-              lineno: resolvedFrame.originalStackFrame.lineNumber || undefined,
-              colno: resolvedFrame.originalStackFrame.column || undefined,
+              lineno:
+                resolvedFrame.originalStackFrame.lineNumber || resolvedFrame.originalStackFrame.line1 || undefined,
+              colno: resolvedFrame.originalStackFrame.column || resolvedFrame.originalStackFrame.column1 || undefined,
             };
           },
         );
@@ -175,6 +176,8 @@ async function resolveStackFrames(
             arguments: [],
             lineNumber: frame.lineNumber ?? 0,
             column: frame.column ?? 0,
+            line1: frame.lineNumber ?? 0,
+            column1: frame.column ?? 0,
           };
         }),
       isServer: false,


### PR DESCRIPTION
backport of https://github.com/getsentry/sentry-javascript/pull/17156