### PR TITLE
test(sveltekit): Pin E2E test app SvelteKit versions and fix failing tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/package.json
@@ -22,7 +22,7 @@
     "@playwright/test": "~1.53.2",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-node": "^5.3.1",
-    "@sveltejs/kit": "^2.31.0",
+    "@sveltejs/kit": "2.31.0",
     "@sveltejs/vite-plugin-svelte": "^6.1.3",
     "svelte": "^5.38.3",
     "svelte-check": "^4.3.1",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/package.json
@@ -22,7 +22,7 @@
     "@playwright/test": "~1.53.2",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-auto": "^3.0.0",
-    "@sveltejs/kit": "^2.21.3",
+    "@sveltejs/kit": "2.41.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^5.0.0-next.115",
     "svelte-check": "^3.6.0",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.test.ts
@@ -337,7 +337,7 @@ test.describe('performance events', () => {
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/redirect2',
-        'sentry.sveltekit.navigation.type': 'goto',
+        'sentry.sveltekit.navigation.type': 'link',
       },
     });
 
@@ -353,7 +353,7 @@ test.describe('performance events', () => {
             'sentry.origin': 'auto.navigation.sveltekit',
             'sentry.op': 'navigation',
             'sentry.source': 'route',
-            'sentry.sveltekit.navigation.type': 'goto',
+            'sentry.sveltekit.navigation.type': 'link',
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/users/[id]',
             'sentry.sample_rate': 1,
@@ -374,7 +374,7 @@ test.describe('performance events', () => {
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/users/[id]',
-        'sentry.sveltekit.navigation.type': 'goto',
+        'sentry.sveltekit.navigation.type': 'link',
       },
     });
   });

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.test.ts
@@ -316,7 +316,7 @@ test.describe('performance events', () => {
             'sentry.origin': 'auto.navigation.sveltekit',
             'sentry.op': 'navigation',
             'sentry.source': 'route',
-            'sentry.sveltekit.navigation.type': 'goto',
+            'sentry.sveltekit.navigation.type': 'link',
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/redirect2',
             'sentry.sample_rate': 1,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
@@ -22,7 +22,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/adapter-node": "^2.0.0",
-    "@sveltejs/kit": "^2.21.3",
+    "@sveltejs/kit": "2.21.3",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^4.2.8",
     "svelte-check": "^3.6.0",


### PR DESCRIPTION
Some of our SvelteKit E2E tests started failing because the SvelteKit version wasn't pinned to a specific version but rather pulled in the latest v2 versions. https://github.com/sveltejs/kit/pull/12896 fixed a bug in Kit's client-side navigation logic that we previously implicitly tested against. 

This PR
- pins all SvelteKit versions used in our e2e tests
- adjusts one of them to use 2.41.0 (the most recent version) and adjust the test to the bugfix 