### PR TITLE
ref(bun): Adjust `mechanism` of errors captured in Bun.serve

### DIFF
--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -246,11 +246,8 @@ function wrapRequestHandler<T extends RouteHandler = RouteHandler>(
             } catch (e) {
               captureException(e, {
                 mechanism: {
-                  type: 'bun',
+                  type: 'auto.http.bun.serve',
                   handled: false,
-                  data: {
-                    function: 'serve',
-                  },
                 },
               });
               throw e;


### PR DESCRIPTION
uses the same mechanism type as the span active when captureException is called

closes #17615 