### PR TITLE
chore: Add `bump_otel_instrumentations` cursor command

### DIFF
--- a/.cursor/commands/bump_otel_instrumentations.md
+++ b/.cursor/commands/bump_otel_instrumentations.md
@@ -1,0 +1,32 @@
+# Bump OpenTelemetry instrumentations
+
+1. Ensure you're on the `develop` branch with the latest changes:
+   - If you have unsaved changes, stash them with `git stash -u`.
+   - If you're on a different branch than `develop`, check out the develop branch using `git checkout develop`.
+   - Pull the latest updates from the remote repository by running `git pull origin develop`.
+
+2. Create a new branch `bump-otel-{yyyy-mm-dd}`, e.g. `bump-otel-2025-03-03`
+
+3. Create a new empty commit with the commit message `feat(deps): Bump OpenTelemetry instrumentations`
+
+4. Push the branch and create a draft PR, note down the PR number as {PR_NUMBER}
+
+5. Create a changelog entry in `CHANGELOG.md` under
+   `- "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott` with the following format:
+   `- feat(deps): Bump OpenTelemetry instrumentations ([#{PR_NUMBER}](https://github.com/getsentry/sentry-javascript/pull/{PR_NUMBER}))`
+
+6. Find the "Upgrade OpenTelemetry instrumentations" rule in `.cursor/rules/upgrade_opentelemetry_instrumentations` and
+   follow those complete instructions step by step.
+   - Create one commit per package in `packages/**` with the commit message
+     `Bump OpenTelemetry instrumentations for {SDK}`, e.g. `Bump OpenTelemetry instrumentation for @sentry/node`
+
+   - For each OpenTelemetry dependency bump, record an entry in the changelog with the format indented under the main
+     entry created in step 5: `- Bump @opentelemetry/{instrumentation} from {previous_version} to {new_version}`, e.g.
+     `- Bump @opentelemetry/instrumentation from 0.204.0 to 0.207.0` **CRITICAL**: Avoid duplicated entries, e.g. if we
+     bump @opentelemetry/instrumentation in two packages, keep a single changelog entry.
+
+7. Regenerate the yarn lockfile and run `yarn yarn-deduplicate`
+
+8. Run `yarn fix` to fix all formatting issues
+
+9. Finally update the PR description to list all dependency bumps

--- a/.cursor/rules/upgrade_opentelemetry_instrumentations.mdc
+++ b/.cursor/rules/upgrade_opentelemetry_instrumentations.mdc
@@ -1,0 +1,33 @@
+---
+description: Use this rule if you are looking to grade OpenTelemetry instrumentations for the Sentry JavaScript SDKs
+globs: *
+alwaysApply: false
+---
+
+# Upgrading OpenTelemetry instrumentations
+
+1. For every package in packages/\*\*:
+   - When upgrading dependencies for OpenTelemetry instrumentations we need to first upgrade `@opentelemetry/instrumentation` to the latest version.
+     **CRITICAL**: `@opentelemetry/instrumentation` MUST NOT include any breaking changes.
+     Read through the changelog of `@opentelemetry/instrumentation` to figure out if breaking changes are included and fail with the reason if it does include breaking changes.
+     You can find the changelog at `https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/CHANGELOG.md`
+
+   - After successfully upgrading `@opentelemetry/instrumentation` upgrade all `@opentelemetry/instrumentation-{instrumentation}` packages, e.g. `@opentelemetry/instrumentation-pg`
+     **CRITICAL**: `@opentelemetry/instrumentation-{instrumentation}` MUST NOT include any breaking changes.
+     Read through the changelog of `@opentelemetry/instrumentation-{instrumentation}` to figure out if breaking changes are included and fail with the reason if it does including breaking changes.
+     You can find the changelogs at `https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/instrumentation-{instrumentation}/CHANGELOG.md`.
+
+   - Finally, upgrade third party instrumentations to their latest versions, these are currently:
+     - @prisma/instrumentation
+
+     **CRITICAL**: Upgrades to third party instrumentations MUST NOT include breaking changes.
+     Read through the changelog of each third party instrumentation to figure out if breaking changes are included and fail with the reason if it does include breaking changes.
+
+2. For packages and apps in dev-packages/\*\*:
+   - If an app depends on `@opentelemetry/instrumentation` >= 0.200.x upgrade it to the latest version.
+     **CRITICAL**: `@opentelemetry/instrumentation` MUST NOT include any breaking changes.
+
+   - If an app depends on `@opentelemetry/instrumentation-http` >= 0.200.x upgrade it to the latest version.
+     **CRITICAL**: `@opentelemetry/instrumentation-http` MUST NOT include any breaking changes.
+
+3. Generate a new yarn lock file.


### PR DESCRIPTION
Bumping OpenTelemetry instrumentations is an important but tedious task, all instrumentations have to be bumped in lockstep across the codebase. That includes easy to miss dev-packages and third party instrumentations like prisma's.

This command should make it easier to do that.

Example of a PR that was kicked off with this command: https://github.com/getsentry/sentry-javascript/pull/18239
