### PR TITLE
test(prisma): Move to yarn prisma

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
@@ -18,7 +18,7 @@ conditionalTest({ min: 20 })('Prisma ORM v7 Tests', () => {
           .withDockerCompose({
             workingDirectory: [cwd],
             readyMatches: ['port 5432'],
-            setupCommand: `prisma generate --schema ${cwd}/prisma/schema.prisma && tsc -p ${cwd}/prisma/tsconfig.json && prisma migrate dev -n sentry-test --schema ${cwd}/prisma/schema.prisma`,
+            setupCommand: `yarn prisma generate --schema ${cwd}/prisma/schema.prisma && tsc -p ${cwd}/prisma/tsconfig.json && yarn prisma migrate dev -n sentry-test --schema ${cwd}/prisma/schema.prisma`,
           })
           .expect({
             transaction: transaction => {


### PR DESCRIPTION
`yarn prisma` is better to use since it uses the correct `node_modules` path. Without it it may break at some point since the global package could be different at some point.

Closes #18976 (added automatically)