### PR TITLE
feat(core): Add `ignoreSentryInternalFrames` option to `thirdPartyErrorFilterIntegration`

### DIFF
--- a/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
+++ b/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
@@ -368,7 +368,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithThirdPartyAndSentryInternalFrames);
@@ -380,7 +380,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithThirdPartySentryInternalAndFirstPartyFrames);
@@ -392,7 +392,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: false,
+          ignoreSentryInternalFrames: false,
         });
 
         const event = clone(eventWithThirdPartyAndSentryInternalFrames);
@@ -419,7 +419,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithThirdPartyAndSentryInternalFrames);
@@ -431,7 +431,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithThirdPartySentryInternalAndFirstPartyFrames);
@@ -478,7 +478,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithContextLine);
@@ -522,7 +522,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithPreContext);
@@ -566,7 +566,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithoutFnApply);
@@ -617,7 +617,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithSentryFrameNotLast);
@@ -662,7 +662,7 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          experimentalExcludeSentryInternalFrames: true,
+          ignoreSentryInternalFrames: true,
         });
 
         const event = clone(eventWithWrongFilename);


### PR DESCRIPTION
Some users get flooded by third party errors despite having set their third party error filtering to `"drop-error-if-contains-third-party-frames"`. This comes from the fact that often the stacktrace includes our internal wrapper logic as last trace in the stack.

With this PR we're trying to work around this by specifically ignoring these frames with a new opt-in mechanism. Marked this as experimental, so users will know this option might lead to errors being misclassified.

- Adds a new experimental option `experimentalExcludeSentryInternalFrames` to the `thirdPartyErrorFilterIntegration`
- Once enabled we apply a strict filter for frames to detect our internal wrapping logic and filter them out so they do not misclassify injected code as internal errors.

Closes https://github.com/getsentry/sentry-javascript/issues/13835