### PR TITLE
chore(llm): Add skill for fixing security vulnerabilities

### DIFF
--- a/.claude/skills/fix-security-vulnerability/SKILL.md
+++ b/.claude/skills/fix-security-vulnerability/SKILL.md
@@ -178,15 +178,21 @@ Recommendation: Safe to bump 5.x → 6.x
 - OTel instrumentation supports mongoose 5.x-8.x
 ```
 
-### Version-specific test - do not bump
+### Version-specific test - dismiss instead
 
 ```
 Package: next
 Location: dev-packages/e2e-tests/test-applications/nextjs-13/package.json
 
-Recommendation: DO NOT BUMP
+Recommendation: DISMISS (do not bump)
 This app specifically tests Next.js 13 compatibility.
-Dismiss the alert - vulnerability only affects CI, not shipped code.
+Vulnerability only affects CI, not shipped code.
+
+Proposed dismissal:
+  Reason: tolerable_risk
+  Comment: "Version-specific E2E test for Next.js 13 - intentionally pinned"
+
+Proceed with dismissal?
 ```
 
 ### Transitive dependency - bump parent


### PR DESCRIPTION
Adds `/fix-security-vulnerability` skill that analyzes Dependabot alerts and proposes fixes.                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                 
  - Fetches alert details via gh api                                                                                                                                                                                                                                             
  - Uses yarn why to trace dependency origin                                                                                                                                                                                                                                   
  - Identifies version-specific test packages that shouldn't be bumped (e.g., nextjs-13)
  - For transitive deps, recommends bumping the parent package rather than using resolutions
  - Presents analysis and waits for approval before making changes
  - Runs dedupe-deps:fix and dedupe-deps:check after updates
  - Never auto-commits