### PR TITLE
fix(nestjs): Add support for Symbol as event name

### DIFF
--- a/packages/nestjs/test/integrations/nest.test.ts
+++ b/packages/nestjs/test/integrations/nest.test.ts
@@ -75,17 +75,72 @@ describe('Nest', () => {
 
         await descriptor.value();
 
-        expect(core.startSpan).toHaveBeenCalled();
+        expect(core.startSpan).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'event test.event',
+          }),
+          expect.any(Function),
+        );
         expect(originalHandler).toHaveBeenCalled();
       });
 
-      it('should wrap array event handlers', async () => {
+      it('should wrap symbol event handlers', async () => {
+        const decorated = wrappedOnEvent(Symbol('test.event'));
+        decorated(mockTarget, 'testMethod', descriptor);
+
+        await descriptor.value();
+
+        expect(core.startSpan).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'event Symbol(test.event)',
+          }),
+          expect.any(Function),
+        );
+        expect(originalHandler).toHaveBeenCalled();
+      });
+
+      it('should wrap string array event handlers', async () => {
         const decorated = wrappedOnEvent(['test.event1', 'test.event2']);
         decorated(mockTarget, 'testMethod', descriptor);
 
         await descriptor.value();
 
-        expect(core.startSpan).toHaveBeenCalled();
+        expect(core.startSpan).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'event test.event1,test.event2',
+          }),
+          expect.any(Function),
+        );
+        expect(originalHandler).toHaveBeenCalled();
+      });
+
+      it('should wrap symbol array event handlers', async () => {
+        const decorated = wrappedOnEvent([Symbol('test.event1'), Symbol('test.event2')]);
+        decorated(mockTarget, 'testMethod', descriptor);
+
+        await descriptor.value();
+
+        expect(core.startSpan).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'event Symbol(test.event1),Symbol(test.event2)',
+          }),
+          expect.any(Function),
+        );
+        expect(originalHandler).toHaveBeenCalled();
+      });
+
+      it('should wrap mixed type array event handlers', async () => {
+        const decorated = wrappedOnEvent([Symbol('test.event1'), 'test.event2', Symbol('test.event3')]);
+        decorated(mockTarget, 'testMethod', descriptor);
+
+        await descriptor.value();
+
+        expect(core.startSpan).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'event Symbol(test.event1),test.event2,Symbol(test.event3)',
+          }),
+          expect.any(Function),
+        );
         expect(originalHandler).toHaveBeenCalled();
       });
 


### PR DESCRIPTION
The `@OnEvent` decorator accepts the following types for its argument:

```typescript
string | symbol | Array<string | symbol>
```

If a Symbol is included in an array, the code to get the eventName will throw a TypeError (String(event)) This occurs because JavaScript’s
Array.prototype.join internally calls ToString on each array element. Per the specification, ToString(Symbol) is not allowed and results in a TypeError.

To avoid this issue, do not rely on String(array) or .join() on arrays containing symbols directly. Instead, explicitly convert each element to a string while handling symbols safely.

I couldn't find a way to test adding multiple `@OnEvent` so the second part can be tested. It didn't have any tests before (as far as I can tell), but would be nice to add them.

doc: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.join
doc: https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tostring

