### PR TITLE
feat(node-core): Add outgoing fetch trace propagation to light mode

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/light-mode/outgoing-fetch/server.js
+++ b/dev-packages/node-core-integration-tests/suites/light-mode/outgoing-fetch/server.js
@@ -1,0 +1,80 @@
+const http = require('http');
+const Sentry = require('@sentry/node-core/light');
+const { loggingTransport, sendPortToRunner } = require('@sentry-internal/node-core-integration-tests');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+  tracePropagationTargets: [/\/api\/v0/, 'v1'],
+});
+
+let capturedV0 = {};
+let capturedV1 = {};
+let capturedV2 = {};
+
+const targetServer = http.createServer((req, res) => {
+  const headers = {
+    'sentry-trace': req.headers['sentry-trace'],
+    baggage: req.headers['baggage'],
+  };
+
+  if (req.url === '/api/v0') {
+    capturedV0 = headers;
+  } else if (req.url === '/api/v1') {
+    capturedV1 = headers;
+  } else if (req.url === '/api/v2') {
+    capturedV2 = headers;
+  }
+
+  res.writeHead(200);
+  res.end('ok');
+});
+
+targetServer.listen(0, () => {
+  const targetPort = targetServer.address().port;
+  const targetUrl = `http://localhost:${targetPort}`;
+
+  const server = http.createServer(async (req, res) => {
+    switch (req.url) {
+      case '/test-auto-propagation': {
+        capturedV0 = {};
+        capturedV1 = {};
+        capturedV2 = {};
+        await fetch(`${targetUrl}/api/v0`);
+        await fetch(`${targetUrl}/api/v1`);
+        await fetch(`${targetUrl}/api/v2`);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ '/api/v0': capturedV0, '/api/v1': capturedV1, '/api/v2': capturedV2 }));
+        break;
+      }
+      case '/test-breadcrumbs': {
+        Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+        await fetch(`${targetUrl}/api/v0`);
+        await fetch(`${targetUrl}/api/v1`);
+        Sentry.captureException(new Error('foo'));
+        res.writeHead(200);
+        res.end('ok');
+        break;
+      }
+      case '/test-suppress-tracing': {
+        capturedV0 = {};
+        capturedV1 = {};
+        await fetch(`${targetUrl}/api/v0`);
+        await Sentry.suppressTracing(() => fetch(`${targetUrl}/api/v1`));
+        Sentry.captureException(new Error('foo'));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ '/api/v0': capturedV0, '/api/v1': capturedV1 }));
+        break;
+      }
+      default: {
+        res.writeHead(404);
+        res.end();
+      }
+    }
+  });
+
+  server.listen(0, () => {
+    sendPortToRunner(server.address().port);
+  });
+});

