### PR TITLE
chore(e2e): Pin react router framework test apps

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/package.json
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/package.json
@@ -24,14 +24,14 @@
     "isbot": "^5.1.22",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router": "7.6.0",
-    "react-router-dom": "7.6.0"
+    "react-router": "7.9.6",
+    "react-router-dom": "7.9.6"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.2",
     "@playwright/test": "~1.53.2",
-    "@react-router/dev": "7.6.0",
-    "@react-router/fs-routes": "7.6.0",
+    "@react-router/dev": "7.9.6",
+    "@react-router/fs-routes": "7.9.6",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@shopify/cli": "3.80.4",
     "@shopify/hydrogen-codegen": "^0.3.3",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-node-20-18/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-node-20-18/package.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "7.6.0",
-    "@react-router/node": "7.6.0",
-    "@react-router/serve": "7.6.0",
+    "react-router": "7.9.6",
+    "@react-router/node": "7.9.6",
+    "@react-router/serve": "7.9.6",
     "@sentry/react-router": "latest || *",
     "isbot": "^5.1.17"
   },
@@ -16,7 +16,7 @@
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",
     "@types/node": "^20",
-    "@react-router/dev": "7.6.0",
+    "@react-router/dev": "7.9.6",
     "@playwright/test": "~1.53.2",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.6.3",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa-node-20-18/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa-node-20-18/package.json
@@ -18,16 +18,16 @@
   },
   "dependencies": {
     "@sentry/react-router": "latest || *",
-    "@react-router/node": "7.5.3",
-    "@react-router/serve": "7.5.3",
+    "@react-router/node": "7.9.6",
+    "@react-router/serve": "7.9.6",
     "isbot": "^5.1.27",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "7.5.3"
+    "react-router": "7.9.6"
   },
   "devDependencies": {
     "@playwright/test": "~1.53.2",
-    "@react-router/dev": "7.5.3",
+    "@react-router/dev": "7.9.6",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",


### PR DESCRIPTION
Pinning these versions as the latest seems to introduce breaking changes that blocks our CI

Closes #18391