### PR TITLE
fix(nextjs): Avoid wrapping middleware files when in standalone mode

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -276,7 +276,7 @@ export function constructWebpackConfigFunction({
       });
 
       // Wrap middleware
-      const canWrapStandaloneMiddleware = userNextConfig.output !== 'standalone' || (major && major < 16);
+      const canWrapStandaloneMiddleware = userNextConfig.output !== 'standalone' || !major || major < 16;
       if ((userSentryOptions.autoInstrumentMiddleware ?? true) && canWrapStandaloneMiddleware) {
         newConfig.module.rules.unshift({
           test: isMiddlewareResource,


### PR DESCRIPTION
This PR attempts to fix #18001 by not wrapping the middleware files if Next.js 16 is the current version and is in standalone output mode which is the problematic scenario.

Investigation:

- Next.js renames `proxy` to `middleware` under the hood.
- By wrapping the middleware a `proxy.js` entry is produced in `middleware.js.nft.json` which wouldn't  be there otherwise, meaning if we don't wrap it then that entry doesn't get produced. So it seems like `@vercel/nft` is somehow adding the `proxy` file as a dependency of itself which fails to copy to the output directory because it was already copied and renamed to `proxy.js` or at least that is what I'm guessing is happening.

