### PR TITLE
ref(core): Avoid looking up openai integration options

### DIFF
--- a/packages/core/src/utils/openai/index.ts
+++ b/packages/core/src/utils/openai/index.ts
@@ -1,4 +1,4 @@
-import { getCurrentScope } from '../../currentScopes';
+import { getClient } from '../../currentScopes';
 import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { SPAN_STATUS_ERROR } from '../../tracing';
@@ -19,13 +19,11 @@ import {
   GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE,
   GEN_AI_SYSTEM_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
-import { OPENAI_INTEGRATION_NAME } from './constants';
 import { instrumentStream } from './streaming';
 import type {
   ChatCompletionChunk,
   InstrumentedMethod,
   OpenAiChatCompletionObject,
-  OpenAiIntegration,
   OpenAiOptions,
   OpenAiResponse,
   OpenAIResponseObject,
@@ -198,18 +196,6 @@ function addRequestAttributes(span: Span, params: Record<string, unknown>): void
   }
 }
 
-function getOptionsFromIntegration(): OpenAiOptions {
-  const scope = getCurrentScope();
-  const client = scope.getClient();
-  const integration = client?.getIntegrationByName(OPENAI_INTEGRATION_NAME) as OpenAiIntegration | undefined;
-  const shouldRecordInputsAndOutputs = integration ? Boolean(client?.getOptions().sendDefaultPii) : false;
-
-  return {
-    recordInputs: integration?.options?.recordInputs ?? shouldRecordInputsAndOutputs,
-    recordOutputs: integration?.options?.recordOutputs ?? shouldRecordInputsAndOutputs,
-  };
-}
-
 /**
  * Instrument a method with Sentry spans
  * Following Sentry AI Agents Manual Instrumentation conventions
@@ -219,10 +205,9 @@ function instrumentMethod<T extends unknown[], R>(
   originalMethod: (...args: T) => Promise<R>,
   methodPath: InstrumentedMethod,
   context: unknown,
-  options?: OpenAiOptions,
+  options: OpenAiOptions,
 ): (...args: T) => Promise<R> {
   return async function instrumentedMethod(...args: T): Promise<R> {
-    const finalOptions = options || getOptionsFromIntegration();
     const requestAttributes = extractRequestAttributes(args, methodPath);
     const model = (requestAttributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE] as string) || 'unknown';
     const operationName = getOperationName(methodPath);
@@ -240,8 +225,8 @@ function instrumentMethod<T extends unknown[], R>(
         },
         async (span: Span) => {
           try {
-            if (finalOptions.recordInputs && args[0] && typeof args[0] === 'object') {
-              addRequestAttributes(span, args[0] as Record<string, unknown>);
+            if (options.recordInputs && params) {
+              addRequestAttributes(span, params);
             }
 
             const result = await originalMethod.apply(context, args);
@@ -249,7 +234,7 @@ function instrumentMethod<T extends unknown[], R>(
             return instrumentStream(
               result as OpenAIStream<ChatCompletionChunk | ResponseStreamingEvent>,
               span,
-              finalOptions.recordOutputs ?? false,
+              options.recordOutputs ?? false,
             ) as unknown as R;
           } catch (error) {
             // For streaming requests that fail before stream creation, we still want to record
@@ -279,12 +264,12 @@ function instrumentMethod<T extends unknown[], R>(
         },
         async (span: Span) => {
           try {
-            if (finalOptions.recordInputs && args[0] && typeof args[0] === 'object') {
-              addRequestAttributes(span, args[0] as Record<string, unknown>);
+            if (options.recordInputs && params) {
+              addRequestAttributes(span, params);
             }
 
             const result = await originalMethod.apply(context, args);
-            addResponseAttributes(span, result, finalOptions.recordOutputs);
+            addResponseAttributes(span, result, options.recordOutputs);
             return result;
           } catch (error) {
             captureException(error, {
@@ -307,7 +292,7 @@ function instrumentMethod<T extends unknown[], R>(
 /**
  * Create a deep proxy for OpenAI client instrumentation
  */
