### PR TITLE
feat(node): Add `maxCacheKeyLength` to Redis integration (remove truncation)

### DIFF
--- a/packages/cloudflare/src/handler.ts
+++ b/packages/cloudflare/src/handler.ts
@@ -1,11 +1,9 @@
 import {
   captureException,
-  continueTrace,
   flush,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  setHttpStatus,
   startSpan,
   withIsolationScope,
 } from '@sentry/core';

--- a/packages/node/src/integrations/tracing/redis.ts
+++ b/packages/node/src/integrations/tracing/redis.ts
@@ -33,6 +33,8 @@ interface RedisOptions {
   /**
    * Maximum length of the cache key added to the span description. If the key exceeds this length, it will be truncated.
    *
+   * Passing `0` will use the full cache key without truncation.
+   *
    * By default, the full cache key is used.
    */
   maxCacheKeyLength?: number;


### PR DESCRIPTION
This removes the automatic truncation of the span description. Now, all cache keys are set in the description.

part of https://github.com/getsentry/sentry-javascript/issues/17389