### PR TITLE
chore: Fix missing changelog quote we use for attribution placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+
 - fix(node): Fix Spotlight configuration precedence to match specification (#18195)
 
 ## 10.25.0


### PR DESCRIPTION
Restores the office quote in our changelog. This quote acts as a placement marker for attribution and is needed by our action.

Alternatively, we could change our action but this is a long-standing quote and part of our culture :)