--- a/dev-packages/node-core-integration-tests/suites/light-mode/outgoing-fetch/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/light-mode/outgoing-fetch/test.ts
@@ -1,0 +1,109 @@
+import crypto from 'crypto';
+import { afterAll, expect, test } from 'vitest';
+import { conditionalTest } from '../../../utils';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+conditionalTest({ min: 22 })('light mode outgoing fetch', () => {
+  test('automatically propagates trace headers to outgoing fetch requests matching tracePropagationTargets', async () => {
+    const traceId = crypto.randomUUID().replace(/-/g, '');
+    const parentSpanId = traceId.substring(0, 16);
+
+    const runner = createRunner(__dirname, 'server.js').start();
+
+    const response = await runner.makeRequest<Record<string, { 'sentry-trace'?: string; baggage?: string }>>(
+      'get',
+      '/test-auto-propagation',
+      {
+        headers: {
+          'sentry-trace': `${traceId}-${parentSpanId}-1`,
+          baggage: `sentry-trace_id=${traceId},sentry-environment=test,sentry-public_key=public`,
+        },
+      },
+    );
+
+    // /api/v0 matches tracePropagationTargets - should have headers
+    expect(response?.['/api/v0']?.['sentry-trace']).toMatch(new RegExp(`^${traceId}-[a-f\\d]{16}-1$`));
+    expect(response?.['/api/v0']?.baggage).toContain(`sentry-trace_id=${traceId}`);
+
+    // /api/v1 matches tracePropagationTargets - should have headers
+    expect(response?.['/api/v1']?.['sentry-trace']).toMatch(new RegExp(`^${traceId}-[a-f\\d]{16}-1$`));
+    expect(response?.['/api/v1']?.baggage).toContain(`sentry-trace_id=${traceId}`);
+
+    // /api/v2 does NOT match tracePropagationTargets - should NOT have headers
+    expect(response?.['/api/v2']?.['sentry-trace']).toBeUndefined();
+    expect(response?.['/api/v2']?.baggage).toBeUndefined();
+  });
+
+  test('does not propagate headers or create breadcrumbs when tracing is suppressed', async () => {
+    const runner = createRunner(__dirname, 'server.js')
+      .expect({
+        event: event => {
+          const breadcrumbs = event.breadcrumbs || [];
+          const httpBreadcrumbs = breadcrumbs.filter(b => b.category === 'http');
+
+          // Only 1 breadcrumb for v0 - the suppressed v1 request should NOT create a breadcrumb
+          expect(httpBreadcrumbs.length).toBe(1);
+          expect(httpBreadcrumbs[0]?.data?.url).toContain('/api/v0');
+        },
+      })
+      .start();
+
+    const response = await runner.makeRequest<Record<string, { 'sentry-trace'?: string; baggage?: string }>>(
+      'get',
+      '/test-suppress-tracing',
+    );
+
+    // v0 (not suppressed) should have trace headers
+    expect(response?.['/api/v0']?.['sentry-trace']).toBeDefined();
+    expect(response?.['/api/v0']?.baggage).toBeDefined();
+
+    // v1 (suppressed) should NOT have trace headers
+    expect(response?.['/api/v1']?.['sentry-trace']).toBeUndefined();
+    expect(response?.['/api/v1']?.baggage).toBeUndefined();
+
+    await runner.completed();
+  });
+
+  test('creates breadcrumbs for outgoing fetch requests', async () => {
+    const runner = createRunner(__dirname, 'server.js')
+      .expect({
+        event: event => {
+          const breadcrumbs = event.breadcrumbs || [];
+          const httpBreadcrumbs = breadcrumbs.filter(b => b.category === 'http');
+
+          expect(httpBreadcrumbs.length).toBe(2);
+
+          expect(httpBreadcrumbs[0]).toEqual(
+            expect.objectContaining({
+              category: 'http',
+              type: 'http',
+              data: expect.objectContaining({
+                'http.method': 'GET',
+                status_code: 200,
+              }),
+            }),
+          );
+
+          expect(httpBreadcrumbs[1]).toEqual(
+            expect.objectContaining({
+              category: 'http',
+              type: 'http',
+              data: expect.objectContaining({
+                'http.method': 'GET',
+                status_code: 200,
+              }),
+            }),
+          );
+        },
+      })
+      .start();
+
+    await runner.makeRequest('get', '/test-breadcrumbs');
+
+    await runner.completed();
+  });
+});

--- a/packages/node-core/src/integrations/node-fetch/SentryNodeFetchInstrumentation.ts
+++ b/packages/node-core/src/integrations/node-fetch/SentryNodeFetchInstrumentation.ts
@@ -2,28 +2,15 @@ import { context } from '@opentelemetry/api';
 import { isTracingSuppressed } from '@opentelemetry/core';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
