### PR TITLE
feat(core): Add `gibibyte` and `pebibyte` to `InformationUnit` type

### DIFF
--- a/packages/core/src/types-hoist/measurement.ts
+++ b/packages/core/src/types-hoist/measurement.ts
@@ -17,9 +17,11 @@ export type InformationUnit =
   | 'megabyte'
   | 'mebibyte'
   | 'gigabyte'
+  | 'gibibyte'
   | 'terabyte'
   | 'tebibyte'
   | 'petabyte'
+  | 'pebibyte'
   | 'exabyte'
   | 'exbibyte';
 


### PR DESCRIPTION
Both of these units are supported by Relay, see https://getsentry.github.io/relay/relay_metrics/enum.InformationUnit.html. 

(somewhat related to #18165. Happy to close if there's a reason why we didn't add them initially) 