### PR TITLE
fix(cloudflare): cloudflare:workers types breaking imported env with DOs

### DIFF
--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -11,7 +11,7 @@ import {
   withIsolationScope,
   withScope,
 } from '@sentry/core';
-import type { DurableObject } from 'cloudflare:workers';
+import type { DurableObject } from '@cloudflare/workers-types';
 import { setAsyncLocalStorageAsyncContextStrategy } from './async';
 import type { CloudflareOptions } from './client';
 import { isInstrumented, markAsInstrumented } from './instrument';
@@ -189,7 +189,7 @@ function wrapMethodWithSentry<T extends OriginalMethod>(
  */
 export function instrumentDurableObjectWithSentry<
   E,
-  T extends DurableObject<E>,
+  T extends DurableObject,
   C extends new (state: DurableObjectState, env: E) => T,
 >(optionsCallback: (env: E) => CloudflareOptions, DurableObjectClass: C): C {
   return new Proxy(DurableObjectClass, {


### PR DESCRIPTION
Fixes type issues in https://github.com/getsentry/sentry-javascript/issues/16099 when using Worker + DOs. 
Not tested using Workflows. 

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
