### PR TITLE
feat(node): Skip context lines lookup when source maps are enabled

### DIFF
--- a/packages/nestjs/src/integrations/contextlines.ts
+++ b/packages/nestjs/src/integrations/contextlines.ts
@@ -1,0 +1,21 @@
+import type { IntegrationFn } from '@sentry/core';
+import { defineIntegration } from '@sentry/core';
+import { contextLinesIntegration as originalContextLinesIntegration } from '@sentry/node';
+
+const _contextLinesIntegration = ((options?: { frameContextLines?: number }) => {
+  return originalContextLinesIntegration({
+    ...options,
+    // Nest.js always enabled this, without an easy way for us to detect this
+    // so we just enable it by default
+    // see: https://github.com/nestjs/nest-cli/blob/f5dbb573df1fe103139026a36b6d0efe65e8e985/actions/start.action.ts#L220
+    hasSourceMaps: true,
+  });
+}) satisfies IntegrationFn;
+
+/**
+ * Capture the lines before and after the frame's context.
+ *
+ * A Nest-specific variant of the node-core contextLineIntegration.
+ * This has source maps enabled by default, as Nest.js enables this under the hood.
+ */
+export const contextLinesIntegration = defineIntegration(_contextLinesIntegration);

--- a/packages/nestjs/src/sdk.ts
+++ b/packages/nestjs/src/sdk.ts
@@ -7,6 +7,7 @@ import {
 } from '@sentry/core';
 import type { NodeClient, NodeOptions, Span } from '@sentry/node';
 import { getDefaultIntegrations as getDefaultNodeIntegrations, init as nodeInit } from '@sentry/node';
+import { contextLinesIntegration } from './integrations/contextlines';
 import { nestIntegration } from './integrations/nest';
 
 /**
@@ -34,7 +35,12 @@ export function init(options: NodeOptions | undefined = {}): NodeClient | undefi
 
 /** Get the default integrations for the NestJS SDK. */
 export function getDefaultIntegrations(options: NodeOptions): Integration[] | undefined {
-  return [nestIntegration(), ...getDefaultNodeIntegrations(options)];
+  return [
+    nestIntegration(),
+    ...getDefaultNodeIntegrations(options).filter(i => i.name !== 'ContextLines'),
+    // Custom variant for Nest.js
+    contextLinesIntegration(),
+  ];
 }
 
 function addNestSpanAttributes(span: Span): void {

--- a/packages/node-core/test/sdk/init.test.ts
+++ b/packages/node-core/test/sdk/init.test.ts
@@ -220,6 +220,11 @@ describe('init()', () => {
 });
 
 describe('validateOpenTelemetrySetup', () => {
+  beforeEach(() => {
+    // just swallowing these
+    vi.spyOn(debug, 'log').mockImplementation(() => {});
+  });
+
   afterEach(() => {
     global.__SENTRY__ = {};
     cleanupOtel();


### PR DESCRIPTION
This improves lookup of files for the node context lines integration, when `--enable-source-maps` is used.

With this setting, error stacks will already be sourcemapped. This can lead to file lookups repeatedly failing, because we try to load files that do not exist in node modules. To avoid this, when we detect that this setting exists, we skip this in cases where we feel confident that this is unnecessary. For now, this is only one case:

* It is a non-in-app frame
* It is a .ts file - this can only happen if the file is source mapped, realistically

In this case, we'll skip trying to lookup the file.

We determine if the setting is defined by looking at `process.env.NODE_OPTIONS` and `process.argv.` 
Additionally, in nest.js this is [always defined](https://github.com/nestjs/nest-cli/blob/f5dbb573df1fe103139026a36b6d0efe65e8e985/actions/start.action.ts#L220), so we always handle it this way there.

Additionally, I also adjusted the log message when we fail to lookup the file, as this looked pretty ominous and unclear how problematic that was, even if this is not really an error per-se.