### PR TITLE
test(react-router): Unflake `flushIfServerless` test

### DIFF
--- a/packages/react-router/test/server/createSentryHandleError.test.ts
+++ b/packages/react-router/test/server/createSentryHandleError.test.ts
@@ -156,7 +156,8 @@ describe('createSentryHandleError', () => {
   });
 
   describe('flushIfServerless behavior', () => {
-    it('should wait for flushIfServerless to complete', async () => {
+    it('waits for flushIfServerless to complete', async () => {
+      vi.useFakeTimers();
       const handleError = createSentryHandleError({});
 
       let resolveFlush: () => void;
@@ -172,7 +173,8 @@ describe('createSentryHandleError', () => {
 
       const handleErrorPromise = handleError(mockError, mockArgs);
 
-      setTimeout(() => resolveFlush(), 10);
+      vi.advanceTimersByTime(10);
+      resolveFlush!();
 
       await handleErrorPromise;
       const endTime = Date.now();


### PR DESCRIPTION
This test flaked before because we used real timers and apparently `setTimeout(_, 10)` sometimes caused an absolute delay <10 ms. Let's use fake timers instead which should(?) ensure that this works correctly in the test fixture.

closes https://github.com/getsentry/sentry-javascript/issues/17611