### PR TITLE
fix(v9/ember): Use updated version for `clean-css`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-classic/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/package.json
@@ -75,7 +75,8 @@
     "node": ">=18"
   },
   "resolutions": {
-    "@babel/traverse": "~7.25.9"
+    "@babel/traverse": "~7.25.9",
+    "clean-css": "^5.3.0"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Backport of #17979