### PR TITLE
fix(cloudflare): Consume body of fetch in the Cloudflare transport

### DIFF
--- a/packages/cloudflare/src/transport.ts
+++ b/packages/cloudflare/src/transport.ts
@@ -89,7 +89,18 @@ export function makeCloudflareTransport(options: CloudflareTransportOptions): Tr
     };
 
     return suppressTracing(() => {
-      return (options.fetch ?? fetch)(options.url, requestOptions).then(response => {
+      return (options.fetch ?? fetch)(options.url, requestOptions).then(async response => {
+        // Consume the response body to satisfy Cloudflare Workers' fetch requirements.
+        // The runtime requires all fetch response bodies to be read or explicitly canceled
+        // to prevent connection stalls and potential deadlocks. We read the body as text
+        // even though we don't use the content, as Sentry's response information is in the headers.
+        // See: https://github.com/getsentry/sentry-javascript/issues/18534
+        try {
+          await response.text();
+        } catch {
+          // no-op
+        }
+
         return {
           statusCode: response.status,
           headers: {

--- a/packages/cloudflare/test/transport.test.ts
+++ b/packages/cloudflare/test/transport.test.ts
@@ -106,6 +106,78 @@ describe('Edge Transport', () => {
       ...REQUEST_OPTIONS,
     });
   });
+
+  describe('Response body consumption (issue #18534)', () => {
+    it('consumes the response body to prevent Cloudflare stalled connection warnings', async () => {
+      const textMock = vi.fn(() => Promise.resolve('OK'));
+      const headers = {
+        get: vi.fn(),
+      };
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          headers,
+          status: 200,
+          text: textMock,
+        }),
+      );
+
+      const transport = makeCloudflareTransport(DEFAULT_EDGE_TRANSPORT_OPTIONS);
+
+      await transport.send(ERROR_ENVELOPE);
+      await transport.flush();
+
+      expect(textMock).toHaveBeenCalledTimes(1);
+      expect(headers.get).toHaveBeenCalledTimes(2);
+      expect(headers.get).toHaveBeenCalledWith('X-Sentry-Rate-Limits');
+      expect(headers.get).toHaveBeenCalledWith('Retry-After');
+    });
+
+    it('handles response body consumption errors gracefully', async () => {
+      const textMock = vi.fn(() => Promise.reject(new Error('Body read error')));
+      const headers = {
+        get: vi.fn(),
+      };
+
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          headers,
+          status: 200,
+          text: textMock,
+        }),
+      );
+
+      const transport = makeCloudflareTransport(DEFAULT_EDGE_TRANSPORT_OPTIONS);
+
+      await expect(transport.send(ERROR_ENVELOPE)).resolves.toBeDefined();
+      await expect(transport.flush()).resolves.toBeDefined();
+
+      expect(textMock).toHaveBeenCalledTimes(1);
+      expect(headers.get).toHaveBeenCalledTimes(2);
+      expect(headers.get).toHaveBeenCalledWith('X-Sentry-Rate-Limits');
+      expect(headers.get).toHaveBeenCalledWith('Retry-After');
+    });
+
+    it('handles a potential never existing use case of a non existing text method', async () => {
+      const headers = {
+        get: vi.fn(),
+      };
+
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          headers,
+          status: 200,
+        }),
+      );
+
+      const transport = makeCloudflareTransport(DEFAULT_EDGE_TRANSPORT_OPTIONS);
+
+      await expect(transport.send(ERROR_ENVELOPE)).resolves.toBeDefined();
+      await expect(transport.flush()).resolves.toBeDefined();
+      expect(headers.get).toHaveBeenCalledTimes(2);
+      expect(headers.get).toHaveBeenCalledWith('X-Sentry-Rate-Limits');
+      expect(headers.get).toHaveBeenCalledWith('Retry-After');
+    });
+  });
 });
 
 describe('IsolatedPromiseBuffer', () => {


### PR DESCRIPTION
(closes #18534)
(closes [JS-1319](https://linear.app/getsentry/issue/JS-1319/cloudflare-transport-doesnt-consume-fetch-response-bodies))

This consumes the body so it is safe to be closed by Cloudflare Workers. Unfortunately this cannot be reproduced locally and is only happening when the worker is being deployed (so there is no E2E test for this)

@AbhiPrasad do you think it is necessary to add this code snippet in the other transports we have? It is what I've read specifically to Cloudflare, since they seem to be super strict on it, but this could potentially be a problem in other runtimes as well.