### PR TITLE
chore(dependabot): Update ignore patterns and add more groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     ignore:
       - dependency-name: '@opentelemetry/instrumentation'
       - dependency-name: '@opentelemetry/instrumentation-*'
+      - dependency-name: 'typescript'
     groups:
       opentelemetry:
         patterns:
@@ -25,7 +26,7 @@ updates:
     versioning-strategy: increase
     commit-message:
       prefix: feat
-      prefix-development: feat
+      prefix-development: chore
       include: scope
     exclude-paths:
       - 'dev-packages/e2e-tests/test-applications/**'


### PR DESCRIPTION
This changes the commit message for dev dependencies to `chore`. We had `feat` before but it doesn't really affect a user, and can be treated as a patch update once we update dev dependencies. But if we update normal dependencies I think `feat` still make sense, as it could potentially provide more features.

This one is also excluding `typescript`

Closes #19044 (added automatically)