### PR TITLE
fix(core): Respect event.event_id in scope.captureEvent return value

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -755,7 +755,7 @@ export class Scope {
    * @returns {string} The id of the captured event.
    */
   public captureEvent(event: Event, hint?: EventHint): string {
-    const eventId = hint?.event_id || uuid4();
+    const eventId = event.event_id || hint?.event_id || uuid4();
 
     if (!this._client) {
       DEBUG_BUILD && debug.warn('No client configured on scope - will not capture event!');


### PR DESCRIPTION
I found a bug while working on the JavaScript SDK integration in [Sentry for Godot](https://github.com/getsentry/sentry-godot) (it's a game engine SDK).

When you call `Sentry.captureEvent({ event_id: "<custom-event-id>" })`, the `event_id` you provide IS actually used when the event is processed and sent to Sentry (because `prepareEvent.ts` correctly checks `event.event_id` first). However, the **return value** from `captureEvent()` is wrong because:

In `sentry-javascript/packages/core/src/scope.ts`:
https://github.com/getsentry/sentry-javascript/blob/170b6f8eec449cbbd2eb0a918b5beafa51826a73/packages/core/src/scope.ts#L758

This only checks `hint?.event_id`, not `event.event_id`. So while your supplied `event_id` gets sent to Sentry correctly, the function returns a newly generated UUID.


Closes #issue_link_here
