### PR TITLE
fix(deps): Bump vite to 5.4.21

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -31932,9 +31932,9 @@ vite@^4.4.9:
     fsevents "~2.3.2"
 
 vite@^5.0.0, vite@^5.4.11, vite@^5.4.5:
-  version "5.4.19"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.19.tgz#20efd060410044b3ed555049418a5e7d1998f959"
-  integrity sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==
+  version "5.4.21"
+  resolved "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz"
+  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
   dependencies:
     esbuild "^0.21.3"
     postcss "^8.4.43"


### PR DESCRIPTION
Addresses CVE-2025-62522 (GHSA-93m4-6634-74q7), a medium severity server.fs.deny bypass via backslash on Windows in vite dev server.
