### PR TITLE
test(e2e): Pin solid/vue tanstack router to 1.41.8

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@sentry/solid": "latest || *",
     "@tailwindcss/vite": "^4.0.6",
-    "@tanstack/solid-router": "^1.132.25",
+    "@tanstack/solid-router": "1.141.8",
     "@tanstack/solid-router-devtools": "^1.132.25",
     "@tanstack/solid-start": "^1.132.25",
     "solid-js": "^1.9.5",

--- a/dev-packages/e2e-tests/test-applications/vue-tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-tanstack-router/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@sentry/vue": "latest || *",
-    "@tanstack/vue-router": "^1.64.0",
+    "@tanstack/vue-router": "1.141.8",
     "vue": "^3.4.15"
   },
   "devDependencies": {


### PR DESCRIPTION
E2E tests for solid/vue tanstack router fail starting `1.42.x`. Pinning these for now until we have figured out what's going on.


Closes #18612 (added automatically)