### PR TITLE
ci: Ignore ticket creation for base branches other than develop/master

### DIFF
--- a/.github/workflows/create-issue-for-unreferenced-prs.yml
+++ b/.github/workflows/create-issue-for-unreferenced-prs.yml
@@ -20,7 +20,8 @@ jobs:
   check_for_issue_reference:
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'Dev: Gitflow')
+      (github.event.pull_request.base.ref == 'develop' || github.event.pull_request.base.ref == 'master')
+      && !contains(github.event.pull_request.labels.*.name, 'Dev: Gitflow')
       && !startsWith(github.event.pull_request.head.ref, 'external-contributor/')
       && !startsWith(github.event.pull_request.head.ref, 'prepare-release/')
       && !startsWith(github.event.pull_request.head.ref, 'dependabot/')


### PR DESCRIPTION
We already had this that #18987 was not closed because it was a PR to another branch (to make it easier for reviewing): https://github.com/getsentry/sentry-javascript/issues/18987#issuecomment-3819973505

When having this a ticket will be opened, but not automatically closed on merge as this workflow is apparently not supported by GitHub if the base branch is not the default (I am not sure if it works for `master`, but if there is a PR to `master` then we should definitely open a ticket, even though it is not autoclosing - just because it might be a mistake that it was opened against `master`)