### PR TITLE
ref(google-cloud-serverless): Add `mechanism.type` to captured errors

### DIFF
--- a/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
@@ -49,7 +49,7 @@ function _wrapCloudEventFunction(
 
         const newCallback = domainify((...args: unknown[]) => {
           if (args[0] !== null && args[0] !== undefined) {
-            captureException(args[0], scope => markEventUnhandled(scope, 'google-cloud-serverless.cloud_event'));
+            captureException(args[0], scope => markEventUnhandled(scope, 'auto.function.serverless.gcp_cloud_event'));
           }
           span.end();
 
@@ -69,7 +69,7 @@ function _wrapCloudEventFunction(
           return handleCallbackErrors(
             () => (fn as CloudEventFunctionWithCallback)(context, newCallback),
             err => {
-              captureException(err, scope => markEventUnhandled(scope, 'google-cloud-serverless.cloud_event'));
+              captureException(err, scope => markEventUnhandled(scope, 'auto.function.serverless.gcp_cloud_event'));
             },
           );
         }

--- a/packages/google-cloud-serverless/src/gcpfunction/events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/events.ts
@@ -52,7 +52,7 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
 
         const newCallback = domainify((...args: unknown[]) => {
           if (args[0] !== null && args[0] !== undefined) {
-            captureException(args[0], scope => markEventUnhandled(scope, 'google-cloud-serverless.event'));
+            captureException(args[0], scope => markEventUnhandled(scope, 'auto.function.serverless.gcp_event'));
           }
           span.end();
 
@@ -72,7 +72,7 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
           return handleCallbackErrors(
             () => (fn as EventFunctionWithCallback)(data, context, newCallback),
             err => {
-              captureException(err, scope => markEventUnhandled(scope, 'google-cloud-serverless.event'));
+              captureException(err, scope => markEventUnhandled(scope, 'auto.function.serverless.gcp_event'));
             },
           );
         }

--- a/packages/google-cloud-serverless/src/gcpfunction/http.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/http.ts
@@ -78,7 +78,7 @@ function _wrapHttpFunction(fn: HttpFunction, options: Partial<WrapperOptions>): 
           return handleCallbackErrors(
             () => fn(req, res),
             err => {
-              captureException(err, scope => markEventUnhandled(scope, 'google-cloud-serverless.http'));
+              captureException(err, scope => markEventUnhandled(scope, 'auto.function.serverless.gcp_http'));
             },
           );
         },

--- a/packages/google-cloud-serverless/src/utils.ts
+++ b/packages/google-cloud-serverless/src/utils.ts
@@ -43,7 +43,7 @@ export function proxyFunction<A extends any[], R, F extends (...args: A) => R>(
 /**
  * Marks an event as unhandled by adding a span processor to the passed scope.
  */
-export function markEventUnhandled(scope: Scope, type = 'google-cloud-serverless'): Scope {
+export function markEventUnhandled(scope: Scope, type: string): Scope {
   scope.addEventProcessor(event => {
     addExceptionMechanism(event, { handled: false, type });
     return event;

--- a/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
@@ -134,6 +134,19 @@ describe('wrapCloudEventFunction', () => {
 
         expect(mockStartSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
         expect(mockCaptureException).toBeCalledWith(error, expect.any(Function));
+
+        const scopeFunction = mockCaptureException.mock.calls[0][1];
+        const event: Event = { exception: { values: [{}] } };
+        let evtProcessor: ((e: Event) => Event) | undefined = undefined;
+        scopeFunction({ addEventProcessor: vi.fn().mockImplementation(proc => (evtProcessor = proc)) });
+
+        expect(evtProcessor).toBeInstanceOf(Function);
+        // @ts-expect-error just mocking around...
+        expect(evtProcessor(event).exception.values[0]?.mechanism).toEqual({
+          handled: false,
+          type: 'auto.function.serverless.gcp_cloud_event',
+        });
+
         expect(mockSpan.end).toBeCalled();
         expect(mockFlush).toBeCalled();
       });
@@ -158,6 +171,19 @@ describe('wrapCloudEventFunction', () => {
 
       expect(mockStartSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
       expect(mockCaptureException).toBeCalledWith(error, expect.any(Function));
+
+      const scopeFunction = mockCaptureException.mock.calls[0][1];
+      const event: Event = { exception: { values: [{}] } };
+      let evtProcessor: ((e: Event) => Event) | undefined = undefined;
+      scopeFunction({ addEventProcessor: vi.fn().mockImplementation(proc => (evtProcessor = proc)) });
+
+      expect(evtProcessor).toBeInstanceOf(Function);
+      // @ts-expect-error just mocking around...
+      expect(evtProcessor(event).exception.values[0]?.mechanism).toEqual({
+        handled: false,
+        type: 'auto.function.serverless.gcp_cloud_event',
+      });
+
       expect(mockSpan.end).toBeCalled();
       expect(mockFlush).toBeCalled();
     });
@@ -204,6 +230,19 @@ describe('wrapCloudEventFunction', () => {
 
       expect(mockStartSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
       expect(mockCaptureException).toBeCalledWith(error, expect.any(Function));
+
+      const scopeFunction = mockCaptureException.mock.calls[0][1];
+      const event: Event = { exception: { values: [{}] } };
+      let evtProcessor: ((e: Event) => Event) | undefined = undefined;
+      scopeFunction({ addEventProcessor: vi.fn().mockImplementation(proc => (evtProcessor = proc)) });
+
+      expect(evtProcessor).toBeInstanceOf(Function);
+      // @ts-expect-error just mocking around...
+      expect(evtProcessor(event).exception.values[0]?.mechanism).toEqual({
+        handled: false,
+        type: 'auto.function.serverless.gcp_cloud_event',
+      });
+
       expect(mockSpan.end).toBeCalled();
       expect(mockFlush).toBeCalled();
     });
@@ -227,6 +266,18 @@ describe('wrapCloudEventFunction', () => {
 
       expect(mockStartSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
       expect(mockCaptureException).toBeCalledWith(error, expect.any(Function));
+
+      const scopeFunction = mockCaptureException.mock.calls[0][1];
+      const event: Event = { exception: { values: [{}] } };
+      let evtProcessor: ((e: Event) => Event) | undefined = undefined;
+      scopeFunction({ addEventProcessor: vi.fn().mockImplementation(proc => (evtProcessor = proc)) });
+
+      expect(evtProcessor).toBeInstanceOf(Function);
+      // @ts-expect-error just mocking around...
+      expect(evtProcessor(event).exception.values[0]?.mechanism).toEqual({
+        handled: false,
+        type: 'auto.function.serverless.gcp_cloud_event',
+      });
     });
   });
 

--- a/packages/google-cloud-serverless/test/gcpfunction/events.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/events.test.ts
@@ -245,7 +245,7 @@ describe('wrapEventFunction', () => {
     // @ts-expect-error just mocking around...
     expect(evtProcessor(event).exception.values[0]?.mechanism).toEqual({
       handled: false,
-      type: 'generic',
+      type: 'auto.function.serverless.gcp_event',
     });
   });
 

--- a/packages/google-cloud-serverless/test/gcpfunction/http.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/http.test.ts
@@ -125,6 +125,19 @@ describe('GCPFunction', () => {
 
       expect(mockStartSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
       expect(mockCaptureException).toBeCalledWith(error, expect.any(Function));
+
+      const scopeFunction = mockCaptureException.mock.calls[0][1];
+      const event: Event = { exception: { values: [{}] } };
+      let evtProcessor: ((e: Event) => Event) | undefined = undefined;
+      scopeFunction({ addEventProcessor: vi.fn().mockImplementation(proc => (evtProcessor = proc)) });
+
+      expect(evtProcessor).toBeInstanceOf(Function);
+      // @ts-expect-error just mocking around...
+      expect(evtProcessor(event).exception.values[0]?.mechanism).toEqual({
+        handled: false,
+        type: 'auto.function.serverless.gcp_http',
+      });
+
       expect(mockSpan.end).toBeCalled();
       expect(mockFlush).toBeCalled();
     });


### PR DESCRIPTION
adjusts the event `mechanism.type` value of GCP serverless events, following the trace origin naming scheme. Values are now identical with the `sentry.origin` span attribute values of the enclosing spans.

ref #17212 
closes https://github.com/getsentry/sentry-javascript/issues/17257