### PR TITLE
ref(core): Add debug log when dropping a span via `ignoreSpans`

### DIFF
--- a/packages/core/src/utils/should-ignore-span.ts
+++ b/packages/core/src/utils/should-ignore-span.ts
@@ -5,7 +5,7 @@ import { debug } from './debug-logger';
 import { isMatchingPattern } from './string';
 
 function logIgnoredSpan(droppedSpan: Pick<SpanJSON, 'description' | 'op'>): void {
-  debug.log(`Ignoring span ${droppedSpan.op} - ${droppedSpan.description}`);
+  debug.log(`Ignoring span ${droppedSpan.op} - ${droppedSpan.description} because it matches \`ignoreSpans\`.`);
 }
 
 /**

--- a/packages/core/src/utils/should-ignore-span.ts
+++ b/packages/core/src/utils/should-ignore-span.ts
@@ -1,6 +1,12 @@
+import { DEBUG_BUILD } from '../debug-build';
 import type { ClientOptions } from '../types-hoist/options';
 import type { SpanJSON } from '../types-hoist/span';
+import { debug } from './debug-logger';
 import { isMatchingPattern } from './string';
+
+function logIgnoredSpan(droppedSpan: Pick<SpanJSON, 'description' | 'op'>): void {
+  debug.log(`Ignoring span ${droppedSpan.op} - ${droppedSpan.description}`);
+}
 
 /**
  * Check if a span should be ignored based on the ignoreSpans configuration.
@@ -16,6 +22,7 @@ export function shouldIgnoreSpan(
   for (const pattern of ignoreSpans) {
     if (isStringOrRegExp(pattern)) {
       if (isMatchingPattern(span.description, pattern)) {
+        DEBUG_BUILD && logIgnoredSpan(span);
         return true;
       }
       continue;
@@ -33,6 +40,7 @@ export function shouldIgnoreSpan(
     // not both op and name actually have to match. This is the most efficient way to check
     // for all combinations of name and op patterns.
     if (nameMatches && opMatches) {
+      DEBUG_BUILD && logIgnoredSpan(span);
       return true;
     }
   }

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -323,7 +323,7 @@ export function showSpanDropWarning(): void {
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
       console.warn(
-        '[Sentry] Returning null from `beforeSendSpan` is disallowed. To drop certain spans, configure the respective integrations directly.',
+        '[Sentry] Returning null from `beforeSendSpan` is disallowed. To drop certain spans, configure the respective integrations directly or use `ignoreSpans`.',
       );
     });
     hasShownSpanDropWarning = true;

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -1445,7 +1445,7 @@ describe('Client', () => {
 
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        '[Sentry] Returning null from `beforeSendSpan` is disallowed. To drop certain spans, configure the respective integrations directly.',
+        '[Sentry] Returning null from `beforeSendSpan` is disallowed. To drop certain spans, configure the respective integrations directly or use `ignoreSpans`.',
       );
       consoleWarnSpy.mockRestore();
     });

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -190,7 +190,7 @@ describe('SentrySpan', () => {
       expect(recordDroppedEventSpy).not.toHaveBeenCalled();
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        '[Sentry] Returning null from `beforeSendSpan` is disallowed. To drop certain spans, configure the respective integrations directly.',
+        '[Sentry] Returning null from `beforeSendSpan` is disallowed. To drop certain spans, configure the respective integrations directly or use `ignoreSpans`.',
       );
       consoleWarnSpy.mockRestore();
     });

--- a/packages/core/test/lib/utils/should-ignore-span.test.ts
+++ b/packages/core/test/lib/utils/should-ignore-span.test.ts
@@ -94,7 +94,9 @@ describe('shouldIgnoreSpan', () => {
     const span = { description: 'testDescription', op: 'testOp' };
     const ignoreSpans = [/test/];
     expect(shouldIgnoreSpan(span, ignoreSpans)).toBe(true);
-    expect(debugLogSpy).toHaveBeenCalledWith('Ignoring span testOp - testDescription');
+    expect(debugLogSpy).toHaveBeenCalledWith(
+      'Ignoring span testOp - testDescription because it matches `ignoreSpans`.',
+    );
   });
 });
 

--- a/packages/core/test/lib/utils/should-ignore-span.test.ts
+++ b/packages/core/test/lib/utils/should-ignore-span.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ClientOptions, SpanJSON } from '../../../src';
+import { debug } from '../../../src/utils/debug-logger';
 import { reparentChildSpans, shouldIgnoreSpan } from '../../../src/utils/should-ignore-span';
 
 describe('shouldIgnoreSpan', () => {
@@ -86,6 +87,14 @@ describe('shouldIgnoreSpan', () => {
     expect(shouldIgnoreSpan(span10, ignoreSpans)).toBe(false);
     expect(shouldIgnoreSpan(span11, ignoreSpans)).toBe(false);
     expect(shouldIgnoreSpan(span12, ignoreSpans)).toBe(false);
+  });
+
+  it('emits a debug log when a span is ignored', () => {
+    const debugLogSpy = vi.spyOn(debug, 'log');
+    const span = { description: 'testDescription', op: 'testOp' };
+    const ignoreSpans = [/test/];
+    expect(shouldIgnoreSpan(span, ignoreSpans)).toBe(true);
+    expect(debugLogSpy).toHaveBeenCalledWith('Ignoring span testOp - testDescription');
   });
 });
 


### PR DESCRIPTION
- Emit a debug log when a span matches `ignoreSpans`
- Adjust the warning when returning `null` in `beforeSendSpan` to suggest `ignoreSpans` instead

closes https://github.com/getsentry/sentry-javascript/issues/17687