### PR TITLE
chore(deps): Bump webpack from 5.104.0 to 5.104.1 in ember-classic e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-classic/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/package.json
@@ -69,7 +69,7 @@
     "loader.js": "~4.7.0",
     "ts-node": "10.9.1",
     "typescript": "~5.4.5",
-    "webpack": "~5.104.0"
+    "webpack": "~5.104.1"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
  - Bumps webpack pin in `ember-classic` e2e test from `~5.104.0` to `~5.104.1`                  
  - Fixes [Dependabot alert                                                        
  #1052](https://github.com/getsentry/sentry-javascript/security/dependabot/1052)
  (CVE-2025-68458, GHSA-8fgc-7cc6-rx7x)
  - Low severity build-time SSRF via `experiments.buildHttp` `allowedUris` bypass