### PR TITLE
chore(llm): Ignore local Claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ packages/gatsby/gatsby-node.d.ts
 
 #junit reports
 packages/**/*.junit.xml
+
+# Local Claude Code settings that should not be committed
+.claude/settings.local.json


### PR DESCRIPTION
Ignore .claude/settings.local.json as these are local settings not intended for version control.

Closes #18894 (added automatically)