### PR TITLE
feat(cloudflare): Allow specifying a custom fetch in Cloudflare transport options

### DIFF
--- a/packages/cloudflare/src/transport.ts
+++ b/packages/cloudflare/src/transport.ts
@@ -2,6 +2,8 @@ import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, Tra
 import { createTransport, SENTRY_BUFFER_FULL_ERROR, suppressTracing } from '@sentry/core';
 
 export interface CloudflareTransportOptions extends BaseTransportOptions {
+  /** Custom fetch function to use. This allows usage of things like Workers VPC */
+  fetch?: typeof fetch;
   /** Fetch API init parameters. */
   fetchOptions?: RequestInit;
 }
@@ -87,7 +89,7 @@ export function makeCloudflareTransport(options: CloudflareTransportOptions): Tr
     };
 
     return suppressTracing(() => {
-      return fetch(options.url, requestOptions).then(response => {
+      return (options.fetch ?? fetch)(options.url, requestOptions).then(response => {
         return {
           statusCode: response.status,
           headers: {

--- a/packages/cloudflare/test/transport.test.ts
+++ b/packages/cloudflare/test/transport.test.ts
@@ -161,4 +161,20 @@ describe('IsolatedPromiseBuffer', () => {
     expect(task1).toHaveBeenCalled();
     expect(task2).toHaveBeenCalled();
   });
+
+  it('should allow for a custom fetch function to be passed in', async () => {
+    const customFetch = vi.fn(async () => {
+      return {
+        headers: new Headers(),
+        status: 200,
+        text: () => Promise.resolve({}),
+      } as unknown as Response;
+    });
+
+    const transport = makeCloudflareTransport({ ...DEFAULT_EDGE_TRANSPORT_OPTIONS, fetch: customFetch });
+
+    await transport.send(ERROR_ENVELOPE);
+    await transport.flush();
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Adds a new transport option to the Cloudflare provider, this allows specifying a custom fetch implementation. This allows for [Workers VPC](https://developers.cloudflare.com/workers-vpc/) to send into an internal Sentry.

Example usage:
```js
export default Sentry.withSentry(
  (env: Env) => ({
    dsn: env.SENTRY_DSN,
    release: env.VERSION_METADATA.tag ?? env.VERSION_METADATA.id,
    transportOptions: {
      fetch: env.SENTRY_VPC_BRIDGE.fetch.bind(env.SENTRY_VPC_BRIDGE),
    },
  }),
  {
    async fetch(req, env) {
      return new Response("ok");
    },
};
```

---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
