### PR TITLE
fix(fetch): Shallow-clone fetch options to prevent mutation

### DIFF
--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -111,7 +111,9 @@ export function instrumentFetchRequest(
   if (shouldAttachHeaders(handlerData.fetchData.url)) {
     const request: string | Request = handlerData.args[0];
 
-    const options: { [key: string]: unknown } = handlerData.args[1] || {};
+    // Shallow clone the options object to avoid mutating the original user-provided object
+    // Examples: users re-using same options object for multiple fetch calls, frozen objects
+    const options: { [key: string]: unknown } = { ...(handlerData.args[1] || {}) };
 
     const headers = _addTracingHeadersToFetchRequest(
       request,


### PR DESCRIPTION
When injecting tracing headers into fetch requests, the SDK was mutating the user's original options object. This caused issues when users reused config objects across requests or when the object was frozen (e.g., from Immer's `produce()`), leading to silent failures. This change shallow clones the options object before modifying it, ensuring the original remains unchanged while still properly injecting the `sentry-trace` and `baggage` headers.

Closes https://github.com/getsentry/sentry-javascript/issues/18828
