### PR TITLE
fix(core): Remove outdated `_experiments.enableMetrics` references from metrics JSDoc

### DIFF
--- a/packages/core/src/metrics/public-api.ts
+++ b/packages/core/src/metrics/public-api.ts
@@ -38,7 +38,7 @@ function captureMetric(type: MetricType, name: string, value: number, options?: 
 }
 
 /**
- * @summary Increment a counter metric. Requires the `_experiments.enableMetrics` option to be enabled.
+ * @summary Increment a counter metric.
  *
  * @param name - The name of the counter metric.
  * @param value - The value to increment by (defaults to 1).
@@ -72,7 +72,7 @@ export function count(name: string, value: number = 1, options?: MetricOptions):
 }
 
 /**
- * @summary Set a gauge metric to a specific value. Requires the `_experiments.enableMetrics` option to be enabled.
+ * @summary Set a gauge metric to a specific value.
  *
  * @param name - The name of the gauge metric.
  * @param value - The current value of the gauge.
@@ -106,7 +106,7 @@ export function gauge(name: string, value: number, options?: MetricOptions): voi
 }
 
 /**
- * @summary Record a value in a distribution metric. Requires the `_experiments.enableMetrics` option to be enabled.
+ * @summary Record a value in a distribution metric.
  *
  * @param name - The name of the distribution metric.
  * @param value - The value to record in the distribution.


### PR DESCRIPTION
Metrics are enabled by default and no longer require the `_experiments.enableMetrics` flag. This removes the outdated JSDoc `@summary` references in `count()`, `gauge()`, and `distribution()` that still mentioned needing to enable the experimental option.

Closes #19253 (added automatically)