### PR TITLE
chore(repo): Disable codecov/project check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,9 +8,7 @@ coverage:
   round: down
   range: '0...1'
   status:
-    project:
-      default:
-        enabled: no
+    project: false
     patch:
       default:
         enabled: no


### PR DESCRIPTION
This check

<img width="849" height="51" alt="image" src="https://github.com/user-attachments/assets/bc90f6b6-3134-4aa6-8a5b-316f333fe24f" />

started failing in CI recently. While we can still merge stuff despite the fail, it blocks releases as I learned the hard way in `10.39.0-alpha.0`. This job is not in our repo's config but added via the Codecov app. It is configured via the `codecov.yml` file in our repo. This PR switches off the project coverage check, since it seems to be flawed at the moment. 

Already talked to @MathurAditya724 who will take another look at the action. Once fixed, we can revert this PR. 