### PR TITLE
test(angular): Bump TS version to 5.9.0 in Angular 20 e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/angular-20/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-20/package.json
@@ -48,5 +48,13 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "sentryTest": {
+    "optionalVariants": [
+      {
+        "build-command": "pnpm test:build-canary",
+        "label": "angular (canary)"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Angular 21 will only support TS 5.9.0 or greater. This breaking change was introduced in the [`next.3` preview release](https://github.com/angular/angular/releases/tag/21.0.0-next.3) and was flagged in our Angular canary test. Bumping the TS version should be safe here since it will be required by NG21 and still fits into the [compatible range of NG20](https://angular.dev/reference/versions). 

closes https://github.com/getsentry/sentry-javascript/issues/17603