### PR TITLE
ref(core): Strengthen `browserPerformanceTimeOrigin` reliability check

### DIFF
--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -91,8 +91,7 @@ function getBrowserTimeOrigin(): number | undefined {
     return undefined;
   }
 
-  // TOOD: We should probably set a much tighter threshold here as skew can already happen within just a few minutes.
-  const threshold = 3_600_000; // 1 hour in milliseconds
+  const threshold = 300_000; // 5 minutes in milliseconds
   const performanceNow = performance.now();
   const dateNow = Date.now();
 

--- a/packages/core/test/lib/utils/time.test.ts
+++ b/packages/core/test/lib/utils/time.test.ts
@@ -7,7 +7,7 @@ async function getFreshPerformanceTimeOrigin() {
   return timeModule.browserPerformanceTimeOrigin();
 }
 
-const RELIABLE_THRESHOLD_MS = 3_600_000;
+const RELIABLE_THRESHOLD_MS = 300_000;
 
 describe('browserPerformanceTimeOrigin', () => {
   it('returns `performance.timeOrigin` if it is available and reliable', async () => {


### PR DESCRIPTION
In `browserPerformanceTimeOrigin`, we test how reliable `performance.timeOrigin` (or its predecessor) is by comparing its timestamp against `performance.now() - Date.now()`. If the delta is larger than 1h, we take the fallback rather than `performance.timeOrigin`. 

For some context, we do this because `performance.timeOrigin` is prone to several inaccuracies, most prominently because it will drift behind the actual current time if users suspend their devices (e.g. closing a laptop, shutting of a phone). This makes the monotonic clock of `timeOrigin` resume where it left off prior to the suspension. It does not resync with the actual wall clock time (for better or worse). 

This PR now makes the reliability check more strict by decreasing the time window from 1h to just 5 minutes. This _should_ catch time drift more often. Now that we improved the fallback via #18715, I think we can give this a shot.