### PR TITLE
fix(node): `tracingChannel` export missing in older node versions

### DIFF
--- a/packages/node-core/src/integrations/pino.ts
+++ b/packages/node-core/src/integrations/pino.ts
@@ -1,4 +1,4 @@
-import { tracingChannel } from 'node:diagnostics_channel';
+import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { Integration, IntegrationFn, LogSeverityLevel } from '@sentry/core';
 import {
   _INTERNAL_captureLog,
@@ -122,8 +122,8 @@ const _pinoIntegration = defineIntegration((userOptions: DeepPartial<PinoOptions
         },
       });
 
-      const injectedChannel = tracingChannel('orchestrion:pino:pino-log');
-      const integratedChannel = tracingChannel('pino_asJson');
+      const injectedChannel = diagnosticsChannel.tracingChannel('orchestrion:pino:pino-log');
+      const integratedChannel = diagnosticsChannel.tracingChannel('pino_asJson');
 
       function onPinoStart(self: Pino, args: PinoHookArgs, result: PinoResult): void {
         if (!shouldTrackLogger(self)) {


### PR DESCRIPTION
I guess this got through CI because we test latest 18 rather than 18.0.0.

This breaks [some supported Electron versions](https://github.com/getsentry/sentry-electron/actions/runs/19306230917/job/55215745023) which are using >18.0.0 but <18.19.0. 

This wont have impacted almost anyone else because Otel requires 18.19.0!

```
[App] [    Main] App threw an error during load
[App] [    Main] file:///home/runner/work/sentry-electron/sentry-electron/test/e2e/dist/error-after-ready/node_modules/@sentry/node-core/build/esm/integrations/pino.js:1
[App] [    Main] import { tracingChannel } from 'node:diagnostics_channel';
[App] [    Main]          ^^^^^^^^^^^^^^
[App] [    Main] SyntaxError: The requested module 'node:diagnostics_channel' does not provide an export named 'tracingChannel'
[App] [    Main]     at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
[App] [    Main]     at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
[App] [    Main] A JavaScript error occurred in the main process
```