### PR TITLE
test(e2e): Pin `import-in-the-middle@1.14.2` due to `@vercel/nft` incompatibility

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/package.json
@@ -23,5 +23,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "import-in-the-middle": "1.14.2"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
@@ -29,7 +29,8 @@
     "overrides": {
       "nitropack": "2.10.0",
       "ofetch": "1.4.0",
-      "@vercel/nft": "0.29.4"
+      "@vercel/nft": "0.29.4",
+      "import-in-the-middle": "1.14.2"
     }
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/package.json
@@ -24,5 +24,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "import-in-the-middle": "1.14.2"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
@@ -34,5 +34,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "import-in-the-middle": "1.14.2"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
@@ -34,5 +34,10 @@
         "label": "nuxt-4 (canary)"
       }
     ]
+  },
+  "pnpm": {
+    "overrides": {
+      "import-in-the-middle": "1.14.2"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/package.json
@@ -34,5 +34,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "import-in-the-middle": "1.14.2"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/package.json
@@ -34,5 +34,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "import-in-the-middle": "1.14.2"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/package.json
@@ -34,5 +34,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "import-in-the-middle": "1.14.2"
+    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart/package.json
@@ -34,5 +34,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "import-in-the-middle": "1.14.2"
+    }
   }
 }


### PR DESCRIPTION
This PR unblocks our CI which pas failing because:

- Nuxt and SolidStart rely on nitro which relies on on `@vercel/nft`
- `import-in-the-middle` received a [bug fix ](https://github.com/nodejs/import-in-the-middle/pull/205/files) which mixes `require` and `import` statements in `hooks.mjs`. This was released [in `1.14.3`](https://github.com/nodejs/import-in-the-middle/releases/tag/import-in-the-middle-v1.14.3)
- Apparently, nft can't trace modules that use both, `import` and `require` statements, so the `require`'d `hooks.js` file is not added to the subset of modules nft returns (we're working on a minimal reproduction and bug report for nft)

As a result, we have to pin IITM to the version before the bugfix (`1.14.2`) until either IITM reverts the fix or NFT releases a fix. The terrible part about this though is that users have to do the same thing for now and there's nothing we can do besides documenting to add an override for IITM. 

Being a JS developer is fun they said...