### PR TITLE
fix(react,solid,vue): Fix parametrization behavior for non-matched routes

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@sentry/solid": "latest || *",
     "@tailwindcss/vite": "^4.0.6",
-    "@tanstack/solid-router": "1.141.8",
+    "@tanstack/solid-router": "^1.141.8",
     "@tanstack/solid-router-devtools": "^1.132.25",
     "@tanstack/solid-start": "^1.132.25",
     "solid-js": "^1.9.5",

--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/src/main.tsx
@@ -39,7 +39,7 @@ const indexRoute = createRoute({
 
 const postsRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: 'posts/',
+  path: 'posts',
 });
 
 const postIdRoute = createRoute({

--- a/dev-packages/e2e-tests/test-applications/tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstack-router/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@sentry/react": "latest || *",
-    "@tanstack/react-router": "1.64.0",
+    "@tanstack/react-router": "^1.64.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/dev-packages/e2e-tests/test-applications/tanstack-router/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/tanstack-router/src/main.tsx
@@ -41,7 +41,7 @@ const indexRoute = createRoute({
 
 const postsRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: 'posts/',
+  path: 'posts',
 });
 
 const postIdRoute = createRoute({

--- a/dev-packages/e2e-tests/test-applications/vue-tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-tanstack-router/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@sentry/vue": "latest || *",
-    "@tanstack/vue-router": "1.141.8",
+    "@tanstack/vue-router": "^1.141.8",
     "vue": "^3.4.15"
   },
   "devDependencies": {

--- a/dev-packages/e2e-tests/test-applications/vue-tanstack-router/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-tanstack-router/src/main.ts
@@ -19,7 +19,7 @@ const indexRoute = createRoute({
 
 const postsRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: 'posts/',
+  path: 'posts',
 });
 
 const postIdRoute = createRoute({

--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -49,14 +49,17 @@ export function tanstackRouterBrowserTracingIntegration(
         );
 
         const lastMatch = matchedRoutes[matchedRoutes.length - 1];
+        // If we only match __root__, we ended up not matching any route at all, so
+        // we fall back to the pathname.
+        const routeMatch = lastMatch?.routeId !== '__root__' ? lastMatch : undefined;
 
         startBrowserTracingPageLoadSpan(client, {
-          name: lastMatch ? lastMatch.routeId : initialWindowLocation.pathname,
+          name: routeMatch ? routeMatch.routeId : initialWindowLocation.pathname,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.tanstack_router',
-            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: lastMatch ? 'route' : 'url',
-            ...routeMatchToParamSpanAttributes(lastMatch),
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeMatch ? 'route' : 'url',
+            ...routeMatchToParamSpanAttributes(routeMatch),
           },
         });
       }
@@ -74,21 +77,23 @@ export function tanstackRouterBrowserTracingIntegration(
             return;
           }
 
-          const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(
+          const matchedRoutesOnBeforeNavigate = castRouterInstance.matchRoutes(
             onBeforeNavigateArgs.toLocation.pathname,
             onBeforeNavigateArgs.toLocation.search,
             { preload: false, throwOnError: false },
           );
 
-          const onBeforeNavigateLastMatch = onResolvedMatchedRoutes[onResolvedMatchedRoutes.length - 1];
+          const onBeforeNavigateLastMatch = matchedRoutesOnBeforeNavigate[matchedRoutesOnBeforeNavigate.length - 1];
+          const onBeforeNavigateRouteMatch =
+            onBeforeNavigateLastMatch?.routeId !== '__root__' ? onBeforeNavigateLastMatch : undefined;
 
           const navigationLocation = WINDOW.location;
           const navigationSpan = startBrowserTracingNavigationSpan(client, {
-            name: onBeforeNavigateLastMatch ? onBeforeNavigateLastMatch.routeId : navigationLocation.pathname,
+            name: onBeforeNavigateRouteMatch ? onBeforeNavigateRouteMatch.routeId : navigationLocation.pathname,
             attributes: {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.tanstack_router',
-              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: onBeforeNavigateLastMatch ? 'route' : 'url',
+              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: onBeforeNavigateRouteMatch ? 'route' : 'url',
             },
           });
 
@@ -96,18 +101,20 @@ export function tanstackRouterBrowserTracingIntegration(
           const unsubscribeOnResolved = castRouterInstance.subscribe('onResolved', onResolvedArgs => {
             unsubscribeOnResolved();
             if (navigationSpan) {
-              const onResolvedMatchedRoutes = castRouterInstance.matchRoutes(
+              const matchedRoutesOnResolved = castRouterInstance.matchRoutes(
                 onResolvedArgs.toLocation.pathname,
                 onResolvedArgs.toLocation.search,
                 { preload: false, throwOnError: false },
               );
 
-              const onResolvedLastMatch = onResolvedMatchedRoutes[onResolvedMatchedRoutes.length - 1];
+              const onResolvedLastMatch = matchedRoutesOnResolved[matchedRoutesOnResolved.length - 1];
+              const onResolvedRouteMatch =
+                onResolvedLastMatch?.routeId !== '__root__' ? onResolvedLastMatch : undefined;
 
-              if (onResolvedLastMatch) {
-                navigationSpan.updateName(onResolvedLastMatch.routeId);
+              if (onResolvedRouteMatch) {
+                navigationSpan.updateName(onResolvedRouteMatch.routeId);
                 navigationSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
-                navigationSpan.setAttributes(routeMatchToParamSpanAttributes(onResolvedLastMatch));
+                navigationSpan.setAttributes(routeMatchToParamSpanAttributes(onResolvedRouteMatch));
               }
             }
           });

--- a/packages/vue/src/tanstackrouter.ts
+++ b/packages/vue/src/tanstackrouter.ts
@@ -43,20 +43,22 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
       if (instrumentPageLoad && initialWindowLocation) {
         const matchedRoutes = router.matchRoutes(
           initialWindowLocation.pathname,
-
           router.options.parseSearch(initialWindowLocation.search),
           { preload: false, throwOnError: false },
         );
 
         const lastMatch = matchedRoutes[matchedRoutes.length - 1];
+        // If we only match __root__, we ended up not matching any route at all, so
+        // we fall back to the pathname.
+        const routeMatch = lastMatch?.routeId !== '__root__' ? lastMatch : undefined;
 
         startBrowserTracingPageLoadSpan(client, {
-          name: lastMatch ? lastMatch.routeId : initialWindowLocation.pathname,
+          name: routeMatch ? routeMatch.routeId : initialWindowLocation.pathname,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.vue.tanstack_router',
-            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: lastMatch ? 'route' : 'url',
-            ...routeMatchToParamSpanAttributes(lastMatch),
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeMatch ? 'route' : 'url',
+            ...routeMatchToParamSpanAttributes(routeMatch),
           },
         });
       }
@@ -87,18 +89,20 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
           );
 
           const onBeforeNavigateLastMatch = onResolvedMatchedRoutes[onResolvedMatchedRoutes.length - 1];
+          const onBeforeNavigateRouteMatch =
+            onBeforeNavigateLastMatch?.routeId !== '__root__' ? onBeforeNavigateLastMatch : undefined;
 
           const navigationLocation = WINDOW.location;
           const navigationSpan = startBrowserTracingNavigationSpan(client, {
-            name: onBeforeNavigateLastMatch
-              ? onBeforeNavigateLastMatch.routeId
+            name: onBeforeNavigateRouteMatch
+              ? onBeforeNavigateRouteMatch.routeId
               : // In SSR/non-browser contexts, WINDOW.location may be undefined, so fall back to the router's location
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 navigationLocation?.pathname || onBeforeNavigateArgs.toLocation.pathname,
             attributes: {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.vue.tanstack_router',
-              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: onBeforeNavigateLastMatch ? 'route' : 'url',
+              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: onBeforeNavigateRouteMatch ? 'route' : 'url',
             },
           });
 
@@ -116,11 +120,13 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
               );
 
               const onResolvedLastMatch = onResolvedMatchedRoutes[onResolvedMatchedRoutes.length - 1];
+              const onResolvedRouteMatch =
+                onResolvedLastMatch?.routeId !== '__root__' ? onResolvedLastMatch : undefined;
 
-              if (onResolvedLastMatch) {
-                navigationSpan.updateName(onResolvedLastMatch.routeId);
+              if (onResolvedRouteMatch) {
+                navigationSpan.updateName(onResolvedRouteMatch.routeId);
                 navigationSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
-                navigationSpan.setAttributes(routeMatchToParamSpanAttributes(onResolvedLastMatch));
+                navigationSpan.setAttributes(routeMatchToParamSpanAttributes(onResolvedRouteMatch));
               }
             }
           });


### PR DESCRIPTION
Our e2e tests started breaking around the `1.142.x` release of tanstack router, we ended up hard-pinning the version to `1.141.8`.

The failures revealed a real behavioral change of matches tanstack router returns when attempting to match a non-existing route.

Previously the matches would be an empty array, but we now get a `__root__` match.

The fix involves checking if the last match is `__root__` and falling back to `url` for `sentry.source` attributes.

Closes: #18672