### PR TITLE
ref(deno): Adjust `mechanism` of errors caught by `globalHandlersIntegration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
   - ref(bun): Adjust `mechanism` of errors captured in Bun.serve ([#17616](https://github.com/getsentry/sentry-javascript/pull/17616))
   - ref(core): Adjust MCP server error event `mechanism` ([#17622](https://github.com/getsentry/sentry-javascript/pull/17622))
   - ref(core): Simplify `linkedErrors` mechanism logic ([#17600](https://github.com/getsentry/sentry-javascript/pull/17600))
-  - ref(deno): Adjust mechanism of errors caught by globalHandlersIntegration ([#17635](https://github.com/getsentry/sentry-javascript/pull/17635))
+  - ref(deno): Adjust `mechanism` of errors caught by `globalHandlersIntegration` ([#17635](https://github.com/getsentry/sentry-javascript/pull/17635))
   - ref(nextjs): Set more specific event `mechanism`s ([#17543](https://github.com/getsentry/sentry-javascript/pull/17543))
   - ref(node-core): Add `mechanism` to cron instrumentations ([#17544](https://github.com/getsentry/sentry-javascript/pull/17544))
   - ref(node-core): Add more specific `mechanism.type` to worker thread errors from `childProcessIntegration` ([#17578](https://github.com/getsentry/sentry-javascript/pull/17578))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - ref(bun): Adjust `mechanism` of errors captured in Bun.serve ([#17616](https://github.com/getsentry/sentry-javascript/pull/17616))
   - ref(core): Adjust MCP server error event `mechanism` ([#17622](https://github.com/getsentry/sentry-javascript/pull/17622))
   - ref(core): Simplify `linkedErrors` mechanism logic ([#17600](https://github.com/getsentry/sentry-javascript/pull/17600))
+  - ref(deno): Adjust mechanism of errors caught by globalHandlersIntegration ([#17635](https://github.com/getsentry/sentry-javascript/pull/17635))
   - ref(nextjs): Set more specific event `mechanism`s ([#17543](https://github.com/getsentry/sentry-javascript/pull/17543))
   - ref(node-core): Add `mechanism` to cron instrumentations ([#17544](https://github.com/getsentry/sentry-javascript/pull/17544))
   - ref(node-core): Add more specific `mechanism.type` to worker thread errors from `childProcessIntegration` ([#17578](https://github.com/getsentry/sentry-javascript/pull/17578))

--- a/packages/deno/src/integrations/globalhandlers.ts
+++ b/packages/deno/src/integrations/globalhandlers.ts
@@ -61,7 +61,7 @@ function installGlobalErrorHandler(client: Client): void {
       originalException: error,
       mechanism: {
         handled: false,
-        type: 'error',
+        type: 'auto.deno.global_handlers.error',
       },
     });
 
@@ -110,7 +110,7 @@ function installGlobalUnhandledRejectionHandler(client: Client): void {
       originalException: error,
       mechanism: {
         handled: false,
-        type: 'unhandledrejection',
+        type: 'auto.deno.global_handlers.unhandledrejection',
       },
     });
 


### PR DESCRIPTION
Now follows the same trace origin-esque naming scheme as the [browser version](https://github.com/getsentry/sentry-javascript/blob/4b562bcbf0a81494627ab2c5a153ddbddb2d89ae/packages/browser/src/integrations/globalhandlers.ts#L101) of `globalHandlersIntegration`.

ref https://github.com/getsentry/sentry-javascript/issues/17212