### PR TITLE
chore(dependabot): Update remix-run all together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
       opentelemetry:
         patterns:
           - '@opentelemetry/*'
+      remix:
+        patterns:
+          - '@remix-run/*'
     versioning-strategy: increase
     commit-message:
       prefix: feat


### PR DESCRIPTION
There were 3 different PRs opened for a remix-run update: #18750 #18747 #18746

Each failed because they needed the other packages to be there. Not all `@remix-run/*` packages follow the same version update, just some. But it is still better to update all together nontheless