### PR TITLE
ref(core): Simplify `linkedErrors` mechanism logic

### DIFF
--- a/packages/core/src/utils/aggregate-errors.ts
+++ b/packages/core/src/utils/aggregate-errors.ts
@@ -101,7 +101,7 @@ function aggregateExceptionsFromError(
 function applyExceptionGroupFieldsForParentException(exception: Exception, exceptionId: number): void {
   exception.mechanism = {
     handled: true,
-    type: 'auto.core.linkedErrors',
+    type: 'auto.core.linked_errors',
     ...exception.mechanism,
     ...(exception.type === 'AggregateError' && { is_exception_group: true }),
     exception_id: exceptionId,

--- a/packages/core/test/lib/utils/aggregate-errors.test.ts
+++ b/packages/core/test/lib/utils/aggregate-errors.test.ts
@@ -176,7 +176,7 @@ describe('applyAggregateErrorsToEvent()', () => {
     applyAggregateErrorsToEvent(exceptionFromError, stackParser, 'cause', 100, event, eventHint);
 
     expect(event.exception?.values?.[event.exception.values.length - 1]?.mechanism?.type).toBe(
-      'auto.core.linkedErrors',
+      'auto.core.linked_errors',
     );
   });
 


### PR DESCRIPTION
Noticed this was more complicated than necessary. Also setting a specific mechanism type but this is unlikely to actually surface if our event capturing logic works correctly.