### PR TITLE
chore(aws-serverless): Fix typo in timeout warning function name

### DIFF
--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -108,7 +108,7 @@ function enhanceScopeWithEnvironmentData(scope: Scope, context: Context, startTi
   });
 }
 
-function setupTimeoutWatning(context: Context, options: WrapperOptions): NodeJS.Timeout | undefined {
+function setupTimeoutWarning(context: Context, options: WrapperOptions): NodeJS.Timeout | undefined {
   // In seconds. You cannot go any more granular than this in AWS Lambda.
   const configuredTimeout = Math.ceil(tryGetRemainingTimeInMillis(context) / 1000);
   const configuredTimeoutMinutes = Math.floor(configuredTimeout / 60);
@@ -220,7 +220,7 @@ export function wrapHandler<TEvent, TResult>(
   return async (event: TEvent, context: Context) => {
     context.callbackWaitsForEmptyEventLoop = options.callbackWaitsForEmptyEventLoop;
 
-    timeoutWarningTimer = setupTimeoutWatning(context, options);
+    timeoutWarningTimer = setupTimeoutWarning(context, options);
 
     async function processResult(): Promise<TResult> {
       const scope = getCurrentScope();
@@ -272,7 +272,7 @@ function wrapStreamingHandler<TEvent, TResult>(
   ): Promise<TResult> => {
     context.callbackWaitsForEmptyEventLoop = options.callbackWaitsForEmptyEventLoop;
 
-    timeoutWarningTimer = setupTimeoutWatning(context, options);
+    timeoutWarningTimer = setupTimeoutWarning(context, options);
 
     async function processStreamingResult(): Promise<TResult> {
       const scope = getCurrentScope();


### PR DESCRIPTION
While exploring the Timeout Warning feature in `Sentry.wrapHandler`, I fount a type in the function name.
It seems `setupTimeoutWarning` was intended name, so I've corrected it accordingly.

## Changes
- Renamed `setupTimeoutWatning` → `setupTimeoutWarning`
- Updated all 3 call sites to use the corrected function name

## Checklist
- [x] Code lints successfully (`yarn lint`)
- [x] No new tests required (typo fix only, no functional changes)