-import type { SanitizedRequestData } from '@sentry/core';
-import {
-  addBreadcrumb,
-  getBreadcrumbLogLevelFromHttpStatusCode,
-  getClient,
-  getSanitizedUrlString,
-  getTraceData,
-  LRUMap,
-  parseUrl,
-  SDK_VERSION,
-} from '@sentry/core';
-import { shouldPropagateTraceForUrl } from '@sentry/opentelemetry';
+import { LRUMap, SDK_VERSION } from '@sentry/core';
 import * as diagch from 'diagnostics_channel';
 import { NODE_MAJOR, NODE_MINOR } from '../../nodeVersion';
-import { mergeBaggageHeaders } from '../../utils/baggage';
+import {
+  addFetchRequestBreadcrumb,
+  addTracePropagationHeadersToFetchRequest,
+  getAbsoluteUrl,
+} from '../../utils/outgoingFetchRequest';
 import type { UndiciRequest, UndiciResponse } from './types';
-
-const SENTRY_TRACE_HEADER = 'sentry-trace';
-const SENTRY_BAGGAGE_HEADER = 'baggage';
-
-// For baggage, we make sure to merge this into a possibly existing header
-const BAGGAGE_HEADER_REGEX = /baggage: (.*)\r\n/;
 
 export type SentryNodeFetchInstrumentationOptions = InstrumentationConfig & {
   /**
@@ -114,7 +101,6 @@ export class SentryNodeFetchInstrumentation extends InstrumentationBase<SentryNo
    * This method is called when a request is created.
    * You can still mutate the request here before it is sent.
    */
-  // eslint-disable-next-line complexity
   private _onRequestCreated({ request }: { request: UndiciRequest }): void {
     const config = this.getConfig();
     const enabled = config.enabled !== false;
@@ -132,70 +118,7 @@ export class SentryNodeFetchInstrumentation extends InstrumentationBase<SentryNo
       return;
     }
 
-    const url = getAbsoluteUrl(request.origin, request.path);
-
-    // Manually add the trace headers, if it applies
-    // Note: We do not use `propagation.inject()` here, because our propagator relies on an active span
-    // Which we do not have in this case
-    // The propagator _may_ overwrite this, but this should be fine as it is the same data
-    const { tracePropagationTargets, propagateTraceparent } = getClient()?.getOptions() || {};
-    const addedHeaders = shouldPropagateTraceForUrl(url, tracePropagationTargets, this._propagationDecisionMap)
-      ? getTraceData({ propagateTraceparent })
-      : undefined;
-
-    if (!addedHeaders) {
-      return;
-    }
-
-    const { 'sentry-trace': sentryTrace, baggage, traceparent } = addedHeaders;
-
-    // We do not want to overwrite existing headers here
-    // If the core UndiciInstrumentation is registered, it will already have set the headers
-    // We do not want to add any then
-    if (Array.isArray(request.headers)) {
-      const requestHeaders = request.headers;
-
-      // We do not want to overwrite existing header here, if it was already set
-      if (sentryTrace && !requestHeaders.includes(SENTRY_TRACE_HEADER)) {
-        requestHeaders.push(SENTRY_TRACE_HEADER, sentryTrace);
-      }
-
-      if (traceparent && !requestHeaders.includes('traceparent')) {
-        requestHeaders.push('traceparent', traceparent);
-      }
-
-      // For baggage, we make sure to merge this into a possibly existing header
-      const existingBaggagePos = requestHeaders.findIndex(header => header === SENTRY_BAGGAGE_HEADER);
-      if (baggage && existingBaggagePos === -1) {
-        requestHeaders.push(SENTRY_BAGGAGE_HEADER, baggage);
-      } else if (baggage) {
-        const existingBaggage = requestHeaders[existingBaggagePos + 1];
-        const merged = mergeBaggageHeaders(existingBaggage, baggage);
-        if (merged) {
-          requestHeaders[existingBaggagePos + 1] = merged;
-        }
-      }
-    } else {
-      const requestHeaders = request.headers;
-      // We do not want to overwrite existing header here, if it was already set
-      if (sentryTrace && !requestHeaders.includes(`${SENTRY_TRACE_HEADER}:`)) {
-        request.headers += `${SENTRY_TRACE_HEADER}: ${sentryTrace}\r\n`;
-      }
-
-      if (traceparent && !requestHeaders.includes('traceparent:')) {
-        request.headers += `traceparent: ${traceparent}\r\n`;
-      }
-
-      const existingBaggage = request.headers.match(BAGGAGE_HEADER_REGEX)?.[1];
-      if (baggage && !existingBaggage) {
-        request.headers += `${SENTRY_BAGGAGE_HEADER}: ${baggage}\r\n`;
-      } else if (baggage) {
-        const merged = mergeBaggageHeaders(existingBaggage, baggage);
-        if (merged) {
-          request.headers = request.headers.replace(BAGGAGE_HEADER_REGEX, `baggage: ${merged}\r\n`);
-        }
-      }
-    }
+    addTracePropagationHeadersToFetchRequest(request, this._propagationDecisionMap);
   }
 
   /**
@@ -215,7 +138,7 @@ export class SentryNodeFetchInstrumentation extends InstrumentationBase<SentryNo
     const shouldIgnore = this._ignoreOutgoingRequestsMap.get(request);
 
     if (breadCrumbsEnabled && !shouldIgnore) {
-      addRequestBreadcrumb(request, response);
+      addFetchRequestBreadcrumb(request, response);
     }
   }
 
@@ -261,73 +184,5 @@ export class SentryNodeFetchInstrumentation extends InstrumentationBase<SentryNo
     }
 
     return ignoreOutgoingRequests(url);
-  }
-}
-
-/** Add a breadcrumb for outgoing requests. */
-function addRequestBreadcrumb(request: UndiciRequest, response: UndiciResponse): void {
-  const data = getBreadcrumbData(request);
-
-  const statusCode = response.statusCode;
-  const level = getBreadcrumbLogLevelFromHttpStatusCode(statusCode);
-
-  addBreadcrumb(
-    {
-      category: 'http',
-      data: {
-        status_code: statusCode,
-        ...data,
-      },
-      type: 'http',
-      level,
-    },
-    {
-      event: 'response',
-      request,
-      response,
-    },
-  );
-}
-
-function getBreadcrumbData(request: UndiciRequest): Partial<SanitizedRequestData> {
-  try {
-    const url = getAbsoluteUrl(request.origin, request.path);
-    const parsedUrl = parseUrl(url);
-
-    const data: Partial<SanitizedRequestData> = {
-      url: getSanitizedUrlString(parsedUrl),
-      'http.method': request.method || 'GET',
-    };
-
-    if (parsedUrl.search) {
-      data['http.query'] = parsedUrl.search;
-    }
-    if (parsedUrl.hash) {
-      data['http.fragment'] = parsedUrl.hash;
-    }
-
-    return data;
-  } catch {
-    return {};
-  }
-}
-
-function getAbsoluteUrl(origin: string, path: string = '/'): string {
-  try {
-    const url = new URL(path, origin);
-    return url.toString();
-  } catch {
-    // fallback: Construct it on our own
-    const url = `${origin}`;
-
-    if (url.endsWith('/') && path.startsWith('/')) {
-      return `${url}${path.slice(1)}`;
-    }
-
-    if (!url.endsWith('/') && !path.startsWith('/')) {
-      return `${url}/${path.slice(1)}`;
-    }
-
-    return `${url}${path}`;
   }
 }

