### PR TITLE
feat(tanstackstart-react): Auto-copy build file to correct folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 Work in this release was contributed by @sebws, @harshit078, and @fedetorre. Thank you for your contributions!
 
-- **feat(tanstackstart-react): Auto-copy instrumentation file to server build output**
+- **feat(tanstackstart-react): Auto-copy instrumentation file to server build output ([#19104](https://github.com/getsentry/sentry-javascript/pull/19104))**
 
   The Sentry TanStack Start Vite plugin now automatically copies the `instrument.server.mjs` file to the correct server build output directory after the build completes. The output directory is auto-detected based on the deployment target (e.g., Nitro), so you no longer need to manually ensure the instrumentation file ends up in the right place. If auto-detection doesn't work for your setup, you can override the file path and output directory manually:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@
 
 Work in this release was contributed by @sebws, @harshit078, and @fedetorre. Thank you for your contributions!
 
+- **feat(tanstackstart-react): Auto-copy instrumentation file to server build output**
+
+  The Sentry TanStack Start Vite plugin now automatically copies the `instrument.server.mjs` file to the correct server build output directory after the build completes. The output directory is auto-detected based on the deployment target (e.g., Nitro), so you no longer need to manually ensure the instrumentation file ends up in the right place. If auto-detection doesn't work for your setup, you can override the file path and output directory manually:
+
+  ```ts
+  // vite.config.ts
+  import { defineConfig } from 'vite';
+  import { sentryTanstackStart } from '@sentry/tanstackstart-react';
+  import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+
+  export default defineConfig({
+    plugins: [
+      tanstackStart(),
+      sentryTanstackStart({
+        org: 'your-org',
+        project: 'your-project',
+
+        // Custom path to the instrumentation file (default: 'instrument.server.mjs')
+        instrumentationFilePath: 'my-instrument.server.mjs',
+
+        // Override the auto-detected server output directory
+        serverOutputDir: 'build/server',
+      }),
+    ],
+  });
+  ```
+
 - **feat(core): Introduces a new `Sentry.setConversationId()` API to track multi turn AI conversations across API calls. ([#18909](https://github.com/getsentry/sentry-javascript/pull/18909))**
 
   You can now set a conversation ID that will be automatically applied to spans within that scope. This allows you to link traces from the same conversation together.

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "build": "vite build && cp instrument.server.mjs .output/server",
+    "build": "vite build",
     "start": "node --import ./.output/server/instrument.server.mjs .output/server/index.mjs",
     "test": "playwright test",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",

--- a/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
+++ b/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
@@ -52,7 +52,6 @@ export function makeCopyInstrumentationFilePlugin(instrumentationFilePath?: stri
           );
         });
       }
-
     },
 
     async closeBundle() {

--- a/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
+++ b/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
@@ -30,8 +30,9 @@ export function makeCopyInstrumentationFilePlugin(instrumentationFilePath?: stri
       console.log('plugins', plugins);
 
       if (hasPlugin('nitro')) {
-        // Nitro case: read server dir from the nitro environment config
-        console.log('resolvedConfig', resolvedConfig);
+        // I don't think we have a way to access the nitro instance directly to get the server dir, so we need to access it via the vite environment config.
+        // This works because Nitro's Vite bundler sets the rollup output dir to the resolved serverDir:
+        // https://github.com/nitrojs/nitro/blob/1954b824597f6ac52fb8b064415cb85d0feda078/src/build/vite/bundler.ts#L35
         const environments = (resolvedConfig as { environments?: ViteEnvironments }).environments;
         const nitroEnv = environments?.nitro;
         if (nitroEnv) {

--- a/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
+++ b/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
@@ -49,6 +49,7 @@ export function makeCopyInstrumentationFilePlugin(): Plugin {
           );
         });
       }
+
     },
 
     async closeBundle() {
@@ -61,7 +62,13 @@ export function makeCopyInstrumentationFilePlugin(): Plugin {
       try {
         await fs.promises.access(instrumentationSource, fs.constants.F_OK);
       } catch {
-        // No instrumentation file found — nothing to copy
+        consoleSandbox(() => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[Sentry TanStack Start] No instrument.server.mjs file found in project root. ' +
+              'The Sentry instrumentation file will not be copied to the build output.',
+          );
+        });
         return;
       }
 

