### PR TITLE
ci: Add automatic flaky test detector

### DIFF
--- a/.github/FLAKY_CI_FAILURE_TEMPLATE.md
+++ b/.github/FLAKY_CI_FAILURE_TEMPLATE.md
@@ -19,11 +19,6 @@ _Not available - check the run link for details_
 
 {{ env.RUN_LINK }}
 
-### Details
-
-- **Result**: {{ env.JOB_RESULT }}
-- **Commit**: {{ env.COMMIT_SHA }}
-
 ---
 
 _This issue was automatically created._

--- a/.github/FLAKY_CI_FAILURE_TEMPLATE.md
+++ b/.github/FLAKY_CI_FAILURE_TEMPLATE.md
@@ -1,0 +1,28 @@
+---
+title: '[Flaky CI]: {{ env.JOB_NAME }}'
+labels: Tests
+---
+
+### Flakiness Type
+
+Other / Unknown
+
+### Name of Job
+
+{{ env.JOB_NAME }}
+
+### Name of Test
+
+_Not available - check the run link for details_
+
+### Link to Test Run
+
+{{ env.RUN_LINK }}
+
+### Details
+
+- **Result**: {{ env.JOB_RESULT }}
+- **Commit**: {{ env.COMMIT_SHA }}
+
+---
+*This issue was automatically created.*

--- a/.github/FLAKY_CI_FAILURE_TEMPLATE.md
+++ b/.github/FLAKY_CI_FAILURE_TEMPLATE.md
@@ -25,4 +25,5 @@ _Not available - check the run link for details_
 - **Commit**: {{ env.COMMIT_SHA }}
 
 ---
-*This issue was automatically created.*
+
+_This issue was automatically created._

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1172,17 +1172,13 @@ jobs:
       issues: write
     steps:
       - name: Check out current commit
-        if:
-          (github.ref == 'refs/heads/develop' || github.event_name == 'pull_request') && (contains(needs.*.result,
-          'failure') || contains(needs.*.result, 'cancelled'))
+        if: github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
       - name: Create issues for failed jobs
-        if:
-          (github.ref == 'refs/heads/develop' || github.event_name == 'pull_request') && (contains(needs.*.result,
-          'failure') || contains(needs.*.result, 'cancelled'))
+        if: github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1173,16 +1173,16 @@ jobs:
     steps:
       - name: Check out current commit
         if:
-          github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result,
-          'cancelled'))
+          (github.ref == 'refs/heads/develop' || github.event_name == 'pull_request') && (contains(needs.*.result,
+          'failure') || contains(needs.*.result, 'cancelled'))
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
       - name: Create issues for failed jobs
         if:
-          github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result,
-          'cancelled'))
+          (github.ref == 'refs/heads/develop' || github.event_name == 'pull_request') && (contains(needs.*.result,
+          'failure') || contains(needs.*.result, 'cancelled'))
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1168,7 +1168,74 @@ jobs:
     # Always run this, even if a dependent job failed
     if: always()
     runs-on: ubuntu-24.04
+    permissions:
+      issues: write
     steps:
+      - name: Create issues for failed jobs
+        if: github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const needs = ${{ toJSON(needs) }};
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            for (const [jobName, jobData] of Object.entries(needs)) {
+              if (jobData.result !== 'failure' && jobData.result !== 'cancelled') {
+                continue;
+              }
+
+              const title = `[Flaky CI]: ${jobName}`;
+
+              // Check for existing open issue with same title
+              const existing = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: 'Tests',
+                per_page: 100
+              });
+
+              const existingIssue = existing.data.find(i => i.title === title);
+
+              if (existingIssue) {
+                console.log(`Issue already exists for ${jobName}: #${existingIssue.number}`);
+                continue;
+              }
+
+              const body = `### Flakiness Type
+
+Other / Unknown
+
+### Name of Job
+
+${jobName}
+
+### Name of Test
+
+_Not available - check the run link for details_
+
+### Link to Test Run
+
+${runUrl}
+
+### Details
+
+- **Result**: ${jobData.result}
+- **Commit**: ${context.sha}
+
+---
+*This issue was automatically created.*`;
+
+              const newIssue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['Tests']
+              });
+              console.log(`Created issue #${newIssue.data.number} for ${jobName}`);
+            }
+
       - name: Check for failures
         if: cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1171,20 +1171,45 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Check out current commit
