### PR TITLE
chore(e2e): Add Makefile to make running specific e2e test apps easier

### DIFF
--- a/dev-packages/e2e-tests/Makefile
+++ b/dev-packages/e2e-tests/Makefile
@@ -1,0 +1,11 @@
+.PHONY: run list
+
+run:
+	@if ! command -v fzf &> /dev/null; then \
+		echo "Error: fzf is required. Install with: brew install fzf"; \
+		exit 1; \
+	fi
+	@ls test-applications | fzf --height=10 --layout=reverse --border=rounded --margin=1.5% --color=dark --prompt="yarn test:run " | xargs -r yarn test:run
+
+list:
+	@ls test-applications

--- a/dev-packages/e2e-tests/README.md
+++ b/dev-packages/e2e-tests/README.md
@@ -33,6 +33,30 @@ yarn test:run <app-name> --variant <variant-name>
 
 Variant name matching is case-insensitive and partial. For example, `--variant 13` will match `nextjs-pages-dir (next@13)` if a matching variant is present in the test app's `package.json`.
 
+### Using the Makefile
+
+Alternatively, you can use the provided Makefile for an interactive test selection experience:
+
+**Prerequisites**: Install `fzf` with Homebrew:
+
+```bash
+brew install fzf
+```
+
+**Run tests interactively**:
+
+```bash
+make run
+```
+
+This will display a fuzzy-finder menu of all available test applications. Select one to run it automatically.
+
+**List all test applications**:
+
+```bash
+make list
+```
+
 For example, if you have the following variants in your test app's `package.json`:
 
 ```json


### PR DESCRIPTION
We have many e2e test apps and it can be cumbersome to type in which exact app you want to run. This PR adds a Makefile that uses `fzf` to give a better experience:

https://github.com/user-attachments/assets/8fe472a6-34ac-4311-81aa-e8d384e51760

Note: Requires having `fzf` installed via `brew install fzf` or other package managers.

