### PR TITLE
chore(node-tests): Upgrade `@langchain/core`

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -30,7 +30,7 @@
     "@hapi/hapi": "^21.3.10",
     "@hono/node-server": "^1.19.4",
     "@langchain/anthropic": "^0.3.10",
-    "@langchain/core": "^0.3.28",
+    "@langchain/core": "^0.3.80",
     "@langchain/langgraph": "^0.2.32",
     "@nestjs/common": "^11",
     "@nestjs/core": "^11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4922,10 +4922,10 @@
     "@anthropic-ai/sdk" "^0.65.0"
     fast-xml-parser "^4.4.1"
 
-"@langchain/core@^0.3.28":
-  version "0.3.78"
-  resolved "https://registry.npmjs.org/@langchain/core/-/core-0.3.78.tgz#40e69fba6688858edbcab4473358ec7affc685fd"
-  integrity sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==
+"@langchain/core@^0.3.80":
+  version "0.3.80"
+  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.3.80.tgz#c494a6944e53ab28bf32dc531e257b17cfc8f797"
+  integrity sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==
   dependencies:
     "@cfworker/json-schema" "^4.0.2"
     ansi-styles "^5.0.0"


### PR DESCRIPTION

Closes https://github.com/getsentry/sentry-javascript/security/dependabot/901


Closes #18721 (added automatically)