### PR TITLE
fix(ember): Use updated version for `clean-css`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-classic/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/package.json
@@ -75,7 +75,8 @@
     "node": ">=18"
   },
   "resolutions": {
-    "@babel/traverse": "~7.25.9"
+    "@babel/traverse": "~7.25.9",
+    "clean-css": "^5.3.0"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
[Ember E2E tests fail](https://github.com/getsentry/sentry-javascript/actions/runs/18656635954/job/53191164591) with `util.isRegExp is not a function`. Apparently, this is a JSDoc/Node issue that was already resolved last year: https://github.com/jsdoc/jsdoc/issues/2126

It is happening since the tests run with Node 24.10.0 instead of 22.20.0. The `isRegExp` API was removed from Node, so I updated the `clean-css` package as it's mentioned in the error stack. However, it could be that we either need to update `ember-cli` or just downgrade the node version for this test.