### PR TITLE
fix(nextjs): handle webpack detection when using rspack

### DIFF
--- a/packages/nextjs/src/config/util.ts
+++ b/packages/nextjs/src/config/util.ts
@@ -163,6 +163,11 @@ export function detectActiveBundler(nextJsVersion: string | undefined): 'turbopa
     return 'webpack';
   }
 
+  // Explicit opt-in to webpack (using rspack) via environment variable
+  if (process.env.NEXT_RSPACK === 'true') {
+    return 'webpack';
+  }
+
   // Fallback to version-based default behavior
   if (nextJsVersion) {
     const turbopackIsDefault = isTurbopackDefaultForVersion(nextJsVersion);

--- a/packages/nextjs/test/config/util.test.ts
+++ b/packages/nextjs/test/config/util.test.ts
@@ -332,6 +332,7 @@ describe('util', () => {
       process.argv = [...originalArgv];
       process.env = { ...originalEnv };
       delete process.env.TURBOPACK;
+      delete process.env.NEXT_RSPACK;
     });
 
     afterEach(() => {
@@ -346,6 +347,11 @@ describe('util', () => {
 
     it('returns webpack when --webpack flag is present', () => {
       process.argv.push('--webpack');
+      expect(util.detectActiveBundler('16.0.0')).toBe('webpack');
+    });
+
+    it('returns webpack when NEXT_RSPACK env var is set', () => {
+      process.env.NEXT_RSPACK = 'true';
       expect(util.detectActiveBundler('16.0.0')).toBe('webpack');
     });
 
@@ -386,6 +392,12 @@ describe('util', () => {
     it('prioritizes TURBOPACK env var over --webpack flag', () => {
       process.env.TURBOPACK = '1';
       process.argv.push('--webpack');
+      expect(util.detectActiveBundler('15.5.0')).toBe('turbopack');
+    });
+
+    it('prioritizes TURBOPACK env var over NEXT_RSPACK env var', () => {
+      process.env.TURBOPACK = '1';
+      process.env.NEXT_RSPACK = 'true';
       expect(util.detectActiveBundler('15.5.0')).toBe('turbopack');
     });
   });


### PR DESCRIPTION
When using Rspack with Next.js, we need to make sure we resolve the active bundler to `webpack` and not `turbopack`. Next.js has similar logic for this [here](https://github.com/vercel/next.js/blob/bd1e86215c3100d0cb24dc0041d95d36725d3e21/packages/next-rspack/index.js#L3-L6). This fixes the issue described in https://github.com/getsentry/sentry-javascript/pull/17868#discussion_r2444255136.