### PR TITLE
chore: Add required size_check for GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1168,6 +1168,7 @@ jobs:
         job_lint,
         job_check_format,
         job_circular_dep_check,
+        job_size_check,
       ]
     # Always run this, even if a dependent job failed
     if: always()


### PR DESCRIPTION
It seems that the size limit was not enforced and a PR could be merged without the job being green, see:

<img width="805" height="625" alt="Screenshot 2025-10-23 at 10 12 20" src="https://github.com/user-attachments/assets/c73054db-515e-41c8-b59c-a60617e3bc8a" />

