### PR TITLE
feat(nitro): Handle sourcemap preparation and upload

### DIFF
--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -38,6 +38,7 @@
     "nitro": ">=3.0.0-0 <4.0.0 || 3.0.260311-beta || 3.0.260415-beta"
   },
   "dependencies": {
+    "@sentry/bundler-plugin-core": "^5.2.0",
     "@sentry/core": "10.49.0",
     "@sentry/node": "10.49.0",
     "@sentry/opentelemetry": "10.49.0"

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -44,8 +44,8 @@
     "@sentry/opentelemetry": "10.49.0"
   },
   "devDependencies": {
-    "h3": "^2.0.1-rc.13",
-    "nitro": "^3.0.260415-beta"
+    "nitro": "^3.0.260415-beta",
+    "h3": "^2.0.1-rc.13"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/nitro/rollup.npm.config.mjs
+++ b/packages/nitro/rollup.npm.config.mjs
@@ -5,7 +5,7 @@ export default [
     makeBaseNPMConfig({
       entrypoints: ['src/index.ts', 'src/runtime/plugins/server.ts'],
       packageSpecificConfig: {
-        external: [/^nitro/, /^h3/, /^srvx/, /^@sentry\/opentelemetry/],
+        external: [/^nitro/, /^h3/, /^srvx/, /^@sentry\/opentelemetry/, '@sentry/bundler-plugin-core'],
       },
     }),
   ),

--- a/packages/nitro/src/config.ts
+++ b/packages/nitro/src/config.ts
@@ -24,10 +24,10 @@ export function setupSentryNitroModule(
     config.tracingChannel = true;
   }
 
-  configureSourcemapSettings(config, moduleOptions);
+  const { sentryEnabledSourcemaps } = configureSourcemapSettings(config, moduleOptions);
 
   config.modules = config.modules || [];
-  config.modules.push(createNitroModule(moduleOptions));
+  config.modules.push(createNitroModule(moduleOptions, sentryEnabledSourcemaps));
 
   return config;
 }

--- a/packages/nitro/src/config.ts
+++ b/packages/nitro/src/config.ts
@@ -1,7 +1,7 @@
 import type { Options as SentryBundlerPluginOptions } from '@sentry/bundler-plugin-core';
-import { debug } from '@sentry/core';
 import type { NitroConfig } from 'nitro/types';
 import { createNitroModule } from './module';
+import { configureSourcemapSettings } from './sourceMaps';
 
 export type SentryNitroOptions = Pick<
   SentryBundlerPluginOptions,
@@ -40,33 +40,10 @@ export function setupSentryNitroModule(
     config.tracingChannel = true;
   }
 
-  const sourcemapUploadDisabled = moduleOptions?.sourcemaps?.disable === true || moduleOptions?.disable === true;
-
-  if (!sourcemapUploadDisabled) {
-    configureSourcemapSettings(config, moduleOptions);
-  }
+  configureSourcemapSettings(config, moduleOptions);
 
   config.modules = config.modules || [];
   config.modules.push(createNitroModule(moduleOptions));
 
   return config;
-}
-
-function configureSourcemapSettings(config: NitroConfig, moduleOptions?: SentryNitroOptions): void {
-  if (config.sourcemap === false) {
-    debug.warn(
-      '[Sentry] You have explicitly disabled source maps (`sourcemap: false`). Sentry is overriding this to `true` so that errors can be un-minified in Sentry. To disable Sentry source map uploads entirely, use `sourcemaps: { disable: true }` in your Sentry options instead.',
-    );
-  }
-  config.sourcemap = true;
-
-  // Nitro v3 has a `sourcemapMinify` plugin that destructively deletes `sourcesContent`,
-  // `x_google_ignoreList`, and clears `mappings` for any chunk containing `node_modules`.
-  // This makes sourcemaps unusable for Sentry.
-  config.experimental = config.experimental || {};
-  config.experimental.sourcemapMinify = false;
-
-  if (moduleOptions?.debug) {
-    debug.log('[Sentry] Enabled source map generation and configured build settings for Sentry source map uploads.');
-  }
 }

--- a/packages/nitro/src/config.ts
+++ b/packages/nitro/src/config.ts
@@ -1,25 +1,9 @@
-import type { Options as SentryBundlerPluginOptions } from '@sentry/bundler-plugin-core';
+import type { BuildTimeOptionsBase } from '@sentry/core';
 import type { NitroConfig } from 'nitro/types';
 import { createNitroModule } from './module';
 import { configureSourcemapSettings } from './sourceMaps';
 
-export type SentryNitroOptions = Pick<
-  SentryBundlerPluginOptions,
-  | 'org'
-  | 'project'
-  | 'authToken'
-  | 'url'
-  | 'headers'
-  | 'debug'
-  | 'silent'
-  | 'errorHandler'
-  | 'telemetry'
-  | 'disable'
-  | 'sourcemaps'
-  | 'release'
-  | 'bundleSizeOptimizations'
-  | '_metaOptions'
->;
+export type SentryNitroOptions = BuildTimeOptionsBase;
 
 /**
  * Modifies the passed in Nitro configuration with automatic build-time instrumentation.

--- a/packages/nitro/src/config.ts
+++ b/packages/nitro/src/config.ts
@@ -1,18 +1,31 @@
+import type { Options as SentryBundlerPluginOptions } from '@sentry/bundler-plugin-core';
+import { debug } from '@sentry/core';
 import type { NitroConfig } from 'nitro/types';
 import { createNitroModule } from './module';
 
-type SentryNitroOptions = {
-  // TODO: Add options
-};
+export type SentryNitroOptions = Pick<
+  SentryBundlerPluginOptions,
+  | 'org'
+  | 'project'
+  | 'authToken'
+  | 'url'
+  | 'headers'
+  | 'debug'
+  | 'silent'
+  | 'errorHandler'
+  | 'telemetry'
+  | 'disable'
+  | 'sourcemaps'
+  | 'release'
+  | 'bundleSizeOptimizations'
+  | '_metaOptions'
+>;
 
 /**
  * Modifies the passed in Nitro configuration with automatic build-time instrumentation.
- *
- * @param config A Nitro configuration object, as usually exported in `nitro.config.ts` or `nitro.config.mjs`.
- * @returns The modified config to be exported
  */
