### PR TITLE
feat(core): Add `ignored` client report event drop reason

### DIFF
--- a/packages/core/src/types-hoist/clientreport.ts
+++ b/packages/core/src/types-hoist/clientreport.ts
@@ -9,7 +9,8 @@ export type EventDropReason =
   | 'sample_rate'
   | 'send_error'
   | 'internal_sdk_error'
-  | 'buffer_overflow';
+  | 'buffer_overflow'
+  | 'ignored';
 
 export type Outcome = {
   reason: EventDropReason;


### PR DESCRIPTION
This PR adds `ignored` as a new allowed client report discard reason. The new reason can already be used (see [ticket](https://linear.app/getsentry/issue/FE-678/add-new-ignore-discard-reason-for-client-reports) for details). Technically, we only need it right now for span-first to record `ignoreSpans` hits. But this reason also meant for more telemetry types, so we can merge it into develop already.

see: https://develop.sentry.dev/sdk/telemetry/client-reports/#envelope-item-payload

closes https://linear.app/getsentry/issue/FE-678/add-new-ignore-discard-reason-for-client-reports