### PR TITLE
feat(bun): Export `skipOpenTelemetrySetup` option

### DIFF
--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -23,6 +23,18 @@ export interface BaseBunOptions {
   /** Sets an optional server name (device name) */
   serverName?: string;
 
+  /**
+   * If this is set to true, the SDK will not set up OpenTelemetry automatically.
+   * In this case, you _have_ to ensure to set it up correctly yourself, including:
+   * * The `SentrySpanProcessor`
+   * * The `SentryPropagator`
+   * * The `SentryContextManager`
+   * * The `SentrySampler`
+   *
+   * If you are registering your own OpenTelemetry Loader Hooks (or `import-in-the-middle` hooks), it is also recommended to set the `registerEsmLoaderHooks` option to false.
+   */
+  skipOpenTelemetrySetup?: boolean;
+
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(this: void, error: Error): void;
 }


### PR DESCRIPTION
As raised in #16969, the Bun SDK doesn't currently export `skipOpenTelemetrySetup` in the SDK init options type, altghough the option can be correctly passed to the underlying `NodeClient`. This PR exports the option now.

https://github.com/getsentry/sentry-javascript/issues/16969#issuecomment-3163126700