### PR TITLE
fix(nextjs): Delete css map files

### DIFF
--- a/packages/nextjs/src/config/getBuildPluginOptions.ts
+++ b/packages/nextjs/src/config/getBuildPluginOptions.ts
@@ -40,7 +40,7 @@ const FILE_PATTERNS = {
 } as const;
 
 // Source map file extensions to delete
-const SOURCEMAP_EXTENSIONS = ['*.js.map', '*.mjs.map', '*.cjs.map'] as const;
+const SOURCEMAP_EXTENSIONS = ['*.js.map', '*.mjs.map', '*.cjs.map', '*.css.map'] as const;
 
 type BuildTool = keyof typeof LOGGER_PREFIXES;
 

--- a/packages/nextjs/test/config/getBuildPluginOptions.test.ts
+++ b/packages/nextjs/test/config/getBuildPluginOptions.test.ts
@@ -308,6 +308,7 @@ describe('getBuildPluginOptions', () => {
         '/path/to/.next/static/**/*.js.map',
         '/path/to/.next/static/**/*.mjs.map',
         '/path/to/.next/static/**/*.cjs.map',
+        '/path/to/.next/static/**/*.css.map',
       ]);
     });
 
@@ -331,6 +332,7 @@ describe('getBuildPluginOptions', () => {
         '/path/to/.next/static/**/*.js.map',
         '/path/to/.next/static/**/*.mjs.map',
         '/path/to/.next/static/**/*.cjs.map',
+        '/path/to/.next/static/**/*.css.map',
       ]);
     });
 
@@ -355,6 +357,7 @@ describe('getBuildPluginOptions', () => {
         '/path/to/.next/static/**/*.js.map',
         '/path/to/.next/static/**/*.mjs.map',
         '/path/to/.next/static/**/*.cjs.map',
+        '/path/to/.next/static/**/*.css.map',
       ]);
     });
 
@@ -788,6 +791,7 @@ describe('getBuildPluginOptions', () => {
         `${complexPath}/static/**/*.js.map`,
         `${complexPath}/static/**/*.mjs.map`,
         `${complexPath}/static/**/*.cjs.map`,
+        `${complexPath}/static/**/*.css.map`,
       ]);
     });
   });


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/18125

We want to delete `*.map.css` files when `deleteSourcemapsAfterUpload` is enabled.