### PR TITLE
fix(react): Do not send additional navigation span on pageload

### DIFF
--- a/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
+++ b/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
@@ -567,6 +567,13 @@ export function handleNavigation(opts: {
     return;
   }
 
+  // Avoid starting a navigation span on initial load when a pageload root span is active.
+  // This commonly happens when lazy routes resolve during the first render and React Router emits a POP.
+  const activeRootSpan = getActiveRootSpan();
+  if (activeRootSpan && spanToJSON(activeRootSpan).op === 'pageload' && navigationType === 'POP') {
+    return;
+  }
+
   if ((navigationType === 'PUSH' || navigationType === 'POP') && branches) {
     const [name, source] = resolveRouteNameAndSource(
       location,


### PR DESCRIPTION
The React Router instrumentation created an additional `navigation` span on `pageload`.

On initial load, the lazy route has the history action `POP` and state `idle`. This leads to the generation of a `navigation` span.

I added a condition to early-return from `handleNavigation` if a page load is going on.

Closes issue (in Linear) https://linear.app/getsentry/issue/FE-551/configure-react-router-for-fully-parameterized-routes-with-sentry