### PR TITLE
fix(core): Prevent `instrumentAnthropicAiClient` breaking MessageStream api

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
@@ -152,6 +152,30 @@ describe('Anthropic integration', () => {
         origin: 'auto.ai.anthropic',
         status: 'ok',
       }),
+      // Fifth span - messages.create with stream: true
+      expect.objectContaining({
+        data: expect.objectContaining({
+          'gen_ai.operation.name': 'messages',
+          'gen_ai.request.model': 'claude-3-haiku-20240307',
+          'gen_ai.request.stream': true,
+        }),
+        description: 'messages claude-3-haiku-20240307 stream-response',
+        op: 'gen_ai.messages',
+        origin: 'auto.ai.anthropic',
+        status: 'ok',
+      }),
+      // Sixth span - messages.stream
+      expect.objectContaining({
+        data: expect.objectContaining({
+          'gen_ai.operation.name': 'messages',
+          'gen_ai.request.model': 'claude-3-haiku-20240307',
+          'gen_ai.request.stream': true,
+        }),
+        description: 'messages claude-3-haiku-20240307 stream-response',
+        op: 'gen_ai.messages',
+        origin: 'auto.ai.anthropic',
+        status: 'ok',
+      }),
     ]),
   };
 
@@ -189,6 +213,21 @@ describe('Anthropic integration', () => {
     ]),
   };
 
+  const EXPECTED_MODEL_ERROR = {
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: '404 Model not found',
+        },
+      ],
+    },
+  };
+
+  const EXPECTED_STREAM_EVENT_HANDLER_MESSAGE = {
+    message: 'stream event from user-added event listener captured',
+  };
+
   createEsmAndCjsTests(__dirname, 'scenario-manual-client.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates anthropic related spans when manually insturmenting client', async () => {
       await createRunner()
@@ -202,8 +241,9 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates anthropic related spans with sendDefaultPii: false', async () => {
       await createRunner()
-        .ignore('event')
+        .expect({ event: EXPECTED_MODEL_ERROR })
         .expect({ transaction: EXPECTED_TRANSACTION_DEFAULT_PII_FALSE })
+        .expect({ event: EXPECTED_STREAM_EVENT_HANDLER_MESSAGE })
         .start()
         .completed();
     });
@@ -212,8 +252,9 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates anthropic related spans with sendDefaultPii: true', async () => {
       await createRunner()
-        .ignore('event')
+        .expect({ event: EXPECTED_MODEL_ERROR })
         .expect({ transaction: EXPECTED_TRANSACTION_DEFAULT_PII_TRUE })
+        .expect({ event: EXPECTED_STREAM_EVENT_HANDLER_MESSAGE })
         .start()
         .completed();
     });
@@ -222,8 +263,9 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-options.mjs', (createRunner, test) => {
     test('creates anthropic related spans with custom options', async () => {
       await createRunner()
-        .ignore('event')
+        .expect({ event: EXPECTED_MODEL_ERROR })
         .expect({ transaction: EXPECTED_TRANSACTION_WITH_OPTIONS })
+        .expect({ event: EXPECTED_STREAM_EVENT_HANDLER_MESSAGE })
         .start()
         .completed();
     });

--- a/packages/core/src/utils/anthropic-ai/index.ts
+++ b/packages/core/src/utils/anthropic-ai/index.ts
@@ -226,7 +226,6 @@ function instrumentMethod<T extends unknown[], R>(
               const messageStream = target.apply(context, args);
               return instrumentStream(messageStream, span, options.recordOutputs ?? false);
             } catch (error) {
-              span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
               captureException(error, {
                 mechanism: {
                   handled: false,
@@ -236,7 +235,12 @@ function instrumentMethod<T extends unknown[], R>(
                   },
                 },
               });
-              span.end();
+
+              if (span.isRecording()) {
+                span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+                span.end();
+              }
+
               throw error;
             }
           },

