### PR TITLE
fix(deps): Bump react-router to 6.30.3

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,7 +63,7 @@
     "react-router-3": "npm:react-router@3.2.0",
     "react-router-4": "npm:react-router@4.1.0",
     "react-router-5": "npm:react-router@5.3.4",
-    "react-router-6": "npm:react-router@6.28.0",
+    "react-router-6": "npm:react-router@6.30.3",
     "redux": "^4.0.5"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7328,11 +7328,6 @@
     react-router-dom "6.30.3"
     turbo-stream "2.4.1"
 
-"@remix-run/router@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.21.0.tgz#c65ae4262bdcfe415dbd4f64ec87676e4a56e2b5"
-  integrity sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==
-
 "@remix-run/router@1.23.2", "@remix-run/router@^1.23.2":
   version "1.23.2"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
@@ -27277,12 +27272,12 @@ react-refresh@^0.14.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-"react-router-6@npm:react-router@6.28.0":
-  version "6.28.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.28.0.tgz#29247c86d7ba901d7e5a13aa79a96723c3e59d0d"
-  integrity sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==
+"react-router-6@npm:react-router@6.30.3":
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
+  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
   dependencies:
-    "@remix-run/router" "1.21.0"
+    "@remix-run/router" "1.23.2"
 
 react-router-dom@6.30.3:
   version "6.30.3"


### PR DESCRIPTION
Bumps the `react-router-6` dev dependency in `@sentry/react` from 6.28.0 to 6.30.3 to resolve CVE-2026-22029 (XSS via open redirects in `@remix-run/router` <= 1.23.1). The updated react-router pulls in the patched `@remix-run/router@1.23.2`.

