### PR TITLE
chore(bun): Fix `install-bun.js` version check and improve upgrade feedback

### DIFF
--- a/packages/bun/scripts/install-bun.js
+++ b/packages/bun/scripts/install-bun.js
@@ -15,7 +15,6 @@ exec('bun --version', (error, version) => {
     console.error('bun is not installed. Installing...');
     installLatestBun();
   } else {
-
     exec('bun upgrade', (error, stdout, stderr) => {
       if (error) {
         console.error('Failed to upgrade bun:', error);


### PR DESCRIPTION
the Bun installation helper script by fixing the Bun version check, removing unused code, and improving developer feedback when Bun is already up to date.

1. fixed incorrect Bun version command
2. removed unused variable
3. improved user feedback(logs a clear message when Bun is already on the latest version instead of silently exiting)
