### PR TITLE
ref(core): Adjust MCP server error event `mechanism`

### DIFF
--- a/packages/core/src/integrations/mcp-server/errorCapture.ts
+++ b/packages/core/src/integrations/mcp-server/errorCapture.ts
@@ -36,7 +36,7 @@ export function captureError(error: Error, errorType?: McpErrorType, extraData?:
 
     captureException(error, {
       mechanism: {
-        type: 'mcp_server',
+        type: 'auto.ai.mcp_server',
         handled: false,
         data: {
           error_type: errorType || 'handler_execution',

--- a/packages/core/test/lib/integrations/mcp-server/mcpServerErrorCapture.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/mcpServerErrorCapture.test.ts
@@ -24,7 +24,7 @@ describe('MCP Server Error Capture', () => {
 
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: {
-          type: 'mcp_server',
+          type: 'auto.ai.mcp_server',
           handled: false,
           data: {
             error_type: 'tool_execution',
@@ -40,7 +40,7 @@ describe('MCP Server Error Capture', () => {
 
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: {
-          type: 'mcp_server',
+          type: 'auto.ai.mcp_server',
           handled: false,
           data: {
             error_type: 'transport',
@@ -56,7 +56,7 @@ describe('MCP Server Error Capture', () => {
 
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: {
-          type: 'mcp_server',
+          type: 'auto.ai.mcp_server',
           handled: false,
           data: {
             error_type: 'protocol',
@@ -72,7 +72,7 @@ describe('MCP Server Error Capture', () => {
 
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: {
-          type: 'mcp_server',
+          type: 'auto.ai.mcp_server',
           handled: false,
           data: {
             error_type: 'validation',
@@ -88,7 +88,7 @@ describe('MCP Server Error Capture', () => {
 
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: {
-          type: 'mcp_server',
+          type: 'auto.ai.mcp_server',
           handled: false,
           data: {
             error_type: 'timeout',
@@ -104,7 +104,7 @@ describe('MCP Server Error Capture', () => {
 
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: {
-          type: 'mcp_server',
+          type: 'auto.ai.mcp_server',
           handled: false,
           data: {
             error_type: 'tool_execution',


### PR DESCRIPTION
This PR adjusts the mechanism type we set to be in line with the trace origin naming scheme. 

ref https://github.com/getsentry/sentry-javascript/issues/17212