### PR TITLE
test(node): Enable additionalDependencies in integration runner

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -14,7 +14,7 @@
     "build:dev": "yarn build",
     "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "tsc -p tsconfig.types.json",
-    "clean": "rimraf -g **/node_modules && run-p clean:script",
+    "clean": "rimraf -g suites/**/node_modules suites/**/tmp_* && run-p clean:script",
     "clean:script": "node scripts/clean.js",
     "lint": "eslint . --format stylish",
     "fix": "eslint . --format stylish --fix",

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-v5.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-v5.mjs
@@ -1,0 +1,75 @@
+import * as Sentry from '@sentry/node';
+import { generateText } from 'ai';
+import { MockLanguageModelV2 } from 'ai/test';
+import { z } from 'zod';
+
+async function run() {
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    await generateText({
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text: 'First span here!' }],
+        }),
+      }),
+      prompt: 'Where is the first span?',
+    });
+
+    // This span should have input and output prompts attached because telemetry is explicitly enabled.
+    await generateText({
+      experimental_telemetry: { isEnabled: true },
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text: 'Second span here!' }],
+        }),
+      }),
+      prompt: 'Where is the second span?',
+    });
+
+    // This span should include tool calls and tool results
+    await generateText({
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          finishReason: 'tool-calls',
+          usage: { inputTokens: 15, outputTokens: 25, totalTokens: 40 },
+          content: [{ type: 'text', text: 'Tool call completed!' }],
+          toolCalls: [
+            {
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+              args: '{ "location": "San Francisco" }',
+            },
+          ],
+        }),
+      }),
+      tools: {
+        getWeather: {
+          parameters: z.object({ location: z.string() }),
+          execute: async args => {
+            return `Weather in ${args.location}: Sunny, 72°F`;
+          },
+        },
+      },
+      prompt: 'What is the weather in San Francisco?',
+    });
+
+    // This span should not be captured because we've disabled telemetry
+    await generateText({
+      experimental_telemetry: { isEnabled: false },
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text: 'Third span here!' }],
+        }),
+      }),
+      prompt: 'Where is the third span?',
+    });
+  });
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -197,6 +197,73 @@ describe('Vercel AI integration', () => {
     ]),
   };
 
