### PR TITLE
feat(deps): Bump `glob` in `@sentry/react-router`

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -55,7 +55,7 @@
     "@sentry/node": "10.38.0",
     "@sentry/react": "10.38.0",
     "@sentry/vite-plugin": "^4.8.0",
-    "glob": "13.0.1"
+    "glob": "^13.0.1"
   },
   "devDependencies": {
     "@react-router/dev": "^7.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18118,15 +18118,6 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@13.0.1, glob@^13.0.0:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.1.tgz#c59a2500c9a5f1ab9cdd370217ced63c2aa81e60"
-  integrity sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==
-  dependencies:
-    minimatch "^10.1.2"
-    minipass "^7.1.2"
-    path-scurry "^2.0.0"
-
 glob@8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
@@ -18149,6 +18140,15 @@ glob@^10.0.0, glob@^10.2.2, glob@^10.3.10, glob@^10.3.4, glob@^10.3.7, glob@^10.
     minipass "^7.1.2"
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
+
+glob@^13.0.0, glob@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.1.tgz#c59a2500c9a5f1ab9cdd370217ced63c2aa81e60"
+  integrity sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==
+  dependencies:
+    minimatch "^10.1.2"
+    minipass "^7.1.2"
+    path-scurry "^2.0.0"
 
 glob@^5.0.10:
   version "5.0.15"


### PR DESCRIPTION
Bumps `glob` from `11.1.0` to `13.0.1` in `@sentry/react-router` to resolve a security vulnerability in the transitive dependency `@isaacs/brace-expansion`.

Dependency chain: `@sentry/react-router` → `glob` → `minimatch` → `@isaacs/brace-expansion`

Details
The previous version of `glob` (11.1.0) pulled in a vulnerable version of `@isaacs/brace-expansion`. The vulnerability has been patched upstream:

`@isaacs/brace-expansion` was patched
`minimatch` released a new version with the fix
`glob` 13.0.1 includes the updated dependencies
This is a dependency-only change with no code modifications.

[CVE](https://github.com/advisories/GHSA-7h2j-956f-4vf2)