### PR TITLE
Revert "chore(deps): bump astro from 4.16.18 to 5.15.9 in /dev-packages/e2e-tests/test-applications/cloudflare-astro (#18259)"

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-astro/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-astro/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "8.1.0",
     "@sentry/astro": "latest || *",
-    "astro": "4.16.18"
+    "astro": "4.16.19"
   },
   "devDependencies": {
     "@astrojs/internal-helpers": "0.4.1"


### PR DESCRIPTION
I think the Astro 4 -> 5 bump broke the optional e2e test. This is really tricky to notice because the optional e2e tests don't run on dependabot PRs. 