### PR TITLE
feat(astro): Align options with shared build time options type

### DIFF
--- a/packages/astro/.eslintrc.cjs
+++ b/packages/astro/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
     {
       files: ['vite.config.ts'],
       parserOptions: {
-        project: ['tsconfig.test.json'],
+        project: ['tsconfig.vite.json'],
       },
     },
   ],

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -1,3 +1,4 @@
+import type { BuildTimeOptionsBase, UnstableVitePluginOptions } from '@sentry/core';
 import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 import type { RouteData } from 'astro';
 
@@ -23,12 +24,16 @@ type SdkInitPaths = {
   serverInitPath?: string;
 };
 
+/**
+ * @deprecated Move these options to the top-level of your Sentry configuration.
+ */
 type SourceMapsOptions = {
   /**
    * If this flag is `true`, and an auth token is detected, the Sentry integration will
    * automatically generate and upload source maps to Sentry during a production build.
    *
    * @default true
+   * @deprecated Use `sourcemaps.disable` instead (with inverted logic)
    */
   enabled?: boolean;
 
@@ -39,18 +44,24 @@ type SourceMapsOptions = {
    *
    * To create an auth token, follow this guide:
    * @see https://docs.sentry.io/product/accounts/auth-tokens/#organization-auth-tokens
+   *
+   * @deprecated Use top-level `authToken` option instead
    */
   authToken?: string;
 
   /**
    * The organization slug of your Sentry organization.
    * Instead of specifying this option, you can also set the `SENTRY_ORG` environment variable.
+   *
+   * @deprecated Use top-level `org` option instead
    */
   org?: string;
 
   /**
    * The project slug of your Sentry project.
    * Instead of specifying this option, you can also set the `SENTRY_PROJECT` environment variable.
+   *
+   * @deprecated Use top-level `project` option instead
    */
   project?: string;
 
@@ -59,6 +70,7 @@ type SourceMapsOptions = {
    * It will not collect any sensitive or user-specific data.
    *
    * @default true
+   * @deprecated Use top-level `telemetry` option instead
    */
   telemetry?: boolean;
 
@@ -71,6 +83,8 @@ type SourceMapsOptions = {
    *
    * The globbing patterns must follow the implementation of the `glob` package.
    * @see https://www.npmjs.com/package/glob#glob-primer
+   *
+   * @deprecated Use `sourcemaps.assets` instead
    */
   assets?: string | Array<string>;
 
@@ -81,6 +95,8 @@ type SourceMapsOptions = {
    * @default [] - By default no files are deleted.
    *
    * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
+   *
+   * @deprecated Use `sourcemaps.filesToDeleteAfterUpload` instead
    */
   filesToDeleteAfterUpload?: string | Array<string>;
 
@@ -95,49 +111,10 @@ type SourceMapsOptions = {
    * changes can occur at any time within a major SDK version.
    *
    * Furthermore, some options are untested with Astro specifically. Use with caution.
+   *
+   * @deprecated Use top-level `unstable_sentryVitePluginOptions` instead
    */
   unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>;
-};
-
-type BundleSizeOptimizationOptions = {
-  /**
-   * If set to `true`, the plugin will attempt to tree-shake (remove) any debugging code within the Sentry SDK.
-   * Note that the success of this depends on tree shaking being enabled in your build tooling.
-   *
-   * Setting this option to `true` will disable features like the SDK's `debug` option.
-   */
-  excludeDebugStatements?: boolean;
-
-  /**
-   * If set to true, the plugin will try to tree-shake performance monitoring statements out.
-   * Note that the success of this depends on tree shaking generally being enabled in your build.
-   * Attention: DO NOT enable this when you're using any performance monitoring-related SDK features (e.g. Sentry.startSpan()).
-   */
-  excludeTracing?: boolean;
-
-  /**
-   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay Shadow DOM recording functionality.
-   * Note that the success of this depends on tree shaking being enabled in your build tooling.
-   *
-   * This option is safe to be used when you do not want to capture any Shadow DOM activity via Sentry Session Replay.
-   */
-  excludeReplayShadowDom?: boolean;
-
-  /**
-   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay `iframe` recording functionality.
-   * Note that the success of this depends on tree shaking being enabled in your build tooling.
-   *
-   * You can safely do this when you do not want to capture any `iframe` activity via Sentry Session Replay.
-   */
-  excludeReplayIframe?: boolean;
-
-  /**
-   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay's Compression Web Worker.
-   * Note that the success of this depends on tree shaking being enabled in your build tooling.
-   *
-   * **Notice:** You should only do use this option if you manually host a compression worker and configure it in your Sentry Session Replay integration config via the `workerUrl` option.
-   */
-  excludeReplayWorker?: boolean;
 };
 
 type InstrumentationOptions = {
@@ -202,7 +179,10 @@ type DeprecatedRuntimeOptions = Record<string, unknown>;
  *
  * If you specify a dedicated init file, the SDK options passed to `sentryAstro` will be ignored.
  */
-export type SentryOptions = SdkInitPaths &
+export type SentryOptions = Omit<BuildTimeOptionsBase, 'release'> &
+  // todo(v11): `release` and `debug` need to be removed from BuildTimeOptionsBase as it is currently conflicting with `DeprecatedRuntimeOptions`
+  UnstableVitePluginOptions<SentryVitePluginOptions> &
+  SdkInitPaths &
   InstrumentationOptions &
   SdkEnabledOptions & {
     /**
@@ -210,19 +190,12 @@ export type SentryOptions = SdkInitPaths &
      *
      * These options are always read from the `sentryAstro` integration.
      * Do not define them in the `sentry.client.config.(js|ts)` or `sentry.server.config.(js|ts)` files.
-     */
-    sourceMapsUploadOptions?: SourceMapsOptions;
-    /**
-     * Options for the Sentry Vite plugin to customize bundle size optimizations.
      *
-     * These options are always read from the `sentryAstro` integration.
-     * Do not define them in the `sentry.client.config.(js|ts)` or `sentry.server.config.(js|ts)` files.
+     * @deprecated This option was deprecated. Please move the options to the top-level configuration.
+     * See the migration guide in the SourceMapsOptions type documentation.
      */
-    bundleSizeOptimizations?: BundleSizeOptimizationOptions;
-    /**
-     * If enabled, prints debug logs during the build process.
-     */
-    debug?: boolean;
+    // eslint-disable-next-line deprecation/deprecation
+    sourceMapsUploadOptions?: SourceMapsOptions;
     // eslint-disable-next-line deprecation/deprecation
   } & DeprecatedRuntimeOptions;
 

--- a/packages/astro/test/buildOptions.test-d.ts
+++ b/packages/astro/test/buildOptions.test-d.ts
@@ -1,0 +1,190 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { SentryOptions } from '../src/integration/types';
+
+describe('Sentry Astro build-time options type', () => {
+  it('includes all options based on type BuildTimeOptionsBase', () => {
+    const completeOptions: SentryOptions = {
+      // --- BuildTimeOptionsBase options ---
+      org: 'test-org',
+      project: 'test-project',
+      authToken: 'test-auth-token',
+      sentryUrl: 'https://sentry.io',
+      headers: { Authorization: ' Bearer test-auth-token' },
+      telemetry: true,
+      silent: false,
+      // eslint-disable-next-line no-console
+      errorHandler: (err: Error) => console.warn(err),
+      debug: false,
+      sourcemaps: {
+        disable: false,
+        assets: ['./dist/**/*'],
+        ignore: ['./dist/*.map'],
+        filesToDeleteAfterUpload: ['./dist/*.map'],
+      },
+      release: {
+        name: 'test-release-1.0.0',
+        create: true,
+        finalize: true,
+        dist: 'test-dist',
+        vcsRemote: 'origin',
+        setCommits: {
+          auto: false,
+          repo: 'test/repo',
+          commit: 'abc123',
+          previousCommit: 'def456',
+          ignoreMissing: false,
+          ignoreEmpty: false,
+        },
+        deploy: {
+          env: 'production',
+          started: 1234567890,
+          finished: 1234567900,
+          time: 10,
+          name: 'deployment-name',
+          url: 'https://example.com',
+        },
+      },
+      bundleSizeOptimizations: {
+        excludeDebugStatements: true,
+        excludeTracing: false,
+        excludeReplayShadowDom: true,
+        excludeReplayIframe: true,
+        excludeReplayWorker: true,
+      },
+
+      // --- UnstableVitePluginOptions ---
+      unstable_sentryVitePluginOptions: {
+        sourcemaps: {
+          assets: './dist/**/*',
+        },
+        bundleSizeOptimizations: {
+          excludeDebugStatements: true,
+        },
+      },
+
+      // --- SentryOptions specific options ---
+      enabled: true,
+      clientInitPath: './src/sentry.client.config.ts',
+      serverInitPath: './src/sentry.server.config.ts',
+      autoInstrumentation: {
+        requestHandler: true,
+      },
+
+      // Deprecated runtime options
+      environment: 'test',
+      dsn: 'https://test@sentry.io/123',
+      sampleRate: 1.0,
+      tracesSampleRate: 1.0,
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+    };
+
+    expectTypeOf(completeOptions).toEqualTypeOf<SentryOptions>();
+  });
+
+  it('includes all deprecated options', () => {
+    const completeOptions: SentryOptions = {
+      // SentryOptions specific options
+      enabled: true,
+      debug: true,
+      clientInitPath: './src/sentry.client.config.ts',
+      serverInitPath: './src/sentry.server.config.ts',
+      autoInstrumentation: {
+        requestHandler: true,
+      },
+      unstable_sentryVitePluginOptions: {
+        sourcemaps: {
+          assets: './dist/**/*',
+        },
+        bundleSizeOptimizations: {
+          excludeDebugStatements: true,
+        },
+      },
+
+      // Deprecated sourceMapsUploadOptions
+      sourceMapsUploadOptions: {
+        enabled: true,
+        authToken: 'deprecated-token',
+        org: 'deprecated-org',
+        project: 'deprecated-project',
+        telemetry: false,
+        assets: './build/**/*',
+        filesToDeleteAfterUpload: ['./build/*.map'],
+        unstable_sentryVitePluginOptions: {
+          sourcemaps: {
+            ignore: ['./build/*.spec.js'],
+          },
+        },
+      },
+    };
+
+    expectTypeOf(completeOptions).toEqualTypeOf<SentryOptions>();
+  });
+
+  it('allows partial configuration', () => {
+    const minimalOptions: SentryOptions = { enabled: true };
+
+    expectTypeOf(minimalOptions).toEqualTypeOf<SentryOptions>();
+
+    const partialOptions: SentryOptions = {
+      enabled: true,
+      debug: false,
+      org: 'my-org',
+      project: 'my-project',
+    };
+
+    expectTypeOf(partialOptions).toEqualTypeOf<SentryOptions>();
+  });
+
+  it('supports BuildTimeOptionsBase options at top level', () => {
+    const baseOptions: SentryOptions = {
+      // Test that all BuildTimeOptionsBase options are available at top level
+      org: 'test-org',
+      project: 'test-project',
+      authToken: 'test-token',
+      sentryUrl: 'https://custom.sentry.io',
+      headers: { 'Custom-Header': 'value' },
+      telemetry: false,
+      silent: true,
+      debug: true,
+      sourcemaps: {
+        disable: false,
+        assets: ['./dist/**/*.js'],
+        ignore: ['./dist/test/**/*'],
+        filesToDeleteAfterUpload: ['./dist/**/*.map'],
+      },
+      release: {
+        name: '1.0.0',
+        create: true,
+        finalize: false,
+      },
+      bundleSizeOptimizations: {
+        excludeDebugStatements: true,
+        excludeTracing: true,
+      },
+    };
+
+    expectTypeOf(baseOptions).toEqualTypeOf<SentryOptions>();
+  });
+
+  it('supports UnstableVitePluginOptions at top level', () => {
+    const viteOptions: SentryOptions = {
+      unstable_sentryVitePluginOptions: {
+        org: 'override-org',
+        project: 'override-project',
+        sourcemaps: {
+          assets: './custom-dist/**/*',
+          ignore: ['./custom-dist/ignore/**/*'],
+        },
+        bundleSizeOptimizations: {
+          excludeDebugStatements: true,
+          excludeTracing: false,
+        },
+        debug: true,
+        silent: false,
+      },
+    };
+
+    expectTypeOf(viteOptions).toEqualTypeOf<SentryOptions>();
+  });
+});

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -20,6 +20,10 @@ const injectScript = vi.fn();
 const config = {
   root: new URL('file://path/to/project'),
   outDir: new URL('file://path/to/project/out'),
+} as AstroConfig;
+
+const baseConfigHookObject = {
+  logger: { warn: vi.fn(), info: vi.fn() },
 };
 
 describe('sentryAstro integration', () => {
@@ -39,7 +43,7 @@ describe('sentryAstro integration', () => {
 
     expect(integration.hooks['astro:config:setup']).toBeDefined();
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
-    await integration.hooks['astro:config:setup']({ updateConfig, injectScript, config });
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
 
     expect(updateConfig).toHaveBeenCalledTimes(1);
     expect(updateConfig).toHaveBeenCalledWith({
@@ -52,23 +56,25 @@ describe('sentryAstro integration', () => {
     });
 
     expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
-    expect(sentryVitePluginSpy).toHaveBeenCalledWith({
-      authToken: 'my-token',
-      org: 'my-org',
-      project: 'my-project',
-      telemetry: false,
-      debug: false,
-      bundleSizeOptimizations: {},
-      sourcemaps: {
-        assets: ['out/**/*'],
-        filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
-      },
-      _metaOptions: {
-        telemetry: {
-          metaFramework: 'astro',
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authToken: 'my-token',
+        org: 'my-org',
+        project: 'my-project',
+        telemetry: false,
+        debug: false,
+        bundleSizeOptimizations: {},
+        sourcemaps: {
+          assets: ['out/**/*'],
+          filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
         },
-      },
-    });
+        _metaOptions: {
+          telemetry: {
+            metaFramework: 'astro',
+          },
+        },
+      }),
+    );
   });
 
   it('falls back to default output dir, if out and root dir are not available', async () => {
@@ -76,26 +82,28 @@ describe('sentryAstro integration', () => {
       sourceMapsUploadOptions: { enabled: true, org: 'my-org', project: 'my-project', telemetry: false },
     });
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
-    await integration.hooks['astro:config:setup']({ updateConfig, injectScript, config: {} });
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config: {} });
 
     expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
-    expect(sentryVitePluginSpy).toHaveBeenCalledWith({
-      authToken: 'my-token',
-      org: 'my-org',
-      project: 'my-project',
-      telemetry: false,
-      debug: false,
-      bundleSizeOptimizations: {},
-      sourcemaps: {
-        assets: ['dist/**/*'],
-        filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
-      },
-      _metaOptions: {
-        telemetry: {
-          metaFramework: 'astro',
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authToken: 'my-token',
+        org: 'my-org',
+        project: 'my-project',
+        telemetry: false,
+        debug: false,
+        bundleSizeOptimizations: {},
+        sourcemaps: {
+          assets: ['dist/**/*'],
+          filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
         },
-      },
-    });
+        _metaOptions: {
+          telemetry: {
+            metaFramework: 'astro',
+          },
+        },
+      }),
+    );
   });
 
   it('sets the correct assets glob for vercel if the Vercel adapter is used', async () => {
@@ -104,6 +112,7 @@ describe('sentryAstro integration', () => {
     });
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({
+      ...baseConfigHookObject,
       updateConfig,
       injectScript,
       config: {
@@ -113,23 +122,25 @@ describe('sentryAstro integration', () => {
     });
 
     expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
-    expect(sentryVitePluginSpy).toHaveBeenCalledWith({
-      authToken: 'my-token',
-      org: 'my-org',
-      project: 'my-project',
-      telemetry: false,
-      debug: false,
-      bundleSizeOptimizations: {},
-      sourcemaps: {
-        assets: ['{.vercel,dist}/**/*'],
-        filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
-      },
-      _metaOptions: {
-        telemetry: {
-          metaFramework: 'astro',
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authToken: 'my-token',
+        org: 'my-org',
+        project: 'my-project',
+        telemetry: false,
+        debug: false,
+        bundleSizeOptimizations: {},
+        sourcemaps: {
+          assets: ['{.vercel,dist}/**/*'],
+          filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
         },
-      },
-    });
+        _metaOptions: {
+          telemetry: {
+            metaFramework: 'astro',
+          },
+        },
+      }),
+    );
   });
 
   it('prefers user-specified assets-globs over the default values', async () => {
@@ -143,6 +154,7 @@ describe('sentryAstro integration', () => {
     });
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({
+      ...baseConfigHookObject,
       updateConfig,
       injectScript,
       // @ts-expect-error - only passing in partial config
@@ -152,23 +164,25 @@ describe('sentryAstro integration', () => {
     });
 
     expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
-    expect(sentryVitePluginSpy).toHaveBeenCalledWith({
-      authToken: 'my-token',
-      org: 'my-org',
-      project: 'my-project',
-      telemetry: true,
-      debug: false,
-      bundleSizeOptimizations: {},
-      sourcemaps: {
-        assets: ['dist/server/**/*, dist/client/**/*'],
-        filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
-      },
-      _metaOptions: {
-        telemetry: {
-          metaFramework: 'astro',
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authToken: 'my-token',
+        org: 'my-org',
+        project: 'my-project',
+        telemetry: true,
+        debug: false,
+        bundleSizeOptimizations: {},
+        sourcemaps: {
+          assets: ['dist/server/**/*, dist/client/**/*'],
+          filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
         },
-      },
-    });
+        _metaOptions: {
+          telemetry: {
+            metaFramework: 'astro',
+          },
+        },
+      }),
+    );
   });
 
   it('prefers user-specified filesToDeleteAfterUpload over the default values', async () => {
@@ -182,6 +196,7 @@ describe('sentryAstro integration', () => {
     });
     // @ts-expect-error - the hook exists, and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({
+      ...baseConfigHookObject,
       updateConfig,
       injectScript,
       // @ts-expect-error - only passing in partial config
@@ -226,6 +241,7 @@ describe('sentryAstro integration', () => {
     });
     // @ts-expect-error - the hook exists, and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({
+      ...baseConfigHookObject,
       updateConfig,
       injectScript,
       // @ts-expect-error - only passing in partial config
@@ -260,10 +276,34 @@ describe('sentryAstro integration', () => {
 
     expect(integration.hooks['astro:config:setup']).toBeDefined();
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
-    await integration.hooks['astro:config:setup']({ updateConfig, injectScript, config });
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
 
     expect(updateConfig).toHaveBeenCalledTimes(0);
     expect(sentryVitePluginSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("doesn't enable source maps if `sourcemaps.disable` is `true`", async () => {
+    const integration = sentryAstro({
+      sourcemaps: { disable: true },
+    });
+
+    expect(integration.hooks['astro:config:setup']).toBeDefined();
+    // @ts-expect-error - the hook exists and we only need to pass what we actually use
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
+
+    expect(updateConfig).toHaveBeenCalledTimes(0);
+    expect(sentryVitePluginSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('enables source maps if `sourcemaps.disable` is not defined', async () => {
+    const integration = sentryAstro({});
+
+    expect(integration.hooks['astro:config:setup']).toBeDefined();
+    // @ts-expect-error - the hook exists and we only need to pass what we actually use
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
+
+    expect(updateConfig).toHaveBeenCalledTimes(1);
+    expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
   });
 
   it("doesn't add the Vite plugin in dev mode", async () => {
@@ -273,7 +313,13 @@ describe('sentryAstro integration', () => {
 
     expect(integration.hooks['astro:config:setup']).toBeDefined();
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
-    await integration.hooks['astro:config:setup']({ updateConfig, injectScript, config, command: 'dev' });
+    await integration.hooks['astro:config:setup']({
+      ...baseConfigHookObject,
+      updateConfig,
+      injectScript,
+      config,
+      command: 'dev',
+    });
 
     expect(updateConfig).toHaveBeenCalledTimes(0);
     expect(sentryVitePluginSpy).toHaveBeenCalledTimes(0);

--- a/packages/astro/test/integration/snippets.test.ts
+++ b/packages/astro/test/integration/snippets.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { buildClientSnippet, buildSdkInitFileImportSnippet, buildServerSnippet } from '../../src/integration/snippets';
+import type { SentryOptions } from '../../src/integration/types';
 
-const allSdkOptions = {
+const allSdkOptions: SentryOptions = {
   dsn: 'my-dsn',
   release: '1.0.0',
   environment: 'staging',

--- a/packages/astro/tsconfig.vite.json
+++ b/packages/astro/tsconfig.vite.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["test/**/*"],
+  "include": ["vite.config.ts"],
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used

--- a/packages/astro/vite.config.ts
+++ b/packages/astro/vite.config.ts
@@ -4,5 +4,9 @@ export default {
   ...baseConfig,
   test: {
     ...baseConfig.test,
+    typecheck: {
+      enabled: true,
+      tsconfig: './tsconfig.test.json',
+    },
   },
 };


### PR DESCRIPTION
As Astro currently mixes build-time and runtime options, the `release` option was omitted from the type. It's only possible to set this option with the `unstable_sentryVitePluginOptions` :( 

Closes https://github.com/getsentry/sentry-javascript/issues/17067