### PR TITLE
fix(v9/node): Add mechanism to `fastifyIntegration` error handler

### DIFF
--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -131,7 +131,7 @@ function handleFastifyError(
   }
 
   if (shouldHandleError(error, request, reply)) {
-    captureException(error);
+    captureException(error, { mechanism: { handled: false, type: 'fastify' } });
   }
 }
 


### PR DESCRIPTION
Backport of #17208 

Marks the captured error as `{ handled: false, type: 'fastify' }`