### PR TITLE
chore(lint): prefer 'unknown' to 'any', fix lint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,9 @@ module.exports = {
     'types/**',
     'scripts/*.js',
   ],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'error',
+  },
   reportUnusedDisableDirectives: true,
   overrides: [
     {
@@ -35,6 +38,9 @@ module.exports = {
       files: ['test/**/*.ts', 'test/**/*.tsx'],
       parserOptions: {
         project: ['tsconfig.test.json'],
+      },
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
       },
     },
     {

--- a/dev-packages/.eslintrc.js
+++ b/dev-packages/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['../.eslintrc.js'],
+  rules: {
+    // tests often have just cause to do evil
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
+};

--- a/dev-packages/browser-integration-tests/.eslintrc.js
+++ b/dev-packages/browser-integration-tests/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     node: true,
   },
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   ignorePatterns: [
     'suites/**/subject.js',

--- a/dev-packages/bundler-tests/.eslintrc.js
+++ b/dev-packages/bundler-tests/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['../../.eslintrc.js'],
+  extends: ['../.eslintrc.js'],
   parserOptions: {
     sourceType: 'module',
   },

--- a/dev-packages/clear-cache-gh-action/.eslintrc.cjs
+++ b/dev-packages/clear-cache-gh-action/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   parserOptions: {
     sourceType: 'module',

--- a/dev-packages/cloudflare-integration-tests/.eslintrc.js
+++ b/dev-packages/cloudflare-integration-tests/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     node: true,
   },
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   overrides: [
     {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/mocks.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/mocks.ts
@@ -3,7 +3,6 @@ import type { GoogleGenAIChat, GoogleGenAIClient, GoogleGenAIResponse } from '@s
 export class MockGoogleGenAI implements GoogleGenAIClient {
   public models: {
     generateContent: (...args: unknown[]) => Promise<GoogleGenAIResponse>;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     generateContentStream: (...args: unknown[]) => Promise<AsyncGenerator<GoogleGenAIResponse, any, unknown>>;
   };
   public chats: {

--- a/dev-packages/e2e-tests/.eslintrc.js
+++ b/dev-packages/e2e-tests/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     node: true,
   },
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   ignorePatterns: ['test-applications/**', 'tmp/**'],
   parserOptions: {

--- a/dev-packages/external-contributor-gh-action/.eslintrc.cjs
+++ b/dev-packages/external-contributor-gh-action/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   parserOptions: {
     sourceType: 'module',

--- a/dev-packages/node-core-integration-tests/.eslintrc.js
+++ b/dev-packages/node-core-integration-tests/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     node: true,
   },
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   overrides: [
     {

--- a/dev-packages/node-integration-tests/.eslintrc.js
+++ b/dev-packages/node-integration-tests/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     node: true,
   },
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   overrides: [
     {

--- a/dev-packages/node-overhead-gh-action/.eslintrc.cjs
+++ b/dev-packages/node-overhead-gh-action/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
     node: true,
   },
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   overrides: [
     {

--- a/dev-packages/rollup-utils/.eslintrc.cjs
+++ b/dev-packages/rollup-utils/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   ignorePatterns: ['otelLoaderTemplate.js.tmpl'],
   sourceType: 'module',

--- a/dev-packages/size-limit-gh-action/.eslintrc.cjs
+++ b/dev-packages/size-limit-gh-action/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
   parserOptions: {
     sourceType: 'module',

--- a/dev-packages/test-utils/.eslintrc.js
+++ b/dev-packages/test-utils/.eslintrc.js
@@ -3,6 +3,6 @@ module.exports = {
     node: true,
   },
   // todo: remove regexp plugin from here once we add it to base.js eslint config for the whole project
-  extends: ['../../.eslintrc.js', 'plugin:regexp/recommended'],
+  extends: ['../.eslintrc.js', 'plugin:regexp/recommended'],
   plugins: ['regexp'],
 };

--- a/packages/aws-serverless/src/integration/instrumentation-aws-lambda/types.ts
+++ b/packages/aws-serverless/src/integration/instrumentation-aws-lambda/types.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Context as OtelContext, Span } from '@opentelemetry/api';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type { Context } from 'aws-lambda';

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -1,6 +1,7 @@
 // Based on Kamil Ogórek's work on:
 // https://github.com/supabase-community/sentry-integration-js
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-lines */
 import { addBreadcrumb } from '../breadcrumbs';
 import { DEBUG_BUILD } from '../debug-build';

--- a/packages/core/src/types-hoist/breadcrumb.ts
+++ b/packages/core/src/types-hoist/breadcrumb.ts
@@ -52,6 +52,7 @@ export interface Breadcrumb {
    *
    * @summary Arbitrary data associated with this breadcrumb.
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: { [key: string]: any };
 
   /**
@@ -70,6 +71,7 @@ export interface Breadcrumb {
 
 /** JSDoc */
 export interface BreadcrumbHint {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 
@@ -90,6 +92,7 @@ export interface XhrBreadcrumbData {
 }
 
 export interface FetchBreadcrumbHint {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   input: any[];
   data?: unknown;
   response?: unknown;

--- a/packages/core/src/types-hoist/context.ts
+++ b/packages/core/src/types-hoist/context.ts
@@ -99,6 +99,7 @@ export interface ResponseContext extends Record<string, unknown> {
 }
 
 export interface TraceContext extends Record<string, unknown> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: { [key: string]: any };
   op?: string;
   parent_span_id?: string;

--- a/packages/core/src/types-hoist/error.ts
+++ b/packages/core/src/types-hoist/error.ts
@@ -2,5 +2,7 @@
  * Just an Error object with arbitrary attributes attached to it.
  */
 export interface ExtendedError extends Error {
+  // TODO: fix in v11, convert any to unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/packages/core/src/types-hoist/event.ts
+++ b/packages/core/src/types-hoist/event.ts
@@ -83,6 +83,7 @@ export interface EventHint {
   syntheticException?: Error | null;
   originalException?: unknown;
   attachments?: Attachment[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: any;
   integrations?: string[];
 }

--- a/packages/core/src/types-hoist/instrument.ts
+++ b/packages/core/src/types-hoist/instrument.ts
@@ -47,6 +47,7 @@ interface SentryFetchData {
 }
 
 export interface HandlerDataFetch {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[];
   fetchData: SentryFetchData; // This data is among other things dumped directly onto the fetch breadcrumb data
   startTimestamp: number;
@@ -74,6 +75,7 @@ export interface HandlerDataDom {
 
 export interface HandlerDataConsole {
   level: ConsoleLevel;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[];
 }
 

--- a/packages/core/src/types-hoist/integration.ts
+++ b/packages/core/src/types-hoist/integration.ts
@@ -47,4 +47,5 @@ export interface Integration {
  * An integration in function form.
  * This is expected to return an integration.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type IntegrationFn<IntegrationType = Integration> = (...rest: any[]) => IntegrationType;

--- a/packages/core/src/types-hoist/misc.ts
+++ b/packages/core/src/types-hoist/misc.ts
@@ -4,6 +4,8 @@ import type { QueryParams } from './request';
  * Data extracted from an incoming request to a node server
  */
 export interface ExtractedNodeRequestData {
+  // TODO: fix in v11, convert any to unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 
   /** Specific headers from the request */

--- a/packages/core/src/types-hoist/polymorphics.ts
+++ b/packages/core/src/types-hoist/polymorphics.ts
@@ -50,12 +50,14 @@ type NextjsRequest = NodeRequest & {
     [key: string]: string;
   };
   query?: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
   };
 };
 
 type ExpressRequest = NodeRequest & {
   baseUrl?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body?: string | { [key: string]: any };
   host?: string;
   hostname?: string;
@@ -70,9 +72,11 @@ type ExpressRequest = NodeRequest & {
     ];
   };
   query?: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
   };
   user?: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
   };
   _reconstructedRoute?: string;

--- a/packages/core/src/types-hoist/samplingcontext.ts
+++ b/packages/core/src/types-hoist/samplingcontext.ts
@@ -6,6 +6,8 @@ import type { SpanAttributes } from './span';
  * Context data passed by the user when starting a transaction, to be used by the tracesSampler method.
  */
 export interface CustomSamplingContext {
+  // TODO: fix in v11, convert any to unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 

--- a/packages/core/src/types-hoist/stackframe.ts
+++ b/packages/core/src/types-hoist/stackframe.ts
@@ -13,7 +13,11 @@ export interface StackFrame {
   in_app?: boolean;
   instruction_addr?: string;
   addr_mode?: string;
+  // TODO: fix in v11, convert any to unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   vars?: { [key: string]: any };
   debug_id?: string;
+  // TODO: fix in v11, convert any to unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   module_metadata?: any;
 }

--- a/packages/core/src/types-hoist/user.ts
+++ b/packages/core/src/types-hoist/user.ts
@@ -2,6 +2,8 @@
  * An interface describing a user of an application or a handled request.
  */
 export interface User {
+  // TODO: fix in v11, convert any to unknown
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
   id?: string | number;
   ip_address?: string | null;

--- a/packages/core/src/utils/aggregate-errors.ts
+++ b/packages/core/src/utils/aggregate-errors.ts
@@ -57,14 +57,14 @@ function aggregateExceptionsFromError(
   // Recursively call this function in order to walk down a chain of errors
   if (isInstanceOf(error[key], Error)) {
     applyExceptionGroupFieldsForParentException(exception, exceptionId);
-    const newException = exceptionFromErrorImplementation(parser, error[key]);
+    const newException = exceptionFromErrorImplementation(parser, error[key] as Error);
     const newExceptionId = newExceptions.length;
     applyExceptionGroupFieldsForChildException(newException, key, newExceptionId, exceptionId);
     newExceptions = aggregateExceptionsFromError(
       exceptionFromErrorImplementation,
       parser,
       limit,
-      error[key],
+      error[key] as ExtendedError,
       key,
       [newException, ...newExceptions],
       newException,
@@ -78,14 +78,14 @@ function aggregateExceptionsFromError(
     error.errors.forEach((childError, i) => {
       if (isInstanceOf(childError, Error)) {
         applyExceptionGroupFieldsForParentException(exception, exceptionId);
-        const newException = exceptionFromErrorImplementation(parser, childError);
+        const newException = exceptionFromErrorImplementation(parser, childError as Error);
         const newExceptionId = newExceptions.length;
         applyExceptionGroupFieldsForChildException(newException, `errors[${i}]`, newExceptionId, exceptionId);
         newExceptions = aggregateExceptionsFromError(
           exceptionFromErrorImplementation,
           parser,
           limit,
-          childError,
+          childError as ExtendedError,
           key,
           [newException, ...newExceptions],
           newException,

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -180,7 +180,9 @@ export function isSyntheticEvent(wat: unknown): boolean {
  * @param base A constructor to be used in a check.
  * @returns A boolean representing the result.
  */
-export function isInstanceOf(wat: any, base: any): boolean {
+// TODO: fix in v11, convert any to unknown
+// export function isInstanceOf<T>(wat: unknown, base: { new (...args: any[]): T }): wat is T {
+export function isInstanceOf<T>(wat: any, base: any): wat is T {
   try {
     return wat instanceof base;
   } catch {

--- a/packages/core/test/lib/utils/is.test.ts
+++ b/packages/core/test/lib/utils/is.test.ts
@@ -107,15 +107,24 @@ describe('isInstanceOf()', () => {
     expect(isInstanceOf(new Date(), Date)).toEqual(true);
     // @ts-expect-error Foo implicity has any type, doesn't have constructor
     expect(isInstanceOf(new Foo(), Foo)).toEqual(true);
-
+    // @ts-expect-error Should only allow constructors
     expect(isInstanceOf(new Error('wat'), Foo)).toEqual(false);
     expect(isInstanceOf(new Date('wat'), Error)).toEqual(false);
+
+    // verify type inference
+    const d: unknown = new Date();
+    const e: Date = isInstanceOf(d, Date) ? d : new Date();
+    expect(e).toEqual(d);
   });
 
   test('should not break with incorrect input', () => {
+    // @ts-expect-error Should only allow constructors
     expect(isInstanceOf(new Error('wat'), 1)).toEqual(false);
+    // @ts-expect-error Should only allow constructors
     expect(isInstanceOf(new Error('wat'), 'wat')).toEqual(false);
+    // @ts-expect-error Should only allow constructors
     expect(isInstanceOf(new Error('wat'), null)).toEqual(false);
+    // @ts-expect-error Should only allow constructors
     expect(isInstanceOf(new Error('wat'), undefined)).toEqual(false);
   });
 });

--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -69,8 +69,8 @@ export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
             screenshotInput={screenshotInput}
             showName={options.showName || options.isNameRequired}
             showEmail={options.showEmail || options.isEmailRequired}
-            defaultName={(userKey && user?.[userKey.name]) || ''}
-            defaultEmail={(userKey && user?.[userKey.email]) || ''}
+            defaultName={String((userKey && user?.[userKey.name]) || '')}
+            defaultEmail={String((userKey && user?.[userKey.email]) || '')}
             onFormClose={() => {
               renderContent(false);
               options.onFormClose?.();

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -11,8 +11,8 @@ type NextRewrite = {
 };
 
 interface WebpackPluginInstance {
-  [index: string]: any;
-  apply: (compiler: any) => void;
+  [index: string]: unknown;
+  apply: (compiler: unknown) => void;
 }
 
 export type NextConfigObject = {

--- a/packages/node/src/integrations/tracing/fastify/types.ts
+++ b/packages/node/src/integrations/tracing/fastify/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export type HandlerOriginal =
   | ((request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) => Promise<void>)
   | ((request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) => void);

--- a/packages/node/src/integrations/tracing/fastify/v3/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/fastify/v3/instrumentation.ts
@@ -1,4 +1,5 @@
 // Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/407f61591ba69a39a6908264379d4d98a48dbec4/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-this-alias */
 /* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */

--- a/packages/node/src/integrations/tracing/fastify/v3/types.ts
+++ b/packages/node/src/integrations/tracing/fastify/v3/types.ts
@@ -1,4 +1,5 @@
 // Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/407f61591ba69a39a6908264379d4d98a48dbec4/plugins/node/opentelemetry-instrumentation-fastify/src/types.ts
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /*
  * Copyright The OpenTelemetry Authors
  *

--- a/packages/node/src/integrations/tracing/fastify/v3/utils.ts
+++ b/packages/node/src/integrations/tracing/fastify/v3/utils.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-dynamic-delete */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /*
  * Copyright The OpenTelemetry Authors
  *

--- a/packages/node/src/integrations/tracing/firebase/otel/patches/firestore.ts
+++ b/packages/node/src/integrations/tracing/firebase/otel/patches/firestore.ts
@@ -38,7 +38,9 @@ import type {
 
 // Inline minimal types used from `shimmer` to avoid importing shimmer's types directly.
 // We only need the shape for `wrap` and `unwrap` used in this file.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ShimmerWrap = (target: any, name: string, wrapper: (...args: any[]) => any) => void;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ShimmerUnwrap = (target: any, name: string) => void;
 
 /**

--- a/packages/node/src/integrations/tracing/firebase/otel/types.ts
+++ b/packages/node/src/integrations/tracing/firebase/otel/types.ts
@@ -1,5 +1,6 @@
 import type { Span } from '@opentelemetry/api';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 // Inlined types from 'firebase/app'
 export interface FirebaseOptions {

--- a/packages/node/src/integrations/tracing/postgresjs.ts
+++ b/packages/node/src/integrations/tracing/postgresjs.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 // Instrumentation for https://github.com/porsager/postgres
+
 import { context, trace } from '@opentelemetry/api';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import {

--- a/packages/remix/src/utils/types.ts
+++ b/packages/remix/src/utils/types.ts
@@ -1,4 +1,5 @@
-export type SentryMetaArgs<MetaFN extends (...args: any) => any> = Parameters<MetaFN>[0] & {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SentryMetaArgs<MetaFN extends (...args: any[]) => any> = Parameters<MetaFN>[0] & {
   data: {
     sentryTrace: string;
     sentryBaggage: string;

--- a/packages/remix/src/vendor/instrumentation.ts
+++ b/packages/remix/src/vendor/instrumentation.ts
@@ -1,5 +1,8 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable import/no-named-as-default-member */
+/* eslint-disable import/no-duplicates */
 
 // Vendored and modified from:
 // https://github.com/justindsmith/opentelemetry-instrumentations-js/blob/3b1e8c3e566e5cc3389e9c28cafce6a5ebb39600/packages/instrumentation-remix/src/instrumentation.ts

--- a/packages/replay-internal/rollup.npm.config.mjs
+++ b/packages/replay-internal/rollup.npm.config.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-named-as-default */
 import nodeResolve from '@rollup/plugin-node-resolve';
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '@sentry-internal/rollup-utils';
 

--- a/packages/replay-internal/src/types/rrweb.ts
+++ b/packages/replay-internal/src/types/rrweb.ts
@@ -69,7 +69,9 @@ export interface CanvasManagerOptions {
     type: string;
     quality: number;
   }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mutationCb: (p: any) => void;
   win: typeof globalThis & Window;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mirror: any;
 }

--- a/packages/vercel-edge/src/vendored/async-local-storage-context-manager.ts
+++ b/packages/vercel-edge/src/vendored/async-local-storage-context-manager.ts
@@ -24,6 +24,7 @@
 
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 /* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Context } from '@opentelemetry/api';
 import { ROOT_CONTEXT } from '@opentelemetry/api';
@@ -44,7 +45,7 @@ export class AsyncLocalStorageContextManager extends AbstractAsyncHooksContextMa
 
   constructor() {
     super();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const MaybeGlobalAsyncLocalStorageConstructor = (GLOBAL_OBJ as any).AsyncLocalStorage;
 
     if (!MaybeGlobalAsyncLocalStorageConstructor) {

--- a/packages/vercel-edge/test/wintercg-fetch.test.ts
+++ b/packages/vercel-edge/test/wintercg-fetch.test.ts
@@ -1,6 +1,5 @@
 import type { HandlerDataFetch, Integration } from '@sentry/core';
 import * as sentryCore from '@sentry/core';
-import * as sentryUtils from '@sentry/core';
 import { createStackParser } from '@sentry/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VercelEdgeClient } from '../src/index';
@@ -12,7 +11,7 @@ class FakeClient extends VercelEdgeClient {
   }
 }
 
-const addFetchInstrumentationHandlerSpy = vi.spyOn(sentryUtils, 'addFetchInstrumentationHandler');
+const addFetchInstrumentationHandlerSpy = vi.spyOn(sentryCore, 'addFetchInstrumentationHandler');
 const instrumentFetchRequestSpy = vi.spyOn(sentryCore, 'instrumentFetchRequest');
 const addBreadcrumbSpy = vi.spyOn(sentryCore, 'addBreadcrumb');
 


### PR DESCRIPTION
Explicitly enable `any` usage in typescript in:

- `dev-packages`, since those are largely integration and E2E tests. (This is done with the addition of a `dev-packages/.eslintrc.js` file.)
- `packages/*/test/`, since those are all tests. (This is done with a rule override added to the root `.eslintrc.js` file.)
- Several one-off allowances, generally for vendored types from third party sources, and cases involving method overwriting that TypeScript can't follow. (These are done with file/line overrides, explicit `as` casting, and adding type inference to the `isInstanceOf` method.)

In other places (ie, in exported production code paths), replace `any` with `unknown`, and upgrade the `@typescript/no-explicit-any` lint rule to an error.

This silences a lot of eslint warnings that were habitually ignored, and encourages us to not opt out of strict type safety in our exported code.

Closes #18489 (added automatically)