### PR TITLE
fix(node): Use snake_case for Fastify's `request-handler` op.

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-fastify/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-fastify/tests/transactions.test.ts
@@ -80,7 +80,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
           data: {
             'sentry.origin': 'auto.http.otel.fastify',
-            'sentry.op': 'request-handler.fastify',
+            'sentry.op': 'request_handler.fastify',
             'service.name': 'fastify',
             'hook.name': 'fastify -> @fastify/otel -> @fastify/middie - route-handler',
             'fastify.type': 'request-handler',
@@ -88,7 +88,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
             'hook.callback.name': 'anonymous',
           },
           description: '@fastify/middie - route-handler',
-          op: 'request-handler.fastify',
+          op: 'request_handler.fastify',
           parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -282,7 +282,7 @@ function addFastifySpanAttributes(span: Span): void {
     return;
   }
 
-  const opPrefix = isHook ? 'hook' : isHandler ? 'middleware' : isRequestHandler ? 'request-handler' : '<unknown>';
+  const opPrefix = isHook ? 'hook' : isHandler ? 'middleware' : isRequestHandler ? 'request_handler' : '<unknown>';
 
   span.setAttributes({
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.otel.fastify',


### PR DESCRIPTION
Following up: https://github.com/getsentry/sentry-javascript/pull/18617

> The span ops should be using snake_case as per our spec: https://develop.sentry.dev/sdk/telemetry/traces/span-operations/



Closes #18730 (added automatically)