### PR TITLE
feat(core): Stream responses Anthropic AI

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario-stream.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario-stream.mjs
@@ -1,0 +1,105 @@
+import { instrumentAnthropicAiClient } from '@sentry/core';
+import * as Sentry from '@sentry/node';
+
+function createMockStreamEvents(model = 'claude-3-haiku-20240307') {
+  async function* generator() {
+    // Provide message metadata early so the span can capture id/model/usage input tokens
+    yield {
+      type: 'content_block_start',
+      message: {
+        id: 'msg_stream_1',
+        type: 'message',
+        role: 'assistant',
+        model,
+        content: [],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+        },
+      },
+    };
+
+    // Streamed text chunks
+    yield { type: 'content_block_delta', delta: { text: 'Hello ' } };
+    yield { type: 'content_block_delta', delta: { text: 'from ' } };
+    yield { type: 'content_block_delta', delta: { text: 'stream!' } };
+
+    // Final usage totals for output tokens
+    yield { type: 'message_delta', usage: { output_tokens: 15 } };
+  }
+
+  return generator();
+}
+
+class MockAnthropic {
+  constructor(config) {
+    this.apiKey = config.apiKey;
+
+    this.messages = {
+      create: this._messagesCreate.bind(this),
+      stream: this._messagesStream.bind(this),
+    };
+  }
+
+  async _messagesCreate(params) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+    if (params?.stream === true) {
+      return createMockStreamEvents(params.model);
+    }
+    // Fallback non-streaming behavior (not used in this scenario)
+    return {
+      id: 'msg_mock123',
+      type: 'message',
+      model: params.model,
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: 'Hello from Anthropic mock!',
+        },
+      ],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 15,
+      },
+    };
+  }
+
+  async _messagesStream(params) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+    return createMockStreamEvents(params?.model);
+  }
+}
+
+async function run() {
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    const mockClient = new MockAnthropic({ apiKey: 'mock-api-key' });
+    const client = instrumentAnthropicAiClient(mockClient);
+
+    // 1) Streaming via stream: true param on messages.create
+    const stream1 = await client.messages.create({
+      model: 'claude-3-haiku-20240307',
+      messages: [{ role: 'user', content: 'Stream this please' }],
+      stream: true,
+    });
+    for await (const _ of stream1) {
+      void _;
+    }
+
+    // 2) Streaming via messages.stream API
+    const stream2 = await client.messages.stream({
+      model: 'claude-3-haiku-20240307',
+      messages: [{ role: 'user', content: 'Stream this too' }],
+    });
+    for await (const _ of stream2) {
+      void _;
+    }
+  });
+}
+
+run();
+
+

