### PR TITLE
Fix spotlight config test assertion

### DIFF
--- a/packages/node-core/test/sdk/init.test.ts
+++ b/packages/node-core/test/sdk/init.test.ts
@@ -218,6 +218,10 @@ describe('init()', () => {
     });
 
     describe('spotlight configuration', () => {
+      afterEach(() => {
+        delete process.env.SENTRY_SPOTLIGHT;
+      });
+
       it('enables spotlight with default URL from `SENTRY_SPOTLIGHT` env variable (truthy value)', () => {
         process.env.SENTRY_SPOTLIGHT = 'true';
 


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Fixes a test failure where `process.env.SENTRY_SPOTLIGHT` was not cleaned up after a test, causing environment variable pollution for subsequent tests.

The failing test expected `spotlight: true` to resolve to `true`, but due to the lingering environment variable, it received the URL from `SENTRY_SPOTLIGHT` instead.

This PR adds an `afterEach` hook to the `spotlight configuration` describe block to ensure `process.env.SENTRY_SPOTLIGHT` is deleted after each test, preventing cross-test contamination.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f9696f9-3843-4420-b2e9-26aedf9b0e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f9696f9-3843-4420-b2e9-26aedf9b0e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