--- a/packages/node-core/src/light/index.ts
+++ b/packages/node-core/src/light/index.ts
@@ -3,6 +3,7 @@ export { LightNodeClient } from './client';
 export { init, getDefaultIntegrations, initWithoutDefaultIntegrations } from './sdk';
 export { setAsyncLocalStorageAsyncContextStrategy } from './asyncLocalStorageStrategy';
 export { httpIntegration } from './integrations/httpIntegration';
+export { nativeNodeFetchIntegration } from './integrations/nativeNodeFetchIntegration';
 
 // Common exports shared with the main entry point
 export * from '../common-exports';

--- a/packages/node-core/src/light/integrations/nativeNodeFetchIntegration.ts
+++ b/packages/node-core/src/light/integrations/nativeNodeFetchIntegration.ts
@@ -1,0 +1,122 @@
+import type { ChannelListener } from 'node:diagnostics_channel';
+import { subscribe } from 'node:diagnostics_channel';
+import type { Integration, IntegrationFn } from '@sentry/core';
+import { getCurrentScope, LRUMap } from '@sentry/core';
+import type { UndiciRequest, UndiciResponse } from '../../integrations/node-fetch/types';
+import {
+  addFetchRequestBreadcrumb,
+  addTracePropagationHeadersToFetchRequest,
+  getAbsoluteUrl,
+} from '../../utils/outgoingFetchRequest';
+
+const INTEGRATION_NAME = 'NodeFetch';
+
+export interface NativeNodeFetchIntegrationOptions {
+  /**
+   * Whether breadcrumbs should be recorded for requests.
+   *
+   * @default `true`
+   */
+  breadcrumbs?: boolean;
+
+  /**
+   * Do not capture breadcrumbs or inject headers for outgoing fetch requests to URLs
+   * where the given callback returns `true`.
+   *
+   * @param url Contains the entire URL, including query string (if any), protocol, host, etc. of the outgoing request.
+   */
+  ignoreOutgoingRequests?: (url: string) => boolean;
+}
+
+const _nativeNodeFetchIntegration = ((options: NativeNodeFetchIntegrationOptions = {}) => {
+  const _options = {
+    breadcrumbs: options.breadcrumbs ?? true,
+    ignoreOutgoingRequests: options.ignoreOutgoingRequests,
+  };
+
+  const propagationDecisionMap = new LRUMap<string, boolean>(100);
+  const ignoreOutgoingRequestsMap = new WeakMap<UndiciRequest, boolean>();
+
+  return {
+    name: INTEGRATION_NAME,
+    setupOnce() {
+      const onRequestCreated = ((_data: unknown) => {
+        const data = _data as { request: UndiciRequest };
+        onUndiciRequestCreated(data.request, _options, propagationDecisionMap, ignoreOutgoingRequestsMap);
+      }) satisfies ChannelListener;
+
+      const onResponseHeaders = ((_data: unknown) => {
+        const data = _data as { request: UndiciRequest; response: UndiciResponse };
+        onUndiciResponseHeaders(data.request, data.response, _options, ignoreOutgoingRequestsMap);
+      }) satisfies ChannelListener;
+
+      subscribe('undici:request:create', onRequestCreated);
+      subscribe('undici:request:headers', onResponseHeaders);
+    },
+  };
+}) satisfies IntegrationFn;
+
+/**
+ * This integration handles outgoing fetch (undici) requests in light mode (without OpenTelemetry).
+ * It propagates trace headers and creates breadcrumbs for responses.
+ */
+export const nativeNodeFetchIntegration = _nativeNodeFetchIntegration as (
+  options?: NativeNodeFetchIntegrationOptions,
+) => Integration & {
+  name: 'NodeFetch';
+  setupOnce: () => void;
+};
+
+function onUndiciRequestCreated(
+  request: UndiciRequest,
+  options: { ignoreOutgoingRequests?: (url: string) => boolean },
+  propagationDecisionMap: LRUMap<string, boolean>,
+  ignoreOutgoingRequestsMap: WeakMap<UndiciRequest, boolean>,
+): void {
+  const shouldIgnore = shouldIgnoreRequest(request, options);
+  ignoreOutgoingRequestsMap.set(request, shouldIgnore);
+
+  if (shouldIgnore) {
+    return;
+  }
+
+  addTracePropagationHeadersToFetchRequest(request, propagationDecisionMap);
+}
+
+function onUndiciResponseHeaders(
+  request: UndiciRequest,
+  response: UndiciResponse,
+  options: { breadcrumbs: boolean },
+  ignoreOutgoingRequestsMap: WeakMap<UndiciRequest, boolean>,
+): void {
+  if (!options.breadcrumbs) {
+    return;
+  }
+
+  const shouldIgnore = ignoreOutgoingRequestsMap.get(request);
+  if (shouldIgnore) {
+    return;
+  }
+
+  addFetchRequestBreadcrumb(request, response);
+}
+
+/** Check if the given outgoing request should be ignored. */
+function shouldIgnoreRequest(
+  request: UndiciRequest,
+  options: { ignoreOutgoingRequests?: (url: string) => boolean },
+): boolean {
+  // Check if tracing is suppressed (e.g. for Sentry's own transport requests)
+  if (getCurrentScope().getScopeData().sdkProcessingMetadata.__SENTRY_SUPPRESS_TRACING__) {
+    return true;
+  }
+
+  const { ignoreOutgoingRequests } = options;
+
+  if (!ignoreOutgoingRequests) {
+    return false;
+  }
+
+  const url = getAbsoluteUrl(request.origin, request.path);
+  return ignoreOutgoingRequests(url);
+}

