### PR TITLE
Revert "test(e2e): Pin `import-in-the-middle@1.14.2` due to `@vercel/nft` incompatibility (#17777)"

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/package.json
@@ -23,10 +23,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "import-in-the-middle": "1.14.2"
-    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
@@ -29,8 +29,7 @@
     "overrides": {
       "nitropack": "2.10.0",
       "ofetch": "1.4.0",
-      "@vercel/nft": "0.29.4",
-      "import-in-the-middle": "1.14.2"
+      "@vercel/nft": "0.29.4"
     }
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/package.json
@@ -24,10 +24,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "import-in-the-middle": "1.14.2"
-    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
@@ -34,10 +34,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "import-in-the-middle": "1.14.2"
-    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
@@ -34,10 +34,5 @@
         "label": "nuxt-4 (canary)"
       }
     ]
-  },
-  "pnpm": {
-    "overrides": {
-      "import-in-the-middle": "1.14.2"
-    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/package.json
@@ -34,10 +34,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "import-in-the-middle": "1.14.2"
-    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/package.json
@@ -34,10 +34,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "import-in-the-middle": "1.14.2"
-    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/package.json
@@ -34,10 +34,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "import-in-the-middle": "1.14.2"
-    }
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart/package.json
@@ -34,10 +34,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "import-in-the-middle": "1.14.2"
-    }
   }
 }


### PR DESCRIPTION
Should be good to revert #17777 since [IITM 1.14.4](https://github.com/nodejs/import-in-the-middle/releases/tag/import-in-the-middle-v1.14.4) was released