### PR TITLE
fix(node): Fix preloading of instrumentation

### DIFF
--- a/packages/nestjs/src/integrations/nest.ts
+++ b/packages/nestjs/src/integrations/nest.ts
@@ -6,15 +6,15 @@ import { SentryNestInstrumentation } from './sentry-nest-instrumentation';
 
 const INTEGRATION_NAME = 'Nest';
 
-const instrumentNestCore = generateInstrumentOnce('Nest-Core', () => {
+const instrumentNestCore = generateInstrumentOnce(`${INTEGRATION_NAME}.Core`, () => {
   return new NestInstrumentationCore();
 });
 
-const instrumentNestCommon = generateInstrumentOnce('Nest-Common', () => {
+const instrumentNestCommon = generateInstrumentOnce(`${INTEGRATION_NAME}.Common`, () => {
   return new SentryNestInstrumentation();
 });
 
-const instrumentNestEvent = generateInstrumentOnce('Nest-Event', () => {
+const instrumentNestEvent = generateInstrumentOnce(`${INTEGRATION_NAME}.Event`, () => {
   return new SentryNestEventInstrumentation();
 });
 

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -90,10 +90,11 @@ interface FastifyHandlerOptions {
 }
 
 const INTEGRATION_NAME = 'Fastify';
-const INTEGRATION_NAME_V5 = 'Fastify-V5';
-const INTEGRATION_NAME_V3 = 'Fastify-V3';
 
-export const instrumentFastifyV3 = generateInstrumentOnce(INTEGRATION_NAME_V3, () => new FastifyInstrumentationV3());
+export const instrumentFastifyV3 = generateInstrumentOnce(
+  `${INTEGRATION_NAME}.v3`,
+  () => new FastifyInstrumentationV3(),
+);
 
 function getFastifyIntegration(): ReturnType<typeof _fastifyIntegration> | undefined {
   const client = getClient();
@@ -135,7 +136,7 @@ function handleFastifyError(
   }
 }
 
-export const instrumentFastify = generateInstrumentOnce(INTEGRATION_NAME_V5, () => {
+export const instrumentFastify = generateInstrumentOnce(`${INTEGRATION_NAME}.v5`, () => {
   const fastifyOtelInstrumentationInstance = new FastifyOtelInstrumentation();
   const plugin = fastifyOtelInstrumentationInstance.plugin();
 

--- a/packages/node/src/integrations/tracing/redis.ts
+++ b/packages/node/src/integrations/tracing/redis.ts
@@ -75,13 +75,13 @@ const cacheResponseHook: RedisResponseCustomAttributeFunction = (span: Span, red
   span.updateName(truncate(spanDescription, 1024));
 };
 
-const instrumentIORedis = generateInstrumentOnce('IORedis', () => {
+const instrumentIORedis = generateInstrumentOnce(`${INTEGRATION_NAME}.IORedis`, () => {
   return new IORedisInstrumentation({
     responseHook: cacheResponseHook,
   });
 });
 
-const instrumentRedisModule = generateInstrumentOnce('Redis', () => {
+const instrumentRedisModule = generateInstrumentOnce(`${INTEGRATION_NAME}.Redis`, () => {
   return new RedisInstrumentation({
     responseHook: cacheResponseHook,
   });

--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -101,7 +101,11 @@ function getPreloadMethods(integrationNames?: string[]): ((() => void) & { id: s
     return instruments;
   }
 
-  return instruments.filter(instrumentation => integrationNames.includes(instrumentation.id));
+  // We match exact matches of instrumentation, but also match prefixes, e.g. "Fastify.v5" will match "Fastify"
+  return instruments.filter(instrumentation => {
+    const id = instrumentation.id;
+    return integrationNames.some(integrationName => id === integrationName || id.startsWith(`${integrationName}.`));
+  });
 }
 
 /** Just exported for tests. */

--- a/packages/node/test/sdk/preload.test.ts
+++ b/packages/node/test/sdk/preload.test.ts
@@ -1,10 +1,27 @@
 import { debug } from '@sentry/core';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetGlobals } from '../helpers/mockSdkInit';
 
 describe('preload', () => {
+  beforeEach(() => {
+    // Mock this to prevent conflicts with other tests
+    vi.mock('../../src/integrations/tracing', async (importOriginal: () => Promise<Record<string, unknown>>) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        getOpenTelemetryInstrumentationToPreload: () => [
+          Object.assign(vi.fn(), { id: 'Http.sentry' }),
+          Object.assign(vi.fn(), { id: 'Http' }),
+          Object.assign(vi.fn(), { id: 'Express' }),
+          Object.assign(vi.fn(), { id: 'Graphql' }),
+        ],
+      };
+    });
+  });
+
   afterEach(() => {
-    vi.resetAllMocks();
     debug.disable();
+    resetGlobals();
 
     delete process.env.SENTRY_DEBUG;
     delete process.env.SENTRY_PRELOAD_INTEGRATIONS;
@@ -29,6 +46,7 @@ describe('preload', () => {
 
     await import('../../src/preload');
 
+    expect(logSpy).toHaveBeenCalledWith('Sentry Logger [log]:', '[Sentry] Preloaded Http.sentry instrumentation');
     expect(logSpy).toHaveBeenCalledWith('Sentry Logger [log]:', '[Sentry] Preloaded Http instrumentation');
     expect(logSpy).toHaveBeenCalledWith('Sentry Logger [log]:', '[Sentry] Preloaded Express instrumentation');
     expect(logSpy).toHaveBeenCalledWith('Sentry Logger [log]:', '[Sentry] Preloaded Graphql instrumentation');
@@ -44,6 +62,7 @@ describe('preload', () => {
 
     await import('../../src/preload');
 
+    expect(logSpy).toHaveBeenCalledWith('Sentry Logger [log]:', '[Sentry] Preloaded Http.sentry instrumentation');
     expect(logSpy).toHaveBeenCalledWith('Sentry Logger [log]:', '[Sentry] Preloaded Http instrumentation');
     expect(logSpy).toHaveBeenCalledWith('Sentry Logger [log]:', '[Sentry] Preloaded Express instrumentation');
     expect(logSpy).not.toHaveBeenCalledWith('Sentry Logger [log]:', '[Sentry] Preloaded Graphql instrumentation');

--- a/packages/react-router/src/server/integration/reactRouterServer.ts
+++ b/packages/react-router/src/server/integration/reactRouterServer.ts
@@ -5,7 +5,7 @@ import { ReactRouterInstrumentation } from '../instrumentation/reactRouter';
 
 const INTEGRATION_NAME = 'ReactRouterServer';
 
-const instrumentReactRouter = generateInstrumentOnce('React-Router-Server', () => {
+const instrumentReactRouter = generateInstrumentOnce(INTEGRATION_NAME, () => {
   return new ReactRouterInstrumentation();
 });
 


### PR DESCRIPTION
Extracted out of https://github.com/getsentry/sentry-javascript/pull/17371

I noticed that we were not fully consistent in instrumentation IDs for integrations that have multiple instrumentation. The intent is that users can provide the _integration name_ (e.g. `Http`) and it will preload all http instrumentation. To achieve this, I adjusted the preload filter code to look for exact matches as well as `startsWith(`${name}.id`)`. I also adjusted the test to be more declarative and mock/reset stuff properly (this lead to issues in the linked PR, and should generally be a bit cleaner).

I also updated all instrumentation IDs to follow this pattern. We should be mindful of following this with new instrumentation we add.