### PR TITLE
fix(nextjs): Add ALS runner fallbacks for serverless environments

### DIFF
--- a/packages/nextjs/src/server/prepareSafeIdGeneratorContext.ts
+++ b/packages/nextjs/src/server/prepareSafeIdGeneratorContext.ts
@@ -1,8 +1,4 @@
-import {
-  type _INTERNAL_RandomSafeContextRunner as RandomSafeContextRunner,
-  debug,
-  GLOBAL_OBJ,
-} from '@sentry/core';
+import { type _INTERNAL_RandomSafeContextRunner as RandomSafeContextRunner, debug, GLOBAL_OBJ } from '@sentry/core';
 import { DEBUG_BUILD } from '../common/debug-build';
 
 // Inline AsyncLocalStorage interface from current types


### PR DESCRIPTION
### Summary

This was introduced by cache components workaround in #18700.

When deploying a Next.js app on Cloudflare Workers and I presume other serverless environments, you would get this error

```
NextJS request failed. Error: Cannot call this AsyncLocalStorage bound function outside of the request in which it was created.
```

This happens because the snapshot becomes stale in the next request invocation.

### Solution

This is more of a best-effort workaround. I added a retry logic based on some criteria, if the first attempt fails due to ALS error then it will grab a new snapshot and re-run it, if that also fails, then it will run the callback directly.

 the flow goes like this:

```mermaid
flowchart TD
    A[callback invoked] --> B{Try cached snapshot}
    B -->|Success| C[Return result]
    B -->|Error| D{Is AsyncLocalStorage error?}
    
    D -->|No| E[Rethrow error]
    D -->|Yes| F[Get fresh snapshot]
    
    F --> G{Fresh snapshot available?}
    G -->|No| H[Execute callback directly]
    G -->|Yes| I[Update cached snapshot]
    
    I --> J{Try fresh snapshot}
    J -->|Success| K[Return result]
    J -->|Error| L{Is AsyncLocalStorage error?}
    
    L -->|No| M[Rethrow error]
    L -->|Yes| N[Execute callback directly]
    
    H --> O[Return result]
    N --> O

    style C fill:#90EE90
    style K fill:#90EE90
    style O fill:#90EE90
    style E fill:#FFB6C1
    style M fill:#FFB6C1
```


Closes #18842 