+  // Todo: Add missing attribute spans for v5
+  // Right now only second span is recorded as it's manually opted in via explicit telemetry option
+  const EXPECTED_TRANSACTION_DEFAULT_PII_FALSE_V5 = {
+    transaction: 'main',
+    spans: expect.arrayContaining([
+      expect.objectContaining({
+        data: {
+          'vercel.ai.model.id': 'mock-model-id',
+          'vercel.ai.model.provider': 'mock-provider',
+          'vercel.ai.operationId': 'ai.generateText',
+          'vercel.ai.pipeline.name': 'generateText',
+          'vercel.ai.prompt': '{"prompt":"Where is the second span?"}',
+          'vercel.ai.response.finishReason': 'stop',
+          'gen_ai.response.text': expect.any(String),
+          'vercel.ai.settings.maxRetries': 2,
+          // 'vercel.ai.settings.maxSteps': 1,
+          'vercel.ai.streaming': false,
+          'gen_ai.prompt': '{"prompt":"Where is the second span?"}',
+          'gen_ai.response.model': 'mock-model-id',
+          'gen_ai.usage.input_tokens': 10,
+          'gen_ai.usage.output_tokens': 20,
+          'gen_ai.usage.total_tokens': 30,
+          'operation.name': 'ai.generateText',
+          'sentry.op': 'gen_ai.invoke_agent',
+          'sentry.origin': 'auto.vercelai.otel',
+        },
+        description: 'generateText',
+        op: 'gen_ai.invoke_agent',
+        origin: 'auto.vercelai.otel',
+        status: 'ok',
+      }),
+      // doGenerate
+      expect.objectContaining({
+        data: {
+          'sentry.origin': 'auto.vercelai.otel',
+          'sentry.op': 'gen_ai.generate_text',
+          'operation.name': 'ai.generateText.doGenerate',
+          'vercel.ai.operationId': 'ai.generateText.doGenerate',
+          'vercel.ai.model.provider': 'mock-provider',
+          'vercel.ai.model.id': 'mock-model-id',
+          'vercel.ai.settings.maxRetries': 2,
+          'gen_ai.system': 'mock-provider',
+          'gen_ai.request.model': 'mock-model-id',
+          'vercel.ai.pipeline.name': 'generateText.doGenerate',
+          'vercel.ai.streaming': false,
+          'vercel.ai.response.finishReason': 'stop',
+          'vercel.ai.response.model': 'mock-model-id',
+          'vercel.ai.response.id': expect.any(String),
+          'gen_ai.response.text': 'Second span here!',
+          'vercel.ai.response.timestamp': expect.any(String),
+          // 'vercel.ai.prompt.format': expect.any(String),
+          'gen_ai.request.messages': expect.any(String),
+          'gen_ai.response.finish_reasons': ['stop'],
+          'gen_ai.usage.input_tokens': 10,
+          'gen_ai.usage.output_tokens': 20,
+          'gen_ai.response.id': expect.any(String),
+          'gen_ai.response.model': 'mock-model-id',
+          'gen_ai.usage.total_tokens': 30,
+        },
+        description: 'generate_text mock-model-id',
+        op: 'gen_ai.generate_text',
+        origin: 'auto.vercelai.otel',
+        status: 'ok',
+      }),
+    ]),
+  };
+
   const EXPECTED_TRANSACTION_DEFAULT_PII_TRUE = {
     transaction: 'main',
     spans: expect.arrayContaining([
@@ -537,6 +604,23 @@ describe('Vercel AI integration', () => {
         .completed();
     });
   });
+
+  // Test with specific Vercel AI v5 version
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-v5.mjs',
+    'instrument.mjs',
+    (createRunner, test) => {
+      test('creates ai related spans with v5', async () => {
+        await createRunner().expect({ transaction: EXPECTED_TRANSACTION_DEFAULT_PII_FALSE_V5 }).start().completed();
+      });
+    },
+    {
+      additionalDependencies: {
+        ai: '^5.0.0',
+      },
+    },
+  );
 
   createEsmAndCjsTests(__dirname, 'scenario-error-in-tool-express.mjs', 'instrument.mjs', (createRunner, test) => {
     test('captures error in tool in express server', async () => {

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -196,18 +196,6 @@ export function createEsmAndCjsTests(
   const tmpDirPath = join(cwd, `tmp_${uniqueId}`);
   mkdirSync(tmpDirPath);
 
-  // Ensure tmp dir is removed on process exit as a fallback
-  CLEANUP_STEPS.add(() => {
-    try {
-      rmSync(tmpDirPath, { recursive: true, force: true });
-    } catch {
-      if (process.env.DEBUG) {
-        // eslint-disable-next-line no-console
-        console.error(`Failed to remove tmp dir: ${tmpDirPath}`);
-      }
-    }
-  });
-
   // Copy ESM files as-is into tmp dir
   const esmScenarioBasename = basename(scenarioPath);
   const esmInstrumentBasename = basename(instrumentPath);


### PR DESCRIPTION
This update enhances the Node integration test runner to support per-scenario dependency overrides via a temporary folder that contains package.json.

When additionalDependencies are provided, the runner now:

1. Creates a unique temp directory with a package.json containing the requested dependencies.
2. Copies the ESM and CJS versions of the scenario and instrument files into the temp directory.
3. Installs the specified dependency versions.
4. Runs tests 

ESM and CJS test modes continue to run normally using the files from the temp workspace.

Also adds:

- Minimal test scenario for vercel AI test using ai@^5.0.0. (Adjusted expectations to match the current v5 output format)