### PR TITLE
test(nuxt): Relax captured unhandled error assertion

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/tests/middleware.test.ts
@@ -125,7 +125,7 @@ test.describe('Server Middleware Instrumentation', () => {
           // This is a timing problem, sometimes Nitro can capture the error first, and sometimes it can't
           // If nitro captures the error first, the type will be 'chained'
           // If Sentry captures the error first, the type will be 'auto.middleware.nuxt'
-          // type: 'auto.middleware.nuxt',
+          type: expect.stringMatching(/^(auto\.middleware\.nuxt|chained)$/),
         }),
       }),
     );


### PR DESCRIPTION
This is the opposite of the flake that happened in https://github.com/getsentry/sentry-javascript/pull/18035, so apparently nuxt-3 flaky tests started after merging that PR.

It looks like the same problem, we have a race condition, if Nitro catches the error first when executing the middleware handler it will be swallowed by an H3 error but it seems the `instanceof` check isn't being satisfied in this case, so perhaps with Nuxt 3, there isn't a unified H3 instance or perhaps we are using a different one for the check.

I will take a better look later, this is a band-aid to stop this from randomly failing our PRs. I couldn't reproduce this locally at all tho.

If we don't like this relaxation we can close this PR and I can spend more time on this, I thought the most important thing here is we do capture an error with the critical information.