### PR TITLE
chore(ci): Fix double issue creation for unreferenced PRs

### DIFF
--- a/.github/workflows/create-issue-for-unreferenced-prs.yml
+++ b/.github/workflows/create-issue-for-unreferenced-prs.yml
@@ -41,10 +41,11 @@ jobs:
               return;
             }
 
-            // Bail if this edit was made by the GitHub Actions bot
+            // Bail if this edit was made by the GitHub Actions bot (this workflow)
             // This prevents infinite loops when we update the PR body with the new issue reference
-            if (context.payload.sender && context.payload.sender.type === 'Bot') {
-              console.log(`PR #${pr.number} was edited by a bot (likely this action), skipping.`);
+            // We check login specifically to not skip edits from other legitimate bots
+            if (context.payload.sender && context.payload.sender.login === 'github-actions[bot]') {
+              console.log(`PR #${pr.number} was edited by github-actions[bot] (this workflow), skipping.`);
               return;
             }
 


### PR DESCRIPTION
This fixes a problem, where our unreferenced PR GH workflow would trigger another new issue being created because of a race condition between creating the issue and updating the PR description automatically.

Closes #18445 (added automatically)