### PR TITLE
fix(nextjs): handle `process.turbopack` is not supported in edge runtime

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -5,7 +5,6 @@ import { getDefaultIntegrations as getReactDefaultIntegrations, init as reactIni
 import { devErrorSymbolicationEventProcessor } from '../common/devErrorSymbolicationEventProcessor';
 import { getVercelEnv } from '../common/getVercelEnv';
 import { isRedirectNavigationError } from '../common/nextNavigationErrorUtils';
-import { isTurbopack } from '../common/utils/isTurbopack';
 import { browserTracingIntegration } from './browserTracingIntegration';
 import { nextjsClientStackFrameNormalizationIntegration } from './clientNormalizationIntegration';
 import { INCOMPLETE_APP_ROUTER_INSTRUMENTATION_TRANSACTION_NAME } from './routing/appRouterRoutingInstrumentation';
@@ -78,7 +77,7 @@ export function init(options: BrowserOptions): Client | undefined {
   }
 
   try {
-    if (isTurbopack()) {
+    if (process.env.TURBOPACK) {
       getGlobalScope().setTag('turbopack', true);
     }
   } catch {

--- a/packages/nextjs/src/common/utils/isTurbopack.ts
+++ b/packages/nextjs/src/common/utils/isTurbopack.ts
@@ -1,8 +1,0 @@
-/**
- * Detect whether running under Turbopack
- */
-export function isTurbopack(): boolean {
-  if (typeof process === 'undefined') return false;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  return process.env?.TURBOPACK === '1' || !!(process as any)?.turbopack;
-}

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -14,7 +14,6 @@ import {
 import type { VercelEdgeOptions } from '@sentry/vercel-edge';
 import { getDefaultIntegrations, init as vercelEdgeInit } from '@sentry/vercel-edge';
 import { isBuild } from '../common/utils/isBuild';
-import { isTurbopack } from '../common/utils/isTurbopack';
 import { flushSafelyWithTimeout } from '../common/utils/responseEnd';
 import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegration';
 
@@ -96,7 +95,7 @@ export function init(options: VercelEdgeOptions = {}): void {
   });
 
   try {
-    if (isTurbopack()) {
+    if (process.env.TURBOPACK) {
       getGlobalScope().setTag('turbopack', true);
     }
   } catch {

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -37,7 +37,6 @@ import {
   TRANSACTION_ATTR_SHOULD_DROP_TRANSACTION,
 } from '../common/span-attributes-with-logic-attached';
 import { isBuild } from '../common/utils/isBuild';
-import { isTurbopack } from '../common/utils/isTurbopack';
 import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegration';
 
 export * from '@sentry/node';
@@ -369,7 +368,7 @@ export function init(options: NodeOptions): NodeClient | undefined {
   }
 
   try {
-    if (isTurbopack()) {
+    if (process.env.TURBOPACK) {
       getGlobalScope().setTag('turbopack', true);
     }
   } catch {


### PR DESCRIPTION
## Summary

Fix: Replace direct usage of `process.turbopack` with a safe fallback using `process.env.TURBOPACK`.

This resolves the error:

```log
web:build: ./node_modules/.pnpm/@sentry+nextjs@10.10.0_@opentelemetry+context-async-hooks@2.1.0_@opentelemetry+api@1.9._08bb47102a2416c860da6a61257d393e/node_modules/@sentry/nextjs/build/esm/edge/index.js:95:9
web:build: Ecmascript file had an error
web:build:   93 |   try {
web:build:   94 |     // @ts-expect-error `process.turbopack` is a magic string that will be replaced by Next.js
web:build: > 95 |     if (process.turbopack) {
web:build:      |         ^^^^^^^^^^^^^^^^^
web:build:   96 |       getGlobalScope().setTag('turbopack', true);
web:build:   97 |     }
web:build:   98 |   } catch {
web:build: 
web:build: A Node.js API is used (process.turbopack at line: 95) which is not supported in the Edge Runtime.
web:build: Learn more: https://nextjs.org/docs/api-reference/edge-runtime
```

---

## Changes

- Replaced all occurrences of `process.turbopack` with:

```ts
export function isTurbopack(): boolean {
  if (typeof process === 'undefined') return false;
  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
  return process.env?.TURBOPACK === '1' || !!(process as any)?.turbopack;
}
```
