### PR TITLE
fix(svelte): Bump svelte dev dependency to `3.59.2`

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "1.4.0",
     "@testing-library/svelte": "^3.2.1",
-    "svelte": "3.49.0",
+    "svelte": "3.59.2",
     "vite": "^3.0.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -30107,10 +30107,10 @@ svelte-hmr@^0.16.0:
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.16.0.tgz#9f345b7d1c1662f1613747ed7e82507e376c1716"
   integrity sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==
 
-svelte@3.49.0:
-  version "3.49.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.49.0.tgz#5baee3c672306de1070c3b7888fc2204e36a4029"
-  integrity sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==
+svelte@3.59.2:
+  version "3.59.2"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.59.2.tgz#a137b28e025a181292b2ae2e3dca90bf8ec73aec"
+  integrity sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==
 
 svelte@^4.2.8:
   version "4.2.8"


### PR DESCRIPTION
  - Bumps `svelte` devDependency in `@sentry/svelte` from `3.49.0` to `3.59.2` to resolve        
  GHSA-gw32-9rmw-qwww (XSS via SSR `<textarea bind:value>`) 

Closes #19209 (added automatically)