### PR TITLE
feat(core): Export `captureException` and `captureMessage` parameter types

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -16,6 +16,8 @@ export type {
   User,
   Session,
   ReportDialogOptions,
+  CaptureContext,
+  ExclusiveEventHintOrCaptureContext,
 } from '@sentry/core';
 
 export type { BrowserOptions } from './client';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,7 @@ export {
 } from './utils/ai/providerSkip';
 export { applyScopeDataToEvent, mergeScopeData } from './utils/applyScopeDataToEvent';
 export { prepareEvent } from './utils/prepareEvent';
+export type { ExclusiveEventHintOrCaptureContext } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';
 export { hasSpansEnabled } from './utils/hasSpansEnabled';
 export { isSentryRequestUrl } from './utils/isSentryRequestUrl';

--- a/packages/node-core/src/index.ts
+++ b/packages/node-core/src/index.ts
@@ -156,6 +156,8 @@ export type {
   User,
   Span,
   FeatureFlagsIntegration,
+  ExclusiveEventHintOrCaptureContext,
+  CaptureContext,
 } from '@sentry/core';
 
 export { logger };


### PR DESCRIPTION
Add exports for `ExclusiveEventHintOrCaptureContext` and `CaptureContext`

closes https://github.com/getsentry/sentry-javascript/issues/18503