### PR TITLE
ref(react): Add mechanism to `reactErrorHandler` and adjust mechanism in `ErrorBoundary`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-19/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-19/tests/errors.test.ts
@@ -20,7 +20,7 @@ test('Catches errors caught by error boundary', async ({ page }) => {
   expect(errorEvent.exception?.values).toHaveLength(2);
   expect(errorEvent.exception?.values?.[0]?.value).toBe('caught error');
   expect(errorEvent.exception?.values?.[0]?.mechanism).toEqual({
-    type: 'auto.function.react.error-handler',
+    type: 'auto.function.react.error_handler',
     handled: true, // true because a callback was provided
     exception_id: 1,
     parent_id: 0,
@@ -54,7 +54,7 @@ test('Catches errors uncaught by error boundary', async ({ page }) => {
   expect(errorEvent.exception?.values).toHaveLength(2);
   expect(errorEvent.exception?.values?.[0]?.value).toBe('uncaught error');
   expect(errorEvent.exception?.values?.[0]?.mechanism).toEqual({
-    type: 'auto.function.react.error-handler',
+    type: 'auto.function.react.error_handler',
     handled: true, // true because a callback was provided
     exception_id: 1,
     parent_id: 0,

--- a/packages/react/src/error.ts
+++ b/packages/react/src/error.ts
@@ -97,7 +97,7 @@ export function reactErrorHandler(
   return (error: any, errorInfo: ErrorInfo) => {
     const hasCallback = !!callback;
     const eventId = captureReactException(error, errorInfo, {
-      mechanism: { handled: hasCallback, type: 'auto.function.react.error-handler' },
+      mechanism: { handled: hasCallback, type: 'auto.function.react.error_handler' },
     });
     if (hasCallback) {
       callback(error, errorInfo, eventId);

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -124,7 +124,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
 
       const handled = this.props.handled != null ? this.props.handled : !!this.props.fallback;
       const eventId = captureReactException(error, errorInfo, {
-        mechanism: { handled, type: 'auto.function.react.error-boundary' },
+        mechanism: { handled, type: 'auto.function.react.error_boundary' },
       });
 
       if (onError) {

--- a/packages/react/test/error.test.ts
+++ b/packages/react/test/error.test.ts
@@ -32,7 +32,7 @@ describe('reactErrorHandler', () => {
 
     expect(captureException).toHaveBeenCalledTimes(1);
     expect(captureException).toHaveBeenCalledWith(error, {
-      mechanism: { handled: false, type: 'auto.function.react.error-handler' },
+      mechanism: { handled: false, type: 'auto.function.react.error_handler' },
     });
   });
 
@@ -49,7 +49,7 @@ describe('reactErrorHandler', () => {
 
     expect(captureException).toHaveBeenCalledTimes(1);
     expect(captureException).toHaveBeenCalledWith(error, {
-      mechanism: { handled: true, type: 'auto.function.react.error-handler' },
+      mechanism: { handled: true, type: 'auto.function.react.error_handler' },
     });
 
     expect(callback).toHaveBeenCalledTimes(1);

--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -385,7 +385,7 @@ describe('ErrorBoundary', () => {
 
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
       expect(mockCaptureException).toHaveBeenLastCalledWith(expect.any(Error), {
-        mechanism: { handled: true, type: 'auto.function.react.error-boundary' },
+        mechanism: { handled: true, type: 'auto.function.react.error_boundary' },
       });
 
       expect(scopeSetContextSpy).toHaveBeenCalledTimes(1);
@@ -444,7 +444,7 @@ describe('ErrorBoundary', () => {
 
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
       expect(mockCaptureException).toHaveBeenLastCalledWith('bam', {
-        mechanism: { handled: true, type: 'auto.function.react.error-boundary' },
+        mechanism: { handled: true, type: 'auto.function.react.error_boundary' },
       });
 
       expect(scopeSetContextSpy).toHaveBeenCalledTimes(1);
@@ -483,7 +483,7 @@ describe('ErrorBoundary', () => {
 
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
       expect(mockCaptureException).toHaveBeenLastCalledWith(expect.any(Error), {
-        mechanism: { handled: true, type: 'auto.function.react.error-boundary' },
+        mechanism: { handled: true, type: 'auto.function.react.error_boundary' },
       });
 
       expect(scopeSetContextSpy).toHaveBeenCalledTimes(1);
@@ -527,7 +527,7 @@ describe('ErrorBoundary', () => {
 
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
       expect(mockCaptureException).toHaveBeenLastCalledWith(expect.any(Error), {
-        mechanism: { handled: true, type: 'auto.function.react.error-boundary' },
+        mechanism: { handled: true, type: 'auto.function.react.error_boundary' },
       });
 
       expect(scopeSetContextSpy).toHaveBeenCalledTimes(1);
@@ -695,7 +695,7 @@ describe('ErrorBoundary', () => {
 
         expect(mockCaptureException).toHaveBeenCalledTimes(1);
         expect(mockCaptureException).toHaveBeenLastCalledWith(expect.any(Object), {
-          mechanism: { handled: expected, type: 'auto.function.react.error-boundary' },
+          mechanism: { handled: expected, type: 'auto.function.react.error_boundary' },
         });
 
         expect(scopeSetContextSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Both mechanisms now follow the trace origin naming scheme.
Decided to make the `handled` value of `reactErrorHandler` depend on the definedness of the passed callback. My thinking is that this is similar to how we set `handled` in the `ErrorBoundary`. 