### PR TITLE
fix(core): Parse method from Request object in fetch

### DIFF
--- a/packages/core/src/instrument/fetch.ts
+++ b/packages/core/src/instrument/fetch.ts
@@ -240,11 +240,16 @@ export function parseFetchArgs(fetchArgs: unknown[]): { method: string; url: str
   }
 
   if (fetchArgs.length === 2) {
-    const [url, options] = fetchArgs as [FetchResource, object];
+    const [resource, options] = fetchArgs as [FetchResource, object];
 
     return {
-      url: getUrlFromResource(url),
-      method: hasProp(options, 'method') ? String(options.method).toUpperCase() : 'GET',
+      url: getUrlFromResource(resource),
+      method: hasProp(options, 'method')
+        ? String(options.method).toUpperCase()
+        : // Request object as first argument
+          isRequest(resource) && hasProp(resource, 'method')
+          ? String(resource.method).toUpperCase()
+          : 'GET',
     };
   }
 

--- a/packages/core/test/lib/instrument/fetch.test.ts
+++ b/packages/core/test/lib/instrument/fetch.test.ts
@@ -27,4 +27,29 @@ describe('instrument > parseFetchArgs', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  describe('fetch with Request object', () => {
+    it.each([
+      [
+        'Request object (as only arg)',
+        [new Request('http://example.com', { method: 'POST' })],
+        { method: 'POST', url: 'http://example.com/' },
+      ],
+      [
+        'Request object (with undefined options arg)',
+        [new Request('http://example.com', { method: 'POST' }), undefined],
+        { method: 'POST', url: 'http://example.com/' },
+      ],
+      [
+        'Request object (with overwritten options arg)',
+        [new Request('http://example.com', { method: 'POST' }), { method: 'DELETE' }],
+        // fetch options overwrite Request object options
+        { method: 'DELETE', url: 'http://example.com/' },
+      ],
+    ])('%s', (_name, args, expected) => {
+      const actual = parseFetchArgs(args as unknown[]);
+
+      expect(actual).toEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
Fixes the case that the instrumentation defaulted to `GET` in case `undefined` was parsed as a second `fetch` argument.

```js
const request = new Request("https://httpbin.org/post", { method: "POST" });

const response = await fetch(request, undefined);   <-- will be GET (should be POST)
```


Closes #18455 (added automatically)