### PR TITLE
fix(core): Fix error handling when sending envelopes

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -875,18 +875,15 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   public sendEnvelope(envelope: Envelope): PromiseLike<TransportMakeRequestResponse> {
     this.emit('beforeEnvelope', envelope);
 
-    if (!this._isEnabled() || !this._transport) {
-      DEBUG_BUILD && debug.error('Transport disabled');
-      return resolvedSyncPromise({});
-    }
-
-    return this._transport.send(envelope).then(
-      response => response,
-      reason => {
+    if (this._isEnabled() && this._transport) {
+      return this._transport.send(envelope).then(null, reason => {
         DEBUG_BUILD && debug.error('Error while sending envelope:', reason);
         return {};
-      },
-    );
+      });
+    }
+
+    DEBUG_BUILD && debug.error('Transport disabled');
+    return resolvedSyncPromise({});
   }
 
   /* eslint-enable @typescript-eslint/unified-signatures */

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -2268,7 +2268,7 @@ describe('Client', () => {
 
       expect(mockSend).toBeCalledTimes(1);
       expect(callback).toBeCalledTimes(1);
-      expect(callback).toBeCalledWith(errorEvent, 'send error');
+      expect(callback).toBeCalledWith(errorEvent, {});
     });
 
     it('passes the response to the hook', async () => {

--- a/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
@@ -14,11 +14,10 @@ export function handleAfterSendEvent(replay: ReplayContainer): AfterSendEventCal
       return;
     }
 
-    const statusCode = sendResponse?.statusCode;
+    const statusCode = sendResponse.statusCode;
 
     // We only want to do stuff on successful error sending, otherwise you get error replays without errors attached
-    // If not using the base transport, we allow `undefined` response (as a custom transport may not implement this correctly yet)
-    // If we do use the base transport, we skip if we encountered an non-OK status code
+    // We skip if we encountered an non-OK status code
     if (!statusCode || statusCode < 200 || statusCode >= 300) {
       return;
     }


### PR DESCRIPTION
I noticed that we actually handled errors in `sendEnvelope` incorrectly - we would resolve this function with the rejection reason, if sending fails. this does not match the type of `TransportMakeRequestResponse`, you could actually get something like this out (and the tests actually incorrectly tested this):

```js
// transport.send() rejects with "fetch does not exist"
const res = await client.sendEnvelope(envelope);
// res --> "fetch does not exist" (string)
```

This PR fixes this to instead resolve with an empty object (which matches the expected return type).

Extracted this out of https://github.com/getsentry/sentry-javascript/pull/17641 because it is actually a bug/fix.