--- a/packages/node-core/src/light/sdk.ts
+++ b/packages/node-core/src/light/sdk.ts
@@ -34,6 +34,7 @@ import { getSpotlightConfig } from '../utils/spotlight';
 import { setAsyncLocalStorageAsyncContextStrategy } from './asyncLocalStorageStrategy';
 import { LightNodeClient } from './client';
 import { httpIntegration } from './integrations/httpIntegration';
+import { nativeNodeFetchIntegration } from './integrations/nativeNodeFetchIntegration';
 
 /**
  * Get default integrations for the Light Node-Core SDK.
@@ -49,6 +50,7 @@ export function getDefaultIntegrations(): Integration[] {
     // Native Wrappers
     consoleIntegration(),
     httpIntegration(),
+    nativeNodeFetchIntegration(),
     // Global Handlers
     onUncaughtExceptionIntegration(),
     onUnhandledRejectionIntegration(),

--- a/packages/node-core/src/utils/outgoingFetchRequest.ts
+++ b/packages/node-core/src/utils/outgoingFetchRequest.ts
@@ -1,0 +1,164 @@
+import type { LRUMap, SanitizedRequestData } from '@sentry/core';
+import {
+  addBreadcrumb,
+  getBreadcrumbLogLevelFromHttpStatusCode,
+  getClient,
+  getSanitizedUrlString,
+  getTraceData,
+  parseUrl,
+  shouldPropagateTraceForUrl,
+} from '@sentry/core';
+import type { UndiciRequest, UndiciResponse } from '../integrations/node-fetch/types';
+import { mergeBaggageHeaders } from './baggage';
+
+const SENTRY_TRACE_HEADER = 'sentry-trace';
+const SENTRY_BAGGAGE_HEADER = 'baggage';
+
+// For baggage, we make sure to merge this into a possibly existing header
+const BAGGAGE_HEADER_REGEX = /baggage: (.*)\r\n/;
+
+/**
+ * Add trace propagation headers to an outgoing fetch/undici request.
+ *
+ * Checks if the request URL matches trace propagation targets,
+ * then injects sentry-trace, traceparent, and baggage headers.
+ */
+// eslint-disable-next-line complexity
+export function addTracePropagationHeadersToFetchRequest(
+  request: UndiciRequest,
+  propagationDecisionMap: LRUMap<string, boolean>,
+): void {
+  const url = getAbsoluteUrl(request.origin, request.path);
+
+  // Manually add the trace headers, if it applies
+  // Note: We do not use `propagation.inject()` here, because our propagator relies on an active span
+  // Which we do not have in this case
+  // The propagator _may_ overwrite this, but this should be fine as it is the same data
+  const { tracePropagationTargets, propagateTraceparent } = getClient()?.getOptions() || {};
+  const addedHeaders = shouldPropagateTraceForUrl(url, tracePropagationTargets, propagationDecisionMap)
+    ? getTraceData({ propagateTraceparent })
+    : undefined;
+
+  if (!addedHeaders) {
+    return;
+  }
+
+  const { 'sentry-trace': sentryTrace, baggage, traceparent } = addedHeaders;
+
+  // We do not want to overwrite existing headers here
+  // If the core UndiciInstrumentation is registered, it will already have set the headers
+  // We do not want to add any then
+  if (Array.isArray(request.headers)) {
+    const requestHeaders = request.headers;
+
+    // We do not want to overwrite existing header here, if it was already set
+    if (sentryTrace && !requestHeaders.includes(SENTRY_TRACE_HEADER)) {
+      requestHeaders.push(SENTRY_TRACE_HEADER, sentryTrace);
+    }
+
+    if (traceparent && !requestHeaders.includes('traceparent')) {
+      requestHeaders.push('traceparent', traceparent);
+    }
+
+    // For baggage, we make sure to merge this into a possibly existing header
+    const existingBaggagePos = requestHeaders.findIndex(header => header === SENTRY_BAGGAGE_HEADER);
+    if (baggage && existingBaggagePos === -1) {
+      requestHeaders.push(SENTRY_BAGGAGE_HEADER, baggage);
+    } else if (baggage) {
+      const existingBaggage = requestHeaders[existingBaggagePos + 1];
+      const merged = mergeBaggageHeaders(existingBaggage, baggage);
+      if (merged) {
+        requestHeaders[existingBaggagePos + 1] = merged;
+      }
+    }
+  } else {
+    const requestHeaders = request.headers;
+    // We do not want to overwrite existing header here, if it was already set
+    if (sentryTrace && !requestHeaders.includes(`${SENTRY_TRACE_HEADER}:`)) {
+      request.headers += `${SENTRY_TRACE_HEADER}: ${sentryTrace}\r\n`;
+    }
+
+    if (traceparent && !requestHeaders.includes('traceparent:')) {
+      request.headers += `traceparent: ${traceparent}\r\n`;
+    }
+
+    const existingBaggage = request.headers.match(BAGGAGE_HEADER_REGEX)?.[1];
+    if (baggage && !existingBaggage) {
+      request.headers += `${SENTRY_BAGGAGE_HEADER}: ${baggage}\r\n`;
+    } else if (baggage) {
+      const merged = mergeBaggageHeaders(existingBaggage, baggage);
+      if (merged) {
+        request.headers = request.headers.replace(BAGGAGE_HEADER_REGEX, `baggage: ${merged}\r\n`);
+      }
+    }
+  }
+}
+
+/** Add a breadcrumb for an outgoing fetch/undici request. */
+export function addFetchRequestBreadcrumb(request: UndiciRequest, response: UndiciResponse): void {
+  const data = getBreadcrumbData(request);
+
+  const statusCode = response.statusCode;
+  const level = getBreadcrumbLogLevelFromHttpStatusCode(statusCode);
+
+  addBreadcrumb(
+    {
+      category: 'http',
+      data: {
+        status_code: statusCode,
+        ...data,
+      },
+      type: 'http',
+      level,
+    },
+    {
+      event: 'response',
+      request,
+      response,
+    },
+  );
+}
+
+function getBreadcrumbData(request: UndiciRequest): Partial<SanitizedRequestData> {
+  try {
+    const url = getAbsoluteUrl(request.origin, request.path);
+    const parsedUrl = parseUrl(url);
+
+    const data: Partial<SanitizedRequestData> = {
+      url: getSanitizedUrlString(parsedUrl),
+      'http.method': request.method || 'GET',
+    };
+
+    if (parsedUrl.search) {
+      data['http.query'] = parsedUrl.search;
+    }
+    if (parsedUrl.hash) {
+      data['http.fragment'] = parsedUrl.hash;
+    }
+
+    return data;
+  } catch {
+    return {};
+  }
+}
+
+/** Get the absolute URL from an origin and path. */
+export function getAbsoluteUrl(origin: string, path: string = '/'): string {
+  try {
+    const url = new URL(path, origin);
+    return url.toString();
+  } catch {
+    // fallback: Construct it on our own
+    const url = `${origin}`;
+
+    if (url.endsWith('/') && path.startsWith('/')) {
+      return `${url}${path.slice(1)}`;
+    }
+
+    if (!url.endsWith('/') && !path.startsWith('/')) {
+      return `${url}/${path}`;
+    }
+
+    return `${url}${path}`;
+  }
+}

