### PR TITLE
fix(replay): Call `sendBufferedReplayOrFlush` when opening/sending feedback

### DIFF
--- a/packages/replay-internal/src/util/addGlobalListeners.ts
+++ b/packages/replay-internal/src/util/addGlobalListeners.ts
@@ -62,14 +62,14 @@ export function addGlobalListeners(replay: ReplayContainer): void {
       if (options?.includeReplay && replay.isEnabled() && replayId && feedbackEvent.contexts?.feedback) {
         // In case the feedback is sent via API and not through our widget, we want to flush replay
         if (feedbackEvent.contexts.feedback.source === 'api') {
-          await replay.flush();
+          await replay.sendBufferedReplayOrFlush();
         }
         feedbackEvent.contexts.feedback.replay_id = replayId;
       }
     });
 
     client.on('openFeedbackWidget', async () => {
-      await replay.flush();
+      await replay.sendBufferedReplayOrFlush();
     });
   }
 }


### PR DESCRIPTION
I noticed that our replays w/ feedbacks have gaps while the user is entering in their feedback. This is because we call `replay.flush` (not to be confused w/ the public replay integration integration which also has a flush) which only flushes the buffer and continues to buffer. What we want is to call `sendBufferedReplayOrFlush` which will convert the buffered replay into a session replay (after flushing) in order to continue recording.
