### PR TITLE
chore(deps): Bump webpack from 5.97.0 to 5.104.0 in ember-classic e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-classic/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/package.json
@@ -69,7 +69,7 @@
     "loader.js": "~4.7.0",
     "ts-node": "10.9.1",
     "typescript": "~5.4.5",
-    "webpack": "~5.97.0"
+    "webpack": "~5.104.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Addresses CVE-2025-68157 (GHSA-38r7-794h-5758), an allowedUris bypass via HTTP redirects in webpack's HttpUriPlugin that could enable SSRF at build time.

https://github.com/getsentry/sentry-javascript/security/dependabot/1047