### PR TITLE
fix(core): Prevent infinite recursion when event processor throws

### DIFF
--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -2020,13 +2020,8 @@ describe('Client', () => {
 
       client.captureMessage('test message');
 
-      // Without the fix, this would cause infinite recursion:
-      // 1. captureMessage -> processor throws -> captureException(__sentry__: true)
-      // 2. captureException -> processor throws again -> captureException(__sentry__: true)
-      // 3. Infinite loop...
-      //
-      // With the fix, the processor is called once for the original message,
-      // and the internal exception event skips event processors entirely.
+      // Should be called once for the original message
+      // internal exception events skips event processors entirely.
       expect(processorCallCount).toBe(1);
 
       // Verify the processor error was captured and sent


### PR DESCRIPTION
When an event processor throws an error, the SDK calls `captureException` to report it with `hint.data.__sentry__ = true`. However, this new event still ran through all event processors, causing infinite recursion if the processor throws on every event.

I'm not sure what's the best way to resolve this, I had a couple of ideas:

1. Mark an "event processor" as faulty and skip if an error is thrown from there by adding metadata in catch blocks.
2. Outright skip event processors for internal exception events in `prepareEvent()`.

I went with (2) because it is consistent with how `beforeSend` is already skipped for these events. The processor error is still captured and sent to Sentry, but it bypasses event processors to break the recursion.

Fixes #19108