### PR TITLE
fix(nuxt): include sentry.config.server.ts in nuxt app types

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -74,20 +74,6 @@ export default defineNuxtModule<ModuleOptions>({
         mode: 'client',
         order: 1,
       });
-
-      // Add the sentry config file to the include array
-      nuxt.hook('prepare:types', options => {
-        const tsConfig = options.tsConfig as { include?: string[] };
-
-        if (!tsConfig.include) {
-          tsConfig.include = [];
-        }
-
-        // Add type references for useRuntimeConfig in root files for nuxt v4
-        // Should be relative to `root/.nuxt`
-        const relativePath = path.relative(nuxt.options.buildDir, clientConfigFile);
-        tsConfig.include.push(relativePath);
-      });
     }
 
     const serverConfigFile = findDefaultSdkInitFile('server', nuxt);
@@ -133,6 +119,26 @@ export default defineNuxtModule<ModuleOptions>({
       addStorageInstrumentation(nuxt);
       addDatabaseInstrumentation(nuxt.options.nitro);
     }
+
+    // Add the sentry config file to the include array
+    nuxt.hook('prepare:types', options => {
+      const tsConfig = options.tsConfig as { include?: string[] };
+
+      if (!tsConfig.include) {
+        tsConfig.include = [];
+      }
+
+      // Add type references for useRuntimeConfig in root files for nuxt v4
+      // Should be relative to `root/.nuxt`
+      if (clientConfigFile) {
+        const relativePath = path.relative(nuxt.options.buildDir, clientConfigFile);
+        tsConfig.include.push(relativePath);
+      }
+      if (serverConfigFile) {
+        const relativePath = path.relative(nuxt.options.buildDir, serverConfigFile);
+        tsConfig.include.push(relativePath);
+      }
+    });
 
     nuxt.hooks.hook('nitro:init', nitro => {
       if (nuxt.options?._prepare) {


### PR DESCRIPTION
The [#17830](https://github.com/getsentry/sentry-javascript/pull/17830) fixes the error explained in #17781 only for the sentry.client.config.ts but the error still exists for the sentry.server.config.ts.

With this PR we add the sentry.config.server.ts to the auto generated tsconfig by extending the types via the [prepare:types hook](https://nuxt.com/docs/4.x/guide/going-further/modules#adding-type-declarations).

This allows useRuntimeConfig to be properly typed in the root sentry.server.config.ts, or where ever the client file is found.

Not sure how this could be tested tho, since it is purely types.

