### PR TITLE
fix(v9/node): Assign default export of `openai` to the instrumented fn

### DIFF
--- a/packages/node/src/integrations/tracing/openai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/openai/instrumentation.ts
@@ -96,6 +96,23 @@ export class SentryOpenAiInstrumentation extends InstrumentationBase<Instrumenta
         enumerable: true,
       });
     }
+
+    // Wrap the default export if it points to the original constructor
+    // Constructor replacement - handle read-only properties
+    // The OpenAI property might have only a getter, so use defineProperty
+    if (exports.default === Original) {
+      try {
+        exports.default = WrappedOpenAI;
+      } catch (error) {
+        // If direct assignment fails, override the property descriptor
+        Object.defineProperty(exports, 'default', {
+          value: WrappedOpenAI,
+          writable: true,
+          configurable: true,
+          enumerable: true,
+        });
+      }
+    }
     return exports;
   }
 }


### PR DESCRIPTION
Both of:
- import OpenAI from `openai`
- import { OpenAI } from`openai`

Should point to the instrumented wrapper function.

Backport of #17320.