### PR TITLE
Add logger bundle variants

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,962 @@
+{
+  "version": "5",
+  "remote": {
+    "https://deno.land/std@0.202.0/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://deno.land/std@0.202.0/assert/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.202.0/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.202.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
+    "https://deno.land/std@0.202.0/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://deno.land/std@0.202.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
+    "https://deno.land/std@0.202.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.202.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://deno.land/std@0.202.0/fmt/colors.ts": "c51c4642678eb690dcf5ffee5918b675bf01a33fba82acf303701ae1a4f8c8d9",
+    "https://deno.land/std@0.202.0/fs/_util.ts": "fbf57dcdc9f7bc8128d60301eece608246971a7836a3bb1e78da75314f08b978",
+    "https://deno.land/std@0.202.0/fs/ensure_dir.ts": "dc64c4c75c64721d4e3fb681f1382f803ff3d2868f08563ff923fdd20d071c40",
+    "https://deno.land/std@0.202.0/fs/ensure_file.ts": "39ac83cc283a20ec2735e956adf5de3e8a3334e0b6820547b5772f71c49ae083",
+    "https://deno.land/std@0.202.0/path/_basename.ts": "057d420c9049821f983f784fd87fa73ac471901fb628920b67972b0f44319343",
+    "https://deno.land/std@0.202.0/path/_constants.ts": "e49961f6f4f48039c0dfed3c3f93e963ca3d92791c9d478ac5b43183413136e0",
+    "https://deno.land/std@0.202.0/path/_dirname.ts": "355e297236b2218600aee7a5301b937204c62e12da9db4b0b044993d9e658395",
+    "https://deno.land/std@0.202.0/path/_extname.ts": "eaaa5aae1acf1f03254d681bd6a8ce42a9cb5b7ff2213a9d4740e8ab31283664",
+    "https://deno.land/std@0.202.0/path/_format.ts": "4a99270d6810f082e614309164fad75d6f1a483b68eed97c830a506cc589f8b4",
+    "https://deno.land/std@0.202.0/path/_from_file_url.ts": "6eadfae2e6f63ad9ee46b26db4a1b16583055c0392acedfb50ed2fc694b6f581",
+    "https://deno.land/std@0.202.0/path/_interface.ts": "6471159dfbbc357e03882c2266d21ef9afdb1e4aa771b0545e90db58a0ba314b",
+    "https://deno.land/std@0.202.0/path/_is_absolute.ts": "05dac10b5e93c63198b92e3687baa2be178df5321c527dc555266c0f4f51558c",
+    "https://deno.land/std@0.202.0/path/_join.ts": "815f5e85b042285175b1492dd5781240ce126c23bd97bad6b8211fe7129c538e",
+    "https://deno.land/std@0.202.0/path/_normalize.ts": "a19ec8706b2707f9dd974662a5cd89fad438e62ab1857e08b314a8eb49a34d81",
+    "https://deno.land/std@0.202.0/path/_os.ts": "30b0c2875f360c9296dbe6b7f2d528f0f9c741cecad2e97f803f5219e91b40a2",
+    "https://deno.land/std@0.202.0/path/_parse.ts": "0f9b0ff43682dd9964eb1c4398610c4e165d8db9d3ac9d594220217adf480cfa",
+    "https://deno.land/std@0.202.0/path/_relative.ts": "27bdeffb5311a47d85be26d37ad1969979359f7636c5cd9fcf05dcd0d5099dc5",
+    "https://deno.land/std@0.202.0/path/_resolve.ts": "7a3616f1093735ed327e758313b79c3c04ea921808ca5f19ddf240cb68d0adf6",
+    "https://deno.land/std@0.202.0/path/_to_file_url.ts": "a141e4a525303e1a3a0c0571fd024552b5f3553a2af7d75d1ff3a503dcbb66d8",
+    "https://deno.land/std@0.202.0/path/_to_namespaced_path.ts": "0d5f4caa2ed98ef7a8786286df6af804b50e38859ae897b5b5b4c8c5930a75c8",
+    "https://deno.land/std@0.202.0/path/_util.ts": "4e191b1bac6b3bf0c31aab42e5ca2e01a86ab5a0d2e08b75acf8585047a86221",
+    "https://deno.land/std@0.202.0/path/basename.ts": "bdfa5a624c6a45564dc6758ef2077f2822978a6dbe77b0a3514f7d1f81362930",
+    "https://deno.land/std@0.202.0/path/common.ts": "ee7505ab01fd22de3963b64e46cff31f40de34f9f8de1fff6a1bd2fe79380000",
+    "https://deno.land/std@0.202.0/path/dirname.ts": "b6533f4ee4174a526dec50c279534df5345836dfdc15318400b08c62a62a39dd",
+    "https://deno.land/std@0.202.0/path/extname.ts": "62c4b376300795342fe1e4746c0de518b4dc9c4b0b4617bfee62a2973a9555cf",
+    "https://deno.land/std@0.202.0/path/format.ts": "110270b238514dd68455a4c54956215a1aff7e37e22e4427b7771cefe1920aa5",
+    "https://deno.land/std@0.202.0/path/from_file_url.ts": "9f5cb58d58be14c775ec2e57fc70029ac8b17ed3bd7fe93e475b07280adde0ac",
+    "https://deno.land/std@0.202.0/path/glob.ts": "593e2c3573883225c25c5a21aaa8e9382a696b8e175ea20a3b6a1471ad17aaed",
+    "https://deno.land/std@0.202.0/path/is_absolute.ts": "0b92eb35a0a8780e9f16f16bb23655b67dace6a8e0d92d42039e518ee38103c1",
+    "https://deno.land/std@0.202.0/path/join.ts": "31c5419f23d91655b08ec7aec403f4e4cd1a63d39e28f6e42642ea207c2734f8",
+    "https://deno.land/std@0.202.0/path/mod.ts": "6e1efb0b13121463aedb53ea51dabf5639a3172ab58c89900bbb72b486872532",
+    "https://deno.land/std@0.202.0/path/normalize.ts": "6ea523e0040979dd7ae2f1be5bf2083941881a252554c0f32566a18b03021955",
+    "https://deno.land/std@0.202.0/path/parse.ts": "be8de342bb9e1924d78dc4d93c45215c152db7bf738ec32475560424b119b394",
+    "https://deno.land/std@0.202.0/path/posix.ts": "0a1c1952d132323a88736d03e92bd236f3ed5f9f079e5823fae07c8d978ee61b",
+    "https://deno.land/std@0.202.0/path/relative.ts": "8bedac226afd360afc45d451a6c29fabceaf32978526bcb38e0c852661f66c61",
+    "https://deno.land/std@0.202.0/path/resolve.ts": "133161e4949fc97f9ca67988d51376b0f5eef8968a6372325ab84d39d30b80dc",
+    "https://deno.land/std@0.202.0/path/separator.ts": "40a3e9a4ad10bef23bc2cd6c610291b6c502a06237c2c4cd034a15ca78dedc1f",
+    "https://deno.land/std@0.202.0/path/to_file_url.ts": "00e6322373dd51ad109956b775e4e72e5f9fa68ce2c6b04e4af2a6eed3825d31",
+    "https://deno.land/std@0.202.0/path/to_namespaced_path.ts": "1b1db3055c343ab389901adfbda34e82b7386bcd1c744d54f9c1496ee0fd0c3d",
+    "https://deno.land/std@0.202.0/path/win32.ts": "8b3f80ef7a462511d5e8020ff490edcaa0a0d118f1b1e9da50e2916bdd73f9dd",
+    "https://deno.land/std@0.202.0/testing/snapshot.ts": "d53cc4ad3250e3a826df9a1a90bc19c9a92c8faa8fd508d16b5e6ce8699310ca",
+    "https://deno.land/std@0.212.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.212.0/assert/_diff.ts": "dcc63d94ca289aec80644030cf88ccbf7acaa6fbd7b0f22add93616b36593840",
+    "https://deno.land/std@0.212.0/assert/_format.ts": "0ba808961bf678437fb486b56405b6fefad2cf87b5809667c781ddee8c32aff4",
+    "https://deno.land/std@0.212.0/assert/assert.ts": "bec068b2fccdd434c138a555b19a2c2393b71dfaada02b7d568a01541e67cdc5",
+    "https://deno.land/std@0.212.0/assert/assert_almost_equals.ts": "8b96b7385cc117668b0720115eb6ee73d04c9bcb2f5d2344d674918c9113688f",
+    "https://deno.land/std@0.212.0/assert/assert_array_includes.ts": "1688d76317fd45b7e93ef9e2765f112fdf2b7c9821016cdfb380b9445374aed1",
+    "https://deno.land/std@0.212.0/assert/assert_equals.ts": "4497c56fe7d2993b0d447926702802fc0becb44e319079e8eca39b482ee01b4e",
+    "https://deno.land/std@0.212.0/assert/assert_exists.ts": "24a7bf965e634f909242cd09fbaf38bde6b791128ece08e33ab08586a7cc55c9",
+    "https://deno.land/std@0.212.0/assert/assert_false.ts": "6f382568e5128c0f855e5f7dbda8624c1ed9af4fcc33ef4a9afeeedcdce99769",
+    "https://deno.land/std@0.212.0/assert/assert_greater.ts": "4945cf5729f1a38874d7e589e0fe5cc5cd5abe5573ca2ddca9d3791aa891856c",
+    "https://deno.land/std@0.212.0/assert/assert_greater_or_equal.ts": "573ed8823283b8d94b7443eb69a849a3c369a8eb9666b2d1db50c33763a5d219",
+    "https://deno.land/std@0.212.0/assert/assert_instance_of.ts": "72dc1faff1e248692d873c89382fa1579dd7b53b56d52f37f9874a75b11ba444",
+    "https://deno.land/std@0.212.0/assert/assert_is_error.ts": "6596f2b5ba89ba2fe9b074f75e9318cda97a2381e59d476812e30077fbdb6ed2",
+    "https://deno.land/std@0.212.0/assert/assert_less.ts": "2b4b3fe7910f65f7be52212f19c3977ecb8ba5b2d6d0a296c83cde42920bb005",
+    "https://deno.land/std@0.212.0/assert/assert_less_or_equal.ts": "b93d212fe669fbde959e35b3437ac9a4468f2e6b77377e7b6ea2cfdd825d38a0",
+    "https://deno.land/std@0.212.0/assert/assert_match.ts": "ec2d9680ed3e7b9746ec57ec923a17eef6d476202f339ad91d22277d7f1d16e1",
+    "https://deno.land/std@0.212.0/assert/assert_not_equals.ts": "f3edda73043bc2c9fae6cbfaa957d5c69bbe76f5291a5b0466ed132c8789df4c",
+    "https://deno.land/std@0.212.0/assert/assert_not_instance_of.ts": "8f720d92d83775c40b2542a8d76c60c2d4aeddaf8713c8d11df8984af2604931",
+    "https://deno.land/std@0.212.0/assert/assert_not_match.ts": "b4b7c77f146963e2b673c1ce4846473703409eb93f5ab0eb60f6e6f8aeffe39f",
+    "https://deno.land/std@0.212.0/assert/assert_not_strict_equals.ts": "da0b8ab60a45d5a9371088378e5313f624799470c3b54c76e8b8abeec40a77be",
+    "https://deno.land/std@0.212.0/assert/assert_object_match.ts": "e85e5eef62a56ce364c3afdd27978ccab979288a3e772e6855c270a7b118fa49",
+    "https://deno.land/std@0.212.0/assert/assert_rejects.ts": "e9e0c8d9c3e164c7ac962c37b3be50577c5a2010db107ed272c4c1afb1269f54",
+    "https://deno.land/std@0.212.0/assert/assert_strict_equals.ts": "0425a98f70badccb151644c902384c12771a93e65f8ff610244b8147b03a2366",
+    "https://deno.land/std@0.212.0/assert/assert_string_includes.ts": "dfb072a890167146f8e5bdd6fde887ce4657098e9f71f12716ef37f35fb6f4a7",
+    "https://deno.land/std@0.212.0/assert/assert_throws.ts": "edddd86b39606c342164b49ad88dd39a26e72a26655e07545d172f164b617fa7",
+    "https://deno.land/std@0.212.0/assert/assertion_error.ts": "9f689a101ee586c4ce92f52fa7ddd362e86434ffdf1f848e45987dc7689976b8",
+    "https://deno.land/std@0.212.0/assert/equal.ts": "fae5e8a52a11d3ac694bbe1a53e13a7969e3f60791262312e91a3e741ae519e2",
+    "https://deno.land/std@0.212.0/assert/fail.ts": "f310e51992bac8e54f5fd8e44d098638434b2edb802383690e0d7a9be1979f1c",
+    "https://deno.land/std@0.212.0/assert/mod.ts": "325df8c0683ad83a873b9691aa66b812d6275fc9fec0b2d180ac68a2c5efed3b",
+    "https://deno.land/std@0.212.0/assert/unimplemented.ts": "47ca67d1c6dc53abd0bd729b71a31e0825fc452dbcd4fde4ca06789d5644e7fd",
+    "https://deno.land/std@0.212.0/assert/unreachable.ts": "38cfecb95d8b06906022d2f9474794fca4161a994f83354fd079cac9032b5145",
+    "https://deno.land/std@0.212.0/fmt/colors.ts": "71e2d7d9911cf3f4f8cceaabe588fd9a4c0228102f4233da62ffd3e421201de7"
+  },
+  "workspace": {
+    "packageJson": {
+      "dependencies": [
+        "npm:@rollup/plugin-commonjs@^25.0.7",
+        "npm:@rollup/plugin-esm-shim@~0.1.5",
+        "npm:@rollup/plugin-json@^6.1.0",
+        "npm:@rollup/plugin-node-resolve@^15.2.3",
+        "npm:@rollup/plugin-replace@^5.0.5",
+        "npm:@rollup/plugin-sucrase@^5.0.2",
+        "npm:@rollup/plugin-terser@~0.4.4",
+        "npm:@rollup/plugin-typescript@^11.1.6",
+        "npm:@rollup/pluginutils@^5.1.0",
+        "npm:@size-limit/file@~11.1.6",
+        "npm:@size-limit/webpack@~11.1.6",
+        "npm:@types/jsdom@^21.1.6",
+        "npm:@types/node@^18.19.1",
+        "npm:@vitest/coverage-v8@^3.2.4",
+        "npm:deepmerge@^4.2.2",
+        "npm:downlevel-dts@0.11",
+        "npm:es-check@^7.2.1",
+        "npm:eslint@8.57.0",
+        "npm:jsdom@^21.1.2",
+        "npm:lerna@7.1.1",
+        "npm:madge@8.0.0",
+        "npm:nodemon@^3.1.10",
+        "npm:npm-run-all2@^6.2.0",
+        "npm:prettier-plugin-astro@~0.14.1",
+        "npm:prettier@^3.6.2",
+        "npm:rimraf@^5.0.10",
+        "npm:rollup-plugin-cleanup@^3.2.1",
+        "npm:rollup-plugin-license@^3.3.1",
+        "npm:rollup@^4.35.0",
+        "npm:size-limit@~11.1.6",
+        "npm:sucrase@^3.35.0",
+        "npm:ts-node@10.9.1",
+        "npm:typescript@5.8",
+        "npm:vitest@^3.2.4",
+        "npm:yalc@^1.0.0-pre.53",
+        "npm:yarn-deduplicate@6.0.2"
+      ]
+    },
+    "members": {
+      "dev-packages/browser-integration-tests": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@babel/core@^7.27.7",
+            "npm:@babel/preset-typescript@^7.16.7",
+            "npm:@playwright/test@1.56",
+            "npm:@sentry-internal/rrweb@2.34.0",
+            "npm:@sentry/browser@10.32.1",
+            "npm:@supabase/supabase-js@2.49.3",
+            "npm:@types/glob@8.0.0",
+            "npm:@types/node@^18.19.1",
+            "npm:axios@^1.12.2",
+            "npm:babel-loader@^8.2.2",
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:fflate@0.8.2",
+            "npm:glob@8.0.3",
+            "npm:html-webpack-plugin@^5.5.0",
+            "npm:webpack@^5.95.0"
+          ]
+        }
+      },
+      "dev-packages/bundle-analyzer-scenarios": {
+        "packageJson": {
+          "dependencies": [
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:html-webpack-plugin@^5.6.0",
+            "npm:webpack-bundle-analyzer@^4.10.2",
+            "npm:webpack@^5.95.0"
+          ]
+        }
+      },
+      "dev-packages/bundler-tests": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@rollup/plugin-node-resolve@^15.2.3",
+            "npm:@sentry/browser@10.32.1",
+            "npm:rollup@4",
+            "npm:vite@5",
+            "npm:vitest@^3.2.4",
+            "npm:webpack@5"
+          ]
+        }
+      },
+      "dev-packages/clear-cache-gh-action": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@actions/core@1.10.1",
+            "npm:@actions/github@5",
+            "npm:eslint-plugin-regexp@^1.15.0"
+          ]
+        }
+      },
+      "dev-packages/cloudflare-integration-tests": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@cloudflare/workers-types@^4.20250922.0",
+            "npm:@langchain/langgraph@^1.0.1",
+            "npm:@sentry-internal/test-utils@10.32.1",
+            "npm:@sentry/cloudflare@10.32.1",
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:hono@4",
+            "npm:vitest@^3.2.4",
+            "npm:wrangler@4.22.0"
+          ]
+        }
+      },
+      "dev-packages/e2e-tests": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@types/glob@8.0.0",
+            "npm:@types/node@^18.19.1",
+            "npm:dotenv@16.0.3",
+            "npm:esbuild@0.20.0",
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:glob@8.0.3",
+            "npm:rimraf@^5.0.10",
+            "npm:ts-node@10.9.1",
+            "npm:yaml@2.2.2"
+          ]
+        }
+      },
+      "dev-packages/external-contributor-gh-action": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@actions/core@1.10.1",
+            "npm:eslint-plugin-regexp@^1.15.0"
+          ]
+        }
+      },
+      "dev-packages/node-core-integration-tests": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@nestjs/common@11",
+            "npm:@nestjs/core@11",
+            "npm:@nestjs/platform-express@11",
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/context-async-hooks@^2.2.0",
+            "npm:@opentelemetry/core@^2.2.0",
+            "npm:@opentelemetry/instrumentation-http@0.208.0",
+            "npm:@opentelemetry/instrumentation@0.208",
+            "npm:@opentelemetry/resources@^2.2.0",
+            "npm:@opentelemetry/sdk-trace-base@^2.2.0",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node-core@10.32.1",
+            "npm:@types/node-cron@^3.0.11",
+            "npm:@types/node-schedule@^2.1.7",
+            "npm:body-parser@^1.20.3",
+            "npm:cors@^2.8.5",
+            "npm:cron@^3.1.6",
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:express@^4.21.1",
+            "npm:globby@11",
+            "npm:http-terminator@^3.2.0",
+            "npm:nock@^13.5.5",
+            "npm:node-cron@^3.0.3",
+            "npm:node-schedule@^2.1.1",
+            "npm:proxy@^2.1.1",
+            "npm:reflect-metadata@0.2.1",
+            "npm:rxjs@^7.8.1",
+            "npm:winston@^3.17.0",
+            "npm:yargs@^16.2.0"
+          ]
+        }
+      },
+      "dev-packages/node-integration-tests": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@anthropic-ai/sdk@0.63.0",
+            "npm:@aws-sdk/client-s3@^3.552.0",
+            "npm:@google/genai@^1.20.0",
+            "npm:@growthbook/growthbook@^1.6.1",
+            "npm:@hapi/hapi@^21.3.10",
+            "npm:@hono/node-server@^1.19.4",
+            "npm:@langchain/anthropic@~0.3.10",
+            "npm:@langchain/core@~0.3.28",
+            "npm:@langchain/langgraph@~0.2.32",
+            "npm:@nestjs/common@11",
+            "npm:@nestjs/core@11",
+            "npm:@nestjs/platform-express@11",
+            "npm:@prisma/client@6.15.0",
+            "npm:@sentry-internal/test-utils@10.32.1",
+            "npm:@sentry/aws-serverless@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@types/amqplib@~0.10.5",
+            "npm:@types/mongodb@^3.6.20",
+            "npm:@types/mysql@^2.15.21",
+            "npm:@types/node-cron@^3.0.11",
+            "npm:@types/node-schedule@^2.1.7",
+            "npm:@types/pg@^8.6.5",
+            "npm:ai@^4.3.16",
+            "npm:amqplib@~0.10.7",
+            "npm:apollo-server@^3.11.1",
+            "npm:body-parser@^1.20.3",
+            "npm:connect@^3.7.0",
+            "npm:consola@^3.2.3",
+            "npm:cors@^2.8.5",
+            "npm:cron@^3.1.6",
+            "npm:dataloader@2.2.2",
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:express@^4.21.1",
+            "npm:file-type@^20.4.1",
+            "npm:generic-pool@^3.9.0",
+            "npm:globby@11",
+            "npm:graphql@^16.3.0",
+            "npm:hono@^4.9.8",
+            "npm:http-terminator@^3.2.0",
+            "npm:ioredis@^5.4.1",
+            "npm:kafkajs@2.2.4",
+            "npm:knex@^2.5.1",
+            "npm:lru-memoizer@2.3.0",
+            "npm:mongodb-memory-server-global@^10.1.4",
+            "npm:mongodb@^3.7.3",
+            "npm:mongoose@^5.13.22",
+            "npm:mysql2@^3.11.3",
+            "npm:mysql@^2.18.1",
+            "npm:nock@^13.5.5",
+            "npm:node-cron@^3.0.3",
+            "npm:node-schedule@^2.1.1",
+            "npm:openai@5.18.1",
+            "npm:pg@8.16.0",
+            "npm:pino@9.9.4",
+            "npm:pino@^9.12.0",
+            "npm:postgres@^3.4.7",
+            "npm:prisma@6.15.0",
+            "npm:proxy@^2.1.1",
+            "npm:react@^18.3.1",
+            "npm:redis@^4.6.14",
+            "npm:reflect-metadata@0.2.1",
+            "npm:rxjs@^7.8.1",
+            "npm:tedious@^18.6.1",
+            "npm:winston@^3.17.0",
+            "npm:yargs@^16.2.0",
+            "npm:zod@^3.24.1"
+          ]
+        }
+      },
+      "dev-packages/node-overhead-gh-action": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@actions/artifact@2.1.11",
+            "npm:@actions/core@1.10.1",
+            "npm:@actions/exec@1.1.1",
+            "npm:@actions/github@5",
+            "npm:@actions/glob@0.4.0",
+            "npm:@actions/io@1.1.3",
+            "npm:@sentry/node@10.32.1",
+            "npm:autocannon@8",
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:express@^4.21.1",
+            "npm:markdown-table@3.0.3",
+            "npm:mysql2@^3.14.4",
+            "npm:tree-kill@1.2.2"
+          ]
+        }
+      },
+      "dev-packages/rollup-utils": {
+        "packageJson": {
+          "dependencies": [
+            "npm:acorn@^8.7.0",
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:recast@~0.20.5"
+          ]
+        }
+      },
+      "dev-packages/size-limit-gh-action": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@actions/artifact@2.1.11",
+            "npm:@actions/core@1.10.1",
+            "npm:@actions/exec@1.1.1",
+            "npm:@actions/github@5",
+            "npm:@actions/glob@0.4.0",
+            "npm:@actions/io@1.1.3",
+            "npm:bytes-iec@3.1.1",
+            "npm:markdown-table@3.0.3"
+          ]
+        }
+      },
+      "dev-packages/test-utils": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@playwright/test@1.56",
+            "npm:@sentry/core@10.32.1",
+            "npm:eslint-plugin-regexp@^1.15.0",
+            "npm:express@^4.21.1"
+          ]
+        }
+      },
+      "packages/angular": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@angular-devkit/build-angular@^14.2.13",
+            "npm:@angular/cli@^14.2.13",
+            "npm:@angular/common@^14.3.0",
+            "npm:@angular/compiler-cli@^14.3.0",
+            "npm:@angular/compiler@^14.3.0",
+            "npm:@angular/core@^14.3.0",
+            "npm:@angular/platform-browser-dynamic@^14.3.0",
+            "npm:@angular/platform-browser@^14.3.0",
+            "npm:@angular/router@^14.3.0",
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@types/node@^14.8.0",
+            "npm:ng-packagr@^14.2.2",
+            "npm:rxjs@7.8.1",
+            "npm:tslib@^2.4.1",
+            "npm:typescript@4.6.4",
+            "npm:zone.js@0.12"
+          ]
+        }
+      },
+      "packages/astro": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@sentry/vite-plugin@^4.6.1",
+            "npm:astro@^3.5.0",
+            "npm:vite@^5.4.11"
+          ]
+        }
+      },
+      "packages/aws-serverless": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/instrumentation-aws-sdk@0.64.0",
+            "npm:@opentelemetry/instrumentation@0.208",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node-core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@types/aws-lambda@^8.10.62",
+            "npm:@types/node@^18.19.1",
+            "npm:@vercel/nft@~0.29.4"
+          ]
+        }
+      },
+      "packages/browser": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry-internal/browser-utils@10.32.1",
+            "npm:@sentry-internal/feedback@10.32.1",
+            "npm:@sentry-internal/integration-shims@10.32.1",
+            "npm:@sentry-internal/replay-canvas@10.32.1",
+            "npm:@sentry-internal/replay@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:fake-indexeddb@^6.2.4"
+          ]
+        }
+      },
+      "packages/browser-utils": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/core@10.32.1"
+          ]
+        }
+      },
+      "packages/bun": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:bun-types@^1.2.9"
+          ]
+        }
+      },
+      "packages/cloudflare": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@cloudflare/workers-types@4.20250922.0",
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:@types/node@^18.19.1",
+            "npm:wrangler@4.22.0"
+          ]
+        }
+      },
+      "packages/core": {
+        "packageJson": {
+          "dependencies": [
+            "npm:zod@^3.24.1"
+          ]
+        }
+      },
+      "packages/deno": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@sentry/core@10.32.1"
+          ]
+        }
+      },
+      "packages/ember": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@babel/core@^7.27.7",
+            "npm:@ember/optional-features@1.3",
+            "npm:@ember/test-helpers@4.0.4",
+            "npm:@embroider/macros@^1.16.0",
+            "npm:@embroider/test-setup@4.0",
+            "npm:@glimmer/component@~1.1.2",
+            "npm:@glimmer/tracking@~1.1.2",
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@types/ember-resolver@5.0.13",
+            "npm:@types/ember@~3.16.5",
+            "npm:@types/ember__debug@^3.16.5",
+            "npm:@types/qunit@~2.19.11",
+            "npm:@types/rsvp@~4.0.3",
+            "npm:babel-eslint@10.1",
+            "npm:broccoli-asset-rev@3.0",
+            "npm:ember-auto-import@^2.7.2",
+            "npm:ember-cli-babel@^8.2.0",
+            "npm:ember-cli-dependency-checker@~3.3.2",
+            "npm:ember-cli-htmlbars@^6.1.1",
+            "npm:ember-cli-inject-live-reload@2.1",
+            "npm:ember-cli-terser@~4.0.2",
+            "npm:ember-cli-typescript@^5.3.0",
+            "npm:ember-cli@~4.12.3",
+            "npm:ember-load-initializers@~2.1.1",
+            "npm:ember-qunit@8.1",
+            "npm:ember-resolver@13.0.2",
+            "npm:ember-sinon-qunit@7.5.0",
+            "npm:ember-source@~4.12.4",
+            "npm:ember-template-lint@~4.16.1",
+            "npm:eslint-plugin-ember@11.9.0",
+            "npm:eslint-plugin-n@15.0.0",
+            "npm:eslint-plugin-qunit@8.0.0",
+            "npm:loader.js@4.7",
+            "npm:qunit-dom@~3.2.1",
+            "npm:qunit@2.22",
+            "npm:sinon@19.0.2",
+            "npm:webpack@5.95"
+          ]
+        }
+      },
+      "packages/eslint-config-sdk": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry-internal/eslint-plugin-sdk@10.32.1",
+            "npm:@sentry-internal/typescript@10.32.1",
+            "npm:@typescript-eslint/eslint-plugin@^5.62.0",
+            "npm:@typescript-eslint/parser@^5.62.0",
+            "npm:eslint-config-prettier@^9.1.0",
+            "npm:eslint-plugin-deprecation@3",
+            "npm:eslint-plugin-import@^2.32.0",
+            "npm:eslint-plugin-jsdoc@^50.6.1",
+            "npm:eslint-plugin-simple-import-sort@^12.1.1",
+            "npm:eslint@8.57.0"
+          ]
+        }
+      },
+      "packages/feedback": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/core@10.32.1",
+            "npm:preact@^10.19.4"
+          ]
+        }
+      },
+      "packages/gatsby": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/react@10.32.1",
+            "npm:@sentry/webpack-plugin@^4.6.1",
+            "npm:@testing-library/react@13",
+            "npm:react-dom@^18.3.1",
+            "npm:react@^18.3.1",
+            "npm:webpack@5"
+          ]
+        }
+      },
+      "packages/google-cloud-serverless": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@google-cloud/bigquery@^5.3.0",
+            "npm:@google-cloud/common@^3.4.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node-core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@types/express@^5.0.6",
+            "npm:@types/node@^18.19.1",
+            "npm:nock@^13.5.5"
+          ]
+        }
+      },
+      "packages/integration-shims": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/core@10.32.1"
+          ]
+        }
+      },
+      "packages/nestjs": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@nestjs/common@10",
+            "npm:@nestjs/core@10",
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/core@^2.2.0",
+            "npm:@opentelemetry/instrumentation-nestjs-core@0.55.0",
+            "npm:@opentelemetry/instrumentation@0.208",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:reflect-metadata@~0.2.2",
+            "npm:rxjs@^7.8.1"
+          ]
+        }
+      },
+      "packages/nextjs": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@rollup/plugin-commonjs@28.0.1",
+            "npm:@sentry-internal/browser-utils@10.32.1",
+            "npm:@sentry/bundler-plugin-core@^4.6.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@sentry/opentelemetry@10.32.1",
+            "npm:@sentry/react@10.32.1",
+            "npm:@sentry/vercel-edge@10.32.1",
+            "npm:@sentry/webpack-plugin@^4.6.1",
+            "npm:eslint-plugin-react@^7.31.11",
+            "npm:next@14.2.35",
+            "npm:react-dom@^18.3.1",
+            "npm:react@^18.3.1",
+            "npm:rollup@^4.35.0",
+            "npm:stacktrace-parser@~0.1.10"
+          ]
+        }
+      },
+      "packages/node": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/context-async-hooks@^2.2.0",
+            "npm:@opentelemetry/core@^2.2.0",
+            "npm:@opentelemetry/instrumentation-amqplib@0.55.0",
+            "npm:@opentelemetry/instrumentation-connect@0.52.0",
+            "npm:@opentelemetry/instrumentation-dataloader@0.26.0",
+            "npm:@opentelemetry/instrumentation-express@0.57.0",
+            "npm:@opentelemetry/instrumentation-fs@0.28.0",
+            "npm:@opentelemetry/instrumentation-generic-pool@0.52.0",
+            "npm:@opentelemetry/instrumentation-graphql@0.56.0",
+            "npm:@opentelemetry/instrumentation-hapi@0.55.0",
+            "npm:@opentelemetry/instrumentation-http@0.208.0",
+            "npm:@opentelemetry/instrumentation-ioredis@0.56.0",
+            "npm:@opentelemetry/instrumentation-kafkajs@0.18.0",
+            "npm:@opentelemetry/instrumentation-knex@0.53.0",
+            "npm:@opentelemetry/instrumentation-koa@0.57.0",
+            "npm:@opentelemetry/instrumentation-lru-memoizer@0.53.0",
+            "npm:@opentelemetry/instrumentation-mongodb@0.61.0",
+            "npm:@opentelemetry/instrumentation-mongoose@0.55.0",
+            "npm:@opentelemetry/instrumentation-mysql2@0.55.0",
+            "npm:@opentelemetry/instrumentation-mysql@0.54.0",
+            "npm:@opentelemetry/instrumentation-pg@0.61.0",
+            "npm:@opentelemetry/instrumentation-redis@0.57.0",
+            "npm:@opentelemetry/instrumentation-tedious@0.27.0",
+            "npm:@opentelemetry/instrumentation-undici@0.19.0",
+            "npm:@opentelemetry/instrumentation@0.208",
+            "npm:@opentelemetry/resources@^2.2.0",
+            "npm:@opentelemetry/sdk-trace-base@^2.2.0",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@prisma/instrumentation@6.19.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node-core@10.32.1",
+            "npm:@sentry/opentelemetry@10.32.1",
+            "npm:@types/node@^18.19.1",
+            "npm:import-in-the-middle@^2.0.1",
+            "npm:minimatch@9"
+          ]
+        }
+      },
+      "packages/node-core": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@apm-js-collab/code-transformer@~0.8.2",
+            "npm:@apm-js-collab/tracing-hooks@~0.3.1",
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/context-async-hooks@^2.2.0",
+            "npm:@opentelemetry/core@^2.2.0",
+            "npm:@opentelemetry/instrumentation@0.208",
+            "npm:@opentelemetry/resources@^2.2.0",
+            "npm:@opentelemetry/sdk-trace-base@^2.2.0",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/opentelemetry@10.32.1",
+            "npm:@types/node@^18.19.1",
+            "npm:import-in-the-middle@^2.0.1"
+          ]
+        }
+      },
+      "packages/node-native": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry-internal/node-native-stacktrace@0.3",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@types/node@^18.19.1"
+          ]
+        }
+      },
+      "packages/nuxt": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@nuxt/kit@^3.13.2",
+            "npm:@nuxt/module-builder@~0.8.4",
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/cloudflare@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node-core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@sentry/rollup-plugin@^4.6.1",
+            "npm:@sentry/vite-plugin@^4.6.1",
+            "npm:@sentry/vue@10.32.1",
+            "npm:nuxi@^3.25.1",
+            "npm:nuxt@^3.13.2",
+            "npm:vite@^5.4.11"
+          ]
+        }
+      },
+      "packages/opentelemetry": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/context-async-hooks@^2.2.0",
+            "npm:@opentelemetry/core@^2.2.0",
+            "npm:@opentelemetry/sdk-trace-base@^2.2.0",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@sentry/core@10.32.1"
+          ]
+        }
+      },
+      "packages/profiling-node": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry-internal/node-cpu-profiler@^2.2.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@types/node@^18.19.1"
+          ]
+        }
+      },
+      "packages/react": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@testing-library/react-hooks@^7.0.2",
+            "npm:@testing-library/react@13",
+            "npm:@types/history@4.7.8",
+            "npm:@types/node-fetch@^2.6.11",
+            "npm:@types/react-router@4.0.25",
+            "npm:@types/react-router@5.1.20",
+            "npm:@types/react@17.0.3",
+            "npm:eslint-plugin-react-hooks@^4.6.0",
+            "npm:eslint-plugin-react@^7.20.5",
+            "npm:history@4.6.0",
+            "npm:history@4.9.0",
+            "npm:react-dom@^18.3.1",
+            "npm:react-router@3.2.0",
+            "npm:react-router@4.1.0",
+            "npm:react-router@5.0.0",
+            "npm:react-router@6.28.0",
+            "npm:react@^18.3.1",
+            "npm:redux@^4.0.5"
+          ]
+        }
+      },
+      "packages/react-router": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/core@^2.2.0",
+            "npm:@opentelemetry/instrumentation@0.208",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@react-router/dev@^7.5.2",
+            "npm:@react-router/node@^7.5.2",
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/cli@^2.58.4",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@sentry/react@10.32.1",
+            "npm:@sentry/vite-plugin@^4.6.1",
+            "npm:glob@11.1.0",
+            "npm:react-router@^7.9.2",
+            "npm:react@^18.3.1",
+            "npm:vite@^6.1.0"
+          ]
+        }
+      },
+      "packages/remix": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/instrumentation@0.208",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@remix-run/node@^2.15.2",
+            "npm:@remix-run/react@^2.15.2",
+            "npm:@remix-run/router@1",
+            "npm:@remix-run/server-runtime@2.15.2",
+            "npm:@sentry/cli@^2.58.2",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@sentry/react@10.32.1",
+            "npm:@types/express@^4.17.14",
+            "npm:glob@^10.3.4",
+            "npm:react-dom@^18.3.1",
+            "npm:react@^18.3.1",
+            "npm:vite@^5.4.11",
+            "npm:yargs@^17.6.0"
+          ]
+        }
+      },
+      "packages/replay-canvas": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry-internal/replay@10.32.1",
+            "npm:@sentry-internal/rrweb@2.40.0",
+            "npm:@sentry/core@10.32.1"
+          ]
+        }
+      },
+      "packages/replay-internal": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@babel/core@^7.27.7",
+            "npm:@sentry-internal/browser-utils@10.32.1",
+            "npm:@sentry-internal/replay-worker@10.32.1",
+            "npm:@sentry-internal/rrweb-snapshot@2.40.0",
+            "npm:@sentry-internal/rrweb@2.40.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:fflate@0.8.2",
+            "npm:jest-matcher-utils@29",
+            "npm:jsdom-worker@0.3"
+          ]
+        }
+      },
+      "packages/replay-worker": {
+        "packageJson": {
+          "dependencies": [
+            "npm:fflate@0.8.2"
+          ]
+        }
+      },
+      "packages/solid": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@solidjs/router@0.15",
+            "npm:@solidjs/testing-library@0.8.5",
+            "npm:@tanstack/solid-router@^1.132.27",
+            "npm:@testing-library/dom@^7.21.4",
+            "npm:@testing-library/jest-dom@^6.4.5",
+            "npm:@testing-library/user-event@^14.5.2",
+            "npm:solid-js@^1.8.11",
+            "npm:vite-plugin-solid@^2.11.6",
+            "npm:vite@^5.4.11"
+          ]
+        }
+      },
+      "packages/solidstart": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@sentry/solid@10.32.1",
+            "npm:@sentry/vite-plugin@^4.6.1",
+            "npm:@solidjs/router@0.15",
+            "npm:@solidjs/start@1",
+            "npm:@solidjs/testing-library@0.8.5",
+            "npm:@testing-library/jest-dom@^6.4.5",
+            "npm:@testing-library/user-event@^14.5.2",
+            "npm:solid-js@^1.8.4",
+            "npm:vinxi@~0.3.12",
+            "npm:vite-plugin-solid@^2.11.6",
+            "npm:vite@^5.4.11"
+          ]
+        }
+      },
+      "packages/svelte": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sveltejs/vite-plugin-svelte@1.4.0",
+            "npm:@testing-library/svelte@^3.2.1",
+            "npm:magic-string@0.30",
+            "npm:svelte@3.49.0",
+            "npm:vite@3"
+          ]
+        }
+      },
+      "packages/sveltekit": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@babel/parser@7.26.9",
+            "npm:@babel/types@^7.26.3",
+            "npm:@sentry/cloudflare@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@sentry/svelte@10.32.1",
+            "npm:@sentry/vite-plugin@^4.6.1",
+            "npm:@sveltejs/kit@^2.0.2",
+            "npm:@sveltejs/vite-plugin-svelte@3",
+            "npm:magic-string@0.30.7",
+            "npm:recast@0.23.11",
+            "npm:sorcery@1.0.0",
+            "npm:svelte@^4.2.8",
+            "npm:vite@^5.4.11"
+          ]
+        }
+      },
+      "packages/tanstackstart-react": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@sentry-internal/browser-utils@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/node@10.32.1",
+            "npm:@sentry/react@10.32.1"
+          ]
+        }
+      },
+      "packages/types": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/core@10.32.1"
+          ]
+        }
+      },
+      "packages/vercel-edge": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@edge-runtime/types@3.0.1",
+            "npm:@opentelemetry/api@^1.9.0",
+            "npm:@opentelemetry/core@^2.2.0",
+            "npm:@opentelemetry/resources@^2.2.0",
+            "npm:@opentelemetry/sdk-trace-base@^2.2.0",
+            "npm:@opentelemetry/semantic-conventions@^1.37.0",
+            "npm:@sentry/core@10.32.1",
+            "npm:@sentry/opentelemetry@10.32.1"
+          ]
+        }
+      },
+      "packages/vue": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/core@10.32.1",
+            "npm:@tanstack/vue-router@^1.64.0",
+            "npm:vue@~3.2.41"
+          ]
+        }
+      },
+      "packages/wasm": {
+        "packageJson": {
+          "dependencies": [
+            "npm:@sentry/browser@10.32.1",
+            "npm:@sentry/core@10.32.1"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/packages/browser/rollup.bundle.config.mjs
+++ b/packages/browser/rollup.bundle.config.mjs
@@ -104,6 +104,55 @@ const tracingReplayFeedbackBaseBundleConfig = makeBaseBundleConfig({
   outputFileBase: () => 'bundles/bundle.tracing.replay.feedback',
 });
 
+const loggerBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.bundle.logger.ts'],
+  licenseTitle: '@sentry/browser (Logger)',
+  outputFileBase: () => 'bundles/bundle.logger',
+});
+
+const tracingLoggerBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.bundle.tracing.logger.ts'],
+  licenseTitle: '@sentry/browser (Performance Monitoring and Logger)',
+  outputFileBase: () => 'bundles/bundle.tracing.logger',
+});
+
+const replayLoggerBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.bundle.replay.logger.ts'],
+  licenseTitle: '@sentry/browser (Replay and Logger)',
+  outputFileBase: () => 'bundles/bundle.replay.logger',
+});
+
+const feedbackLoggerBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.bundle.feedback.logger.ts'],
+  licenseTitle: '@sentry/browser (Feedback and Logger)',
+  outputFileBase: () => 'bundles/bundle.feedback.logger',
+});
+
+const tracingReplayLoggerBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.bundle.tracing.replay.logger.ts'],
+  licenseTitle: '@sentry/browser (Performance Monitoring, Replay, and Logger)',
+  outputFileBase: () => 'bundles/bundle.tracing.replay.logger',
+});
+
+const replayFeedbackLoggerBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.bundle.replay.feedback.logger.ts'],
+  licenseTitle: '@sentry/browser (Replay, Feedback, and Logger)',
+  outputFileBase: () => 'bundles/bundle.replay.feedback.logger',
+});
+
+const tracingReplayFeedbackLoggerBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.bundle.tracing.replay.feedback.logger.ts'],
+  licenseTitle: '@sentry/browser (Performance Monitoring, Replay, Feedback, and Logger)',
+  outputFileBase: () => 'bundles/bundle.tracing.replay.feedback.logger',
+});
+
 builds.push(
   ...makeBundleConfigVariants(baseBundleConfig),
   ...makeBundleConfigVariants(tracingBaseBundleConfig),
@@ -112,6 +161,13 @@ builds.push(
   ...makeBundleConfigVariants(tracingReplayBaseBundleConfig),
   ...makeBundleConfigVariants(replayFeedbackBaseBundleConfig),
   ...makeBundleConfigVariants(tracingReplayFeedbackBaseBundleConfig),
+  ...makeBundleConfigVariants(loggerBaseBundleConfig),
+  ...makeBundleConfigVariants(tracingLoggerBaseBundleConfig),
+  ...makeBundleConfigVariants(replayLoggerBaseBundleConfig),
+  ...makeBundleConfigVariants(feedbackLoggerBaseBundleConfig),
+  ...makeBundleConfigVariants(tracingReplayLoggerBaseBundleConfig),
+  ...makeBundleConfigVariants(replayFeedbackLoggerBaseBundleConfig),
+  ...makeBundleConfigVariants(tracingReplayFeedbackLoggerBaseBundleConfig),
 );
 
 export default builds;

--- a/packages/browser/src/index.bundle.feedback.logger.ts
+++ b/packages/browser/src/index.bundle.feedback.logger.ts
@@ -1,0 +1,15 @@
+import { browserTracingIntegrationShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
+import { feedbackAsyncIntegration } from './feedbackAsync';
+
+export * from './index.bundle.base';
+
+export { logger } from '@sentry/core';
+
+export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
+
+export {
+  browserTracingIntegrationShim as browserTracingIntegration,
+  feedbackAsyncIntegration as feedbackAsyncIntegration,
+  feedbackAsyncIntegration as feedbackIntegration,
+  replayIntegrationShim as replayIntegration,
+};

--- a/packages/browser/src/index.bundle.logger.ts
+++ b/packages/browser/src/index.bundle.logger.ts
@@ -1,0 +1,16 @@
+import {
+  browserTracingIntegrationShim,
+  feedbackIntegrationShim,
+  replayIntegrationShim,
+} from '@sentry-internal/integration-shims';
+
+export * from './index.bundle.base';
+
+export { logger } from '@sentry/core';
+
+export {
+  browserTracingIntegrationShim as browserTracingIntegration,
+  feedbackIntegrationShim as feedbackAsyncIntegration,
+  feedbackIntegrationShim as feedbackIntegration,
+  replayIntegrationShim as replayIntegration,
+};

--- a/packages/browser/src/index.bundle.replay.feedback.logger.ts
+++ b/packages/browser/src/index.bundle.replay.feedback.logger.ts
@@ -1,0 +1,16 @@
+import { browserTracingIntegrationShim } from '@sentry-internal/integration-shims';
+import { feedbackAsyncIntegration } from './feedbackAsync';
+
+export * from './index.bundle.base';
+
+export { logger } from '@sentry/core';
+
+export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
+
+export { replayIntegration, getReplay } from '@sentry-internal/replay';
+
+export {
+  browserTracingIntegrationShim as browserTracingIntegration,
+  feedbackAsyncIntegration as feedbackAsyncIntegration,
+  feedbackAsyncIntegration as feedbackIntegration,
+};

--- a/packages/browser/src/index.bundle.replay.logger.ts
+++ b/packages/browser/src/index.bundle.replay.logger.ts
@@ -1,0 +1,13 @@
+import { browserTracingIntegrationShim, feedbackIntegrationShim } from '@sentry-internal/integration-shims';
+
+export * from './index.bundle.base';
+
+export { logger } from '@sentry/core';
+
+export { replayIntegration, getReplay } from '@sentry-internal/replay';
+
+export {
+  browserTracingIntegrationShim as browserTracingIntegration,
+  feedbackIntegrationShim as feedbackAsyncIntegration,
+  feedbackIntegrationShim as feedbackIntegration,
+};

--- a/packages/browser/src/index.bundle.tracing.logger.ts
+++ b/packages/browser/src/index.bundle.tracing.logger.ts
@@ -1,0 +1,33 @@
+import { registerSpanErrorInstrumentation } from '@sentry/core';
+import { feedbackIntegrationShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
+
+registerSpanErrorInstrumentation();
+
+export * from './index.bundle.base';
+
+export {
+  getActiveSpan,
+  getRootSpan,
+  startSpan,
+  startInactiveSpan,
+  startSpanManual,
+  startNewTrace,
+  withActiveSpan,
+  getSpanDescendants,
+  setMeasurement,
+  logger,
+} from '@sentry/core';
+
+export {
+  browserTracingIntegration,
+  startBrowserTracingNavigationSpan,
+  startBrowserTracingPageLoadSpan,
+} from './tracing/browserTracingIntegration';
+export { reportPageLoaded } from './tracing/reportPageLoaded';
+export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
+
+export {
+  feedbackIntegrationShim as feedbackAsyncIntegration,
+  feedbackIntegrationShim as feedbackIntegration,
+  replayIntegrationShim as replayIntegration,
+};

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.logger.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.logger.ts
@@ -1,0 +1,31 @@
+import { registerSpanErrorInstrumentation } from '@sentry/core';
+import { feedbackIntegrationShim } from '@sentry-internal/integration-shims';
+
+registerSpanErrorInstrumentation();
+
+export * from './index.bundle.base';
+
+export {
+  getActiveSpan,
+  getRootSpan,
+  startSpan,
+  startInactiveSpan,
+  startSpanManual,
+  startNewTrace,
+  withActiveSpan,
+  getSpanDescendants,
+  setMeasurement,
+  logger,
+} from '@sentry/core';
+
+export {
+  browserTracingIntegration,
+  startBrowserTracingNavigationSpan,
+  startBrowserTracingPageLoadSpan,
+} from './tracing/browserTracingIntegration';
+export { reportPageLoaded } from './tracing/reportPageLoaded';
+export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
+
+export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
+
+export { replayIntegration, getReplay } from '@sentry-internal/replay';

--- a/packages/browser/src/index.bundle.tracing.replay.logger.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.logger.ts
@@ -1,0 +1,31 @@
+import { registerSpanErrorInstrumentation } from '@sentry/core';
+import { feedbackIntegrationShim } from '@sentry-internal/integration-shims';
+
+registerSpanErrorInstrumentation();
+
+export * from './index.bundle.base';
+
+export {
+  getActiveSpan,
+  getRootSpan,
+  startSpan,
+  startInactiveSpan,
+  startSpanManual,
+  startNewTrace,
+  withActiveSpan,
+  getSpanDescendants,
+  setMeasurement,
+  logger,
+} from '@sentry/core';
+
+export {
+  browserTracingIntegration,
+  startBrowserTracingNavigationSpan,
+  startBrowserTracingPageLoadSpan,
+} from './tracing/browserTracingIntegration';
+export { reportPageLoaded } from './tracing/reportPageLoaded';
+export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
+
+export { feedbackIntegrationShim as feedbackAsyncIntegration, feedbackIntegrationShim as feedbackIntegration };
+
+export { replayIntegration, getReplay } from '@sentry-internal/replay';


### PR DESCRIPTION
 Adds 7 new logger bundle variants to `@sentry/browser` that combine the logger integration with various other features (tracing, replay, feedback).

  ## Bundles Added

  - `bundle.logger`
  - `bundle.tracing.logger`
  - `bundle.replay.logger`
  - `bundle.feedback.logger`
  - `bundle.tracing.replay.logger`
  - `bundle.replay.feedback.logger`
  - `bundle.tracing.replay.feedback.logger`

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [x] Link an issue if there is one related to your pull request. If no issue is linked, one will be auto-generated and linked.

Closes [#issue_link_here
](https://github.com/getsentry/sentry-javascript/issues/16314)