### PR TITLE
Fix local variables capturing for out-of-app frames

### DIFF
--- a/packages/node-core/src/integrations/local-variables/common.ts
+++ b/packages/node-core/src/integrations/local-variables/common.ts
@@ -99,6 +99,12 @@ export interface LocalVariablesIntegrationOptions {
    * Maximum number of exceptions to capture local variables for per second before rate limiting is triggered.
    */
   maxExceptionsPerSecond?: number;
+  /**
+   * When true, local variables will be captured for all frames, including those that are not in_app.
+   *
+   * Defaults to `false`.
+   */
+  includeOutOfAppFrames?: boolean;
 }
 
 export interface LocalVariablesWorkerArgs extends LocalVariablesIntegrationOptions {

--- a/packages/node-core/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node-core/src/integrations/local-variables/local-variables-async.ts
@@ -39,8 +39,8 @@ export const localVariablesAsyncIntegration = defineIntegration(((
       if (
         // We need to have vars to add
         frameLocalVariables.vars === undefined ||
-        // We're not interested in frames that are not in_app because the vars are not relevant
-        frame.in_app === false ||
+        // Only skip out-of-app frames if includeOutOfAppFrames is not true
+        (frame.in_app === false && integrationOptions.includeOutOfAppFrames !== true) ||
         // The function names need to match
         !functionNamesMatch(frame.function, frameLocalVariables.function)
       ) {

--- a/packages/node-core/src/integrations/local-variables/test-helpers.ts
+++ b/packages/node-core/src/integrations/local-variables/test-helpers.ts
@@ -1,0 +1,48 @@
+// // TEST-ONLY: allow tests to access the cache
+
+import type { LRUMap } from '@sentry/core';
+import type { FrameVariables } from './common';
+
+/**
+ * Provides test helper methods for interacting with the local variables cache.
+ * These methods are intended for use in unit tests to inspect and manipulate
+ * the internal cache of frame variables used by the LocalVariables integration.
+ *
+ * @param cachedFrames - The LRUMap instance storing cached frame variables.
+ * @returns An object containing helper methods for cache inspection and mutation.
+ */
+export function localVariablesTestHelperMethods(cachedFrames: LRUMap<string, FrameVariables[]>): {
+  _getCachedFramesCount: () => number;
+  _getFirstCachedFrame: () => FrameVariables[] | undefined;
+  _setCachedFrame: (hash: string, frames: FrameVariables[]) => void;
+} {
+  /**
+   * Returns the number of entries in the local variables cache.
+   */
+  function _getCachedFramesCount(): number {
+    return cachedFrames.size;
+  }
+
+  /**
+   * Returns the first set of cached frame variables, or undefined if the cache is empty.
+   */
+  function _getFirstCachedFrame(): FrameVariables[] | undefined {
+    return cachedFrames.values()[0];
+  }
+
+  /**
+   * Sets the cached frame variables for a given stack hash.
+   *
+   * @param hash - The stack hash to associate with the cached frames.
+   * @param frames - The frame variables to cache.
+   */
+  function _setCachedFrame(hash: string, frames: FrameVariables[]): void {
+    cachedFrames.set(hash, frames);
+  }
+
+  return {
+    _getCachedFramesCount,
+    _getFirstCachedFrame,
+    _setCachedFrame,
+  };
+}

--- a/packages/node-core/test/integrations/local-variables-async.test.ts
+++ b/packages/node-core/test/integrations/local-variables-async.test.ts
@@ -1,0 +1,73 @@
+import type { Event, EventHint, StackFrame } from '@sentry/core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getCurrentScope, NodeClient } from '../../src';
+import type { FrameVariables } from '../../src/integrations/local-variables/common';
+import { LOCAL_VARIABLES_KEY } from '../../src/integrations/local-variables/common';
+import { localVariablesAsyncIntegration } from '../../src/integrations/local-variables/local-variables-async';
+import { getDefaultNodeClientOptions } from '../helpers/getDefaultNodeClientOptions';
+
+describe('LocalVariablesAsync', () => {
+  beforeEach(() => {
+    const options = getDefaultNodeClientOptions({
+      includeLocalVariables: true,
+      dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    });
+    const client = new NodeClient(options);
+    getCurrentScope().setClient(client);
+  });
+
+  it('does not add local variables to out of app frames by default', async () => {
+    const eventName = 'test-exclude-LocalVariables-out-of-app-frames';
+    const event = getTestEvent(eventName);
+    const integration = localVariablesAsyncIntegration({});
+    await integration.setup?.(getCurrentScope().getClient<NodeClient>()!);
+
+    const hint: EventHint = {
+      originalException: {
+        [LOCAL_VARIABLES_KEY]: [{ function: eventName, vars: { foo: 'bar' } } as FrameVariables],
+      },
+    };
+
+    const processedEvent = integration.processEvent?.(event, hint, getCurrentScope().getClient<NodeClient>()!) as Event;
+
+    expect(processedEvent.exception?.values?.[0]?.stacktrace?.frames?.[0]?.vars).toBeUndefined();
+  });
+
+  it('adds local variables to out of app frames when includeOutOfAppFrames is true', async () => {
+    const eventName = 'test-include-LocalVariables-out-of-app-frames';
+    const event = getTestEvent(eventName);
+    const integration = localVariablesAsyncIntegration({ includeOutOfAppFrames: true });
+    await integration.setup?.(getCurrentScope().getClient<NodeClient>()!);
+
+    const hint: EventHint = {
+      originalException: {
+        [LOCAL_VARIABLES_KEY]: [{ function: eventName, vars: { foo: 'bar' } } as FrameVariables],
+      },
+    };
+
+    const processedEvent = integration.processEvent?.(event, hint, getCurrentScope().getClient<NodeClient>()!) as Event;
+
+    expect(processedEvent.exception?.values?.[0]?.stacktrace?.frames?.[0]?.vars).toEqual({ foo: 'bar' });
+  });
+});
+
+function getTestEvent(fnName = 'test'): Event {
+  return {
+    exception: {
+      values: [
+        {
+          stacktrace: {
+            frames: [
+              {
+                in_app: false,
+                function: fnName,
+                lineno: 1,
+                colno: 1,
+              } as StackFrame,
+            ],
+          },
+        },
+      ],
+    },
+  };
+}

--- a/packages/node-core/test/integrations/local-variables.test.ts
+++ b/packages/node-core/test/integrations/local-variables.test.ts
@@ -1,0 +1,75 @@
+import type { Event, StackFrame } from '@sentry/core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getCurrentScope, NodeClient } from '../../src';
+import type { FrameVariables } from '../../src/integrations/local-variables/common';
+import type { DebugSession } from '../../src/integrations/local-variables/local-variables-sync';
+import { hashFrames, localVariablesSyncIntegration } from '../../src/integrations/local-variables/local-variables-sync';
+import { getDefaultNodeClientOptions } from '../helpers/getDefaultNodeClientOptions';
+
+const mockSession: DebugSession = {
+  configureAndConnect: () => {},
+  setPauseOnExceptions: () => {},
+  getLocalVariables: () => {},
+};
+
+describe('LocalVariables', () => {
+  beforeEach(() => {
+    const options = getDefaultNodeClientOptions({
+      includeLocalVariables: true,
+      dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    });
+    const client = new NodeClient(options);
+    getCurrentScope().setClient(client);
+  });
+
+  it('does not add local variables to out of app frames by default', async () => {
+    const eventName = 'test-exclude-LocalVariables-out-of-app-frames';
+    const event = getTestEvent(eventName);
+    const integration = localVariablesSyncIntegration({}, mockSession);
+    await integration.setupOnce?.();
+
+    const hash = hashFrames(event.exception!.values![0]!.stacktrace!.frames);
+    // @ts-expect-error test helper method
+    integration._setCachedFrame(hash!, [{ function: eventName, vars: { foo: 'bar' } } as FrameVariables]);
+
+    const processedEvent = integration.processEvent?.(event, {}, {} as any) as Event;
+
+    expect(processedEvent.exception?.values?.[0]?.stacktrace?.frames?.[0]?.vars).toBeUndefined();
+  });
+
+  it('adds local variables to out of app frames when includeOutOfAppFrames is true', async () => {
+    const eventName = 'test-include-LocalVariables-out-of-app-frames';
+    const event = getTestEvent(eventName);
+    const integration = localVariablesSyncIntegration({ includeOutOfAppFrames: true }, mockSession);
+    await integration.setupOnce?.();
+
+    const hash = hashFrames(event.exception!.values![0]!.stacktrace!.frames);
+    // @ts-expect-error test helper method
+    integration._setCachedFrame(hash!, [{ function: eventName, vars: { foo: 'bar' } } as FrameVariables]);
+
+    const processedEvent = integration.processEvent?.(event, {}, {} as any) as Event;
+
+    expect(processedEvent.exception?.values?.[0]?.stacktrace?.frames?.[0]?.vars).toEqual({ foo: 'bar' });
+  });
+});
+
+function getTestEvent(fnName = 'test'): Event {
+  return {
+    exception: {
+      values: [
+        {
+          stacktrace: {
+            frames: [
+              {
+                in_app: false,
+                function: fnName,
+                lineno: 1,
+                colno: 1,
+              } as StackFrame,
+            ],
+          },
+        },
+      ],
+    },
+  };
+}


### PR DESCRIPTION
This commit addresses an issue where local variables were not being captured for out-of-app frames.

The `localVariablesSyncIntegration` had a race condition where it would process events before the debugger session was fully initialized. This was fixed by awaiting the session creation in `setupOnce`.

Additionally, this PR adds tests for the `localVariablesAsyncIntegration` to ensure it correctly handles the `includeOutOfAppFrames` option.

--
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`): The tests fail `Error: Failed to resolve entry for package "@sentry/browser". The package may have incorrect main/module/exports specified in its package.json.`
