### PR TITLE
feat(react-router): Automatically flush on serverless for loaders/actions

### DIFF
--- a/packages/react-router/test/server/wrapSentryHandleRequest.test.ts
+++ b/packages/react-router/test/server/wrapSentryHandleRequest.test.ts
@@ -176,27 +176,6 @@ describe('wrapSentryHandleRequest', () => {
   });
 });
 
-test('should not set span attributes when parameterized path does not exist', async () => {
-  const mockActiveSpan = {};
-  const mockRootSpan = { setAttributes: vi.fn() };
-
-  (getActiveSpan as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockActiveSpan);
-  (getRootSpan as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockRootSpan);
-
-  const originalHandler = vi.fn().mockResolvedValue('test');
-  const wrappedHandler = wrapSentryHandleRequest(originalHandler);
-
-  const routerContext = {
-    staticHandlerContext: {
-      matches: [],
-    },
-  } as any;
-
-  await wrappedHandler(new Request('https://guapo.chulo'), 200, new Headers(), routerContext, {} as any);
-
-  expect(mockRootSpan.setAttributes).not.toHaveBeenCalled();
-});
-
 describe('getMetaTagTransformer', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/react-router/test/server/wrapServerLoader.test.ts
+++ b/packages/react-router/test/server/wrapServerLoader.test.ts
@@ -3,6 +3,15 @@ import type { LoaderFunctionArgs } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { wrapServerLoader } from '../../src/server/wrapServerLoader';
 
+vi.mock('@sentry/core', async () => {
+  const actual = await vi.importActual('@sentry/core');
+  return {
+    ...actual,
+    startSpan: vi.fn(),
+    flushIfServerless: vi.fn(),
+  };
+});
+
 describe('wrapServerLoader', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -12,11 +21,12 @@ describe('wrapServerLoader', () => {
     const mockLoaderFn = vi.fn().mockResolvedValue('result');
     const mockArgs = { request: new Request('http://test.com') } as LoaderFunctionArgs;
 
-    const spy = vi.spyOn(core, 'startSpan');
+    (core.startSpan as any).mockImplementation((_: any, fn: any) => fn());
+
     const wrappedLoader = wrapServerLoader({}, mockLoaderFn);
     await wrappedLoader(mockArgs);
 
-    expect(spy).toHaveBeenCalledWith(
+    expect(core.startSpan).toHaveBeenCalledWith(
       {
         name: 'Executing Server Loader',
         attributes: {
@@ -27,6 +37,7 @@ describe('wrapServerLoader', () => {
       expect.any(Function),
     );
     expect(mockLoaderFn).toHaveBeenCalledWith(mockArgs);
+    expect(core.flushIfServerless).toHaveBeenCalled();
   });
 
   it('should wrap a loader function with custom options', async () => {
@@ -40,11 +51,12 @@ describe('wrapServerLoader', () => {
     const mockLoaderFn = vi.fn().mockResolvedValue('result');
     const mockArgs = { request: new Request('http://test.com') } as LoaderFunctionArgs;
 
-    const spy = vi.spyOn(core, 'startSpan');
+    (core.startSpan as any).mockImplementation((_: any, fn: any) => fn());
+
     const wrappedLoader = wrapServerLoader(customOptions, mockLoaderFn);
     await wrappedLoader(mockArgs);
 
-    expect(spy).toHaveBeenCalledWith(
+    expect(core.startSpan).toHaveBeenCalledWith(
       {
         name: 'Custom Loader',
         attributes: {
@@ -56,5 +68,43 @@ describe('wrapServerLoader', () => {
       expect.any(Function),
     );
     expect(mockLoaderFn).toHaveBeenCalledWith(mockArgs);
+    expect(core.flushIfServerless).toHaveBeenCalled();
+  });
+
+  it('should call flushIfServerless on successful execution', async () => {
+    const mockLoaderFn = vi.fn().mockResolvedValue('result');
+    const mockArgs = { request: new Request('http://test.com') } as LoaderFunctionArgs;
+
+    (core.startSpan as any).mockImplementation((_: any, fn: any) => fn());
+
+    const wrappedLoader = wrapServerLoader({}, mockLoaderFn);
+    await wrappedLoader(mockArgs);
+
+    expect(core.flushIfServerless).toHaveBeenCalled();
+  });
+
+  it('should call flushIfServerless even when loader throws an error', async () => {
+    const mockError = new Error('Loader failed');
+    const mockLoaderFn = vi.fn().mockRejectedValue(mockError);
+    const mockArgs = { request: new Request('http://test.com') } as LoaderFunctionArgs;
+
+    (core.startSpan as any).mockImplementation((_: any, fn: any) => fn());
+
+    const wrappedLoader = wrapServerLoader({}, mockLoaderFn);
+
+    await expect(wrappedLoader(mockArgs)).rejects.toThrow('Loader failed');
+    expect(core.flushIfServerless).toHaveBeenCalled();
+  });
+
+  it('should propagate errors from loader function', async () => {
+    const mockError = new Error('Test error');
+    const mockLoaderFn = vi.fn().mockRejectedValue(mockError);
+    const mockArgs = { request: new Request('http://test.com') } as LoaderFunctionArgs;
+
+    (core.startSpan as any).mockImplementation((_: any, fn: any) => fn());
+
+    const wrappedLoader = wrapServerLoader({}, mockLoaderFn);
+
+    await expect(wrappedLoader(mockArgs)).rejects.toBe(mockError);
   });
 });


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/17228
ref https://linear.app/getsentry/issue/JS-793/improve-sentry-react-router-steps