### PR TITLE
test(profiling): Add tests for current state of profiling

### DIFF
--- a/dev-packages/browser-integration-tests/suites/profiling/legacyMode/subject.js
+++ b/dev-packages/browser-integration-tests/suites/profiling/legacyMode/subject.js
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserProfilingIntegration()],
+  tracesSampleRate: 1,
+  profilesSampleRate: 1,
+});
+
+function fibonacci(n) {
+  if (n <= 1) {
+    return n;
+  }
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+await Sentry.startSpanManual({ name: 'root-fibonacci-2', parentSpan: null, forceTransaction: true }, async span => {
+  fibonacci(30);
+
+  // Timeout to prevent flaky tests. Integration samples every 20ms, if function is too fast it might not get sampled
+  await new Promise(resolve => setTimeout(resolve, 21));
+  span.end();
+});

--- a/dev-packages/browser-integration-tests/suites/profiling/legacyMode/test.ts
+++ b/dev-packages/browser-integration-tests/suites/profiling/legacyMode/test.ts
@@ -1,0 +1,98 @@
+import { expect } from '@playwright/test';
+import type { Event, Profile } from '@sentry/core';
+import { sentryTest } from '../../../utils/fixtures';
+import { properEnvelopeRequestParser, waitForTransactionRequestOnUrl } from '../../../utils/helpers';
+
+sentryTest('does not send profile envelope when document-policy is not set', async ({ page, getLocalTestUrl }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  await page.goto(url);
+
+  const req = await waitForTransactionRequestOnUrl(page, url);
+  const transactionEvent = properEnvelopeRequestParser<Event>(req, 0);
+  const profileEvent = properEnvelopeRequestParser<Profile>(req, 1);
+
+  expect(transactionEvent).toBeDefined();
+
+  expect(profileEvent).toBeUndefined();
+});
+
+sentryTest('sends profile envelope in legacy mode', async ({ page, getLocalTestUrl }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname, responseHeaders: { 'Document-Policy': 'js-profiling' } });
+  await page.goto(url);
+
+  const req = await waitForTransactionRequestOnUrl(page, url);
+  const profileEvent = properEnvelopeRequestParser<Profile>(req, 1);
+
+  const profile = profileEvent.profile;
+
+  expect(profileEvent).toBeDefined();
+  expect(profileEvent.profile).toBeDefined();
+
+  expect(profile.samples).toBeDefined();
+  expect(profile.stacks).toBeDefined();
+  expect(profile.frames).toBeDefined();
+  expect(profile.thread_metadata).toBeDefined();
+
+  // Samples
+  expect(profile.samples.length).toBeGreaterThanOrEqual(2);
+  for (const sample of profile.samples) {
+    expect(typeof sample.elapsed_since_start_ns).toBe('string');
+    expect(sample.elapsed_since_start_ns).toMatch(/^\d+$/); // Numeric string
+    expect(parseInt(sample.elapsed_since_start_ns, 10)).toBeGreaterThanOrEqual(0);
+
+    expect(typeof sample.stack_id).toBe('number');
+    expect(sample.stack_id).toBeGreaterThanOrEqual(0);
+    expect(sample.thread_id).toBe('0'); // Should be main thread
+  }
+
+  // Stacks
+  expect(profile.stacks.length).toBeGreaterThan(0);
+  for (const stack of profile.stacks) {
+    expect(Array.isArray(stack)).toBe(true);
+    for (const frameIndex of stack) {
+      expect(typeof frameIndex).toBe('number');
+      expect(frameIndex).toBeGreaterThanOrEqual(0);
+      expect(frameIndex).toBeLessThan(profile.frames.length);
+    }
+  }
+
+  // Frames
+  expect(profile.frames.length).toBeGreaterThan(0);
+  for (const frame of profile.frames) {
+    expect(frame).toHaveProperty('function');
+    expect(frame).toHaveProperty('abs_path');
+    expect(frame).toHaveProperty('lineno');
+    expect(frame).toHaveProperty('colno');
+
+    expect(typeof frame.function).toBe('string');
+    expect(typeof frame.abs_path).toBe('string');
+    expect(typeof frame.lineno).toBe('number');
+    expect(typeof frame.colno).toBe('number');
+  }
+
+  const functionNames = profile.frames.map(frame => frame.function).filter(name => name !== '');
+
+  expect(functionNames).toEqual(
+    expect.arrayContaining([
+      '_startRootSpan',
+      'withScope',
+      'createChildOrRootSpan',
+      'startSpanManual',
+      'startProfileForSpan',
+      'startJSSelfProfile',
+    ]),
+  );
+
+  expect(profile.thread_metadata).toHaveProperty('0');
+  expect(profile.thread_metadata['0']).toHaveProperty('name');
+  expect(profile.thread_metadata['0'].name).toBe('main');
+
+  // Test that profile duration makes sense (should be > 20ms based on test setup)
+  const startTime = parseInt(profile.samples[0].elapsed_since_start_ns, 10);
+  const endTime = parseInt(profile.samples[profile.samples.length - 1].elapsed_since_start_ns, 10);
+  const durationNs = endTime - startTime;
+  const durationMs = durationNs / 1_000_000; // Convert ns to ms
+
+  // Should be at least 20ms based on our setTimeout(21) in the test
+  expect(durationMs).toBeGreaterThan(20);
+});


### PR DESCRIPTION
While working on https://github.com/getsentry/sentry-javascript/issues/17279, I added some tests and this PR is the extracted test for the current behavior.
