### PR TITLE
ci: Ensure we fail on cancelled jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1137,6 +1137,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1


### PR DESCRIPTION
See https://github.com/getsentry/sentry-javascript/actions/runs/17398257702/job/49385642947, this seems to not trigger the failure, I guess this is `cancelled` not `failure`

I could not really find good documentation on this but I suppose this should work!