### PR TITLE
fix(core): Check `fetch` support with data URL

### DIFF
--- a/packages/core/src/utils/supports.ts
+++ b/packages/core/src/utils/supports.ts
@@ -80,7 +80,8 @@ function _isFetchSupported(): boolean {
 
   try {
     new Headers();
-    new Request('http://www.example.com');
+    // Deno requires a valid URL so '' cannot be used as an argument
+    new Request('data:,');
     new Response();
     return true;
   } catch {


### PR DESCRIPTION
As Deno requires a valid URL when calling `new Request`, `example.com` was used but this caused problems. 

This PR changes it to a data URL as it does not rely on external dependencies and is a valid URL in Deno.

Fixes: https://github.com/getsentry/sentry-javascript/issues/18218

Previous PR for that: https://github.com/getsentry/sentry-javascript/pull/5630