### PR TITLE
test(node): Avoid using specific port for node-integration-tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario.mjs
@@ -2,8 +2,6 @@ import Anthropic from '@anthropic-ai/sdk';
 import * as Sentry from '@sentry/node';
 import express from 'express';
 
-const PORT = 3333;
-
 function startMockAnthropicServer() {
   const app = express();
   app.use(express.json());
@@ -50,7 +48,7 @@ function startMockAnthropicServer() {
       },
     });
   });
-  return app.listen(PORT);
+  return app.listen();
 }
 
 async function run() {
@@ -59,7 +57,7 @@ async function run() {
   await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
     const client = new Anthropic({
       apiKey: 'mock-api-key',
-      baseURL: `http://localhost:${PORT}/anthropic`,
+      baseURL: `http://localhost:${server.address().port}/anthropic`,
     });
 
     // First test: basic message completion

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/scenario.mjs
@@ -2,8 +2,6 @@ import { GoogleGenAI } from '@google/genai';
 import * as Sentry from '@sentry/node';
 import express from 'express';
 
-const PORT = 3333;
-
 function startMockGoogleGenAIServer() {
   const app = express();
   app.use(express.json());
@@ -39,7 +37,7 @@ function startMockGoogleGenAIServer() {
     });
   });
 
-  return app.listen(PORT);
+  return app.listen();
 }
 
 async function run() {
@@ -48,7 +46,7 @@ async function run() {
   await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
     const client = new GoogleGenAI({
       apiKey: 'mock-api-key',
-      httpOptions: { baseUrl: `http://localhost:${PORT}` },
+      httpOptions: { baseUrl: `http://localhost:${server.address().port}` },
     });
 
     // Test 1: chats.create and sendMessage flow

--- a/dev-packages/node-integration-tests/suites/tracing/openai/scenario-root-span.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/scenario-root-span.mjs
@@ -1,8 +1,6 @@
 import express from 'express';
 import OpenAI from 'openai';
 
-const PORT = 3333;
-
 function startMockOpenAiServer() {
   const app = express();
   app.use(express.json());
@@ -31,14 +29,14 @@ function startMockOpenAiServer() {
       },
     });
   });
-  return app.listen(PORT);
+  return app.listen();
 }
 
 async function run() {
   const server = startMockOpenAiServer();
 
   const client = new OpenAI({
-    baseURL: `http://localhost:${PORT}/openai`,
+    baseURL: `http://localhost:${server.address().port}/openai`,
     apiKey: 'mock-api-key',
   });
 


### PR DESCRIPTION
This may flake, so just using any available port instead.