### PR TITLE
fix(astro): Ensure traces are correctly propagated for static routes

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-4/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "astro dev --force",
-    "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
+    "start": "node ./dist/server/entry.mjs",
     "astro": "astro",
     "test:build": "pnpm install && pnpm build",
     "test:assert": "TEST_ENV=production playwright test"

--- a/dev-packages/e2e-tests/test-applications/astro-4/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-4/playwright.config.mjs
@@ -7,7 +7,7 @@ if (!testEnv) {
 }
 
 const config = getPlaywrightConfig({
-  startCommand: 'node ./dist/server/entry.mjs',
+  startCommand: 'pnpm start',
 });
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.client.test.ts
@@ -70,7 +70,6 @@ test.describe('client-side errors', () => {
       contexts: {
         trace: {
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
           span_id: expect.stringMatching(/[a-f0-9]{16}/),
         },
       },

--- a/dev-packages/e2e-tests/test-applications/astro-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-5/package.json
@@ -7,6 +7,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "start": "node ./dist/server/entry.mjs",
     "test:build": "pnpm install && pnpm build",
     "test:assert": "TEST_ENV=production playwright test"
   },

--- a/dev-packages/e2e-tests/test-applications/astro-5/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-5/playwright.config.mjs
@@ -7,7 +7,7 @@ if (!testEnv) {
 }
 
 const config = getPlaywrightConfig({
-  startCommand: 'node ./dist/server/entry.mjs',
+  startCommand: 'pnpm start',
 });
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/astro-5/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-5/tests/errors.client.test.ts
@@ -70,7 +70,6 @@ test.describe('client-side errors', () => {
       contexts: {
         trace: {
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
           span_id: expect.stringMatching(/[a-f0-9]{16}/),
         },
       },

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -146,16 +146,14 @@ async function enhanceHttpServerSpan(
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.astro',
     });
 
-    if (!parametrizedRoute) {
-      return next();
+    if (parametrizedRoute) {
+      rootSpan.setAttributes({
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        'http.route': parametrizedRoute,
+      });
+
+      isolationScope.setTransactionName(`${method} ${parametrizedRoute}`);
     }
-
-    rootSpan.setAttributes({
-      [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
-      'http.route': parametrizedRoute,
-    });
-
-    isolationScope.setTransactionName(`${method} ${parametrizedRoute}`);
 
     try {
       const originalResponse = await next();

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -6,6 +6,7 @@ import {
   getIsolationScope,
   getRootSpan,
   objectify,
+  SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD,
   spanToJSON,
   stripUrlQueryAndFragment,
   winterCGRequestToRequestData,
@@ -166,7 +167,6 @@ async function enhanceHttpServerSpan(
   } finally {
     await flushIfServerless();
   }
-
 }
 
 async function instrumentRequestStartHttpServerSpan(
@@ -216,6 +216,8 @@ async function instrumentRequestStartHttpServerSpan(
           const attributes: SpanAttributes = {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.astro',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
+            [SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD]: method,
+            // This is here for backwards compatibility, we used to set this here before
             method,
             url: stripUrlQueryAndFragment(ctx.url.href),
           };

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -1,9 +1,12 @@
-import type { RequestEventData, Scope, SpanAttributes } from '@sentry/core';
+/* eslint-disable max-lines */
+import type { Span, SpanAttributes } from '@sentry/core';
 import {
   addNonEnumerableProperty,
-  extractQueryParamsFromUrl,
   flushIfServerless,
+  getIsolationScope,
+  getRootSpan,
   objectify,
+  spanToJSON,
   stripUrlQueryAndFragment,
   winterCGRequestToRequestData,
 } from '@sentry/core';
@@ -66,23 +69,60 @@ export const handleRequest: (options?: MiddlewareOptions) => MiddlewareResponseH
   };
 
   return async (ctx, next) => {
-    // if there is an active span, we know that this handle call is nested and hence
-    // we don't create a new domain for it. If we created one, nested server calls would
-    // create new transactions instead of adding a child span to the currently active span.
-    if (getActiveSpan()) {
-      return instrumentRequest(ctx, next, handlerOptions);
+    // If no Sentry client exists, just bail
+    // Apart from the case when no Sentry.init() is called at all, this also happens
+    // if a prerendered page is hit first before a ssr page is called
+    // For regular prerendered pages, this is fine as we do not want to instrument them at runtime anyhow
+    // BUT for server-islands requests on a static page, this can be problematic...
+    // TODO: Today, this leads to inconsistent behavior: If a prerendered page is hit first (before _any_ ssr page is called),
+    // Sentry.init() has not been called yet (as this is only injected in SSR pages), so server-island requests are not instrumented
+    // If any SSR route is hit before, the client will already be set up and everything will work as expected :O
+    // To reproduce this: Run the astro-5 "tracing.serverIslands.test" only
+    if (!getClient()) {
+      return next();
     }
-    return withIsolationScope(isolationScope => {
-      return instrumentRequest(ctx, next, handlerOptions, isolationScope);
-    });
+
+    const isDynamicPageRequest = checkIsDynamicPageRequest(ctx);
+
+    // For static (prerendered) routes, we only want to inject the parametrized route meta tags
+    if (!isDynamicPageRequest) {
+      return handleStaticRoute(ctx, next);
+    }
+
+    const activeSpan = getActiveSpan();
+    const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
+
+    // if there is an active span, we just want to enhance it with routing data etc.
+    if (rootSpan && spanToJSON(rootSpan).op === 'http.server') {
+      return enhanceHttpServerSpan(ctx, next, rootSpan);
+    }
+
+    return instrumentRequestStartHttpServerSpan(ctx, next, handlerOptions);
   };
 };
 
-async function instrumentRequest(
+async function handleStaticRoute(
   ctx: Parameters<MiddlewareResponseHandler>[0],
   next: Parameters<MiddlewareResponseHandler>[1],
-  options: MiddlewareOptions,
-  isolationScope?: Scope,
+): Promise<Response> {
+  const parametrizedRoute = getParametrizedRoute(ctx);
+  try {
+    const originalResponse = await next();
+
+    // We never want to continue a trace here, so we do not inject trace data
+    // But we do want to inject the parametrized route, as this is used for client-side route parametrization
+    const metaTagsStr = getMetaTagsStr({ injectTraceData: false, parametrizedRoute });
+    return injectMetaTagsInResponse(originalResponse, metaTagsStr);
+  } catch (e) {
+    sendErrorToSentry(e);
+    throw e;
+  }
+}
+
+async function enhanceHttpServerSpan(
+  ctx: Parameters<MiddlewareResponseHandler>[0],
+  next: Parameters<MiddlewareResponseHandler>[1],
+  rootSpan: Span,
 ): Promise<Response> {
   // Make sure we don't accidentally double wrap (e.g. user added middleware and integration auto added it)
   const locals = ctx.locals as AstroLocalsWithSentry | undefined;
@@ -93,177 +133,169 @@ async function instrumentRequest(
     addNonEnumerableProperty(locals, '__sentry_wrapped__', true);
   }
 
-  const isDynamicPageRequest = checkIsDynamicPageRequest(ctx);
+  const request = ctx.request;
+  const isolationScope = getIsolationScope();
+  const method = request.method;
+
+  try {
+    const parametrizedRoute = getParametrizedRoute(ctx);
+
+    rootSpan.setAttributes({
+      // This is here for backwards compatibility, we used to set this here before
+      method,
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.astro',
+    });
+
+    if (!parametrizedRoute) {
+      return next();
+    }
+
+    rootSpan.setAttributes({
+      [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+      'http.route': parametrizedRoute,
+    });
+
+    isolationScope.setTransactionName(`${method} ${parametrizedRoute}`);
+
+    try {
+      const originalResponse = await next();
+      const metaTagsStr = getMetaTagsStr({ injectTraceData: true, parametrizedRoute });
+      return injectMetaTagsInResponse(originalResponse, metaTagsStr);
+    } catch (e) {
+      sendErrorToSentry(e);
+      throw e;
+    }
+  } finally {
+    await flushIfServerless();
+  }
+
+  // TODO: flush if serverless (first extract function)
+}
+
+async function instrumentRequestStartHttpServerSpan(
+  ctx: Parameters<MiddlewareResponseHandler>[0],
+  next: Parameters<MiddlewareResponseHandler>[1],
+  options: MiddlewareOptions,
+): Promise<Response> {
+  // Make sure we don't accidentally double wrap (e.g. user added middleware and integration auto added it)
+  const locals = ctx.locals as AstroLocalsWithSentry | undefined;
+  if (locals?.__sentry_wrapped__) {
+    return next();
+  }
+  if (locals) {
+    addNonEnumerableProperty(locals, '__sentry_wrapped__', true);
+  }
 
   const request = ctx.request;
 
-  const { method, headers } = isDynamicPageRequest
-    ? request
-    : // headers can only be accessed in dynamic routes. Accessing `request.headers` in a static route
-      // will make the server log a warning.
-      { method: request.method, headers: undefined };
+  // Note: We guard outside of this function call that the request is dynamic
+  // accessing headers on a static route would throw
+  const { method, headers } = request;
 
-  return continueTrace(
-    {
-      sentryTrace: headers?.get('sentry-trace') || undefined,
-      baggage: headers?.get('baggage'),
-    },
-    async () => {
-      getCurrentScope().setSDKProcessingMetadata({
-        // We store the request on the current scope, not isolation scope,
-        // because we may have multiple requests nested inside each other
-        normalizedRequest: (isDynamicPageRequest
-          ? winterCGRequestToRequestData(request)
-          : {
-              method,
-              url: request.url,
-              query_string: extractQueryParamsFromUrl(request.url),
-            }) satisfies RequestEventData,
-      });
+  return withIsolationScope(isolationScope => {
+    return continueTrace(
+      {
+        sentryTrace: headers?.get('sentry-trace') || undefined,
+        baggage: headers?.get('baggage'),
+      },
+      async () => {
+        getCurrentScope().setSDKProcessingMetadata({
+          // We store the request on the current scope, not isolation scope,
+          // because we may have multiple requests nested inside each other
+          normalizedRequest: winterCGRequestToRequestData(request),
+        });
 
-      if (options.trackClientIp && isDynamicPageRequest) {
-        getCurrentScope().setUser({ ip_address: ctx.clientAddress });
-      }
-
-      try {
-        // `routePattern` is available after Astro 5
-        const contextWithRoutePattern = ctx as Parameters<MiddlewareResponseHandler>[0] & { routePattern?: string };
-        const rawRoutePattern = contextWithRoutePattern.routePattern;
-
-        // @ts-expect-error Implicit any on Symbol.for (This is available in Astro 5)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        const routesFromManifest = ctx?.[Symbol.for('context.routes')]?.manifest?.routes;
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        const matchedRouteSegmentsFromManifest = routesFromManifest?.find(
-          (route: { routeData?: { route?: string } }) => route?.routeData?.route === rawRoutePattern,
-        )?.routeData?.segments;
-
-        const parametrizedRoute =
-          // Astro v5 - Joining the segments to get the correct casing of the parametrized route
-          (matchedRouteSegmentsFromManifest && joinRouteSegments(matchedRouteSegmentsFromManifest)) ||
-          // Fallback (Astro v4 and earlier)
-          interpolateRouteFromUrlAndParams(ctx.url.pathname, ctx.params);
-
-        const source = parametrizedRoute ? 'route' : 'url';
-        // storing res in a variable instead of directly returning is necessary to
-        // invoke the catch block if next() throws
-
-        const attributes: SpanAttributes = {
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.astro',
-          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
-          method,
-          url: stripUrlQueryAndFragment(ctx.url.href),
-        };
-
-        if (ctx.url.search) {
-          attributes['http.query'] = ctx.url.search;
+        if (options.trackClientIp) {
+          isolationScope.setUser({ ip_address: ctx.clientAddress });
         }
 
-        if (ctx.url.hash) {
-          attributes['http.fragment'] = ctx.url.hash;
+        try {
+          const parametrizedRoute = getParametrizedRoute(ctx);
+
+          const source = parametrizedRoute ? 'route' : 'url';
+          // storing res in a variable instead of directly returning is necessary to
+          // invoke the catch block if next() throws
+
+          const attributes: SpanAttributes = {
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.astro',
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
+            method,
+            url: stripUrlQueryAndFragment(ctx.url.href),
+          };
+
+          if (parametrizedRoute) {
+            attributes['http.route'] = parametrizedRoute;
+          }
+
+          if (ctx.url.search) {
+            attributes['http.query'] = ctx.url.search;
+          }
+
+          if (ctx.url.hash) {
+            attributes['http.fragment'] = ctx.url.hash;
+          }
+
+          isolationScope.setTransactionName(`${method} ${parametrizedRoute || ctx.url.pathname}`);
+
+          const res = await startSpan(
+            {
+              attributes,
+              name: `${method} ${parametrizedRoute || ctx.url.pathname}`,
+              op: 'http.server',
+            },
+            async span => {
+              try {
+                const originalResponse = await next();
+                if (originalResponse.status) {
+                  setHttpStatus(span, originalResponse.status);
+                }
+
+                const metaTagsStr = getMetaTagsStr({ injectTraceData: true, parametrizedRoute });
+                return injectMetaTagsInResponse(originalResponse, metaTagsStr);
+              } catch (e) {
+                sendErrorToSentry(e);
+                throw e;
+              }
+            },
+          );
+          return res;
+        } finally {
+          await flushIfServerless();
         }
-
-        isolationScope?.setTransactionName(`${method} ${parametrizedRoute || ctx.url.pathname}`);
-
-        const res = await startSpan(
-          {
-            attributes,
-            name: `${method} ${parametrizedRoute || ctx.url.pathname}`,
-            op: 'http.server',
-          },
-          async span => {
-            try {
-              const originalResponse = await next();
-              if (originalResponse.status) {
-                setHttpStatus(span, originalResponse.status);
-              }
-
-              const client = getClient();
-              const contentType = originalResponse.headers.get('content-type');
-
-              const isPageloadRequest = contentType?.startsWith('text/html');
-              if (!isPageloadRequest || !client) {
-                return originalResponse;
-              }
-
-              // Type case necessary b/c the body's ReadableStream type doesn't include
-              // the async iterator that is actually available in Node
-              // We later on use the async iterator to read the body chunks
-              // see https://github.com/microsoft/TypeScript/issues/39051
-              const originalBody = originalResponse.body as NodeJS.ReadableStream | null;
-              if (!originalBody) {
-                return originalResponse;
-              }
-
-              const decoder = new TextDecoder();
-
-              const newResponseStream = new ReadableStream({
-                start: async controller => {
-                  // Assign to a new variable to avoid TS losing the narrower type checked above.
-                  const body = originalBody;
-
-                  async function* bodyReporter(): AsyncGenerator<string | Buffer> {
-                    try {
-                      for await (const chunk of body) {
-                        yield chunk;
-                      }
-                    } catch (e) {
-                      // Report stream errors coming from user code or Astro rendering.
-                      sendErrorToSentry(e);
-                      throw e;
-                    }
-                  }
-
-                  try {
-                    for await (const chunk of bodyReporter()) {
-                      const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
-                      const modifiedHtml = addMetaTagToHead(html, parametrizedRoute);
-                      controller.enqueue(new TextEncoder().encode(modifiedHtml));
-                    }
-                  } catch (e) {
-                    controller.error(e);
-                  } finally {
-                    controller.close();
-                  }
-                },
-              });
-
-              return new Response(newResponseStream, originalResponse);
-            } catch (e) {
-              sendErrorToSentry(e);
-              throw e;
-            }
-          },
-        );
-        return res;
-      } finally {
-        await flushIfServerless();
-      }
-      // TODO: flush if serverless (first extract function)
-    },
-  );
+        // TODO: flush if serverless (first extract function)
+      },
+    );
+  });
 }
 
 /**
  * This function optimistically assumes that the HTML coming in chunks will not be split
  * within the <head> tag. If this still happens, we simply won't replace anything.
  */
-function addMetaTagToHead(htmlChunk: string, parametrizedRoute?: string): string {
-  if (typeof htmlChunk !== 'string') {
-    return htmlChunk;
-  }
-  const metaTags = parametrizedRoute
-    ? `${getTraceMetaTags()}\n<meta name="sentry-route-name" content="${encodeURIComponent(parametrizedRoute)}"/>\n`
-    : getTraceMetaTags();
-
-  if (!metaTags) {
+function addMetaTagToHead(htmlChunk: string, metaTagsStr: string): string {
+  if (typeof htmlChunk !== 'string' || !metaTagsStr) {
     return htmlChunk;
   }
 
-  const content = `<head>${metaTags}`;
-
+  const content = `<head>${metaTagsStr}`;
   return htmlChunk.replace('<head>', content);
+}
+
+function getMetaTagsStr({
+  injectTraceData,
+  parametrizedRoute,
+}: {
+  injectTraceData: boolean;
+  parametrizedRoute: string | undefined;
+}): string {
+  const parts = [];
+  if (injectTraceData) {
+    parts.push(getTraceMetaTags());
+  }
+  if (parametrizedRoute) {
+    parts.push(`<meta name="sentry-route-name" content="${encodeURIComponent(parametrizedRoute)}"/>`);
+  }
+  return parts.join('\n');
 }
 
 /**
@@ -375,4 +407,91 @@ function joinRouteSegments(segments: RoutePart[][]): string {
   );
 
   return `/${parthArray.join('/')}`;
+}
+
+function getParametrizedRoute(
+  ctx: Parameters<MiddlewareResponseHandler>[0] & { routePattern?: string },
+): string | undefined {
+  try {
+    // `routePattern` is available after Astro 5
+    const contextWithRoutePattern = ctx;
+    const rawRoutePattern = contextWithRoutePattern.routePattern;
+
+    // @ts-expect-error Implicit any on Symbol.for (This is available in Astro 5)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const routesFromManifest = ctx?.[Symbol.for('context.routes')]?.manifest?.routes;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const matchedRouteSegmentsFromManifest = routesFromManifest?.find(
+      (route: { routeData?: { route?: string } }) => route?.routeData?.route === rawRoutePattern,
+    )?.routeData?.segments;
+
+    return (
+      // Astro v5 - Joining the segments to get the correct casing of the parametrized route
+      (matchedRouteSegmentsFromManifest && joinRouteSegments(matchedRouteSegmentsFromManifest)) ||
+      // Fallback (Astro v4 and earlier)
+      interpolateRouteFromUrlAndParams(ctx.url.pathname, ctx.params)
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function injectMetaTagsInResponse(originalResponse: Response, metaTagsStr: string): Response {
+  try {
+    const client = getClient();
+    const contentType = originalResponse.headers.get('content-type');
+
+    const isPageloadRequest = contentType?.startsWith('text/html');
+    if (!isPageloadRequest || !client) {
+      return originalResponse;
+    }
+
+    // Type case necessary b/c the body's ReadableStream type doesn't include
+    // the async iterator that is actually available in Node
+    // We later on use the async iterator to read the body chunks
+    // see https://github.com/microsoft/TypeScript/issues/39051
+    const originalBody = originalResponse.body as NodeJS.ReadableStream | null;
+    if (!originalBody) {
+      return originalResponse;
+    }
+
+    const decoder = new TextDecoder();
+
+    const newResponseStream = new ReadableStream({
+      start: async controller => {
+        // Assign to a new variable to avoid TS losing the narrower type checked above.
+        const body = originalBody;
+
+        async function* bodyReporter(): AsyncGenerator<string | Buffer> {
+          try {
+            for await (const chunk of body) {
+              yield chunk;
+            }
+          } catch (e) {
+            // Report stream errors coming from user code or Astro rendering.
+            sendErrorToSentry(e);
+            throw e;
+          }
+        }
+
+        try {
+          for await (const chunk of bodyReporter()) {
+            const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
+            const modifiedHtml = addMetaTagToHead(html, metaTagsStr);
+            controller.enqueue(new TextEncoder().encode(modifiedHtml));
+          }
+        } catch (e) {
+          controller.error(e);
+        } finally {
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(newResponseStream, originalResponse);
+  } catch (e) {
+    sendErrorToSentry(e);
+    throw e;
+  }
 }

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -167,7 +167,6 @@ async function enhanceHttpServerSpan(
     await flushIfServerless();
   }
 
-  // TODO: flush if serverless (first extract function)
 }
 
 async function instrumentRequestStartHttpServerSpan(

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -437,11 +437,10 @@ function getParametrizedRoute(
 
 function injectMetaTagsInResponse(originalResponse: Response, metaTagsStr: string): Response {
   try {
-    const client = getClient();
     const contentType = originalResponse.headers.get('content-type');
 
     const isPageloadRequest = contentType?.startsWith('text/html');
-    if (!isPageloadRequest || !client) {
+    if (!isPageloadRequest) {
       return originalResponse;
     }
 

--- a/packages/astro/src/server/sdk.ts
+++ b/packages/astro/src/server/sdk.ts
@@ -1,5 +1,5 @@
 import { applySdkMetadata } from '@sentry/core';
-import type { NodeClient, NodeOptions } from '@sentry/node';
+import type { Event, NodeClient, NodeOptions } from '@sentry/node';
 import { init as initNodeSdk } from '@sentry/node';
 
 /**
@@ -13,5 +13,28 @@ export function init(options: NodeOptions): NodeClient | undefined {
 
   applySdkMetadata(opts, 'astro', ['astro', 'node']);
 
-  return initNodeSdk(opts);
+  const client = initNodeSdk(opts);
+
+  client?.addEventProcessor(
+    Object.assign(
+      (event: Event) => {
+        // For http.server spans that did not go though the astro middleware,
+        // we want to drop them
+        // this is the case with http.server spans of prerendered pages
+        // we do not care about those, as they are effectively static
+        if (
+          event.type === 'transaction' &&
+          event.contexts?.trace?.op === 'http.server' &&
+          event.contexts?.trace?.origin === 'auto.http.otel.http'
+        ) {
+          return null;
+        }
+
+        return event;
+      },
+      { id: 'AstroHttpEventProcessor' },
+    ),
+  );
+
+  return client;
 }

--- a/packages/astro/src/server/sdk.ts
+++ b/packages/astro/src/server/sdk.ts
@@ -1,5 +1,5 @@
 import { applySdkMetadata } from '@sentry/core';
-import type { Event, NodeClient, NodeOptions } from '@sentry/node';
+import type { NodeClient, NodeOptions } from '@sentry/node';
 import { init as initNodeSdk } from '@sentry/node';
 
 /**
@@ -13,28 +13,5 @@ export function init(options: NodeOptions): NodeClient | undefined {
 
   applySdkMetadata(opts, 'astro', ['astro', 'node']);
 
-  const client = initNodeSdk(opts);
-
-  client?.addEventProcessor(
-    Object.assign(
-      (event: Event) => {
-        // For http.server spans that did not go though the astro middleware,
-        // we want to drop them
-        // this is the case with http.server spans of prerendered pages
-        // we do not care about those, as they are effectively static
-        if (
-          event.type === 'transaction' &&
-          event.contexts?.trace?.op === 'http.server' &&
-          event.contexts?.trace?.origin === 'auto.http.otel.http'
-        ) {
-          return null;
-        }
-
-        return event;
-      },
-      { id: 'AstroHttpEventProcessor' },
-    ),
-  );
-
-  return client;
+  return initNodeSdk(opts);
 }


### PR DESCRIPTION
This refactors the astro middleware a bit to be more correct & future proof.

Right now, http.server spans are not emitted by the node http integration because import-in-the-middle does not work with Astro. So we emit our own. This PR makes astro ready to also handle the base http.server spans and enhance them with routing information.

It also handles static routes better: these do not emit spans anymore now, and do not continue traces, but instead only propagate the parametrized route to the client, no trace data.

One fundamental problem remains that is not fixed in this PR: `Sentry.init()` is only injected via `page-ssr` into SSR pages. This means that only once any SSR page is hit, the server-side part of Sentry is initialized. If you hit a prerendered (static) page first, sentry will not be initialized and thus neither errors are captured nor spans created. For regular prerendered pages this should be fine because we do not need to run anything at runtime there. However, when you hit a prerendered page that has a server-island, the server island (which is dynamic) will not be instrumented either because Sentry is not initialized yet.

I don't think we can fix this with the current set of primitives we have, so this is a future problem to look into...