### PR TITLE
chore(core): export `TracesSamplerSamplingContext` of types-hoist

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -400,7 +400,7 @@ export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from
 export type { PropagationContext, TracePropagationTargets, SerializedTraceData } from './types-hoist/tracing';
 export type { StartSpanOptions } from './types-hoist/startSpanOptions';
 export type { TraceparentData, TransactionSource } from './types-hoist/transaction';
-export type { CustomSamplingContext, SamplingContext } from './types-hoist/samplingcontext';
+export type { TracesSamplerSamplingContext, CustomSamplingContext, SamplingContext } from './types-hoist/samplingcontext';
 export type {
   DurationUnit,
   InformationUnit,


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/15277, `TracesSamplerSamplingContext` is added to and exported from [types-hoist], but is not being exported from [index.ts].

I'm following the [instruction], and I want to inject `(samplingContext: TracesSamplerSamplingContext) => number | boolean` to a function that is wrapping `Sentry.init`, but I can't because `TracesSamplerSamplingContext` is not recognized :(

<!--link-->
[types-hoist]: https://github.com/getsentry/sentry-javascript/blob/14eba5676149317f2e2b31143a0590256d32c094/packages/core/src/types-hoist/samplingcontext.ts#L47
[index.ts]: https://github.com/getsentry/sentry-javascript/blob/14eba5676149317f2e2b31143a0590256d32c094/packages/core/src/index.ts#L403
[instruction]: https://docs.sentry.io/platforms/javascript/guides/react/tracing/configure-sampling/#sampling-function-tracessampler