### PR TITLE
test(v9/nextjs): Update error listener for generateMetadata test (#17199)

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/tests/generation-functions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/tests/generation-functions.test.ts
@@ -42,15 +42,16 @@ test('Should send a transaction and an error event for a faulty generateMetadata
   });
 
   const errorEventPromise = waitForError('nextjs-14', errorEvent => {
-    return errorEvent?.exception?.values?.[0]?.value === 'generateMetadata Error';
+    return (
+      errorEvent?.exception?.values?.[0]?.value === 'generateMetadata Error' &&
+      errorEvent.transaction === 'Page.generateMetadata (/generation-functions)'
+    );
   });
 
   await page.goto(`/generation-functions?metadataTitle=${testTitle}&shouldThrowInGenerateMetadata=1`);
 
   const errorEvent = await errorEventPromise;
   const transactionEvent = await transactionPromise;
-
-  expect(errorEvent.transaction).toBe('Page.generateMetadata (/generation-functions)');
 
   // Assert that isolation scope works properly
   expect(errorEvent.tags?.['my-isolated-tag']).toBe(true);


### PR DESCRIPTION
backports https://github.com/getsentry/sentry-javascript/pull/17199