### PR TITLE
fix(node): Add mechanism to `fastifyIntegration` error handler

### DIFF
--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -131,7 +131,7 @@ function handleFastifyError(
   }
 
   if (shouldHandleError(error, request, reply)) {
-    captureException(error);
+    captureException(error, { mechanism: { handled: false, type: 'fastify' } });
   }
 }
 


### PR DESCRIPTION
While investigating https://github.com/getsentry/sentry-javascript/issues/17119, I saw that our fastifyIntegration error handler doesn't set a mechanism when calling `captureException`. This leads to the SDK assigning the generic fallback mechanism and marking the error as `handled: true`. This makes it hard to 1. identify that the error was captured by our fastify instrumentation and 2. marks the error as handled, when it's probably not. 