### PR TITLE
ref(feedback): Remove duplicate `sendFeedback` rejection message

### DIFF
--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -55,12 +55,6 @@ export const sendFeedback: SendFeedback = (
         return resolve(eventId);
       }
 
-      if (response && typeof response.statusCode === 'number' && response.statusCode === 0) {
-        return reject(
-          'Unable to send Feedback. This is because of network issues, or because you are using an ad-blocker.',
-        );
-      }
-
       if (response && typeof response.statusCode === 'number' && response.statusCode === 403) {
         return reject(
           'Unable to send Feedback. This could be because this domain is not in your list of allowed domains.',


### PR DESCRIPTION
Noticed this by chance, this is a redundant message (we also use this as general fallback anyhow).