### PR TITLE
fix(nextjs): Don't use chalk in turbopack config file

### DIFF
--- a/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
+++ b/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
@@ -1,5 +1,4 @@
 import { debug } from '@sentry/core';
-import * as chalk from 'chalk';
 import type { RouteManifest } from '../manifest/types';
 import type { NextConfigObject, TurbopackMatcherWithRule, TurbopackOptions } from '../types';
 import { generateValueInjectionRules } from './generateValueInjectionRules';
@@ -57,9 +56,7 @@ export function safelyAddTurbopackRule(
   // If the rule already exists, we don't want to mess with it.
   if (existingRules[matcher]) {
     debug.log(
-      `${chalk.cyan(
-        'info',
-      )} - Turbopack rule already exists for ${matcher}. Please remove it from your Next.js config in order for Sentry to work properly.`,
+      `[@sentry/nextjs] - Turbopack rule already exists for ${matcher}. Please remove it from your Next.js config in order for Sentry to work properly.`,
     );
     return existingRules;
   }


### PR DESCRIPTION
We don't know yet why but this config code seems to be evaluated once at runtime for some users when using turbopack. The chalk import breaks with `Failed to load external module @sentry/nextjs: Error [ERR_REQUIRE_ESM]`.
Just getting rid of this import for now to not break apps.

We're still investigating together with Vercel why this this code gets pulled in.

closes https://github.com/getsentry/sentry-javascript/issues/17691


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the chalk import and replaces the colored debug message with a plain "[@sentry/nextjs]"-prefixed string in Turbopack rule handling.
> 
> - **Next.js Turbopack config**:
>   - Remove `chalk` import from `packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts`.
>   - Replace `chalk`-based colored `debug.log` with a plain `"[@sentry/nextjs] - ..."` message in `safelyAddTurbopackRule`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9026ac4a88c80541cffc9d8d49b4a5ab2bcc369e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->