--- a/packages/node-core/test/light/integrations/nativeNodeFetchIntegration.test.ts
+++ b/packages/node-core/test/light/integrations/nativeNodeFetchIntegration.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as Sentry from '../../../src/light';
+import { nativeNodeFetchIntegration } from '../../../src/light/integrations/nativeNodeFetchIntegration';
+import { cleanupLightSdk } from '../../helpers/mockLightSdkInit';
+
+describe('Light Mode | nativeNodeFetchIntegration', () => {
+  afterEach(() => {
+    cleanupLightSdk();
+  });
+
+  describe('integration configuration', () => {
+    it('has correct integration name', () => {
+      const integration = nativeNodeFetchIntegration();
+      expect(integration.name).toBe('NodeFetch');
+    });
+
+    it('accepts options', () => {
+      const integration = nativeNodeFetchIntegration({
+        breadcrumbs: false,
+        ignoreOutgoingRequests: (_url: string) => false,
+      });
+
+      expect(integration.name).toBe('NodeFetch');
+    });
+
+    it('has setupOnce method', () => {
+      const integration = nativeNodeFetchIntegration();
+      expect(typeof integration.setupOnce).toBe('function');
+    });
+  });
+
+  describe('export from light mode', () => {
+    it('exports nativeNodeFetchIntegration', () => {
+      expect(Sentry.nativeNodeFetchIntegration).toBeDefined();
+      expect(typeof Sentry.nativeNodeFetchIntegration).toBe('function');
+    });
+
+    it('nativeNodeFetchIntegration creates an integration with correct name', () => {
+      const integration = Sentry.nativeNodeFetchIntegration();
+      expect(integration.name).toBe('NodeFetch');
+    });
+  });
+});

--- a/packages/node-core/test/light/sdk.test.ts
+++ b/packages/node-core/test/light/sdk.test.ts
@@ -99,6 +99,13 @@ describe('Light Mode | SDK', () => {
 
       expect(integrationNames).toContain('Http');
     });
+
+    it('includes NodeFetch integration for outgoing fetch trace propagation', () => {
+      const integrations = Sentry.getDefaultIntegrations();
+      const integrationNames = integrations.map(i => i.name);
+
+      expect(integrationNames).toContain('NodeFetch');
+    });
   });
 
   describe('isInitialized', () => {

--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -85,7 +85,7 @@ function getAbsoluteUrl(origin: string, path: string = '/'): string {
   }
 
   if (!url.endsWith('/') && !path.startsWith('/')) {
-    return `${url}/${path.slice(1)}`;
+    return `${url}/${path}`;
   }
 
   return `${url}${path}`;


### PR DESCRIPTION
This PR adds a fetch integration for light mode for outgoing trace propagation.

It also extracts shared fetch request functionality from node-core to reduce duplication.

This PR is the counter part to the http integration: https://github.com/getsentry/sentry-javascript/pull/19258

Closes #19264 (added automatically)