### PR TITLE
feat(astro): Streamline astro build logs

### DIFF
--- a/packages/react-router/src/vite/makeEnableSourceMapsPlugin.ts
+++ b/packages/react-router/src/vite/makeEnableSourceMapsPlugin.ts
@@ -15,7 +15,7 @@ export function makeEnableSourceMapsPlugin(options: SentryReactRouterBuildOption
         ...viteConfig,
         build: {
           ...viteConfig.build,
-          sourcemap: getUpdatedSourceMapSettings(viteConfig, options),
+          sourcemap: _getUpdatedSourceMapSettings(viteConfig, options),
         },
       };
     },
@@ -37,7 +37,7 @@ export function makeEnableSourceMapsPlugin(options: SentryReactRouterBuildOption
  *
  * --> only exported for testing
  */
-export function getUpdatedSourceMapSettings(
+export function _getUpdatedSourceMapSettings(
   viteConfig: UserConfig,
   sentryPluginOptions?: SentryReactRouterBuildOptions,
 ): boolean | 'inline' | 'hidden' {

--- a/packages/react-router/test/vite/sourceMaps.test.ts
+++ b/packages/react-router/test/vite/sourceMaps.test.ts
@@ -1,6 +1,6 @@
 import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getUpdatedSourceMapSettings, makeEnableSourceMapsPlugin } from '../../src/vite/makeEnableSourceMapsPlugin';
+import { _getUpdatedSourceMapSettings, makeEnableSourceMapsPlugin } from '../../src/vite/makeEnableSourceMapsPlugin';
 
 const mockedSentryVitePlugin = {
   name: 'sentry-vite-debug-id-upload-plugin',
@@ -33,7 +33,7 @@ describe('makeEnableSourceMapsPlugin()', () => {
   });
 });
 
-describe('getUpdatedSourceMapSettings', () => {
+describe('_getUpdatedSourceMapSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -42,7 +42,7 @@ describe('getUpdatedSourceMapSettings', () => {
 
   describe('when sourcemap is false', () => {
     it('should keep sourcemap as false and show warning', () => {
-      const result = getUpdatedSourceMapSettings({ build: { sourcemap: false } });
+      const result = _getUpdatedSourceMapSettings({ build: { sourcemap: false } });
 
       expect(result).toBe(false);
       // eslint-disable-next-line no-console
@@ -58,7 +58,7 @@ describe('getUpdatedSourceMapSettings', () => {
       ['inline', 'inline'],
       [true, true],
     ] as ('inline' | 'hidden' | boolean)[][])('should keep sourcemap as %s when set to %s', (input, expected) => {
-      const result = getUpdatedSourceMapSettings({ build: { sourcemap: input } }, { debug: true });
+      const result = _getUpdatedSourceMapSettings({ build: { sourcemap: input } }, { debug: true });
 
       expect(result).toBe(expected);
       // eslint-disable-next-line no-console
@@ -72,7 +72,7 @@ describe('getUpdatedSourceMapSettings', () => {
     it.each([[undefined], ['invalid'], ['something'], [null]])(
       'should set sourcemap to hidden when value is %s',
       input => {
-        const result = getUpdatedSourceMapSettings({ build: { sourcemap: input as any } });
+        const result = _getUpdatedSourceMapSettings({ build: { sourcemap: input as any } });
 
         expect(result).toBe('hidden');
         // eslint-disable-next-line no-console
@@ -85,7 +85,7 @@ describe('getUpdatedSourceMapSettings', () => {
     );
 
     it('should set sourcemap to hidden when build config is empty', () => {
-      const result = getUpdatedSourceMapSettings({});
+      const result = _getUpdatedSourceMapSettings({});
 
       expect(result).toBe('hidden');
       // eslint-disable-next-line no-console

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -70,7 +70,7 @@ export function makeEnableSourceMapsVitePlugin(options: SentrySolidStartPluginOp
           ...viteConfig,
           build: {
             ...viteConfig.build,
-            sourcemap: getUpdatedSourceMapSettings(viteConfig, options),
+            sourcemap: _getUpdatedSourceMapSettings(viteConfig, options),
           },
         };
       },
@@ -93,7 +93,7 @@ export function makeEnableSourceMapsVitePlugin(options: SentrySolidStartPluginOp
  *
  * --> only exported for testing
  */
-export function getUpdatedSourceMapSettings(
+export function _getUpdatedSourceMapSettings(
   viteConfig: UserConfig,
   sentryPluginOptions?: SentrySolidStartPluginOptions,
 ): boolean | 'inline' | 'hidden' {

--- a/packages/solidstart/test/vite/sourceMaps.test.ts
+++ b/packages/solidstart/test/vite/sourceMaps.test.ts
@@ -1,7 +1,7 @@
 import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  getUpdatedSourceMapSettings,
+  _getUpdatedSourceMapSettings,
   makeAddSentryVitePlugin,
   makeEnableSourceMapsVitePlugin,
 } from '../../src/vite/sourceMaps';
@@ -171,7 +171,7 @@ describe('makeAddSentryVitePlugin()', () => {
   });
 });
 
-describe('getUpdatedSourceMapSettings', () => {
+describe('_getUpdatedSourceMapSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -180,7 +180,7 @@ describe('getUpdatedSourceMapSettings', () => {
 
   describe('when sourcemap is false', () => {
     it('should keep sourcemap as false and show warning', () => {
-      const result = getUpdatedSourceMapSettings({ build: { sourcemap: false } });
+      const result = _getUpdatedSourceMapSettings({ build: { sourcemap: false } });
 
       expect(result).toBe(false);
       // eslint-disable-next-line no-console
@@ -196,7 +196,7 @@ describe('getUpdatedSourceMapSettings', () => {
       ['inline', 'inline'],
       [true, true],
     ] as ('inline' | 'hidden' | boolean)[][])('should keep sourcemap as %s when set to %s', (input, expected) => {
-      const result = getUpdatedSourceMapSettings({ build: { sourcemap: input } }, { debug: true });
+      const result = _getUpdatedSourceMapSettings({ build: { sourcemap: input } }, { debug: true });
 
       expect(result).toBe(expected);
       // eslint-disable-next-line no-console
@@ -210,7 +210,7 @@ describe('getUpdatedSourceMapSettings', () => {
     it.each([[undefined], ['invalid'], ['something'], [null]])(
       'should set sourcemap to hidden when value is %s',
       input => {
-        const result = getUpdatedSourceMapSettings({ build: { sourcemap: input as any } });
+        const result = _getUpdatedSourceMapSettings({ build: { sourcemap: input as any } });
 
         expect(result).toBe('hidden');
         // eslint-disable-next-line no-console
@@ -223,7 +223,7 @@ describe('getUpdatedSourceMapSettings', () => {
     );
 
     it('should set sourcemap to hidden when build config is empty', () => {
-      const result = getUpdatedSourceMapSettings({});
+      const result = _getUpdatedSourceMapSettings({});
 
       expect(result).toBe('hidden');
       // eslint-disable-next-line no-console


### PR DESCRIPTION
This streamlines astro build logs in two ways:

1. Guard all logs (except the deprecation warning) behind `debug: true`
2. Use the astro logger instead of `console.log` everywhere. This automatically prepends the message with `@sentry/astro`, so no need for our own prefix there - see https://docs.astro.build/en/reference/integrations-reference/#astrointegrationlogger