### PR TITLE
feat(nextjs): Remove tracing from middleware wrappers

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/tests/middleware.test.ts
@@ -1,7 +1,15 @@
 import { expect, test } from '@playwright/test';
 import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
 
+const packageJson = require('../package.json');
+const nextjsVersion = packageJson.dependencies.next;
+const nextjsMajor = Number(nextjsVersion.split('.')[0]);
+
 test('Should create a transaction for middleware', async ({ request }) => {
+  test.skip(
+    nextjsMajor === 13,
+    'Middleware transactions are not created in Next.js 13 after dropping tracing from middleware',
+  );
   const middlewareTransactionPromise = waitForTransaction('nextjs-pages-dir', async transactionEvent => {
     return transactionEvent?.transaction === 'middleware GET';
   });
@@ -22,6 +30,10 @@ test('Should create a transaction for middleware', async ({ request }) => {
 });
 
 test('Faulty middlewares', async ({ request }) => {
+  test.skip(
+    nextjsMajor === 13,
+    'Middleware transactions are not created in Next.js 13 after dropping tracing from middleware',
+  );
   const middlewareTransactionPromise = waitForTransaction('nextjs-pages-dir', async transactionEvent => {
     return transactionEvent?.transaction === 'middleware GET';
   });
@@ -53,6 +65,10 @@ test('Faulty middlewares', async ({ request }) => {
 });
 
 test('Should trace outgoing fetch requests inside middleware and create breadcrumbs for it', async ({ request }) => {
+  test.skip(
+    nextjsMajor === 13,
+    'Middleware transactions are not created in Next.js 13 after dropping tracing from middleware',
+  );
   const middlewareTransactionPromise = waitForTransaction('nextjs-pages-dir', async transactionEvent => {
     return (
       transactionEvent?.transaction === 'middleware GET' &&

--- a/packages/nextjs/src/common/wrapMiddlewareWithSentry.ts
+++ b/packages/nextjs/src/common/wrapMiddlewareWithSentry.ts
@@ -1,4 +1,4 @@
-import { captureException, handleCallbackErrors } from '@sentry/core';
+import { captureException, getCurrentScope, handleCallbackErrors } from '@sentry/core';
 import { flushSafelyWithTimeout, waitUntil } from '../common/utils/responseEnd';
 import type { EdgeRouteHandler } from '../edge/types';
 
@@ -39,6 +39,10 @@ export function wrapMiddlewareWithSentry<H extends EdgeRouteHandler>(
           }
         }
       }
+
+      const req: unknown = args[0];
+      const spanName = req instanceof Request ? `middleware ${req.method}` : 'middleware';
+      getCurrentScope().setTransactionName(spanName);
 
       return handleCallbackErrors(
         () => wrappingTarget.apply(thisArg, args),

--- a/packages/nextjs/src/common/wrapMiddlewareWithSentry.ts
+++ b/packages/nextjs/src/common/wrapMiddlewareWithSentry.ts
@@ -1,24 +1,23 @@
-import type { TransactionSource } from '@sentry/core';
 import {
   captureException,
   getActiveSpan,
   getCurrentScope,
   getRootSpan,
   handleCallbackErrors,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setCapturedScopesOnSpan,
-  startSpan,
   winterCGRequestToRequestData,
   withIsolationScope,
 } from '@sentry/core';
 import { flushSafelyWithTimeout, waitUntil } from '../common/utils/responseEnd';
 import { isPathnameUnderSentryTunnelRoute } from '../common/utils/tunnelPathnameMatch';
 import type { EdgeRouteHandler } from '../edge/types';
-import { SENTRY_KIND } from '@sentry/conventions/attributes';
 
 /**
- * Wraps Next.js middleware with Sentry error and performance instrumentation.
+ * Wraps Next.js middleware with Sentry error instrumentation.
+ *
+ * The middleware transaction itself is created by Next.js' native OpenTelemetry instrumentation
+ * (the `Middleware.execute` span, normalized by `enhanceMiddlewareRootSpan`), so this wrapper no
+ * longer starts its own span. It only forks an isolation scope, captures errors, and flushes.
  *
  * @param middleware The middleware handler.
  * @returns a wrapped middleware handler.
@@ -33,6 +32,7 @@ export function wrapMiddlewareWithSentry<H extends EdgeRouteHandler>(
           ? (globalThis as Record<string, unknown>)._sentryRewritesTunnelPath
           : undefined;
 
+      // TODO: This can never work with Turbopack, need to remove it for consistency between builds.
       if (tunnelRoute && typeof tunnelRoute === 'string') {
         const req: unknown = args[0];
         // Check if the current request matches the tunnel route
@@ -53,66 +53,43 @@ export function wrapMiddlewareWithSentry<H extends EdgeRouteHandler>(
           }
         }
       }
+
       // TODO: We still should add central isolation scope creation for when our build-time instrumentation does not work anymore with turbopack.
       return withIsolationScope(isolationScope => {
         const req: unknown = args[0];
         const currentScope = getCurrentScope();
 
-        let spanName: string;
-        let spanSource: TransactionSource;
-
         if (req instanceof Request) {
           isolationScope.setSDKProcessingMetadata({
             normalizedRequest: winterCGRequestToRequestData(req),
           });
-          spanName = `middleware ${req.method}`;
-          spanSource = 'url';
+          currentScope.setTransactionName(`middleware ${req.method}`);
         } else {
-          spanName = 'middleware';
-          spanSource = 'component';
+          currentScope.setTransactionName('middleware');
         }
 
-        currentScope.setTransactionName(spanName);
-
         const activeSpan = getActiveSpan();
-
         if (activeSpan) {
-          // If there is an active span, it likely means that the automatic Next.js OTEL instrumentation worked and we can
-          // rely on that for parameterization.
-          spanName = 'middleware';
-          spanSource = 'component';
-
+          // If there is an active span, the native Next.js OTEL instrumentation created the middleware root span.
+          // Bind our forked scopes to it so the transaction picks up the isolation scope instead of the global one.
           const rootSpan = getRootSpan(activeSpan);
           if (rootSpan) {
             setCapturedScopesOnSpan(rootSpan, currentScope, isolationScope);
           }
         }
 
-        return startSpan(
-          {
-            name: spanName,
-            op: 'http.server.middleware',
-            attributes: {
-              [SENTRY_KIND]: 'server',
-              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: spanSource,
-              [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.nextjs.wrap_middleware',
-            },
+        return handleCallbackErrors(
+          () => wrappingTarget.apply(thisArg, args),
+          error => {
+            captureException(error, {
+              mechanism: {
+                type: 'auto.function.nextjs.wrap_middleware',
+                handled: false,
+              },
+            });
           },
           () => {
-            return handleCallbackErrors(
-              () => wrappingTarget.apply(thisArg, args),
-              error => {
-                captureException(error, {
-                  mechanism: {
-                    type: 'auto.function.nextjs.wrap_middleware',
-                    handled: false,
-                  },
-                });
-              },
-              () => {
-                waitUntil(flushSafelyWithTimeout());
-              },
-            );
+            waitUntil(flushSafelyWithTimeout());
           },
         );
       });


### PR DESCRIPTION
closes getsentry/sentry-javascript#18308