### PR TITLE
chore(ci): Fix external contributor action when multiple contributions existed

### DIFF
--- a/dev-packages/external-contributor-gh-action/index.mjs
+++ b/dev-packages/external-contributor-gh-action/index.mjs
@@ -7,7 +7,7 @@ const UNRELEASED_HEADING = `## Unreleased
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 `;
 
-const contributorMessageRegex = /Work in this release was contributed by (.+)\. Thank you for your contribution!/;
+const contributorMessageRegex = /Work in this release was contributed by (.+)\. Thank you for your contributions?!/;
 
 async function run() {
   const { getInput } = core;


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/13335 added a plural `s` to the contribution message when multiple people contributed to the repo but the regex for the lookup lacks this.