### PR TITLE
feat(core): Allow to pass `onSuccess` to `handleCallbackErrors`

### DIFF
--- a/packages/core/src/utils/handleCallbackErrors.ts
+++ b/packages/core/src/utils/handleCallbackErrors.ts
@@ -1,5 +1,30 @@
 import { isThenable } from '../utils/is';
 
+/* eslint-disable */
+// Vendor "Awaited" in to be TS 3.8 compatible
+type AwaitedPromise<T> = T extends null | undefined
+  ? T // special case for `null | undefined` when not in `--strictNullChecks` mode
+  : T extends object & { then(onfulfilled: infer F, ...args: infer _): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+    ? F extends (value: infer V, ...args: infer _) => any // if the argument to `then` is callable, extracts the first argument
+      ? V // normally this would recursively unwrap, but this is not possible in TS3.8
+      : never // the argument to `then` was not callable
+    : T; // non-object or non-thenable
+/* eslint-enable */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function handleCallbackErrors<Fn extends () => Promise<any>, PromiseValue = AwaitedPromise<ReturnType<Fn>>>(
+  fn: Fn,
+  onError: (error: unknown) => void,
+  onFinally?: () => void,
+  onSuccess?: (result: PromiseValue) => void,
+): ReturnType<Fn>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function handleCallbackErrors<Fn extends () => any>(
+  fn: Fn,
+  onError: (error: unknown) => void,
+  onFinally?: () => void,
+  onSuccess?: (result: ReturnType<Fn>) => void,
+): ReturnType<Fn>;
 /**
  * Wrap a callback function with error handling.
  * If an error is thrown, it will be passed to the `onError` callback and re-thrown.
@@ -14,7 +39,13 @@ import { isThenable } from '../utils/is';
 export function handleCallbackErrors<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Fn extends () => any,
->(fn: Fn, onError: (error: unknown) => void, onFinally: () => void = () => {}): ReturnType<Fn> {
+  ValueType = ReturnType<Fn>,
+>(
+  fn: Fn,
+  onError: (error: unknown) => void,
+  onFinally: () => void = () => {},
+  onSuccess: (result: ValueType | AwaitedPromise<ValueType>) => void = () => {},
+): ValueType {
   let maybePromiseResult: ReturnType<Fn>;
   try {
     maybePromiseResult = fn();
@@ -24,7 +55,7 @@ export function handleCallbackErrors<
     throw e;
   }
 
-  return maybeHandlePromiseRejection(maybePromiseResult, onError, onFinally);
+  return maybeHandlePromiseRejection(maybePromiseResult, onError, onFinally, onSuccess);
 }
 
 /**
@@ -37,12 +68,14 @@ function maybeHandlePromiseRejection<MaybePromise>(
   value: MaybePromise,
   onError: (error: unknown) => void,
   onFinally: () => void,
+  onSuccess: (result: MaybePromise | AwaitedPromise<MaybePromise>) => void,
 ): MaybePromise {
   if (isThenable(value)) {
     // @ts-expect-error - the isThenable check returns the "wrong" type here
     return value.then(
       res => {
         onFinally();
+        onSuccess(res);
         return res;
       },
       e => {
@@ -54,5 +87,6 @@ function maybeHandlePromiseRejection<MaybePromise>(
   }
 
   onFinally();
+  onSuccess(value);
   return value;
 }

--- a/packages/core/test/lib/utils/handleCallbackErrors.test.ts
+++ b/packages/core/test/lib/utils/handleCallbackErrors.test.ts
@@ -148,4 +148,94 @@ describe('handleCallbackErrors', () => {
       expect(onFinally).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('onSuccess', () => {
+    it('triggers after successful sync callback', () => {
+      const onError = vi.fn();
+      const onFinally = vi.fn();
+      const onSuccess = vi.fn();
+
+      const fn = vi.fn(() => 'aa');
+
+      const res = handleCallbackErrors(fn, onError, onFinally, onSuccess);
+
+      expect(res).toBe('aa');
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinally).toHaveBeenCalledTimes(1);
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+      expect(onSuccess).toHaveBeenCalledWith('aa');
+    });
+
+    it('does not trigger onSuccess after error in sync callback', () => {
+      const error = new Error('test error');
+
+      const onError = vi.fn();
+      const onFinally = vi.fn();
+      const onSuccess = vi.fn();
+
+      const fn = vi.fn(() => {
+        throw error;
+      });
+
+      expect(() => handleCallbackErrors(fn, onError, onFinally, onSuccess)).toThrow(error);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(onFinally).toHaveBeenCalledTimes(1);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('triggers after successful async callback', async () => {
+      const onError = vi.fn();
+      const onFinally = vi.fn();
+      const onSuccess = vi.fn();
+
+      const fn = vi.fn(async () => 'aa');
+
+      const res = handleCallbackErrors(fn, onError, onFinally, onSuccess);
+
+      expect(res).toBeInstanceOf(Promise);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinally).not.toHaveBeenCalled();
+
+      const value = await res;
+      expect(value).toBe('aa');
+
+      expect(onFinally).toHaveBeenCalledTimes(1);
+      expect(onSuccess).toHaveBeenCalled();
+      expect(onSuccess).toHaveBeenCalledWith('aa');
+    });
+
+    it('does not trigger onSuccess after error in async callback', async () => {
+      const onError = vi.fn();
+      const onFinally = vi.fn();
+      const onSuccess = vi.fn();
+
+      const error = new Error('test error');
+
+      const fn = vi.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        throw error;
+      });
+
+      const res = handleCallbackErrors(fn, onError, onFinally, onSuccess);
+
+      expect(res).toBeInstanceOf(Promise);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinally).not.toHaveBeenCalled();
+
+      await expect(res).rejects.toThrow(error);
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(onFinally).toHaveBeenCalledTimes(1);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
I've seen a few places where we are wrapping things that could be sync or async, and we want to do something with the return value. By adding an onSuccess handler to `handelCallbackErrors` we can handle this more generically in the future:

```js
const wrapped = handleCallbackErrors(
  () => fn(), 
  // error handler
  (_err) => {}, 
  // finally handler
  () => {},
  // success handler, gets value or resolved value if function returns a promise
  (_value) => {}
);
```

While scanning a bit for places where we could already use this, I also found two bugs around this, opened separate PRs for them:
* https://github.com/getsentry/sentry-javascript/pull/17680
* https://github.com/getsentry/sentry-javascript/pull/17681