### PR TITLE
test(hono): Fix hono e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8.31",
     "@cloudflare/workers-types": "^4.20250521.0",
+    "typescript": "^5.9.3",
     "vitest": "3.1.0",
     "wrangler": "4.22.0"
   },

--- a/dev-packages/e2e-tests/test-applications/cloudflare-hono/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-hono/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "lib": ["ESNext"],
     "jsx": "react-jsx",
+    "types": ["@cloudflare/workers-types/experimental"],
     "jsxImportSource": "hono/jsx"
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
ATM there are failing Hono E2E tests (e.g. [here](https://github.com/getsentry/sentry-javascript/actions/runs/18714106732/job/53370082672?pr=17998)), which print out following:

```sh
Error: src/index.ts(20,3): error TS2584: Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.
```

The reason was, that the types were not there yet. I just wonder why it was working before. In follow up PRs I will try to update Cloudflare tests with its integrations.