### PR TITLE
feat(meta): Unify detection of serverless environments and add Cloud Run

### DIFF
--- a/packages/nuxt/src/runtime/utils.ts
+++ b/packages/nuxt/src/runtime/utils.ts
@@ -103,6 +103,7 @@ export async function flushIfServerless(): Promise<void> {
   const isServerless =
     !!process.env.FUNCTIONS_WORKER_RUNTIME || // Azure Functions
     !!process.env.LAMBDA_TASK_ROOT || // AWS Lambda
+    !!process.env.K_SERVICE || // Google Cloud Run
     !!process.env.CF_PAGES || // Cloudflare
     !!process.env.VERCEL ||
     !!process.env.NETLIFY;

--- a/packages/solidstart/src/server/utils.ts
+++ b/packages/solidstart/src/server/utils.ts
@@ -5,7 +5,13 @@ import { DEBUG_BUILD } from '../common/debug-build';
 
 /** Flush the event queue to ensure that events get sent to Sentry before the response is finished and the lambda ends */
 export async function flushIfServerless(): Promise<void> {
-  const isServerless = !!process.env.LAMBDA_TASK_ROOT || !!process.env.VERCEL;
+  const isServerless =
+    !!process.env.FUNCTIONS_WORKER_RUNTIME || // Azure Functions
+    !!process.env.LAMBDA_TASK_ROOT || // AWS Lambda
+    !!process.env.K_SERVICE || // Google Cloud Run
+    !!process.env.CF_PAGES || // Cloudflare
+    !!process.env.VERCEL ||
+    !!process.env.NETLIFY;
 
   if (isServerless) {
     try {

--- a/packages/sveltekit/src/server-common/utils.ts
+++ b/packages/sveltekit/src/server-common/utils.ts
@@ -22,9 +22,15 @@ export async function flushIfServerless(): Promise<void> {
     return;
   }
 
-  const platformSupportsStreaming = !process.env.LAMBDA_TASK_ROOT && !process.env.VERCEL;
+  const isServerless =
+    !!process.env.FUNCTIONS_WORKER_RUNTIME || // Azure Functions
+    !!process.env.LAMBDA_TASK_ROOT || // AWS Lambda
+    !!process.env.K_SERVICE || // Google Cloud Run
+    !!process.env.CF_PAGES || // Cloudflare
+    !!process.env.VERCEL ||
+    !!process.env.NETLIFY;
 
-  if (!platformSupportsStreaming) {
+  if (isServerless) {
     try {
       DEBUG_BUILD && debug.log('Flushing events...');
       await flush(2000);


### PR DESCRIPTION
Adds Google Cloud Run environment variable to serverless detection to wait until flushing. 

Documented here: https://cloud.google.com/run/docs/configuring/services/environment-variables#reserved

related to this: https://github.com/getsentry/sentry-javascript/issues/17165