### PR TITLE
ref(node): Inline types imported from `shimmer`

### DIFF
--- a/packages/node/src/integrations/tracing/firebase/otel/patches/firestore.ts
+++ b/packages/node/src/integrations/tracing/firebase/otel/patches/firestore.ts
@@ -16,7 +16,6 @@ import {
   ATTR_SERVER_PORT,
 } from '@opentelemetry/semantic-conventions';
 import type { SpanAttributes } from '@sentry/core';
-import type { unwrap as shimmerUnwrap, wrap as shimmerWrap } from 'shimmer';
 import type { FirebaseInstrumentation } from '../firebaseInstrumentation';
 import type {
   AddDocType,
@@ -37,6 +36,11 @@ import type {
   WithFieldValue,
 } from '../types';
 
+// Inline minimal types used from `shimmer` to avoid importing shimmer's types directly.
+// We only need the shape for `wrap` and `unwrap` used in this file.
+type ShimmerWrap = (target: any, name: string, wrapper: (...args: any[]) => any) => void;
+type ShimmerUnwrap = (target: any, name: string) => void;
+
 /**
  *
  * @param tracer - Opentelemetry Tracer
@@ -47,8 +51,8 @@ import type {
 export function patchFirestore(
   tracer: Tracer,
   firestoreSupportedVersions: string[],
-  wrap: typeof shimmerWrap,
-  unwrap: typeof shimmerUnwrap,
+  wrap: ShimmerWrap,
+  unwrap: ShimmerUnwrap,
   config: FirebaseInstrumentationConfig,
 ): InstrumentationNodeModuleDefinition {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -102,8 +106,8 @@ export function patchFirestore(
 function wrapMethods(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   moduleExports: any,
-  wrap: typeof shimmerWrap,
-  unwrap: typeof shimmerUnwrap,
+  wrap: ShimmerWrap,
+  unwrap: ShimmerUnwrap,
   tracer: Tracer,
   firestoreSpanCreationHook: FirestoreSpanCreationHook,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -121,7 +125,7 @@ function wrapMethods(
 function unwrapMethods(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   moduleExports: any,
-  unwrap: typeof shimmerUnwrap,
+  unwrap: ShimmerUnwrap,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
   for (const method of ['addDoc', 'getDocs', 'setDoc', 'deleteDoc']) {


### PR DESCRIPTION
Unblocks OTEL upgrades, where `shimmer` is not a sub-dependency anymore.