### PR TITLE
test(nestjs): Add canary test for latest

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -115,9 +115,6 @@ jobs:
             build-command: 'test:build-canary'
             label: 'nuxt-4 (canary)'
           - test-application: 'nestjs-11'
-            build-command: 'test:build-canary'
-            label: 'nestjs-11 (next)'
-          - test-application: 'nestjs-11'
             build-command: 'test:build-latest'
             label: 'nestjs-11 (latest)'
 

--- a/dev-packages/e2e-tests/test-applications/nestjs-11/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-11/package.json
@@ -11,7 +11,6 @@
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "test": "playwright test",
     "test:build": "pnpm install",
-    "test:build-canary": "pnpm install && pnpm add @nestjs/common@next @nestjs/core@next @nestjs/platform-express@next @nestjs/microservices@next && pnpm add -D @nestjs/cli@next @nestjs/testing@next && pnpm build",
     "test:build-latest": "pnpm install && pnpm add @nestjs/common@latest @nestjs/core@latest @nestjs/platform-express@latest @nestjs/microservices@latest && pnpm add -D @nestjs/cli@latest @nestjs/testing@latest && pnpm build",
     "test:assert": "pnpm test"
   },
@@ -50,17 +49,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "sentryTest": {
-    "optionalVariants": [
-      {
-        "build-command": "pnpm test:build-canary",
-        "label": "nestjs-11 (next)"
-      },
-      {
-        "build-command": "pnpm test:build-latest",
-        "label": "nestjs-11 (latest)"
-      }
-    ]
   }
 }


### PR DESCRIPTION
Adding a canary test for nestjs using the `latest` tag. There is also a `next` tag that seems to be used for upcoming majors, but using that all the tests break so I removed it again for now.

see [npm nestjs/core tags](https://www.npmjs.com/package/@nestjs/core?activeTab=versions)

Closes https://github.com/getsentry/sentry-javascript/issues/18668
