### PR TITLE
chore(dependabot): Allow all packages to update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    allow:
-      - dependency-name: '@sentry/*'
-      - dependency-name: '@playwright/test'
-      - dependency-name: '@opentelemetry/*'
     ignore:
       - dependency-name: '@opentelemetry/instrumentation'
       - dependency-name: '@opentelemetry/instrumentation-*'


### PR DESCRIPTION
A very bold move. Let's make dependabot update all our packages. This was once added in #9752. But I think if we explicilty add an "allow" block, it will automatically ignore others. Which also means when we remove the "allow" block it would also include the ones I just removed.
