### PR TITLE
doc(sveltekit): Update documentation link for SvelteKit guide

### DIFF
--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -25,7 +25,7 @@ functionality related to SvelteKit.
 ## Installation
 
 To get started installing the SDK, use the Sentry Next.js Wizard by running the following command in your terminal or
-read the [Getting Started Docs](https://docs.sentry.io/platforms/javascript/guides/nextjs/):
+read the [Getting Started Docs](https://docs.sentry.io/platforms/javascript/guides/sveltekit/):
 
 ```sh
 npx @sentry/wizard@latest -i sveltekit


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

The 'Getting Started Docs' for Sentry with SvelteKit was pointing at the Next.js guide. It's now updated to point at the correct guide.