### PR TITLE
fix(node): Add missing AI instrumentation functions imports

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -134,6 +134,9 @@ export {
   consoleIntegration,
   wrapMcpServerWithSentry,
   featureFlagsIntegration,
+  instrumentOpenAiClient,
+  instrumentGoogleGenAIClient,
+  instrumentAnthropicAiClient,
 } from '@sentry/core';
 
 export type {


### PR DESCRIPTION
Add missing AI instrumentation functions imports, sometimes we ask users to import the manual instrumentation function e.g when working with nextjs vercel edge runtime. 