### PR TITLE
test(vue): Added canary and latest test variants to Vue tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/vue-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-3/package.json
@@ -12,9 +12,11 @@
     "type-check": "vue-tsc --build --force",
     "test": "playwright test",
     "test:build": "pnpm install && pnpm build",
-    "test:assert": "playwright test",
-    "test:build-canary": "pnpm install && pnpm add vue@alpha && pnpm build",
-    "test:build-latest": "pnpm install && pnpm add vue@latest && pnpm build"
+    "test:assert": "pnpm test:print-version && playwright test",
+    "test:build-canary": "pnpm install && pnpm test:install-canary && pnpm build",
+    "test:build-latest": "pnpm install && pnpm add vue@latest && pnpm build",
+    "test:install-canary": "pnpm add vue@$(git ls-remote --tags --sort='v:refname' https://github.com/vuejs/core.git | tail -n1 | awk -F'/' '{print $NF}')",
+    "test:print-version": "node -p \"'Vue version: ' + require('vue/package.json').version\""
   },
   "dependencies": {
     "@sentry/vue": "latest || *",


### PR DESCRIPTION
This pull request adds new test scripts and Sentry test configuration variants to the `vue-3` test application. 

The main goal is to enable automated testing of the application against both the latest and canary (alpha) versions of Vue, improving compatibility and early detection of issues with upcoming Vue releases.

Vue has several tags but no single tag is considered the "cutting-edge" of Vue releases. [The docs suggest using](https://vuejs.org/about/releases#pre-releases) `install-vue` tool but none of the suggested tags are suitable:

- `canary` latest publish is 2 years ago `3.2`
- `edge` covers the main branch and not the latest releases, currently sitting at `3.5.xx`
- `alpha` latest alpha release, already outdated with `beta` releases are coming through
- `beta` will be outdated once `rc` releases start going through
- `rc` will be outdated once the stable version comes through

So it doesn't feel like there is one good option here, so I opted to instead use git to query the latest tag on the Vue repo and just use that, it's not true canary and it will sometimes install other versions but I'm out of ideas. Happy to hear more thoughts and ideas here!

I will reach out to Vue team members to see if they can make `canary` live again.

closes #18679 