### PR TITLE
fix(core): Remove check and always respect ai.telemetry.functionId for Vercel AI gen spans

### DIFF
--- a/packages/core/src/utils/vercel-ai/index.ts
+++ b/packages/core/src/utils/vercel-ai/index.ts
@@ -178,9 +178,10 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
   span.setAttribute('ai.pipeline.name', nameWthoutAi);
   span.updateName(nameWthoutAi);
 
-  // If a Telemetry name is set and it is a pipeline span, use that as the operation name
+  // If a telemetry name is set and the span represents a pipeline, use it as the operation name.
+  // This name can be set at the request level by adding `experimental_telemetry.functionId`.
   const functionId = attributes[AI_TELEMETRY_FUNCTION_ID_ATTRIBUTE];
-  if (functionId && typeof functionId === 'string' && name.split('.').length - 1 === 1) {
+  if (functionId && typeof functionId === 'string') {
     span.updateName(`${nameWthoutAi} ${functionId}`);
     span.setAttribute('gen_ai.function_id', functionId);
   }


### PR DESCRIPTION
This PR fixes a mismatch between ai.telemetry.functionId and gen_ai.function_id. Function ids were ignored unless the span name contained exactly one dot. This caused:

- gen_ai.function_id to be missing or inconsistent for valid generation spans.
- Mismatch between ai.telemetry.functionId and gen_ai.function_id, making trace exploration and metrics harder to interpret.

We now always respect experimental_telemetry.functionId when present, where function id could be set as part of request. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always update Vercel AI generate span names and set `gen_ai.function_id` when `experimental_telemetry.functionId` is present, removing the dot-count check.
> 
> - **Core (Vercel AI span processing)**:
>   - In `packages/core/src/utils/vercel-ai/index.ts` `processGenerateSpan`:
>     - Remove `name.split('.')` dot-count check; always apply `experimental_telemetry.functionId`.
>     - When present, append function ID to the operation name and set `gen_ai.function_id`.
>     - Clarify comments on telemetry function ID usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b9fa48c29a9191c19494edfb6a1b827e0cf1ad2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->