### PR TITLE
feta(nextjs)!: Flip default value for `useRunAfterProductionCompileHook` turbopack builds

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -507,7 +507,7 @@ export type SentryBuildOptions = {
    *
    * When false, use the traditional approach of uploading sourcemaps during each webpack build. For Turbopack no sourcemaps will be uploaded.
    *
-   * @default false
+   * @default true for Turbopack, false for Webpack
    */
   useRunAfterProductionCompileHook?: boolean;
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -294,7 +294,11 @@ function getFinalConfigObject(
     }
   }
 
-  if (userSentryOptions?.useRunAfterProductionCompileHook === true && supportsProductionCompileHook()) {
+  // If not explicitly set, turbopack uses the runAfterProductionCompile hook (as there are no alternatives), webpack does not.
+  const shouldUseRunAfterProductionCompileHook =
+    userSentryOptions?.useRunAfterProductionCompileHook ?? (isTurbopack ? true : false);
+
+  if (shouldUseRunAfterProductionCompileHook && supportsProductionCompileHook()) {
     if (incomingUserNextConfigObject?.compiler?.runAfterProductionCompile === undefined) {
       incomingUserNextConfigObject.compiler ??= {};
       incomingUserNextConfigObject.compiler.runAfterProductionCompile = async ({ distDir }) => {
@@ -379,7 +383,7 @@ function getFinalConfigObject(
             releaseName,
             routeManifest,
             nextJsVersion,
-            useRunAfterProductionCompileHook: userSentryOptions?.useRunAfterProductionCompileHook,
+            useRunAfterProductionCompileHook: shouldUseRunAfterProductionCompileHook,
           }),
     ...(isTurbopackSupported && isTurbopack
       ? {

--- a/packages/nextjs/test/config/withSentryConfig.test.ts
+++ b/packages/nextjs/test/config/withSentryConfig.test.ts
@@ -872,15 +872,73 @@ describe('withSentryConfig', () => {
       expect(finalConfig.compiler?.runAfterProductionCompile).toBeInstanceOf(Function);
     });
 
+    it('defaults to true for turbopack when useRunAfterProductionCompileHook is not specified', () => {
+      process.env.TURBOPACK = '1';
+      vi.spyOn(util, 'getNextjsVersion').mockReturnValue('15.4.1');
+      vi.spyOn(util, 'supportsProductionCompileHook').mockReturnValue(true);
+
+      const sentryOptions = {}; // No useRunAfterProductionCompileHook specified
+
+      const finalConfig = materializeFinalNextConfig(exportedNextConfig, undefined, sentryOptions);
+
+      expect(finalConfig.compiler?.runAfterProductionCompile).toBeInstanceOf(Function);
+
+      delete process.env.TURBOPACK;
+    });
+
+    it('defaults to false for webpack when useRunAfterProductionCompileHook is not specified', () => {
+      delete process.env.TURBOPACK;
+      vi.spyOn(util, 'supportsProductionCompileHook').mockReturnValue(true);
+
+      const sentryOptions = {}; // No useRunAfterProductionCompileHook specified
+
+      const cleanConfig = { ...exportedNextConfig };
+      delete cleanConfig.compiler;
+
+      const finalConfig = materializeFinalNextConfig(cleanConfig, undefined, sentryOptions);
+
+      expect(finalConfig.compiler?.runAfterProductionCompile).toBeUndefined();
+    });
+
+    it('respects explicit false setting for turbopack', () => {
+      process.env.TURBOPACK = '1';
+      vi.spyOn(util, 'getNextjsVersion').mockReturnValue('15.4.1');
+      vi.spyOn(util, 'supportsProductionCompileHook').mockReturnValue(true);
+
+      const sentryOptions = {
+        useRunAfterProductionCompileHook: false,
+      };
+
+      const cleanConfig = { ...exportedNextConfig };
+      delete cleanConfig.compiler;
+
+      const finalConfig = materializeFinalNextConfig(cleanConfig, undefined, sentryOptions);
+
+      expect(finalConfig.compiler?.runAfterProductionCompile).toBeUndefined();
+
+      delete process.env.TURBOPACK;
+    });
+
+    it('respects explicit true setting for webpack', () => {
+      delete process.env.TURBOPACK;
+      vi.spyOn(util, 'supportsProductionCompileHook').mockReturnValue(true);
+
+      const sentryOptions = {
+        useRunAfterProductionCompileHook: true,
+      };
+
+      const finalConfig = materializeFinalNextConfig(exportedNextConfig, undefined, sentryOptions);
+
+      expect(finalConfig.compiler?.runAfterProductionCompile).toBeInstanceOf(Function);
+    });
+
     it('works with turbopack builds when TURBOPACK env is set', () => {
       process.env.TURBOPACK = '1';
       vi.spyOn(util, 'getNextjsVersion').mockReturnValue('15.4.1');
       vi.spyOn(util, 'supportsProductionCompileHook').mockReturnValue(true);
 
       const sentryOptions = {
-        _experimental: {
-          useRunAfterProductionCompileHook: true,
-        },
+        useRunAfterProductionCompileHook: true,
       };
 
       const finalConfig = materializeFinalNextConfig(exportedNextConfig, undefined, sentryOptions);
@@ -895,9 +953,7 @@ describe('withSentryConfig', () => {
       vi.spyOn(util, 'supportsProductionCompileHook').mockReturnValue(true);
 
       const sentryOptions = {
-        _experimental: {
-          useRunAfterProductionCompileHook: true,
-        },
+        useRunAfterProductionCompileHook: true,
       };
 
       const finalConfig = materializeFinalNextConfig(exportedNextConfig, undefined, sentryOptions);


### PR DESCRIPTION
This PR flips the default value for `useRunAfterProductionCompileHook` when using `next build --turbopack` from `false` to `true`.

Technically this is behaviourally breaking but since we'll release this together with https://github.com/getsentry/sentry-javascript/pull/17721, which promotes the flag from experimental state we can ship this without a new major.



