### PR TITLE
fix(core): Find the correct IP address regardless their case

### DIFF
--- a/packages/core/src/vendor/getIpAddress.ts
+++ b/packages/core/src/vendor/getIpAddress.ts
@@ -52,10 +52,18 @@ export const ipHeaderNames = [
  * will be returned.
  */
 export function getClientIPAddress(headers: { [key: string]: string | string[] | undefined }): string | null {
+  // Build a map of lowercase header names to their values for case-insensitive lookup
+  // This is needed because headers from different sources may have different casings
+  const lowerCaseHeaders: { [key: string]: string | string[] | undefined } = {};
+
+  for (const key of Object.keys(headers)) {
+    lowerCaseHeaders[key.toLowerCase()] = headers[key];
+  }
+
   // This will end up being Array<string | string[] | undefined | null> because of the various possible values a header
   // can take
   const headerValues = ipHeaderNames.map((headerName: string) => {
-    const rawValue = headers[headerName];
+    const rawValue = lowerCaseHeaders[headerName.toLowerCase()];
     const value = Array.isArray(rawValue) ? rawValue.join(';') : rawValue;
 
     if (headerName === 'Forwarded') {

--- a/packages/core/test/lib/vendor/getClientIpAddress.test.ts
+++ b/packages/core/test/lib/vendor/getClientIpAddress.test.ts
@@ -29,4 +29,13 @@ describe('getClientIPAddress', () => {
 
     expect(ip).toEqual(expectedIP);
   });
+
+  it('should find headers regardless of case', () => {
+    const headers = {
+      'Cf-Connecting-Ip': '1.1.1.1',
+    };
+
+    const ip = getClientIPAddress(headers);
+    expect(ip).toEqual('1.1.1.1');
+  });
 });


### PR DESCRIPTION
closes [FE-681](https://linear.app/getsentry/issue/FE-681/senddefaultpii-sets-cloudflare-worker-ip-instead-of-the-one-from-the)

It seems that in some cases the headers do have a different casing. E.g. in Cloudflare Workers the `[CF-Connecting-IP](https://developers.cloudflare.com/fundamentals/reference/http-headers/#cf-connecting-ip)` is actually send as `Cf-Connecting-Ip`. 

<img width="635" height="223" alt="Screenshot 2026-01-19 at 13 15 27" src="https://github.com/user-attachments/assets/e427e10d-35b7-4743-980c-3ff0d5cc1d51" />

According to [RFC7540 8.1.2](https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2) the headers are case-insensitive, but for HTTP2 they must be lowercase. So theoretically this would fix also HTTP2 lower case headers