--- a/packages/core/src/utils/anthropic-ai/constants.ts
+++ b/packages/core/src/utils/anthropic-ai/constants.ts
@@ -4,6 +4,7 @@ export const ANTHROPIC_AI_INTEGRATION_NAME = 'Anthropic_AI';
 // https://docs.anthropic.com/en/api/models-list
 export const ANTHROPIC_AI_INSTRUMENTED_METHODS = [
   'messages.create',
+  'messages.stream',
   'messages.countTokens',
   'models.get',
   'completions.create',

--- a/packages/core/src/utils/anthropic-ai/index.ts
+++ b/packages/core/src/utils/anthropic-ai/index.ts
@@ -191,7 +191,7 @@ function instrumentMethod<T extends unknown[], R>(
 
             const result = await originalMethod.apply(context, args);
             return instrumentStream(
-              result as unknown as AsyncIterable<AnthropicAiStreamingEvent>,
+              result as AsyncIterable<AnthropicAiStreamingEvent>,
               span,
               finalOptions.recordOutputs ?? false,
             ) as unknown as R;

--- a/packages/core/src/utils/anthropic-ai/index.ts
+++ b/packages/core/src/utils/anthropic-ai/index.ts
@@ -1,7 +1,8 @@
 import { getCurrentScope } from '../../currentScopes';
 import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
-import { startSpan } from '../../tracing/trace';
+import { SPAN_STATUS_ERROR } from '../../tracing';
+import { startSpan, startSpanManual } from '../../tracing/trace';
 import type { Span, SpanAttributeValue } from '../../types-hoist/span';
 import {
   ANTHROPIC_AI_RESPONSE_TIMESTAMP_ATTRIBUTE,
@@ -22,14 +23,17 @@ import {
 } from '../ai/gen-ai-attributes';
 import { buildMethodPath, getFinalOperationName, getSpanOperation, setTokenUsageAttributes } from '../ai/utils';
 import { ANTHROPIC_AI_INTEGRATION_NAME } from './constants';
+import { instrumentStream } from './streaming';
 import type {
   AnthropicAiClient,
   AnthropicAiInstrumentedMethod,
   AnthropicAiIntegration,
   AnthropicAiOptions,
   AnthropicAiResponse,
+  AnthropicAiStreamingEvent,
 } from './types';
 import { shouldInstrument } from './utils';
+
 /**
  * Extract request attributes from method arguments
  */
@@ -168,7 +172,47 @@ function instrumentMethod<T extends unknown[], R>(
     const model = requestAttributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE] ?? 'unknown';
     const operationName = getFinalOperationName(methodPath);
 
-    // TODO: Handle streaming responses
+    const params = typeof args[0] === 'object' ? (args[0] as Record<string, unknown>) : undefined;
+    const isStreamRequested = Boolean(params?.stream);
+    const isStreamingMethod = methodPath === 'messages.stream';
+
+    if (isStreamRequested || isStreamingMethod) {
+      return startSpanManual(
+        {
+          name: `${operationName} ${model} stream-response`,
+          op: getSpanOperation(methodPath),
+          attributes: requestAttributes as Record<string, SpanAttributeValue>,
+        },
+        async (span: Span) => {
+          try {
+            if (finalOptions.recordInputs && params) {
+              addPrivateRequestAttributes(span, params);
+            }
+
+            const result = await originalMethod.apply(context, args);
+            return instrumentStream(
+              result as unknown as AsyncIterable<AnthropicAiStreamingEvent>,
+              span,
+              finalOptions.recordOutputs ?? false,
+            ) as unknown as R;
+          } catch (error) {
+            span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+            captureException(error, {
+              mechanism: {
+                handled: false,
+                type: 'auto.ai.anthropic',
+                data: {
+                  function: methodPath,
+                },
+              },
+            });
+            span.end();
+            throw error;
+          }
+        },
+      );
+    }
+
     return startSpan(
       {
         name: `${operationName} ${model}`,

--- a/packages/core/src/utils/anthropic-ai/streaming.ts
+++ b/packages/core/src/utils/anthropic-ai/streaming.ts
@@ -1,0 +1,217 @@
+import { captureException } from '../../exports';
+import { SPAN_STATUS_ERROR } from '../../tracing';
+import type { Span } from '../../types-hoist/span';
+import {
+  ANTHROPIC_AI_RESPONSE_TIMESTAMP_ATTRIBUTE,
+  GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE,
+  GEN_AI_RESPONSE_ID_ATTRIBUTE,
+  GEN_AI_RESPONSE_MODEL_ATTRIBUTE,
+  GEN_AI_RESPONSE_STREAMING_ATTRIBUTE,
+  GEN_AI_RESPONSE_TEXT_ATTRIBUTE,
+} from '../ai/gen-ai-attributes';
+import { setTokenUsageAttributes } from '../ai/utils';
+import type { AnthropicAiStreamingEvent } from './types';
+
+/**
+ * State object used to accumulate information from a stream of Anthropic AI events.
+ */
+
+interface StreamingState {
+  /** Types of events encountered in the stream. */
+  eventTypes: string[];
+  /** Collected response text fragments (for output recording). */
+  responseTexts: string[];
+  /** Reasons for finishing the response, as reported by the API. */
+  finishReasons: string[];
+  /** The response ID. */
+  responseId: string;
+  /** The model name. */
+  responseModel: string;
+  /** The timestamp of the response. */
+  responseTimestamp: number;
+  /** Number of prompt/input tokens used. */
+  promptTokens: number | undefined;
+  /** Number of completion/output tokens used. */
+  completionTokens: number | undefined;
+  /** Number of cache creation input tokens used. */
+  cacheCreationInputTokens: number | undefined;
+  /** Number of cache read input tokens used. */
+  cacheReadInputTokens: number | undefined;
+}
+
+/**
+ * Checks if an event is an error event
+ * @param event - The event to process
+ * @param state - The state of the streaming process
+ * @param recordOutputs - Whether to record outputs
+ * @param span - The span to update
+ * @returns Whether an error occurred
+ */
+
+function isErrorEvent(
+  event: AnthropicAiStreamingEvent,
+  state: StreamingState,
+  recordOutputs: boolean,
+  span: Span,
+): boolean {
+  if ('type' in event && typeof event.type === 'string') {
+    state.eventTypes.push(event.type);
+
+    // If the event is an error, set the span status and capture the error
+    // These error events are not rejected by the API by default, but are sent as metadata of the response
+    if (event.type === 'error') {
+      const message = event.error?.message ?? 'internal_error';
+      span.setStatus({ code: SPAN_STATUS_ERROR, message });
+      captureException(new Error(`anthropic_stream_error: ${message}`), {
+        mechanism: {
+          handled: false,
+          type: 'auto.ai.anthropic',
+          data: {
+            function: 'anthropic_stream_error',
+          },
+        },
+        data: {
+          function: 'anthropic_stream_error',
+        },
+      });
+      return true;
+    }
+
+    if (recordOutputs && event.type === 'content_block_delta') {
+      const text = event.delta?.text ?? '';
+      if (text) state.responseTexts.push(text);
+    }
+  }
+  return false;
+}
+
+/**
+ * Processes the message metadata of an event
+ * @param event - The event to process
+ * @param state - The state of the streaming process
+ */
+
+function handleMessageMetadata(event: AnthropicAiStreamingEvent, state: StreamingState): void {
+  // The token counts shown in the usage field of the message_delta event are cumulative.
+  // @see https://docs.anthropic.com/en/docs/build-with-claude/streaming#event-types
+  if (event.type === 'message_delta' && event.usage) {
+    if ('output_tokens' in event.usage && typeof event.usage.output_tokens === 'number') {
+      state.completionTokens = event.usage.output_tokens;
+    }
+  }
+
+  if (event.message) {
+    const message = event.message;
+
+    if (message.id) state.responseId = message.id;
+    if (message.model) state.responseModel = message.model;
+    if (message.stop_reason) state.finishReasons.push(message.stop_reason);
+
+    if (message.usage) {
+      if (typeof message.usage.input_tokens === 'number') state.promptTokens = message.usage.input_tokens;
+      if (typeof message.usage.cache_creation_input_tokens === 'number')
+        state.cacheCreationInputTokens = message.usage.cache_creation_input_tokens;
+      if (typeof message.usage.cache_read_input_tokens === 'number')
+        state.cacheReadInputTokens = message.usage.cache_read_input_tokens;
+    }
+  }
+}
+
+/**
+ * Processes an event
+ * @param event - The event to process
+ * @param state - The state of the streaming process
+ * @param recordOutputs - Whether to record outputs
+ * @param span - The span to update
+ */
+
+function processEvent(
+  event: AnthropicAiStreamingEvent,
+  state: StreamingState,
+  recordOutputs: boolean,
+  span: Span,
+): void {
+  if (!(event && typeof event === 'object')) {
+    state.eventTypes.push('unknown:non-object');
+    return;
+  }
+
+  const isError = isErrorEvent(event, state, recordOutputs, span);
+  if (isError) return;
+
+  handleMessageMetadata(event, state);
+}
+
+/**
+ * Instruments an async iterable stream of Anthropic events, updates the span with
+ * streaming attributes and (optionally) the aggregated output text, and yields
+ * each event from the input stream unchanged.
+ */
+export async function* instrumentStream(
+  stream: AsyncIterable<AnthropicAiStreamingEvent>,
+  span: Span,
+  recordOutputs: boolean,
+): AsyncGenerator<AnthropicAiStreamingEvent, void, unknown> {
+  const state: StreamingState = {
+    eventTypes: [],
+    responseTexts: [],
+    finishReasons: [],
+    responseId: '',
+    responseModel: '',
+    responseTimestamp: 0,
+    promptTokens: undefined,
+    completionTokens: undefined,
+    cacheCreationInputTokens: undefined,
+    cacheReadInputTokens: undefined,
+  };
+
+  try {
+    for await (const event of stream) {
+      processEvent(event, state, recordOutputs, span);
+      yield event;
+    }
+  } finally {
+    // Set common response attributes if available
+    if (state.responseId) {
+      span.setAttributes({
+        [GEN_AI_RESPONSE_ID_ATTRIBUTE]: state.responseId,
+      });
+    }
+    if (state.responseModel) {
+      span.setAttributes({
+        [GEN_AI_RESPONSE_MODEL_ATTRIBUTE]: state.responseModel,
+      });
+    }
+    if (state.responseTimestamp) {
+      span.setAttributes({
+        [ANTHROPIC_AI_RESPONSE_TIMESTAMP_ATTRIBUTE]: new Date(state.responseTimestamp * 1000).toISOString(),
+      });
+    }
+
+    setTokenUsageAttributes(
+      span,
+      state.promptTokens,
+      state.completionTokens,
+      state.cacheCreationInputTokens,
+      state.cacheReadInputTokens,
+    );
+
+    span.setAttributes({
+      [GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]: true,
+    });
+
+    if (state.finishReasons.length > 0) {
+      span.setAttributes({
+        [GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]: JSON.stringify(state.finishReasons),
+      });
+    }
+
+    if (recordOutputs && state.responseTexts.length > 0) {
+      span.setAttributes({
+        [GEN_AI_RESPONSE_TEXT_ATTRIBUTE]: state.responseTexts.join(''),
+      });
+    }
+
+    span.end();
+  }
+}

--- a/packages/core/src/utils/anthropic-ai/types.ts
+++ b/packages/core/src/utils/anthropic-ai/types.ts
@@ -61,3 +61,44 @@ export interface AnthropicAiIntegration {
 }
 
 export type AnthropicAiInstrumentedMethod = (typeof ANTHROPIC_AI_INSTRUMENTED_METHODS)[number];
+
+/**
+ * Message type for Anthropic AI
+ */
+export type AnthropicAiMessage = {
+  id: string;
+  type: 'message';
+  role: string;
+  model: string;
+  content: unknown[];
+  stop_reason: string | null;
+  stop_sequence: number | null;
+  usage?: {
+    input_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation?: unknown;
+    output_tokens?: number; // Not final; do not treat as total. Use `message_delta.usage.output_tokens` for the final total.
+    service_tier?: string;
+  };
+};
+
+/**
+ * Streaming event type for Anthropic AI
+ */
+export type AnthropicAiStreamingEvent = {
+  type: 'message_delta' | 'content_block_start' | 'content_block_delta' | 'content_block_stop' | 'error';
+  error?: {
+    type: string;
+    message: string;
+  };
+  index?: number;
+  delta?: {
+    type: unknown;
+    text?: string;
+  };
+  usage?: {
+    output_tokens: number; // Final total output tokens; emitted on the last `message_delta` event
+  };
+  message?: AnthropicAiMessage;
+};


### PR DESCRIPTION
This PR adds support for streamed Anthropic Messages API responses in the Core AI instrumentation. It detects streaming via `messages.create({…, stream: true})` and `messages.stream(...),` and marks spans with stream related attributes. It also aggregates token usage from stream events and records streamed text when PII capture is enabled.