### PR TITLE
fix(deno,cloudflare): Prioritize name from params over name from options

### DIFF
--- a/packages/cloudflare/src/opentelemetry/tracer.ts
+++ b/packages/cloudflare/src/opentelemetry/tracer.ts
@@ -27,8 +27,8 @@ class SentryCloudflareTraceProvider implements TracerProvider {
 class SentryCloudflareTracer implements Tracer {
   public startSpan(name: string, options?: SpanOptions): Span {
     return startInactiveSpan({
-      name,
       ...options,
+      name,
       attributes: {
         ...options?.attributes,
         'sentry.cloudflare_tracer': true,
@@ -56,8 +56,8 @@ class SentryCloudflareTracer implements Tracer {
     const opts = (typeof options === 'object' && options !== null ? options : {}) as SpanOptions;
 
     const spanOpts = {
-      name,
       ...opts,
+      name,
       attributes: {
         ...opts.attributes,
         'sentry.cloudflare_tracer': true,

--- a/packages/deno/src/opentelemetry/tracer.ts
+++ b/packages/deno/src/opentelemetry/tracer.ts
@@ -35,8 +35,8 @@ class SentryDenoTracer implements Tracer {
     const op = this._mapSpanKindToOp(options?.kind);
 
     return startInactiveSpan({
-      name,
       ...options,
+      name,
       attributes: {
         ...options?.attributes,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
@@ -69,8 +69,8 @@ class SentryDenoTracer implements Tracer {
     const op = this._mapSpanKindToOp(opts.kind);
 
     const spanOpts = {
-      name,
       ...opts,
+      name,
       attributes: {
         ...opts.attributes,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',


### PR DESCRIPTION
I was playing around with #15466 and saw that the span names for the Prisma integration are different than the ones with actual OTel support, such as `@sentry/node`.

Cloudflare (no `prisma:client:` prefix):

<img width="200" height="978" alt="Screenshot 2026-01-13 at 15 48 41" src="https://github.com/user-attachments/assets/6b70a719-3c62-4799-af9c-cc15fe5aef8e" />

Express / Node (prefix is there):

<img width="200" height="917" alt="Screenshot 2026-01-13 at 17 18 05" src="https://github.com/user-attachments/assets/e4677cff-b3d9-4695-871a-e64ad05b4810" />

Within the `@prisma/instrumentation`, which is used for our integration, the name [is added properly](https://github.com/prisma/prisma/blob/d4ec055ee9e13e62351bf72643fc978b3d315ae3/packages/instrumentation/src/ActiveTracingHelper.ts#L83), but the `options` are not updated on purpose, as the source of truth is the `name` itself - OTel also uses the name directly: https://github.com/open-telemetry/opentelemetry-js/blob/87a0b455e5f7f36d9b05b41b6bf11d114dcc854c/packages/opentelemetry-sdk-trace-base/src/Tracer.ts#L149

There is no further explanation in #16714 why [the `name` came before the spreading `options`](https://github.com/getsentry/sentry-javascript/pull/16714/files#diff-595e62985088cbceb347c68deb88b69569b35edee895929d72a7f690ac13ecf7R59).

--- 

With this PR the Prisma integration does work correctly:

<img width="200" height="843" alt="Screenshot 2026-01-13 at 17 23 06" src="https://github.com/user-attachments/assets/39fa89a3-9b31-4640-ac0c-a517d6457b62" />

--- 

Since the same code was copied over to Deno, I also fixed it there.
