### PR TITLE
feat(react-router): Streamline build logs

### DIFF
--- a/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
+++ b/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
@@ -84,14 +84,13 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
   // set a default value no option was set
   if (typeof sourceMapsUploadOptions?.filesToDeleteAfterUpload === 'undefined') {
     updatedFilesToDeleteAfterUpload = [`${reactRouterConfig.buildDirectory}/**/*.map`];
-    if (debug) {
+    debug &&
       // eslint-disable-next-line no-console
       console.info(
         `[Sentry] Automatically setting \`sourceMapsUploadOptions.filesToDeleteAfterUpload: ${JSON.stringify(
           updatedFilesToDeleteAfterUpload,
         )}\` to delete generated source maps after they were uploaded to Sentry.`,
       );
-    }
   }
   if (updatedFilesToDeleteAfterUpload) {
     try {
@@ -108,11 +107,10 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
       await Promise.all(
         filePathsToDelete.map(filePathToDelete =>
           rm(filePathToDelete, { force: true }).catch((e: unknown) => {
-            if (debug) {
-              // This is allowed to fail - we just don't do anything
+            // This is allowed to fail - we just don't do anything
+            debug &&
               // eslint-disable-next-line no-console
               console.debug(`An error occurred while attempting to delete asset: ${filePathToDelete}`, e);
-            }
           }),
         ),
       );

--- a/packages/react-router/src/vite/makeEnableSourceMapsPlugin.ts
+++ b/packages/react-router/src/vite/makeEnableSourceMapsPlugin.ts
@@ -1,4 +1,3 @@
-import { consoleSandbox } from '@sentry/core';
 import type { Plugin, UserConfig } from 'vite';
 import type { SentryReactRouterBuildOptions } from './types';
 
@@ -47,36 +46,35 @@ export function getUpdatedSourceMapSettings(
   let updatedSourceMapSetting = viteSourceMap;
 
   const settingKey = 'vite.build.sourcemap';
+  const debug = sentryPluginOptions?.debug;
 
   if (viteSourceMap === false) {
     updatedSourceMapSetting = viteSourceMap;
 
-    consoleSandbox(() => {
-      //  eslint-disable-next-line no-console
+    if (debug) {
+      // Longer debug message with more details
+      // eslint-disable-next-line no-console
       console.warn(
         `[Sentry] Source map generation is currently disabled in your Vite configuration (\`${settingKey}: false \`). This setting is either a default setting or was explicitly set in your configuration. Sentry won't override this setting. Without source maps, code snippets on the Sentry Issues page will remain minified. To show unminified code, enable source maps in \`${settingKey}\` (e.g. by setting them to \`hidden\`).`,
       );
-    });
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn('[Sentry] Source map generation is disabled in your Vite configuration.');
+    }
   } else if (viteSourceMap && ['hidden', 'inline', true].includes(viteSourceMap)) {
     updatedSourceMapSetting = viteSourceMap;
 
-    if (sentryPluginOptions?.debug) {
-      consoleSandbox(() => {
-        // eslint-disable-next-line no-console
-        console.log(
-          `[Sentry] We discovered \`${settingKey}\` is set to \`${viteSourceMap.toString()}\`. Sentry will keep this source map setting. This will un-minify the code snippet on the Sentry Issue page.`,
-        );
-      });
-    }
+    debug &&
+      // eslint-disable-next-line no-console
+      console.log(
+        `[Sentry] We discovered \`${settingKey}\` is set to \`${viteSourceMap.toString()}\`. Sentry will keep this source map setting. This will un-minify the code snippet on the Sentry Issue page.`,
+      );
   } else {
     updatedSourceMapSetting = 'hidden';
-
-    consoleSandbox(() => {
-      //  eslint-disable-next-line no-console
+    debug && //  eslint-disable-next-line no-console
       console.log(
         `[Sentry] Enabled source map generation in the build options with \`${settingKey}: 'hidden'\`. The source maps  will be deleted after they were uploaded to Sentry.`,
       );
-    });
   }
 
   return updatedSourceMapSetting;

--- a/packages/react-router/test/vite/sourceMaps.test.ts
+++ b/packages/react-router/test/vite/sourceMaps.test.ts
@@ -41,13 +41,29 @@ describe('getUpdatedSourceMapSettings', () => {
   });
 
   describe('when sourcemap is false', () => {
-    it('should keep sourcemap as false and show warning', () => {
+    it('should keep sourcemap as false and show short warning when debug is disabled', () => {
       const result = getUpdatedSourceMapSettings({ build: { sourcemap: false } });
 
       expect(result).toBe(false);
       // eslint-disable-next-line no-console
       expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('[Sentry] Source map generation is currently disabled'),
+        '[Sentry] Source map generation is disabled in your Vite configuration.',
+      );
+    });
+
+    it('should keep sourcemap as false and show long warning when debug is enabled', () => {
+      const result = getUpdatedSourceMapSettings({ build: { sourcemap: false } }, { debug: true });
+
+      expect(result).toBe(false);
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[Sentry] Source map generation is currently disabled in your Vite configuration'),
+      );
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'This setting is either a default setting or was explicitly set in your configuration.',
+        ),
       );
     });
   });
@@ -72,7 +88,7 @@ describe('getUpdatedSourceMapSettings', () => {
     it.each([[undefined], ['invalid'], ['something'], [null]])(
       'should set sourcemap to hidden when value is %s',
       input => {
-        const result = getUpdatedSourceMapSettings({ build: { sourcemap: input as any } });
+        const result = getUpdatedSourceMapSettings({ build: { sourcemap: input as any } }, { debug: true });
 
         expect(result).toBe('hidden');
         // eslint-disable-next-line no-console
@@ -85,7 +101,7 @@ describe('getUpdatedSourceMapSettings', () => {
     );
 
     it('should set sourcemap to hidden when build config is empty', () => {
-      const result = getUpdatedSourceMapSettings({});
+      const result = getUpdatedSourceMapSettings({}, { debug: true });
 
       expect(result).toBe('hidden');
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Streamlines react router build logs. Those are mostly already gated behind `debug`, so smaller changes here:

1. Streamline with style from other parts of the SDK
2. Log compact message when source maps are disabled without `debug: true`
3. Add some tests for this