### PR TITLE
test(node-native): Increase worker block timeout

### DIFF
--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/worker-block.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/worker-block.mjs
@@ -2,4 +2,4 @@ import { longWork } from './long-work.js';
 
 setTimeout(() => {
   longWork();
-}, 4000);
+}, 5000);


### PR DESCRIPTION
I saw this test flake (doesn't happen a lot but still). I had a quick look at the integration and one idea I had is that maybe sometimes the worker thread blocks before the watchdog is ready and that the thread therefore never gets detected. So here I just increase the timeout before blocking to see if that helps (let me know if that doesn't make any sense).

Closes https://github.com/getsentry/sentry-javascript/issues/18688