+        if: github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github
+
       - name: Create issues for failed jobs
         if: github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
             const needs = ${{ toJSON(needs) }};
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Read and parse template
+            const template = fs.readFileSync('.github/FLAKY_CI_FAILURE_TEMPLATE.md', 'utf8');
+            const [, frontmatter, body] = template.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
 
             for (const [jobName, jobData] of Object.entries(needs)) {
               if (jobData.result !== 'failure' && jobData.result !== 'cancelled') {
                 continue;
               }
 
-              const title = `[Flaky CI]: ${jobName}`;
+              // Replace template variables
+              const vars = {
+                'JOB_NAME': jobName,
+                'JOB_RESULT': jobData.result,
+                'RUN_LINK': runUrl,
+                'COMMIT_SHA': context.sha
+              };
+
+              let title = frontmatter.match(/title:\s*'(.*)'/)[1];
+              let issueBody = body;
+              for (const [key, value] of Object.entries(vars)) {
+                const pattern = new RegExp(`\\{\\{\\s*env\\.${key}\\s*\\}\\}`, 'g');
+                title = title.replace(pattern, value);
+                issueBody = issueBody.replace(pattern, value);
+              }
 
               // Check for existing open issue with same title
               const existing = await github.rest.issues.listForRepo({
@@ -1202,35 +1227,11 @@ jobs:
                 continue;
               }
 
-              const body = `### Flakiness Type
-
-Other / Unknown
-
-### Name of Job
-
-${jobName}
-
-### Name of Test
-
-_Not available - check the run link for details_
-
-### Link to Test Run
-
-${runUrl}
-
-### Details
-
-- **Result**: ${jobData.result}
-- **Commit**: ${context.sha}
-
----
-*This issue was automatically created.*`;
-
               const newIssue = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: title,
-                body: body,
+                body: issueBody.trim(),
                 labels: ['Tests']
               });
               console.log(`Created issue #${newIssue.data.number} for ${jobName}`);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1172,13 +1172,13 @@ jobs:
       issues: write
     steps:
       - name: Check out current commit
-        if: (github.ref == 'refs/heads/develop' || github.event_name == 'pull_request') && contains(needs.*.result, 'failure')
+        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
       - name: Create issues for failed jobs
-        if: (github.ref == 'refs/heads/develop' || github.event_name == 'pull_request') && contains(needs.*.result, 'failure')
+        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1204,7 +1204,7 @@ jobs:
             const [, frontmatter, bodyTemplate] = template.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
 
             // Get existing open issues with Tests label
-            const existing = await github.rest.issues.listForRepo({
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1172,13 +1172,17 @@ jobs:
       issues: write
     steps:
       - name: Check out current commit
-        if: github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+        if:
+          github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result,
+          'cancelled'))
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
       - name: Create issues for failed jobs
-        if: github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+        if:
+          github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result,
+          'cancelled'))
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1172,13 +1172,13 @@ jobs:
       issues: write
     steps:
       - name: Check out current commit
-        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
+        if: (github.ref == 'refs/heads/develop' || github.event_name == 'pull_request') && contains(needs.*.result, 'failure')
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
       - name: Create issues for failed jobs
-        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
+        if: (github.ref == 'refs/heads/develop' || github.event_name == 'pull_request') && contains(needs.*.result, 'failure')
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1230,7 +1230,7 @@ jobs:
                 issueBody = issueBody.replace(pattern, value);
               }
 
-              const existingIssue = existing.data.find(i => i.title === title);
+              const existingIssue = existing.find(i => i.title === title);
 
               if (existingIssue) {
                 console.log(`Issue already exists for ${jobName}: #${existingIssue.number}`);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1172,17 +1172,13 @@ jobs:
       issues: write
     steps:
       - name: Check out current commit
-        if:
-          github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result,
-          'cancelled'))
+        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
       - name: Create issues for failed jobs
-        if:
-          github.ref == 'refs/heads/develop' && (contains(needs.*.result, 'failure') || contains(needs.*.result,
-          'cancelled'))
+        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
         uses: actions/github-script@v7
         with:
           script: |
@@ -1196,9 +1192,7 @@ jobs:
               per_page: 100
             });
 
