### PR TITLE
fix(node): Fix `this` context for vercel AI instrumentation

### DIFF
--- a/packages/node/src/integrations/tracing/anthropic-ai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/anthropic-ai/instrumentation.ts
@@ -5,7 +5,7 @@ import {
   InstrumentationNodeModuleDefinition,
 } from '@opentelemetry/instrumentation';
 import type { AnthropicAiClient, AnthropicAiOptions, Integration } from '@sentry/core';
-import { ANTHROPIC_AI_INTEGRATION_NAME, getCurrentScope, instrumentAnthropicAiClient, SDK_VERSION } from '@sentry/core';
+import { ANTHROPIC_AI_INTEGRATION_NAME, getClient, instrumentAnthropicAiClient, SDK_VERSION } from '@sentry/core';
 
 const supportedVersions = ['>=0.19.2 <1.0.0'];
 
@@ -61,10 +61,10 @@ export class SentryAnthropicAiInstrumentation extends InstrumentationBase<Instru
 
     const WrappedAnthropic = function (this: unknown, ...args: unknown[]) {
       const instance = Reflect.construct(Original, args);
-      const scopeClient = getCurrentScope().getClient();
-      const integration = scopeClient?.getIntegrationByName<AnthropicAiIntegration>(ANTHROPIC_AI_INTEGRATION_NAME);
+      const client = getClient();
+      const integration = client?.getIntegrationByName<AnthropicAiIntegration>(ANTHROPIC_AI_INTEGRATION_NAME);
       const integrationOpts = integration?.options;
-      const defaultPii = Boolean(scopeClient?.getOptions().sendDefaultPii);
+      const defaultPii = Boolean(client?.getOptions().sendDefaultPii);
 
       const { recordInputs, recordOutputs } = determineRecordingSettings(integrationOpts, defaultPii);
 

--- a/packages/node/src/integrations/tracing/openai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/openai/instrumentation.ts
@@ -5,7 +5,7 @@ import {
   InstrumentationNodeModuleDefinition,
 } from '@opentelemetry/instrumentation';
 import type { Integration, OpenAiClient, OpenAiOptions } from '@sentry/core';
-import { getCurrentScope, instrumentOpenAiClient, OPENAI_INTEGRATION_NAME, SDK_VERSION } from '@sentry/core';
+import { getClient, instrumentOpenAiClient, OPENAI_INTEGRATION_NAME, SDK_VERSION } from '@sentry/core';
 
 const supportedVersions = ['>=4.0.0 <6'];
 
@@ -57,10 +57,10 @@ export class SentryOpenAiInstrumentation extends InstrumentationBase<Instrumenta
 
     const WrappedOpenAI = function (this: unknown, ...args: unknown[]) {
       const instance = Reflect.construct(Original, args);
-      const scopeClient = getCurrentScope().getClient();
-      const integration = scopeClient?.getIntegrationByName<OpenAiIntegration>(OPENAI_INTEGRATION_NAME);
+      const client = getClient();
+      const integration = client?.getIntegrationByName<OpenAiIntegration>(OPENAI_INTEGRATION_NAME);
       const integrationOpts = integration?.options;
-      const defaultPii = Boolean(scopeClient?.getOptions().sendDefaultPii);
+      const defaultPii = Boolean(client?.getOptions().sendDefaultPii);
 
       const { recordInputs, recordOutputs } = determineRecordingSettings(integrationOpts, defaultPii);
 

--- a/packages/node/src/integrations/tracing/vercelai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/vercelai/instrumentation.ts
@@ -7,7 +7,7 @@ import {
   addNonEnumerableProperty,
   captureException,
   getActiveSpan,
-  getCurrentScope,
+  getClient,
   handleCallbackErrors,
   isThenable,
   SDK_VERSION,
@@ -218,7 +218,7 @@ export class SentryVercelAiInstrumentation extends InstrumentationBase {
           const existingExperimentalTelemetry = args[0].experimental_telemetry || {};
           const isEnabled = existingExperimentalTelemetry.isEnabled;
 
-          const client = getCurrentScope().getClient();
+          const client = getClient();
           const integration = client?.getIntegrationByName<VercelAiIntegration>(INTEGRATION_NAME);
           const integrationOptions = integration?.options;
           const shouldRecordInputsAndOutputs = integration ? Boolean(client?.getOptions().sendDefaultPii) : false;


### PR DESCRIPTION
Noticed while working on https://github.com/getsentry/sentry-javascript/pull/17679, we incorrectly changed the `this` context here (which is also why TS complained).

I rewrote this to a proxy which should keep the context properly.