### PR TITLE
fix(nextjs): Return correct `lastEventId` for SSR pages

### DIFF
--- a/packages/nextjs/src/common/pages-router-instrumentation/_error.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/_error.ts
@@ -1,4 +1,4 @@
-import { captureException, httpRequestToRequestData, withScope } from '@sentry/core';
+import { captureException, getIsolationScope, httpRequestToRequestData, withScope } from '@sentry/core';
 import type { NextPageContext } from 'next';
 import { flushSafelyWithTimeout, waitUntil } from '../utils/responseEnd';
 
@@ -56,6 +56,9 @@ export async function captureUnderscoreErrorException(contextOrProps: ContextOrP
       },
     });
   });
+
+  // Set the lastEventId on the isolation scope so it's accessible via lastEventId()
+  getIsolationScope().setLastEventId(eventId);
 
   waitUntil(flushSafelyWithTimeout());
 


### PR DESCRIPTION
Fixes an issue where `Sentry.lastEventId()` would return `undefined` after calling `captureUnderscoreErrorException()` in Next.js error pages. In Next.js SSR, each incoming request gets its own isolation scope (forked automatically).
The function now explicitly sets the event ID on the isolation scope, making it accessible via `lastEventId()` for displaying error reference IDs to users on custom error pages. Includes a test to verify the fix (test breaks without setting the ID on the isolation scope).

Closes https://github.com/getsentry/sentry-javascript/issues/19217
