### PR TITLE
feat(browser): Export `sendFeedback` from CDN bundles

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-pii.mjs
@@ -8,8 +8,5 @@ Sentry.init({
   tracesSampleRate: 1.0,
   sendDefaultPii: true,
   transport: loggingTransport,
-  integrations: [
-    Sentry.anthropicAIIntegration(),
-    nodeContextIntegration(),
-  ],
+  integrations: [Sentry.anthropicAIIntegration(), nodeContextIntegration()],
 });

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument.mjs
@@ -9,8 +9,5 @@ Sentry.init({
   sendDefaultPii: false,
   transport: loggingTransport,
   // Force include the integration
-  integrations: [
-    Sentry.anthropicAIIntegration(),
-    nodeContextIntegration(),
-  ],
+  integrations: [Sentry.anthropicAIIntegration(), nodeContextIntegration()],
 });

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario-stream.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario-stream.mjs
@@ -101,5 +101,3 @@ async function run() {
 }
 
 run();
-
-

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario.mjs
@@ -8,7 +8,7 @@ class MockAnthropic {
     // Create messages object with create and countTokens methods
     this.messages = {
       create: this._messagesCreate.bind(this),
-      countTokens: this._messagesCountTokens.bind(this)
+      countTokens: this._messagesCountTokens.bind(this),
     };
 
     this.models = {
@@ -56,8 +56,8 @@ class MockAnthropic {
 
     // For countTokens, just return input_tokens
     return {
-        input_tokens: 15
-      }
+      input_tokens: 15,
+    };
   }
 
   async _modelsRetrieve(modelId) {
@@ -69,7 +69,7 @@ class MockAnthropic {
       id: modelId,
       name: modelId,
       created_at: 1715145600,
-      model: modelId,  // Add model field to match the check in addResponseAttributes
+      model: modelId, // Add model field to match the check in addResponseAttributes
     };
   }
 }
@@ -86,9 +86,7 @@ async function run() {
     await client.messages.create({
       model: 'claude-3-haiku-20240307',
       system: 'You are a helpful assistant.',
-      messages: [
-        { role: 'user', content: 'What is the capital of France?' },
-      ],
+      messages: [{ role: 'user', content: 'What is the capital of France?' }],
       temperature: 0.7,
       max_tokens: 100,
     });
@@ -106,9 +104,7 @@ async function run() {
     // Third test: count tokens with cached tokens
     await client.messages.countTokens({
       model: 'claude-3-haiku-20240307',
-      messages: [
-        { role: 'user', content: 'What is the capital of France?' },
-      ],
+      messages: [{ role: 'user', content: 'What is the capital of France?' }],
     });
 
     // Fourth test: models.retrieve

--- a/packages/browser/src/index.bundle.feedback.ts
+++ b/packages/browser/src/index.bundle.feedback.ts
@@ -3,7 +3,7 @@ import { feedbackAsyncIntegration } from './feedbackAsync';
 
 export * from './index.bundle.base';
 
-export { getFeedback } from '@sentry-internal/feedback';
+export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
 
 export {
   browserTracingIntegrationShim as browserTracingIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -22,7 +22,9 @@ export {
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from './tracing/browserTracingIntegration';
-export { getFeedback } from '@sentry-internal/feedback';
+
+export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
+
 export { feedbackAsyncIntegration as feedbackAsyncIntegration, feedbackAsyncIntegration as feedbackIntegration };
 
 export { replayIntegration, getReplay } from '@sentry-internal/replay';


### PR DESCRIPTION
This adds the `sendFeedback` method to the CDN bundle exports. This should not really add bundle size as this is used by the feedback integration anyhow I believe.

(Some unrelated prettier fixes somehow also got into this PR, not sure how this got on develop)