### PR TITLE
ref(replay-internal): Add mechanism to error caught by `replayIntegration` in debug mode

### DIFF
--- a/packages/replay-internal/src/util/logger.ts
+++ b/packages/replay-internal/src/util/logger.ts
@@ -76,8 +76,8 @@ function makeReplayDebugLogger(): ReplayDebugLogger {
       if (_capture) {
         captureException(error, {
           mechanism: {
-            handled: false,
-            type: 'replay',
+            handled: true,
+            type: 'auto.function.replay.debug',
           },
         });
       } else if (_trace) {

--- a/packages/replay-internal/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay-internal/test/integration/sendReplayEvent.test.ts
@@ -399,7 +399,12 @@ describe('Integration | sendReplayEvent', () => {
     expect(spyHandleException).toHaveBeenCalledTimes(5);
     const expectedError = new Error('Unable to send Replay - max retries exceeded');
     (expectedError as any).cause = new Error('Something bad happened');
-    expect(spyHandleException).toHaveBeenLastCalledWith(expectedError);
+    expect(spyHandleException).toHaveBeenLastCalledWith(expectedError, {
+      mechanism: {
+        handled: true,
+        type: 'auto.function.replay.debug',
+      },
+    });
 
     const spyHandleExceptionCall = spyHandleException.mock.calls;
     expect(spyHandleExceptionCall[spyHandleExceptionCall.length - 1][0]?.cause.message).toEqual(

--- a/packages/replay-internal/test/unit/util/logger.test.ts
+++ b/packages/replay-internal/test/unit/util/logger.test.ts
@@ -52,7 +52,12 @@ describe('logger', () => {
       const err = new Error('An error');
       debug.exception(err, 'a message');
       if (captureExceptions) {
-        expect(mockCaptureException).toHaveBeenCalledWith(err);
+        expect(mockCaptureException).toHaveBeenCalledWith(err, {
+          mechanism: {
+            handled: true,
+            type: 'auto.function.replay.debug',
+          },
+        });
       }
       expect(mockLogError).toHaveBeenCalledWith('[Replay] ', 'a message');
       expect(mockLogError).toHaveBeenLastCalledWith('[Replay] ', err);
@@ -75,7 +80,12 @@ describe('logger', () => {
       const err = new Error('An error');
       debug.exception(err);
       if (captureExceptions) {
-        expect(mockCaptureException).toHaveBeenCalledWith(err);
+        expect(mockCaptureException).toHaveBeenCalledWith(err, {
+          mechanism: {
+            handled: true,
+            type: 'auto.function.replay.debug',
+          },
+        });
         expect(mockAddBreadcrumb).not.toHaveBeenCalled();
       }
       expect(mockLogError).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Decided to go with `handled: true` since we handle the error but only optionally send it to sentry for debug purposes

closes #17265 