### PR TITLE
fix(browser): Ensure propagated `parentSpanId` stays consistent during trace in TwP mode

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta-precedence/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta-precedence/test.ts
@@ -30,10 +30,13 @@ sentryTest.describe('When `consistentTraceSampling` is `true` and page contains 
       const clientReportPromise = waitForClientReportRequest(page);
 
       await sentryTest.step('Initial pageload', async () => {
+        // negative sampling decision -> no pageload txn
         await page.goto(url);
       });
 
       await sentryTest.step('Make fetch request', async () => {
+        // The fetch requests starts a new trace on purpose. So we only want the
+        // sampling decision and rand to be the same as from the meta tag but not the trace id or DSC
         const tracingHeadersPromise = waitForTracingHeadersOnUrl(page, 'http://sentry-test-external.io');
 
         await page.locator('#btn2').click();

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance-propagateTraceparent/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance-propagateTraceparent/subject.js
@@ -1,1 +1,2 @@
-fetch('http://sentry-test-site.example/0').then();
+fetch('http://sentry-test-site.example/0');
+fetch('http://sentry-test-site.example/1');

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance-propagateTraceparent/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance-propagateTraceparent/test.ts
@@ -12,21 +12,36 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    const [, request] = await Promise.all([page.goto(url), page.waitForRequest('http://sentry-test-site.example/0')]);
+    const [, request0, request1] = await Promise.all([
+      page.goto(url),
+      page.waitForRequest('http://sentry-test-site.example/0'),
+      page.waitForRequest('http://sentry-test-site.example/1'),
+    ]);
 
-    const requestHeaders = request.headers();
+    const requestHeaders0 = request0.headers();
 
-    const traceparentData = extractTraceparentData(requestHeaders['sentry-trace']);
+    const traceparentData = extractTraceparentData(requestHeaders0['sentry-trace']);
     expect(traceparentData).toMatchObject({
       traceId: expect.stringMatching(/^([a-f0-9]{32})$/),
       parentSpanId: expect.stringMatching(/^([a-f0-9]{16})$/),
       parentSampled: undefined,
     });
 
-    expect(requestHeaders).toMatchObject({
+    expect(requestHeaders0).toMatchObject({
       'sentry-trace': `${traceparentData?.traceId}-${traceparentData?.parentSpanId}`,
       baggage: expect.stringContaining(`sentry-trace_id=${traceparentData?.traceId}`),
       traceparent: `00-${traceparentData?.traceId}-${traceparentData?.parentSpanId}-00`,
     });
+
+    const requestHeaders1 = request1.headers();
+    expect(requestHeaders1).toMatchObject({
+      'sentry-trace': `${traceparentData?.traceId}-${traceparentData?.parentSpanId}`,
+      baggage: expect.stringContaining(`sentry-trace_id=${traceparentData?.traceId}`),
+      traceparent: `00-${traceparentData?.traceId}-${traceparentData?.parentSpanId}-00`,
+    });
+
+    expect(requestHeaders1['sentry-trace']).toBe(requestHeaders0['sentry-trace']);
+    expect(requestHeaders1['baggage']).toBe(requestHeaders0['baggage']);
+    expect(requestHeaders1['traceparent']).toBe(requestHeaders0['traceparent']);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-propagateTraceparent/init.js
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  // in browser TwP means not setting tracesSampleRate but adding browserTracingIntegration,
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration()],
+  tracePropagationTargets: ['http://sentry-test-site.example'],
+  propagateTraceparent: true,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-propagateTraceparent/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-propagateTraceparent/template.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <!-- Purposefully emitting the `sampled` flag in the sentry-trace tag -->
+    <meta name="sentry-trace" content="12345678901234567890123456789012-1234567890123456" />
+    <meta
+      name="baggage"
+      content="sentry-trace_id=12345678901234567890123456789012,sentry-public_key=public,sentry-release=1.0.0,sentry-environment=prod,sentry-sample_rand=0.42"
+    />
+  </head>
+  <body>
+    <button id="errorBtn">Throw Error</button>
+    <button id="fetchBtn">Fetch Request</button>
+    <button id="xhrBtn">XHR Request</button>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-propagateTraceparent/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-propagateTraceparent/test.ts
@@ -1,0 +1,130 @@
+import { expect } from '@playwright/test';
+import { extractTraceparentData } from '@sentry/core';
+import { sentryTest } from '../../../../utils/fixtures';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
+
+const META_TAG_TRACE_ID = '12345678901234567890123456789012';
+const META_TAG_PARENT_SPAN_ID = '1234567890123456';
+const META_TAG_BAGGAGE =
+  'sentry-trace_id=12345678901234567890123456789012,sentry-public_key=public,sentry-release=1.0.0,sentry-environment=prod,sentry-sample_rand=0.42';
+
+sentryTest(
+  'outgoing fetch requests have new traceId after navigation (with propagateTraceparent)',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.route('http://sentry-test-site.example/**', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
+
+    await page.goto(url);
+
+    const requestPromise = page.waitForRequest('http://sentry-test-site.example/*');
+    await page.locator('#fetchBtn').click();
+    const request = await requestPromise;
+    const headers = request.headers();
+
+    const sentryTraceParentData = extractTraceparentData(headers['sentry-trace']);
+    // sampling decision is deferred because TwP means we didn't sample any span
+    expect(sentryTraceParentData).toEqual({
+      traceId: META_TAG_TRACE_ID,
+      parentSpanId: expect.stringMatching(/^[0-9a-f]{16}$/),
+      parentSampled: undefined,
+    });
+    expect(headers['baggage']).toBe(META_TAG_BAGGAGE);
+    // but traceparent propagates a negative sampling decision because it has no concept of deferred sampling
+    expect(headers['traceparent']).toBe(
+      `00-${sentryTraceParentData?.traceId}-${sentryTraceParentData?.parentSpanId}-00`,
+    );
+
+    const requestPromise2 = page.waitForRequest('http://sentry-test-site.example/*');
+    await page.locator('#fetchBtn').click();
+    const request2 = await requestPromise2;
+    const headers2 = request2.headers();
+
+    const sentryTraceParentData2 = extractTraceparentData(headers2['sentry-trace']);
+    expect(sentryTraceParentData2).toEqual(sentryTraceParentData);
+
+    await page.goto(`${url}#navigation`);
+
+    const requestPromise3 = page.waitForRequest('http://sentry-test-site.example/*');
+    await page.locator('#fetchBtn').click();
+    const request3 = await requestPromise3;
+    const headers3 = request3.headers();
+
+    const sentryTraceParentData3 = extractTraceparentData(headers3['sentry-trace']);
+    // sampling decision is deferred because TwP means we didn't sample any span
+    expect(sentryTraceParentData3).toEqual({
+      traceId: expect.not.stringContaining(sentryTraceParentData!.traceId!),
+      parentSpanId: expect.not.stringContaining(sentryTraceParentData!.parentSpanId!),
+      parentSampled: undefined,
+    });
+
+    expect(headers3['baggage']).toMatch(
+      /sentry-environment=production,sentry-public_key=public,sentry-trace_id=[0-9a-f]{32}/,
+    );
+    expect(headers3['baggage']).not.toContain(`sentry-trace_id=${META_TAG_TRACE_ID}`);
+    // but traceparent propagates a negative sampling decision because it has no concept of deferred sampling
+    expect(headers3['traceparent']).toBe(
+      `00-${sentryTraceParentData3!.traceId}-${sentryTraceParentData3!.parentSpanId}-00`,
+    );
+
+    const requestPromise4 = page.waitForRequest('http://sentry-test-site.example/*');
+    await page.locator('#fetchBtn').click();
+    const request4 = await requestPromise4;
+    const headers4 = request4.headers();
+
+    const sentryTraceParentData4 = extractTraceparentData(headers4['sentry-trace']);
+    expect(sentryTraceParentData4).toEqual(sentryTraceParentData3);
+  },
+);
+
+sentryTest('outgoing XHR requests have new traceId after navigation', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipTracingTest()) {
+    sentryTest.skip();
+  }
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.route('http://sentry-test-site.example/**', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.goto(url);
+
+  const requestPromise = page.waitForRequest('http://sentry-test-site.example/*');
+  await page.locator('#xhrBtn').click();
+  const request = await requestPromise;
+  const headers = request.headers();
+
+  // sampling decision is deferred because TwP means we didn't sample any span
+  expect(headers['sentry-trace']).toMatch(new RegExp(`^${META_TAG_TRACE_ID}-[0-9a-f]{16}$`));
+  expect(headers['baggage']).toBe(META_TAG_BAGGAGE);
+
+  await page.goto(`${url}#navigation`);
+
+  const requestPromise2 = page.waitForRequest('http://sentry-test-site.example/*');
+  await page.locator('#xhrBtn').click();
+  const request2 = await requestPromise2;
+  const headers2 = request2.headers();
+
+  // sampling decision is deferred because TwP means we didn't sample any span
+  expect(headers2['sentry-trace']).toMatch(/^[0-9a-f]{32}-[0-9a-f]{16}$/);
+  expect(headers2['baggage']).not.toBe(`${META_TAG_TRACE_ID}-${META_TAG_PARENT_SPAN_ID}`);
+  expect(headers2['baggage']).toMatch(
+    /sentry-environment=production,sentry-public_key=public,sentry-trace_id=[0-9a-f]{32}/,
+  );
+  expect(headers2['baggage']).not.toContain(`sentry-trace_id=${META_TAG_TRACE_ID}`);
+});

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -553,6 +553,9 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
         const scope = getCurrentScope();
         scope.setPropagationContext(propagationContext);
         if (!hasSpansEnabled()) {
+          // for browser, we wanna keep the spanIds consistent during the entire lifetime of the trace
+          // this works by setting the propagationSpanId to a random spanId so that we have a consistent
+          // span id to propagate in TwP mode (!hasSpansEnabled())
           scope.getPropagationContext().propagationSpanId = generateSpanId();
         }
 

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -5,6 +5,7 @@ import {
   browserPerformanceTimeOrigin,
   dateTimestampInSeconds,
   debug,
+  generateSpanId,
   generateTraceId,
   getClient,
   getCurrentScope,
@@ -12,6 +13,7 @@ import {
   getIsolationScope,
   getLocationHref,
   GLOBAL_OBJ,
+  hasSpansEnabled,
   parseStringToURLObject,
   propagationContextFromHeaders,
   registerSpanErrorInstrumentation,
@@ -512,10 +514,19 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
 
         maybeEndActiveSpan();
 
-        getIsolationScope().setPropagationContext({ traceId: generateTraceId(), sampleRand: Math.random() });
+        getIsolationScope().setPropagationContext({
+          traceId: generateTraceId(),
+          sampleRand: Math.random(),
+          propagationSpanId: hasSpansEnabled() ? undefined : generateSpanId(),
+        });
 
         const scope = getCurrentScope();
-        scope.setPropagationContext({ traceId: generateTraceId(), sampleRand: Math.random() });
+        scope.setPropagationContext({
+          traceId: generateTraceId(),
+          sampleRand: Math.random(),
+          propagationSpanId: hasSpansEnabled() ? undefined : generateSpanId(),
+        });
+
         // We reset this to ensure we do not have lingering incorrect data here
         // places that call this hook may set this where appropriate - else, the URL at span sending time is used
         scope.setSDKProcessingMetadata({
@@ -541,6 +552,9 @@ export const browserTracingIntegration = ((_options: Partial<BrowserTracingOptio
 
         const scope = getCurrentScope();
         scope.setPropagationContext(propagationContext);
+        if (!hasSpansEnabled()) {
+          scope.getPropagationContext().propagationSpanId = generateSpanId();
+        }
 
         // We store the normalized request data on the scope, so we get the request data at time of span creation
         // otherwise, the URL etc. may already be of the following navigation, and we'd report the wrong URL

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -723,23 +723,28 @@ describe('browserTracingIntegration', () => {
 
       expect(oldCurrentScopePropCtx).toEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
+        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
       expect(oldIsolationScopePropCtx).toEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
+        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
       expect(newCurrentScopePropCtx).toEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
+        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
       expect(newIsolationScopePropCtx).toEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
+        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
 
       expect(newIsolationScopePropCtx.traceId).not.toEqual(oldIsolationScopePropCtx.traceId);
       expect(newCurrentScopePropCtx.traceId).not.toEqual(oldCurrentScopePropCtx.traceId);
+      expect(newIsolationScopePropCtx.propagationSpanId).not.toEqual(oldIsolationScopePropCtx.propagationSpanId);
     });
 
     it("saves the span's positive sampling decision and its DSC on the propagationContext when the span finishes", () => {
@@ -761,6 +766,7 @@ describe('browserTracingIntegration', () => {
       expect(propCtxBeforeEnd).toStrictEqual({
         sampleRand: expect.any(Number),
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
+        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
       });
 
       navigationSpan!.end();
@@ -770,6 +776,7 @@ describe('browserTracingIntegration', () => {
         traceId: propCtxBeforeEnd.traceId,
         sampled: true,
         sampleRand: expect.any(Number),
+        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         dsc: {
           release: undefined,
           org_id: undefined,
@@ -803,6 +810,7 @@ describe('browserTracingIntegration', () => {
       expect(propCtxBeforeEnd).toStrictEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
         sampleRand: expect.any(Number),
+        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
       });
 
       navigationSpan!.end();
@@ -812,6 +820,7 @@ describe('browserTracingIntegration', () => {
         traceId: propCtxBeforeEnd.traceId,
         sampled: false,
         sampleRand: expect.any(Number),
+        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         dsc: {
           release: undefined,
           org_id: undefined,

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -728,7 +728,6 @@ describe('browserTracingIntegration', () => {
       });
       expect(oldIsolationScopePropCtx).toEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
-        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
       expect(newCurrentScopePropCtx).toEqual({
@@ -763,20 +762,18 @@ describe('browserTracingIntegration', () => {
       });
 
       const propCtxBeforeEnd = getCurrentScope().getPropagationContext();
-      expect(propCtxBeforeEnd).toStrictEqual({
+      expect(propCtxBeforeEnd).toEqual({
         sampleRand: expect.any(Number),
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
-        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
       });
 
       navigationSpan!.end();
 
       const propCtxAfterEnd = getCurrentScope().getPropagationContext();
-      expect(propCtxAfterEnd).toStrictEqual({
+      expect(propCtxAfterEnd).toEqual({
         traceId: propCtxBeforeEnd.traceId,
         sampled: true,
         sampleRand: expect.any(Number),
-        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         dsc: {
           release: undefined,
           org_id: undefined,
@@ -807,20 +804,18 @@ describe('browserTracingIntegration', () => {
       });
 
       const propCtxBeforeEnd = getCurrentScope().getPropagationContext();
-      expect(propCtxBeforeEnd).toStrictEqual({
+      expect(propCtxBeforeEnd).toEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
         sampleRand: expect.any(Number),
-        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
       });
 
       navigationSpan!.end();
 
       const propCtxAfterEnd = getCurrentScope().getPropagationContext();
-      expect(propCtxAfterEnd).toStrictEqual({
+      expect(propCtxAfterEnd).toEqual({
         traceId: propCtxBeforeEnd.traceId,
         sampled: false,
         sampleRand: expect.any(Number),
-        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         dsc: {
           release: undefined,
           org_id: undefined,

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -17,7 +17,7 @@ import type { SpanStatus } from '../types-hoist/spanStatus';
 import { addNonEnumerableProperty } from '../utils/object';
 import { generateSpanId } from '../utils/propagationContext';
 import { timestampInSeconds } from '../utils/time';
-import { generateSentryTraceHeader } from '../utils/tracing';
+import { generateSentryTraceHeader, generateTraceparentHeader } from '../utils/tracing';
 import { consoleSandbox } from './debug-logger';
 import { _getSpanForScope } from './spanOnScope';
 
@@ -75,6 +75,15 @@ export function spanToTraceHeader(span: Span): string {
   const { traceId, spanId } = span.spanContext();
   const sampled = spanIsSampled(span);
   return generateSentryTraceHeader(traceId, spanId, sampled);
+}
+
+/**
+ * Convert a Span to a W3C traceparent header.
+ */
+export function spanToTraceparentHeader(span: Span): string {
+  const { traceId, spanId } = span.spanContext();
+  const sampled = spanIsSampled(span);
+  return generateTraceparentHeader(traceId, spanId, sampled);
 }
 
 /**

--- a/packages/core/src/utils/traceData.ts
+++ b/packages/core/src/utils/traceData.ts
@@ -9,8 +9,8 @@ import type { Span } from '../types-hoist/span';
 import type { SerializedTraceData } from '../types-hoist/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from './baggage';
 import { debug } from './debug-logger';
-import { getActiveSpan, spanToTraceHeader } from './spanUtils';
-import { extractTraceparentData, generateSentryTraceHeader, TRACEPARENT_REGEXP } from './tracing';
+import { getActiveSpan, spanToTraceHeader, spanToTraceparentHeader } from './spanUtils';
+import { generateSentryTraceHeader, generateTraceparentHeader, TRACEPARENT_REGEXP } from './tracing';
 
 /**
  * Extracts trace propagation data from the current span or from the client's scope (via transaction or propagation
@@ -58,7 +58,7 @@ export function getTraceData(
   };
 
   if (options.propagateTraceparent) {
-    const traceparent = _sentryTraceToTraceParentHeader(sentryTrace);
+    const traceparent = span ? spanToTraceparentHeader(span) : scopeToTraceparentHeader(scope);
     if (traceparent) {
       traceData.traceparent = traceparent;
     }
@@ -75,22 +75,7 @@ function scopeToTraceHeader(scope: Scope): string {
   return generateSentryTraceHeader(traceId, propagationSpanId, sampled);
 }
 
-/**
- * Builds a W3C traceparent header from the given sentry-trace header.
- *
- * Why parse that header and not create traceparent from primitives?
- * We want these two headers to always have the same ids. The easiest way to do this is to take
- * one of them as the source of truth (sentry-trace) and derive the other from it.
- *
- * Most importantly, this guarantees parentSpanId consistency between sentry-trace and traceparent
- * in tracing without performance (TwP) mode, where we always generate a random parentSpanId.
- *
- * Exported for testing
- */
-export function _sentryTraceToTraceParentHeader(sentryTrace: string): string | undefined {
-  const { traceId, parentSpanId, parentSampled } = extractTraceparentData(sentryTrace) || {};
-  if (!traceId || !parentSpanId) {
-    return undefined;
-  }
-  return `00-${traceId}-${parentSpanId}-${parentSampled ? '01' : '00'}`;
+function scopeToTraceparentHeader(scope: Scope): string {
+  const { traceId, sampled, propagationSpanId } = scope.getPropagationContext();
+  return generateTraceparentHeader(traceId, propagationSpanId, sampled);
 }

--- a/packages/core/src/utils/tracing.ts
+++ b/packages/core/src/utils/tracing.ts
@@ -103,6 +103,17 @@ export function generateSentryTraceHeader(
 }
 
 /**
+ * Creates a W3C traceparent header from the given trace and span ids.
+ */
+export function generateTraceparentHeader(
+  traceId: string | undefined = generateTraceId(),
+  spanId: string | undefined = generateSpanId(),
+  sampled?: boolean,
+): string {
+  return `00-${traceId}-${spanId}-${sampled ? '01' : '00'}`;
+}
+
+/**
  * Given any combination of an incoming trace, generate a sample rand based on its defined semantics.
  *
  * Read more: https://develop.sentry.dev/sdk/telemetry/traces/#propagated-random-value

--- a/packages/core/test/lib/utils/traceData.test.ts
+++ b/packages/core/test/lib/utils/traceData.test.ts
@@ -15,7 +15,6 @@ import {
 import { getAsyncContextStrategy } from '../../../src/asyncContext';
 import { freezeDscOnSpan } from '../../../src/tracing/dynamicSamplingContext';
 import type { Span } from '../../../src/types-hoist/span';
-import { _sentryTraceToTraceParentHeader } from '../../../src/utils/traceData';
 import type { TestClientOptions } from '../../mocks/client';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
 
@@ -347,36 +346,5 @@ describe('getTraceData', () => {
 
     expect(traceData.traceparent).toBeDefined();
     expect(traceData.traceparent).toMatch(/00-12345678901234567890123456789099-[0-9a-f]{16}-00/);
-  });
-});
-
-describe('_sentryTraceToTraceParentHeader', () => {
-  it('returns positively sampled traceparent header for sentry-trace with positive sampling decision', () => {
-    const traceparent = _sentryTraceToTraceParentHeader('12345678901234567890123456789012-1234567890123456-1');
-    expect(traceparent).toBe('00-12345678901234567890123456789012-1234567890123456-01');
-  });
-
-  it('returns negatively sampled traceparent header for sentry-trace with negative sampling decision', () => {
-    const traceparent = _sentryTraceToTraceParentHeader('12345678901234567890123456789012-1234567890123456-0');
-    expect(traceparent).toBe('00-12345678901234567890123456789012-1234567890123456-00');
-  });
-
-  it('returns negatively sampled traceparent header for sentry-trace with no/deferred sampling decision', () => {
-    const traceparent = _sentryTraceToTraceParentHeader('12345678901234567890123456789012-1234567890123456');
-    expect(traceparent).toBe('00-12345678901234567890123456789012-1234567890123456-00');
-  });
-
-  it.each([
-    '12345678901234567890123456789012--0',
-    '-12345678901234567890123456789012-0',
-    '--1',
-    '0',
-    '1',
-    '',
-    '00-12345678901234567890123456789012-1234567890123456-01',
-    '00-12345678901234567890123456789012-1234567890123456-00',
-  ])('returns undefined if the sentry-trace header is invalid (%s)', sentryTrace => {
-    const traceparent = _sentryTraceToTraceParentHeader(sentryTrace);
-    expect(traceparent).toBeUndefined();
   });
 });

--- a/packages/core/test/lib/utils/tracing.test.ts
+++ b/packages/core/test/lib/utils/tracing.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, test } from 'vitest';
-import { extractTraceparentData, propagationContextFromHeaders, shouldContinueTrace } from '../../../src/utils/tracing';
+import {
+  extractTraceparentData,
+  generateTraceparentHeader,
+  propagationContextFromHeaders,
+  shouldContinueTrace,
+} from '../../../src/utils/tracing';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
 
 const EXAMPLE_SENTRY_TRACE = '12312012123120121231201212312012-1121201211212012-1';
@@ -175,5 +180,22 @@ describe('shouldContinueTrace', () => {
 
     const result = shouldContinueTrace(client, '123456');
     expect(result).toBe(false);
+  });
+});
+
+describe('generateTraceparentHeader', () => {
+  test('returns a traceparent header with the given ids and positive sampling decision', () => {
+    const traceparent = generateTraceparentHeader('12345678901234567890123456789012', '1234567890123456', true);
+    expect(traceparent).toBe('00-12345678901234567890123456789012-1234567890123456-01');
+  });
+
+  test('returns a traceparent header with the given ids and negative sampling decision', () => {
+    const traceparent = generateTraceparentHeader('12345678901234567890123456789012', '1234567890123456', false);
+    expect(traceparent).toBe('00-12345678901234567890123456789012-1234567890123456-00');
+  });
+
+  test('no sampling decision passed, creates a negatively sampled traceparent header', () => {
+    const traceparent = generateTraceparentHeader('12345678901234567890123456789012', '1234567890123456');
+    expect(traceparent).toBe('00-12345678901234567890123456789012-1234567890123456-00');
   });
 });


### PR DESCRIPTION
This PR adjusts how we set treat the `parentSpanId` when propagating it in an SDK configured for [tracing without performance](https://develop.sentry.dev/sdk/telemetry/traces/tracing-without-performance). Previously, we didn't set the `propagationSpanId` on the `propagationContext` (which is supposed to be serialized to the parent span id in the `sentry-trace` (and `traceparent`) header, if no active span is present.
This had the consequence that every time `getTraceData()` was called, we'd return a new, random (non-existing) parent span id. Meaning, that if we generate both, `sentry-trace` and `traceparent` headers via `getTraceData()` they'd end up with different parent span ids in the respective hedaers.

With this change, we now set a `propagationSpanId` on the PC, which has two effects:
 1. consistent parent span id in `sentry-trace` and `traceparent` headers for the same outgoing request
 2. consistent parent span ids in all outgoing requests until the next navigation when the PC is recycled

So this prolongs the time span in which we propagate the same parent span id. Since this span doesn't exist, I _think_ this is fine. Though happy to drop this if reviewers have concerns. The main benefit with this change is 1 in combination with us generating `traceparent` from raw data rather than parsing the already generated `sentry-trace` header and converting its parts into `traceparent`.

(TwP was a mistake)