### PR TITLE
chore(repo): Adjust "Publishing a Release" document to include internal changes section in changelog

### DIFF
--- a/docs/publishing-a-release.md
+++ b/docs/publishing-a-release.md
@@ -45,7 +45,7 @@ These have also been documented via [Cursor Rules](../.cursor/rules/publishing-r
 2. Create a new section in the changelog with the previously determined version number.
 3. Paste in the logs you copied earlier.
 4. If there are any important features or fixes, highlight them under the `Important Changes` subheading. If there are no important changes, don't include this section. If the `Important Changes` subheading is used, put all other user-facing changes under the `Other Changes` subheading.
-5. Any changes that are purely internal (e.g. internal refactors `ref` without user-facing changes, tests, chores, etc) should be put under a `<details>` block, where the `<summary>` heading is "Internal Changes" (see example).
+5. Any changes that are purely internal (e.g. internal refactors (`ref`) without user-facing changes, tests, chores, etc) should be put under a `<details>` block, where the `<summary>` heading is "Internal Changes" (see example).
 6. Make sure the changelog entries are ordered alphabetically.
 7. If any of the PRs are from external contributors, include underneath the commits
    `Work in this release contributed by <list of external contributors' GitHub usernames>. Thank you for your contributions!`.


### PR DESCRIPTION
This PR updates our release publishing guide to include an "Internal Changes" block which is toggle-able as a `<details>` HTML element. Cursor's release publishing rule references this document, so I don't think we need to adjust the cursor rule. Likewise, our `yarn changelog` list already includes all changes anyway, so I think this is the only place that needs updating.

side-note: Given this makes changelog creation a _bit_ more cumbersome, I think using Cursor for it is ideal.