### PR TITLE
test(e2e/firebase): Fix firebase e2e test failing due to outdated rules file

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-firebase/firestore.rules
+++ b/dev-packages/e2e-tests/test-applications/node-firebase/firestore.rules
@@ -3,15 +3,7 @@ rules_version='2'
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      // This rule allows anyone with your database reference to view, edit,
-      // and delete all data in your database. It is useful for getting
-      // started, but it is configured to expire after 30 days because it
-      // leaves your app open to attackers. At that time, all client
-      // requests to your database will be denied.
-      //
-      // Make sure to write security rules for your app before that time, or
-      // else all client requests to your database will be denied until you
-      // update your rules.
+      // general access within this test app's emulator is fine
       allow read, write: if true;
     }
   }


### PR DESCRIPTION
To test our firebase instrumentation, we spin up a firebase emulator with firestore rules.
Looks like by default, the generated rules file was set to only allow general data access for 30 days. This caused CI to suddenly fail from Aug 17 onwards (and went unnoticed until today due to Hackweek). 
Since this is just us running the emulator in a CI job, I think it's okay to allow access unconditionally. Not sure though, so happy to think of something else if reviewers have concerns. 