### PR TITLE
fix(core): Subtract `performance.now()` from `browserPerformanceTimeOrigin` fallback

### DIFF
--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -125,9 +125,9 @@ function getBrowserTimeOrigin(): number | undefined {
     return navigationStart;
   }
 
-  // TODO: We should probably fall back to Date.now() - performance.now(), since this is still more accurate than just Date.now() (?)
-  // Either both timeOrigin and navigationStart are skewed or neither is available, fallback to Date.
-  return dateNow;
+  // Either both timeOrigin and navigationStart are skewed or neither is available, fallback to subtracting
+  // `performance.now()` from `Date.now()`.
+  return dateNow - performanceNow;
 }
 
 /**


### PR DESCRIPTION
This PR fixes a "bug" where we previously returned just `Date.now()` as a fallback for getting the timeOrigin if more precise `performance.timeOrigin` or `performance.timing.navigationStart` were not available or unreliable.

This fix now subtracts `performance.now()` from `Date.now()` which should make the fallback more accurate.

Closes #18716 (added automatically)