### PR TITLE
fix(deps): Bump node-forge to 1.3.2 

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -23293,9 +23293,9 @@ node-fetch@^2.3.0, node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^2.6.9:
     whatwg-url "^5.0.0"
 
 node-forge@^1, node-forge@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.2.tgz#d0d2659a26eef778bf84d73e7f55c08144ee7750"
+  integrity sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==
 
 node-gyp-build@^4.2.2:
   version "4.6.0"


### PR DESCRIPTION
Bump transitive dependency node-forge from 1.3.1 to 1.3.2 to address CVE-2025-12816  

node-forge is a transitive dependency pulled in by:
  - @vinxi/listhen (via @sentry/solidstart)
  - listhen (via vinxi → nitropack)
  - selfsigned (via @angular-devkit/build-angular → webpack-dev-server)
  - google-p12-pem (via @google-cloud/common → google-auth-library)

All parent packages specify ^1.3.1 or ^1, so updating the lockfile to 1.3.2 is a safe patch bump with no breaking changes.