### PR TITLE
test(cloudflare-mcp): Pin mcp sdk to 1.24.0

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
@@ -15,7 +15,7 @@
     "test:dev": "TEST_ENV=development playwright test"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.22.0",
+    "@modelcontextprotocol/sdk": "1.24.0",
     "@sentry/cloudflare": "latest || *",
     "agents": "^0.2.23",
     "zod": "^3.25.76"


### PR DESCRIPTION
Our CI was failing with v1.25.0. Pinned to 1.24.0.

More info: https://github.com/modelcontextprotocol/typescript-sdk/issues/1302

Closes #18525 (added automatically)