### PR TITLE
feat(nextjs): Print Turbopack note for deprecated webpack options

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -122,8 +122,16 @@ function migrateDeprecatedWebpackOptions(userSentryOptions: SentryBuildOptions):
     return newValue ?? deprecatedValue;
   };
 
-  const deprecatedMessage = (deprecatedPath: string, newPath: string): string =>
-    `[@sentry/nextjs] DEPRECATION WARNING: ${deprecatedPath} is deprecated and will be removed in a future version. Use ${newPath} instead.`;
+  const deprecatedMessage = (deprecatedPath: string, newPath: string): string => {
+    const message = `[@sentry/nextjs] DEPRECATION WARNING: ${deprecatedPath} is deprecated and will be removed in a future version. Use ${newPath} instead.`;
+
+    // In Turbopack builds, webpack configuration is not applied, so webpack-scoped options won't have any effect.
+    if (detectActiveBundler() === 'turbopack' && newPath.startsWith('webpack.')) {
+      return `${message} (Not supported with Turbopack.)`;
+    }
+
+    return message;
+  };
 
   /* eslint-disable deprecation/deprecation */
   // Migrate each deprecated option to the new path, but only if the new path isn't already set

--- a/packages/nextjs/test/config/withSentryConfig.test.ts
+++ b/packages/nextjs/test/config/withSentryConfig.test.ts
@@ -390,6 +390,21 @@ describe('withSentryConfig', () => {
         );
       });
 
+      it('adds a turbopack note when the deprecated option only applies to webpack', () => {
+        process.env.TURBOPACK = '1';
+        vi.spyOn(util, 'getNextjsVersion').mockReturnValue('16.0.0');
+
+        const sentryOptions = {
+          disableLogger: true,
+        };
+
+        materializeFinalNextConfig(exportedNextConfig, undefined, sentryOptions);
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Use webpack.treeshake.removeDebugLogging instead. (Not supported with Turbopack.)'),
+        );
+      });
+
       it('does not warn when using new webpack path', () => {
         delete process.env.TURBOPACK;
 


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/18758

Prints a note if a user is using deprecated webpack options with turbopack.