### PR TITLE
feat(node): Do not drop 300 and 304 status codes by default

### DIFF
--- a/packages/node-core/src/integrations/http/index.ts
+++ b/packages/node-core/src/integrations/http/index.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, RequestOptions } from 'node:http';
-import { defineIntegration } from '@sentry/core';
+import { debug, defineIntegration } from '@sentry/core';
+import { DEBUG_BUILD } from '../../debug-build';
 import { generateInstrumentOnce } from '../../otel/instrument';
 import type { SentryHttpInstrumentationOptions } from './SentryHttpInstrumentation';
 import { SentryHttpInstrumentation } from './SentryHttpInstrumentation';
@@ -62,10 +63,10 @@ interface HttpOptions {
 
   /**
    * Do not capture spans for incoming HTTP requests with the given status codes.
-   * By default, spans with 404 status code are ignored.
+   * By default, spans with some 3xx and 4xx status codes are ignored.
    * Expects an array of status codes or a range of status codes, e.g. [[300,399], 404] would ignore 3xx and 404 status codes.
    *
-   * @default `[[401, 404], [300, 399]]`
+   * @default `[[401, 404], 301, 303, [305, 399]]`
    */
   dropSpansForIncomingRequestStatusCodes?: (number | [number, number])[];
 
@@ -115,7 +116,10 @@ export const instrumentSentryHttp = generateInstrumentOnce<SentryHttpInstrumenta
 export const httpIntegration = defineIntegration((options: HttpOptions = {}) => {
   const dropSpansForIncomingRequestStatusCodes = options.dropSpansForIncomingRequestStatusCodes ?? [
     [401, 404],
-    [300, 399],
+    // 300, 302 and 304 are possibly valid status codes we do not want to filter
+    301,
+    303,
+    [305, 399],
   ];
 
   return {
@@ -133,18 +137,12 @@ export const httpIntegration = defineIntegration((options: HttpOptions = {}) => 
       // Drop transaction if it has a status code that should be ignored
       if (event.type === 'transaction') {
         const statusCode = event.contexts?.trace?.data?.['http.response.status_code'];
-        if (
-          typeof statusCode === 'number' &&
-          dropSpansForIncomingRequestStatusCodes.some(code => {
-            if (typeof code === 'number') {
-              return code === statusCode;
-            }
-
-            const [min, max] = code;
-            return statusCode >= min && statusCode <= max;
-          })
-        ) {
-          return null;
+        if (typeof statusCode === 'number') {
+          const shouldDrop = shouldFilterStatusCode(statusCode, dropSpansForIncomingRequestStatusCodes);
+          if (shouldDrop) {
+            DEBUG_BUILD && debug.log('Dropping transaction due to status code', statusCode);
+            return null;
+          }
         }
       }
 
@@ -152,3 +150,17 @@ export const httpIntegration = defineIntegration((options: HttpOptions = {}) => 
     },
   };
 });
+
+/**
+ * If the given status code should be filtered for the given list of status codes/ranges.
+ */
+function shouldFilterStatusCode(statusCode: number, dropForStatusCodes: (number | [number, number])[]): boolean {
+  return dropForStatusCodes.some(code => {
+    if (typeof code === 'number') {
+      return code === statusCode;
+    }
+
+    const [min, max] = code;
+    return statusCode >= min && statusCode <= max;
+  });
+}

--- a/packages/node-core/src/integrations/http/index.ts
+++ b/packages/node-core/src/integrations/http/index.ts
@@ -66,7 +66,7 @@ interface HttpOptions {
    * By default, spans with some 3xx and 4xx status codes are ignored (see @default).
    * Expects an array of status codes or a range of status codes, e.g. [[300,399], 404] would ignore 3xx and 404 status codes.
    *
-   * @default `[[401, 404], 301, 303, [305, 399]]`
+   * @default `[[401, 404], [301, 303], [305, 399]]`
    */
   dropSpansForIncomingRequestStatusCodes?: (number | [number, number])[];
 

--- a/packages/node-core/src/integrations/http/index.ts
+++ b/packages/node-core/src/integrations/http/index.ts
@@ -116,9 +116,8 @@ export const instrumentSentryHttp = generateInstrumentOnce<SentryHttpInstrumenta
 export const httpIntegration = defineIntegration((options: HttpOptions = {}) => {
   const dropSpansForIncomingRequestStatusCodes = options.dropSpansForIncomingRequestStatusCodes ?? [
     [401, 404],
-    // 300, 302 and 304 are possibly valid status codes we do not want to filter
-    301,
-    303,
+    // 300 and 304 are possibly valid status codes we do not want to filter
+    [301, 303],
     [305, 399],
   ];
 

--- a/packages/node-core/src/integrations/http/index.ts
+++ b/packages/node-core/src/integrations/http/index.ts
@@ -63,7 +63,7 @@ interface HttpOptions {
 
   /**
    * Do not capture spans for incoming HTTP requests with the given status codes.
-   * By default, spans with some 3xx and 4xx status codes are ignored.
+   * By default, spans with some 3xx and 4xx status codes are ignored (see @default).
    * Expects an array of status codes or a range of status codes, e.g. [[300,399], 404] would ignore 3xx and 404 status codes.
    *
    * @default `[[401, 404], 301, 303, [305, 399]]`

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -3,7 +3,7 @@ import { diag } from '@opentelemetry/api';
 import type { HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import type { Span } from '@sentry/core';
-import { defineIntegration, getClient, hasSpansEnabled } from '@sentry/core';
+import { debug, defineIntegration, getClient, hasSpansEnabled } from '@sentry/core';
 import type { HTTPModuleRequestIncomingMessage, NodeClient } from '@sentry/node-core';
 import {
   type SentryHttpInstrumentationOptions,
@@ -13,6 +13,7 @@ import {
   NODE_VERSION,
   SentryHttpInstrumentation,
 } from '@sentry/node-core';
+import { DEBUG_BUILD } from '../debug-build';
 import type { NodeClientOptions } from '../types';
 
 const INTEGRATION_NAME = 'Http';
@@ -84,10 +85,10 @@ interface HttpOptions {
 
   /**
    * Do not capture spans for incoming HTTP requests with the given status codes.
-   * By default, spans with 404 status code are ignored.
+   * By default, spans with some 3xx and 4xx status codes are ignored.
    * Expects an array of status codes or a range of status codes, e.g. [[300,399], 404] would ignore 3xx and 404 status codes.
    *
-   * @default `[[401, 404], [300, 399]]`
+   * @default `[[401, 404], 301, 303, [305, 399]]`
    */
   dropSpansForIncomingRequestStatusCodes?: (number | [number, number])[];
 
@@ -195,7 +196,10 @@ export function _shouldUseOtelHttpInstrumentation(
 export const httpIntegration = defineIntegration((options: HttpOptions = {}) => {
   const dropSpansForIncomingRequestStatusCodes = options.dropSpansForIncomingRequestStatusCodes ?? [
     [401, 404],
-    [300, 399],
+    // 300, 302 and 304 are possibly valid status codes we do not want to filter
+    301,
+    303,
+    [305, 399],
   ];
 
   return {
@@ -225,18 +229,12 @@ export const httpIntegration = defineIntegration((options: HttpOptions = {}) => 
       // Drop transaction if it has a status code that should be ignored
       if (event.type === 'transaction') {
         const statusCode = event.contexts?.trace?.data?.['http.response.status_code'];
-        if (
-          typeof statusCode === 'number' &&
-          dropSpansForIncomingRequestStatusCodes.some(code => {
-            if (typeof code === 'number') {
-              return code === statusCode;
-            }
-
-            const [min, max] = code;
-            return statusCode >= min && statusCode <= max;
-          })
-        ) {
-          return null;
+        if (typeof statusCode === 'number') {
+          const shouldDrop = shouldFilterStatusCode(statusCode, dropSpansForIncomingRequestStatusCodes);
+          if (shouldDrop) {
+            DEBUG_BUILD && debug.log('Dropping transaction due to status code', statusCode);
+            return null;
+          }
         }
       }
 
@@ -281,4 +279,18 @@ function getConfigWithDefaults(options: Partial<HttpOptions> = {}): HttpInstrume
   } satisfies HttpInstrumentationConfig;
 
   return instrumentationConfig;
+}
+
+/**
+ * If the given status code should be filtered for the given list of status codes/ranges.
+ */
+function shouldFilterStatusCode(statusCode: number, dropForStatusCodes: (number | [number, number])[]): boolean {
+  return dropForStatusCodes.some(code => {
+    if (typeof code === 'number') {
+      return code === statusCode;
+    }
+
+    const [min, max] = code;
+    return statusCode >= min && statusCode <= max;
+  });
 }

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -196,9 +196,8 @@ export function _shouldUseOtelHttpInstrumentation(
 export const httpIntegration = defineIntegration((options: HttpOptions = {}) => {
   const dropSpansForIncomingRequestStatusCodes = options.dropSpansForIncomingRequestStatusCodes ?? [
     [401, 404],
-    // 300, 302 and 304 are possibly valid status codes we do not want to filter
-    301,
-    303,
+    // 300 and 304 are possibly valid status codes we do not want to filter
+    [301, 303],
     [305, 399],
   ];
 

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -88,7 +88,7 @@ interface HttpOptions {
    * By default, spans with some 3xx and 4xx status codes are ignored (see @default).
    * Expects an array of status codes or a range of status codes, e.g. [[300,399], 404] would ignore 3xx and 404 status codes.
    *
-   * @default `[[401, 404], 301, 303, [305, 399]]`
+   * @default `[[401, 404], [301, 303], [305, 399]]`
    */
   dropSpansForIncomingRequestStatusCodes?: (number | [number, number])[];
 

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -144,7 +144,6 @@ export const instrumentSentryHttp = generateInstrumentOnce<SentryHttpInstrumenta
   },
 );
 
-
 export const instrumentOtelHttp = generateInstrumentOnce<HttpInstrumentationConfig>(INTEGRATION_NAME, config => {
   const instrumentation = new HttpInstrumentation({
     ...config,

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -85,7 +85,7 @@ interface HttpOptions {
 
   /**
    * Do not capture spans for incoming HTTP requests with the given status codes.
-   * By default, spans with some 3xx and 4xx status codes are ignored.
+   * By default, spans with some 3xx and 4xx status codes are ignored (see @default).
    * Expects an array of status codes or a range of status codes, e.g. [[300,399], 404] would ignore 3xx and 404 status codes.
    *
    * @default `[[401, 404], 301, 303, [305, 399]]`
@@ -143,6 +143,7 @@ export const instrumentSentryHttp = generateInstrumentOnce<SentryHttpInstrumenta
     return new SentryHttpInstrumentation(options);
   },
 );
+
 
 export const instrumentOtelHttp = generateInstrumentOnce<HttpInstrumentationConfig>(INTEGRATION_NAME, config => {
   const instrumentation = new HttpInstrumentation({


### PR DESCRIPTION
Looking at https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#redirection_messages, it seems that we should not filter out 300, 302 and 304 status codes by default:

> [300 Multiple Choices](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/300)
In [agent-driven content negotiation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Content_negotiation#agent-driven_negotiation), the request has more than one possible response and the user agent or user should choose one of them. There is no standardized way for clients to automatically choose one of the responses, so this is rarely used.
> [304 Not Modified](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304)
This is used for caching purposes. It tells the client that the response has not been modified, so the client can continue to use the same [cached](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching) version of the response.

In contrast, the others seem safe to continue to filter:

> [301 Moved Permanently](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/301)
The URL of the requested resource has been changed permanently. The new URL is given in the response.

> [302 Found](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/302)
This response code means that the URI of requested resource has been changed temporarily. Further changes in the URI might be made in the future, so the same URI should be used by the client in future requests.

> [303 See Other](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/303)
The server sent this response to direct the client to get the requested resource at another URI with a [GET](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/GET) request.

> [305 Use Proxy Deprecated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#305_use_proxy)
Defined in a previous version of the HTTP specification to indicate that a requested response must be accessed by a proxy. It has been deprecated due to security concerns regarding in-band configuration of a proxy.

> [306 unused](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#306_unused)
This response code is no longer used; but is reserved. It was used in a previous version of the HTTP/1.1 specification.

> [307 Temporary Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/307)
The server sends this response to direct the client to get the requested resource at another URI with the same method that was used in the prior request. This has the same semantics as the 302 Found response code, with the exception that the user agent must not change the HTTP method used: if a [POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/POST) was used in the first request, a POST must be used in the redirected request.

> [308 Permanent Redirect](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/308)
This means that the resource is now permanently located at another URI, specified by the [Location](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Location) response header. This has the same semantics as the 301 Moved Permanently HTTP response code, with the exception that the user agent must not change the HTTP method used: if a [POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/POST) was used in the first request, a POST must be used in the second request.

eventually it makes sense to unify this between node/node-core, but this should happen when we merge the httpIntegration split PR.