### PR TITLE
fix(core): Avoid blocking the process for weightBasedFlushing

### DIFF
--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -23,6 +23,7 @@ import type { SpanJSON } from '../../src/types-hoist/span';
 import * as debugLoggerModule from '../../src/utils/debug-logger';
 import * as miscModule from '../../src/utils/misc';
 import * as timeModule from '../../src/utils/time';
+import * as timerModule from '../../src/utils/timer';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 import { AdHocIntegration, AsyncTestIntegration, TestIntegration } from '../mocks/integration';
 import { makeFakeTransport } from '../mocks/transport';
@@ -3076,6 +3077,27 @@ describe('Client', () => {
 
       expect(sendEnvelopeSpy).not.toHaveBeenCalled();
     });
+
+    it('uses safeUnref on flush timer to not block process exit', () => {
+      const safeUnrefSpy = vi.spyOn(timerModule, 'safeUnref');
+
+      const options = getDefaultTestClientOptions({
+        dsn: PUBLIC_DSN,
+        enableLogs: true,
+      });
+      const client = new TestClient(options);
+      const scope = new Scope();
+      scope.setClient(client);
+
+      // Capture a log which will start the flush timer
+      _INTERNAL_captureLog({ message: 'test log', level: 'info' }, scope);
+
+      // Verify safeUnref was called on the timer
+      expect(safeUnrefSpy).toHaveBeenCalledTimes(1);
+      expect(safeUnrefSpy).toHaveBeenCalledWith(expect.anything());
+
+      safeUnrefSpy.mockRestore();
+    });
   });
 
   describe('metric weight-based flushing', () => {
@@ -3141,6 +3163,26 @@ describe('Client', () => {
       client.emit('flush');
 
       expect(sendEnvelopeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses safeUnref on flush timer to not block process exit', () => {
+      const safeUnrefSpy = vi.spyOn(timerModule, 'safeUnref');
+
+      const options = getDefaultTestClientOptions({
+        dsn: PUBLIC_DSN,
+      });
+      const client = new TestClient(options);
+      const scope = new Scope();
+      scope.setClient(client);
+
+      // Capture a metric which will start the flush timer
+      _INTERNAL_captureMetric({ name: 'test_metric', value: 42, type: 'counter', attributes: {} }, { scope });
+
+      // Verify safeUnref was called on the timer
+      expect(safeUnrefSpy).toHaveBeenCalledTimes(1);
+      expect(safeUnrefSpy).toHaveBeenCalledWith(expect.anything());
+
+      safeUnrefSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
closes #19171
closes [JS-1641](https://linear.app/getsentry/issue/JS-1641/metrics-flush-timer-should-use-unref-to-not-block-process-exit)

This was is something that got missed by Copilot on #19062