### PR TITLE
chore(tanstackstart-react): clean up re-exported types

### DIFF
--- a/packages/tanstackstart-react/src/index.types.ts
+++ b/packages/tanstackstart-react/src/index.types.ts
@@ -22,11 +22,7 @@ export declare const contextLinesIntegration: typeof clientSdk.contextLinesInteg
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
-export declare function getSentryRelease(fallback?: string): string | undefined;
-
 export declare const ErrorBoundary: typeof clientSdk.ErrorBoundary;
-export declare const createReduxEnhancer: typeof clientSdk.createReduxEnhancer;
-export declare const showReportDialog: typeof clientSdk.showReportDialog;
 export declare const withErrorBoundary: typeof clientSdk.withErrorBoundary;
 
 export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/18373
