### PR TITLE
ref(node-core): Adjust `mechanism` of `onUnhandledRejection` and `onUnhandledException` integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - ref(node): Adjust mechanism of express, hapi and fastify error handlers ([#17623](https://github.com/getsentry/sentry-javascript/pull/17623))
   - ref(node-core): Add `mechanism` to cron instrumentations ([#17544](https://github.com/getsentry/sentry-javascript/pull/17544))
   - ref(node-core): Add more specific `mechanism.type` to worker thread errors from `childProcessIntegration` ([#17578](https://github.com/getsentry/sentry-javascript/pull/17578))
+  - ref(node-core): Adjust `mechanism` of `onUnhandledRejection` and `onUnhandledException` integrations ([#17636](https://github.com/getsentry/sentry-javascript/pull/17636))
   - ref(node): Add mechanism to errors captured via connect and koa integrations ([#17579](https://github.com/getsentry/sentry-javascript/pull/17579))
   - ref(nuxt): Add and adjust `mechanism.type` in error events ([#17599](https://github.com/getsentry/sentry-javascript/pull/17599))
   - ref(react): Add mechanism to `reactErrorHandler` and adjust mechanism in `ErrorBoundary` ([#17602](https://github.com/getsentry/sentry-javascript/pull/17602))

--- a/dev-packages/node-core-integration-tests/suites/cron/node-schedule/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/cron/node-schedule/test.ts
@@ -74,7 +74,7 @@ test('node-schedule instrumentation', async () => {
             {
               type: 'Error',
               value: 'Error in cron job',
-              mechanism: { type: 'onunhandledrejection', handled: false },
+              mechanism: { type: 'auto.node.onunhandledrejection', handled: false },
             },
           ],
         },

--- a/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/basic.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/basic.js
@@ -1,0 +1,9 @@
+const Sentry = require('@sentry/node');
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  transport: loggingTransport,
+});
+
+throw new Error('foo');

--- a/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -1,6 +1,7 @@
 import * as childProcess from 'child_process';
 import * as path from 'path';
 import { describe, expect, test } from 'vitest';
+import { createRunner } from '../../../utils/runner';
 
 describe('OnUncaughtException integration', () => {
   test('should close process on uncaught error with no additional listeners registered', () =>
@@ -73,5 +74,31 @@ describe('OnUncaughtException integration', () => {
           done();
         });
       }));
+  });
+
+  test('sets correct event mechanism', async () => {
+    await createRunner(__dirname, 'basic.js')
+      .expect({
+        event: {
+          level: 'fatal',
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'foo',
+                mechanism: {
+                  type: 'auto.node.onuncaughtexception',
+                  handled: false,
+                },
+                stacktrace: {
+                  frames: expect.any(Array),
+                },
+              },
+            ],
+          },
+        },
+      })
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
@@ -83,7 +83,7 @@ test rejection`);
                 type: 'Error',
                 value: 'test rejection',
                 mechanism: {
-                  type: 'onunhandledrejection',
+                  type: 'auto.node.onunhandledrejection',
                   handled: false,
                 },
                 stacktrace: {
@@ -109,7 +109,7 @@ test rejection`);
                 type: 'Error',
                 value: 'test rejection',
                 mechanism: {
-                  type: 'onunhandledrejection',
+                  type: 'auto.node.onunhandledrejection',
                   handled: false,
                 },
                 stacktrace: {

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/basic.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/basic.js
@@ -1,0 +1,9 @@
+const Sentry = require('@sentry/node');
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  transport: loggingTransport,
+});
+
+throw new Error('foo');

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -1,6 +1,7 @@
 import * as childProcess from 'child_process';
 import * as path from 'path';
 import { describe, expect, test } from 'vitest';
+import { createRunner } from '../../../utils/runner';
 
 describe('OnUncaughtException integration', () => {
   test('should close process on uncaught error with no additional listeners registered', () =>
@@ -73,5 +74,31 @@ describe('OnUncaughtException integration', () => {
           done();
         });
       }));
+  });
+
+  test('sets correct event mechanism', async () => {
+    await createRunner(__dirname, 'basic.js')
+      .expect({
+        event: {
+          level: 'fatal',
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'foo',
+                mechanism: {
+                  type: 'auto.node.onuncaughtexception',
+                  handled: false,
+                },
+                stacktrace: {
+                  frames: expect.any(Array),
+                },
+              },
+            ],
+          },
+        },
+      })
+      .start()
+      .completed();
   });
 });

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/test.ts
@@ -84,7 +84,7 @@ test rejection`);
                 type: 'Error',
                 value: 'test rejection',
                 mechanism: {
-                  type: 'onunhandledrejection',
+                  type: 'auto.node.onunhandledrejection',
                   handled: false,
                 },
                 stacktrace: {
@@ -110,7 +110,7 @@ test rejection`);
                 type: 'Error',
                 value: 'test rejection',
                 mechanism: {
-                  type: 'onunhandledrejection',
+                  type: 'auto.node.onunhandledrejection',
                   handled: false,
                 },
                 stacktrace: {

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -256,7 +256,7 @@ const USELESS_EXCEPTION_EVENT: Event = {
     values: [
       {},
       {
-        mechanism: { type: 'onunhandledrejection', handled: false },
+        mechanism: { type: 'auto.node.onunhandledrejection', handled: false },
       },
     ],
   },

--- a/packages/node-core/src/integrations/onuncaughtexception.ts
+++ b/packages/node-core/src/integrations/onuncaughtexception.ts
@@ -108,7 +108,7 @@ export function makeErrorHandler(client: NodeClient, options: OnUncaughtExceptio
             },
             mechanism: {
               handled: false,
-              type: 'onuncaughtexception',
+              type: 'auto.node.onuncaughtexception',
             },
           });
         }

--- a/packages/node-core/src/integrations/onunhandledrejection.ts
+++ b/packages/node-core/src/integrations/onunhandledrejection.ts
@@ -69,7 +69,7 @@ export function makeUnhandledPromiseHandler(
         },
         mechanism: {
           handled: false,
-          type: 'onunhandledrejection',
+          type: 'auto.node.onunhandledrejection',
         },
       });
     });


### PR DESCRIPTION
mechanism type now follows the trace origin-esque naming, similarly to global handlers [in browser](https://github.com/getsentry/sentry-javascript/blob/4b562bcbf0a81494627ab2c5a153ddbddb2d89ae/packages/browser/src/integrations/globalhandlers.ts#L101)

ref https://github.com/getsentry/sentry-javascript/issues/17212