### PR TITLE
chore(e2e): Bump zod in e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express-v5/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^18.19.1",
     "express": "^5.1.0",
     "typescript": "~5.0.0",
-    "zod": "~3.24.3"
+    "zod": "~3.25.0"
   },
   "devDependencies": {
     "@playwright/test": "~1.53.2",

--- a/dev-packages/e2e-tests/test-applications/node-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^18.19.1",
     "express": "^4.21.2",
     "typescript": "~5.0.0",
-    "zod": "~3.24.3"
+    "zod": "~3.25.0"
   },
   "devDependencies": {
     "@playwright/test": "~1.53.2",

--- a/dev-packages/e2e-tests/test-applications/tsx-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^18.19.1",
     "express": "^4.21.2",
     "typescript": "~5.0.0",
-    "zod": "~3.24.3"
+    "zod": "~3.25.0"
   },
   "devDependencies": {
     "@playwright/test": "~1.50.0",


### PR DESCRIPTION
The lower version is currently breaking our ci, the version lacks v3 exports that are used by `zod-to-json-schema`.