### PR TITLE
feat(core): Use `maxValueLength` on error messages

### DIFF
--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -147,8 +147,17 @@ export function applyClientOptions(event: Event, options: ClientOptions): void {
   }
 
   const request = event.request;
-  if (request?.url) {
-    request.url = maxValueLength ? truncate(request.url, maxValueLength) : request.url;
+  if (request?.url && maxValueLength) {
+    request.url = truncate(request.url, maxValueLength);
+  }
+
+  if (maxValueLength) {
+    event.exception?.values?.forEach(exception => {
+      if (exception.value) {
+        // Truncates error messages
+        exception.value = truncate(exception.value, maxValueLength);
+      }
+    });
   }
 }
 

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -21,7 +21,6 @@ import type { ErrorEvent, Event, TransactionEvent } from '../../src/types-hoist/
 import type { SpanJSON } from '../../src/types-hoist/span';
 import * as debugLoggerModule from '../../src/utils/debug-logger';
 import * as miscModule from '../../src/utils/misc';
-import * as stringModule from '../../src/utils/string';
 import * as timeModule from '../../src/utils/time';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 import { AdHocIntegration, AsyncTestIntegration, TestIntegration } from '../mocks/integration';
@@ -37,7 +36,6 @@ const clientProcess = vi.spyOn(TestClient.prototype as any, '_process');
 
 vi.spyOn(miscModule, 'uuid4').mockImplementation(() => '12312012123120121231201212312012');
 vi.spyOn(debugLoggerModule, 'consoleSandbox').mockImplementation(cb => cb());
-vi.spyOn(stringModule, 'truncate').mockImplementation(str => str);
 vi.spyOn(timeModule, 'dateTimestampInSeconds').mockImplementation(() => 2020);
 
 describe('Client', () => {
@@ -259,6 +257,36 @@ describe('Client', () => {
             ],
           },
           timestamp: 2020,
+        }),
+      );
+    });
+
+    test('does not truncate exception values by default', () => {
+      const exceptionMessageLength = 10_000;
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
+      const client = new TestClient(options);
+
+      client.captureException(new Error('a'.repeat(exceptionMessageLength)));
+      expect(TestClient.instance!.event).toEqual(
+        expect.objectContaining({
+          exception: {
+            values: [{ type: 'Error', value: 'a'.repeat(exceptionMessageLength) }],
+          },
+        }),
+      );
+    });
+
+    test('truncates exception values according to `maxValueLength` option', () => {
+      const maxValueLength = 10;
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, maxValueLength });
+      const client = new TestClient(options);
+
+      client.captureException(new Error('a'.repeat(50)));
+      expect(TestClient.instance!.event).toEqual(
+        expect.objectContaining({
+          exception: {
+            values: [{ type: 'Error', value: `${'a'.repeat(maxValueLength)}...` }],
+          },
         }),
       );
     });


### PR DESCRIPTION
It can happen that error messages are too long and exceed the maximum envelope size (mentioned in https://github.com/getsentry/sentry-javascript/issues/18219). `maxValueLength` now also checks for long error messages and truncates them.