### PR TITLE
chore(publish): Fix publish order for `@sentry/types`

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -4,14 +4,14 @@ preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   # NPM Targets
   ## 1. Base Packages, node or browser SDKs depend on
-  ## 1.1 Types
-  - name: npm
-    id: '@sentry/types'
-    includeNames: /^sentry-types-\d.*\.tgz$/
-  ## 1.2 Core SDKs
+  ## 1.1 Core SDKs
   - name: npm
     id: '@sentry/core'
     includeNames: /^sentry-core-\d.*\.tgz$/
+    ## 1.2 Types
+  - name: npm
+    id: '@sentry/types'
+    includeNames: /^sentry-types-\d.*\.tgz$/
   - name: npm
     id: '@sentry/node-core'
     includeNames: /^sentry-node-core-\d.*\.tgz$/


### PR DESCRIPTION
Types depends on core but we accidentally published it before core. Not the end of the world but theoretically, if publishing core failed, we would have published a faulty types package. h/t @BYK for detecting this!

Closes #18431