### PR TITLE
feat(replay): Promote `_experiments.autoFlushOnFeedback` option as default

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -61,6 +61,8 @@ Sentry.init({
 });
 ```
 
+- (Session Replay) The `_experiments.autoFlushOnFeedback` option was removed and is now default behavior.
+
 ## 3. Behaviour Changes
 
 ### Removal of First Input Delay (FID) Web Vital Reporting

--- a/dev-packages/browser-integration-tests/suites/replay/autoFlushOnFeedback/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/autoFlushOnFeedback/init.js
@@ -5,9 +5,6 @@ window.Replay = Sentry.replayIntegration({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   useCompression: false,
-  _experiments: {
-    autoFlushOnFeedback: true,
-  },
 });
 
 Sentry.init({

--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -939,7 +939,7 @@ export class ReplayContainer implements ReplayContainerInterface {
 
       // There is no way to remove these listeners, so ensure they are only added once
       if (!this._hasInitializedCoreListeners) {
-        addGlobalListeners(this, { autoFlushOnFeedback: this._options._experiments.autoFlushOnFeedback });
+        addGlobalListeners(this);
 
         this._hasInitializedCoreListeners = true;
       }

--- a/packages/replay-internal/src/types/replay.ts
+++ b/packages/replay-internal/src/types/replay.ts
@@ -235,6 +235,9 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
      * https://github.com/rrweb-io/rrweb/blob/master/docs/recipes/cross-origin-iframes.md#considerations
      */
     recordCrossOriginIframes: boolean;
+    /**
+     * @deprecated This option is now the default behavior and the option is no longer needed. It will be removed in the next major version.
+     */
     autoFlushOnFeedback: boolean;
     /**
      * Completetly ignore mutations matching the given selectors.

--- a/packages/replay-internal/src/types/replay.ts
+++ b/packages/replay-internal/src/types/replay.ts
@@ -236,11 +236,7 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
      */
     recordCrossOriginIframes: boolean;
     /**
-     * @deprecated This option is now the default behavior and the option is no longer needed. It will be removed in the next major version.
-     */
-    autoFlushOnFeedback: boolean;
-    /**
-     * Completetly ignore mutations matching the given selectors.
+     * Completely ignore mutations matching the given selectors.
      * This can be used if a specific type of mutation is causing (e.g. performance) problems.
      * NOTE: This can be dangerous to use, as mutations are applied as incremental patches.
      * Make sure to verify that the captured replays still work when using this option.

--- a/packages/replay-internal/src/util/addGlobalListeners.ts
+++ b/packages/replay-internal/src/util/addGlobalListeners.ts
@@ -16,10 +16,7 @@ import type { ReplayContainer } from '../types';
 /**
  * Add global listeners that cannot be removed.
  */
-export function addGlobalListeners(
-  replay: ReplayContainer,
-  { autoFlushOnFeedback }: { autoFlushOnFeedback?: boolean },
-): void {
+export function addGlobalListeners(replay: ReplayContainer): void {
   // Listeners from core SDK //
   const client = getClient();
 
@@ -64,17 +61,15 @@ export function addGlobalListeners(
       const replayId = replay.getSessionId();
       if (options?.includeReplay && replay.isEnabled() && replayId && feedbackEvent.contexts?.feedback) {
         // In case the feedback is sent via API and not through our widget, we want to flush replay
-        if (feedbackEvent.contexts.feedback.source === 'api' && autoFlushOnFeedback) {
+        if (feedbackEvent.contexts.feedback.source === 'api') {
           await replay.flush();
         }
         feedbackEvent.contexts.feedback.replay_id = replayId;
       }
     });
 
-    if (autoFlushOnFeedback) {
-      client.on('openFeedbackWidget', async () => {
-        await replay.flush();
-      });
-    }
+    client.on('openFeedbackWidget', async () => {
+      await replay.flush();
+    });
   }
 }


### PR DESCRIPTION
Flushing on feedback widget opening is better than on submit as you get more relevant replay context, so we are going to make this the default behavior and remove the configuration option. This is deprecated in https://github.com/getsentry/sentry-javascript/pull/17219