### PR TITLE
chore(e2e): Pin `@embroider/addon-shim` to 1.10.0 for the e2e ember-embroider

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -68,5 +68,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "@embroider/addon-shim": "1.10.0"
+    }
   }
 }


### PR DESCRIPTION
See: https://github.com/embroider-build/embroider/issues/2609