### PR TITLE
ref(e2e-ember): Remove `@embroider/addon-shim` override

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -68,10 +68,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "@embroider/addon-shim": "1.10.0"
-    }
   }
 }


### PR DESCRIPTION
We needed the override because version 10.0.1 didn't have a valid package.json (https://github.com/embroider-build/embroider/issues/2609).

They released version 10.0.2 now.
