### PR TITLE
fix(core): Fix operation name for openai responses API 

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
@@ -38,8 +38,8 @@ describe('OpenAI integration', () => {
       // Second span - responses API
       expect.objectContaining({
         data: {
-          'gen_ai.operation.name': 'chat',
-          'sentry.op': 'gen_ai.chat',
+          'gen_ai.operation.name': 'responses',
+          'sentry.op': 'gen_ai.responses',
           'sentry.origin': 'manual',
           'gen_ai.system': 'openai',
           'gen_ai.request.model': 'gpt-3.5-turbo',
@@ -55,8 +55,8 @@ describe('OpenAI integration', () => {
           'openai.usage.completion_tokens': 8,
           'openai.usage.prompt_tokens': 5,
         },
-        description: 'chat gpt-3.5-turbo',
-        op: 'gen_ai.chat',
+        description: 'responses gpt-3.5-turbo',
+        op: 'gen_ai.responses',
         origin: 'manual',
         status: 'ok',
       }),
@@ -105,8 +105,8 @@ describe('OpenAI integration', () => {
       // Fifth span - responses API streaming
       expect.objectContaining({
         data: {
-          'gen_ai.operation.name': 'chat',
-          'sentry.op': 'gen_ai.chat',
+          'gen_ai.operation.name': 'responses',
+          'sentry.op': 'gen_ai.responses',
           'sentry.origin': 'manual',
           'gen_ai.system': 'openai',
           'gen_ai.request.model': 'gpt-4',
@@ -124,8 +124,8 @@ describe('OpenAI integration', () => {
           'openai.usage.completion_tokens': 10,
           'openai.usage.prompt_tokens': 6,
         },
-        description: 'chat gpt-4 stream-response',
-        op: 'gen_ai.chat',
+        description: 'responses gpt-4 stream-response',
+        op: 'gen_ai.responses',
         origin: 'manual',
         status: 'ok',
       }),
@@ -182,8 +182,8 @@ describe('OpenAI integration', () => {
       // Second span - responses API with PII
       expect.objectContaining({
         data: {
-          'gen_ai.operation.name': 'chat',
-          'sentry.op': 'gen_ai.chat',
+          'gen_ai.operation.name': 'responses',
+          'sentry.op': 'gen_ai.responses',
           'sentry.origin': 'manual',
           'gen_ai.system': 'openai',
           'gen_ai.request.model': 'gpt-3.5-turbo',
@@ -201,8 +201,8 @@ describe('OpenAI integration', () => {
           'openai.usage.completion_tokens': 8,
           'openai.usage.prompt_tokens': 5,
         },
-        description: 'chat gpt-3.5-turbo',
-        op: 'gen_ai.chat',
+        description: 'responses gpt-3.5-turbo',
+        op: 'gen_ai.responses',
         origin: 'manual',
         status: 'ok',
       }),
@@ -255,8 +255,8 @@ describe('OpenAI integration', () => {
       // Fifth span - responses API streaming with PII
       expect.objectContaining({
         data: expect.objectContaining({
-          'gen_ai.operation.name': 'chat',
-          'sentry.op': 'gen_ai.chat',
+          'gen_ai.operation.name': 'responses',
+          'sentry.op': 'gen_ai.responses',
           'sentry.origin': 'manual',
           'gen_ai.system': 'openai',
           'gen_ai.request.model': 'gpt-4',
@@ -276,8 +276,8 @@ describe('OpenAI integration', () => {
           'openai.usage.completion_tokens': 10,
           'openai.usage.prompt_tokens': 6,
         }),
-        description: 'chat gpt-4 stream-response',
-        op: 'gen_ai.chat',
+        description: 'responses gpt-4 stream-response',
+        op: 'gen_ai.responses',
         origin: 'manual',
         status: 'ok',
       }),

--- a/packages/core/src/utils/gen-ai-attributes.ts
+++ b/packages/core/src/utils/gen-ai-attributes.ts
@@ -150,4 +150,5 @@ export const OPENAI_RESPONSE_STREAM_ATTRIBUTE = 'openai.response.stream';
  */
 export const OPENAI_OPERATIONS = {
   CHAT: 'chat',
+  RESPONSES: 'responses',
 } as const;

--- a/packages/core/src/utils/openai/utils.ts
+++ b/packages/core/src/utils/openai/utils.ts
@@ -29,8 +29,7 @@ export function getOperationName(methodPath: string): string {
     return OPENAI_OPERATIONS.CHAT;
   }
   if (methodPath.includes('responses')) {
-    // The responses API is also a chat operation
-    return OPENAI_OPERATIONS.CHAT;
+    return OPENAI_OPERATIONS.RESPONSES;
   }
   return methodPath.split('.').pop() || 'unknown';
 }

--- a/packages/core/test/lib/utils/openai-utils.test.ts
+++ b/packages/core/test/lib/utils/openai-utils.test.ts
@@ -17,9 +17,9 @@ describe('openai-utils', () => {
       expect(getOperationName('some.path.chat.completions.method')).toBe('chat');
     });
 
-    it('should return chat for responses methods', () => {
-      expect(getOperationName('responses.create')).toBe('chat');
-      expect(getOperationName('some.path.responses.method')).toBe('chat');
+    it('should return responses for responses methods', () => {
+      expect(getOperationName('responses.create')).toBe('responses');
+      expect(getOperationName('some.path.responses.method')).toBe('responses');
     });
 
     it('should return the last part of path for unknown methods', () => {
@@ -35,7 +35,7 @@ describe('openai-utils', () => {
   describe('getSpanOperation', () => {
     it('should prefix operation with gen_ai', () => {
       expect(getSpanOperation('chat.completions.create')).toBe('gen_ai.chat');
-      expect(getSpanOperation('responses.create')).toBe('gen_ai.chat');
+      expect(getSpanOperation('responses.create')).toBe('gen_ai.responses');
       expect(getSpanOperation('some.custom.operation')).toBe('gen_ai.operation');
     });
   });


### PR DESCRIPTION
According to https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-operation-name

> “If one of them applies, then the respective value MUST be used; otherwise, a custom value MAY be used.” 

and because the responses api also allows file and image input we can assume it's not really a chat completion

closes: https://github.com/getsentry/sentry-javascript/issues/17192