### PR TITLE
test(node-core): Proof that withMonitor doesn't create a new trace

### DIFF
--- a/packages/node-core/test/integration/transactions.test.ts
+++ b/packages/node-core/test/integration/transactions.test.ts
@@ -9,6 +9,7 @@ describe('Integration | Transactions', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     cleanupOtel();
+    vi.useRealTimers();
   });
 
   it('correctly creates transaction & spans', async () => {


### PR DESCRIPTION
In #18029 the expectation is that the `withMonitor` is creating a new trace. Currently it is not reflected in the docs what is expected when `withMonitor` is executed. This test proofs that this is the case.