### PR TITLE
chore(v8/craft): Use version templating for aws layer

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -146,7 +146,7 @@ targets:
   # whenever we release a new v8 version—otherwise we would overwrite the current major lambda layer.
   - name: aws-lambda-layer
     includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha|rc)\.\d+)?\.zip$/
-    layerName: SentryNodeServerlessSDKv8
+    layerName: SentryNodeServerlessSDKv{{{major}}}
     compatibleRuntimes:
       - name: node
         versions:


### PR DESCRIPTION
Craft now supports mustach-style template variables for versions which means we no longer have to worry about manually keeping track of the major in the layer name.

Related: https://github.com/getsentry/craft/pull/678

Closes: #18674
