### PR TITLE
test(e2e): Pin agents package in cloudflare-mcp test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.24.0",
     "@sentry/cloudflare": "latest || *",
-    "agents": "0.2.23",
+    "agents": "0.2.32",
     "zod": "^3.25.76"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/cloudflare/agents/releases/tag/agents%400.2.34 started externalizing the ai package. Pinning this to the version before this let's our tests pass.

When bumping the `agents` package to `0.3.0` and adding `ai` with v6 types start breaking. 

Closes #18611 (added automatically)