### PR TITLE
feat(test-utils): Add a way to wait for single spans for Span streaming

### DIFF
--- a/dev-packages/test-utils/src/index.ts
+++ b/dev-packages/test-utils/src/index.ts
@@ -8,6 +8,10 @@ export {
   waitForSession,
   waitForPlainRequest,
   waitForMetric,
+  waitForSpanV2,
+  waitForSpansV2,
+  waitForSpanV2Envelope,
+  getSpanV2Op,
 } from './event-proxy-server';
 
 export { getPlaywrightConfig } from './playwright-config';


### PR DESCRIPTION
How it should be used is in the JSDoc. It worked quite well for my Cloudflare tests

Closes #18987 (added automatically)