### PR TITLE
chore(ci): Skip build job when no code changes present

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
       needs.job_get_metadata.outputs.changed_any_code == 'true' ||
       needs.job_get_metadata.outputs.is_base_branch == 'true' ||
       needs.job_get_metadata.outputs.is_release == 'true' ||
-      (needs.job_get_metadata.outputs.is_gitflow_sync == 'false' && needs.job_get_metadata.outputs.has_gitflow_label == 'false')
+      (needs.job_get_metadata.outputs.is_gitflow_sync == 'false' && needs.job_get_metadata.outputs.has_gitflow_label == 'false' && needs.job_get_metadata.outputs.changed_any_code == 'true')
     steps:
       - name: Check out base commit (${{ github.event.pull_request.base.sha }})
         uses: actions/checkout@v6


### PR DESCRIPTION
Fixes issue where `job_build` would run for PRs that have no code changes (e.g. markdown only changes). This was accidentally broken in #10421 when the `changed_any_code` check was removed from the last condition.

The last condition `is_gitflow_sync == 'false' && has_gitflow_label == 'false'` was true for all regular prs basically which meant `changed_any_code` had no influence on those PRs.
