### PR TITLE
chore(bugbot): Add testing conventions code review rules

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -48,8 +48,13 @@ Do not flag the issues below if they appear in tests.
 
 ## Testing Conventions
 
-- When reviewing a `feat(*)` PR, check if the PR includes at least one integration or E2E test. If neither of the two are present, add a comment, recommending to add one.
-- Check that tests actually test the newly added behaviour. For instance, when checking on sent payloads by the SDK, ensure that the newly added data is asserted thoroughly.
+- When reviewing a `feat` PR, check if the PR includes at least one integration or E2E test.
+  If neither of the two are present, add a comment, recommending to add one.
+- When reviewing a `fix` PR, check if the PR includes at least one unit, integration or e2e test that tests the regression this PR fixes.
+  Usually this means the test failed prior to the fix and passes with the fix.
+  If no tests are present, add a comment recommending to add one.
+- Check that tests actually test the newly added behaviour.
+  For instance, when checking on sent payloads by the SDK, ensure that the newly added data is asserted thoroughly.
 - Flag usage of `expect.objectContaining` and other relaxed assertions, when a test expects something NOT to be included in a payload but there's no respective assertion.
 - Flag usage of conditionals in one test and recommend splitting up the test for the different paths.
 - Flag usage of loops testing multiple scenarios in one test and recommend using `(it)|(test).each` instead.


### PR DESCRIPTION
This PR adds some rules to bugbot's rulest to flag some testing-related issues we'd like to avoid. Like with all AI rules, there are for sure exceptions to the new rules, so no problem with us ignoring any of these flags. But I think having an additional reminder that testing is necessary would be a good change. LMK what you think!

Happy to add/remove/change rules as reviewers see fit.

Closes #18435