### PR TITLE
build: Update to typescript 5.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "size-limit": "~11.1.6",
     "sucrase": "^3.35.0",
     "ts-node": "10.9.1",
-    "typescript": "~5.0.0",
+    "typescript": "~5.8.0",
     "vitest": "^3.2.4",
     "yalc": "^1.0.0-pre.53",
     "yarn-deduplicate": "6.0.2"

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -564,7 +564,9 @@ export function addProfileToGlobalCache(profile_id: string, profile: JSSelfProfi
   PROFILE_MAP.set(profile_id, profile);
 
   if (PROFILE_MAP.size > 30) {
-    const last: string = PROFILE_MAP.keys().next().value;
-    PROFILE_MAP.delete(last);
+    const last = PROFILE_MAP.keys().next().value;
+    if (last) {
+      PROFILE_MAP.delete(last);
+    }
   }
 }

--- a/packages/core/src/utils/lru.ts
+++ b/packages/core/src/utils/lru.ts
@@ -27,7 +27,10 @@ export class LRUMap<K, V> {
   public set(key: K, value: V): void {
     if (this._cache.size >= this._maxSize) {
       // keys() returns an iterator in insertion order so keys().next() gives us the oldest key
-      this._cache.delete(this._cache.keys().next().value);
+      const nextKey = this._cache.keys().next().value;
+      if (nextKey) {
+        this._cache.delete(nextKey);
+      }
     }
     this._cache.set(key, value);
   }

--- a/packages/nextjs/tsconfig.test.json
+++ b/packages/nextjs/tsconfig.test.json
@@ -9,6 +9,7 @@
 
     // require for top-level await
     "module": "Node16",
+    "moduleResolution": "Node16",
     "target": "es2017",
 
     // other package-specific, test-specific options

--- a/packages/node-core/tsconfig.json
+++ b/packages/node-core/tsconfig.json
@@ -5,6 +5,7 @@
 
   "compilerOptions": {
     "lib": ["es2018", "es2020.string"],
-    "module": "Node16"
+    "module": "Node16",
+    "moduleResolution": "Node16"
   }
 }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -5,6 +5,7 @@
 
   "compilerOptions": {
     "lib": ["es2018", "es2020.string"],
-    "module": "Node16"
+    "module": "Node16",
+    "moduleResolution": "Node16"
   }
 }

--- a/packages/nuxt/src/runtime/plugins/sentry-cloudflare.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry-cloudflare.server.ts
@@ -1,4 +1,3 @@
-import type { IncomingRequestCfProperties } from '@cloudflare/workers-types';
 import type { CloudflareOptions } from '@sentry/cloudflare';
 import { setAsyncLocalStorageAsyncContextStrategy, wrapRequestHandler } from '@sentry/cloudflare';
 import { debug, getDefaultIsolationScope, getIsolationScope, getTraceData } from '@sentry/core';
@@ -64,8 +63,9 @@ export const sentryCloudflareNitroPlugin =
           const request = new Request(url, {
             method: event.method,
             headers: event.headers,
+            // @ts-expect-error - 'cf' is a valid property in the RequestInit type for Cloudflare
             cf: getCfProperties(event),
-          }) as Request<unknown, IncomingRequestCfProperties<unknown>>;
+          });
 
           const requestHandlerOptions = {
             options: cloudflareOptions,

--- a/packages/pino-transport/tsconfig.json
+++ b/packages/pino-transport/tsconfig.json
@@ -5,6 +5,7 @@
 
   "compilerOptions": {
     "lib": ["es2018", "es2020.string"],
-    "module": "Node16"
+    "module": "Node16",
+    "moduleResolution": "Node16"
   }
 }

--- a/packages/remix/src/vendor/instrumentation.ts
+++ b/packages/remix/src/vendor/instrumentation.ts
@@ -310,11 +310,7 @@ export class RemixInstrumentation extends InstrumentationBase {
                   const { actionFormDataAttributes: actionFormAttributes } = plugin.getConfig();
 
                   formData.forEach((value: unknown, key: string) => {
-                    if (
-                      actionFormAttributes?.[key] &&
-                      actionFormAttributes[key] !== false &&
-                      typeof value === 'string'
-                    ) {
+                    if (actionFormAttributes?.[key] && typeof value === 'string') {
                       const keyName = actionFormAttributes[key] === true ? key : actionFormAttributes[key];
                       span.setAttribute(`formData.${keyName}`, value.toString());
                     }

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "nock": "^13.5.5",
-    "typescript": "~5.0.0"
+    "typescript": "~5.8.0"
   },
   "resolutions": {
     "@sentry/browser": "file:../../../browser",

--- a/packages/remix/tsconfig.test.json
+++ b/packages/remix/tsconfig.test.json
@@ -8,6 +8,7 @@
     "types": ["node"],
     // Required for top-level await in tests
     "module": "Node16",
+    "moduleResolution": "Node16",
     "target": "ES2017",
 
     "esModuleInterop": true

--- a/packages/sveltekit/src/worker/cloudflare.ts
+++ b/packages/sveltekit/src/worker/cloudflare.ts
@@ -39,7 +39,7 @@ export function initCloudflareSentryHandle(options: CloudflareOptions): Handle {
       return wrapRequestHandler(
         {
           options: opts,
-          request: event.request as Request<unknown, IncomingRequestCfProperties<unknown>>,
+          request: event.request,
           // @ts-expect-error This will exist in Cloudflare
           context: event.platform.context,
           // We don't want to capture errors here, as we want to capture them in the `sentryHandle` handler

--- a/packages/tanstackstart-react/tsconfig.json
+++ b/packages/tanstackstart-react/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "lib": ["es2018", "es2020.string"],
-    "module": "Node16"
+    "module": "Node16",
+    "moduleResolution": "Node16"
   }
 }

--- a/packages/tanstackstart/tsconfig.json
+++ b/packages/tanstackstart/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src/**/*"],
   "compilerOptions": {
     "lib": ["es2018", "es2020.string"],
-    "module": "Node16"
+    "module": "Node16",
+    "moduleResolution": "Node16"
   }
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -13,7 +13,7 @@
     "tsconfig.json"
   ],
   "peerDependencies": {
-    "typescript": "~5.0.0"
+    "typescript": "~5.8.0"
   },
   "scripts": {
     "clean": "yarn rimraf sentry-internal-typescript-*.tgz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29862,7 +29862,7 @@ typescript@4.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
-"typescript@>=3 < 6", typescript@^5.0.4, typescript@^5.4.4, typescript@^5.7.3:
+"typescript@>=3 < 6", typescript@^5.0.4, typescript@^5.4.4, typescript@^5.7.3, typescript@~5.8.0:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
@@ -29876,11 +29876,6 @@ typescript@next:
   version "5.2.0-dev.20230530"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.0-dev.20230530.tgz#4251ade97a9d8a86850c4d5c3c4f3e1cb2ccf52c"
   integrity sha512-bIoMajCZWzLB+pWwncaba/hZc6dRnw7x8T/fenOnP9gYQB/gc4xdm48AXp5SH5I/PvvSeZ/dXkUMtc8s8BiDZw==
-
-typescript@~5.0.0:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.39"


### PR DESCRIPTION
This updates the TS version we use to 5.8.0.

We still downlevel to 3.8 so this should not be breaking (even if we were to use newer features eventually), downlevel-dts will fail/or our tests anyhow if we use some features that cannot be downlevelled.