### PR TITLE
chore(e2e): Pin to react-router 7.10.1 in spa e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/package.json
@@ -18,16 +18,16 @@
   },
   "dependencies": {
     "@sentry/react-router": "latest || *",
-    "@react-router/node": "^7.5.3",
-    "@react-router/serve": "^7.5.3",
+    "@react-router/node": "7.10.1",
+    "@react-router/serve": "7.10.1",
     "isbot": "^5.1.27",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.1.5"
+    "react-router": "7.10.1"
   },
   "devDependencies": {
     "@playwright/test": "~1.56.0",
-    "@react-router/dev": "^7.5.3",
+    "@react-router/dev": "7.10.1",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",


### PR DESCRIPTION
The newly released [React Router 7.11.0](https://github.com/remix-run/react-router/pull/14507) introduced vite preview support(https://github.com/remix-run/react-router/pull/14507). This change has a bug that affects SPA mode (`ssr: false`). 

When building in SPA mode, React Router correctly builds the server bundle (`build/server/index.js`) and then removes it with the message `Removing the server build... due to ssr:false`.

The new vite preview implementation doesn't account for this removal and attempts to import the deleted `build/server/index.js` file when starting the preview server, causing:

 > Cannot find module '/build/server/index.js'


Closes #18549 (added automatically)