### PR TITLE
chore(tests): Add unordered mode to cloudflare test runner

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/hono/basic/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/hono/basic/test.ts
@@ -47,6 +47,7 @@ it('Hono app captures errors', async ({ signal }) => {
         }),
       );
     })
+    .unordered()
     .start(signal);
   await runner.makeRequest('get', '/error', { expectError: true });
   await runner.completed();


### PR DESCRIPTION
So far if multiple expected envelopes were chained on the cloudflare test runner, the runner expected them to arrive in the order pre-defined by the caller, else the test would fail. This can sometimes be too strict, resulting in flakes. This PR adds an unordered mode to the runner that lifts the order restriction on incoming envelopes.

This mode is also used in the hono cloudflare test now.

Closes https://github.com/getsentry/sentry-javascript/issues/18589
