### PR TITLE
feat(node-native): Upgrade `@sentry-internal/node-native-stacktrace` to `0.2.2`

### DIFF
--- a/packages/node-native/package.json
+++ b/packages/node-native/package.json
@@ -63,7 +63,7 @@
     "build:tarball": "npm pack"
   },
   "dependencies": {
-    "@sentry-internal/node-native-stacktrace": "^0.2.0",
+    "@sentry-internal/node-native-stacktrace": "^0.2.2",
     "@sentry/core": "9.40.0",
     "@sentry/node": "9.40.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6847,10 +6847,10 @@
     detect-libc "^2.0.3"
     node-abi "^3.73.0"
 
-"@sentry-internal/node-native-stacktrace@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/node-native-stacktrace/-/node-native-stacktrace-0.2.0.tgz#d759d9ba62101aea46829c436aec490d4a63f9f7"
-  integrity sha512-MPkjcXFUaBVxbpx8whvqQu7UncriCt3nUN7uA+ojgauHF2acvSp5nJCqKM2a4KInFWNiI1AxJ6tLE7EuBJ4WBQ==
+"@sentry-internal/node-native-stacktrace@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/node-native-stacktrace/-/node-native-stacktrace-0.2.2.tgz#b32dde884642f100dd691b12b643361040825eeb"
+  integrity sha512-ZRS+a1Ik+w6awjp9na5vHBqLNkIxysfGDswLVAkjtVdBUxtfsEVI8OA6r8PijJC5Gm1oAJJap2e9H7TSiCUQIQ==
   dependencies:
     detect-libc "^2.0.4"
     node-abi "^3.73.0"


### PR DESCRIPTION
Although the way we pin this dep allows for patch versions, let's explicitly bump this because https://github.com/getsentry/sentry-javascript-node-native-stacktrace/releases/tag/0.2.2 includes a pretty nice fix for cross-platform timings.

Thanks again to @matthew-nicholson-anrok for the contribution :)