### PR TITLE
chore: Skip releasing v10 AWS layer

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -144,16 +144,17 @@ targets:
     includeNames: /^sentry-internal-eslint-config-sdk-\d.*\.tgz$/
 
   # AWS Lambda Layer target
-  - name: aws-lambda-layer
-    includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
-    layerName: SentryNodeServerlessSDKv10
-    compatibleRuntimes:
-      - name: node
-        versions:
-          - nodejs18.x
-          - nodejs20.x
-          - nodejs22.x
-    license: MIT
+  # Commented out until we release v10, otherwise we'd override the current v9 layer
+  # - name: aws-lambda-layer
+  #   includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
+  #   layerName: SentryNodeServerlessSDKv10
+  #   compatibleRuntimes:
+  #     - name: node
+  #       versions:
+  #         - nodejs18.x
+  #         - nodejs20.x
+  #         - nodejs22.x
+  #   license: MIT
 
   # CDN Bundle Target
   - name: gcs


### PR DESCRIPTION
We need to skip releasing the v10 AWS Lambda layer, otherwise the current v9 Layer gets overridden
