### PR TITLE
test(e2e): Pin @shopify/remix-oxygen to unblock ci

### DIFF
--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/package.json
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/package.json
@@ -22,9 +22,9 @@
     "@sentry/vite-plugin": "^4.6.1",
     "@shopify/hydrogen": "2025.4.0",
     "@shopify/remix-oxygen": "2.0.10",
-    "graphql": "16.6.0",
-    "graphql-tag": "2.12.6",
-    "isbot": "3.8.0",
+    "graphql": "^16.6.0",
+    "graphql-tag": "^2.12.6",
+    "isbot": "^3.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
The `remix-hydrogen` E2E test started failing, pinning for now.


Closes #18814 (added automatically)