### PR TITLE
fix(node): Fix exports for openai instrumentation

### DIFF
--- a/packages/node/src/integrations/tracing/openai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/openai/instrumentation.ts
@@ -85,8 +85,6 @@ export class SentryOpenAiInstrumentation extends InstrumentationBase<Instrumenta
 
     // Constructor replacement - handle read-only properties
     // The OpenAI property might have only a getter, so use defineProperty
-    // Constructor replacement works the same for both ESM and CJS modules
-    // We can directly assign to exports.OpenAI in both module systems
     try {
       exports.OpenAI = WrappedOpenAI;
     } catch (error) {


### PR DESCRIPTION
Fixed an issue where default exports in CommonJS were failing. Returning a new exports object was overriding some default export functionality. I removed some redundant code as well. 