### PR TITLE
fix(browser): Ensure request from `diagnoseSdkConnectivity` does not create span

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/init.js
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration({ idleTimeout: 3000, childSpanTimeout: 3000 })],
+  tracesSampleRate: 1,
+});

--- a/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/subject.js
@@ -1,0 +1,1 @@
+Sentry.diagnoseSdkConnectivity().then(res => console.log('SDK connectivity:', res));

--- a/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/test.ts
@@ -1,0 +1,38 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../utils/helpers';
+
+sentryTest('makes a call to sentry.io to diagnose SDK connectivity', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const pageloadRequestPromise = waitForTransactionRequest(page, e => e.contexts?.trace?.op === 'pageload');
+
+  // mock sdk connectivity url to avoid making actual request to sentry.io
+  page.route('**/api/4509632503087104/envelope/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      body: '{}',
+    });
+  });
+
+  let diagnoseMessage: string | undefined;
+  page.on('console', msg => {
+    if (msg.text().includes('SDK connectivity:')) {
+      diagnoseMessage = msg.text();
+    }
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  const pageLoadEvent = envelopeRequestParser(await pageloadRequestPromise);
+
+  // udnefined is expected and means the request was successful
+  expect(diagnoseMessage).toEqual('SDK connectivity: undefined');
+
+  // the request to sentry.io should not be traced, hence no http.client span should be sent.
+  const httpClientSpans = pageLoadEvent.spans?.filter(s => s.op === 'http.client');
+  expect(httpClientSpans).toHaveLength(0);
+});

--- a/packages/browser/test/diagnose-sdk.test.ts
+++ b/packages/browser/test/diagnose-sdk.test.ts
@@ -162,4 +162,18 @@ describe('diagnoseSdkConnectivity', () => {
       credentials: 'omit',
     });
   });
+
+  it('calls suppressTracing to avoid tracing the fetch call to sentry', async () => {
+    const suppressTracingSpy = vi.spyOn(sentryCore, 'suppressTracing');
+
+    const mockClient: Partial<Client> = {
+      getDsn: vi.fn().mockReturnValue('https://test@example.com/123'),
+    };
+    mockGetClient.mockReturnValue(mockClient);
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await diagnoseSdkConnectivity();
+
+    expect(suppressTracingSpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
- **fix(browser): Ensure request from `diagnoseSdkConnectivity` does not create span**
- **improve test**

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
