### PR TITLE
fix(browser): Stringify span context in linked traces log statement

### DIFF
--- a/packages/browser/src/tracing/linkedTraces.ts
+++ b/packages/browser/src/tracing/linkedTraces.ts
@@ -177,10 +177,10 @@ export function addPreviousTraceSpanLink(
   if (Date.now() / 1000 - previousTraceInfo.startTimestamp <= PREVIOUS_TRACE_MAX_DURATION) {
     if (DEBUG_BUILD) {
       debug.log(
-        `Adding previous_trace ${previousTraceSpanCtx} link to span ${{
+        `Adding previous_trace \`${JSON.stringify(previousTraceSpanCtx)}\` link to span \`${JSON.stringify({
           op: spanJson.op,
           ...span.spanContext(),
-        }}`,
+        })}\``,
       );
     }
 


### PR DESCRIPTION
I came upon this log `Sentry Logger [log]: Adding previous_trace [object Object] link to span [object Object]` and this PR fixes this by stringifying the context. 

One concern I have with that is that the object could be too large (stringifying takes too long) or circular. But this should be very unlikely in this case. However, if someone else shares this concerns we might change the log to either limit the depth or to only log specific entries of the object (might add bundle size). 


Closes #18377