### PR TITLE
chore: Add external contributor to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+Work in this release was contributed by @harshit078. Thank you for your contribution!
+
 ## 10.37.0
 
 ### Important Changes


### PR DESCRIPTION
The run to add the contributor failed to do so: https://github.com/getsentry/sentry-javascript/actions/runs/21393991938/job/61609775062


Closes #19006 (added automatically)