### PR TITLE
fix(core,browser): Delete SentryNonRecordingSpan from fetch/xhr map

### DIFF
--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -81,19 +81,23 @@ export function instrumentFetchRequest(
 
   const shouldCreateSpanResult = hasSpansEnabled() && shouldCreateSpan(url);
 
-  if (handlerData.endTimestamp && shouldCreateSpanResult) {
+  if (handlerData.endTimestamp) {
     const spanId = handlerData.fetchData.__span;
     if (!spanId) return;
 
     const span = spans[spanId];
-    if (span) {
-      endSpan(span, handlerData);
 
-      _callOnRequestSpanEnd(span, handlerData, spanOriginOrOptions);
+    if (span) {
+      // Only end the span and call hooks if we're actually recording
+      if (shouldCreateSpanResult) {
+        endSpan(span, handlerData);
+        _callOnRequestSpanEnd(span, handlerData, spanOriginOrOptions);
+      }
 
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete spans[spanId];
     }
+
     return undefined;
   }
 


### PR DESCRIPTION
This resolves a leak where `SentryNonRecordingSpan` are pilled up when `tracingSampleRate` is set to `0`. Theoretically `SentryNonRecordingSpan` are still treated as spans and added to the `spans` list, but never removed

By moving `shouldCreateSpanResult` closer to the actual span logic, this is now resolved.

Closes #19337 (added automatically)