### PR TITLE
test(node-integration-tests): pin ai@5.0.30 to fix test fails

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/test.ts
@@ -406,7 +406,7 @@ describe('Vercel AI integration (V5)', () => {
     },
     {
       additionalDependencies: {
-        ai: '^5.0.0',
+        ai: '5.0.30',
       },
     },
   );
@@ -422,7 +422,7 @@ describe('Vercel AI integration (V5)', () => {
     },
     {
       additionalDependencies: {
-        ai: '^5.0.0',
+        ai: '5.0.30',
       },
     },
   );
@@ -541,7 +541,7 @@ describe('Vercel AI integration (V5)', () => {
     },
     {
       additionalDependencies: {
-        ai: '^5.0.0',
+        ai: '5.0.30',
       },
     },
   );
@@ -557,7 +557,7 @@ describe('Vercel AI integration (V5)', () => {
     },
     {
       additionalDependencies: {
-        ai: '^5.0.0',
+        ai: '5.0.30',
       },
     },
   );


### PR DESCRIPTION
Something 5.0.31 causes weird errors around `msw` not being found.
Potentially related: https://github.com/vercel/ai/issues/8469