### PR TITLE
fix(cloudflare): Missing events inside waitUntil

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers/src/index.ts
@@ -81,7 +81,7 @@ export default Sentry.withSentry(
     },
   }),
   {
-    async fetch(request, env) {
+    async fetch(request, env, ctx) {
       const url = new URL(request.url);
       switch (url.pathname) {
         case '/rpc/throwException':
@@ -96,6 +96,20 @@ export default Sentry.withSentry(
             }
           }
           break;
+        case '/waitUntil':
+          console.log('waitUntil called');
+
+          const longRunningTask = async () => {
+            await new Promise(resolve => setTimeout(resolve, 3000));
+
+            console.log('ʕっ•ᴥ•ʔっ');
+            Sentry.captureException(new Error('ʕノ•ᴥ•ʔノ ︵ ┻━┻'));
+          };
+
+          ctx.waitUntil(longRunningTask());
+
+          return new Response(null, { status: 200 });
+
         case '/throwException':
           throw new Error('To be recorded in Sentry.');
         default:

--- a/packages/cloudflare/src/flush.ts
+++ b/packages/cloudflare/src/flush.ts
@@ -1,4 +1,5 @@
 import type { ExecutionContext } from '@cloudflare/workers-types';
+import { startSpan, withScope } from '@sentry/core';
 
 type FlushLock = {
   readonly ready: Promise<void>;
@@ -22,9 +23,20 @@ export function makeFlushLock(context: ExecutionContext): FlushLock {
   const originalWaitUntil = context.waitUntil.bind(context) as typeof context.waitUntil;
   context.waitUntil = promise => {
     pending++;
+
     return originalWaitUntil(
-      promise.finally(() => {
-        if (--pending === 0) resolveAllDone();
+      // Wrap the promise in a new scope and transaction so spans created inside
+      // waitUntil callbacks are properly isolated from the HTTP request transaction
+      withScope(() =>
+        startSpan({ forceTransaction: true, op: 'cloudflare.wait_until', name: 'waitUntil' }, async () => {
+          // By awaiting the promise inside the new scope, all of its continuations
+          // will execute in this isolated scope
+          await promise;
+        }),
+      ).finally(() => {
+        if (--pending === 0) {
+          resolveAllDone();
+        }
       }),
     );
   };


### PR DESCRIPTION
This is a follow up to #16681.

## Problem

The `waitUntil` could take longer than the actual request is taking, which is actually a good thing and wanted by Cloudflare. By definition of our implementation we are ending the root span at the end of the request, while the promise inside `waitUntil` could still generate events. These events are only send while the root span is still active ("Event 1" in the mermaid diagram), but are not send anymore when the root span ended ("Event 2") and are basically dropped.

```mermaid
sequenceDiagram
    participant R as Request
    participant W as waitUntil
    participant S as Sentry Spans

    Note over R: Request starts
    activate R
    
    R->>S: Root span starts
    activate S
    
    Note over R,W: User calls ctx.waitUntil(promise)
    R->>W: Promise created
    activate W
    
    W->>S: Event 1 ✓
    Note over S: Captured (span still active)
    
    Note over R: Request handler returns
    deactivate R
    
    R->>S: Root span ends
    deactivate S
    
    Note over W: waitUntil continues running...
    
    W->>S: Event 2 ✗
    Note over S: LOST!<br/>Span already ended
    
    W->>W: waitUntil completes
    deactivate W                          
```

## Solution

> **Note:** I think that span streaming (which is coming soon) could fix that problem 🤞

While the solution is not perfect, it is mitigating the problem. To mitigate it we add a new transaction for the `waitUntil`, which means it is free of the root span duration, but it still has the information of the trace and its span parent.

```mermaid
sequenceDiagram
    participant R as Request
    participant W as waitUntil
    participant S1 as Root Span
    participant S2 as waitUntil Transaction

    Note over R: Request starts
    activate R
    
    R->>S1: Root span starts
    activate S1
    
    Note over R,W: User calls ctx.waitUntil(promise)
    R->>W: Promise created
    activate W
    
    W->>S2: waitUntil transaction starts
    activate S2
    
    W->>S2: Event 1 ✓
    
    Note over R: Request handler returns
    deactivate R
    
    R->>S1: Root span ends
    deactivate S1
    
    Note over W: waitUntil continues running...
    
    W->>S2: Event 2 ✓
    Note over S2: Captured!<br/>waitUntil transaction still active
    
    W->>S2: waitUntil transaction ends
    deactivate S2
    
    W->>W: waitUntil completes
    deactivate W
```

## Side effects

That actually causes one slight problem, where I don't have the solution for, except writing documentation. 

When there is a manual sentry span added inside a `waitUntil` it will have the wrong parent span, since the parent is the same as the one of the request. Since by the time of the execution of `asyncFn()` the parent will be request, and not `asyncFn`. However, this can be solved when the user adds a `forceTransaction: true` manually inside the `Sentry.startSpan`, since then it will decouple again and will have the correct parent span.

```js
const asyncFn = await () => {
  await somethingAsync();
  
  // this will have the wrong parent span
  // unless `forceTransaction: true` is given
  return Sentry.startSpan({}, async () => {
    await moreAsyncFunctionality();
  });
};

waitUntil(asyncFn())
```