### PR TITLE
ci: Fix running of only changed E2E tests

### DIFF
--- a/dev-packages/e2e-tests/lib/getTestMatrix.ts
+++ b/dev-packages/e2e-tests/lib/getTestMatrix.ts
@@ -46,7 +46,7 @@ function run(): void {
     },
   });
 
-  const { base, head, optional } = values;
+  const { base, head = 'HEAD', optional } = values;
 
   const testApplications = globSync('*/package.json', {
     cwd: `${__dirname}/../test-applications`,
@@ -174,7 +174,7 @@ function getAffectedTestApplications(
 }
 
 function getChangedTestApps(base: string, head?: string): false | Set<string> {
-  const changedFiles = execSync(`git diff --name-only ${base}${head ? `..${head}` : ''} -- dev-packages/e2e-tests/`, {
+  const changedFiles = execSync(`git diff --name-only ${base}${head ? `..${head}` : ''} -- .`, {
     encoding: 'utf-8',
   })
     .toString()


### PR DESCRIPTION
Noticed here: https://github.com/getsentry/sentry-javascript/actions/runs/17542916888/job/49818463117 that this was not actually working 🤔 

I played around a bit with this locally, and this change made it work for me. Not sure why the `path` part is not working as expected, but we filter for the correct changes anyhow below, so this should be fine IMHO.