--- a/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
+++ b/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
@@ -44,8 +44,7 @@ export function makeCopyInstrumentationFilePlugin(): Plugin {
         consoleSandbox(() => {
           // eslint-disable-next-line no-console
           console.warn(
-            '[Sentry TanStack Start] Could not determine server output directory. ' +
-              'Could not detect nitro, cloudflare, or netlify vite plugin. ' +
+            '[Sentry TanStack Start] Could not detect nitro, cloudflare, or netlify vite plugin. ' +
               'The instrument.server.mjs file will not be copied to the build output automatically.',
           );
         });

--- a/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
+++ b/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
@@ -16,6 +16,8 @@ import type { Plugin, ResolvedConfig } from 'vite';
  */
 export function makeCopyInstrumentationFilePlugin(instrumentationFilePath?: string): Plugin {
   let serverOutputDir: string | undefined;
+  type RollupOutputDir = { dir?: string } | Array<{ dir?: string }>;
+  type ViteEnvironments = Record<string, { build?: { rollupOptions?: { output?: RollupOutputDir } } }>;
 
   return {
     name: 'sentry-tanstackstart-copy-instrumentation-file',
@@ -25,14 +27,12 @@ export function makeCopyInstrumentationFilePlugin(instrumentationFilePath?: stri
     configResolved(resolvedConfig: ResolvedConfig) {
       const plugins = resolvedConfig.plugins || [];
       const hasPlugin = (name: string): boolean => plugins.some(p => p.name?.includes(name));
+      console.log('plugins', plugins);
 
       if (hasPlugin('nitro')) {
         // Nitro case: read server dir from the nitro environment config
-        // Vite 6 environment configs are not part of the public type definitions yet,
-        // so we need to access them via an index signature.
-        const environments = (resolvedConfig as Record<string, unknown>)['environments'] as
-          | Record<string, { build?: { rollupOptions?: { output?: { dir?: string } | Array<{ dir?: string }> } } }>
-          | undefined;
+        console.log('resolvedConfig', resolvedConfig);
+        const environments = (resolvedConfig as { environments?: ViteEnvironments }).environments;
         const nitroEnv = environments?.nitro;
         if (nitroEnv) {
           const rollupOutput = nitroEnv.build?.rollupOptions?.output;

--- a/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
+++ b/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
@@ -1,4 +1,3 @@
-import { consoleSandbox } from '@sentry/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Plugin, ResolvedConfig } from 'vite';
@@ -56,13 +55,11 @@ export function makeCopyInstrumentationFilePlugin(options?: CopyInstrumentationF
         // There seems to be no way for users to configure the server output dir for these plugins, so we just assume it's `dist/server`, which is the default output dir.
         serverOutputDir = path.resolve(resolvedConfig.root, 'dist', 'server');
       } else {
-        consoleSandbox(() => {
-          // eslint-disable-next-line no-console
-          console.warn(
-            '[Sentry TanStack Start] Could not detect nitro, cloudflare, or netlify vite plugin. ' +
-              'The instrument.server.mjs file will not be copied to the build output automatically.',
-          );
-        });
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[Sentry] Could not detect nitro, cloudflare, or netlify vite plugin. ' +
+            'The instrument.server.mjs file will not be copied to the build output automatically.',
+        );
       }
     },
 
@@ -77,13 +74,11 @@ export function makeCopyInstrumentationFilePlugin(options?: CopyInstrumentationF
       try {
         await fs.promises.access(instrumentationSource, fs.constants.F_OK);
       } catch {
-        consoleSandbox(() => {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[Sentry TanStack Start] No ${instrumentationFileName} file found in project root. ` +
-              'The Sentry instrumentation file will not be copied to the build output.',
-          );
-        });
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[Sentry] No ${instrumentationFileName} file found in project root. ` +
+            'The Sentry instrumentation file will not be copied to the build output.',
+        );
         return;
       }
 
@@ -93,15 +88,11 @@ export function makeCopyInstrumentationFilePlugin(options?: CopyInstrumentationF
       try {
         await fs.promises.mkdir(serverOutputDir, { recursive: true });
         await fs.promises.copyFile(instrumentationSource, destination);
-        consoleSandbox(() => {
-          // eslint-disable-next-line no-console
-          console.log(`[Sentry TanStack Start] Copied ${destinationFileName} to ${destination}`);
-        });
+        // eslint-disable-next-line no-console
+        console.log(`[Sentry] Copied ${destinationFileName} to ${destination}`);
       } catch (error) {
-        consoleSandbox(() => {
-          // eslint-disable-next-line no-console
-          console.warn(`[Sentry TanStack Start] Failed to copy ${destinationFileName} to build output.`, error);
-        });
+        // eslint-disable-next-line no-console
+        console.warn(`[Sentry] Failed to copy ${destinationFileName} to build output.`, error);
       }
     },
   };

--- a/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
+++ b/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
@@ -1,0 +1,78 @@
+import { consoleSandbox } from '@sentry/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Plugin, ResolvedConfig } from 'vite';
+
+/**
+ * Creates a Vite plugin that copies the user's `instrument.server.mjs` file
+ * to the server build output directory after the build completes.
+ *
+ * Supports:
+ * - Nitro deployments (reads output dir from the Nitro Vite environment config)
+ * - Cloudflare/Netlify deployments (outputs to `dist/server`)
+ */
+export function makeCopyInstrumentationFilePlugin(): Plugin {
+  let serverOutputDir: string | undefined;
+
+  return {
+    name: 'sentry-tanstackstart-copy-instrumentation-file',
+    apply: 'build',
+    enforce: 'post',
+
+    configResolved(resolvedConfig: ResolvedConfig) {
+      // Nitro case: read server dir from the nitro environment config
+      // Vite 6 environment configs are not part of the public type definitions yet,
+      // so we need to access them via an index signature.
+      const environments = (resolvedConfig as Record<string, unknown>)['environments'] as
+        | Record<string, { build?: { rollupOptions?: { output?: { dir?: string } | Array<{ dir?: string }> } } }>
+        | undefined;
+      const nitroEnv = environments?.nitro;
+      if (nitroEnv) {
+        const rollupOutput = nitroEnv.build?.rollupOptions?.output;
+        const dir = Array.isArray(rollupOutput) ? rollupOutput[0]?.dir : rollupOutput?.dir;
+        if (dir) {
+          serverOutputDir = dir;
+          return;
+        }
+      }
+
+      // Cloudflare/Netlify case: detect by plugin name
+      const plugins = resolvedConfig.plugins || [];
+      const hasCloudflareOrNetlify = plugins.some(p => /cloudflare|netlify/i.test(p.name));
+      if (hasCloudflareOrNetlify) {
+        serverOutputDir = path.resolve(resolvedConfig.root, 'dist', 'server');
+      }
+    },
+
+    async closeBundle() {
+      if (!serverOutputDir) {
+        return;
+      }
+
+      const instrumentationSource = path.resolve(process.cwd(), 'instrument.server.mjs');
+
+      try {
+        await fs.promises.access(instrumentationSource, fs.constants.F_OK);
+      } catch {
+        // No instrumentation file found — nothing to copy
+        return;
+      }
+
+      const destination = path.resolve(serverOutputDir, 'instrument.server.mjs');
+
+      try {
+        await fs.promises.mkdir(serverOutputDir, { recursive: true });
+        await fs.promises.copyFile(instrumentationSource, destination);
+        consoleSandbox(() => {
+          // eslint-disable-next-line no-console
+          console.log(`[Sentry TanStack Start] Copied instrument.server.mjs to ${destination}`);
+        });
+      } catch (error) {
+        consoleSandbox(() => {
+          // eslint-disable-next-line no-console
+          console.warn('[Sentry TanStack Start] Failed to copy instrument.server.mjs to build output.', error);
+        });
+      }
+    },
+  };
+}

--- a/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
+++ b/packages/tanstackstart-react/src/vite/copyInstrumentationFile.ts
@@ -24,7 +24,7 @@ export function makeCopyInstrumentationFilePlugin(instrumentationFilePath?: stri
 
     configResolved(resolvedConfig: ResolvedConfig) {
       const plugins = resolvedConfig.plugins || [];
-      const hasPlugin = (name: string): boolean => plugins.some(p => p.name === name);
+      const hasPlugin = (name: string): boolean => plugins.some(p => p.name?.includes(name));
 
       if (hasPlugin('nitro')) {
         // Nitro case: read server dir from the nitro environment config

--- a/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
+++ b/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
@@ -1,6 +1,7 @@
 import type { BuildTimeOptionsBase } from '@sentry/core';
 import type { Plugin } from 'vite';
 import { makeAutoInstrumentMiddlewarePlugin } from './autoInstrumentMiddleware';
+import { makeCopyInstrumentationFilePlugin } from './copyInstrumentationFile';
 import { makeAddSentryVitePlugin, makeEnableSourceMapsVitePlugin } from './sourceMaps';
 
 /**
@@ -52,6 +53,9 @@ export function sentryTanstackStart(options: SentryTanstackStartOptions = {}): P
   }
 
   const plugins: Plugin[] = [...makeAddSentryVitePlugin(options)];
+
+  // copy instrumentation file to build output
+  plugins.push(makeCopyInstrumentationFilePlugin());
 
   // middleware auto-instrumentation
   if (options.autoInstrumentMiddleware !== false) {

--- a/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
+++ b/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
@@ -29,6 +29,20 @@ export interface SentryTanstackStartOptions extends BuildTimeOptionsBase {
    * @default 'instrument.server.mjs'
    */
   instrumentationFilePath?: string;
+
+  /**
+   * Custom server output directory path for the instrumentation file.
+   *
+   * By default, the plugin auto-detects the output directory:
+   * - For Nitro: reads from Vite environment config
+   * - For Cloudflare/Netlify: uses `dist/server`
+   *
+   * Use this option to override the default when your deployment target
+   * uses a non-standard output directory.
+   *
+   * @example 'build/server'
+   */
+  serverOutputDir?: string;
 }
 
 /**
@@ -64,7 +78,12 @@ export function sentryTanstackStart(options: SentryTanstackStartOptions = {}): P
   const plugins: Plugin[] = [...makeAddSentryVitePlugin(options)];
 
   // copy instrumentation file to build output
-  plugins.push(makeCopyInstrumentationFilePlugin(options.instrumentationFilePath));
+  plugins.push(
+    makeCopyInstrumentationFilePlugin({
+      instrumentationFilePath: options.instrumentationFilePath,
+      serverOutputDir: options.serverOutputDir,
+    }),
+  );
 
   // middleware auto-instrumentation
   if (options.autoInstrumentMiddleware !== false) {

--- a/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
+++ b/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
@@ -20,6 +20,15 @@ export interface SentryTanstackStartOptions extends BuildTimeOptionsBase {
    * @default true
    */
   autoInstrumentMiddleware?: boolean;
+
+  /**
+   * Path to the instrumentation file to be copied to the server build output directory.
+   *
+   * Relative paths are resolved from the current working directory.
+   *
+   * @default 'instrument.server.mjs'
+   */
+  instrumentationFilePath?: string;
 }
 
 /**
@@ -55,7 +64,7 @@ export function sentryTanstackStart(options: SentryTanstackStartOptions = {}): P
   const plugins: Plugin[] = [...makeAddSentryVitePlugin(options)];
 
   // copy instrumentation file to build output
-  plugins.push(makeCopyInstrumentationFilePlugin());
+  plugins.push(makeCopyInstrumentationFilePlugin(options.instrumentationFilePath));
 
   // middleware auto-instrumentation
   if (options.autoInstrumentMiddleware !== false) {

--- a/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
+++ b/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
@@ -119,7 +119,7 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
       expect(fs.promises.access).toHaveBeenCalled();
     });
 
-    it('does not set output dir when neither Nitro nor Cloudflare/Netlify is detected', () => {
+    it('logs a warning and does not set output dir when no recognized plugin is detected', () => {
       const resolvedConfig = {
         root: '/project',
         plugins: [{ name: 'some-other-plugin' }],
@@ -131,26 +131,11 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
 
       (plugin.closeBundle as AnyFunction)();
 
-      expect(fs.promises.access).not.toHaveBeenCalled();
-
-      warnSpy.mockRestore();
-    });
-
-    it('logs a warning when no recognized deployment plugin is detected', () => {
-      const resolvedConfig = {
-        root: '/project',
-        plugins: [{ name: 'some-other-plugin' }],
-      } as unknown as ResolvedConfig;
-
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
-
       expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry TanStack Start] Could not determine server output directory. ' +
-          'Could not detect nitro, cloudflare, or netlify vite plugin. ' +
+        '[Sentry TanStack Start] Could not detect nitro, cloudflare, or netlify vite plugin. ' +
           'The instrument.server.mjs file will not be copied to the build output automatically.',
       );
+      expect(fs.promises.access).not.toHaveBeenCalled();
 
       warnSpy.mockRestore();
     });

--- a/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
+++ b/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
@@ -132,7 +132,7 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
       (plugin.closeBundle as AnyFunction)();
 
       expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry TanStack Start] Could not detect nitro, cloudflare, or netlify vite plugin. ' +
+        '[Sentry] Could not detect nitro, cloudflare, or netlify vite plugin. ' +
           'The instrument.server.mjs file will not be copied to the build output automatically.',
       );
       expect(fs.promises.access).not.toHaveBeenCalled();
@@ -283,7 +283,7 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
       expect(fs.promises.access).toHaveBeenCalled();
       expect(fs.promises.copyFile).not.toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry TanStack Start] No instrument.server.mjs file found in project root. ' +
+        '[Sentry] No instrument.server.mjs file found in project root. ' +
           'The Sentry instrumentation file will not be copied to the build output.',
       );
 
@@ -318,7 +318,7 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
       await (plugin.closeBundle as AnyFunction)();
 
       expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry TanStack Start] Failed to copy instrument.server.mjs to build output.',
+        '[Sentry] Failed to copy instrument.server.mjs to build output.',
         expect.any(Error),
       );
     });
@@ -388,7 +388,7 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
       await (customPlugin.closeBundle as AnyFunction)();
 
       expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry TanStack Start] No custom/my-instrument.mjs file found in project root. ' +
+        '[Sentry] No custom/my-instrument.mjs file found in project root. ' +
           'The Sentry instrumentation file will not be copied to the build output.',
       );
       expect(fs.promises.copyFile).not.toHaveBeenCalled();

--- a/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
+++ b/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
@@ -196,7 +196,7 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
       warnSpy.mockRestore();
     });
 
-    it('does nothing when instrumentation file does not exist', async () => {
+    it('warns and does not copy when instrumentation file does not exist', async () => {
       const resolvedConfig = {
         root: '/project',
         plugins: [{ name: 'nitro' }],
@@ -217,10 +217,18 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
 
       vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
 
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
       await (plugin.closeBundle as AnyFunction)();
 
       expect(fs.promises.access).toHaveBeenCalled();
       expect(fs.promises.copyFile).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Sentry TanStack Start] No instrument.server.mjs file found in project root. ' +
+          'The Sentry instrumentation file will not be copied to the build output.',
+      );
+
+      warnSpy.mockRestore();
     });
 
     it('logs a warning when copy fails', async () => {

--- a/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
+++ b/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
@@ -1,0 +1,249 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Plugin, ResolvedConfig } from 'vite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeCopyInstrumentationFilePlugin } from '../../src/vite/copyInstrumentationFile';
+
+vi.mock('fs', () => ({
+  promises: {
+    access: vi.fn(),
+    mkdir: vi.fn(),
+    copyFile: vi.fn(),
+  },
+  constants: {
+    F_OK: 0,
+  },
+}));
+
+type AnyFunction = (...args: unknown[]) => unknown;
+
+describe('makeCopyInstrumentationFilePlugin()', () => {
+  let plugin: Plugin;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin = makeCopyInstrumentationFilePlugin();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('has the correct plugin name', () => {
+    expect(plugin.name).toBe('sentry-tanstackstart-copy-instrumentation-file');
+  });
+
+  it('applies only to build', () => {
+    expect(plugin.apply).toBe('build');
+  });
+
+  it('enforces post', () => {
+    expect(plugin.enforce).toBe('post');
+  });
+
+  describe('configResolved', () => {
+    it('detects Nitro environment and reads output dir', () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [],
+        environments: {
+          nitro: {
+            build: {
+              rollupOptions: {
+                output: {
+                  dir: '/project/.output/server',
+                },
+              },
+            },
+          },
+        },
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      // Verify by calling closeBundle - it should attempt to access the file
+      vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
+      (plugin.closeBundle as AnyFunction)();
+
+      expect(fs.promises.access).toHaveBeenCalled();
+    });
+
+    it('detects Nitro environment with array rollup output', () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [],
+        environments: {
+          nitro: {
+            build: {
+              rollupOptions: {
+                output: [{ dir: '/project/.output/server' }],
+              },
+            },
+          },
+        },
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
+      (plugin.closeBundle as AnyFunction)();
+
+      expect(fs.promises.access).toHaveBeenCalled();
+    });
+
+    it('detects Cloudflare plugin and sets dist/server as output dir', () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [{ name: 'vite-plugin-cloudflare' }],
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
+      (plugin.closeBundle as AnyFunction)();
+
+      expect(fs.promises.access).toHaveBeenCalled();
+    });
+
+    it('detects Netlify plugin and sets dist/server as output dir', () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [{ name: 'netlify-plugin' }],
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
+      (plugin.closeBundle as AnyFunction)();
+
+      expect(fs.promises.access).toHaveBeenCalled();
+    });
+
+    it('does not set output dir when neither Nitro nor Cloudflare/Netlify is detected', () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [{ name: 'some-other-plugin' }],
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      (plugin.closeBundle as AnyFunction)();
+
+      expect(fs.promises.access).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('closeBundle', () => {
+    it('copies instrumentation file when it exists and output dir is set', async () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [],
+        environments: {
+          nitro: {
+            build: {
+              rollupOptions: {
+                output: {
+                  dir: '/project/.output/server',
+                },
+              },
+            },
+          },
+        },
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
+      vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
+      vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
+
+      await (plugin.closeBundle as AnyFunction)();
+
+      expect(fs.promises.access).toHaveBeenCalledWith(
+        path.resolve(process.cwd(), 'instrument.server.mjs'),
+        fs.constants.F_OK,
+      );
+      expect(fs.promises.mkdir).toHaveBeenCalledWith('/project/.output/server', { recursive: true });
+      expect(fs.promises.copyFile).toHaveBeenCalledWith(
+        path.resolve(process.cwd(), 'instrument.server.mjs'),
+        path.resolve('/project/.output/server', 'instrument.server.mjs'),
+      );
+    });
+
+    it('does nothing when no server output dir is detected', async () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [{ name: 'some-other-plugin' }],
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      await (plugin.closeBundle as AnyFunction)();
+
+      expect(fs.promises.access).not.toHaveBeenCalled();
+      expect(fs.promises.copyFile).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when instrumentation file does not exist', async () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [],
+        environments: {
+          nitro: {
+            build: {
+              rollupOptions: {
+                output: {
+                  dir: '/project/.output/server',
+                },
+              },
+            },
+          },
+        },
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
+
+      await (plugin.closeBundle as AnyFunction)();
+
+      expect(fs.promises.access).toHaveBeenCalled();
+      expect(fs.promises.copyFile).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning when copy fails', async () => {
+      const resolvedConfig = {
+        root: '/project',
+        plugins: [],
+        environments: {
+          nitro: {
+            build: {
+              rollupOptions: {
+                output: {
+                  dir: '/project/.output/server',
+                },
+              },
+            },
+          },
+        },
+      } as unknown as ResolvedConfig;
+
+      (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+      vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
+      vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
+      vi.mocked(fs.promises.copyFile).mockRejectedValueOnce(new Error('Permission denied'));
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await (plugin.closeBundle as AnyFunction)();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Sentry TanStack Start] Failed to copy instrument.server.mjs to build output.',
+        expect.any(Error),
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
+++ b/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
@@ -10,9 +10,6 @@ vi.mock('fs', () => ({
     mkdir: vi.fn(),
     copyFile: vi.fn(),
   },
-  constants: {
-    F_OK: 0,
-  },
 }));
 
 type AnyFunction = (...args: unknown[]) => unknown;
@@ -53,29 +50,6 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
       (plugin.configResolved as AnyFunction)(resolvedConfig);
 
       // Verify by calling closeBundle - it should attempt to access the file
-      vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
-      (plugin.closeBundle as AnyFunction)();
-
-      expect(fs.promises.access).toHaveBeenCalled();
-    });
-
-    it('detects Nitro environment with array rollup output', () => {
-      const resolvedConfig = {
-        root: '/project',
-        plugins: [{ name: 'nitro' }],
-        environments: {
-          nitro: {
-            build: {
-              rollupOptions: {
-                output: [{ dir: '/project/.output/server' }],
-              },
-            },
-          },
-        },
-      } as unknown as ResolvedConfig;
-
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
-
       vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
       (plugin.closeBundle as AnyFunction)();
 
@@ -175,10 +149,7 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
 
       await (plugin.closeBundle as AnyFunction)();
 
-      expect(fs.promises.access).toHaveBeenCalledWith(
-        path.resolve(process.cwd(), 'instrument.server.mjs'),
-        fs.constants.F_OK,
-      );
+      expect(fs.promises.access).toHaveBeenCalledWith(path.resolve(process.cwd(), 'instrument.server.mjs'));
       expect(fs.promises.mkdir).toHaveBeenCalledWith('/project/.output/server', { recursive: true });
       expect(fs.promises.copyFile).toHaveBeenCalledWith(
         path.resolve(process.cwd(), 'instrument.server.mjs'),
@@ -259,10 +230,7 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
 
       await (customPlugin.closeBundle as AnyFunction)();
 
-      expect(fs.promises.access).toHaveBeenCalledWith(
-        path.resolve(process.cwd(), 'custom/path/my-instrument.mjs'),
-        fs.constants.F_OK,
-      );
+      expect(fs.promises.access).toHaveBeenCalledWith(path.resolve(process.cwd(), 'custom/path/my-instrument.mjs'));
       expect(fs.promises.copyFile).toHaveBeenCalledWith(
         path.resolve(process.cwd(), 'custom/path/my-instrument.mjs'),
         path.resolve('/project/.output/server', 'my-instrument.mjs'),

--- a/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
+++ b/packages/tanstackstart-react/test/vite/copyInstrumentationFile.test.ts
@@ -43,213 +43,178 @@ describe('makeCopyInstrumentationFilePlugin()', () => {
     vi.restoreAllMocks();
   });
 
-  describe('configResolved', () => {
-    it('detects Nitro environment and reads output dir', async () => {
-      const resolvedConfig = createNitroConfig();
+  it('copies instrumentation file with Nitro config', async () => {
+    const resolvedConfig = createNitroConfig();
 
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
+    (plugin.configResolved as AnyFunction)(resolvedConfig);
 
-      vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
 
-      await (plugin.closeBundle as AnyFunction)();
+    await (plugin.closeBundle as AnyFunction)();
 
-      expect(fs.promises.mkdir).toHaveBeenCalledWith('/project/.output/server', { recursive: true });
-    });
-
-    it.each(['cloudflare', 'netlify'])('detects %s plugin and sets dist/server as output dir', async pluginName => {
-      const resolvedConfig = {
-        root: '/project',
-        plugins: [{ name: pluginName }],
-      } as unknown as ResolvedConfig;
-
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
-
-      vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
-
-      await (plugin.closeBundle as AnyFunction)();
-
-      expect(fs.promises.mkdir).toHaveBeenCalledWith(path.resolve('/project', 'dist', 'server'), { recursive: true });
-    });
-
-    it('logs a warning and does not set output dir when no recognized plugin is detected', () => {
-      const resolvedConfig = {
-        root: '/project',
-        plugins: [{ name: 'some-other-plugin' }],
-      } as unknown as ResolvedConfig;
-
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
-
-      (plugin.closeBundle as AnyFunction)();
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry] Could not detect nitro, cloudflare, or netlify vite plugin. ' +
-          'The instrument.server.mjs file will not be copied to the build output automatically.',
-      );
-      expect(fs.promises.access).not.toHaveBeenCalled();
-
-      warnSpy.mockRestore();
-    });
-
-    it('uses serverOutputDir option when provided, bypassing auto-detection', async () => {
-      const customPlugin = makeCopyInstrumentationFilePlugin({ serverOutputDir: 'build/custom-server' });
-
-      const resolvedConfig = {
-        root: '/project',
-        plugins: [{ name: 'some-other-plugin' }],
-      } as unknown as ResolvedConfig;
-
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      (customPlugin.configResolved as AnyFunction)(resolvedConfig);
-
-      // No warning should be logged since serverOutputDir is provided
-      expect(warnSpy).not.toHaveBeenCalled();
-
-      vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
-
-      await (customPlugin.closeBundle as AnyFunction)();
-
-      // Verify the custom serverOutputDir is used
-      expect(fs.promises.mkdir).toHaveBeenCalledWith(path.resolve('/project', 'build/custom-server'), {
-        recursive: true,
-      });
-      expect(fs.promises.copyFile).toHaveBeenCalledWith(
-        path.resolve(process.cwd(), 'instrument.server.mjs'),
-        path.resolve('/project', 'build/custom-server', 'instrument.server.mjs'),
-      );
-
-      warnSpy.mockRestore();
-    });
+    expect(fs.promises.access).toHaveBeenCalledWith(path.resolve(process.cwd(), 'instrument.server.mjs'));
+    expect(fs.promises.mkdir).toHaveBeenCalledWith('/project/.output/server', { recursive: true });
+    expect(fs.promises.copyFile).toHaveBeenCalledWith(
+      path.resolve(process.cwd(), 'instrument.server.mjs'),
+      path.resolve('/project/.output/server', 'instrument.server.mjs'),
+    );
   });
 
-  describe('closeBundle', () => {
-    it('copies instrumentation file when it exists and output dir is set', async () => {
-      const resolvedConfig = createNitroConfig();
+  it.each(['cloudflare', 'netlify'])('copies instrumentation file with %s config', async pluginName => {
+    const resolvedConfig = {
+      root: '/project',
+      plugins: [{ name: pluginName }],
+    } as unknown as ResolvedConfig;
 
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
+    (plugin.configResolved as AnyFunction)(resolvedConfig);
 
-      vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
 
-      await (plugin.closeBundle as AnyFunction)();
+    await (plugin.closeBundle as AnyFunction)();
 
-      expect(fs.promises.access).toHaveBeenCalledWith(path.resolve(process.cwd(), 'instrument.server.mjs'));
-      expect(fs.promises.mkdir).toHaveBeenCalledWith('/project/.output/server', { recursive: true });
-      expect(fs.promises.copyFile).toHaveBeenCalledWith(
-        path.resolve(process.cwd(), 'instrument.server.mjs'),
-        path.resolve('/project/.output/server', 'instrument.server.mjs'),
-      );
+    expect(fs.promises.mkdir).toHaveBeenCalledWith(path.resolve('/project', 'dist', 'server'), { recursive: true });
+  });
+
+  it('warns and does nothing when no recognized plugin is detected', async () => {
+    const resolvedConfig = {
+      root: '/project',
+      plugins: [{ name: 'some-other-plugin' }],
+    } as unknown as ResolvedConfig;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+    await (plugin.closeBundle as AnyFunction)();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Sentry] Could not detect nitro, cloudflare, or netlify vite plugin. ' +
+        'The instrument.server.mjs file will not be copied to the build output automatically.',
+    );
+    expect(fs.promises.access).not.toHaveBeenCalled();
+    expect(fs.promises.copyFile).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('uses serverOutputDir option bypassing auto-detection', async () => {
+    const customPlugin = makeCopyInstrumentationFilePlugin({ serverOutputDir: 'build/custom-server' });
+
+    const resolvedConfig = {
+      root: '/project',
+      plugins: [{ name: 'some-other-plugin' }],
+    } as unknown as ResolvedConfig;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (customPlugin.configResolved as AnyFunction)(resolvedConfig);
+
+    // No warning should be logged since serverOutputDir is provided
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
+
+    await (customPlugin.closeBundle as AnyFunction)();
+
+    // Verify the custom serverOutputDir is used
+    expect(fs.promises.mkdir).toHaveBeenCalledWith(path.resolve('/project', 'build/custom-server'), {
+      recursive: true,
+    });
+    expect(fs.promises.copyFile).toHaveBeenCalledWith(
+      path.resolve(process.cwd(), 'instrument.server.mjs'),
+      path.resolve('/project', 'build/custom-server', 'instrument.server.mjs'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns when instrumentation file does not exist', async () => {
+    const resolvedConfig = createNitroConfig();
+
+    (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+    vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await (plugin.closeBundle as AnyFunction)();
+
+    expect(fs.promises.access).toHaveBeenCalled();
+    expect(fs.promises.copyFile).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Sentry] No instrument.server.mjs file found in project root. ' +
+        'The Sentry instrumentation file will not be copied to the build output.',
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns when copy operation fails', async () => {
+    const resolvedConfig = createNitroConfig();
+
+    (plugin.configResolved as AnyFunction)(resolvedConfig);
+
+    vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.copyFile).mockRejectedValueOnce(new Error('Permission denied'));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await (plugin.closeBundle as AnyFunction)();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Sentry] Failed to copy instrument.server.mjs to build output.',
+      expect.any(Error),
+    );
+  });
+
+  it('uses custom instrumentation file path', async () => {
+    const customPlugin = makeCopyInstrumentationFilePlugin({
+      instrumentationFilePath: 'custom/path/my-instrument.mjs',
     });
 
-    it('does nothing when no server output dir is detected', async () => {
-      const resolvedConfig = {
-        root: '/project',
-        plugins: [{ name: 'some-other-plugin' }],
-      } as unknown as ResolvedConfig;
+    const resolvedConfig = createNitroConfig();
 
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (customPlugin.configResolved as AnyFunction)(resolvedConfig);
 
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
+    vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
+    vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
 
-      await (plugin.closeBundle as AnyFunction)();
+    await (customPlugin.closeBundle as AnyFunction)();
 
-      expect(fs.promises.access).not.toHaveBeenCalled();
-      expect(fs.promises.copyFile).not.toHaveBeenCalled();
+    expect(fs.promises.access).toHaveBeenCalledWith(path.resolve(process.cwd(), 'custom/path/my-instrument.mjs'));
+    expect(fs.promises.copyFile).toHaveBeenCalledWith(
+      path.resolve(process.cwd(), 'custom/path/my-instrument.mjs'),
+      path.resolve('/project/.output/server', 'my-instrument.mjs'),
+    );
+  });
 
-      warnSpy.mockRestore();
-    });
+  it('warns with custom file name when file not found', async () => {
+    const customPlugin = makeCopyInstrumentationFilePlugin({ instrumentationFilePath: 'custom/my-instrument.mjs' });
 
-    it('warns and does not copy when instrumentation file does not exist', async () => {
-      const resolvedConfig = createNitroConfig();
+    const resolvedConfig = createNitroConfig();
 
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
+    (customPlugin.configResolved as AnyFunction)(resolvedConfig);
 
-      vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
+    vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
 
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      await (plugin.closeBundle as AnyFunction)();
+    await (customPlugin.closeBundle as AnyFunction)();
 
-      expect(fs.promises.access).toHaveBeenCalled();
-      expect(fs.promises.copyFile).not.toHaveBeenCalled();
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry] No instrument.server.mjs file found in project root. ' +
-          'The Sentry instrumentation file will not be copied to the build output.',
-      );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Sentry] No custom/my-instrument.mjs file found in project root. ' +
+        'The Sentry instrumentation file will not be copied to the build output.',
+    );
+    expect(fs.promises.copyFile).not.toHaveBeenCalled();
 
-      warnSpy.mockRestore();
-    });
-
-    it('logs a warning when copy fails', async () => {
-      const resolvedConfig = createNitroConfig();
-
-      (plugin.configResolved as AnyFunction)(resolvedConfig);
-
-      vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.copyFile).mockRejectedValueOnce(new Error('Permission denied'));
-
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      await (plugin.closeBundle as AnyFunction)();
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry] Failed to copy instrument.server.mjs to build output.',
-        expect.any(Error),
-      );
-    });
-
-    it('uses custom instrumentation file path when provided', async () => {
-      const customPlugin = makeCopyInstrumentationFilePlugin({
-        instrumentationFilePath: 'custom/path/my-instrument.mjs',
-      });
-
-      const resolvedConfig = createNitroConfig();
-
-      (customPlugin.configResolved as AnyFunction)(resolvedConfig);
-
-      vi.mocked(fs.promises.access).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.mkdir).mockResolvedValueOnce(undefined);
-      vi.mocked(fs.promises.copyFile).mockResolvedValueOnce(undefined);
-
-      await (customPlugin.closeBundle as AnyFunction)();
-
-      expect(fs.promises.access).toHaveBeenCalledWith(path.resolve(process.cwd(), 'custom/path/my-instrument.mjs'));
-      expect(fs.promises.copyFile).toHaveBeenCalledWith(
-        path.resolve(process.cwd(), 'custom/path/my-instrument.mjs'),
-        path.resolve('/project/.output/server', 'my-instrument.mjs'),
-      );
-    });
-
-    it('warns with custom file name when custom instrumentation file is not found', async () => {
-      const customPlugin = makeCopyInstrumentationFilePlugin({ instrumentationFilePath: 'custom/my-instrument.mjs' });
-
-      const resolvedConfig = createNitroConfig();
-
-      (customPlugin.configResolved as AnyFunction)(resolvedConfig);
-
-      vi.mocked(fs.promises.access).mockRejectedValueOnce(new Error('ENOENT'));
-
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      await (customPlugin.closeBundle as AnyFunction)();
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[Sentry] No custom/my-instrument.mjs file found in project root. ' +
-          'The Sentry instrumentation file will not be copied to the build output.',
-      );
-      expect(fs.promises.copyFile).not.toHaveBeenCalled();
-
-      warnSpy.mockRestore();
-    });
+    warnSpy.mockRestore();
   });
 });

--- a/packages/tanstackstart-react/test/vite/sentryTanstackStart.test.ts
+++ b/packages/tanstackstart-react/test/vite/sentryTanstackStart.test.ts
@@ -28,6 +28,12 @@ const mockMiddlewarePlugin: Plugin = {
   transform: vi.fn(),
 };
 
+const mockCopyInstrumentationPlugin: Plugin = {
+  name: 'sentry-tanstackstart-copy-instrumentation-file',
+  apply: 'build',
+  enforce: 'post',
+};
+
 vi.mock('../../src/vite/sourceMaps', () => ({
   makeAddSentryVitePlugin: vi.fn(() => [mockSourceMapsConfigPlugin, mockSentryVitePlugin]),
   makeEnableSourceMapsVitePlugin: vi.fn(() => [mockEnableSourceMapsPlugin]),
@@ -35,6 +41,10 @@ vi.mock('../../src/vite/sourceMaps', () => ({
 
 vi.mock('../../src/vite/autoInstrumentMiddleware', () => ({
   makeAutoInstrumentMiddlewarePlugin: vi.fn(() => mockMiddlewarePlugin),
+}));
+
+vi.mock('../../src/vite/copyInstrumentationFile', () => ({
+  makeCopyInstrumentationFilePlugin: vi.fn(() => mockCopyInstrumentationPlugin),
 }));
 
 describe('sentryTanstackStart()', () => {
@@ -51,7 +61,12 @@ describe('sentryTanstackStart()', () => {
     it('returns source maps plugins in production mode', () => {
       const plugins = sentryTanstackStart({ autoInstrumentMiddleware: false });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockEnableSourceMapsPlugin]);
+      expect(plugins).toEqual([
+        mockSourceMapsConfigPlugin,
+        mockSentryVitePlugin,
+        mockCopyInstrumentationPlugin,
+        mockEnableSourceMapsPlugin,
+      ]);
     });
 
     it('returns no plugins in development mode', () => {
@@ -68,7 +83,7 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: true },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
+      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockCopyInstrumentationPlugin]);
     });
 
     it('returns Sentry Vite plugins but not enable source maps plugin when sourcemaps.disable is "disable-upload"', () => {
@@ -77,7 +92,7 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: 'disable-upload' },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
+      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockCopyInstrumentationPlugin]);
     });
 
     it('returns Sentry Vite plugins and enable source maps plugin when sourcemaps.disable is false', () => {
@@ -86,7 +101,12 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: false },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockEnableSourceMapsPlugin]);
+      expect(plugins).toEqual([
+        mockSourceMapsConfigPlugin,
+        mockSentryVitePlugin,
+        mockCopyInstrumentationPlugin,
+        mockEnableSourceMapsPlugin,
+      ]);
     });
   });
 
@@ -94,7 +114,12 @@ describe('sentryTanstackStart()', () => {
     it('includes middleware plugin by default', () => {
       const plugins = sentryTanstackStart({ sourcemaps: { disable: true } });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockMiddlewarePlugin]);
+      expect(plugins).toEqual([
+        mockSourceMapsConfigPlugin,
+        mockSentryVitePlugin,
+        mockCopyInstrumentationPlugin,
+        mockMiddlewarePlugin,
+      ]);
     });
 
     it('includes middleware plugin when autoInstrumentMiddleware is true', () => {
@@ -103,7 +128,12 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: true },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockMiddlewarePlugin]);
+      expect(plugins).toEqual([
+        mockSourceMapsConfigPlugin,
+        mockSentryVitePlugin,
+        mockCopyInstrumentationPlugin,
+        mockMiddlewarePlugin,
+      ]);
     });
 
     it('does not include middleware plugin when autoInstrumentMiddleware is false', () => {
@@ -112,7 +142,7 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: true },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
+      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockCopyInstrumentationPlugin]);
     });
 
     it('passes correct options to makeAutoInstrumentMiddlewarePlugin', () => {


### PR DESCRIPTION
Automatically copy `instrument.server.mjs` into the server build output after build. Output directory is auto-detected based on the deployment target (Nitro, Cloudflare, Netlify). We also provide `instrumentationFilePath` and `serverOutputDir` options as escape hatches if auto-detection doesn't work.

To detect the deployment target we search the vite plugin list for plugins with names containing the deployment target (e.g. `nitro`). In the nitro case we then read the target directory from `nitroEnv.build.rollupOptions.output`. For netlify and cloudflare we assume `dist/server`. 

Limitations:
- Currently by default only works for `instrument.server.mjs` files in the root of the project. This is how we ask users to set it up in the docs and has basically no performance overhead. For other cases users will have to use the override options as it is now, but we could definitely think about extending that.

Closes https://github.com/getsentry/sentry-javascript/issues/18665
