### PR TITLE
chore: Ignore `lerna.json` for prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ dev-packages/browser-integration-tests/fixtures
 
 /.nx/cache
 /.nx/workspace-data
+
+lerna.json


### PR DESCRIPTION
This caused issues in releases where the file got modified somewhere in the lerna pipeline which then failed our prettier job.

Closes #19289 (added automatically)