### PR TITLE
fix(test): Remove hard-coded SDK version assertion

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/metrics/simple/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/metrics/simple/test.ts
@@ -136,7 +136,7 @@ sentryTest('should capture all metric types', async ({ getLocalTestUrl, page }) 
             },
             'sentry.sdk.version': {
               type: 'string',
-              value: '10.32.1',
+              value: expect.any(String),
             },
             'user.email': {
               type: 'string',


### PR DESCRIPTION
I accidentally left a hard-coded SDK version in a test recently added by me. This PR fixes that so that CI doesn't break on the next release


Closes #18772 (added automatically)