### PR TITLE
ref(remix): Avoid unnecessary error wrapping `HandleDocumentRequestFunction`

### DIFF
--- a/packages/remix/src/server/errors.ts
+++ b/packages/remix/src/server/errors.ts
@@ -1,11 +1,4 @@
-import type {
-  ActionFunction,
-  ActionFunctionArgs,
-  EntryContext,
-  HandleDocumentRequestFunction,
-  LoaderFunction,
-  LoaderFunctionArgs,
-} from '@remix-run/node';
+import type { ActionFunction, ActionFunctionArgs, LoaderFunction, LoaderFunctionArgs } from '@remix-run/node';
 import { isRouteErrorResponse } from '@remix-run/router';
 import type { RequestEventData, Span } from '@sentry/core';
 import {
@@ -77,36 +70,6 @@ export async function captureRemixServerException(err: unknown, name: string, re
 
     return scope;
   });
-}
-
-/**
- * Wraps the original `HandleDocumentRequestFunction` with error handling.
- *
- * @param origDocumentRequestFunction The original `HandleDocumentRequestFunction`.
- * @param requestContext The request context.
- *
- * @returns The wrapped `HandleDocumentRequestFunction`.
- */
-export function errorHandleDocumentRequestFunction(
-  this: unknown,
-  origDocumentRequestFunction: HandleDocumentRequestFunction,
-  requestContext: {
-    request: Request;
-    responseStatusCode: number;
-    responseHeaders: Headers;
-    context: EntryContext;
-    loadContext?: Record<string, unknown>;
-  },
-): HandleDocumentRequestFunction {
-  const { request, responseStatusCode, responseHeaders, context, loadContext } = requestContext;
-
-  return handleCallbackErrors(
-    () => origDocumentRequestFunction.call(this, request, responseStatusCode, responseHeaders, context, loadContext),
-    err => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      captureRemixServerException(err, 'HandleDocumentRequestFunction', request);
-    },
-  );
 }
 
 /**

--- a/packages/remix/src/server/errors.ts
+++ b/packages/remix/src/server/errors.ts
@@ -101,11 +101,10 @@ export function errorHandleDocumentRequestFunction(
   const { request, responseStatusCode, responseHeaders, context, loadContext } = requestContext;
 
   return handleCallbackErrors(
-    () => {
-      return origDocumentRequestFunction.call(this, request, responseStatusCode, responseHeaders, context, loadContext);
-    },
+    () => origDocumentRequestFunction.call(this, request, responseStatusCode, responseHeaders, context, loadContext),
     err => {
-      throw err;
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      captureRemixServerException(err, 'HandleDocumentRequestFunction', request);
     },
   );
 }

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -6,7 +6,6 @@ import type {
   ActionFunctionArgs,
   AppLoadContext,
   CreateRequestHandlerFunction,
-  EntryContext,
   HandleDocumentRequestFunction,
   LoaderFunction,
   LoaderFunctionArgs,

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -119,22 +119,7 @@ function getTraceAndBaggage(): {
 
 function makeWrappedDocumentRequestFunction(instrumentTracing?: boolean) {
   return function (origDocumentRequestFunction: HandleDocumentRequestFunction): HandleDocumentRequestFunction {
-    return async function (
-      this: unknown,
-      request: Request,
-      responseStatusCode: number,
-      responseHeaders: Headers,
-      context: EntryContext,
-      loadContext?: Record<string, unknown>,
-    ): Promise<Response> {
-      const documentRequestContext = {
-        request,
-        responseStatusCode,
-        responseHeaders,
-        context,
-        loadContext,
-      };
-
+    return async function (this: unknown, request: Request, ...args: unknown[]): Promise<Response> {
       if (instrumentTracing) {
         const activeSpan = getActiveSpan();
         const rootSpan = activeSpan && getRootSpan(activeSpan);
@@ -155,11 +140,11 @@ function makeWrappedDocumentRequestFunction(instrumentTracing?: boolean) {
             },
           },
           () => {
-            return origDocumentRequestFunction.call(this, documentRequestContext);
+            return origDocumentRequestFunction.call(this, request, ...args);
           },
         );
       } else {
-        return origDocumentRequestFunction.call(this, documentRequestContext);
+        return origDocumentRequestFunction.call(this, request, ...args);
       }
     };
   };

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -39,7 +39,7 @@ import {
 import { DEBUG_BUILD } from '../utils/debug-build';
 import { createRoutes, getTransactionName } from '../utils/utils';
 import { extractData, isResponse, json } from '../utils/vendor/response';
-import { captureRemixServerException, errorHandleDataFunction, errorHandleDocumentRequestFunction } from './errors';
+import { captureRemixServerException, errorHandleDataFunction } from './errors';
 
 type AppData = unknown;
 type RemixRequest = Parameters<RequestHandler>[0];
@@ -155,11 +155,11 @@ function makeWrappedDocumentRequestFunction(instrumentTracing?: boolean) {
             },
           },
           () => {
-            return errorHandleDocumentRequestFunction.call(this, origDocumentRequestFunction, documentRequestContext);
+            return origDocumentRequestFunction.call(this, documentRequestContext);
           },
         );
       } else {
-        return errorHandleDocumentRequestFunction.call(this, origDocumentRequestFunction, documentRequestContext);
+        return origDocumentRequestFunction.call(this, documentRequestContext);
       }
     };
   };


### PR DESCRIPTION
Noticed while working on https://github.com/getsentry/sentry-javascript/pull/17679, this was actually incorrect here. `handleCallbackErrors` does not actually do anything, you need to still call the function you want to call in the error case!

Actually we can just drop this as this error is handled by some other handler anyhow, I think, according to the tests!