### PR TITLE
feat(core): Support new client discard reason `invalid`

### DIFF
--- a/packages/core/src/types-hoist/clientreport.ts
+++ b/packages/core/src/types-hoist/clientreport.ts
@@ -10,7 +10,8 @@ export type EventDropReason =
   | 'send_error'
   | 'internal_sdk_error'
   | 'buffer_overflow'
-  | 'ignored';
+  | 'ignored'
+  | 'invalid';
 
 export type Outcome = {
   reason: EventDropReason;


### PR DESCRIPTION
This new reason can be used when the client drops telemetry items due to failing internal validation (e.g. dropping replays that contain invalid session times)

ref https://github.com/getsentry/sentry-javascript/issues/18316
depends on https://github.com/getsentry/snuba/pull/7654
closes https://linear.app/getsentry/issue/FE-690/update-js-sdk-to-support-client-discard-invalid
