### PR TITLE
fix(core): Update client options to allow explicit `undefined`

### DIFF
--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -78,7 +78,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    *
    * @default undefined
    */
-  dsn?: string;
+  dsn?: string | undefined;
 
   /**
    * Sets the release. Release names are strings, but some formats are detected by Sentry and might be
@@ -88,7 +88,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    *
    * @default undefined
    */
-  release?: string;
+  release?: string | undefined;
 
   /**
    * The current environment of your application (e.g. "production").
@@ -98,7 +98,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    *
    * @default "production"
    */
-  environment?: string;
+  environment?: string | undefined;
 
   /**
    * Sets the distribution of the application. Distributions are used to disambiguate build or
@@ -106,7 +106,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    *
    * @default undefined
    */
-  dist?: string;
+  dist?: string | undefined;
 
   /**
    * List of integrations that should be installed after SDK was initialized.


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] ~If you've added code that should be tested, please add tests~.
- [x] ~Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`)~.

---

Currently with `exactOptionalPropertyTypes` enabled ([which is now the default for new TS projects](https://github.com/microsoft/TypeScript/pull/61813)) doing something like this is not allowed:

```
Sentry.init({
  dsn: process.env.SENTRY_DSN,
  environment: process.env.SENTRY_ENV ?? process.env.RAILS_ENV
});
```

as while `undefined` is supported, the types don't allow it as an explicit value.

It looks like this has come up before and Sentry is wanting to support it, though I'm not sure what ended up happening because [the end ticket got closed without any associated PR](https://github.com/getsentry/sentry-javascript/issues/4730).

I've purposely just opened this updating the client option properties that I think this feature is most commonly used with