### PR TITLE
add byte size limit and oldest first truncation for gen_ai messages

### DIFF
--- a/packages/core/src/utils/ai/messageTruncation.ts
+++ b/packages/core/src/utils/ai/messageTruncation.ts
@@ -1,0 +1,37 @@
+export function getByteSize(str: string): number {
+  return new TextEncoder().encode(str).length;
+}
+
+export function truncateMessagesByBytes(messages: unknown[], maxBytes: number): unknown[] {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return messages;
+  }
+
+  const messagesJson = JSON.stringify(messages);
+  const totalBytes = getByteSize(messagesJson);
+
+  if (totalBytes <= maxBytes) {
+    return messages;
+  }
+
+  let truncatedMessages = [...messages];
+
+  while (truncatedMessages.length > 0) {
+    const truncatedJson = JSON.stringify(truncatedMessages);
+    const truncatedBytes = getByteSize(truncatedJson);
+
+    if (truncatedBytes <= maxBytes) {
+      break;
+    }
+
+    truncatedMessages.shift();
+  }
+
+  return truncatedMessages;
+}
+
+export const DEFAULT_GEN_AI_MESSAGES_BYTE_LIMIT = 100000;
+
+export function truncateGenAiMessages(messages: unknown[]): unknown[] {
+  return truncateMessagesByBytes(messages, DEFAULT_GEN_AI_MESSAGES_BYTE_LIMIT);
+}

--- a/packages/core/src/utils/anthropic-ai/index.ts
+++ b/packages/core/src/utils/anthropic-ai/index.ts
@@ -23,6 +23,7 @@ import {
   GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE,
   GEN_AI_SYSTEM_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
+import { truncateGenAiMessages } from '../ai/messageTruncation';
 import { buildMethodPath, getFinalOperationName, getSpanOperation, setTokenUsageAttributes } from '../ai/utils';
 import { handleCallbackErrors } from '../handleCallbackErrors';
 import { instrumentAsyncIterableStream, instrumentMessageStream } from './streaming';
@@ -71,16 +72,16 @@ function extractRequestAttributes(args: unknown[], methodPath: string): Record<s
   return attributes;
 }
 
-/**
- * Add private request attributes to spans.
- * This is only recorded if recordInputs is true.
- */
 function addPrivateRequestAttributes(span: Span, params: Record<string, unknown>): void {
   if ('messages' in params) {
-    span.setAttributes({ [GEN_AI_REQUEST_MESSAGES_ATTRIBUTE]: JSON.stringify(params.messages) });
+    const messages = params.messages;
+    const truncatedMessages = truncateGenAiMessages(messages as unknown[]);
+    span.setAttributes({ [GEN_AI_REQUEST_MESSAGES_ATTRIBUTE]: JSON.stringify(truncatedMessages) });
   }
   if ('input' in params) {
-    span.setAttributes({ [GEN_AI_REQUEST_MESSAGES_ATTRIBUTE]: JSON.stringify(params.input) });
+    const input = params.input;
+    const truncatedInput = truncateGenAiMessages(input as unknown[]);
+    span.setAttributes({ [GEN_AI_REQUEST_MESSAGES_ATTRIBUTE]: JSON.stringify(truncatedInput) });
   }
   if ('prompt' in params) {
     span.setAttributes({ [GEN_AI_PROMPT_ATTRIBUTE]: JSON.stringify(params.prompt) });

--- a/packages/core/src/utils/openai/index.ts
+++ b/packages/core/src/utils/openai/index.ts
@@ -19,6 +19,7 @@ import {
   GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE,
   GEN_AI_SYSTEM_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
+import { truncateGenAiMessages } from '../ai/messageTruncation';
 import { OPENAI_INTEGRATION_NAME } from './constants';
 import { instrumentStream } from './streaming';
 import type {
@@ -188,13 +189,16 @@ function addResponseAttributes(span: Span, result: unknown, recordOutputs?: bool
   }
 }
 
-// Extract and record AI request inputs, if present. This is intentionally separate from response attributes.
 function addRequestAttributes(span: Span, params: Record<string, unknown>): void {
   if ('messages' in params) {
-    span.setAttributes({ [GEN_AI_REQUEST_MESSAGES_ATTRIBUTE]: JSON.stringify(params.messages) });
+    const messages = params.messages;
+    const truncatedMessages = truncateGenAiMessages(messages as unknown[]);
+    span.setAttributes({ [GEN_AI_REQUEST_MESSAGES_ATTRIBUTE]: JSON.stringify(truncatedMessages) });
   }
   if ('input' in params) {
-    span.setAttributes({ [GEN_AI_REQUEST_MESSAGES_ATTRIBUTE]: JSON.stringify(params.input) });
+    const input = params.input;
+    const truncatedInput = truncateGenAiMessages(input as unknown[]);
+    span.setAttributes({ [GEN_AI_REQUEST_MESSAGES_ATTRIBUTE]: JSON.stringify(truncatedInput) });
   }
 }
 


### PR DESCRIPTION
**Description:**

fixes: #17809

- Implements message truncation for `gen_ai.request.messages` and `vercel.ai.prompt` to prevent oversized payloads from exceeding ingestion limits.

**Changes:**
- Add `messageTruncation.ts` utility with byte size calculation and oldest-first truncation
- Apply truncation to all AI integrations (OpenAI, Google GenAI, Anthropic, Vercel AI)
- Set 100KB default limit for gen_ai messages
- Preserve recent message context by removing oldest messages first