### PR TITLE
chore: Add `changelog` script back to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:types:watch": "ts-node scripts/build-types-watch.ts",
     "build:tarball": "run-s clean:tarballs build:tarballs",
     "build:tarballs": "lerna run build:tarball",
+    "changelog": "ts-node ./scripts/get-commit-list.ts",
     "circularDepCheck": "lerna run circularDepCheck",
     "clean": "run-s clean:build clean:caches",
     "clean:build": "lerna run clean",


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/17497 probably accidentally removed our changelog script.