-function createDeepProxy<T extends object>(target: T, currentPath = '', options?: OpenAiOptions): T {
+function createDeepProxy<T extends object>(target: T, currentPath = '', options: OpenAiOptions): T {
   return new Proxy(target, {
     get(obj: object, prop: string): unknown {
       const value = (obj as Record<string, unknown>)[prop];
@@ -336,6 +321,13 @@ function createDeepProxy<T extends object>(target: T, currentPath = '', options?
  * Instrument an OpenAI client with Sentry tracing
  * Can be used across Node.js, Cloudflare Workers, and Vercel Edge
  */
-export function instrumentOpenAiClient<T extends object>(client: T, options?: OpenAiOptions): T {
-  return createDeepProxy(client, '', options);
+export function instrumentOpenAiClient<T extends object>(openAiClient: T, options?: OpenAiOptions): T {
+  const sendDefaultPii = Boolean(getClient()?.getOptions().sendDefaultPii);
+
+  const _options = {
+    recordInputs: sendDefaultPii,
+    recordOutputs: sendDefaultPii,
+    ...options,
+  };
+  return createDeepProxy(openAiClient, '', _options);
 }

--- a/packages/node/src/integrations/tracing/openai/index.ts
+++ b/packages/node/src/integrations/tracing/openai/index.ts
@@ -3,9 +3,9 @@ import { defineIntegration, OPENAI_INTEGRATION_NAME } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 import { SentryOpenAiInstrumentation } from './instrumentation';
 
-export const instrumentOpenAi = generateInstrumentOnce(
+export const instrumentOpenAi = generateInstrumentOnce<OpenAiOptions>(
   OPENAI_INTEGRATION_NAME,
-  () => new SentryOpenAiInstrumentation({}),
+  options => new SentryOpenAiInstrumentation(options),
 );
 
 const _openAiIntegration = ((options: OpenAiOptions = {}) => {
@@ -13,7 +13,7 @@ const _openAiIntegration = ((options: OpenAiOptions = {}) => {
     name: OPENAI_INTEGRATION_NAME,
     options,
     setupOnce() {
-      instrumentOpenAi();
+      instrumentOpenAi(options);
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/node/src/integrations/tracing/openai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/openai/instrumentation.ts
@@ -4,14 +4,12 @@ import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
 } from '@opentelemetry/instrumentation';
-import type { Integration, OpenAiClient, OpenAiOptions } from '@sentry/core';
-import { getClient, instrumentOpenAiClient, OPENAI_INTEGRATION_NAME, SDK_VERSION } from '@sentry/core';
+import type { OpenAiClient, OpenAiOptions } from '@sentry/core';
+import { getClient, instrumentOpenAiClient, SDK_VERSION } from '@sentry/core';
 
 const supportedVersions = ['>=4.0.0 <6'];
 
-export interface OpenAiIntegration extends Integration {
-  options: OpenAiOptions;
-}
+type OpenAiInstrumentationOptions = InstrumentationConfig & OpenAiOptions;
 
 /**
  * Represents the patched shape of the OpenAI module export.
@@ -22,22 +20,10 @@ interface PatchedModuleExports {
 }
 
 /**
- * Determines telemetry recording settings.
- */
-function determineRecordingSettings(
-  integrationOptions: OpenAiOptions | undefined,
-  defaultEnabled: boolean,
-): { recordInputs: boolean; recordOutputs: boolean } {
-  const recordInputs = integrationOptions?.recordInputs ?? defaultEnabled;
-  const recordOutputs = integrationOptions?.recordOutputs ?? defaultEnabled;
-  return { recordInputs, recordOutputs };
-}
-
-/**
  * Sentry OpenAI instrumentation using OpenTelemetry.
  */
-export class SentryOpenAiInstrumentation extends InstrumentationBase<InstrumentationConfig> {
-  public constructor(config: InstrumentationConfig = {}) {
+export class SentryOpenAiInstrumentation extends InstrumentationBase<OpenAiInstrumentationOptions> {
+  public constructor(config: OpenAiInstrumentationOptions = {}) {
     super('@sentry/instrumentation-openai', SDK_VERSION, config);
   }
 
@@ -54,15 +40,15 @@ export class SentryOpenAiInstrumentation extends InstrumentationBase<Instrumenta
    */
   private _patch(exports: PatchedModuleExports): PatchedModuleExports | void {
     const Original = exports.OpenAI;
+    const config = this.getConfig();
 
     const WrappedOpenAI = function (this: unknown, ...args: unknown[]) {
       const instance = Reflect.construct(Original, args);
       const client = getClient();
-      const integration = client?.getIntegrationByName<OpenAiIntegration>(OPENAI_INTEGRATION_NAME);
-      const integrationOpts = integration?.options;
       const defaultPii = Boolean(client?.getOptions().sendDefaultPii);
 
-      const { recordInputs, recordOutputs } = determineRecordingSettings(integrationOpts, defaultPii);
+      const recordInputs = config.recordInputs ?? defaultPii;
+      const recordOutputs = config.recordOutputs ?? defaultPii;
 
       return instrumentOpenAiClient(instance as OpenAiClient, {
         recordInputs,


### PR DESCRIPTION
This avoids looking up the integration for openai instrumentation, instead relying on this being passed in (which it already is). When manually instrumenting the client you need to pass in the options directly.

1. Node: Options are passed from the integration to instrumentOpenAiClient anyhow, so nothing changes
2. cloudflare/vercel-edge: There is no integration, users need to manually call instrumentOpenAiClient() and pass in the options anyhow (no integration to look anything up from exists there)

See also https://github.com/getsentry/sentry-javascript/pull/17694