### PR TITLE
test(nextjs): Fix canary tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2018",
+    "allowImportingTsExtensions": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/dev-packages/e2e-tests/test-applications/nextjs-turbo/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-turbo/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
Adding `allowImportingTsExtensions` fixes our tests on canary.

Likely the culprit for this change:
ref https://github.com/vercel/next.js/pull/81400#issuecomment-3187603046

We're still waiting for a reply, if this was unintentional we can revert this PR here.

closes https://github.com/getsentry/sentry-javascript/issues/17412
closes https://github.com/getsentry/sentry-javascript/issues/17411
closes https://github.com/getsentry/sentry-javascript/issues/17410
closes https://github.com/getsentry/sentry-javascript/issues/17409