-            const failedJobs = jobs.data.jobs.filter(job =>
-              job.conclusion === 'failure' || job.conclusion === 'cancelled'
-            );
+            const failedJobs = jobs.data.jobs.filter(job => job.conclusion === 'failure');
 
             if (failedJobs.length === 0) {
               console.log('No failed jobs found');

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1187,42 +1187,54 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const needs = ${{ toJSON(needs) }};
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Fetch actual job details from the API to get descriptive names
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100
+            });
+
+            const failedJobs = jobs.data.jobs.filter(job =>
+              job.conclusion === 'failure' || job.conclusion === 'cancelled'
+            );
+
+            if (failedJobs.length === 0) {
+              console.log('No failed jobs found');
+              return;
+            }
 
             // Read and parse template
             const template = fs.readFileSync('.github/FLAKY_CI_FAILURE_TEMPLATE.md', 'utf8');
-            const [, frontmatter, body] = template.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+            const [, frontmatter, bodyTemplate] = template.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
 
-            for (const [jobName, jobData] of Object.entries(needs)) {
-              if (jobData.result !== 'failure' && jobData.result !== 'cancelled') {
-                continue;
-              }
+            // Get existing open issues with Tests label
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'Tests',
+              per_page: 100
+            });
+
+            for (const job of failedJobs) {
+              const jobName = job.name;
+              const jobUrl = job.html_url;
 
               // Replace template variables
               const vars = {
                 'JOB_NAME': jobName,
-                'JOB_RESULT': jobData.result,
-                'RUN_LINK': runUrl,
-                'COMMIT_SHA': context.sha
+                'RUN_LINK': jobUrl
               };
 
               let title = frontmatter.match(/title:\s*'(.*)'/)[1];
-              let issueBody = body;
+              let issueBody = bodyTemplate;
               for (const [key, value] of Object.entries(vars)) {
                 const pattern = new RegExp(`\\{\\{\\s*env\\.${key}\\s*\\}\\}`, 'g');
                 title = title.replace(pattern, value);
                 issueBody = issueBody.replace(pattern, value);
               }
-
-              // Check for existing open issue with same title
-              const existing = await github.rest.issues.listForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                labels: 'Tests',
-                per_page: 100
-              });
 
               const existingIssue = existing.data.find(i => i.title === title);
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1185,14 +1185,14 @@ jobs:
             const fs = require('fs');
 
             // Fetch actual job details from the API to get descriptive names
-            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: context.runId,
               per_page: 100
             });
 
-            const failedJobs = jobs.data.jobs.filter(job => job.conclusion === 'failure');
+            const failedJobs = jobs.filter(job => job.conclusion === 'failure');
 
             if (failedJobs.length === 0) {
               console.log('No failed jobs found');

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/errors.test.ts
@@ -56,3 +56,8 @@ test('To not crash app from withMonitor', async ({ baseURL }) => {
   expect(response2.message).toBe('This is an exception withMonitor: 2');
   expect(response1.pid).toBe(response2.pid); //Just to double-check, TBS
 });
+
+// TODO: Remove this test - added temporarily to test flaky CI issue creation
+test('Intentional failure for testing flaky CI workflow', async () => {
+  expect(true).toBe(false);
+});

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/errors.test.ts
@@ -56,8 +56,3 @@ test('To not crash app from withMonitor', async ({ baseURL }) => {
   expect(response2.message).toBe('This is an exception withMonitor: 2');
   expect(response1.pid).toBe(response2.pid); //Just to double-check, TBS
 });
-
-// TODO: Remove this test - added temporarily to test flaky CI issue creation
-test('Intentional failure for testing flaky CI workflow', async () => {
-  expect(true).toBe(false);
-});


### PR DESCRIPTION
Manually checking for flakes and opening issues is a bit annoying. I was thinking we could add a ci workflow to automate this. The action only runs when merging to develop. Could also be done on PRs but seems unnecessarily complicated. My thinking is that for a push to develop to happen, all the test must first have passed in the original PR. Therefore if the test then fails on develop we know it's a flake. Open for ideas/improvements/cleanups or let me know if there might be any cases I am missing that could lead to false positives.

Example issue created with this: https://github.com/getsentry/sentry-javascript/issues/18693

It doesn't get all the details but I think basically the most important is a link to the run so we can then investigate further. Also the logic for creating the issues is a bit ugly, but not sure if we can make it cleaner given that I want to create one issue per failed test not dump it all into one issue.
