### PR TITLE
fix(nextjs): Flush in route handlers

### DIFF
--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -12,12 +12,14 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setCapturedScopesOnSpan,
   setHttpStatus,
+  vercelWaitUntil,
   winterCGHeadersToDict,
   withIsolationScope,
   withScope,
 } from '@sentry/core';
 import { isNotFoundNavigationError, isRedirectNavigationError } from './nextNavigationErrorUtils';
 import type { RouteHandlerContext } from './types';
+import { flushSafelyWithTimeout } from './utils/responseEnd';
 import { commonObjectToIsolationScope } from './utils/tracingUtils';
 
 /**
@@ -91,6 +93,9 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
                     },
                   });
                 }
+              },
+              () => {
+                vercelWaitUntil(flushSafelyWithTimeout());
               },
             );
 


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/JS-783/nextjs-no-data-being-sent-from-server-side-functions
closes https://github.com/getsentry/sentry-javascript/issues/17193

This will not fix this issue for prod deployments with turbopack as we do not have any build time instrumentation for route handlers there _yet_. In this case the current suggestion is to use:
```ts
import { after} from 'next/server';
import * as Sentry from '@sentry/nextjs';

export function GET() {
    after(() => {
        Sentry.flush();
    });
    // rest of your handler
}

```