### PR TITLE
chore: Ignore dependabot, prepare-release and Gitflow for PR references

### DIFF
--- a/.github/workflows/create-issue-for-unreferenced-prs.yml
+++ b/.github/workflows/create-issue-for-unreferenced-prs.yml
@@ -19,6 +19,11 @@ concurrency:
 jobs:
   check_for_issue_reference:
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'Dev: Gitflow')
+      && !startsWith(github.event.pull_request.head.ref, 'external-contributor/')
+      && !startsWith(github.event.pull_request.head.ref, 'prepare-release/')
+      && !startsWith(github.event.pull_request.head.ref, 'dependabot/')
     steps:
       - name: Check PR Body and Title for Issue Reference
         uses: actions/github-script@v8


### PR DESCRIPTION
<!-- #0  🤫 -->

We don't need to add tickets for our internal releases such as https://github.com/getsentry/sentry-javascript/pull/18378, [Gitflow automations](https://github.com/getsentry/sentry-javascript/pull/18255) or [contributor updates](https://github.com/getsentry/sentry-javascript/pull/15156)