### PR TITLE
feat(nextjs): remove tracing from pages router API routes templates

### DIFF
--- a/packages/nextjs/rollup.npm.config.mjs
+++ b/packages/nextjs/rollup.npm.config.mjs
@@ -40,7 +40,7 @@ export default [
   ...makeNPMConfigVariants(
     makeBaseNPMConfig({
       entrypoints: [
-        'src/config/templates/apiWrapperTemplate.ts',
+        'src/config/templates/edgeApiWrapperTemplate.ts',
         'src/config/templates/middlewareWrapperTemplate.ts',
         'src/config/templates/pageWrapperTemplate.ts',
         'src/config/templates/requestAsyncStorageShim.ts',

--- a/packages/nextjs/test/config/loaders.test.ts
+++ b/packages/nextjs/test/config/loaders.test.ts
@@ -152,19 +152,19 @@ describe('webpack loaders', () => {
       },
       {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/pages/api/testApiRoute.ts',
-        expectedWrappingTargetKind: 'api-route',
+        expectedWrappingTargetKind: undefined,
       },
       {
         resourcePath: './src/pages/api/testApiRoute.ts',
-        expectedWrappingTargetKind: 'api-route',
+        expectedWrappingTargetKind: undefined,
       },
       {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/pages/api/nested/testApiRoute.js',
-        expectedWrappingTargetKind: 'api-route',
+        expectedWrappingTargetKind: undefined,
       },
       {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/pages/api/nested/testApiRoute.custom.js',
-        expectedWrappingTargetKind: 'api-route',
+        expectedWrappingTargetKind: undefined,
       },
       {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/app/nested/route.ts',

--- a/packages/nextjs/test/config/wrappingLoader.test.ts
+++ b/packages/nextjs/test/config/wrappingLoader.test.ts
@@ -9,13 +9,6 @@ vi.mock('fs', { spy: true });
 const originalReadfileSync = fs.readFileSync;
 
 vi.spyOn(fs, 'readFileSync').mockImplementation((filePath, options) => {
-  if (filePath.toString().endsWith('/config/templates/apiWrapperTemplate.js')) {
-    return originalReadfileSync(
-      path.join(__dirname, '../../build/cjs/config/templates/apiWrapperTemplate.js'),
-      options,
-    );
-  }
-
   if (filePath.toString().endsWith('/config/templates/pageWrapperTemplate.js')) {
     return originalReadfileSync(
       path.join(__dirname, '../../build/cjs/config/templates/pageWrapperTemplate.js'),
@@ -65,44 +58,6 @@ const defaultLoaderThis = {
 };
 
 describe('wrappingLoader', () => {
-  it('should correctly wrap API routes on unix', async () => {
-    const callback = vi.fn();
-
-    const userCode = `
-      export default function handler(req, res) {
-        res.json({ foo: "bar" });
-      }
-    `;
-    const userCodeSourceMap = undefined;
-
-    const loaderPromise = new Promise<void>(resolve => {
-      const loaderThis = {
-        ...defaultLoaderThis,
-        resourcePath: '/my/pages/my/route.ts',
-        callback: callback.mockImplementation(() => {
-          resolve();
-        }),
-        getOptions() {
-          return {
-            pagesDir: '/my/pages',
-            appDir: '/my/app',
-            pageExtensionRegex: DEFAULT_PAGE_EXTENSION_REGEX,
-            excludeServerRoutes: [],
-            wrappingTargetKind: 'api-route',
-            vercelCronsConfig: undefined,
-            nextjsRequestAsyncStorageModulePath: '/my/request-async-storage.js',
-          };
-        },
-      } satisfies LoaderThis<WrappingLoaderOptions>;
-
-      wrappingLoader.call(loaderThis, userCode, userCodeSourceMap);
-    });
-
-    await loaderPromise;
-
-    expect(callback).toHaveBeenCalledWith(null, expect.stringContaining("'/my/route'"), expect.anything());
-  });
-
   describe('middleware wrapping', () => {
     it('should export proxy when user exports named "proxy" export', async () => {
       const callback = vi.fn();


### PR DESCRIPTION
Removes Next.js pages API wrapping logic but keeps it for edge runtime