### PR TITLE
fix(nuxt): Added top-level fallback exports

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -28,7 +28,8 @@
         "import": "./build/esm/index.server.js",
         "require": "./build/cjs/index.server.js"
       },
-      "import": "./build/esm/index.server.js"
+      "import": "./build/esm/index.server.js",
+      "require": "./build/cjs/index.server.js"
     },
     "./module": {
       "types": "./build/module/types.d.ts",


### PR DESCRIPTION
It seems that in some cases where an `environment` in Vite is set to something other than `node` or `browser`, it won't be able to figure out the correct import paths.

This PR ensures that when Vite (or other tools) can't determine the environment from "browser" or "node" conditions alone, then it falls back to the server bundle similar to what we do in Next.js.

In the issue's case it was set to `nuxt` or rather `vitest-environment-nuxt` which doesn't seem like a pattern to account for.

closes #18070