### PR TITLE
test(ember): Un-skip ember embroider test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -68,8 +68,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "sentryTest": {
-    "skip": true
   }
 }


### PR DESCRIPTION
We skipped this because some dependency issues made this break, it seems to work again.