### PR TITLE
fix(nuxt): Do not drop parametrized routes

### DIFF
--- a/packages/nuxt/src/server/sdk.ts
+++ b/packages/nuxt/src/server/sdk.ts
@@ -43,6 +43,14 @@ export function lowQualityTransactionsFilter(options: SentryNuxtServerOptions): 
       if (event.type !== 'transaction' || !event.transaction) {
         return event;
       }
+
+      // Check if this looks like a parametrized route (contains :param or :param() patterns)
+      const hasRouteParameters = /\/:[^(/\s]*(\([^)]*\))?[^/\s]*/.test(event.transaction);
+
+      if (hasRouteParameters) {
+        return event;
+      }
+
       // We don't want to send transaction for file requests, so everything ending with a *.someExtension should be filtered out
       // path.extname will return an empty string for normal page requests
       if (path.extname(event.transaction)) {

--- a/packages/nuxt/test/server/sdk.test.ts
+++ b/packages/nuxt/test/server/sdk.test.ts
@@ -42,7 +42,7 @@ describe('Nuxt Server SDK', () => {
       expect(init({})).not.toBeUndefined();
     });
 
-    describe('low quality transactions filter (%s)', () => {
+    describe('lowQualityTransactionsFilter (%s)', () => {
       const beforeSendEvent = vi.fn(event => event);
       const client = init({
         dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -63,7 +63,8 @@ describe('Nuxt Server SDK', () => {
         expect(beforeSendEvent).not.toHaveBeenCalled();
       });
 
-      it.each(['GET /', 'POST /_server'])(
+      // Nuxt parametrizes routes sometimes in a special way - especially catchAll o.O
+      it.each(['GET /', 'POST /_server', 'GET /catchAll/:id(.*)*', 'GET /article/:slug()', 'GET /user/:id'])(
         'does not filter out high quality or route transactions (%s)',
         async transaction => {
           client.captureEvent({ type: 'transaction', transaction });


### PR DESCRIPTION
I just found out Nuxt is dropping spans for catch-all routes. This fixes this.

related to https://github.com/getsentry/sentry-javascript/pull/16843 (as we have parametrized routes since then)
