### PR TITLE
test(e2e): Bump hono in `cloudflare.hono` test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@sentry/cloudflare": "latest || *",
-    "hono": "4.7.10"
+    "hono": "4.9.7"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8.31",


### PR DESCRIPTION
testing https://github.com/getsentry/sentry-javascript/pull/17630 because cloudflare-hono is an optional e2e test app and doesn't run on dependabot PRs