### PR TITLE
chore: add oxfmt changes to blame ignore rev list

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -24,3 +24,6 @@ c88ff463a5566194a454b58bc555f183cf9ee813
 
 # chore: Ensure prettier is run on all files #17497
 90edf65b3d93c89ae576b063a839541022f478cf
+
+# chore: Unignore HTML files and reformat with oxfmt (#19311)
+b1d25bb2462feb02defcdb28221759e26c115d99


### PR DESCRIPTION
Suggested by @Lms24 as a cleanup to #19311 to avoid cluttering our git workflows