### PR TITLE
feat(core,node-core): Consolidate bun and node types with ServerRuntimeOptions

### DIFF
--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -1,12 +1,12 @@
 import type { BaseTransportOptions, ClientOptions, Options } from '@sentry/core';
-import type { ServerRuntimeOptions } from '@sentry/node-core';
+import type { OpenTelemetryServerRuntimeOptions } from '@sentry/node-core';
 
 /**
  * Base options for the Sentry Bun SDK.
- * Extends the common WinterTC options shared with Node.js and other server-side SDKs.
+ * Extends the common WinterTC options with OpenTelemetry support shared with Node.js and other server-side SDKs.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface BaseBunOptions extends ServerRuntimeOptions {}
+export interface BaseBunOptions extends OpenTelemetryServerRuntimeOptions {}
 
 /**
  * Configuration options for the Sentry Bun SDK

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -387,7 +387,7 @@ export type { Extra, Extras } from './types-hoist/extra';
 export type { Integration, IntegrationFn } from './types-hoist/integration';
 export type { Mechanism } from './types-hoist/mechanism';
 export type { ExtractedNodeRequestData, HttpHeaderValue, Primitive, WorkerLocation } from './types-hoist/misc';
-export type { ClientOptions, CoreOptions as Options } from './types-hoist/options';
+export type { ClientOptions, CoreOptions as Options, ServerRuntimeOptions } from './types-hoist/options';
 export type { Package } from './types-hoist/package';
 export type { PolymorphicEvent, PolymorphicRequest } from './types-hoist/polymorphics';
 export type {

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -12,6 +12,95 @@ import type { TracePropagationTargets } from './tracing';
 import type { BaseTransportOptions, Transport } from './transport';
 
 /**
+ * Base options for WinterTC-compatible server-side JavaScript runtimes.
+ * This interface contains common configuration options shared between
+ * SDKs.
+ */
+export interface ServerRuntimeOptions {
+  /**
+   * List of strings/regex controlling to which outgoing requests
+   * the SDK will attach tracing headers.
+   *
+   * By default the SDK will attach those headers to all outgoing
+   * requests. If this option is provided, the SDK will match the
+   * request URL of outgoing requests against the items in this
+   * array, and only attach tracing headers if a match was found.
+   *
+   * @example
+   * ```js
+   * Sentry.init({
+   *   tracePropagationTargets: ['api.site.com'],
+   * });
+   * ```
+   */
+  tracePropagationTargets?: TracePropagationTargets;
+
+  /**
+   * Sets an optional server name (device name).
+   *
+   * This is useful for identifying which server or instance is sending events.
+   */
+  serverName?: string;
+
+  /**
+   * If you use Spotlight by Sentry during development, use
+   * this option to forward captured Sentry events to Spotlight.
+   *
+   * Either set it to true, or provide a specific Spotlight Sidecar URL.
+   *
+   * More details: https://spotlightjs.com/
+   *
+   * IMPORTANT: Only set this option to `true` while developing, not in production!
+   */
+  spotlight?: boolean | string;
+
+  /**
+   * If set to `false`, the SDK will not automatically detect the `serverName`.
+   *
+   * This is useful if you are using the SDK in a CLI app or Electron where the
+   * hostname might be considered PII.
+   *
+   * @default true
+   */
+  includeServerName?: boolean;
+
+  /**
+   * By default, the SDK will try to identify problems with your instrumentation setup and warn you about it.
+   * If you want to disable these warnings, set this to `true`.
+   */
+  disableInstrumentationWarnings?: boolean;
+
+  /**
+   * Controls how many milliseconds to wait before shutting down. The default is 2 seconds. Setting this too low can cause
+   * problems for sending events from command line applications. Setting it too
+   * high can cause the application to block for users with network connectivity
+   * problems.
+   */
+  shutdownTimeout?: number;
+
+  /**
+   * Configures in which interval client reports will be flushed. Defaults to `60_000` (milliseconds).
+   */
+  clientReportFlushInterval?: number;
+
+  /**
+   * The max. duration in seconds that the SDK will wait for parent spans to be finished before discarding a span.
+   * The SDK will automatically clean up spans that have no finished parent after this duration.
+   * This is necessary to prevent memory leaks in case of parent spans that are never finished or otherwise dropped/missing.
+   * However, if you have very long-running spans in your application, a shorter duration might cause spans to be discarded too early.
+   * In this case, you can increase this duration to a value that fits your expected data.
+   *
+   * Defaults to 300 seconds (5 minutes).
+   */
+  maxSpanWaitDuration?: number;
+
+  /**
+   * Callback that is executed when a fatal global error occurs.
+   */
+  onFatalError?(this: void, error: Error): void;
+}
+
+/**
  * A filter object for ignoring spans.
  * At least one of the properties (`op` or `name`) must be set.
  */

