### PR TITLE
fix(tests): un-override nitro dep version for nuxt-3 test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
@@ -27,7 +27,6 @@
   },
   "pnpm": {
     "overrides": {
-      "nitropack": "2.10.0",
       "ofetch": "1.4.0",
       "@vercel/nft": "0.29.4"
     }


### PR DESCRIPTION
Nitro `2.10` was failing our tests due to 500 errors, logs didn't show anything about what was failing but removing the override which then makes it use nitro `2.12.9` makes the tests pass again.

I tried almost all releases from `2.10` to `2.12.8` and they all fail the tests due to timeouts, so only the very last release is the one working, I think we might have a deep dependency causing this, but for now this works for our tests.

Nitropack shouldn't even be part of user dependencies as it is determined by the Nuxt version accepted range.