### PR TITLE
fix(node): relax Fastify's `setupFastifyErrorHandler` argument type

### DIFF
--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -14,7 +14,7 @@ import {
 import { generateInstrumentOnce } from '@sentry/node-core';
 import { DEBUG_BUILD } from '../../../debug-build';
 import { FastifyOtelInstrumentation } from './fastify-otel/index';
-import type { FastifyInstance, FastifyReply, FastifyRequest } from './types';
+import type { FastifyInstance, FastifyMinimal, FastifyReply, FastifyRequest } from './types';
 import { FastifyInstrumentationV3 } from './v3/instrumentation';
 
 /**
@@ -244,7 +244,7 @@ function defaultShouldHandleError(_error: Error, _request: FastifyRequest, reply
  * app.listen({ port: 3000 });
  * ```
  */
-export function setupFastifyErrorHandler(fastify: FastifyInstance, options?: Partial<FastifyHandlerOptions>): void {
+export function setupFastifyErrorHandler(fastify: FastifyMinimal, options?: Partial<FastifyHandlerOptions>): void {
   if (options?.shouldHandleError) {
     getFastifyIntegration()?.setShouldHandleError(options.shouldHandleError);
   }

--- a/packages/node/src/integrations/tracing/fastify/types.ts
+++ b/packages/node/src/integrations/tracing/fastify/types.ts
@@ -27,6 +27,15 @@ export interface FastifyInstance {
   addHook(hook: 'onRequest', handler: (request: FastifyRequest, reply: FastifyReply) => void): FastifyInstance;
 }
 
+/**
+ * Minimal type for `setupFastifyErrorHandler` parameter.
+ * Uses structural typing without overloads to avoid exactOptionalPropertyTypes issues.
+ * https://github.com/getsentry/sentry-javascript/issues/18619
+ */
+export type FastifyMinimal = {
+  register: (plugin: (instance: any, opts: any, done: () => void) => void) => unknown;
+};
+
 export interface FastifyReply {
   send: () => FastifyReply;
   statusCode: number;


### PR DESCRIPTION
When using [exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes), it is pretty hard to match Fastify's instance types given all the missing overloads from the partial signature we have. The problematic area is around `addHook`.

We either need to have all the signatures implemented exactly, or outright import Fastify's types which is not ideal since it is not a dependency.

I opted to relax the types specifically for `setupFastifyErrorHandler` by providing a minimal instance with the one method it needs to avoid TS trying to matching the other properties and methods signatures, not ideal but simple enough.

I verified that this works for Fastify v3 throughout v5

closes #18619