### PR TITLE
feat(core): Add data-sentry-label support in htmlTreeAsString

### DIFF
--- a/packages/core/test/lib/utils/browser.test.ts
+++ b/packages/core/test/lib/utils/browser.test.ts
@@ -5,7 +5,7 @@ import { htmlTreeAsString } from '../../../src/utils/browser';
 beforeAll(() => {
   const dom = new JSDOM();
   global.document = dom.window.document;
-  global.HTMLElement = new JSDOM().window.HTMLElement;
+  global.HTMLElement = dom.window.HTMLElement;
 });
 
 describe('htmlTreeAsString', () => {
@@ -72,5 +72,84 @@ describe('htmlTreeAsString', () => {
     expect(htmlTreeAsString(document.querySelector('button'), { maxStringLength: 100 })).toBe(
       'div#main-cta > div.container > button.bg-blue-500.hover:bg-blue-700.text-white.hover:text-blue-100',
     );
+  });
+
+  describe('data-sentry-label support', () => {
+    it('returns data-sentry-label when element has the attribute directly', () => {
+      const el = document.createElement('div');
+      el.innerHTML = '<button data-sentry-label="SubmitButton" class="btn" />';
+      document.body.appendChild(el);
+
+      expect(htmlTreeAsString(document.querySelector('button'))).toBe(
+        'body > div > [data-sentry-label="SubmitButton"]',
+      );
+    });
+
+    it('includes data-sentry-label from ancestor element in the path', () => {
+      const el = document.createElement('div');
+      el.innerHTML = `<div data-sentry-label="LoginForm">
+        <div class="form-group">
+          <button id="submit-btn" class="btn" />
+        </div>
+      </div>`;
+      document.body.appendChild(el);
+
+      expect(htmlTreeAsString(document.getElementById('submit-btn'))).toBe(
+        'div > [data-sentry-label="LoginForm"] > div.form-group > button#submit-btn.btn',
+      );
+    });
+
+    it('finds data-sentry-label on a distant ancestor within traverse limit', () => {
+      const el = document.createElement('div');
+      el.innerHTML = `<div data-sentry-label="DeepForm">
+        <div class="level-1">
+          <div class="level-2">
+            <div class="level-3">
+              <div class="level-4">
+                <div class="level-5">
+                  <button id="deep-btn" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>`;
+      document.body.appendChild(el);
+
+      const result = htmlTreeAsString(document.getElementById('deep-btn'));
+      expect(result).toContain('[data-sentry-label="DeepForm"]');
+    });
+
+    it('does not add prefix if data-sentry-label is already in cssSelector path', () => {
+      const el = document.createElement('div');
+      el.innerHTML = `<div data-sentry-label="OuterLabel">
+        <div data-sentry-label="InnerLabel">
+          <button id="btn" />
+        </div>
+      </div>`;
+      document.body.appendChild(el);
+
+      expect(htmlTreeAsString(document.getElementById('btn'))).toBe('[data-sentry-label="InnerLabel"] > button#btn');
+    });
+
+    it('returns normal cssSelector when no data-sentry-label exists', () => {
+      const el = document.createElement('div');
+      el.innerHTML = `<div class="container">
+        <button id="no-label-btn" class="btn" />
+      </div>`;
+      document.body.appendChild(el);
+
+      expect(htmlTreeAsString(document.getElementById('no-label-btn'))).toBe(
+        'body > div > div.container > button#no-label-btn.btn',
+      );
+    });
+
+    it('prioritizes data-sentry-label over data-sentry-component', () => {
+      const el = document.createElement('div');
+      el.innerHTML = '<button data-sentry-component="MyComponent" data-sentry-label="MyLabel" class="btn" />';
+      document.body.appendChild(el);
+
+      expect(htmlTreeAsString(document.querySelector('button'))).toBe('body > div > [data-sentry-label="MyLabel"]');
+    });
   });
 });


### PR DESCRIPTION


## Summary

This PR adds support for the `data-sentry-label` attribute in `htmlTreeAsString` function, allowing developers to annotate DOM elements with stable identifiers for better breadcrumb and INP span identification.

This is a partial solution to https://github.com/getsentry/sentry/issues/104128.


## Changes

- Added `data-sentry-label` attribute detection in `_htmlElementAsString()` - takes priority over `data-sentry-component` and `data-sentry-element`
- Added `_getSentryLabel()` helper function that traverses up to 15 DOM levels to find the nearest `data-sentry-label `attribute
- If `data-sentry-label` is found on an ancestor (beyond the standard 5-level traversal), it prefixes the CSS selector:
`[data-sentry-label="ProductCard"] div.container > button.btn`
- Added comprehensive unit tests for the new functionality

## Why this helps

In React Native Web and other frameworks with long/generated CSS class names, the current 80-character limit causes selectors to be truncated immediately, producing highly ambiguous selectors that can match 100+ elements on a page.

With `data-sentry-label`, developers can annotate interactive elements with stable identifiers:

```html
 <div data-sentry-label="Product-ItemRow">
    <div class="css-175oi2r r-1awozwy r-18u37iz r-1wtj0ep">
      <div class="css-175oi2r r-1awozwy r-6koalj r-18u37iz">
         <div class="css-1jxf684 r-bcqeeo r-1ttztb7 r-qvutc0 r-poiln3">
          Item Title
        </div>
      </div>
    </div>
  </div>
```

#### Before (current behavior):
```css
div.css-1jxf684.r-bcqeeo.r-1ttztb7.r-qvutc0.r-poiln3
```
This selector hits the 80-character limit immediately. If these classes represent common text styling, the selector matches every text element with that styling across the entire application.


#### After (with this PR):
```css
[data-sentry-label="Product-ItemRow"] div.css-1jxf684.r-bcqeeo.r-1ttztb7.r-qvutc0.r-poiln3
```
The label prefix identifies which specific row the interaction occurred in.




This significantly improves the precision and usefulness of generated CSS selectors in INP spans.


##   Checklist

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).