### PR TITLE
feat(cloudflare): export the init method

### DIFF
--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -107,7 +107,7 @@ export { sentryPagesPlugin } from './pages-plugin';
 export { wrapRequestHandler } from './request';
 
 export { CloudflareClient } from './client';
-export { getDefaultIntegrations } from './sdk';
+export { getDefaultIntegrations, init } from './sdk';
 
 export { fetchIntegration } from './integrations/fetch';
 export { vercelAIIntegration } from './integrations/tracing/vercelai';


### PR DESCRIPTION
I'm creating little helpers to handle trace propagation on regular durable object rpc calls. To do this I needed access to the `init` method to initialize a new sdk instance (just like sentry/cloudflare does for the methods it auto-instruments). So, if you guys are open to it, hoping to get access to the init method.

Example of how I'm using it here -> https://github.com/marbemac/cloudflare-sentry-effect-tracing/blob/main/worker/rpc-tracing-helpers.ts#L112.