### PR TITLE
ref(node): Remove duplicate function `isCjs`

### DIFF
--- a/packages/cloudflare/src/utils/commonjs.ts
+++ b/packages/cloudflare/src/utils/commonjs.ts
@@ -1,8 +1,0 @@
-/** Detect CommonJS. */
-export function isCjs(): boolean {
-  try {
-    return typeof module !== 'undefined' && typeof module.exports !== 'undefined';
-  } catch {
-    return false;
-  }
-}

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "@sentry/core": "10.32.1",
-    "@sentry/node": "10.32.1"
+    "@sentry/node": "10.32.1",
+    "@sentry/node-core": "10.32.1"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^5.3.0",

--- a/packages/google-cloud-serverless/src/sdk.ts
+++ b/packages/google-cloud-serverless/src/sdk.ts
@@ -2,12 +2,9 @@ import type { Integration, Options } from '@sentry/core';
 import { applySdkMetadata } from '@sentry/core';
 import type { NodeClient, NodeOptions } from '@sentry/node';
 import { getDefaultIntegrationsWithoutPerformance, init as initNode } from '@sentry/node';
+import { isCjs } from '@sentry/node-core';
 import { googleCloudGrpcIntegration } from './integrations/google-cloud-grpc';
 import { googleCloudHttpIntegration } from './integrations/google-cloud-http';
-
-function isCjs(): boolean {
-  return typeof require !== 'undefined';
-}
 
 function getCjsOnlyIntegrations(): Integration[] {
   return isCjs()


### PR DESCRIPTION
While working on something else I stumbled over this unused, duplicated function. Also, there was still one implementation in Google Cloud Serverless, which checked for `typeof require !== 'undefined'`, which does not work well all the time (see this PR: https://github.com/getsentry/sentry-javascript/pull/15927).


Closes #18663 (added automatically)