### PR TITLE
fix(v8/react): Add support for React Router sub-routes from `handle` (#17277)

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/.gitignore
@@ -1,0 +1,29 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
+!*.d.ts

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/.npmrc
@@ -1,0 +1,2 @@
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "react-router-7-lazy-routes",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@sentry/react": "latest || *",
+    "@types/react": "18.0.0",
+    "@types/react-dom": "18.0.0",
+    "express": "4.20.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-router-dom": "7.6.0",
+    "react-scripts": "5.0.1",
+    "typescript": "~5.0.0"
+  },
+  "scripts": {
+    "build": "react-scripts build",
+    "start": "serve -s build",
+    "test": "playwright test",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "test:build": "pnpm install && npx playwright install && pnpm build",
+    "test:build-ts3.8": "pnpm install && pnpm add typescript@3.8 && npx playwright install && pnpm build",
+    "test:build-canary": "pnpm install && pnpm add react@canary react-dom@canary && npx playwright install && pnpm build",
+    "test:assert": "pnpm test"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@playwright/test": "~1.53.2",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "serve": "14.0.1",
+    "npm-run-all2": "^6.2.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/playwright.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm start`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/public/index.html
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Web site created using create-react-app" />
+    <title>React App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/globals.d.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/globals.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  recordedTransactions?: string[];
+  capturedExceptionId?: string;
+  sentryReplayId?: string;
+}

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/index.tsx
@@ -1,0 +1,74 @@
+import * as Sentry from '@sentry/react';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import {
+  Navigate,
+  PatchRoutesOnNavigationFunction,
+  RouterProvider,
+  createBrowserRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from 'react-router-dom';
+import Index from './pages/Index';
+
+
+Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
+  dsn: process.env.REACT_APP_E2E_TEST_DSN,
+  integrations: [
+    Sentry.reactRouterV7BrowserTracingIntegration({
+      useEffect: React.useEffect,
+      useLocation,
+      useNavigationType,
+      createRoutesFromChildren,
+      matchRoutes,
+      trackFetchStreamPerformance: true,
+      enableAsyncRouteHandlers: true,
+    }),
+  ],
+  // We recommend adjusting this value in production, or using tracesSampler
+  // for finer control
+  tracesSampleRate: 1.0,
+  release: 'e2e-test',
+
+  tunnel: 'http://localhost:3031',
+});
+
+const sentryCreateBrowserRouter = Sentry.wrapCreateBrowserRouterV7(createBrowserRouter);
+
+const router = sentryCreateBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <Index />,
+    },
+    {
+      path: '/lazy',
+      handle: {
+        lazyChildren: () => import('./pages/InnerLazyRoutes').then(module => module.someMoreNestedRoutes),
+      },
+    },
+    {
+      path: '/static',
+      element: <>Hello World</>,
+    },
+    {
+      path: '*',
+      element: <Navigate to="/" replace />,
+    },
+  ],
+  {
+    async patchRoutesOnNavigation({ matches, patch }: Parameters<PatchRoutesOnNavigationFunction>[0]) {
+      const leafRoute = matches[matches.length - 1]?.route;
+      if (leafRoute?.id && leafRoute?.handle?.lazyChildren) {
+        const children = await leafRoute.handle.lazyChildren();
+        patch(leafRoute.id, children);
+      }
+    },
+  },
+);
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(<RouterProvider router={router} />);

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/pages/Index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/pages/Index.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+const Index = () => {
+  return (
+    <>
+      <Link to="/lazy/inner/123/456/789" id="navigation">
+        navigate
+      </Link>
+    </>
+  );
+};
+
+export default Index;

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/pages/InnerLazyRoutes.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/pages/InnerLazyRoutes.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export const someMoreNestedRoutes = [
+  {
+    path: 'inner',
+    children: [
+      {
+        index: true,
+        element: <>Level 1</>,
+      },
+      {
+        path: ':id',
+        children: [
+          {
+            index: true,
+            element: <>Level 1 ID</>,
+          },
+          {
+            path: ':anotherId',
+            children: [
+              {
+                index: true,
+                element: <>Level 1 ID Another ID</>,
+              },
+              {
+                path: ':someAnotherId',
+                element: <div id="innermost-lazy-route">
+                  Rendered
+                </div>,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/react-app-env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'react-router-7-lazy-routes',
+});

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/tests/transactions.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+
+test('Creates a pageload transaction with parameterized route', async ({ page }) => {
+  const transactionPromise = waitForTransaction('react-router-7-lazy-routes', async transactionEvent => {
+    return (
+      !!transactionEvent?.transaction &&
+      transactionEvent.contexts?.trace?.op === 'pageload' &&
+      transactionEvent.transaction === '/lazy/inner/:id/:anotherId/:someAnotherId'
+    );
+  });
+
+  await page.goto('/lazy/inner/1/2/3');
+  const event = await transactionPromise;
+
+
+  const lazyRouteContent = page.locator('id=innermost-lazy-route');
+
+  await expect(lazyRouteContent).toBeVisible();
+
+  // Validate the transaction event
+  expect(event.transaction).toBe('/lazy/inner/:id/:anotherId/:someAnotherId');
+  expect(event.type).toBe('transaction');
+  expect(event.contexts?.trace?.op).toBe('pageload');
+});
+
+test('Creates a navigation transaction inside a lazy route', async ({ page }) => {
+  const transactionPromise = waitForTransaction('react-router-7-lazy-routes', async transactionEvent => {
+    return (
+      !!transactionEvent?.transaction &&
+      transactionEvent.contexts?.trace?.op === 'navigation' &&
+      transactionEvent.transaction === '/lazy/inner/:id/:anotherId/:someAnotherId'
+    );
+  });
+
+  await page.goto('/');
+
+  // Check if the navigation link exists
+  const navigationLink = page.locator('id=navigation');
+  await expect(navigationLink).toBeVisible();
+
+  // Click the navigation link to navigate to the lazy route
+  await navigationLink.click();
+  const event = await transactionPromise;
+
+  // Check if the lazy route content is rendered
+  const lazyRouteContent = page.locator('id=innermost-lazy-route');
+
+  await expect(lazyRouteContent).toBeVisible();
+
+  // Validate the transaction event
+  expect(event.transaction).toBe('/lazy/inner/:id/:anotherId/:someAnotherId');
+  expect(event.type).toBe('transaction');
+  expect(event.contexts?.trace?.op).toBe('navigation');
+});

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -13,6 +13,7 @@ export type Location = {
 export interface NonIndexRouteObject {
   caseSensitive?: boolean;
   children?: RouteObject[];
+  handle?: Record<string, any>;
   element?: React.ReactNode | null;
   errorElement?: React.ReactNode | null;
   index?: any;
@@ -22,6 +23,7 @@ export interface NonIndexRouteObject {
 export interface IndexRouteObject {
   caseSensitive?: boolean;
   children?: undefined;
+  handle?: Record<string, any>;
   element?: React.ReactNode | null;
   errorElement?: React.ReactNode | null;
   index: any;

--- a/packages/react/test/reactrouterv6-compat-utils.test.tsx
+++ b/packages/react/test/reactrouterv6-compat-utils.test.tsx
@@ -1,0 +1,315 @@
+import { describe, expect, it, test } from 'vitest';
+import { checkRouteForAsyncHandler, getNumberOfUrlSegments } from '../src/reactrouterv6-compat-utils';
+import type { RouteObject } from '../src/types';
+
+describe('getNumberOfUrlSegments', () => {
+  test.each([
+    ['regular path', '/projects/123/views/234', 4],
+    ['single param parameterized path', '/users/:id/details', 3],
+    ['multi param parameterized path', '/stores/:storeId/products/:productId', 4],
+    ['regex path', String(/\/api\/post[0-9]/), 2],
+  ])('%s', (_: string, input, output) => {
+    expect(getNumberOfUrlSegments(input)).toEqual(output);
+  });
+});
+
+describe('checkRouteForAsyncHandler', () => {
+  it('should not create nested proxies when called multiple times on the same route', () => {
+    const mockHandler = () => Promise.resolve([]);
+    const route: RouteObject = {
+      path: '/test',
+      handle: {
+        lazyChildren: mockHandler,
+      },
+    };
+
+    checkRouteForAsyncHandler(route);
+    checkRouteForAsyncHandler(route);
+
+    const proxiedHandler = route.handle?.lazyChildren;
+    expect(typeof proxiedHandler).toBe('function');
+    expect(proxiedHandler).not.toBe(mockHandler);
+
+    expect((proxiedHandler as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+
+    const proxyHandler = (proxiedHandler as any)?.__sentry_proxied__;
+    expect(proxyHandler).toBe(true);
+  });
+
+  it('should handle routes without handle property', () => {
+    const route: RouteObject = {
+      path: '/test',
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with non-function handle properties', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: {
+        someData: 'not a function',
+      },
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with null/undefined handle properties', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: null as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with mixed function and non-function handle properties', () => {
+    const mockHandler = () => Promise.resolve([]);
+    const route: RouteObject = {
+      path: '/test',
+      handle: {
+        lazyChildren: mockHandler,
+        someData: 'not a function',
+        anotherData: 123,
+      },
+    };
+
+    checkRouteForAsyncHandler(route);
+
+    const proxiedHandler = route.handle?.lazyChildren;
+    expect(typeof proxiedHandler).toBe('function');
+    expect(proxiedHandler).not.toBe(mockHandler);
+    expect((proxiedHandler as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+
+    // Non-function properties should remain unchanged
+    expect(route.handle?.someData).toBe('not a function');
+    expect(route.handle?.anotherData).toBe(123);
+  });
+
+  it('should handle nested routes with async handlers', () => {
+    const parentHandler = () => Promise.resolve([]);
+    const childHandler = () => Promise.resolve([]);
+
+    const route: RouteObject = {
+      path: '/parent',
+      handle: {
+        lazyChildren: parentHandler,
+      },
+      children: [
+        {
+          path: '/child',
+          handle: {
+            lazyChildren: childHandler,
+          },
+        },
+      ],
+    };
+
+    checkRouteForAsyncHandler(route);
+
+    // Check parent handler is proxied
+    const proxiedParentHandler = route.handle?.lazyChildren;
+    expect(typeof proxiedParentHandler).toBe('function');
+    expect(proxiedParentHandler).not.toBe(parentHandler);
+    expect((proxiedParentHandler as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+
+    // Check child handler is proxied
+    const proxiedChildHandler = route.children?.[0]?.handle?.lazyChildren;
+    expect(typeof proxiedChildHandler).toBe('function');
+    expect(proxiedChildHandler).not.toBe(childHandler);
+    expect((proxiedChildHandler as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+  });
+
+  it('should handle deeply nested routes', () => {
+    const level1Handler = () => Promise.resolve([]);
+    const level2Handler = () => Promise.resolve([]);
+    const level3Handler = () => Promise.resolve([]);
+
+    const route: RouteObject = {
+      path: '/level1',
+      handle: {
+        lazyChildren: level1Handler,
+      },
+      children: [
+        {
+          path: '/level2',
+          handle: {
+            lazyChildren: level2Handler,
+          },
+          children: [
+            {
+              path: '/level3',
+              handle: {
+                lazyChildren: level3Handler,
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    checkRouteForAsyncHandler(route);
+
+    // Check all handlers are proxied
+    expect((route.handle?.lazyChildren as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+    expect((route.children?.[0]?.handle?.lazyChildren as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(
+      true,
+    );
+    expect(
+      (route.children?.[0]?.children?.[0]?.handle?.lazyChildren as { __sentry_proxied__?: boolean }).__sentry_proxied__,
+    ).toBe(true);
+  });
+
+  it('should handle routes with multiple async handlers', () => {
+    const handler1 = () => Promise.resolve([]);
+    const handler2 = () => Promise.resolve([]);
+    const handler3 = () => Promise.resolve([]);
+
+    const route: RouteObject = {
+      path: '/test',
+      handle: {
+        lazyChildren: handler1,
+        asyncLoader: handler2,
+        dataLoader: handler3,
+      },
+    };
+
+    checkRouteForAsyncHandler(route);
+
+    // Check all handlers are proxied
+    expect((route.handle?.lazyChildren as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+    expect((route.handle?.asyncLoader as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+    expect((route.handle?.dataLoader as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+  });
+
+  it('should not re-proxy already proxied functions', () => {
+    const mockHandler = () => Promise.resolve([]);
+    const route: RouteObject = {
+      path: '/test',
+      handle: {
+        lazyChildren: mockHandler,
+      },
+    };
+
+    // First call should proxy the function
+    checkRouteForAsyncHandler(route);
+    const firstProxiedHandler = route.handle?.lazyChildren;
+    expect(firstProxiedHandler).not.toBe(mockHandler);
+    expect((firstProxiedHandler as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+
+    // Second call should not create a new proxy
+    checkRouteForAsyncHandler(route);
+    const secondProxiedHandler = route.handle?.lazyChildren;
+    expect(secondProxiedHandler).toBe(firstProxiedHandler); // Should be the same proxy
+    expect((secondProxiedHandler as { __sentry_proxied__?: boolean }).__sentry_proxied__).toBe(true);
+  });
+
+  it('should handle routes with empty children array', () => {
+    const route: RouteObject = {
+      path: '/test',
+      children: [],
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with undefined children', () => {
+    const route: RouteObject = {
+      path: '/test',
+      children: undefined,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with null children', () => {
+    const route: RouteObject = {
+      path: '/test',
+      children: null as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with non-array children', () => {
+    const route: RouteObject = {
+      path: '/test',
+      children: 'not an array' as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with handle that is not an object', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: 'not an object' as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with handle that is null', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: null as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with handle that is undefined', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: undefined as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with handle that is a function', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: (() => {}) as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with handle that is a string', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: 'string handle' as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with handle that is a number', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: 42 as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with handle that is a boolean', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: true as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+
+  it('should handle routes with handle that is an array', () => {
+    const route: RouteObject = {
+      path: '/test',
+      handle: [] as any,
+    };
+
+    expect(() => checkRouteForAsyncHandler(route)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Backports #17277 to v8