### PR TITLE
chore(dependabot): Update ignore patterns and add more groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,13 @@ updates:
       opentelemetry:
         patterns:
           - '@opentelemetry/*'
+      remix:
+        patterns:
+          - '@remix-run/*'
     versioning-strategy: increase
     commit-message:
       prefix: feat
       prefix-development: feat
       include: scope
     exclude-paths:
-      - 'dev-packages/e2e-tests/test-applications/'
+      - 'dev-packages/e2e-tests/test-applications/**'


### PR DESCRIPTION
This resurrects #18885 and also adds a glob to the `exclude-paths`.

I suspect that `dev-packages` still got updates because there were missing glob patterns: `**`. At least this is what I understood from the docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#exclude-paths-