--- a/packages/core/src/utils/anthropic-ai/index.ts
+++ b/packages/core/src/utils/anthropic-ai/index.ts
@@ -210,8 +210,6 @@ function instrumentMethod<T extends unknown[], R>(
       const isStreamingMethod = methodPath === 'messages.stream';
 
       if (isStreamRequested || isStreamingMethod) {
-        const messageStream = target.apply(context, args);
-
         // Create span for instrumentation using startSpanManual
         return startSpanManual(
           {
@@ -225,6 +223,7 @@ function instrumentMethod<T extends unknown[], R>(
                 addPrivateRequestAttributes(span, params);
               }
 
+              const messageStream = target.apply(context, args);
               return instrumentStream(messageStream, span, options.recordOutputs ?? false);
             } catch (error) {
               span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });

--- a/packages/core/src/utils/anthropic-ai/streaming.ts
+++ b/packages/core/src/utils/anthropic-ai/streaming.ts
@@ -15,7 +15,7 @@ import type { AnthropicAiStreamingEvent } from './types';
 /**
  * State object used to accumulate information from a stream of Anthropic AI events.
  */
-export interface StreamingState {
+interface StreamingState {
   /** Collected response text fragments (for output recording). */
   responseTexts: string[];
   /** Reasons for finishing the response, as reported by the API. */
@@ -182,7 +182,7 @@ function handleContentBlockStop(event: AnthropicAiStreamingEvent, state: Streami
  * @param recordOutputs - Whether to record outputs
  * @param span - The span to update
  */
-export function processEvent(
+function processEvent(
   event: AnthropicAiStreamingEvent,
   state: StreamingState,
   recordOutputs: boolean,
@@ -210,7 +210,7 @@ export function processEvent(
 /**
  * Finalizes span attributes when stream processing completes
  */
-export function finalizeStreamSpan(state: StreamingState, span: Span, recordOutputs: boolean): void {
+function finalizeStreamSpan(state: StreamingState, span: Span, recordOutputs: boolean): void {
   // Set common response attributes if available
   if (state.responseId) {
     span.setAttributes({

--- a/packages/core/src/utils/anthropic-ai/streaming.ts
+++ b/packages/core/src/utils/anthropic-ai/streaming.ts
@@ -211,6 +211,10 @@ function processEvent(
  * Finalizes span attributes when stream processing completes
  */
 function finalizeStreamSpan(state: StreamingState, span: Span, recordOutputs: boolean): void {
+  if (!span.isRecording()) {
+    return;
+  }
+
   // Set common response attributes if available
   if (state.responseId) {
     span.setAttributes({
@@ -254,9 +258,7 @@ function finalizeStreamSpan(state: StreamingState, span: Span, recordOutputs: bo
     });
   }
 
-  if (span.isRecording()) {
-    span.end();
-  }
+  span.end();
 }
 
 /**

--- a/packages/core/src/utils/anthropic-ai/streaming.ts
+++ b/packages/core/src/utils/anthropic-ai/streaming.ts
@@ -254,7 +254,9 @@ function finalizeStreamSpan(state: StreamingState, span: Span, recordOutputs: bo
     });
   }
 
-  span.end();
+  if (span.isRecording()) {
+    span.end();
+  }
 }
 
 /**
@@ -289,14 +291,17 @@ export function instrumentStream<R extends { on: (...args: unknown[]) => void }>
   });
 
   stream.on('error', (error: unknown) => {
-    span.setStatus({ code: SPAN_STATUS_ERROR, message: 'stream_error' });
     captureException(error, {
       mechanism: {
         handled: false,
         type: 'auto.ai.anthropic.stream_error',
       },
     });
-    span.end();
+
+    if (span.isRecording()) {
+      span.setStatus({ code: SPAN_STATUS_ERROR, message: 'stream_error' });
+      span.end();
+    }
   });
 
   return stream;


### PR DESCRIPTION
Previously, we completely walked over anthropic's SDK and replaced `message.stream` with our own method that returns an async generator. This breaks the SDK as `MessageStream` has further user callable api, such as adding event handlers.

This fix proxies `message.stream` instead of replacing it with our own method. Instead of returning an async generator, we now hook into various events to do our instrumentation.

Streams requested via `stream: true` are expected to return async generators, so the current approach still holds, the only change is that we proxy instead of overwrite.

Fixes: #17734