### PR TITLE
chore(v9): Tag packages with v9

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -12,7 +12,8 @@
   "type": "module",
   "module": "build/fesm2015/sentry-angular.mjs",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "peerDependencies": {
     "@angular/common": ">= 14.x <= 20.x",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -50,7 +50,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "peerDependencies": {
     "astro": ">=3.x || >=4.0.0-beta || >=5.x"

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -61,7 +61,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/core": "9.43.0"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry-internal/browser-utils": "9.43.0",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/core": "9.43.0",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -46,7 +46,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -18,7 +18,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "files": [
     "/build"

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -10,7 +10,8 @@
     "ember-addon"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "directories": {
     "doc": "doc",

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -19,7 +19,8 @@
   ],
   "main": "src/index.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry-internal/eslint-plugin-sdk": "9.43.0",

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -19,7 +19,8 @@
   ],
   "main": "src/index.js",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "scripts": {
     "clean": "yarn rimraf sentry-internal-eslint-plugin-sdk-*.tgz",

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/core": "9.43.0"

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -42,7 +42,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/core": "9.43.0",

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -45,7 +45,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/core": "9.43.0",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -41,7 +41,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -73,7 +73,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -54,7 +54,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/node-native/package.json
+++ b/packages/node-native/package.json
@@ -41,7 +41,8 @@
     "node": ">=18"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "files": [
     "/build",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -62,7 +62,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -40,7 +40,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "peerDependencies": {
     "nuxt": ">=3.7.0 || 4.x"

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/core": "9.43.0"

--- a/packages/pino-transport/package.json
+++ b/packages/pino-transport/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/core": "9.43.0",

--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -36,7 +36,8 @@
     "node": ">=18"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "files": [
     "/build",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -31,7 +31,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/browser": "9.43.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -61,7 +61,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -53,7 +53,8 @@
     "yalc:publish": "yalc publish --push --sig"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "repository": {
     "type": "git",

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -40,7 +40,8 @@
   ],
   "sideEffects": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "scripts": {
     "build": "run-p build:transpile build:types build:bundle",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -41,7 +41,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/browser": "9.43.0",

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -54,7 +54,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "peerDependencies": {
     "@solidjs/router": "^0.13.4",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/browser": "9.43.0",

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -35,7 +35,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "peerDependencies": {
     "@sveltejs/kit": "2.x",

--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -47,7 +47,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/tanstackstart/package.json
+++ b/packages/tanstackstart/package.json
@@ -37,7 +37,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -7,7 +7,8 @@
   "author": "Sentry",
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "files": [
     "tsconfig.json"

--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/browser": "9.43.0",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -36,7 +36,8 @@
     }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v9"
   },
   "dependencies": {
     "@sentry/browser": "9.43.0",


### PR DESCRIPTION
After this gets merged, we should not do a v9 release before v10 is released.