### PR TITLE
chore(github): Adjust `BUGBOT.md` rules to flag invalid op and origin values during review

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -32,7 +32,7 @@ Do not flag the issues below if they appear in tests.
 
 - When calling any `startSpan` API (`startInactiveSpan`, `startSpanManual`, etc), always ensure that the following span attributes are set:
   - `SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN` (`'sentry.origin'`) with a proper span origin
-    - a proper origin must only contain [a-z], [A-Z], [0-9] and `_` characters.
+    - a proper origin must only contain [a-z], [A-Z], [0-9], `_` and `.` characters.
     - flag any non-conforming origin values as invalid and link to the trace origin specification (https://develop.sentry.dev/sdk/telemetry/traces/trace-origin/)
   - `SEMANTIC_ATTRIBUTE_SENTRY_OP` (`'sentry.op'`) with a proper span op
     - Span ops should be lower case only, and use snake_case. The `.` character is used to delimit op parts.


### PR DESCRIPTION
based on the invalid origin values reported in https://github.com/getsentry/sentry-javascript/issues/18350 (and a bunch more invalid values in other SDKs) let's make bugbot a bit smarter to flag stuff like this in the future