### PR TITLE
ci: Do not run dependabot on e2e test applications

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,5 @@ updates:
       prefix: feat
       prefix-development: feat
       include: scope
+    exclude-paths:
+      - 'dev-packages/e2e-tests/test-applications/'


### PR DESCRIPTION
Not sure if this will also avoid these warnings from security alerts, but it's worth a try.