### PR TITLE
fix(react): Memoize wrapped component to prevent rerenders

### DIFF
--- a/packages/react-router/test/client/react-exports.test.ts
+++ b/packages/react-router/test/client/react-exports.test.ts
@@ -76,7 +76,7 @@ describe('Re-exports from React SDK', () => {
       });
 
       expect(WrappedComponent).toBeDefined();
-      expect(typeof WrappedComponent).toBe('function');
+      expect(typeof WrappedComponent).toBe('object');
       expect(WrappedComponent.displayName).toBe('errorBoundary(TestComponent)');
 
       const { getByText } = render(React.createElement(WrappedComponent));

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -222,11 +222,11 @@ function withErrorBoundary<P extends Record<string, any>>(
 ): React.FC<P> {
   const componentDisplayName = WrappedComponent.displayName || WrappedComponent.name || UNKNOWN_COMPONENT;
 
-  const Wrapped: React.FC<P> = (props: P) => (
+  const Wrapped = React.memo((props: P) => (
     <ErrorBoundary {...errorBoundaryOptions}>
       <WrappedComponent {...props} />
     </ErrorBoundary>
-  );
+  )) as unknown as React.FC<P>;
 
   Wrapped.displayName = `errorBoundary(${componentDisplayName})`;
 


### PR DESCRIPTION
Cursor failed me on this one so fixing here.

closes https://github.com/getsentry/sentry-javascript/issues/17183