### PR TITLE
ref(browser): Adjust `mechanism.type` in globalHandlersIntegration

### DIFF
--- a/dev-packages/browser-integration-tests/suites/errors/fetch/test.ts
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch/test.ts
@@ -24,7 +24,7 @@ sentryTest('handles fetch network errors @firefox', async ({ getLocalTestUrl, pa
     value: error,
     mechanism: {
       handled: false,
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
     },
   });
 });
@@ -51,7 +51,7 @@ sentryTest('handles fetch network errors on subdomains @firefox', async ({ getLo
     value: error,
     mechanism: {
       handled: false,
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
     },
   });
 });
@@ -78,7 +78,7 @@ sentryTest('handles fetch invalid header name errors @firefox', async ({ getLoca
     value: error,
     mechanism: {
       handled: false,
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
     },
     stacktrace: {
       frames: expect.any(Array),
@@ -110,7 +110,7 @@ sentryTest('handles fetch invalid header value errors @firefox', async ({ getLoc
     value: error,
     mechanism: {
       handled: false,
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
     },
     stacktrace: {
       frames: expect.any(Array),
@@ -152,7 +152,7 @@ sentryTest('handles fetch invalid URL scheme errors @firefox', async ({ getLocal
     value: error,
     mechanism: {
       handled: false,
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
     },
     stacktrace: {
       frames: expect.any(Array),
@@ -184,7 +184,7 @@ sentryTest('handles fetch credentials in url errors @firefox', async ({ getLocal
     value: error,
     mechanism: {
       handled: false,
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
     },
     stacktrace: {
       frames: expect.any(Array),
@@ -215,7 +215,7 @@ sentryTest('handles fetch invalid mode errors @firefox', async ({ getLocalTestUr
     value: error,
     mechanism: {
       handled: false,
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
     },
     stacktrace: {
       frames: expect.any(Array),
@@ -245,7 +245,7 @@ sentryTest('handles fetch invalid request method errors @firefox', async ({ getL
     value: error,
     mechanism: {
       handled: false,
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
     },
     stacktrace: {
       frames: expect.any(Array),
@@ -277,7 +277,7 @@ sentryTest(
       value: error,
       mechanism: {
         handled: false,
-        type: 'onunhandledrejection',
+        type: 'auto.browser.global_handlers.onunhandledrejection',
       },
       stacktrace: {
         frames: expect.any(Array),

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/non-string-arg/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/non-string-arg/test.ts
@@ -33,7 +33,7 @@ sentryTest(
       type: 'Error',
       value: 'Object captured as exception with keys: otherKey, type',
       mechanism: {
-        type: 'onerror',
+        type: 'auto.browser.global_handlers.onerror',
         handled: false,
       },
       stacktrace: {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/syntax-errors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/syntax-errors/test.ts
@@ -28,7 +28,7 @@ sentryTest('should catch syntax errors', async ({ getLocalTestUrl, page, browser
     type: 'SyntaxError',
     value: "Failed to execute 'appendChild' on 'Node': Unexpected token '{'",
     mechanism: {
-      type: 'onerror',
+      type: 'auto.browser.global_handlers.onerror',
       handled: false,
     },
     stacktrace: {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-errors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-errors/test.ts
@@ -28,7 +28,7 @@ sentryTest('should catch thrown errors', async ({ getLocalTestUrl, page, browser
     type: 'Error',
     value: 'realError',
     mechanism: {
-      type: 'onerror',
+      type: 'auto.browser.global_handlers.onerror',
       handled: false,
     },
     stacktrace: {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-objects/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-objects/test.ts
@@ -30,7 +30,7 @@ sentryTest('should catch thrown objects', async ({ getLocalTestUrl, page, browse
     type: 'Error',
     value: 'Object captured as exception with keys: error, somekey',
     mechanism: {
-      type: 'onerror',
+      type: 'auto.browser.global_handlers.onerror',
       handled: false,
     },
     stacktrace: {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-strings/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/thrown-strings/test.ts
@@ -28,7 +28,7 @@ sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page, browse
     type: 'Error',
     value: 'stringError',
     mechanism: {
-      type: 'onerror',
+      type: 'auto.browser.global_handlers.onerror',
       handled: false,
     },
     stacktrace: {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/custom-event/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/custom-event/test.ts
@@ -20,7 +20,7 @@ sentryTest(
       type: 'Error',
       value: 'promiseError',
       mechanism: {
-        type: 'onunhandledrejection',
+        type: 'auto.browser.global_handlers.onunhandledrejection',
         handled: false,
       },
       stacktrace: {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/event/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/event/test.ts
@@ -15,7 +15,7 @@ sentryTest('should capture a random Event with type unhandledrejection', async (
     type: 'Event',
     value: 'Event `Event` (type=unhandledrejection) captured as promise rejection',
     mechanism: {
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
       handled: false,
     },
   });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-errors/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-errors/test.ts
@@ -13,7 +13,7 @@ sentryTest('should catch thrown errors', async ({ getLocalTestUrl, page }) => {
     type: 'Error',
     value: 'promiseError',
     mechanism: {
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
       handled: false,
     },
     stacktrace: {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-null/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-null/test.ts
@@ -13,7 +13,7 @@ sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page }) => {
     type: 'UnhandledRejection',
     value: 'Non-Error promise rejection captured with value: null',
     mechanism: {
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
       handled: false,
     },
   });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-number/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-number/test.ts
@@ -13,7 +13,7 @@ sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page }) => {
     type: 'UnhandledRejection',
     value: 'Non-Error promise rejection captured with value: 123',
     mechanism: {
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
       handled: false,
     },
   });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-object-complex/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-object-complex/test.ts
@@ -13,7 +13,7 @@ sentryTest('should capture unhandledrejection with a complex object', async ({ g
     type: 'UnhandledRejection',
     value: 'Object captured as promise rejection with keys: a, b, c, d, e',
     mechanism: {
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
       handled: false,
     },
   });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-objects/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-objects/test.ts
@@ -13,7 +13,7 @@ sentryTest('should capture unhandledrejection with an object', async ({ getLocal
     type: 'UnhandledRejection',
     value: 'Object captured as promise rejection with keys: a, b, c',
     mechanism: {
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
       handled: false,
     },
   });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-strings/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-strings/test.ts
@@ -13,7 +13,7 @@ sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page }) => {
     type: 'UnhandledRejection',
     value: 'Non-Error promise rejection captured with value: stringError',
     mechanism: {
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
       handled: false,
     },
   });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-undefined/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/thrown-undefined/test.ts
@@ -13,7 +13,7 @@ sentryTest('should catch thrown strings', async ({ getLocalTestUrl, page }) => {
     type: 'UnhandledRejection',
     value: 'Non-Error promise rejection captured with value: undefined',
     mechanism: {
-      type: 'onunhandledrejection',
+      type: 'auto.browser.global_handlers.onunhandledrejection',
       handled: false,
     },
   });

--- a/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.client.test.ts
@@ -31,7 +31,7 @@ test.describe('client-side errors', () => {
           {
             mechanism: {
               handled: false,
-              type: 'onerror',
+              type: 'auto.browser.global_handlers.onerror',
             },
             type: 'Error',
             value: 'client error',

--- a/dev-packages/e2e-tests/test-applications/astro-5/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-5/tests/errors.client.test.ts
@@ -31,7 +31,7 @@ test.describe('client-side errors', () => {
           {
             mechanism: {
               handled: false,
-              type: 'onerror',
+              type: 'auto.browser.global_handlers.onerror',
             },
             type: 'Error',
             value: 'client error',

--- a/dev-packages/e2e-tests/test-applications/solid-solidrouter/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-solidrouter/tests/errors.test.ts
@@ -17,7 +17,7 @@ test('sends an error', async ({ page }) => {
           type: 'Error',
           value: 'Error thrown from Solid E2E test app',
           mechanism: {
-            type: 'onerror',
+            type: 'auto.browser.global_handlers.onerror',
             handled: false,
           },
         },

--- a/dev-packages/e2e-tests/test-applications/solid/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solid/tests/errors.test.ts
@@ -17,7 +17,7 @@ test('sends an error', async ({ page }) => {
           type: 'Error',
           value: 'Error thrown from Solid E2E test app',
           mechanism: {
-            type: 'onerror',
+            type: 'auto.browser.global_handlers.onerror',
             handled: false,
           },
         },

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/tests/errors.test.ts
@@ -29,7 +29,7 @@ test('errors on frontend and backend are connected by the same trace', async ({ 
         {
           mechanism: {
             handled: false,
-            type: 'onunhandledrejection',
+            type: 'auto.browser.global_handlers.onunhandledrejection',
           },
           stacktrace: expect.any(Object),
           type: 'Error',

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -72,7 +72,7 @@ function _installGlobalOnErrorHandler(client: Client): void {
       originalException: error,
       mechanism: {
         handled: false,
-        type: 'onerror',
+        type: 'auto.browser.global_handlers.onerror',
       },
     });
   });
@@ -98,7 +98,7 @@ function _installGlobalOnUnhandledRejectionHandler(client: Client): void {
       originalException: error,
       mechanism: {
         handled: false,
-        type: 'onunhandledrejection',
+        type: 'auto.browser.global_handlers.onunhandledrejection',
       },
     });
   });


### PR DESCRIPTION
Adjusts the `mechanism.type` field for errors caught `onerror` or `onunhandledrejection`. Aligns the naming scheme with [trace origin](https://develop.sentry.dev/sdk/telemetry/traces/trace-origin/) naming scheme.

ref #17250 
ref #17212 