--- a/packages/node-core/src/index.ts
+++ b/packages/node-core/src/index.ts
@@ -50,7 +50,7 @@ export { NodeClient } from './sdk/client';
 export { cron } from './cron';
 export { NODE_VERSION } from './nodeVersion';
 
-export type { NodeOptions, ServerRuntimeOptions } from './types';
+export type { NodeOptions, OpenTelemetryServerRuntimeOptions } from './types';
 
 export {
   // This needs exporting so the NodeClient can be used without calling init

--- a/packages/node-core/src/types.ts
+++ b/packages/node-core/src/types.ts
@@ -1,54 +1,15 @@
 import type { Span as WriteableSpan } from '@opentelemetry/api';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
-import type { ClientOptions, Options, SamplingContext, Scope, Span, TracePropagationTargets } from '@sentry/core';
+import type { ClientOptions, Options, SamplingContext, Scope, ServerRuntimeOptions, Span } from '@sentry/core';
 import type { NodeTransportOptions } from './transports';
 
 /**
- * Base options for WinterTC-compatible server-side JavaScript runtimes.
- * This interface contains common configuration options shared between
- * Node.js, Bun, and other WinterTC-compliant runtime SDKs.
- *
- * @see https://wintercg.org/
+ * Base options for WinterTC-compatible server-side JavaScript runtimes with OpenTelemetry support.
+ * This interface extends the base ServerRuntimeOptions from @sentry/core with OpenTelemetry-specific configuration options.
+ * Used by Node.js, Bun, and other WinterTC-compliant runtime SDKs that support OpenTelemetry instrumentation.
  */
-export interface ServerRuntimeOptions {
-  /**
-   * List of strings/regex controlling to which outgoing requests
-   * the SDK will attach tracing headers.
-   *
-   * By default the SDK will attach those headers to all outgoing
-   * requests. If this option is provided, the SDK will match the
-   * request URL of outgoing requests against the items in this
-   * array, and only attach tracing headers if a match was found.
-   *
-   * @example
-   * ```js
-   * Sentry.init({
-   *   tracePropagationTargets: ['api.site.com'],
-   * });
-   * ```
-   */
-  tracePropagationTargets?: TracePropagationTargets;
-
-  /**
-   * Sets an optional server name (device name).
-   *
-   * This is useful for identifying which server or instance is sending events.
-   */
-  serverName?: string;
-
-  /**
-   * If you use Spotlight by Sentry during development, use
-   * this option to forward captured Sentry events to Spotlight.
-   *
-   * Either set it to true, or provide a specific Spotlight Sidecar URL.
-   *
-   * More details: https://spotlightjs.com/
-   *
-   * IMPORTANT: Only set this option to `true` while developing, not in production!
-   */
-  spotlight?: boolean | string;
-
+export interface OpenTelemetryServerRuntimeOptions extends ServerRuntimeOptions {
   /**
    * If this is set to true, the SDK will not set up OpenTelemetry automatically.
    * In this case, you _have_ to ensure to set it up correctly yourself, including:
@@ -58,35 +19,6 @@ export interface ServerRuntimeOptions {
    * * The `SentrySampler`
    */
   skipOpenTelemetrySetup?: boolean;
-
-  /**
-   * If set to `false`, the SDK will not automatically detect the `serverName`.
-   *
-   * This is useful if you are using the SDK in a CLI app or Electron where the
-   * hostname might be considered PII.
-   *
-   * @default true
-   */
-  includeServerName?: boolean;
-
-  /**
-   * By default, the SDK will try to identify problems with your instrumentation setup and warn you about it.
-   * If you want to disable these warnings, set this to `true`.
-   */
-  disableInstrumentationWarnings?: boolean;
-
-  /**
-   * Controls how many milliseconds to wait before shutting down. The default is 2 seconds. Setting this too low can cause
-   * problems for sending events from command line applications. Setting it too
-   * high can cause the application to block for users with network connectivity
-   * problems.
-   */
-  shutdownTimeout?: number;
-
-  /**
-   * Configures in which interval client reports will be flushed. Defaults to `60_000` (milliseconds).
-   */
-  clientReportFlushInterval?: number;
 
   /**
    * Provide an array of OpenTelemetry Instrumentations that should be registered.
@@ -99,29 +31,13 @@ export interface ServerRuntimeOptions {
    * Provide an array of additional OpenTelemetry SpanProcessors that should be registered.
    */
   openTelemetrySpanProcessors?: SpanProcessor[];
-
-  /**
-   * The max. duration in seconds that the SDK will wait for parent spans to be finished before discarding a span.
-   * The SDK will automatically clean up spans that have no finished parent after this duration.
-   * This is necessary to prevent memory leaks in case of parent spans that are never finished or otherwise dropped/missing.
-   * However, if you have very long-running spans in your application, a shorter duration might cause spans to be discarded too early.
-   * In this case, you can increase this duration to a value that fits your expected data.
-   *
-   * Defaults to 300 seconds (5 minutes).
-   */
-  maxSpanWaitDuration?: number;
-
-  /**
-   * Callback that is executed when a fatal global error occurs.
-   */
-  onFatalError?(this: void, error: Error): void;
 }
 
 /**
  * Base options for the Sentry Node SDK.
- * Extends the common WinterTC options shared with Bun and other server-side SDKs.
+ * Extends the common WinterTC options with OpenTelemetry support shared with Bun and other server-side SDKs.
  */
-export interface BaseNodeOptions extends ServerRuntimeOptions {
+export interface BaseNodeOptions extends OpenTelemetryServerRuntimeOptions {
   /**
    * Sets profiling sample rate when @sentry/profiling-node is installed
    *

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -1,13 +1,13 @@
 import type { Span as WriteableSpan } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { ClientOptions, Options, SamplingContext, Scope, Span } from '@sentry/core';
-import type { NodeTransportOptions, ServerRuntimeOptions } from '@sentry/node-core';
+import type { NodeTransportOptions, OpenTelemetryServerRuntimeOptions } from '@sentry/node-core';
 
 /**
  * Base options for the Sentry Node SDK.
- * Extends the common WinterTC options shared with Bun and other server-side SDKs.
+ * Extends the common WinterTC options with OpenTelemetry support shared with Bun and other server-side SDKs.
  */
-export interface BaseNodeOptions extends ServerRuntimeOptions {
+export interface BaseNodeOptions extends OpenTelemetryServerRuntimeOptions {
   /**
    * Sets profiling sample rate when @sentry/profiling-node is installed
    *


### PR DESCRIPTION
closes #18437
closes [JS-1272](https://linear.app/getsentry/issue/JS-1272/extend-bunoptions-with-nodeoptions)

This adds a new type `ServerRuntimeOptions` inside `@sentry/core`, a type which can be used for all SDKs without OpenTelemetry suppport. In case OpenTelemetry support is needed `OpenTelemetryServerRuntimeOptions` are exported from `@sentry/node-core`, which extends `ServerRuntimeOptions` with the options which are needed to support OTel.

For now we don't have a nice testing strategy for Bun yet, and I didn't want to copy paste all Node integration/e2e tests just for this, I'm still up for suggestions.