### PR TITLE
fix(browser): Ensure idle span duration is adjusted when child spans are ignored

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans/init.js
@@ -1,0 +1,49 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    Sentry.browserTracingIntegration({
+      idleTimeout: 3000,
+      finalTimeout: 3000,
+      childSpanTimeout: 3000,
+    }),
+  ],
+  ignoreSpans: [/ignore/],
+  tracesSampleRate: 1,
+  debug: true,
+});
+
+const waitFor = time => new Promise(resolve => setTimeout(resolve, time));
+
+Sentry.startSpanManual(
+  {
+    name: 'take-me',
+  },
+  async span => {
+    await waitFor(500);
+    span.end();
+  },
+);
+
+Sentry.startSpanManual(
+  {
+    name: 'ignore-me',
+  },
+  async span => {
+    await waitFor(1500);
+    span.end();
+  },
+);
+
+Sentry.startSpanManual(
+  {
+    name: 'ignore-me-too',
+  },
+  async span => {
+    await waitFor(2500);
+    span.end();
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans/test.ts
@@ -1,0 +1,29 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../utils/fixtures';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../utils/helpers';
+
+sentryTest(
+  'adjusts the end timestamp of the root idle span if child spans are ignored',
+  async ({ getLocalTestUrl, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
+    const url = await getLocalTestUrl({ testDir: __dirname });
+    await page.goto(url);
+
+    const eventData = envelopeRequestParser(await pageloadRequestPromise);
+
+    const { start_timestamp: startTimestamp, timestamp: endTimestamp } = eventData;
+    const durationSeconds = endTimestamp! - startTimestamp!;
+
+    const spans = eventData.spans || [];
+
+    expect(durationSeconds).toBeGreaterThan(0);
+    expect(durationSeconds).toBeLessThan(1.5);
+
+    expect(spans.some(span => span.description === 'take-me')).toBe(true);
+    expect(spans.some(span => span.description?.includes('ignore-me'))).toBe(false);
+  },
+);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1347,6 +1347,7 @@ function processBeforeSend(
         if (droppedSpans) {
           client.recordDroppedEvent('before_send', 'span', droppedSpans);
         }
+
         processedEvent.spans = processedSpans;
       }
     }


### PR DESCRIPTION
This PR fixes a problem reported in https://github.com/getsentry/sentry-javascript/issues/17451 where ignoring spans in idle root spans (pageload and navigations most prominently) caused the root span duration to be perceived much longer than reasonable. This is only a problem for idle spans in browser, so this PR applies a pragmatic fix to adjust the end time stamp: 

We already adjust the time stamp when we end the idle span. So we might as well at this point take any to-be-removed-because-of-`ignoreSpans` spans out of this calculation. This should work well enough without throwing a bunch of idle-span specific logic into the client or completely changing the point in the event lifecycle where `ignoreSpans` is applied.

closes https://github.com/getsentry/sentry-javascript/issues/17451