### PR TITLE
feat(winston): Add customLevelMap for winston transport

### DIFF
--- a/dev-packages/node-integration-tests/suites/winston/subject.ts
+++ b/dev-packages/node-integration-tests/suites/winston/subject.ts
@@ -65,6 +65,18 @@ async function run(): Promise<void> {
     });
   }
 
+  if (process.env.WITH_FILTER === 'true') {
+    const FilteredSentryWinstonTransport = Sentry.createSentryWinstonTransport(Transport, {
+      levels: ['error'],
+    });
+    const filteredLogger = winston.createLogger({
+      transports: [new FilteredSentryWinstonTransport()],
+    });
+
+    filteredLogger.info('Ignored message');
+    filteredLogger.error('Test error message');
+  }
+
   // If unmapped custom level is requested (tests debug line for unknown levels)
   if (process.env.UNMAPPED_CUSTOM_LEVEL === 'true') {
     const customLevels = {

--- a/dev-packages/node-integration-tests/suites/winston/test.ts
+++ b/dev-packages/node-integration-tests/suites/winston/test.ts
@@ -123,6 +123,71 @@ describe('winston integration', () => {
     await runner.completed();
   });
 
+  test("should capture winston logs with filter but don't show custom level warnings", async () => {
+    const runner = createRunner(__dirname, 'subject.ts')
+      .withEnv({ WITH_FILTER: 'true' })
+      .expect({
+        log: {
+          items: [
+            {
+              timestamp: expect.any(Number),
+              level: 'info',
+              body: 'Test info message',
+              severity_number: expect.any(Number),
+              trace_id: expect.any(String),
+              attributes: {
+                'sentry.origin': { value: 'auto.log.winston', type: 'string' },
+                'sentry.release': { value: '1.0.0', type: 'string' },
+                'sentry.environment': { value: 'test', type: 'string' },
+                'sentry.sdk.name': { value: 'sentry.javascript.node', type: 'string' },
+                'sentry.sdk.version': { value: expect.any(String), type: 'string' },
+                'server.address': { value: expect.any(String), type: 'string' },
+              },
+            },
+            {
+              timestamp: expect.any(Number),
+              level: 'error',
+              body: 'Test error message',
+              severity_number: expect.any(Number),
+              trace_id: expect.any(String),
+              attributes: {
+                'sentry.origin': { value: 'auto.log.winston', type: 'string' },
+                'sentry.release': { value: '1.0.0', type: 'string' },
+                'sentry.environment': { value: 'test', type: 'string' },
+                'sentry.sdk.name': { value: 'sentry.javascript.node', type: 'string' },
+                'sentry.sdk.version': { value: expect.any(String), type: 'string' },
+                'server.address': { value: expect.any(String), type: 'string' },
+              },
+            },
+            {
+              timestamp: expect.any(Number),
+              level: 'error',
+              body: 'Test error message',
+              severity_number: expect.any(Number),
+              trace_id: expect.any(String),
+              attributes: {
+                'sentry.origin': { value: 'auto.log.winston', type: 'string' },
+                'sentry.release': { value: '1.0.0', type: 'string' },
+                'sentry.environment': { value: 'test', type: 'string' },
+                'sentry.sdk.name': { value: 'sentry.javascript.node', type: 'string' },
+                'sentry.sdk.version': { value: expect.any(String), type: 'string' },
+                'server.address': { value: expect.any(String), type: 'string' },
+              },
+            },
+          ],
+        },
+      })
+      .start();
+
+    await runner.completed();
+
+    const logs = runner.getLogs();
+
+    const warning = logs.find(log => log.includes('Winston log level info is not captured by Sentry.'));
+
+    expect(warning).not.toBeDefined();
+  });
+
   test('should capture winston logs with metadata', async () => {
     const runner = createRunner(__dirname, 'subject.ts')
       .withEnv({ WITH_METADATA: 'true' })

--- a/packages/node-core/src/integrations/winston.ts
+++ b/packages/node-core/src/integrations/winston.ts
@@ -103,15 +103,15 @@ export function createSentryWinstonTransport<TransportStreamInstance extends obj
         attributes[SPLAT_SYMBOL] = undefined;
 
         const customLevel = sentryWinstonOptions?.customLevelMap?.[levelFromSymbol as string];
-        const logSeverityLevel =
-          customLevel ?? WINSTON_LEVEL_TO_LOG_SEVERITY_LEVEL_MAP[levelFromSymbol as string] ?? 'info';
+        const winstonLogLevel = WINSTON_LEVEL_TO_LOG_SEVERITY_LEVEL_MAP[levelFromSymbol as string];
+        const logSeverityLevel = customLevel ?? winstonLogLevel ?? 'info';
 
         if (this._levels.has(logSeverityLevel)) {
           captureLog(logSeverityLevel, message as string, {
             ...attributes,
             'sentry.origin': 'auto.log.winston',
           });
-        } else if (!customLevel) {
+        } else if (!customLevel && !winstonLogLevel) {
           DEBUG_BUILD &&
             debug.log(
               `Winston log level ${levelFromSymbol} is not captured by Sentry. Please add ${levelFromSymbol} to the "customLevelMap" option of the Sentry Winston transport.`,


### PR DESCRIPTION
closes #18868
closes [JS-1498](https://linear.app/getsentry/issue/JS-1498/allow-customization-of-level-mapping-in-createsentrywinstontransport)

ATM it is not possible to map custom levels to OpenTelemetry levels. The option `customLevelMap` has been added to make this possible. Which means that custom levels would have never been send to Sentry, as they were not mapped correctly.

Now when there are custom levels it can be used like this:

```js
const customLevels = {
  levels: {
    customCritical: 0,
    customNotice: 2,
  },
};

const SentryWinstonTransport = Sentry.createSentryWinstonTransport(Transport, {
  customLevelMap: {
    customCritical: 'fatal',
    customNotice: 'info',
  },
});

const mappedLogger = winston.createLogger({
  levels: customLevels.levels,
  level: 'customNotice', // this needs to be added due to https://github.com/winstonjs/winston/issues/1491
  transports: [new SentryWinstonTransport()],
});
```

### Merge checklist

- [x] Sentry Docs update issue has been created