### PR TITLE
feat(browser): Add replay.feedback CDN bundle

### DIFF
--- a/packages/browser/rollup.bundle.config.mjs
+++ b/packages/browser/rollup.bundle.config.mjs
@@ -85,6 +85,13 @@ const tracingReplayBaseBundleConfig = makeBaseBundleConfig({
   outputFileBase: () => 'bundles/bundle.tracing.replay',
 });
 
+const replayFeedbackBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.bundle.replay.feedback.ts'],
+  licenseTitle: '@sentry/browser (Replay, and Feedback)',
+  outputFileBase: () => 'bundles/bundle.replay.feedback',
+});
+
 const tracingReplayFeedbackBaseBundleConfig = makeBaseBundleConfig({
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.tracing.replay.feedback.ts'],
@@ -98,6 +105,7 @@ builds.push(
   ...makeBundleConfigVariants(replayBaseBundleConfig),
   ...makeBundleConfigVariants(feedbackBaseBundleConfig),
   ...makeBundleConfigVariants(tracingReplayBaseBundleConfig),
+  ...makeBundleConfigVariants(replayFeedbackBaseBundleConfig),
   ...makeBundleConfigVariants(tracingReplayFeedbackBaseBundleConfig),
 );
 

--- a/packages/browser/src/index.bundle.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.replay.feedback.ts
@@ -1,0 +1,14 @@
+import { browserTracingIntegrationShim } from '@sentry-internal/integration-shims';
+import { feedbackAsyncIntegration } from './feedbackAsync';
+
+export * from './index.bundle.base';
+
+export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
+
+export {
+  browserTracingIntegrationShim as browserTracingIntegration,
+  feedbackAsyncIntegration as feedbackAsyncIntegration,
+  feedbackAsyncIntegration as feedbackIntegration,
+};
+
+export { replayIntegration, getReplay } from '@sentry-internal/replay';


### PR DESCRIPTION
I think we originally decided to only have a error + feedback bundle and a error + tracing + replay + feedback bundle for simplicity. But I suppose it does not really make things easier that there is exactly one (error + replay + feedback) missing, so I'd just add this here now. Esp. if we want to add this in the loader this will be much easier to handle.