### PR TITLE
ref(react-router): Deprecate ErrorBoundary exports

### DIFF
--- a/packages/react-router/src/client/index.ts
+++ b/packages/react-router/src/client/index.ts
@@ -3,13 +3,16 @@ export * from '@sentry/browser';
 export { init } from './sdk';
 export { reactRouterTracingIntegration } from './tracingIntegration';
 
-export {
-  captureReactException,
-  reactErrorHandler,
-  Profiler,
-  withProfiler,
-  useProfiler,
-  ErrorBoundary,
-  withErrorBoundary,
-} from '@sentry/react';
+export { captureReactException, reactErrorHandler, Profiler, withProfiler, useProfiler } from '@sentry/react';
+
+/**
+ * @deprecated ErrorBoundary is deprecated, use react router's error boundary instead.
+ * See https://docs.sentry.io/platforms/javascript/guides/react-router/#report-errors-from-error-boundaries
+ */
+export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
+
+/**
+ * @deprecated ErrorBoundaryProps and FallbackRender are deprecated, use react router's error boundary instead.
+ * See https://docs.sentry.io/platforms/javascript/guides/react-router/#report-errors-from-error-boundaries
+ */
 export type { ErrorBoundaryProps, FallbackRender } from '@sentry/react';


### PR DESCRIPTION
The ErrorBoundary exported in the SDK only works on the client and is not intended to be used.

Use react router's error boundary instead: https://docs.sentry.io/platforms/javascript/guides/react-router/#report-errors-from-error-boundaries.
