### PR TITLE
test(nextjs): Run prod e2e tests in turbopack

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-turbo/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-turbo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build > .tmp_build_stdout 2> .tmp_build_stderr || (cat .tmp_build_stdout && cat .tmp_build_stderr && exit 1)",
+    "build": "next build --turbopack > .tmp_build_stdout 2> .tmp_build_stderr || (cat .tmp_build_stdout && cat .tmp_build_stderr && exit 1)",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "test:prod": "TEST_ENV=production playwright test",
     "test:dev": "TEST_ENV=development playwright test",

--- a/dev-packages/e2e-tests/test-applications/nextjs-turbo/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/nextjs-turbo/playwright.config.mjs
@@ -7,7 +7,7 @@ if (!testEnv) {
 
 const config = getPlaywrightConfig(
   {
-    startCommand: testEnv === 'development' ? 'pnpm next dev -p 3030 --turbo' : 'pnpm next start -p 3030',
+    startCommand: testEnv === 'development' ? 'pnpm next dev -p 3030 --turbopack' : 'pnpm next start -p 3030',
     port: 3030,
   },
   {


### PR DESCRIPTION
Changes the build command for the next.js turbopack e2e test to also run the prod tests with turbopack.

ref https://linear.app/getsentry/project/turbopack-support-nextjs-80713aa82b5a