### PR TITLE
fix(nuxt): include `sentry.client.config.ts` in nuxt app types

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -82,7 +82,7 @@ export default defineNuxtModule<ModuleOptions>({
         // Add type references for useRuntimeConfig in root files for nuxt v4
         // Should be relative to `root/.nuxt`
         const relativePath = path.relative(nuxt.options.buildDir, clientConfigFile);
-        options.tsConfig.include.push(`../${relativePath}`);
+        options.tsConfig.include.push(relativePath);
       });
     }
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -73,13 +73,14 @@ export default defineNuxtModule<ModuleOptions>({
         order: 1,
       });
 
+      // Add the sentry config file to the include array
       nuxt.hook('prepare:types', options => {
-        // Add the sentry config file to the include array
         if (!options.tsConfig.include) {
           options.tsConfig.include = [];
         }
 
         // Add type references for useRuntimeConfig in root files for nuxt v4
+        // Should be relative to `root/.nuxt`
         options.tsConfig.include.push('../sentry.client.config.ts');
       });
     }

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -81,7 +81,8 @@ export default defineNuxtModule<ModuleOptions>({
 
         // Add type references for useRuntimeConfig in root files for nuxt v4
         // Should be relative to `root/.nuxt`
-        options.tsConfig.include.push('../sentry.client.config.ts');
+        const relativePath = path.relative(nuxt.options.buildDir, clientConfigFile);
+        options.tsConfig.include.push(`../${relativePath}`);
       });
     }
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -72,6 +72,16 @@ export default defineNuxtModule<ModuleOptions>({
         mode: 'client',
         order: 1,
       });
+
+      nuxt.hook('prepare:types', options => {
+        // Add the sentry config file to the include array
+        if (!options.tsConfig.include) {
+          options.tsConfig.include = [];
+        }
+
+        // Add type references for useRuntimeConfig in root files for nuxt v4
+        options.tsConfig.include.push('../sentry.client.config.ts');
+      });
     }
 
     const serverConfigFile = findDefaultSdkInitFile('server', nuxt);


### PR DESCRIPTION
# What

Fixes #17781 by adding the `sentry.config.client.ts` to the auto generated tsconfig by extending the types via the [`prepare:types` hook](https://nuxt.com/docs/4.x/guide/going-further/modules#adding-type-declarations).

This allows `useRuntimeConfig` to be properly typed in the root `sentry.client.config.ts`, or where ever the client file is found.

Not sure how this could be tested tho, since it is purely types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `prepare:types` hook to include the client Sentry config in Nuxt’s generated `tsconfig` for proper typing.
> 
> - **Nuxt module (`packages/nuxt/src/module.ts`)**:
>   - **Types setup**: Add `prepare:types` hook to ensure `tsconfig.include` contains the relative path to the detected client Sentry config (`sentry.client.config.ts`), enabling proper typing (e.g., `useRuntimeConfig`) in root config files for Nuxt v4.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4de6d439e42daa976492a95a5778772f747bf32b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->