### PR TITLE
feat(opentelemetry): Support `db.system.name` attribute for database spans

### DIFF
--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -1,6 +1,7 @@
 import type { Attributes, AttributeValue } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import {
+  ATTR_DB_SYSTEM_NAME,
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_ROUTE,
   ATTR_URL_FULL,
@@ -47,7 +48,7 @@ export function inferSpanData(spanName: string, attributes: SpanAttributes, kind
   }
 
   // eslint-disable-next-line deprecation/deprecation
-  const dbSystem = attributes[SEMATTRS_DB_SYSTEM];
+  const dbSystem = attributes[ATTR_DB_SYSTEM_NAME] || attributes[SEMATTRS_DB_SYSTEM];
   const opIsCache =
     typeof attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'string' &&
     attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP].startsWith('cache.');

--- a/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
+++ b/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
@@ -2,6 +2,7 @@
 import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import {
+  ATTR_DB_SYSTEM_NAME,
   ATTR_HTTP_ROUTE,
   SEMATTRS_DB_STATEMENT,
   SEMATTRS_DB_SYSTEM,
@@ -143,6 +144,48 @@ describe('parseSpanDescription', () => {
       SpanKind.CLIENT,
       {
         description: 'test name',
+        op: 'db',
+        source: 'task',
+      },
+    ],
+    [
+      'works with db.system.name (stable attribute)',
+      {
+        [ATTR_DB_SYSTEM_NAME]: 'postgresql',
+        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+      },
+      'test name',
+      SpanKind.CLIENT,
+      {
+        description: 'SELECT * from users',
+        op: 'db',
+        source: 'task',
+      },
+    ],
+    [
+      'works with db.system.name without statement',
+      {
+        [ATTR_DB_SYSTEM_NAME]: 'postgresql',
+      },
+      'test name',
+      SpanKind.CLIENT,
+      {
+        description: 'test name',
+        op: 'db',
+        source: 'task',
+      },
+    ],
+    [
+      'prefers db.system.name over deprecated db.system',
+      {
+        [ATTR_DB_SYSTEM_NAME]: 'postgresql',
+        [SEMATTRS_DB_SYSTEM]: 'mysql',
+        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+      },
+      'test name',
+      SpanKind.CLIENT,
+      {
+        description: 'SELECT * from users',
         op: 'db',
         source: 'task',
       },


### PR DESCRIPTION
Supports the now stable `db.system.name` semantic convention attribute alongside the deprecated `db.system` attribute when identifying database spans.


Closes #18903 (added automatically)