-export function withSentryConfig(config: NitroConfig, moduleOptions?: SentryNitroOptions): NitroConfig {
-  return setupSentryNitroModule(config, moduleOptions);
+export function withSentryConfig(config: NitroConfig, sentryOptions?: SentryNitroOptions): NitroConfig {
+  return setupSentryNitroModule(config, sentryOptions);
 }
 
 /**
@@ -20,15 +33,40 @@ export function withSentryConfig(config: NitroConfig, moduleOptions?: SentryNitr
  */
 export function setupSentryNitroModule(
   config: NitroConfig,
-  _moduleOptions?: SentryNitroOptions,
+  moduleOptions?: SentryNitroOptions,
   _serverConfigFile?: string,
 ): NitroConfig {
   if (!config.tracingChannel) {
     config.tracingChannel = true;
   }
 
+  const sourcemapUploadDisabled = moduleOptions?.sourcemaps?.disable === true || moduleOptions?.disable === true;
+
+  if (!sourcemapUploadDisabled) {
+    configureSourcemapSettings(config, moduleOptions);
+  }
+
   config.modules = config.modules || [];
-  config.modules.push(createNitroModule());
+  config.modules.push(createNitroModule(moduleOptions));
 
   return config;
+}
+
+function configureSourcemapSettings(config: NitroConfig, moduleOptions?: SentryNitroOptions): void {
+  if (config.sourcemap === false) {
+    debug.warn(
+      '[Sentry] You have explicitly disabled source maps (`sourcemap: false`). Sentry is overriding this to `true` so that errors can be un-minified in Sentry. To disable Sentry source map uploads entirely, use `sourcemaps: { disable: true }` in your Sentry options instead.',
+    );
+  }
+  config.sourcemap = true;
+
+  // Nitro v3 has a `sourcemapMinify` plugin that destructively deletes `sourcesContent`,
+  // `x_google_ignoreList`, and clears `mappings` for any chunk containing `node_modules`.
+  // This makes sourcemaps unusable for Sentry.
+  config.experimental = config.experimental || {};
+  config.experimental.sourcemapMinify = false;
+
+  if (moduleOptions?.debug) {
+    debug.log('[Sentry] Enabled source map generation and configured build settings for Sentry source map uploads.');
+  }
 }

--- a/packages/nitro/src/module.ts
+++ b/packages/nitro/src/module.ts
@@ -1,14 +1,17 @@
 import type { NitroModule } from 'nitro/types';
+import type { SentryNitroOptions } from './config';
 import { instrumentServer } from './instruments/instrumentServer';
+import { setupSourceMaps } from './sourceMaps';
 
 /**
  * Creates a Nitro module to setup the Sentry SDK.
  */
-export function createNitroModule(): NitroModule {
+export function createNitroModule(sentryOptions?: SentryNitroOptions): NitroModule {
   return {
     name: 'sentry',
     setup: nitro => {
       instrumentServer(nitro);
+      setupSourceMaps(nitro, sentryOptions);
     },
   };
 }

--- a/packages/nitro/src/module.ts
+++ b/packages/nitro/src/module.ts
@@ -6,12 +6,12 @@ import { setupSourceMaps } from './sourceMaps';
 /**
  * Creates a Nitro module to setup the Sentry SDK.
  */
-export function createNitroModule(sentryOptions?: SentryNitroOptions): NitroModule {
+export function createNitroModule(sentryOptions?: SentryNitroOptions, sentryEnabledSourcemaps?: boolean): NitroModule {
   return {
     name: 'sentry',
     setup: nitro => {
       instrumentServer(nitro);
-      setupSourceMaps(nitro, sentryOptions);
+      setupSourceMaps(nitro, sentryOptions, sentryEnabledSourcemaps);
     },
   };
 }

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -1,0 +1,91 @@
+import type { Options } from '@sentry/bundler-plugin-core';
+import { createSentryBuildPluginManager } from '@sentry/bundler-plugin-core';
+import type { Nitro } from 'nitro/types';
+import type { SentryNitroOptions } from './config';
+
+/**
+ * Registers a `compiled` hook to upload source maps after the build completes.
+ */
+export function setupSourceMaps(nitro: Nitro, options?: SentryNitroOptions): void {
+  // The `compiled` hook fires on EVERY rebuild during `nitro dev` watch mode.
+  // nitro.options.dev is reliably set by the time module setup runs.
+  if (nitro.options.dev) {
+    return;
+  }
+
+  // Respect user's explicit disable
+  if (options?.sourcemaps?.disable === true || options?.disable === true) {
+    return;
+  }
+
+  nitro.hooks.hook('compiled', async (_nitro: Nitro) => {
+    await handleSourceMapUpload(_nitro, options);
+  });
+}
+
+/**
+ * Handles the actual source map upload after the build completes.
+ */
+async function handleSourceMapUpload(nitro: Nitro, options?: SentryNitroOptions): Promise<void> {
+  const outputDir = nitro.options.output.serverDir;
+  const pluginOptions = getPluginOptions(options);
+
+  const sentryBuildPluginManager = createSentryBuildPluginManager(pluginOptions, {
+    buildTool: 'nitro',
+    loggerPrefix: '[@sentry/nitro]',
+  });
+
+  await sentryBuildPluginManager.telemetry.emitBundlerPluginExecutionSignal();
+  await sentryBuildPluginManager.createRelease();
+
+  if (options?.sourcemaps?.disable !== 'disable-upload') {
+    await sentryBuildPluginManager.injectDebugIds([outputDir]);
+    await sentryBuildPluginManager.uploadSourcemaps([outputDir], {
+      // We don't prepare the artifacts because we injected debug IDs manually before
+      prepareArtifacts: false,
+    });
+  }
+
+  await sentryBuildPluginManager.deleteArtifacts();
+}
+
+/**
+ * Normalizes the beginning of a path from e.g. ../../../ to ./
+ */
+function normalizePath(path: string): string {
+  return path.replace(/^(\.\.\/)+/, './');
+}
+
+/**
+ * Builds the plugin options for `createSentryBuildPluginManager` from the Sentry Nitro options.
+ *
+ * Only exported for testing purposes.
+ */
+export function getPluginOptions(options?: SentryNitroOptions): Options {
+  return {
+    org: options?.org ?? process.env.SENTRY_ORG,
+    project: options?.project ?? process.env.SENTRY_PROJECT,
+    authToken: options?.authToken ?? process.env.SENTRY_AUTH_TOKEN,
+    url: options?.url ?? process.env.SENTRY_URL,
+    headers: options?.headers,
+    telemetry: options?.telemetry ?? true,
+    debug: options?.debug ?? false,
+    silent: options?.silent ?? false,
+    errorHandler: options?.errorHandler,
+    sourcemaps: {
+      disable: options?.sourcemaps?.disable,
+      assets: options?.sourcemaps?.assets,
+      ignore: options?.sourcemaps?.ignore,
+      filesToDeleteAfterUpload: options?.sourcemaps?.filesToDeleteAfterUpload ?? ['**/*.map'],
+      rewriteSources: (source: string) => normalizePath(source),
+    },
+    release: options?.release,
+    bundleSizeOptimizations: options?.bundleSizeOptimizations,
+    _metaOptions: {
+      telemetry: {
+        metaFramework: 'nitro',
+      },
+      ...options?._metaOptions,
+    },
+  };
+}

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -96,7 +96,7 @@ export function getPluginOptions(options?: SentryNitroOptions): Options {
  */
 export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: SentryNitroOptions): void {
   const sourcemapUploadDisabled = moduleOptions?.sourcemaps?.disable === true || moduleOptions?.disable === true;
-  if (!sourcemapUploadDisabled) {
+  if (sourcemapUploadDisabled) {
     return;
   }
 
@@ -105,11 +105,13 @@ export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: 
       '[Sentry] You have explicitly disabled source maps (`sourcemap: false`). Sentry is overriding this to `true` so that errors can be un-minified in Sentry. To disable Sentry source map uploads entirely, use `sourcemaps: { disable: true }` in your Sentry options instead.',
     );
   }
+
   config.sourcemap = true;
 
   // Nitro v3 has a `sourcemapMinify` plugin that destructively deletes `sourcesContent`,
   // `x_google_ignoreList`, and clears `mappings` for any chunk containing `node_modules`.
   // This makes sourcemaps unusable for Sentry.
+  // FIXME: Not sure about this one, it works either way?
   config.experimental = config.experimental || {};
   config.experimental.sourcemapMinify = false;
 

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -6,7 +6,7 @@ import type { SentryNitroOptions } from './config';
 /**
  * Registers a `compiled` hook to upload source maps after the build completes.
  */
-export function setupSourceMaps(nitro: Nitro, options?: SentryNitroOptions): void {
+export function setupSourceMaps(nitro: Nitro, options?: SentryNitroOptions, sentryEnabledSourcemaps?: boolean): void {
   // The `compiled` hook fires on EVERY rebuild during `nitro dev` watch mode.
   // nitro.options.dev is reliably set by the time module setup runs.
   if (nitro.options.dev) {
@@ -19,16 +19,20 @@ export function setupSourceMaps(nitro: Nitro, options?: SentryNitroOptions): voi
   }
 
   nitro.hooks.hook('compiled', async (_nitro: Nitro) => {
-    await handleSourceMapUpload(_nitro, options);
+    await handleSourceMapUpload(_nitro, options, sentryEnabledSourcemaps);
   });
 }
 
 /**
  * Handles the actual source map upload after the build completes.
  */
-async function handleSourceMapUpload(nitro: Nitro, options?: SentryNitroOptions): Promise<void> {
+async function handleSourceMapUpload(
+  nitro: Nitro,
+  options?: SentryNitroOptions,
+  sentryEnabledSourcemaps?: boolean,
+): Promise<void> {
   const outputDir = nitro.options.output.serverDir;
-  const pluginOptions = getPluginOptions(options);
+  const pluginOptions = getPluginOptions(options, sentryEnabledSourcemaps);
 
   const sentryBuildPluginManager = createSentryBuildPluginManager(pluginOptions, {
     buildTool: 'nitro',
@@ -61,7 +65,10 @@ function normalizePath(path: string): string {
  *
  * Only exported for testing purposes.
  */
-export function getPluginOptions(options?: SentryNitroOptions): BundlerPluginOptions {
+export function getPluginOptions(
+  options?: SentryNitroOptions,
+  sentryEnabledSourcemaps?: boolean,
+): BundlerPluginOptions {
   return {
     org: options?.org ?? process.env.SENTRY_ORG,
     project: options?.project ?? process.env.SENTRY_PROJECT,
@@ -76,7 +83,8 @@ export function getPluginOptions(options?: SentryNitroOptions): BundlerPluginOpt
       disable: options?.sourcemaps?.disable,
       assets: options?.sourcemaps?.assets,
       ignore: options?.sourcemaps?.ignore,
-      filesToDeleteAfterUpload: options?.sourcemaps?.filesToDeleteAfterUpload ?? ['**/*.map'],
+      filesToDeleteAfterUpload:
+        options?.sourcemaps?.filesToDeleteAfterUpload ?? (sentryEnabledSourcemaps ? ['**/*.map'] : undefined),
       rewriteSources: options?.sourcemaps?.rewriteSources ?? ((source: string) => normalizePath(source)),
     },
     release: options?.release,
@@ -99,10 +107,13 @@ export function getPluginOptions(options?: SentryNitroOptions): BundlerPluginOpt
       - We enable source maps for Sentry
       - Configure `filesToDeleteAfterUpload` to clean up .map files after upload
 */
-export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: SentryNitroOptions): void {
+export function configureSourcemapSettings(
+  config: NitroConfig,
+  moduleOptions?: SentryNitroOptions,
+): { sentryEnabledSourcemaps: boolean } {
   const sourcemapUploadDisabled = moduleOptions?.sourcemaps?.disable === true;
   if (sourcemapUploadDisabled) {
-    return;
+    return { sentryEnabledSourcemaps: false };
   }
 
   if (config.sourcemap === false) {
@@ -110,9 +121,10 @@ export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: 
     console.warn(
       '[@sentry/nitro] You have explicitly disabled source maps (`sourcemap: false`). Sentry will not upload source maps, and errors will not be unminified. To let Sentry handle source maps, remove the `sourcemap` option from your Nitro config, or use `sourcemaps: { disable: true }` in your Sentry options to silence this warning.',
     );
-    return;
+    return { sentryEnabledSourcemaps: false };
   }
 
+  let sentryEnabledSourcemaps = false;
   if (config.sourcemap === true) {
     if (moduleOptions?.debug) {
       // eslint-disable-next-line no-console
@@ -121,6 +133,7 @@ export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: 
   } else {
     // User did not explicitly set sourcemap — enable it for Sentry
     config.sourcemap = true;
+    sentryEnabledSourcemaps = true;
     if (moduleOptions?.debug) {
       // eslint-disable-next-line no-console
       console.log(
@@ -134,4 +147,6 @@ export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: 
   // This makes sourcemaps unusable for Sentry.
   config.experimental = config.experimental || {};
   config.experimental.sourcemapMinify = false;
+
+  return { sentryEnabledSourcemaps };
 }

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -9,24 +9,25 @@ import type { SentryNitroOptions } from './config';
 export function setupSourceMaps(nitro: Nitro, options?: SentryNitroOptions, sentryEnabledSourcemaps?: boolean): void {
   // The `compiled` hook fires on EVERY rebuild during `nitro dev` watch mode.
   // nitro.options.dev is reliably set by the time module setup runs.
-  if (nitro.options.dev) {
-    return;
-  }
-
-  // Nitro spawns a nested Nitro instance for prerendering with the user's `modules` re-installed.
-  // Uploading here would double-upload source maps and create a duplicate release.
-  if (nitro.options.preset === 'nitro-prerender') {
-    return;
-  }
-
-  // Respect user's explicit disable
-  if (options?.sourcemaps?.disable === true) {
+  if (shouldSkipSourcemapUpload(nitro, options)) {
     return;
   }
 
   nitro.hooks.hook('compiled', async (_nitro: Nitro) => {
     await handleSourceMapUpload(_nitro, options, sentryEnabledSourcemaps);
   });
+}
+
+/**
+ * Determines if sourcemap uploads should be skipped.
+ */
+function shouldSkipSourcemapUpload(nitro: Nitro, options?: SentryNitroOptions): boolean {
+  return !!(
+    nitro.options.dev ||
+    nitro.options.preset === 'nitro-prerender' ||
+    nitro.options.sourcemap === false ||
+    options?.sourcemaps?.disable === true
+  );
 }
 
 /**

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -90,9 +90,16 @@ export function getPluginOptions(options?: SentryNitroOptions): BundlerPluginOpt
   };
 }
 
-/**
- * Configures the Nitro config to enable source map generation.
- */
+/*  Source map configuration rules:
+    1. User explicitly disabled source maps (sourcemap: false)
+      - Keep their setting, emit a warning that errors won't be unminified in Sentry
+      - We will not upload anything
+    2. User enabled source map generation (true)
+      - Keep their setting (don't modify besides uploading)
+    3. User did not set source maps (undefined)
+      - We enable source maps for Sentry
+      - Configure `filesToDeleteAfterUpload` to clean up .map files after upload
+*/
 export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: SentryNitroOptions): void {
   const sourcemapUploadDisabled = moduleOptions?.sourcemaps?.disable === true;
   if (sourcemapUploadDisabled) {
@@ -101,20 +108,26 @@ export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: 
 
   if (config.sourcemap === false) {
     debug.warn(
-      '[Sentry] You have explicitly disabled source maps (`sourcemap: false`). Sentry is overriding this to `true` so that errors can be un-minified in Sentry. To disable Sentry source map uploads entirely, use `sourcemaps: { disable: true }` in your Sentry options instead.',
+      '[Sentry] You have explicitly disabled source maps (`sourcemap: false`). Sentry will not upload source maps, and errors will not be unminified. To let Sentry handle source maps, remove the `sourcemap` option from your Nitro config, or use `sourcemaps: { disable: true }` in your Sentry options to silence this warning.',
     );
+    return;
   }
 
-  config.sourcemap = true;
+  if (config.sourcemap === true) {
+    if (moduleOptions?.debug) {
+      debug.log('[Sentry] Source maps are already enabled. Sentry will upload them for error unminification.');
+    }
+  } else {
+    // User did not explicitly set sourcemap — enable it for Sentry
+    config.sourcemap = true;
+    if (moduleOptions?.debug) {
+      debug.log('[Sentry] Enabled source map generation for Sentry. Source map files will be deleted after upload.');
+    }
+  }
 
   // Nitro v3 has a `sourcemapMinify` plugin that destructively deletes `sourcesContent`,
   // `x_google_ignoreList`, and clears `mappings` for any chunk containing `node_modules`.
   // This makes sourcemaps unusable for Sentry.
-  // FIXME: Not sure about this one, it works either way?
   config.experimental = config.experimental || {};
   config.experimental.sourcemapMinify = false;
-
-  if (moduleOptions?.debug) {
-    debug.log('[Sentry] Enabled source map generation and configured build settings for Sentry source map uploads.');
-  }
 }

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -156,13 +156,15 @@ export function configureSourcemapSettings(
       console.log('[@sentry/nitro] Source maps are already enabled. Sentry will upload them for error unminification.');
     }
   } else {
-    // User did not explicitly set sourcemap — enable it for Sentry
-    config.sourcemap = true;
+    // User did not explicitly set sourcemap, enable hidden source maps for Sentry.
+    // Nitro types `sourcemap` as `boolean`, but it forwards the value to Vite which supports `'hidden'`.
+    // `'hidden'` emits .map files without adding a `//# sourceMappingURL=` comment to the output, avoiding public exposure.
+    (config as { sourcemap?: unknown }).sourcemap = 'hidden';
     sentryEnabledSourcemaps = true;
     if (moduleOptions?.debug) {
       // eslint-disable-next-line no-console
       console.log(
-        '[@sentry/nitro] Enabled source map generation for Sentry. Source map files will be deleted after upload.',
+        '[@sentry/nitro] Enabled hidden source map generation for Sentry. Source map files will be deleted after upload.',
       );
     }
   }

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -13,6 +13,12 @@ export function setupSourceMaps(nitro: Nitro, options?: SentryNitroOptions, sent
     return;
   }
 
+  // Nitro spawns a nested Nitro instance for prerendering with the user's `modules` re-installed.
+  // Uploading here would double-upload source maps and create a duplicate release.
+  if (nitro.options.preset === 'nitro-prerender') {
+    return;
+  }
+
   // Respect user's explicit disable
   if (options?.sourcemaps?.disable === true) {
     return;

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -39,15 +39,15 @@ async function handleSourceMapUpload(nitro: Nitro, options?: SentryNitroOptions)
   await sentryBuildPluginManager.telemetry.emitBundlerPluginExecutionSignal();
   await sentryBuildPluginManager.createRelease();
 
+  await sentryBuildPluginManager.injectDebugIds([outputDir]);
+
   if (options?.sourcemaps?.disable !== 'disable-upload') {
-    await sentryBuildPluginManager.injectDebugIds([outputDir]);
     await sentryBuildPluginManager.uploadSourcemaps([outputDir], {
       // We don't prepare the artifacts because we injected debug IDs manually before
       prepareArtifacts: false,
     });
+    await sentryBuildPluginManager.deleteArtifacts();
   }
-
-  await sentryBuildPluginManager.deleteArtifacts();
 }
 
 /**

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -77,7 +77,7 @@ export function getPluginOptions(options?: SentryNitroOptions): BundlerPluginOpt
       assets: options?.sourcemaps?.assets,
       ignore: options?.sourcemaps?.ignore,
       filesToDeleteAfterUpload: options?.sourcemaps?.filesToDeleteAfterUpload ?? ['**/*.map'],
-      rewriteSources: (source: string) => normalizePath(source),
+      rewriteSources: options?.sourcemaps?.rewriteSources ?? ((source: string) => normalizePath(source)),
     },
     release: options?.release,
     bundleSizeOptimizations: options?.bundleSizeOptimizations,

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -68,17 +68,32 @@ function normalizePath(path: string): string {
 }
 
 /**
+ * Removes a trailing slash from a path so glob patterns can be appended cleanly.
+ */
+function removeTrailingSlash(path: string): string {
+  return path.replace(/\/$/, '');
+}
+
+/**
  * Builds the plugin options for `createSentryBuildPluginManager` from the Sentry Nitro options.
  *
  * Only exported for testing purposes.
  */
+// oxlint-disable-next-line complexity
 export function getPluginOptions(
   options?: SentryNitroOptions,
   sentryEnabledSourcemaps?: boolean,
   outputDir?: string,
 ): BundlerPluginOptions {
   const defaultFilesToDelete =
-    sentryEnabledSourcemaps && outputDir ? [`${outputDir.replace(/\\/g, '/')}/**/*.map`] : undefined;
+    sentryEnabledSourcemaps && outputDir ? [`${removeTrailingSlash(outputDir)}/**/*.map`] : undefined;
+
+  if (options?.debug && defaultFilesToDelete && options?.sourcemaps?.filesToDeleteAfterUpload === undefined) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[@sentry/nitro] Setting \`sourcemaps.filesToDeleteAfterUpload: ["${defaultFilesToDelete[0]}"]\` to delete generated source maps after they were uploaded to Sentry.`,
+    );
+  }
 
   return {
     org: options?.org ?? process.env.SENTRY_ORG,

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -39,7 +39,7 @@ async function handleSourceMapUpload(
   sentryEnabledSourcemaps?: boolean,
 ): Promise<void> {
   const outputDir = nitro.options.output.serverDir;
-  const pluginOptions = getPluginOptions(options, sentryEnabledSourcemaps);
+  const pluginOptions = getPluginOptions(options, sentryEnabledSourcemaps, outputDir);
 
   const sentryBuildPluginManager = createSentryBuildPluginManager(pluginOptions, {
     buildTool: 'nitro',
@@ -75,7 +75,11 @@ function normalizePath(path: string): string {
 export function getPluginOptions(
   options?: SentryNitroOptions,
   sentryEnabledSourcemaps?: boolean,
+  outputDir?: string,
 ): BundlerPluginOptions {
+  const defaultFilesToDelete =
+    sentryEnabledSourcemaps && outputDir ? [`${outputDir.replace(/\\/g, '/')}/**/*.map`] : undefined;
+
   return {
     org: options?.org ?? process.env.SENTRY_ORG,
     project: options?.project ?? process.env.SENTRY_PROJECT,
@@ -90,8 +94,7 @@ export function getPluginOptions(
       disable: options?.sourcemaps?.disable,
       assets: options?.sourcemaps?.assets,
       ignore: options?.sourcemaps?.ignore,
-      filesToDeleteAfterUpload:
-        options?.sourcemaps?.filesToDeleteAfterUpload ?? (sentryEnabledSourcemaps ? ['**/*.map'] : undefined),
+      filesToDeleteAfterUpload: options?.sourcemaps?.filesToDeleteAfterUpload ?? defaultFilesToDelete,
       rewriteSources: options?.sourcemaps?.rewriteSources ?? ((source: string) => normalizePath(source)),
     },
     release: options?.release,

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -26,6 +26,7 @@ function shouldSkipSourcemapUpload(nitro: Nitro, options?: SentryNitroOptions): 
     nitro.options.dev ||
     nitro.options.preset === 'nitro-prerender' ||
     nitro.options.sourcemap === false ||
+    (nitro.options.sourcemap as unknown) === 'inline' ||
     options?.sourcemaps?.disable === true
   );
 }
@@ -141,7 +142,10 @@ export function configureSourcemapSettings(
     return { sentryEnabledSourcemaps: false };
   }
 
-  if (config.sourcemap === false) {
+  // Nitro types `sourcemap` as `boolean`, but it forwards the value to Vite which also accepts `'hidden'` and `'inline'`.
+  const userSourcemap = (config as { sourcemap?: boolean | 'hidden' | 'inline' }).sourcemap;
+
+  if (userSourcemap === false) {
     // eslint-disable-next-line no-console
     console.warn(
       '[@sentry/nitro] You have explicitly disabled source maps (`sourcemap: false`). Sentry will not upload source maps, and errors will not be unminified. To let Sentry handle source maps, remove the `sourcemap` option from your Nitro config, or use `sourcemaps: { disable: true }` in your Sentry options to silence this warning.',
@@ -149,15 +153,24 @@ export function configureSourcemapSettings(
     return { sentryEnabledSourcemaps: false };
   }
 
+  if (userSourcemap === 'inline') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[@sentry/nitro] You have set `sourcemap: "inline"`. Inline source maps are embedded in the output bundle, so there are no `.map` files to upload. Sentry will not upload source maps. Set `sourcemap: "hidden"` (or leave it unset) to let Sentry upload source maps and un-minify errors.',
+    );
+    return { sentryEnabledSourcemaps: false };
+  }
+
   let sentryEnabledSourcemaps = false;
-  if (config.sourcemap === true) {
+  if (userSourcemap === true || userSourcemap === 'hidden') {
     if (moduleOptions?.debug) {
       // eslint-disable-next-line no-console
-      console.log('[@sentry/nitro] Source maps are already enabled. Sentry will upload them for error unminification.');
+      console.log(
+        `[@sentry/nitro] Source maps are already enabled (\`sourcemap: ${JSON.stringify(userSourcemap)}\`). Sentry will upload them for error unminification.`,
+      );
     }
   } else {
     // User did not explicitly set sourcemap, enable hidden source maps for Sentry.
-    // Nitro types `sourcemap` as `boolean`, but it forwards the value to Vite which supports `'hidden'`.
     // `'hidden'` emits .map files without adding a `//# sourceMappingURL=` comment to the output, avoiding public exposure.
     (config as { sourcemap?: unknown }).sourcemap = 'hidden';
     sentryEnabledSourcemaps = true;

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -1,4 +1,4 @@
-import type { Options } from '@sentry/bundler-plugin-core';
+import type { Options as BundlerPluginOptions } from '@sentry/bundler-plugin-core';
 import { createSentryBuildPluginManager } from '@sentry/bundler-plugin-core';
 import { debug } from '@sentry/core';
 import type { Nitro, NitroConfig } from 'nitro/types';
@@ -15,7 +15,7 @@ export function setupSourceMaps(nitro: Nitro, options?: SentryNitroOptions): voi
   }
 
   // Respect user's explicit disable
-  if (options?.sourcemaps?.disable === true || options?.disable === true) {
+  if (options?.sourcemaps?.disable === true) {
     return;
   }
 
@@ -62,12 +62,12 @@ function normalizePath(path: string): string {
  *
  * Only exported for testing purposes.
  */
-export function getPluginOptions(options?: SentryNitroOptions): Options {
+export function getPluginOptions(options?: SentryNitroOptions): BundlerPluginOptions {
   return {
     org: options?.org ?? process.env.SENTRY_ORG,
     project: options?.project ?? process.env.SENTRY_PROJECT,
     authToken: options?.authToken ?? process.env.SENTRY_AUTH_TOKEN,
-    url: options?.url ?? process.env.SENTRY_URL,
+    url: options?.sentryUrl ?? process.env.SENTRY_URL,
     headers: options?.headers,
     telemetry: options?.telemetry ?? true,
     debug: options?.debug ?? false,
@@ -86,7 +86,6 @@ export function getPluginOptions(options?: SentryNitroOptions): Options {
       telemetry: {
         metaFramework: 'nitro',
       },
-      ...options?._metaOptions,
     },
   };
 }
@@ -95,7 +94,7 @@ export function getPluginOptions(options?: SentryNitroOptions): Options {
  * Configures the Nitro config to enable source map generation.
  */
 export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: SentryNitroOptions): void {
-  const sourcemapUploadDisabled = moduleOptions?.sourcemaps?.disable === true || moduleOptions?.disable === true;
+  const sourcemapUploadDisabled = moduleOptions?.sourcemaps?.disable === true;
   if (sourcemapUploadDisabled) {
     return;
   }

--- a/packages/nitro/src/sourceMaps.ts
+++ b/packages/nitro/src/sourceMaps.ts
@@ -1,6 +1,5 @@
 import type { Options as BundlerPluginOptions } from '@sentry/bundler-plugin-core';
 import { createSentryBuildPluginManager } from '@sentry/bundler-plugin-core';
-import { debug } from '@sentry/core';
 import type { Nitro, NitroConfig } from 'nitro/types';
 import type { SentryNitroOptions } from './config';
 
@@ -107,21 +106,26 @@ export function configureSourcemapSettings(config: NitroConfig, moduleOptions?: 
   }
 
   if (config.sourcemap === false) {
-    debug.warn(
-      '[Sentry] You have explicitly disabled source maps (`sourcemap: false`). Sentry will not upload source maps, and errors will not be unminified. To let Sentry handle source maps, remove the `sourcemap` option from your Nitro config, or use `sourcemaps: { disable: true }` in your Sentry options to silence this warning.',
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[@sentry/nitro] You have explicitly disabled source maps (`sourcemap: false`). Sentry will not upload source maps, and errors will not be unminified. To let Sentry handle source maps, remove the `sourcemap` option from your Nitro config, or use `sourcemaps: { disable: true }` in your Sentry options to silence this warning.',
     );
     return;
   }
 
   if (config.sourcemap === true) {
     if (moduleOptions?.debug) {
-      debug.log('[Sentry] Source maps are already enabled. Sentry will upload them for error unminification.');
+      // eslint-disable-next-line no-console
+      console.log('[@sentry/nitro] Source maps are already enabled. Sentry will upload them for error unminification.');
     }
   } else {
     // User did not explicitly set sourcemap — enable it for Sentry
     config.sourcemap = true;
     if (moduleOptions?.debug) {
-      debug.log('[Sentry] Enabled source map generation for Sentry. Source map files will be deleted after upload.');
+      // eslint-disable-next-line no-console
+      console.log(
+        '[@sentry/nitro] Enabled source map generation for Sentry. Source map files will be deleted after upload.',
+      );
     }
   }
 

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -1,0 +1,301 @@
+import type { NitroConfig } from 'nitro/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SentryNitroOptions } from '../src/config';
+import { setupSentryNitroModule } from '../src/config';
+import { getPluginOptions, setupSourceMaps } from '../src/sourceMaps';
+
+vi.mock('../src/instruments/instrumentServer', () => ({
+  instrumentServer: vi.fn(),
+}));
+
+describe('getPluginOptions', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns default options when no options are provided', () => {
+    const options = getPluginOptions();
+
+    expect(options).toEqual(
+      expect.objectContaining({
+        telemetry: true,
+        debug: false,
+        silent: false,
+        sourcemaps: expect.objectContaining({
+          filesToDeleteAfterUpload: ['**/*.map'],
+          rewriteSources: expect.any(Function),
+        }),
+        _metaOptions: expect.objectContaining({
+          telemetry: expect.objectContaining({
+            metaFramework: 'nitro',
+          }),
+        }),
+      }),
+    );
+    expect(options.org).toBeUndefined();
+    expect(options.project).toBeUndefined();
+    expect(options.authToken).toBeUndefined();
+    expect(options.url).toBeUndefined();
+  });
+
+  it('uses environment variables as fallback', () => {
+    process.env.SENTRY_ORG = 'env-org';
+    process.env.SENTRY_PROJECT = 'env-project';
+    process.env.SENTRY_AUTH_TOKEN = 'env-token';
+    process.env.SENTRY_URL = 'https://custom.sentry.io';
+
+    const options = getPluginOptions();
+
+    expect(options.org).toBe('env-org');
+    expect(options.project).toBe('env-project');
+    expect(options.authToken).toBe('env-token');
+    expect(options.url).toBe('https://custom.sentry.io');
+  });
+
+  it('prefers direct options over environment variables', () => {
+    process.env.SENTRY_ORG = 'env-org';
+    process.env.SENTRY_AUTH_TOKEN = 'env-token';
+
+    const options = getPluginOptions({
+      org: 'direct-org',
+      authToken: 'direct-token',
+    });
+
+    expect(options.org).toBe('direct-org');
+    expect(options.authToken).toBe('direct-token');
+  });
+
+  it('passes through all user options', () => {
+    const sentryOptions: SentryNitroOptions = {
+      org: 'my-org',
+      project: 'my-project',
+      authToken: 'my-token',
+      url: 'https://my-sentry.io',
+      headers: { 'X-Custom': 'header' },
+      debug: true,
+      silent: true,
+      telemetry: false,
+      errorHandler: () => {},
+      release: { name: 'v1.0.0' },
+      sourcemaps: {
+        assets: ['dist/**'],
+        ignore: ['dist/test/**'],
+        filesToDeleteAfterUpload: ['dist/**/*.map'],
+      },
+    };
+
+    const options = getPluginOptions(sentryOptions);
+
+    expect(options.org).toBe('my-org');
+    expect(options.project).toBe('my-project');
+    expect(options.authToken).toBe('my-token');
+    expect(options.url).toBe('https://my-sentry.io');
+    expect(options.headers).toEqual({ 'X-Custom': 'header' });
+    expect(options.debug).toBe(true);
+    expect(options.silent).toBe(true);
+    expect(options.telemetry).toBe(false);
+    expect(options.errorHandler).toBeDefined();
+    expect(options.release).toEqual({ name: 'v1.0.0' });
+    expect(options.sourcemaps?.assets).toEqual(['dist/**']);
+    expect(options.sourcemaps?.ignore).toEqual(['dist/test/**']);
+    expect(options.sourcemaps?.filesToDeleteAfterUpload).toEqual(['dist/**/*.map']);
+  });
+
+  it('normalizes source paths via rewriteSources', () => {
+    const options = getPluginOptions();
+    const rewriteSources = options.sourcemaps?.rewriteSources;
+
+    expect(rewriteSources?.('../../../src/index.ts', undefined)).toBe('./src/index.ts');
+    expect(rewriteSources?.('../../lib/utils.ts', undefined)).toBe('./lib/utils.ts');
+    expect(rewriteSources?.('./src/index.ts', undefined)).toBe('./src/index.ts');
+    expect(rewriteSources?.('src/index.ts', undefined)).toBe('src/index.ts');
+  });
+
+  it('always sets metaFramework to nitro', () => {
+    const options = getPluginOptions({ _metaOptions: { loggerPrefixOverride: '[custom]' } });
+
+    expect(options._metaOptions?.telemetry?.metaFramework).toBe('nitro');
+    expect(options._metaOptions?.loggerPrefixOverride).toBe('[custom]');
+  });
+
+  it('passes through sourcemaps.disable', () => {
+    const options = getPluginOptions({ sourcemaps: { disable: 'disable-upload' } });
+
+    expect(options.sourcemaps?.disable).toBe('disable-upload');
+  });
+});
+
+describe('setupSentryNitroModule', () => {
+  it('enables sourcemap generation on the config', () => {
+    const config: NitroConfig = {};
+    setupSentryNitroModule(config);
+
+    expect(config.sourcemap).toBe(true);
+  });
+
+  it('forces sourcemap to true even when user set it to false', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const config: NitroConfig = { sourcemap: false };
+    setupSentryNitroModule(config);
+
+    expect(config.sourcemap).toBe(true);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('overriding this to `true`'));
+    consoleSpy.mockRestore();
+  });
+
+  it('keeps sourcemap true when user already set it', () => {
+    const config: NitroConfig = { sourcemap: true };
+    setupSentryNitroModule(config);
+
+    expect(config.sourcemap).toBe(true);
+  });
+
+  it('disables experimental sourcemapMinify', () => {
+    const config: NitroConfig = {};
+    setupSentryNitroModule(config);
+
+    expect(config.experimental?.sourcemapMinify).toBe(false);
+  });
+
+  it('sets sourcemapExcludeSources to false in rollupConfig', () => {
+    const config: NitroConfig = {};
+    setupSentryNitroModule(config);
+
+    expect(config.rollupConfig?.output?.sourcemapExcludeSources).toBe(false);
+  });
+
+  it('preserves existing experimental config', () => {
+    const config: NitroConfig = {
+      experimental: {
+        sourcemapMinify: undefined,
+      },
+    };
+    setupSentryNitroModule(config);
+
+    expect(config.experimental?.sourcemapMinify).toBe(false);
+  });
+
+  it('preserves existing rollupConfig', () => {
+    const config: NitroConfig = {
+      rollupConfig: {
+        output: {
+          format: 'esm' as const,
+        },
+      },
+    };
+    setupSentryNitroModule(config);
+
+    expect(config.rollupConfig?.output?.format).toBe('esm');
+    expect(config.rollupConfig?.output?.sourcemapExcludeSources).toBe(false);
+  });
+
+  it('skips sourcemap config when sourcemaps.disable is true', () => {
+    const config: NitroConfig = { sourcemap: false };
+    setupSentryNitroModule(config, { sourcemaps: { disable: true } });
+
+    // Should NOT override the user's sourcemap: false
+    expect(config.sourcemap).toBe(false);
+    expect(config.rollupConfig).toBeUndefined();
+  });
+
+  it('skips sourcemap config when disable is true', () => {
+    const config: NitroConfig = { sourcemap: false };
+    setupSentryNitroModule(config, { disable: true });
+
+    // Should NOT override the user's sourcemap: false
+    expect(config.sourcemap).toBe(false);
+    expect(config.rollupConfig).toBeUndefined();
+  });
+
+  it('still adds module when sourcemaps are disabled', () => {
+    const config: NitroConfig = {};
+    setupSentryNitroModule(config, { sourcemaps: { disable: true } });
+
+    expect(config.modules).toBeDefined();
+    expect(config.modules?.length).toBe(1);
+  });
+
+  it('enables tracing', () => {
+    const config: NitroConfig = {};
+    setupSentryNitroModule(config);
+
+    // @ts-expect-error -- Nitro tracing config is not out yet
+    expect(config.tracing).toBe(true);
+  });
+
+  it('adds the sentry module', () => {
+    const config: NitroConfig = {};
+    setupSentryNitroModule(config);
+
+    expect(config.modules).toBeDefined();
+    expect(config.modules?.length).toBe(1);
+  });
+});
+
+describe('setupSourceMaps', () => {
+  it('does not register hook in dev mode', () => {
+    const hookFn = vi.fn();
+    const nitro = {
+      options: { dev: true, output: { serverDir: '/output/server' } },
+      hooks: { hook: hookFn },
+    } as any;
+
+    setupSourceMaps(nitro);
+
+    expect(hookFn).not.toHaveBeenCalled();
+  });
+
+  it('does not register hook when sourcemaps.disable is true', () => {
+    const hookFn = vi.fn();
+    const nitro = {
+      options: { dev: false, output: { serverDir: '/output/server' } },
+      hooks: { hook: hookFn },
+    } as any;
+
+    setupSourceMaps(nitro, { sourcemaps: { disable: true } });
+
+    expect(hookFn).not.toHaveBeenCalled();
+  });
+
+  it('does not register hook when disable is true', () => {
+    const hookFn = vi.fn();
+    const nitro = {
+      options: { dev: false, output: { serverDir: '/output/server' } },
+      hooks: { hook: hookFn },
+    } as any;
+
+    setupSourceMaps(nitro, { disable: true });
+
+    expect(hookFn).not.toHaveBeenCalled();
+  });
+
+  it('registers compiled hook in production mode', () => {
+    const hookFn = vi.fn();
+    const nitro = {
+      options: { dev: false, output: { serverDir: '/output/server' } },
+      hooks: { hook: hookFn },
+    } as any;
+
+    setupSourceMaps(nitro);
+
+    expect(hookFn).toHaveBeenCalledWith('compiled', expect.any(Function));
+  });
+
+  it('registers compiled hook with custom options', () => {
+    const hookFn = vi.fn();
+    const nitro = {
+      options: { dev: false, output: { serverDir: '/output/server' } },
+      hooks: { hook: hookFn },
+    } as any;
+
+    setupSourceMaps(nitro, { org: 'my-org', project: 'my-project' });
+
+    expect(hookFn).toHaveBeenCalledWith('compiled', expect.any(Function));
+  });
+});

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -56,20 +56,23 @@ describe('getPluginOptions', () => {
     expect(options.org).toBe('env-org');
     expect(options.project).toBe('env-project');
     expect(options.authToken).toBe('env-token');
-    expect(options.url).toBe('https://custom.sentry.io');
+    expect(options.url).toBe('https://custom.sentry.io'); // sentryUrl maps to url
   });
 
   it('prefers direct options over environment variables', () => {
     process.env.SENTRY_ORG = 'env-org';
     process.env.SENTRY_AUTH_TOKEN = 'env-token';
+    process.env.SENTRY_URL = 'https://env.sentry.io';
 
     const options = getPluginOptions({
       org: 'direct-org',
       authToken: 'direct-token',
+      sentryUrl: 'https://direct.sentry.io',
     });
 
     expect(options.org).toBe('direct-org');
     expect(options.authToken).toBe('direct-token');
+    expect(options.url).toBe('https://direct.sentry.io');
   });
 
   it('passes through all user options', () => {
@@ -77,7 +80,7 @@ describe('getPluginOptions', () => {
       org: 'my-org',
       project: 'my-project',
       authToken: 'my-token',
-      url: 'https://my-sentry.io',
+      sentryUrl: 'https://my-sentry.io',
       headers: { 'X-Custom': 'header' },
       debug: true,
       silent: true,
@@ -119,10 +122,9 @@ describe('getPluginOptions', () => {
   });
 
   it('always sets metaFramework to nitro', () => {
-    const options = getPluginOptions({ _metaOptions: { loggerPrefixOverride: '[custom]' } });
+    const options = getPluginOptions();
 
     expect(options._metaOptions?.telemetry?.metaFramework).toBe('nitro');
-    expect(options._metaOptions?.loggerPrefixOverride).toBe('[custom]');
   });
 
   it('passes through sourcemaps.disable', () => {
@@ -182,11 +184,11 @@ describe('configureSourcemapSettings', () => {
     expect(config.sourcemap).toBe(false);
   });
 
-  it('skips sourcemap config when disable is true', () => {
-    const config: NitroConfig = { sourcemap: false };
-    configureSourcemapSettings(config, { disable: true });
+  it('still configures sourcemaps when sourcemaps.disable is disable-upload', () => {
+    const config: NitroConfig = {};
+    configureSourcemapSettings(config, { sourcemaps: { disable: 'disable-upload' } });
 
-    expect(config.sourcemap).toBe(false);
+    expect(config.sourcemap).toBe(true);
   });
 });
 
@@ -236,18 +238,6 @@ describe('setupSourceMaps', () => {
     } as any;
 
     setupSourceMaps(nitro, { sourcemaps: { disable: true } });
-
-    expect(hookFn).not.toHaveBeenCalled();
-  });
-
-  it('does not register hook when disable is true', () => {
-    const hookFn = vi.fn();
-    const nitro = {
-      options: { dev: false, output: { serverDir: '/output/server' } },
-      hooks: { hook: hookFn },
-    } as any;
-
-    setupSourceMaps(nitro, { disable: true });
 
     expect(hookFn).not.toHaveBeenCalled();
   });

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -215,6 +215,25 @@ describe('configureSourcemapSettings', () => {
     expect(result.sentryEnabledSourcemaps).toBe(false);
   });
 
+  it('keeps sourcemap "hidden" when user already set it and does not enable deletion', () => {
+    const config = { sourcemap: 'hidden' } as unknown as NitroConfig;
+    const result = configureSourcemapSettings(config);
+
+    expect((config as { sourcemap?: unknown }).sourcemap).toBe('hidden');
+    expect(result.sentryEnabledSourcemaps).toBe(false);
+  });
+
+  it('keeps sourcemap "inline", warns, and does not enable uploads', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const config = { sourcemap: 'inline' } as unknown as NitroConfig;
+    const result = configureSourcemapSettings(config);
+
+    expect((config as { sourcemap?: unknown }).sourcemap).toBe('inline');
+    expect(result.sentryEnabledSourcemaps).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('`sourcemap: "inline"`'));
+    warnSpy.mockRestore();
+  });
+
   it('disables experimental sourcemapMinify', () => {
     const config: NitroConfig = {};
     configureSourcemapSettings(config);

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -20,7 +20,7 @@ describe('getPluginOptions', () => {
   });
 
   it('returns default options when no options are provided', () => {
-    const options = getPluginOptions();
+    const options = getPluginOptions(undefined, true);
 
     expect(options).toEqual(
       expect.objectContaining({
@@ -42,6 +42,18 @@ describe('getPluginOptions', () => {
     expect(options.project).toBeUndefined();
     expect(options.authToken).toBeUndefined();
     expect(options.url).toBeUndefined();
+  });
+
+  it('does not default filesToDeleteAfterUpload when user enabled sourcemaps themselves', () => {
+    const options = getPluginOptions(undefined, false);
+
+    expect(options.sourcemaps?.filesToDeleteAfterUpload).toBeUndefined();
+  });
+
+  it('respects user-provided filesToDeleteAfterUpload even when Sentry enabled sourcemaps', () => {
+    const options = getPluginOptions({ sourcemaps: { filesToDeleteAfterUpload: ['dist/**/*.map'] } }, true);
+
+    expect(options.sourcemaps?.filesToDeleteAfterUpload).toEqual(['dist/**/*.map']);
   });
 
   it('uses environment variables as fallback', () => {
@@ -145,17 +157,19 @@ describe('getPluginOptions', () => {
 describe('configureSourcemapSettings', () => {
   it('enables sourcemap generation on the config', () => {
     const config: NitroConfig = {};
-    configureSourcemapSettings(config);
+    const result = configureSourcemapSettings(config);
 
     expect(config.sourcemap).toBe(true);
+    expect(result.sentryEnabledSourcemaps).toBe(true);
   });
 
   it('respects user explicitly disabling sourcemaps and warns', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const config: NitroConfig = { sourcemap: false };
-    configureSourcemapSettings(config);
+    const result = configureSourcemapSettings(config);
 
     expect(config.sourcemap).toBe(false);
+    expect(result.sentryEnabledSourcemaps).toBe(false);
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('explicitly disabled source maps'));
     warnSpy.mockRestore();
   });
@@ -171,9 +185,10 @@ describe('configureSourcemapSettings', () => {
 
   it('keeps sourcemap true when user already set it', () => {
     const config: NitroConfig = { sourcemap: true };
-    configureSourcemapSettings(config);
+    const result = configureSourcemapSettings(config);
 
     expect(config.sourcemap).toBe(true);
+    expect(result.sentryEnabledSourcemaps).toBe(false);
   });
 
   it('disables experimental sourcemapMinify', () => {

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -20,7 +20,7 @@ describe('getPluginOptions', () => {
   });
 
   it('returns default options when no options are provided', () => {
-    const options = getPluginOptions(undefined, true);
+    const options = getPluginOptions(undefined, true, '/project/.output/server');
 
     expect(options).toEqual(
       expect.objectContaining({
@@ -28,7 +28,7 @@ describe('getPluginOptions', () => {
         debug: false,
         silent: false,
         sourcemaps: expect.objectContaining({
-          filesToDeleteAfterUpload: ['**/*.map'],
+          filesToDeleteAfterUpload: ['/project/.output/server/**/*.map'],
           rewriteSources: expect.any(Function),
         }),
         _metaOptions: expect.objectContaining({

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -1,4 +1,3 @@
-import { debug } from '@sentry/core';
 import type { NitroConfig } from 'nitro/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SentryNitroOptions } from '../src/config';
@@ -143,17 +142,17 @@ describe('configureSourcemapSettings', () => {
   });
 
   it('respects user explicitly disabling sourcemaps and warns', () => {
-    const debugSpy = vi.spyOn(debug, 'warn').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const config: NitroConfig = { sourcemap: false };
     configureSourcemapSettings(config);
 
     expect(config.sourcemap).toBe(false);
-    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('explicitly disabled source maps'));
-    debugSpy.mockRestore();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('explicitly disabled source maps'));
+    warnSpy.mockRestore();
   });
 
   it('does not modify experimental config when user disabled sourcemaps', () => {
-    vi.spyOn(debug, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     const config: NitroConfig = { sourcemap: false };
     configureSourcemapSettings(config);
 

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -51,9 +51,33 @@ describe('getPluginOptions', () => {
   });
 
   it('respects user-provided filesToDeleteAfterUpload even when Sentry enabled sourcemaps', () => {
-    const options = getPluginOptions({ sourcemaps: { filesToDeleteAfterUpload: ['dist/**/*.map'] } }, true);
+    const options = getPluginOptions(
+      { sourcemaps: { filesToDeleteAfterUpload: ['dist/**/*.map'] } },
+      true,
+      '/project/.output/server',
+    );
 
     expect(options.sourcemaps?.filesToDeleteAfterUpload).toEqual(['dist/**/*.map']);
+  });
+
+  it('logs the default filesToDeleteAfterUpload glob in debug mode', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    getPluginOptions({ debug: true }, true, '/project/.output/server');
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('/project/.output/server/**/*.map'));
+    logSpy.mockRestore();
+  });
+
+  it('does not log the default glob when user provides filesToDeleteAfterUpload', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    getPluginOptions(
+      { debug: true, sourcemaps: { filesToDeleteAfterUpload: ['dist/**/*.map'] } },
+      true,
+      '/project/.output/server',
+    );
+
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('filesToDeleteAfterUpload'));
+    logSpy.mockRestore();
   });
 
   it('uses environment variables as fallback', () => {

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -179,11 +179,11 @@ describe('getPluginOptions', () => {
 });
 
 describe('configureSourcemapSettings', () => {
-  it('enables sourcemap generation on the config', () => {
+  it('enables hidden sourcemap generation on the config', () => {
     const config: NitroConfig = {};
     const result = configureSourcemapSettings(config);
 
-    expect(config.sourcemap).toBe(true);
+    expect(config.sourcemap).toBe('hidden');
     expect(result.sentryEnabledSourcemaps).toBe(true);
   });
 
@@ -244,7 +244,7 @@ describe('configureSourcemapSettings', () => {
     const config: NitroConfig = {};
     configureSourcemapSettings(config, { sourcemaps: { disable: 'disable-upload' } });
 
-    expect(config.sourcemap).toBe(true);
+    expect(config.sourcemap).toBe('hidden');
   });
 });
 

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -274,6 +274,18 @@ describe('setupSourceMaps', () => {
     expect(hookFn).not.toHaveBeenCalled();
   });
 
+  it('does not register hook in nitro-prerender preset', () => {
+    const hookFn = vi.fn();
+    const nitro = {
+      options: { dev: false, preset: 'nitro-prerender', output: { serverDir: '/output/server' } },
+      hooks: { hook: hookFn },
+    } as any;
+
+    setupSourceMaps(nitro);
+
+    expect(hookFn).not.toHaveBeenCalled();
+  });
+
   it('registers compiled hook in production mode', () => {
     const hookFn = vi.fn();
     const nitro = {

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -195,8 +195,7 @@ describe('setupSentryNitroModule', () => {
     const config: NitroConfig = {};
     setupSentryNitroModule(config);
 
-    // @ts-expect-error -- Nitro tracing config is not out yet
-    expect(config.tracing).toBe(true);
+    expect(config.tracingChannel).toBe(true);
   });
 
   it('adds the sentry module', () => {

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -274,6 +274,18 @@ describe('setupSourceMaps', () => {
     expect(hookFn).not.toHaveBeenCalled();
   });
 
+  it('does not register hook when nitro sourcemap is disabled', () => {
+    const hookFn = vi.fn();
+    const nitro = {
+      options: { dev: false, sourcemap: false, output: { serverDir: '/output/server' } },
+      hooks: { hook: hookFn },
+    } as any;
+
+    setupSourceMaps(nitro);
+
+    expect(hookFn).not.toHaveBeenCalled();
+  });
+
   it('does not register hook in nitro-prerender preset', () => {
     const hookFn = vi.fn();
     const nitro = {

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -142,14 +142,23 @@ describe('configureSourcemapSettings', () => {
     expect(config.sourcemap).toBe(true);
   });
 
-  it('forces sourcemap to true even when user set it to false', () => {
+  it('respects user explicitly disabling sourcemaps and warns', () => {
     const debugSpy = vi.spyOn(debug, 'warn').mockImplementation(() => {});
     const config: NitroConfig = { sourcemap: false };
     configureSourcemapSettings(config);
 
-    expect(config.sourcemap).toBe(true);
-    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('overriding this to `true`'));
+    expect(config.sourcemap).toBe(false);
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('explicitly disabled source maps'));
     debugSpy.mockRestore();
+  });
+
+  it('does not modify experimental config when user disabled sourcemaps', () => {
+    vi.spyOn(debug, 'warn').mockImplementation(() => {});
+    const config: NitroConfig = { sourcemap: false };
+    configureSourcemapSettings(config);
+
+    expect(config.experimental).toBeUndefined();
+    vi.restoreAllMocks();
   });
 
   it('keeps sourcemap true when user already set it', () => {

--- a/packages/nitro/test/sourceMaps.test.ts
+++ b/packages/nitro/test/sourceMaps.test.ts
@@ -120,6 +120,15 @@ describe('getPluginOptions', () => {
     expect(rewriteSources?.('src/index.ts', undefined)).toBe('src/index.ts');
   });
 
+  it('uses user-provided rewriteSources when given', () => {
+    const customRewrite = (source: string) => `/custom/${source}`;
+    const options = getPluginOptions({ sourcemaps: { rewriteSources: customRewrite } });
+
+    expect(options.sourcemaps?.rewriteSources?.('../../../src/index.ts', undefined)).toBe(
+      '/custom/../../../src/index.ts',
+    );
+  });
+
   it('always sets metaFramework to nitro', () => {
     const options = getPluginOptions();
 


### PR DESCRIPTION
Adds automatic sourcemap handling to the Nitro SDK, using `@sentry/bundler-plugin-core` for builder-agnostic post-build upload.

Nitro uses rollup or rolldown, so it made sense to make it as agnostic as possible.

Closes #17992 

---

**This PR is part of a stack:**

- https://github.com/getsentry/sentry-javascript/pull/20358
- https://github.com/getsentry/sentry-javascript/pull/19224
- https://github.com/getsentry/sentry-javascript/pull/19225
- https://github.com/getsentry/sentry-javascript/pull/19304 👈