### PR TITLE
ref(core): Streamline `module_metadata` assignment and cleanup functions

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -6,6 +6,7 @@ import { DEBUG_BUILD } from './debug-build';
 import { createEventEnvelope, createSessionEnvelope } from './envelope';
 import type { IntegrationIndex } from './integration';
 import { afterSetupIntegrations, setupIntegration, setupIntegrations } from './integration';
+import { stripMetadataFromStackFrames } from './metadata';
 import type { Scope } from './scope';
 import { updateSession } from './session';
 import {
@@ -1124,9 +1125,13 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
           throw _makeDoNotSendEventError(`${beforeSendLabel} returned \`null\`, will not send event.`);
         }
 
-        const session = currentScope.getSession() || isolationScope.getSession();
-        if (isError && session) {
-          this._updateSessionFromEvent(session, processedEvent);
+        if (isError) {
+          const session = currentScope.getSession() || isolationScope.getSession();
+          if (session) {
+            this._updateSessionFromEvent(session, processedEvent);
+          }
+
+          stripMetadataFromStackFrames(processedEvent);
         }
 
         if (isTransaction) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,7 +101,7 @@ export { functionToStringIntegration } from './integrations/functiontostring';
 export { inboundFiltersIntegration } from './integrations/eventFilters';
 export { eventFiltersIntegration } from './integrations/eventFilters';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
-export { moduleMetadataIntegration } from './integrations/metadata';
+export { moduleMetadataIntegration } from './integrations/moduleMetadata';
 export { requestDataIntegration } from './integrations/requestdata';
 export { captureConsoleIntegration } from './integrations/captureconsole';
 export { dedupeIntegration } from './integrations/dedupe';

--- a/packages/core/src/integrations/moduleMetadata.ts
+++ b/packages/core/src/integrations/moduleMetadata.ts
@@ -1,7 +1,5 @@
 import { defineIntegration } from '../integration';
-import { addMetadataToStackFrames, stripMetadataFromStackFrames } from '../metadata';
-import type { EventItem } from '../types-hoist/envelope';
-import { forEachEnvelopeItem } from '../utils/envelope';
+import { addMetadataToStackFrames } from '../metadata';
 
 /**
  * Adds module metadata to stack frames.
@@ -16,20 +14,6 @@ export const moduleMetadataIntegration = defineIntegration(() => {
   return {
     name: 'ModuleMetadata',
     setup(client) {
-      // We need to strip metadata from stack frames before sending them to Sentry since these are client side only.
-      client.on('beforeEnvelope', envelope => {
-        forEachEnvelopeItem(envelope, (item, type) => {
-          if (type === 'event') {
-            const event = Array.isArray(item) ? (item as EventItem)[1] : undefined;
-
-            if (event) {
-              stripMetadataFromStackFrames(event);
-              item[1] = event;
-            }
-          }
-        });
-      });
-
       client.on('applyFrameMetadata', event => {
         // Only apply stack frame metadata to error events
         if (event.type) {

--- a/packages/core/src/integrations/moduleMetadata.ts
+++ b/packages/core/src/integrations/moduleMetadata.ts
@@ -1,5 +1,7 @@
 import { defineIntegration } from '../integration';
-import { addMetadataToStackFrames } from '../metadata';
+import { addMetadataToStackFrames, stripMetadataFromStackFrames } from '../metadata';
+import type { EventItem } from '../types-hoist/envelope';
+import { forEachEnvelopeItem } from '../utils/envelope';
 
 /**
  * Adds module metadata to stack frames.
@@ -14,6 +16,20 @@ export const moduleMetadataIntegration = defineIntegration(() => {
   return {
     name: 'ModuleMetadata',
     setup(client) {
+      // We need to strip metadata from stack frames before sending them to Sentry since these are client side only.
+      client.on('beforeEnvelope', envelope => {
+        forEachEnvelopeItem(envelope, (item, type) => {
+          if (type === 'event') {
+            const event = Array.isArray(item) ? (item as EventItem)[1] : undefined;
+
+            if (event) {
+              stripMetadataFromStackFrames(event);
+              item[1] = event;
+            }
+          }
+        });
+      });
+
       client.on('applyFrameMetadata', event => {
         // Only apply stack frame metadata to error events
         if (event.type) {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -53,28 +53,19 @@ export function getMetadataForUrl(parser: StackParser, filename: string): any | 
  * Metadata is injected by the Sentry bundler plugins using the `_experiments.moduleMetadata` config option.
  */
 export function addMetadataToStackFrames(parser: StackParser, event: Event): void {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    event.exception!.values!.forEach(exception => {
-      if (!exception.stacktrace) {
+  event.exception?.values?.forEach(exception => {
+    exception.stacktrace?.frames?.forEach(frame => {
+      if (!frame.filename || frame.module_metadata) {
         return;
       }
 
-      for (const frame of exception.stacktrace.frames || []) {
-        if (!frame.filename || frame.module_metadata) {
-          continue;
-        }
+      const metadata = getMetadataForUrl(parser, frame.filename);
 
-        const metadata = getMetadataForUrl(parser, frame.filename);
-
-        if (metadata) {
-          frame.module_metadata = metadata;
-        }
+      if (metadata) {
+        frame.module_metadata = metadata;
       }
     });
-  } catch {
-    // To save bundle size we're just try catching here instead of checking for the existence of all the different objects.
-  }
+  });
 }
 
 /**

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -81,18 +81,9 @@ export function addMetadataToStackFrames(parser: StackParser, event: Event): voi
  * Strips metadata from stack frames.
  */
 export function stripMetadataFromStackFrames(event: Event): void {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    event.exception!.values!.forEach(exception => {
-      if (!exception.stacktrace) {
-        return;
-      }
-
-      for (const frame of exception.stacktrace.frames || []) {
-        delete frame.module_metadata;
-      }
+  event.exception?.values?.forEach(exception => {
+    exception.stacktrace?.frames?.forEach(frame => {
+      delete frame.module_metadata;
     });
-  } catch {
-    // To save bundle size we're just try catching here instead of checking for the existence of all the different objects.
-  }
+  });
 }


### PR DESCRIPTION
Quick PR to streamline the stack frame `module_metadata` property assignment (`addMetadataToStackFrames`) and cleanup (`stripMetadataFromStackFrames`) logic, since we can use optional chaining now without a bundle size hit from polyfilling. 

Originally went with moving the cleanup logic into the client but decided against it due to the bundle size hit (see comment).