### PR TITLE
docs: Update supported Angular version in README

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -16,7 +16,7 @@
 
 ## Angular Version Compatibility
 
-This SDK officially supports Angular 14 to 19.
+This SDK officially supports Angular 14 to 20.
 
 If you're using an older Angular version please check the
 [compatibility table in the docs](https://docs.sentry.io/platforms/javascript/guides/angular/#angular-version-compatibility).


### PR DESCRIPTION
Looking at: [This release](https://github.com/getsentry/sentry-javascript/releases/tag/9.24.0) Sentry's Angular package does support version 20.

But looking at the README we can see: 
>This SDK officially supports Angular 14 to 19.

I suggest to update the README to make it more clear that Angular 20 is supported.