### PR TITLE
feat(profiling): Add support for Node v24 in the prune script

### DIFF
--- a/packages/profiling-node/scripts/prune-profiler-binaries.js
+++ b/packages/profiling-node/scripts/prune-profiler-binaries.js
@@ -63,6 +63,7 @@ const NODE_TO_ABI = {
   18: '108',
   20: '115',
   22: '127',
+  24: '134',
 };
 
 if (NODE) {
@@ -76,6 +77,8 @@ if (NODE) {
     NODE = NODE_TO_ABI['20'];
   } else if (NODE.startsWith('22')) {
     NODE = NODE_TO_ABI['22'];
+  } else if (NODE.startsWith('24')) {
+    NODE = NODE_TO_ABI['24'];
   } else {
     ARGV_ERRORS.push(
       `❌ Sentry: Invalid node version passed as argument, please make sure --target_node is a valid major node version. Supported versions are ${Object.keys(

--- a/packages/profiling-node/test/prune-profiler-binaries.test.ts
+++ b/packages/profiling-node/test/prune-profiler-binaries.test.ts
@@ -1,0 +1,24 @@
+import { spawnSync } from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('prune-profiler-binaries', () => {
+  it('should check if the node version is valid', () => {
+    const currentNode = process.version.split('v')[1];
+    const result = spawnSync(
+      'node',
+      [
+        path.join(__dirname, '../scripts/prune-profiler-binaries.js'),
+        '--target_platform=linux',
+        '--target_arch=x64',
+        '--target_stdlib=glibc',
+        `--target_dir_path=${os.tmpdir()}`,
+        `--target_node=${currentNode}`,
+      ],
+      { encoding: 'utf8' },
+    );
+
+    expect(result.stdout).not.toContain('Invalid node version passed as argument');
+  });
+});


### PR DESCRIPTION
(closes #18428)
(closes [JS-1266](https://linear.app/getsentry/issue/JS-1266/sentry-prune-profiler-binaries-does-not-recognize-nodejs-24-as-a-valid))

This adds support for Node v24 in the prune script. 

On top this also adds a test that is testing against the current Node version (as suggested in https://github.com/getsentry/sentry-javascript/pull/14491#pullrequestreview-2468295980). Since we have [a matrix](https://github.com/getsentry/sentry-javascript/blob/a906759fd8769d264498598dc16dab8af26377ea/.github/workflows/build.yml#L747) for our integration tests, this test would fail once we add Node v26 - where we are forced to update the ABI manually.

Theoretically we could also use [node-abi](https://www.npmjs.com/package/node-abi), but decided against it to keep the dependencies low.