### PR TITLE
feat(core): add cloudflare flushing logic to core util

### DIFF
--- a/packages/core/src/utils/cloudflareWaitUntil.ts
+++ b/packages/core/src/utils/cloudflareWaitUntil.ts
@@ -10,13 +10,14 @@ export type MinimalCloudflareContext = {
  */
 function _getCloudflareContext(): MinimalCloudflareContext | undefined {
   const cfContextSymbol = Symbol.for('__cloudflare-context__');
-  const globalWithCfContext = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
-    [cfContextSymbol]?: {
-      ctx: MinimalCloudflareContext;
-    };
-  };
 
-  return globalWithCfContext[cfContextSymbol]?.ctx;
+  return (
+    GLOBAL_OBJ as typeof GLOBAL_OBJ & {
+      [cfContextSymbol]?: {
+        ctx: MinimalCloudflareContext;
+      };
+    }
+  )[cfContextSymbol]?.ctx;
 }
 
 /**

--- a/packages/core/src/utils/flushIfServerless.ts
+++ b/packages/core/src/utils/flushIfServerless.ts
@@ -59,7 +59,7 @@ export async function flushIfServerless(
   }
 
   if (isCloudflareWaitUntilAvailable()) {
-    // If the cloudflareWaitUntil function is available, use it to flush the events, if not then fallback to the regular flush
+    // If the cloudflareWaitUntil function is available, use it to flush the events
     cloudflareWaitUntil(flushWithTimeout(timeout));
     return;
   }


### PR DESCRIPTION
### 

I was working on investigating Next.js support on Cloudflare workers, and we aren't getting any traces or errors for a few reasons. One of the issues relevant to this PR is our flushing did not handle Cloudflare’s `waitUntil` unless passed explicitly.

This is not feasible within some platforms due to them abstracting away the handler entry away from the user (e.g: opennext).

So I dug around the runtime and found that it was possible to grab it via a symbol similar to `VercelWaitUntil`. The implementation here checks if it is available, and if it is, then it uses it.

This can be useful for many other SDKs as previously it was always required to pass the Cloudflare  from the context around.

_Note: that this doesn't fix the Next.js issues support completely as I still need to do some other fixes on the SDK level._

#### What I considered

- I considered [importing `waitUntil` from the `cloudflare:workers`](https://developers.cloudflare.com/changelog/2025-08-08-add-waituntil-cloudflare-workers/), but it is tricky to include at the core level as an external, and also very weird to include in other SDKs.
- Adding a wrapper around the Cloudflare opennext adapter to do this in Next.js SDK, but that's a larger effort that has a lot of DX implications, so I will leave that to another PR.