### PR TITLE
feat: Publish AWS Lambda Layer for Node 24

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -153,6 +153,7 @@ targets:
           - nodejs18.x
           - nodejs20.x
           - nodejs22.x
+          - nodejs24.x
     license: MIT
 
   # CDN Bundle Target


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/16058#issuecomment-3575525285

Node 24 is now supported: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported, we can publish.

I wish there was a better way to keep track of this, we kind of have to keep an eye on the above aws lambda runtime docs to know when exactly the release happens.