### PR TITLE
docs(nuxt): Remove beta notice

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -4,15 +4,13 @@
   </a>
 </p>
 
-# Official Sentry SDK for Nuxt (BETA)
+# Official Sentry SDK for Nuxt
 
 [![npm version](https://img.shields.io/npm/v/@sentry/nuxt.svg)](https://www.npmjs.com/package/@sentry/nuxt)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/nuxt.svg)](https://www.npmjs.com/package/@sentry/nuxt)
 [![npm dt](https://img.shields.io/npm/dt/@sentry/nuxt.svg)](https://www.npmjs.com/package/@sentry/nuxt)
 
-This SDK is in **Beta**. The API is stable but updates may include minor changes in behavior. Please reach out on
-[GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns. This
-SDK is for [Nuxt](https://nuxt.com/). If you're using [Vue](https://vuejs.org/) see our
+This SDK is for [Nuxt](https://nuxt.com/). If you're using [Vue](https://vuejs.org/) see our
 [Vue SDK here](https://github.com/getsentry/sentry-javascript/tree/develop/packages/vue).
 
 ## Links
@@ -21,16 +19,12 @@ SDK is for [Nuxt](https://nuxt.com/). If you're using [Vue](https://vuejs.org/) 
 
 ## Compatibility
 
-The minimum supported version of Nuxt is `3.0.0`.
+The minimum supported version of Nuxt is `3.7.0` (`3.14.0+` recommended).
 
 ## General
 
 This package is a wrapper around `@sentry/node` for the server and `@sentry/vue` for the client side, with added
 functionality related to Nuxt.
-
-**Limitations:**
-
-- Server monitoring is not available during development mode (`nuxt dev`)
 
 ## Manual Setup
 
@@ -112,20 +106,18 @@ Sentry.init({
 ## Uploading Source Maps
 
 To upload source maps, you have to enable client source maps in your `nuxt.config.ts`. Then, you add your project
-settings to the `sentry.sourceMapsUploadOptions` of your `nuxt.config.ts`:
+settings to `sentry` in your `nuxt.config.ts`:
 
 ```javascript
 // nuxt.config.ts
 export default defineNuxtConfig({
-  sourcemap: { client: true },
+  sourcemap: { client: 'hidden' },
 
   modules: ['@sentry/nuxt/module'],
   sentry: {
-    sourceMapsUploadOptions: {
-      org: 'your-org-slug',
-      project: 'your-project-slug',
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-    },
+    org: 'your-org-slug',
+    project: 'your-project-slug',
+    authToken: process.env.SENTRY_AUTH_TOKEN,
   },
 });
 ```

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -145,7 +145,7 @@ export default defineNuxtModule<ModuleOptions>({
             consoleSandbox(() => {
               // eslint-disable-next-line no-console
               console.log(
-                `[Sentry] Using \`${serverConfigFile}\` for server-side Sentry configuration. To activate the Sentry on the Nuxt server-side, this file must be preloaded when starting your application. Make sure to add this where you deploy and/or run your application. Read more here: https://docs.sentry.io/platforms/javascript/guides/nuxt/install/.`,
+                `[Sentry] Using \`${serverConfigFile}\` for server-side Sentry configuration. To activate Sentry on the Nuxt server-side, this file must be preloaded when starting your application. Make sure to add this where you deploy and/or run your application. Read more here: https://docs.sentry.io/platforms/javascript/guides/nuxt/install/.`,
               );
 
               if (nitro.options.dev) {

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -112,15 +112,6 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.hooks.hook('nitro:init', nitro => {
       if (serverConfigFile?.includes('.server.config')) {
-        if (nitro.options.dev) {
-          consoleSandbox(() => {
-            // eslint-disable-next-line no-console
-            console.log(
-              '[Sentry] Your application is running in development mode. Note: @sentry/nuxt does not work as expected on the server-side (Nitro). Errors are reported, but tracing does not work.',
-            );
-          });
-        }
-
         consoleSandbox(() => {
           const serverDir = nitro.options.output.serverDir;
 
@@ -154,8 +145,20 @@ export default defineNuxtModule<ModuleOptions>({
             consoleSandbox(() => {
               // eslint-disable-next-line no-console
               console.log(
-                `[Sentry] Using your \`${serverConfigFile}\` file for the server-side Sentry configuration. Make sure to add the Node option \`import\` to the Node command where you deploy and/or run your application. This preloads the Sentry configuration at server startup. You can do this via a command-line flag (\`node --import ${serverConfigRelativePath} [...]\`) or via an environment variable (\`NODE_OPTIONS='--import ${serverConfigRelativePath}' node [...]\`).`,
+                `[Sentry] Using \`${serverConfigFile}\` for server-side Sentry configuration. To activate the Sentry on the Nuxt server-side, this file must be preloaded when starting your application. Make sure to add this where you deploy and/or run your application. Read more here: https://docs.sentry.io/platforms/javascript/guides/nuxt/install/.`,
               );
+
+              if (nitro.options.dev) {
+                // eslint-disable-next-line no-console
+                console.log(
+                  `[Sentry] During development, preload Sentry with the NODE_OPTIONS environment variable: \`NODE_OPTIONS='--import ${serverConfigRelativePath}' nuxt dev\`. The file is generated in the build directory (usually '.nuxt'). If you delete the build directory, run \`nuxt dev\` to regenerate it.`,
+                );
+              } else {
+                // eslint-disable-next-line no-console
+                console.log(
+                  `[Sentry] When running your built application, preload Sentry via a command-line flag (\`node --import ${serverConfigRelativePath} [...]\`) or via an environment variable (\`NODE_OPTIONS='--import ${serverConfigRelativePath}' node [...]\`).`,
+                );
+              }
             });
           }
         }


### PR DESCRIPTION
Removes the beta notice from the readme.

I also changed some logs as it's actually possible to enable tracing during dev mode - thankfully, the command prints you the correct path to the Sentry server config 🙌 
