### PR TITLE
docs: Reword changelog for google gen ai integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Work in this release was contributed by @Karibash. Thank you for your contributi
 
 - **feat(cloudflare,vercel-edge): Add support for Google Gen AI instrumentation ([#17723](https://github.com/getsentry/sentry-javascript/pull/17723))**
 
-  The SDK now supports manually instrumenting Google's Generative AI operations in Cloudflare Workers and Vercel Edge Runtime environments, providing insights into your AI operations. You can use `const wrappedClient = Sentry.instrumentGoogleGenAIClient(genAiClient)` to get an instrumented client.
+  The SDK now supports manually instrumenting Google's Gen AI operations in Cloudflare Workers and Vercel Edge Runtime environments, providing insights into your AI operations. You can use `const wrappedClient = Sentry.instrumentGoogleGenAIClient(genAiClient)` to get an instrumented client.
 
 ### Other Changes
 


### PR DESCRIPTION
`GoogleGenerativeAI` could be mistaken for a different SDK, and the package name is also incorrect. It’s best to refer to this as the Google Gen AI SDK, as described in the official documentation: https://cloud.google.com/vertex-ai/generative-ai/docs/sdks/overview
.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CHANGELOG wording to use "Google Gen AI", rename `GoogleGenerativeAI` to `GoogleGenAI`, and correct package from `@google/generative-ai` to `@google/genai`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 872d22384fe4de09ab42072a24a68bf43cc941da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->