### PR TITLE
fix(core): Only set template attributes on logs if parameters exist

### DIFF
--- a/packages/core/src/logs/exports.ts
+++ b/packages/core/src/logs/exports.ts
@@ -153,7 +153,9 @@ export function _INTERNAL_captureLog(
   const beforeLogMessage = beforeLog.message;
   if (isParameterizedString(beforeLogMessage)) {
     const { __sentry_template_string__, __sentry_template_values__ = [] } = beforeLogMessage;
-    processedLogAttributes['sentry.message.template'] = __sentry_template_string__;
+    if (__sentry_template_values__?.length) {
+      processedLogAttributes['sentry.message.template'] = __sentry_template_string__;
+    }
     __sentry_template_values__.forEach((param, index) => {
       processedLogAttributes[`sentry.message.parameter.${index}`] = param;
     });

--- a/packages/core/test/lib/logs/exports.test.ts
+++ b/packages/core/test/lib/logs/exports.test.ts
@@ -281,6 +281,16 @@ describe('_INTERNAL_captureLog', () => {
     });
   });
 
+  it('does not set the template attribute if there are no parameters', () => {
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const client = new TestClient(options);
+
+    _INTERNAL_captureLog({ level: 'debug', message: fmt`User logged in` }, client, undefined);
+
+    const logAttributes = _INTERNAL_getLogBuffer(client)?.[0]?.attributes;
+    expect(logAttributes).toEqual({});
+  });
+
   it('processes logs through beforeSendLog when provided', () => {
     const beforeSendLog = vi.fn().mockImplementation(log => ({
       ...log,


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/17479
