### PR TITLE
feat(replay/logs): Only attach sampled replay Ids to logs

### DIFF
--- a/packages/core/src/logs/internal.ts
+++ b/packages/core/src/logs/internal.ts
@@ -151,8 +151,10 @@ export function _INTERNAL_captureLog(
   setLogAttribute(processedLogAttributes, 'sentry.sdk.name', name);
   setLogAttribute(processedLogAttributes, 'sentry.sdk.version', version);
 
-  const replay = client.getIntegrationByName<Integration & { getReplayId: () => string }>('Replay');
-  setLogAttribute(processedLogAttributes, 'sentry.replay_id', replay?.getReplayId());
+  const replay = client.getIntegrationByName<Integration & { getReplayId: (onlyIfSampled?: boolean) => string }>(
+    'Replay',
+  );
+  setLogAttribute(processedLogAttributes, 'sentry.replay_id', replay?.getReplayId(true));
 
   const beforeLogMessage = beforeLog.message;
   if (isParameterizedString(beforeLogMessage)) {

--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -280,13 +280,16 @@ export class Replay implements Integration {
 
   /**
    * Get the current session ID.
+   *
+   * @param onlyIfSampled - If true, will only return the session ID if the session is sampled.
+   *
    */
-  public getReplayId(): string | undefined {
+  public getReplayId(onlyIfSampled?: boolean): string | undefined {
     if (!this._replay?.isEnabled()) {
       return;
     }
 
-    return this._replay.getSessionId();
+    return this._replay.getSessionId(onlyIfSampled);
   }
 
   /**

--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -719,8 +719,15 @@ export class ReplayContainer implements ReplayContainerInterface {
     this._debouncedFlush.cancel();
   }
 
-  /** Get the current session (=replay) ID */
-  public getSessionId(): string | undefined {
+  /** Get the current session (=replay) ID
+   *
+   * @param onlyIfSampled - If true, will only return the session ID if the session is sampled.
+   */
+  public getSessionId(onlyIfSampled?: boolean): string | undefined {
+    if (onlyIfSampled && this.session?.sampled === false) {
+      return undefined;
+    }
+
     return this.session?.id;
   }
 

--- a/packages/replay-internal/test/integration/getReplayId.test.ts
+++ b/packages/replay-internal/test/integration/getReplayId.test.ts
@@ -30,4 +30,113 @@ describe('Integration | getReplayId', () => {
 
     expect(integration.getReplayId()).toBeUndefined();
   });
+
+  describe('onlyIfSampled parameter', () => {
+    it('returns replay ID for session mode when onlyIfSampled=true', async () => {
+      const { integration, replay } = await mockSdk({
+        replayOptions: {
+          stickySession: true,
+        },
+      });
+
+      // Should be in session mode by default with sessionSampleRate: 1.0
+      expect(replay.recordingMode).toBe('session');
+      expect(replay.session?.sampled).toBe('session');
+
+      expect(integration.getReplayId(true)).toBeDefined();
+      expect(integration.getReplayId(true)).toEqual(replay.session?.id);
+    });
+
+    it('returns replay ID for buffer mode when onlyIfSampled=true', async () => {
+      const { integration, replay } = await mockSdk({
+        replayOptions: {
+          stickySession: true,
+        },
+        sentryOptions: {
+          replaysSessionSampleRate: 0.0,
+          replaysOnErrorSampleRate: 1.0,
+        },
+      });
+
+      // Force buffer mode by manually setting session
+      if (replay.session) {
+        replay.session.sampled = 'buffer';
+        replay.recordingMode = 'buffer';
+      }
+
+      expect(integration.getReplayId(true)).toBeDefined();
+      expect(integration.getReplayId(true)).toEqual(replay.session?.id);
+    });
+
+    it('returns undefined for unsampled sessions when onlyIfSampled=true', async () => {
+      const { integration, replay } = await mockSdk({
+        replayOptions: {
+          stickySession: true,
+        },
+        sentryOptions: {
+          replaysSessionSampleRate: 1.0, // Start enabled to create session
+          replaysOnErrorSampleRate: 0.0,
+        },
+      });
+
+      // Manually create an unsampled session by overriding the existing one
+      replay.session = {
+        id: 'test-unsampled-session',
+        started: Date.now(),
+        lastActivity: Date.now(),
+        segmentId: 0,
+        sampled: false,
+      };
+
+      expect(integration.getReplayId(true)).toBeUndefined();
+      // But default behavior should still return the ID
+      expect(integration.getReplayId()).toBe('test-unsampled-session');
+      expect(integration.getReplayId(false)).toBe('test-unsampled-session');
+    });
+
+    it('maintains backward compatibility when onlyIfSampled is not provided', async () => {
+      const { integration, replay } = await mockSdk({
+        replayOptions: {
+          stickySession: true,
+        },
+        sentryOptions: {
+          replaysSessionSampleRate: 1.0, // Start with a session to ensure initialization
+          replaysOnErrorSampleRate: 0.0,
+        },
+      });
+
+      const testCases: Array<{ sampled: 'session' | 'buffer' | false; sessionId: string }> = [
+        { sampled: 'session', sessionId: 'session-test-id' },
+        { sampled: 'buffer', sessionId: 'buffer-test-id' },
+        { sampled: false, sessionId: 'unsampled-test-id' },
+      ];
+
+      for (const { sampled, sessionId } of testCases) {
+        replay.session = {
+          id: sessionId,
+          started: Date.now(),
+          lastActivity: Date.now(),
+          segmentId: 0,
+          sampled,
+        };
+
+        // Default behavior should always return the ID
+        expect(integration.getReplayId()).toBe(sessionId);
+      }
+    });
+
+    it('returns undefined when replay is disabled regardless of onlyIfSampled', async () => {
+      const { integration } = await mockSdk({
+        replayOptions: {
+          stickySession: true,
+        },
+      });
+
+      integration.stop();
+
+      expect(integration.getReplayId()).toBeUndefined();
+      expect(integration.getReplayId(true)).toBeUndefined();
+      expect(integration.getReplayId(false)).toBeUndefined();
+    });
+  });
 });

--- a/packages/replay-internal/test/unit/getSessionId.test.ts
+++ b/packages/replay-internal/test/unit/getSessionId.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Session } from '../../src/types';
+import { setupReplayContainer } from '../utils/setupReplayContainer';
+
+describe('Unit | ReplayContainer | getSessionId', () => {
+  it('returns session ID when session exists', () => {
+    const replay = setupReplayContainer();
+    const mockSession: Session = {
+      id: 'test-session-id',
+      started: Date.now(),
+      lastActivity: Date.now(),
+      segmentId: 0,
+      sampled: 'session',
+    };
+    replay.session = mockSession;
+
+    expect(replay.getSessionId()).toBe('test-session-id');
+  });
+
+  it('returns undefined when no session exists', () => {
+    const replay = setupReplayContainer();
+    replay.session = undefined;
+
+    expect(replay.getSessionId()).toBeUndefined();
+  });
+
+  describe('onlyIfSampled parameter', () => {
+    it('returns session ID for sampled=session when onlyIfSampled=true', () => {
+      const replay = setupReplayContainer();
+      const mockSession: Session = {
+        id: 'test-session-id',
+        started: Date.now(),
+        lastActivity: Date.now(),
+        segmentId: 0,
+        sampled: 'session',
+      };
+      replay.session = mockSession;
+
+      expect(replay.getSessionId(true)).toBe('test-session-id');
+    });
+
+    it('returns session ID for sampled=buffer when onlyIfSampled=true', () => {
+      const replay = setupReplayContainer();
+      const mockSession: Session = {
+        id: 'test-session-id',
+        started: Date.now(),
+        lastActivity: Date.now(),
+        segmentId: 0,
+        sampled: 'buffer',
+      };
+      replay.session = mockSession;
+
+      expect(replay.getSessionId(true)).toBe('test-session-id');
+    });
+
+    it('returns undefined for sampled=false when onlyIfSampled=true', () => {
+      const replay = setupReplayContainer();
+      const mockSession: Session = {
+        id: 'test-session-id',
+        started: Date.now(),
+        lastActivity: Date.now(),
+        segmentId: 0,
+        sampled: false,
+      };
+      replay.session = mockSession;
+
+      expect(replay.getSessionId(true)).toBeUndefined();
+    });
+
+    it('returns session ID for sampled=false when onlyIfSampled=false (default)', () => {
+      const replay = setupReplayContainer();
+      const mockSession: Session = {
+        id: 'test-session-id',
+        started: Date.now(),
+        lastActivity: Date.now(),
+        segmentId: 0,
+        sampled: false,
+      };
+      replay.session = mockSession;
+
+      expect(replay.getSessionId()).toBe('test-session-id');
+      expect(replay.getSessionId(false)).toBe('test-session-id');
+    });
+
+    it('returns undefined when no session exists regardless of onlyIfSampled', () => {
+      const replay = setupReplayContainer();
+      replay.session = undefined;
+
+      expect(replay.getSessionId(true)).toBeUndefined();
+      expect(replay.getSessionId(false)).toBeUndefined();
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('maintains existing behavior when onlyIfSampled is not provided', () => {
+      const replay = setupReplayContainer();
+
+      // Test with different sampling states
+      const testCases: Array<{ sampled: Session['sampled']; expected: string | undefined }> = [
+        { sampled: 'session', expected: 'test-session-id' },
+        { sampled: 'buffer', expected: 'test-session-id' },
+        { sampled: false, expected: 'test-session-id' },
+      ];
+
+      testCases.forEach(({ sampled, expected }) => {
+        const mockSession: Session = {
+          id: 'test-session-id',
+          started: Date.now(),
+          lastActivity: Date.now(),
+          segmentId: 0,
+          sampled,
+        };
+        replay.session = mockSession;
+
+        expect(replay.getSessionId()).toBe(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds an option to `getSessionId` and `getSessionId` to only return a value if the replay is sampled.

ref https://github.com/getsentry/sentry-javascript/issues/17676

