### PR TITLE
ref(astro): Adjust `mechanism` on error events captured by astro middleware

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.server.test.ts
@@ -47,11 +47,8 @@ test.describe('server-side errors', () => {
         values: [
           {
             mechanism: {
-              data: {
-                function: 'astroMiddleware',
-              },
               handled: false,
-              type: 'astro',
+              type: 'auto.middleware.astro',
             },
             stacktrace: expect.any(Object),
             type: 'TypeError',
@@ -136,11 +133,8 @@ test.describe('server-side errors', () => {
         values: [
           {
             mechanism: {
-              data: {
-                function: 'astroMiddleware',
-              },
               handled: false,
-              type: 'astro',
+              type: 'auto.middleware.astro',
             },
             stacktrace: expect.any(Object),
             type: 'Error',

--- a/dev-packages/e2e-tests/test-applications/astro-5/tests/errors.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-5/tests/errors.server.test.ts
@@ -47,11 +47,8 @@ test.describe('server-side errors', () => {
         values: [
           {
             mechanism: {
-              data: {
-                function: 'astroMiddleware',
-              },
               handled: false,
-              type: 'astro',
+              type: 'auto.middleware.astro',
             },
             stacktrace: expect.any(Object),
             type: 'TypeError',
@@ -136,11 +133,8 @@ test.describe('server-side errors', () => {
         values: [
           {
             mechanism: {
-              data: {
-                function: 'astroMiddleware',
-              },
               handled: false,
-              type: 'astro',
+              type: 'auto.middleware.astro',
             },
             stacktrace: expect.any(Object),
             type: 'Error',

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -50,11 +50,8 @@ function sendErrorToSentry(e: unknown): unknown {
 
   captureException(objectifiedErr, {
     mechanism: {
-      type: 'astro',
+      type: 'auto.middleware.astro',
       handled: false,
-      data: {
-        function: 'astroMiddleware',
-      },
     },
   });
 

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -168,7 +168,7 @@ describe('sentryMiddleware', () => {
     await expect(async () => middleware(ctx, next)).rejects.toThrowError();
 
     expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
-      mechanism: { handled: false, type: 'astro', data: { function: 'astroMiddleware' } },
+      mechanism: { handled: false, type: 'auto.middleware.astro' },
     });
   });
 
@@ -205,7 +205,7 @@ describe('sentryMiddleware', () => {
     await expect(() => resultFromNext!.text()).rejects.toThrowError();
 
     expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
-      mechanism: { handled: false, type: 'astro', data: { function: 'astroMiddleware' } },
+      mechanism: { handled: false, type: 'auto.middleware.astro' },
     });
   });
 


### PR DESCRIPTION
mechanism type now follows the trace origin naming scheme

closes #17612 