### PR TITLE
chore: Add `publish_release` command

### DIFF
--- a/.cursor/commands/publish_release.md
+++ b/.cursor/commands/publish_release.md
@@ -1,0 +1,5 @@
+# Release Command
+
+Execute the standard Sentry JavaScript SDK release process.
+
+Find the "publishing_release" rule in `.cursor/rules/publishing_release` and follow those complete instructions step by step.

--- a/docs/publishing-a-release.md
+++ b/docs/publishing-a-release.md
@@ -4,6 +4,8 @@ _These steps are only relevant to Sentry employees when preparing and publishing
 
 These have also been documented via [Cursor Rules](../.cursor/rules/publishing-release.mdc).
 
+You can run a pre-configured command in cursor by just typing `/publish_release` into the chat window to automate the steps below.
+
 **If you want to release a new SDK for the first time, be sure to follow the
 [New SDK Release Checklist](./new-sdk-release-checklist.md)**
 


### PR DESCRIPTION
This will enable just executing `/publish_release` within a cursor chat for creating a new release.

https://cursor.com/docs/agent/chat/commands 👀 