### PR TITLE
feat(core): Remove default value of `maxValueLength: 250`

### DIFF
--- a/packages/core/src/integrations/extraerrordata.ts
+++ b/packages/core/src/integrations/extraerrordata.ts
@@ -34,7 +34,7 @@ const _extraErrorDataIntegration = ((options: Partial<ExtraErrorDataOptions> = {
   return {
     name: INTEGRATION_NAME,
     processEvent(event, hint, client) {
-      const { maxValueLength = 250 } = client.getOptions();
+      const { maxValueLength } = client.getOptions();
       return _enhanceEventWithErrorData(event, hint, depth, captureErrorCause, maxValueLength);
     },
   };
@@ -47,7 +47,7 @@ function _enhanceEventWithErrorData(
   hint: EventHint = {},
   depth: number,
   captureErrorCause: boolean,
-  maxValueLength: number,
+  maxValueLength: number | undefined,
 ): Event {
   if (!hint.originalException || !isError(hint.originalException)) {
     return event;
@@ -85,7 +85,7 @@ function _enhanceEventWithErrorData(
 function _extractErrorData(
   error: ExtendedError,
   captureErrorCause: boolean,
-  maxValueLength: number,
+  maxValueLength: number | undefined,
 ): Record<string, unknown> | null {
   // We are trying to enhance already existing event, so no harm done if it won't succeed
   try {
@@ -109,7 +109,12 @@ function _extractErrorData(
         continue;
       }
       const value = error[key];
-      extraErrorInfo[key] = isError(value) || typeof value === 'string' ? truncate(`${value}`, maxValueLength) : value;
+      extraErrorInfo[key] =
+        isError(value) || typeof value === 'string'
+          ? maxValueLength
+            ? truncate(`${value}`, maxValueLength)
+            : `${value}`
+          : value;
     }
 
     // Error.cause is a standard property that is non enumerable, we therefore need to access it separately.

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -184,8 +184,6 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
 
   /**
    * Maximum number of chars a single value can have before it will be truncated.
-   *
-   * @default 250
    */
   maxValueLength?: number;
 

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -132,7 +132,7 @@ export function prepareEvent(
  * @param event event instance to be enhanced
  */
 export function applyClientOptions(event: Event, options: ClientOptions): void {
-  const { environment, release, dist, maxValueLength = 250 } = options;
+  const { environment, release, dist, maxValueLength } = options;
 
   // empty strings do not make sense for environment, release, and dist
   // so we handle them the same as if they were not provided
@@ -148,7 +148,7 @@ export function applyClientOptions(event: Event, options: ClientOptions): void {
 
   const request = event.request;
   if (request?.url) {
-    request.url = truncate(request.url, maxValueLength);
+    request.url = maxValueLength ? truncate(request.url, maxValueLength) : request.url;
   }
 }
 

--- a/packages/core/test/lib/integrations/extraerrordata.test.ts
+++ b/packages/core/test/lib/integrations/extraerrordata.test.ts
@@ -55,6 +55,27 @@ describe('ExtraErrorData()', () => {
     });
   });
 
+  it('should not truncate extra data without maxValueLength', () => {
+    const error = new TypeError('foo') as ExtendedError;
+    error.baz = 42;
+    error.foo = 'a'.repeat(300);
+
+    const enhancedEvent = extraErrorData.processEvent?.(
+      event,
+      {
+        originalException: error,
+      },
+      new TestClient(getDefaultTestClientOptions()),
+    ) as Event;
+
+    expect(enhancedEvent.contexts).toEqual({
+      TypeError: {
+        baz: 42,
+        foo: `${'a'.repeat(300)}`,
+      },
+    });
+  });
+
   it('should extract error data from the error cause with the same policy', () => {
     const error = new TypeError('foo') as ExtendedError;
     error.cause = new SyntaxError('bar') as ExtendedError;


### PR DESCRIPTION
The SDK should only truncate when really necessary on the client. Therefore, the default value of 250 is removed.

Part of https://github.com/getsentry/sentry-javascript/issues/17389
