### PR TITLE
ref: Make `lastReleasePos` checks for yarn changelog stricter

### DIFF
--- a/scripts/get-commit-list.ts
+++ b/scripts/get-commit-list.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 function run(): void {
   const commits = execSync('git log --format="- %s"').toString().split('\n');
 
-  const lastReleasePos = commits.findIndex(commit => /- meta(.*)changelog/i.test(commit));
+  const lastReleasePos = commits.findIndex(commit => /- meta\(changelog\)/i.test(commit));
 
   const newCommits = commits.splice(0, lastReleasePos).filter(commit => {
     // Filter out merge commits


### PR DESCRIPTION
Commits like `meta: Re-organize changelog to add v8 page` tripped this up. Our changelog entries always follow `meta(changelog)` so we should just check for that.
