### PR TITLE
ref(nuxt): Remove `defineNitroPlugin` wrapper

### DIFF
--- a/packages/nuxt/src/runtime/plugins/database.server.ts
+++ b/packages/nuxt/src/runtime/plugins/database.server.ts
@@ -11,7 +11,8 @@ import {
   type StartSpanOptions,
 } from '@sentry/core';
 import type { Database, PreparedStatement } from 'db0';
-import { defineNitroPlugin, useDatabase } from 'nitropack/runtime';
+import type { NitroAppPlugin } from 'nitropack';
+import { useDatabase } from 'nitropack/runtime';
 import type { DatabaseConnectionConfig as DatabaseConfig } from 'nitropack/types';
 // @ts-expect-error - This is a virtual module
 import { databaseConfig } from '#sentry/database-config.mjs';
@@ -34,7 +35,7 @@ const SENTRY_ORIGIN = 'auto.db.nuxt';
 /**
  * Creates a Nitro plugin that instruments the database calls.
  */
-export default defineNitroPlugin(() => {
+export default (() => {
   try {
     const _databaseConfig = databaseConfig as Record<string, DatabaseConfig>;
     const databaseInstances = Object.keys(databaseConfig);
@@ -56,7 +57,7 @@ export default defineNitroPlugin(() => {
 
     debug.error('[Nitro Database Plugin]: Failed to instrument database:', error);
   }
-});
+}) satisfies NitroAppPlugin;
 
 /**
  * Instruments a database instance with Sentry.

--- a/packages/nuxt/src/runtime/plugins/sentry.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry.server.ts
@@ -6,13 +6,13 @@ import {
   withIsolationScope,
 } from '@sentry/core';
 import type { EventHandler, H3Event } from 'h3';
-import { defineNitroPlugin } from 'nitropack/runtime';
+import type { NitroAppPlugin } from 'nitropack';
 import type { NuxtRenderHTMLContext } from 'nuxt/app';
 import { sentryCaptureErrorHook } from '../hooks/captureErrorHook';
 import { updateRouteBeforeResponse } from '../hooks/updateRouteBeforeResponse';
 import { addSentryTracingMetaTags } from '../utils';
 
-export default defineNitroPlugin(nitroApp => {
+export default (nitroApp => {
   nitroApp.h3App.handler = patchEventHandler(nitroApp.h3App.handler);
 
   nitroApp.hooks.hook('beforeResponse', updateRouteBeforeResponse);
@@ -36,7 +36,7 @@ export default defineNitroPlugin(nitroApp => {
       );
     }
   });
-});
+}) satisfies NitroAppPlugin;
 
 function patchEventHandler(handler: EventHandler): EventHandler {
   return new Proxy(handler, {

--- a/packages/nuxt/src/runtime/plugins/storage.server.ts
+++ b/packages/nuxt/src/runtime/plugins/storage.server.ts
@@ -12,7 +12,8 @@ import {
   startSpan,
   type StartSpanOptions,
 } from '@sentry/core';
-import { defineNitroPlugin, useStorage } from 'nitropack/runtime';
+import type { NitroAppPlugin } from 'nitropack';
+import { useStorage } from 'nitropack/runtime';
 import type { CacheEntry, ResponseCacheEntry } from 'nitropack/types';
 import type { Driver, Storage } from 'unstorage';
 // @ts-expect-error - This is a virtual module
@@ -34,7 +35,7 @@ const CACHE_HIT_METHODS = new Set<DriverMethod>(['hasItem', 'getItem', 'getItemR
 /**
  * Creates a Nitro plugin that instruments the storage driver.
  */
-export default defineNitroPlugin(async _nitroApp => {
+export default (async _nitroApp => {
   // This runs at runtime when the Nitro server starts
   const storage = useStorage();
   // Mounts are suffixed with a colon, so we need to add it to the set items
@@ -63,7 +64,7 @@ export default defineNitroPlugin(async _nitroApp => {
 
   // Wrap the mount method to instrument future mounts
   storage.mount = wrapStorageMount(storage);
-});
+}) satisfies NitroAppPlugin;
 
 /**
  * Instruments a driver by wrapping all method calls using proxies.


### PR DESCRIPTION
The wrapper is not needed, as it's just making the sure the types are correct. We can just use the type.

For reference, this is the code for the wrapper: https://github.com/nitrojs/nitro/blob/f663e76df6b25610432c915f19d3cf7c5c19f72e/src/runtime/internal/plugin.ts

Closes https://github.com/getsentry/sentry-javascript/issues/19277
