### PR TITLE
fix(vue): Make `options` parameter optional on `attachErrorHandler`

### DIFF
--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -4,7 +4,7 @@ import { formatComponentName, generateComponentTrace } from './vendor/components
 
 type UnknownFunc = (...args: unknown[]) => void;
 
-export const attachErrorHandler = (app: Vue, options: VueOptions): void => {
+export const attachErrorHandler = (app: Vue, options?: Partial<VueOptions>): void => {
   const { errorHandler: originalErrorHandler } = app.config;
 
   app.config.errorHandler = (error: Error, vm: ViewModel, lifecycleHook: string): void => {
@@ -16,7 +16,8 @@ export const attachErrorHandler = (app: Vue, options: VueOptions): void => {
       trace,
     };
 
-    if (options.attachProps && vm) {
+    // TODO(v11): guard via sendDefaultPii?
+    if (options?.attachProps !== false && vm) {
       // Vue2 - $options.propsData
       // Vue3 - $props
       if (vm.$options?.propsData) {

--- a/packages/vue/test/errorHandler.test.ts
+++ b/packages/vue/test/errorHandler.test.ts
@@ -112,6 +112,25 @@ describe('attachErrorHandler', () => {
               // assert
               t.expect.errorToHaveBeenCaptured().withProps(props);
             });
+
+            test('`propsData` is added, if no options are provided to `attachErrorHandler`', () => {
+              // arrange
+              const props = { stubProp: 'stubData' };
+              const t = testHarness({
+                vm: {
+                  $props: props,
+                },
+                optionsUndefined: true,
+              });
+
+              // act
+              vi.useFakeTimers();
+              expect(() => t.run()).toThrow(DummyError);
+              vi.runAllTimers();
+
+              // assert
+              t.expect.errorToHaveBeenCaptured().withProps(props);
+            });
           });
 
           describe('and `vm.$props` is defined', () => {
@@ -220,6 +239,7 @@ type TestHarnessOpts = {
   enableConsole?: boolean;
   silent?: boolean;
   attachProps?: boolean;
+  optionsUndefined?: boolean;
 };
 
 class DummyError extends Error {
@@ -236,6 +256,7 @@ const testHarness = ({
   enableErrorHandler,
   enableConsole,
   vm,
+  optionsUndefined = false,
 }: TestHarnessOpts) => {
   vi.useFakeTimers();
   const providedErrorHandlerSpy = vi.fn();
@@ -274,13 +295,15 @@ const testHarness = ({
   }
   /* eslint-enable no-global-assign */
 
-  const options: Options = {
-    attachProps: !!attachProps,
-    tracingOptions: {},
-    trackComponents: [],
-    timeout: 0,
-    hooks: [] as Operation[],
-  };
+  const options: Options | undefined = optionsUndefined
+    ? undefined
+    : {
+        attachProps: !!attachProps,
+        tracingOptions: {},
+        trackComponents: [],
+        timeout: 0,
+        hooks: [] as Operation[],
+      };
 
   return {
     run: () => {


### PR DESCRIPTION
Looks like our Vue documentation for how to [dynamically attach an errorHandler](https://docs.sentry.io/platforms/javascript/guides/vue/features/multiple-apps/#dynamic-initialization) to a Vue app advertised that `attachErrorHandler` can be called without having to specify options. Intuitively, this makes sense to me since the only option we actually read is `attachProps`. We can instead default this to true (just like in the main Vue init option) and make the `options` parameter optional. 

For v11, we should consider gating prop data attachment behind `sendDefaultPii`. I added a TODO to the code.

closes https://github.com/getsentry/sentry-javascript/issues/18060