### PR TITLE
test(node-core): Fix wrong import in node core IPv6 integration test

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/ipv6/scenario.ts
+++ b/dev-packages/node-core-integration-tests/suites/ipv6/scenario.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/node';
+import * as Sentry from '@sentry/node-core';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({


### PR DESCRIPTION
Accidentally added a wrong import when finishing work in #17708 