### PR TITLE
feat(bun): Expose spotlight option in TypeScript

### DIFF
--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -23,6 +23,18 @@ export interface BaseBunOptions {
   serverName?: string;
 
   /**
+   * If you use Spotlight by Sentry during development, use
+   * this option to forward captured Sentry events to Spotlight.
+   *
+   * Either set it to true, or provide a specific Spotlight Sidecar URL.
+   *
+   * More details: https://spotlightjs.com/
+   *
+   * IMPORTANT: Only set this option to `true` while developing, not in production!
+   */
+  spotlight?: boolean | string;
+
+  /**
    * If this is set to true, the SDK will not set up OpenTelemetry automatically.
    * In this case, you _have_ to ensure to set it up correctly yourself, including:
    * * The `SentrySpanProcessor`

--- a/packages/bun/test/init.test.ts
+++ b/packages/bun/test/init.test.ts
@@ -38,6 +38,20 @@ describe('init()', () => {
       expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(0);
     });
 
+    it('enables spotlight with default URL from config `true`', () => {
+      const client = init({ dsn: PUBLIC_DSN, spotlight: true });
+
+      expect(client?.getOptions().spotlight).toBe(true);
+      expect(client?.getOptions().integrations.some(integration => integration.name === 'Spotlight')).toBe(true);
+    });
+
+    it('disables spotlight from config `false`', () => {
+      const client = init({ dsn: PUBLIC_DSN, spotlight: false });
+
+      expect(client?.getOptions().spotlight).toBe(false);
+      expect(client?.getOptions().integrations.some(integration => integration.name === 'Spotlight')).toBe(false);
+    });
+
     it('installs merged default integrations, with overrides provided through options', () => {
       const mockDefaultIntegrations = [
         new MockIntegration('Some mock integration 2.1'),


### PR DESCRIPTION
(closes #18419)
(closes [JS-1261](https://linear.app/getsentry/issue/JS-1261/add-support-for-spotlight-in-sentrybun))

It seems that for Bun we are already using the init function of `@sentry/node`, so all the options are passed do satisfy the `NodeOptions`. This is now re-exporting `spotlight` as an option.

(related: #17349)