### PR TITLE
 feat(cloudflare): Split alarms into multiple traces and link them

### DIFF
--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -85,7 +85,7 @@ export function instrumentDurableObjectWithSentry<
       if (obj.alarm && typeof obj.alarm === 'function') {
         // Alarms are independent invocations, so we start a new trace and link to the previous alarm
         obj.alarm = wrapMethodWithSentry(
-          { options, context, spanName: 'alarm', spanOp: 'function', startNewTrace: true, linkPreviousTrace: true },
+          { options, context, spanName: 'alarm', spanOp: 'function', startNewTrace: true },
           obj.alarm,
         );
       }

--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -83,7 +83,11 @@ export function instrumentDurableObjectWithSentry<
       }
 
       if (obj.alarm && typeof obj.alarm === 'function') {
-        obj.alarm = wrapMethodWithSentry({ options, context, spanName: 'alarm' }, obj.alarm);
+        // Alarms are independent invocations, so we start a new trace and link to the previous alarm
+        obj.alarm = wrapMethodWithSentry(
+          { options, context, spanName: 'alarm', spanOp: 'function', startNewTrace: true, linkPreviousTrace: true },
+          obj.alarm,
+        );
       }
 
       if (obj.webSocketMessage && typeof obj.webSocketMessage === 'function') {

--- a/packages/cloudflare/src/instrumentations/instrumentDurableObjectStorage.ts
+++ b/packages/cloudflare/src/instrumentations/instrumentDurableObjectStorage.ts
@@ -1,20 +1,31 @@
 import type { DurableObjectStorage } from '@cloudflare/workers-types';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+import { isThenable, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+import { storeSpanContext } from '../utils/traceLinks';
 
-const STORAGE_METHODS_TO_INSTRUMENT = ['get', 'put', 'delete', 'list'] as const;
+const STORAGE_METHODS_TO_INSTRUMENT = ['get', 'put', 'delete', 'list', 'setAlarm', 'getAlarm', 'deleteAlarm'] as const;
 
 type StorageMethod = (typeof STORAGE_METHODS_TO_INSTRUMENT)[number];
+
+type WaitUntil = (promise: Promise<unknown>) => void;
 
 /**
  * Instruments DurableObjectStorage methods with Sentry spans.
  *
  * Wraps the following async methods:
  * - get, put, delete, list (KV API)
+ * - setAlarm, getAlarm, deleteAlarm (Alarm API)
+ *
+ * When setAlarm is called, it also stores the current span context so that when
+ * the alarm fires later, it can link back to the trace that called setAlarm.
  *
  * @param storage - The DurableObjectStorage instance to instrument
+ * @param waitUntil - Optional waitUntil function to defer span context storage
  * @returns An instrumented DurableObjectStorage instance
  */
-export function instrumentDurableObjectStorage(storage: DurableObjectStorage): DurableObjectStorage {
+export function instrumentDurableObjectStorage(
+  storage: DurableObjectStorage,
+  waitUntil?: WaitUntil,
+): DurableObjectStorage {
   return new Proxy(storage, {
     get(target, prop, _receiver) {
       // Use `target` as the receiver instead of the proxy (`_receiver`).
@@ -46,7 +57,33 @@ export function instrumentDurableObjectStorage(storage: DurableObjectStorage): D
             },
           },
           () => {
-            return (original as (...args: unknown[]) => unknown).apply(target, args);
+            const teardown = async (): Promise<void> => {
+              // When setAlarm is called, store the current span context so that when the alarm
+              // fires later, it can link back to the trace that called setAlarm.
+              // We use the original (uninstrumented) storage (target) to avoid creating a span
+              // for this internal operation. The storage is deferred via waitUntil to not block.
+              if (methodName === 'setAlarm') {
+                await storeSpanContext(target, 'alarm');
+              }
+            };
+
+            const result = (original as (...args: unknown[]) => unknown).apply(target, args);
+
+            if (!isThenable(result)) {
+              waitUntil?.(teardown());
+
+              return result;
+            }
+
+            return result.then(
+              res => {
+                waitUntil?.(teardown());
+                return res;
+              },
+              e => {
+                throw e;
+              },
+            );
           },
         );
       };

--- a/packages/cloudflare/src/utils/instrumentContext.ts
+++ b/packages/cloudflare/src/utils/instrumentContext.ts
@@ -41,13 +41,14 @@ export function instrumentContext<T extends ContextType>(ctx: T): T {
   // If so, wrap the storage with instrumentation
   if ('storage' in ctx && ctx.storage) {
     const originalStorage = ctx.storage;
+    const waitUntil = 'waitUntil' in ctx && typeof ctx.waitUntil === 'function' ? ctx.waitUntil.bind(ctx) : undefined;
     let instrumentedStorage: DurableObjectStorage | undefined;
     descriptors.storage = {
       configurable: true,
       enumerable: true,
       get: () => {
         if (!instrumentedStorage) {
-          instrumentedStorage = instrumentDurableObjectStorage(originalStorage);
+          instrumentedStorage = instrumentDurableObjectStorage(originalStorage, waitUntil);
         }
         return instrumentedStorage;
       },

--- a/packages/cloudflare/src/utils/traceLinks.ts
+++ b/packages/cloudflare/src/utils/traceLinks.ts
@@ -1,0 +1,84 @@
+import type { DurableObjectStorage } from '@cloudflare/workers-types';
+import { TraceFlags } from '@opentelemetry/api';
+import { getActiveSpan } from '@sentry/core';
+
+/** Storage key prefix for the span context that links consecutive method invocations */
+const SENTRY_TRACE_LINK_KEY_PREFIX = '__SENTRY_TRACE_LINK__';
+
+/** Stored span context for creating span links */
+export interface StoredSpanContext {
+  traceId: string;
+  spanId: string;
+  sampled: boolean;
+}
+
+/** Span link structure for connecting traces */
+export interface SpanLink {
+  context: {
+    traceId: string;
+    spanId: string;
+    traceFlags: number;
+  };
+  attributes?: Record<string, string>;
+}
+
+/**
+ * Gets the storage key for a specific method's trace link.
+ */
+export function getTraceLinkKey(methodName: string): string {
+  return `${SENTRY_TRACE_LINK_KEY_PREFIX}${methodName}`;
+}
+
+/**
+ * Stores the current span context in Durable Object storage for trace linking.
+ * Uses the original uninstrumented storage to avoid creating spans for internal operations.
+ * Errors are silently ignored to prevent internal storage failures from propagating to user code.
+ */
+export async function storeSpanContext(originalStorage: DurableObjectStorage, methodName: string): Promise<void> {
+  try {
+    const activeSpan = getActiveSpan();
+    if (activeSpan) {
+      const spanContext = activeSpan.spanContext();
+      const storedContext: StoredSpanContext = {
+        traceId: spanContext.traceId,
+        spanId: spanContext.spanId,
+        sampled: spanContext.traceFlags === TraceFlags.SAMPLED,
+      };
+      await originalStorage.put(getTraceLinkKey(methodName), storedContext);
+    }
+  } catch {
+    // Silently ignore storage errors to prevent internal failures from affecting user code
+  }
+}
+
+/**
+ * Retrieves a stored span context from Durable Object storage.
+ */
+export async function getStoredSpanContext(
+  originalStorage: DurableObjectStorage,
+  methodName: string,
+): Promise<StoredSpanContext | undefined> {
+  try {
+    return await originalStorage.get<StoredSpanContext>(getTraceLinkKey(methodName));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Builds span links from a stored span context.
+ */
+export function buildSpanLinks(storedContext: StoredSpanContext): SpanLink[] {
+  return [
+    {
+      context: {
+        traceId: storedContext.traceId,
+        spanId: storedContext.spanId,
+        traceFlags: storedContext.sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
+      },
+      attributes: {
+        'sentry.link.type': 'previous_trace',
+      },
+    },
+  ];
+}

--- a/packages/cloudflare/src/utils/traceLinks.ts
+++ b/packages/cloudflare/src/utils/traceLinks.ts
@@ -1,7 +1,7 @@
 import type { DurableObjectStorage } from '@cloudflare/workers-types';
 import { TraceFlags } from '@opentelemetry/api';
 import type { SpanLink } from '@sentry/core';
-import { debug, getActiveSpan } from '@sentry/core';
+import { debug, getActiveSpan, SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE, spanIsSampled } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 
 /** Storage key prefix for the span context that links consecutive method invocations */
@@ -34,7 +34,7 @@ export async function storeSpanContext(originalStorage: DurableObjectStorage, me
       const storedContext: StoredSpanContext = {
         traceId: spanContext.traceId,
         spanId: spanContext.spanId,
-        sampled: spanContext.traceFlags === TraceFlags.SAMPLED,
+        sampled: spanIsSampled(activeSpan),
       };
       await originalStorage.put(getTraceLinkKey(methodName), storedContext);
     }
@@ -70,7 +70,7 @@ export function buildSpanLinks(storedContext: StoredSpanContext): SpanLink[] {
         traceFlags: storedContext.sampled ? TraceFlags.SAMPLED : TraceFlags.NONE,
       },
       attributes: {
-        'sentry.link.type': 'previous_trace',
+        [SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE]: 'previous_trace',
       },
     },
   ];

--- a/packages/cloudflare/src/utils/traceLinks.ts
+++ b/packages/cloudflare/src/utils/traceLinks.ts
@@ -1,6 +1,8 @@
 import type { DurableObjectStorage } from '@cloudflare/workers-types';
 import { TraceFlags } from '@opentelemetry/api';
-import { getActiveSpan } from '@sentry/core';
+import type { SpanLink } from '@sentry/core';
+import { debug, getActiveSpan } from '@sentry/core';
+import { DEBUG_BUILD } from '../debug-build';
 
 /** Storage key prefix for the span context that links consecutive method invocations */
 const SENTRY_TRACE_LINK_KEY_PREFIX = '__SENTRY_TRACE_LINK__';
@@ -10,16 +12,6 @@ export interface StoredSpanContext {
   traceId: string;
   spanId: string;
   sampled: boolean;
-}
-
-/** Span link structure for connecting traces */
-export interface SpanLink {
-  context: {
-    traceId: string;
-    spanId: string;
-    traceFlags: number;
-  };
-  attributes?: Record<string, string>;
 }
 
 /**
@@ -46,8 +38,9 @@ export async function storeSpanContext(originalStorage: DurableObjectStorage, me
       };
       await originalStorage.put(getTraceLinkKey(methodName), storedContext);
     }
-  } catch {
+  } catch (error) {
     // Silently ignore storage errors to prevent internal failures from affecting user code
+    DEBUG_BUILD && debug.log(`[CloudflareClient] Error storing span context for method ${methodName}`, error);
   }
 }
 

--- a/packages/cloudflare/src/wrapMethodWithSentry.ts
+++ b/packages/cloudflare/src/wrapMethodWithSentry.ts
@@ -6,6 +6,7 @@ import {
   type Scope,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  startNewTrace as startNewTraceCore,
   startSpan,
   withIsolationScope,
   withScope,
@@ -14,6 +15,7 @@ import type { CloudflareOptions } from './client';
 import { flushAndDispose } from './flush';
 import { ensureInstrumented } from './instrument';
 import { init } from './sdk';
+import { buildSpanLinks, getStoredSpanContext, storeSpanContext } from './utils/traceLinks';
 
 /** Extended DurableObjectState with originalStorage exposed by instrumentContext */
 interface InstrumentedDurableObjectState extends DurableObjectState {
@@ -24,7 +26,21 @@ type MethodWrapperOptions = {
   spanName?: string;
   spanOp?: string;
   options: CloudflareOptions;
-  context: ExecutionContext | DurableObjectState;
+  context: ExecutionContext | InstrumentedDurableObjectState;
+  /**
+   * If true, starts a fresh trace instead of inheriting from a parent trace.
+   * Useful for scheduled/independent invocations like alarms.
+   * @default false
+   */
+  startNewTrace?: boolean;
+  /**
+   * If true, stores the current span context and links to the previous invocation's span.
+   * Requires `startNewTrace` to be true. Uses Durable Object storage to persist the link.
+   * The link is set asynchronously via `span.addLinks()` in a `waitUntil` to avoid blocking.
+   *
+   * @default false
+   */
+  linkPreviousTrace?: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,7 +48,8 @@ export type UncheckedMethod = (...args: any[]) => any;
 type OriginalMethod = UncheckedMethod;
 
 /**
- * Wraps a method with Sentry tracing.
+ * Wraps a method with Sentry error tracking and optional tracing.
+ * Supports starting new traces and linking to previous invocations via Durable Object storage.
  *
  * @param wrapperOptions - The options for the wrapper.
  * @param handler - The method to wrap.
@@ -51,44 +68,58 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
     original =>
       new Proxy(original, {
         apply(target, thisArg, args: Parameters<T>) {
-          const currentClient = getClient();
-          // if a client is already set, use withScope, otherwise use withIsolationScope
-          const sentryWithScope = currentClient ? withScope : withIsolationScope;
+          const { startNewTrace, linkPreviousTrace } = wrapperOptions;
 
-          const wrappedFunction = (scope: Scope): unknown => {
+          // For startNewTrace, always use withIsolationScope to ensure a fresh scope
+          // Otherwise, use existing client's scope or isolation scope
+          const currentClient = getClient();
+          const sentryWithScope = startNewTrace ? withIsolationScope : currentClient ? withScope : withIsolationScope;
+
+          const wrappedFunction = (scope: Scope): unknown | Promise<unknown> => {
             // In certain situations, the passed context can become undefined.
             // For example, for Astro while prerendering pages at build time.
             // see: https://github.com/getsentry/sentry-javascript/issues/13217
-            const context = wrapperOptions.context as InstrumentedDurableObjectState | undefined;
+            const context: typeof wrapperOptions.context | undefined = wrapperOptions.context;
 
             const waitUntil = context?.waitUntil?.bind?.(context);
+            const storage = context && 'originalStorage' in context ? context.originalStorage : undefined;
 
-            let currentClient = scope.getClient();
+            let scopeClient = scope.getClient();
             // Check if client exists AND is still usable (transport not disposed)
             // This handles the case where a previous handler disposed the client
             // but the scope still holds a reference to it (e.g., alarm handlers in Durable Objects)
-            if (!currentClient?.getTransport()) {
+            // For startNewTrace, always create a fresh client
+            if (startNewTrace || !scopeClient?.getTransport()) {
               const client = init({
                 ...wrapperOptions.options,
                 ctx: context as unknown as ExecutionContext | undefined,
               });
               scope.setClient(client);
-              currentClient = client;
+              scopeClient = client;
             }
 
-            const clientToDispose = currentClient;
+            const clientToDispose = scopeClient;
+            const methodName = wrapperOptions.spanName || 'unknown';
+
+            const teardown = async (): Promise<void> => {
+              if (linkPreviousTrace && storage) {
+                await storeSpanContext(storage, methodName);
+              }
+              await flushAndDispose(clientToDispose);
+            };
 
             if (!wrapperOptions.spanName) {
               try {
                 if (callback) {
                   callback(...args);
                 }
+
                 const result = Reflect.apply(target, thisArg, args);
 
                 if (isThenable(result)) {
                   return result.then(
                     (res: unknown) => {
-                      waitUntil?.(flushAndDispose(clientToDispose));
+                      waitUntil?.(teardown());
                       return res;
                     },
                     (e: unknown) => {
@@ -98,12 +129,12 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
                           handled: false,
                         },
                       });
-                      waitUntil?.(flushAndDispose(clientToDispose));
+                      waitUntil?.(teardown());
                       throw e;
                     },
                   );
                 } else {
-                  waitUntil?.(flushAndDispose(clientToDispose));
+                  waitUntil?.(teardown());
                   return result;
                 }
               } catch (e) {
@@ -113,11 +144,12 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
                     handled: false,
                   },
                 });
-                waitUntil?.(flushAndDispose(clientToDispose));
+                waitUntil?.(teardown());
                 throw e;
               }
             }
 
+            const spanName = wrapperOptions.spanName || methodName;
             const attributes = wrapperOptions.spanOp
               ? {
                   [SEMANTIC_ATTRIBUTE_SENTRY_OP]: wrapperOptions.spanOp,
@@ -125,42 +157,71 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
                 }
               : {};
 
-            return startSpan({ name: wrapperOptions.spanName, attributes }, () => {
-              try {
-                const result = Reflect.apply(target, thisArg, args);
-
-                if (isThenable(result)) {
-                  return result.then(
-                    (res: unknown) => {
-                      waitUntil?.(flushAndDispose(clientToDispose));
-                      return res;
-                    },
-                    (e: unknown) => {
-                      captureException(e, {
-                        mechanism: {
-                          type: 'auto.faas.cloudflare.durable_object',
-                          handled: false,
-                        },
-                      });
-                      waitUntil?.(flushAndDispose(clientToDispose));
-                      throw e;
-                    },
+            const executeSpan = (): unknown => {
+              return startSpan({ name: spanName, attributes }, span => {
+                // When linking to previous trace, fetch the stored context and add links asynchronously
+                // This avoids blocking the response while fetching from storage
+                if (linkPreviousTrace && storage) {
+                  waitUntil?.(
+                    getStoredSpanContext(storage, methodName).then(storedContext => {
+                      if (storedContext) {
+                        span.addLinks(buildSpanLinks(storedContext));
+                        // TODO: Remove this once EAP can store span links. We currently only set this attribute so that we
+                        // can obtain the previous trace information from the EAP store. Long-term, EAP will handle
+                        // span links and then we should remove this again. Also throwing in a TODO(v11), to remind us
+                        // to check this at v11 time :)
+                        const sampledFlag = storedContext.sampled ? '1' : '0';
+                        span.setAttribute(
+                          'sentry.previous_trace',
+                          `${storedContext.traceId}-${storedContext.spanId}-${sampledFlag}`,
+                        );
+                      }
+                    }),
                   );
-                } else {
-                  waitUntil?.(flushAndDispose(clientToDispose));
-                  return result;
                 }
-              } catch (e) {
-                captureException(e, {
-                  mechanism: {
-                    type: 'auto.faas.cloudflare.durable_object',
-                    handled: false,
-                  },
-                });
-                waitUntil?.(flushAndDispose(clientToDispose));
-                throw e;
-              }
-            });
+
+                try {
+                  const result = Reflect.apply(target, thisArg, args);
+
+                  if (isThenable(result)) {
+                    return result.then(
+                      (res: unknown) => {
+                        waitUntil?.(teardown());
+                        return res;
+                      },
+                      (e: unknown) => {
+                        captureException(e, {
+                          mechanism: {
+                            type: 'auto.faas.cloudflare.durable_object',
+                            handled: false,
+                          },
+                        });
+                        waitUntil?.(teardown());
+                        throw e;
+                      },
+                    );
+                  } else {
+                    waitUntil?.(teardown());
+                    return result;
+                  }
+                } catch (e) {
+                  captureException(e, {
+                    mechanism: {
+                      type: 'auto.faas.cloudflare.durable_object',
+                      handled: false,
+                    },
+                  });
+                  waitUntil?.(teardown());
+                  throw e;
+                }
+              });
+            };
+
+            if (startNewTrace) {
+              return startNewTraceCore(() => executeSpan());
+            }
+
+            return executeSpan();
           };
 
           return sentryWithScope(wrappedFunction);

--- a/packages/cloudflare/src/wrapMethodWithSentry.ts
+++ b/packages/cloudflare/src/wrapMethodWithSentry.ts
@@ -30,17 +30,14 @@ type MethodWrapperOptions = {
   /**
    * If true, starts a fresh trace instead of inheriting from a parent trace.
    * Useful for scheduled/independent invocations like alarms.
-   * @default false
-   */
-  startNewTrace?: boolean;
-  /**
-   * If true, stores the current span context and links to the previous invocation's span.
-   * Requires `startNewTrace` to be true. Uses Durable Object storage to persist the link.
-   * The link is set asynchronously via `span.addLinks()` in a `waitUntil` to avoid blocking.
+   *
+   * If true, it also stores the current span context and links to the previous invocation's span.
+   * Uses Durable Object storage to persist the link. The link is set asynchronously via `span.addLinks()`
+   * in a `waitUntil` to avoid blocking.
    *
    * @default false
    */
-  linkPreviousTrace?: boolean;
+  startNewTrace?: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -68,7 +65,7 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
     original =>
       new Proxy(original, {
         apply(target, thisArg, args: Parameters<T>) {
-          const { startNewTrace, linkPreviousTrace } = wrapperOptions;
+          const { startNewTrace } = wrapperOptions;
 
           // For startNewTrace, always use withIsolationScope to ensure a fresh scope
           // Otherwise, use existing client's scope or isolation scope
@@ -102,7 +99,7 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
             const methodName = wrapperOptions.spanName || 'unknown';
 
             const teardown = async (): Promise<void> => {
-              if (linkPreviousTrace && storage) {
+              if (startNewTrace && storage) {
                 await storeSpanContext(storage, methodName);
               }
               await flushAndDispose(clientToDispose);
@@ -149,7 +146,6 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
               }
             }
 
-            const spanName = wrapperOptions.spanName || methodName;
             const attributes = wrapperOptions.spanOp
               ? {
                   [SEMANTIC_ATTRIBUTE_SENTRY_OP]: wrapperOptions.spanOp,
@@ -158,10 +154,10 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
               : {};
 
             const executeSpan = (): unknown => {
-              return startSpan({ name: spanName, attributes }, span => {
+              return startSpan({ name: methodName, attributes }, span => {
                 // When linking to previous trace, fetch the stored context and add links asynchronously
                 // This avoids blocking the response while fetching from storage
-                if (linkPreviousTrace && storage) {
+                if (startNewTrace && storage) {
                   waitUntil?.(
                     getStoredSpanContext(storage, methodName).then(storedContext => {
                       if (storedContext) {

--- a/packages/cloudflare/test/instrumentDurableObjectStorage.test.ts
+++ b/packages/cloudflare/test/instrumentDurableObjectStorage.test.ts
@@ -1,13 +1,22 @@
 import * as sentryCore from '@sentry/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { instrumentDurableObjectStorage } from '../src/instrumentations/instrumentDurableObjectStorage';
+import * as traceLinks from '../src/utils/traceLinks';
 
 vi.mock('@sentry/core', async importOriginal => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<typeof sentryCore>();
   return {
     ...actual,
     startSpan: vi.fn((opts, callback) => callback()),
     getActiveSpan: vi.fn(),
+  };
+});
+
+vi.mock('../src/utils/traceLinks', async importOriginal => {
+  const actual = await importOriginal<typeof traceLinks>();
+  return {
+    ...actual,
+    storeSpanContext: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -150,18 +159,131 @@ describe('instrumentDurableObjectStorage', () => {
     });
   });
 
-  describe('non-instrumented methods', () => {
-    it('does not instrument alarm methods', async () => {
+  describe('alarm methods', () => {
+    it('instruments setAlarm', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.setAlarm(Date.now() + 1000);
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_setAlarm',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'setAlarm',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+
+    it('stores span context when setAlarm is called (async)', async () => {
+      const mockStorage = createMockStorage();
+      const waitUntil = vi.fn();
+      const instrumented = instrumentDurableObjectStorage(mockStorage, waitUntil);
+
+      await instrumented.setAlarm(Date.now() + 1000);
+
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      expect(traceLinks.storeSpanContext).toHaveBeenCalledWith(mockStorage, 'alarm');
+    });
+
+    it('calls teardown after promise resolves (async case)', async () => {
+      const callOrder: string[] = [];
+      let resolveStorage: () => void;
+      const storagePromise = new Promise<void>(resolve => {
+        resolveStorage = resolve;
+      });
+
+      const mockStorage = createMockStorage();
+      mockStorage.setAlarm = vi.fn().mockImplementation(() => {
+        callOrder.push('setAlarm started');
+        return storagePromise.then(() => {
+          callOrder.push('setAlarm resolved');
+        });
+      });
+
+      const waitUntil = vi.fn().mockImplementation(() => {
+        callOrder.push('waitUntil called');
+      });
+
+      const instrumented = instrumentDurableObjectStorage(mockStorage, waitUntil);
+      const resultPromise = instrumented.setAlarm(Date.now() + 1000);
+
+      // Before resolving, waitUntil should not have been called yet
+      expect(waitUntil).not.toHaveBeenCalled();
+      expect(callOrder).toEqual(['setAlarm started']);
+
+      // Resolve the storage promise
+      resolveStorage!();
+      await resultPromise;
+
+      // After resolving, waitUntil should have been called
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual(['setAlarm started', 'setAlarm resolved', 'waitUntil called']);
+    });
+
+    it('calls teardown immediately for sync results', () => {
+      const callOrder: string[] = [];
+
+      const mockStorage = createMockStorage();
+      // Make setAlarm return a sync value (not a promise)
+      mockStorage.setAlarm = vi.fn().mockImplementation(() => {
+        callOrder.push('setAlarm executed');
+        return undefined; // sync return
+      });
+
+      const waitUntil = vi.fn().mockImplementation(() => {
+        callOrder.push('waitUntil called');
+      });
+
+      const instrumented = instrumentDurableObjectStorage(mockStorage, waitUntil);
+      instrumented.setAlarm(Date.now() + 1000);
+
+      // For sync results, waitUntil should be called immediately after
+      expect(waitUntil).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual(['setAlarm executed', 'waitUntil called']);
+    });
+
+    it('instruments getAlarm', async () => {
       const mockStorage = createMockStorage();
       const instrumented = instrumentDurableObjectStorage(mockStorage);
 
       await instrumented.getAlarm();
-      await instrumented.setAlarm(Date.now() + 1000);
-      await instrumented.deleteAlarm();
 
-      expect(sentryCore.startSpan).not.toHaveBeenCalled();
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_getAlarm',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'getAlarm',
+          }),
+        },
+        expect.any(Function),
+      );
     });
 
+    it('instruments deleteAlarm', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.deleteAlarm();
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_deleteAlarm',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'deleteAlarm',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('non-instrumented methods', () => {
     it('does not instrument deleteAll, sync, transaction', async () => {
       const mockStorage = createMockStorage();
       const instrumented = instrumentDurableObjectStorage(mockStorage);

--- a/packages/cloudflare/test/traceLinks.test.ts
+++ b/packages/cloudflare/test/traceLinks.test.ts
@@ -1,0 +1,201 @@
+import { TraceFlags } from '@opentelemetry/api';
+import * as sentryCore from '@sentry/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildSpanLinks, getStoredSpanContext, getTraceLinkKey, storeSpanContext } from '../src/utils/traceLinks';
+
+vi.mock('@sentry/core', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getActiveSpan: vi.fn(),
+  };
+});
+
+describe('traceLinks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getTraceLinkKey', () => {
+    it('returns prefixed key for method name', () => {
+      expect(getTraceLinkKey('alarm')).toBe('__SENTRY_TRACE_LINK__alarm');
+    });
+
+    it('returns prefixed key for custom method name', () => {
+      expect(getTraceLinkKey('myCustomMethod')).toBe('__SENTRY_TRACE_LINK__myCustomMethod');
+    });
+
+    it('handles empty method name', () => {
+      expect(getTraceLinkKey('')).toBe('__SENTRY_TRACE_LINK__');
+    });
+  });
+
+  describe('storeSpanContext', () => {
+    it('stores span context with sampled=true when traceFlags is SAMPLED', async () => {
+      const mockSpanContext = {
+        traceId: 'abc123def456789012345678901234ab',
+        spanId: '1234567890abcdef',
+        traceFlags: TraceFlags.SAMPLED,
+      };
+      const mockSpan = {
+        spanContext: vi.fn().mockReturnValue(mockSpanContext),
+      };
+      vi.mocked(sentryCore.getActiveSpan).mockReturnValue(mockSpan as any);
+
+      const mockStorage = createMockStorage();
+      await storeSpanContext(mockStorage, 'alarm');
+
+      expect(mockStorage.put).toHaveBeenCalledWith('__SENTRY_TRACE_LINK__alarm', {
+        traceId: 'abc123def456789012345678901234ab',
+        spanId: '1234567890abcdef',
+        sampled: true,
+      });
+    });
+
+    it('stores span context with sampled=false when traceFlags is NONE', async () => {
+      const mockSpanContext = {
+        traceId: 'abc123def456789012345678901234ab',
+        spanId: '1234567890abcdef',
+        traceFlags: TraceFlags.NONE,
+      };
+      const mockSpan = {
+        spanContext: vi.fn().mockReturnValue(mockSpanContext),
+      };
+      vi.mocked(sentryCore.getActiveSpan).mockReturnValue(mockSpan as any);
+
+      const mockStorage = createMockStorage();
+      await storeSpanContext(mockStorage, 'alarm');
+
+      expect(mockStorage.put).toHaveBeenCalledWith('__SENTRY_TRACE_LINK__alarm', {
+        traceId: 'abc123def456789012345678901234ab',
+        spanId: '1234567890abcdef',
+        sampled: false,
+      });
+    });
+
+    it('does not store when no active span', async () => {
+      vi.mocked(sentryCore.getActiveSpan).mockReturnValue(undefined);
+
+      const mockStorage = createMockStorage();
+      await storeSpanContext(mockStorage, 'alarm');
+
+      expect(mockStorage.put).not.toHaveBeenCalled();
+    });
+
+    it('silently ignores storage errors', async () => {
+      const mockSpanContext = {
+        traceId: 'abc123def456789012345678901234ab',
+        spanId: '1234567890abcdef',
+        traceFlags: TraceFlags.SAMPLED,
+      };
+      const mockSpan = {
+        spanContext: vi.fn().mockReturnValue(mockSpanContext),
+      };
+      vi.mocked(sentryCore.getActiveSpan).mockReturnValue(mockSpan as any);
+
+      const mockStorage = createMockStorage();
+      mockStorage.put = vi.fn().mockRejectedValue(new Error('Storage quota exceeded'));
+
+      await expect(storeSpanContext(mockStorage, 'alarm')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getStoredSpanContext', () => {
+    it('retrieves stored span context', async () => {
+      const storedContext = {
+        traceId: 'abc123def456789012345678901234ab',
+        spanId: '1234567890abcdef',
+        sampled: true,
+      };
+      const mockStorage = createMockStorage();
+      mockStorage.get = vi.fn().mockResolvedValue(storedContext);
+
+      const result = await getStoredSpanContext(mockStorage, 'alarm');
+
+      expect(mockStorage.get).toHaveBeenCalledWith('__SENTRY_TRACE_LINK__alarm');
+      expect(result).toEqual(storedContext);
+    });
+
+    it('returns undefined when no stored context', async () => {
+      const mockStorage = createMockStorage();
+      mockStorage.get = vi.fn().mockResolvedValue(undefined);
+
+      const result = await getStoredSpanContext(mockStorage, 'alarm');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when storage throws', async () => {
+      const mockStorage = createMockStorage();
+      mockStorage.get = vi.fn().mockRejectedValue(new Error('Storage error'));
+
+      const result = await getStoredSpanContext(mockStorage, 'alarm');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('buildSpanLinks', () => {
+    it('builds span links with SAMPLED traceFlags when sampled is true', () => {
+      const storedContext = {
+        traceId: 'abc123def456789012345678901234ab',
+        spanId: '1234567890abcdef',
+        sampled: true,
+      };
+
+      const links = buildSpanLinks(storedContext);
+
+      expect(links).toHaveLength(1);
+      expect(links[0]).toEqual({
+        context: {
+          traceId: 'abc123def456789012345678901234ab',
+          spanId: '1234567890abcdef',
+          traceFlags: TraceFlags.SAMPLED,
+        },
+        attributes: {
+          'sentry.link.type': 'previous_trace',
+        },
+      });
+    });
+
+    it('builds span links with NONE traceFlags when sampled is false', () => {
+      const storedContext = {
+        traceId: 'abc123def456789012345678901234ab',
+        spanId: '1234567890abcdef',
+        sampled: false,
+      };
+
+      const links = buildSpanLinks(storedContext);
+
+      expect(links).toHaveLength(1);
+      expect(links[0]).toEqual({
+        context: {
+          traceId: 'abc123def456789012345678901234ab',
+          spanId: '1234567890abcdef',
+          traceFlags: TraceFlags.NONE,
+        },
+        attributes: {
+          'sentry.link.type': 'previous_trace',
+        },
+      });
+    });
+  });
+});
+
+function createMockStorage(): any {
+  return {
+    get: vi.fn().mockResolvedValue(undefined),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(false),
+    list: vi.fn().mockResolvedValue(new Map()),
+    getAlarm: vi.fn().mockResolvedValue(null),
+    setAlarm: vi.fn().mockResolvedValue(undefined),
+    deleteAlarm: vi.fn().mockResolvedValue(undefined),
+    deleteAll: vi.fn().mockResolvedValue(undefined),
+    sync: vi.fn().mockResolvedValue(undefined),
+    transaction: vi.fn().mockImplementation(async (cb: () => unknown) => cb()),
+    sql: {
+      exec: vi.fn(),
+    },
+  };
+}

--- a/packages/cloudflare/test/wrapMethodWithSentry.test.ts
+++ b/packages/cloudflare/test/wrapMethodWithSentry.test.ts
@@ -32,6 +32,7 @@ vi.mock('@sentry/core', async importOriginal => {
     withIsolationScope: vi.fn((callback: (scope: unknown) => unknown) => callback(createMockScope())),
     withScope: vi.fn((callback: (scope: unknown) => unknown) => callback(createMockScope())),
     startSpan: vi.fn((opts, callback) => callback(createMockSpan())),
+    startNewTrace: vi.fn(callback => callback()),
     captureException: vi.fn(),
     flush: vi.fn().mockResolvedValue(true),
     getActiveSpan: vi.fn(),
@@ -51,6 +52,7 @@ function createMockSpan() {
   return {
     setAttribute: vi.fn(),
     setAttributes: vi.fn(),
+    addLinks: vi.fn(),
     spanContext: vi.fn().mockReturnValue({
       traceId: 'test-trace-id-12345678901234567890',
       spanId: 'test-span-id',
@@ -82,7 +84,7 @@ describe('wrapMethodWithSentry', () => {
   });
 
   describe('basic wrapping', () => {
-    it('wraps a sync method and returns its result', () => {
+    it('wraps a sync method and returns its result synchronously (not a Promise)', () => {
       const handler = vi.fn().mockReturnValue('sync-result');
       const options = {
         options: {},
@@ -90,9 +92,44 @@ describe('wrapMethodWithSentry', () => {
       };
 
       const wrapped = wrapMethodWithSentry(options, handler);
-      wrapped();
+      const result = wrapped();
 
       expect(handler).toHaveBeenCalled();
+      expect(result).not.toBeInstanceOf(Promise);
+      expect(result).toBe('sync-result');
+    });
+
+    it('wraps a sync method with spanName and preserves sync behavior', () => {
+      const handler = vi.fn().mockReturnValue('sync-result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+        spanName: 'test-span',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      const result = wrapped();
+
+      expect(handler).toHaveBeenCalled();
+      expect(result).not.toBeInstanceOf(Promise);
+      expect(result).toBe('sync-result');
+    });
+
+    it('wraps a sync method with startNewTrace and preserves sync behavior', () => {
+      const handler = vi.fn().mockReturnValue('sync-result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+        spanName: 'test-span',
+        startNewTrace: true,
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      const result = wrapped();
+
+      expect(handler).toHaveBeenCalled();
+      expect(result).not.toBeInstanceOf(Promise);
+      expect(result).toBe('sync-result');
     });
 
     it('wraps an async method and returns a promise', async () => {
@@ -103,9 +140,42 @@ describe('wrapMethodWithSentry', () => {
       };
 
       const wrapped = wrapMethodWithSentry(options, handler);
-      await wrapped();
+      const result = wrapped();
 
+      expect(result).toBeInstanceOf(Promise);
+      await expect(result).resolves.toBe('async-result');
       expect(handler).toHaveBeenCalled();
+    });
+
+    it('does not change sync/async behavior when linkPreviousTrace is true (links are set via waitUntil)', () => {
+      const handler = vi.fn().mockReturnValue('sync-result');
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(undefined),
+        put: vi.fn().mockResolvedValue(undefined),
+      };
+      const waitUntilPromises: Promise<void>[] = [];
+      const context = {
+        waitUntil: vi.fn((p: Promise<void>) => waitUntilPromises.push(p)),
+        originalStorage: mockStorage,
+      } as any;
+
+      const options = {
+        options: {},
+        context,
+        spanName: 'alarm',
+        startNewTrace: true,
+        linkPreviousTrace: true,
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      const result = wrapped();
+
+      // linkPreviousTrace does not make the result async - links are set via waitUntil
+      expect(result).not.toBeInstanceOf(Promise);
+      expect(result).toBe('sync-result');
+
+      // The link fetching happens via waitUntil, not blocking the response
+      expect(context.waitUntil).toHaveBeenCalled();
     });
 
     it('marks handler as instrumented', () => {
@@ -225,6 +295,203 @@ describe('wrapMethodWithSentry', () => {
           handled: false,
         },
       });
+    });
+  });
+
+  describe('startNewTrace option', () => {
+    it('uses withIsolationScope when startNewTrace is true', async () => {
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+        startNewTrace: true,
+        spanName: 'alarm',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      expect(sentryCore.withIsolationScope).toHaveBeenCalled();
+    });
+
+    it('uses startNewTrace when startNewTrace is true and spanName is set', async () => {
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+        startNewTrace: true,
+        spanName: 'alarm',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      expect(sentryCore.startNewTrace).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('does not use startNewTrace when startNewTrace is false', async () => {
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+        startNewTrace: false,
+        spanName: 'test-span',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      expect(sentryCore.startNewTrace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('linkPreviousTrace option', () => {
+    it('retrieves stored span context when linkPreviousTrace is true', async () => {
+      const storedContext = {
+        traceId: 'previous-trace-id-1234567890123456',
+        spanId: 'previous-span-id',
+      };
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(storedContext),
+        put: vi.fn().mockResolvedValue(undefined),
+      };
+      const context = {
+        waitUntil: vi.fn(),
+        originalStorage: mockStorage,
+      } as any;
+
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context,
+        startNewTrace: true,
+        linkPreviousTrace: true,
+        spanName: 'alarm',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      expect(mockStorage.get).toHaveBeenCalledWith('__SENTRY_TRACE_LINK__alarm');
+    });
+
+    it('builds span links from stored context', async () => {
+      const storedContext = {
+        traceId: 'previous-trace-id-1234567890123456',
+        spanId: 'previous-span-id',
+      };
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(storedContext),
+        put: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const mockSpan = createMockSpan();
+      vi.mocked(sentryCore.startSpan).mockImplementation((opts, callback) => callback(mockSpan as any));
+
+      const waitUntilPromises: Promise<void>[] = [];
+      const context = {
+        waitUntil: vi.fn((p: Promise<void>) => waitUntilPromises.push(p)),
+        originalStorage: mockStorage,
+      } as any;
+
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context,
+        startNewTrace: true,
+        linkPreviousTrace: true,
+        spanName: 'alarm',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      // Wait for waitUntil promises to resolve (setSpanLinks is called via waitUntil)
+      await Promise.all(waitUntilPromises);
+
+      // addLinks should be called on the span with the stored context
+      expect(mockSpan.addLinks).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            context: expect.objectContaining({
+              traceId: 'previous-trace-id-1234567890123456',
+              spanId: 'previous-span-id',
+            }),
+            attributes: { 'sentry.link.type': 'previous_trace' },
+          }),
+        ]),
+      );
+    });
+
+    it('stores span context after execution when linkPreviousTrace is true', async () => {
+      vi.mocked(sentryCore.getActiveSpan).mockReturnValue({
+        spanContext: vi.fn().mockReturnValue({
+          traceId: 'current-trace-id-123456789012345678',
+          spanId: 'current-span-id',
+        }),
+      } as any);
+
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(undefined),
+        put: vi.fn().mockResolvedValue(undefined),
+      };
+      const context = {
+        waitUntil: vi.fn(),
+        originalStorage: mockStorage,
+      } as any;
+
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context,
+        startNewTrace: true,
+        linkPreviousTrace: true,
+        spanName: 'alarm',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      // Should store span context for future linking
+      expect(mockStorage.put).toHaveBeenCalledWith('__SENTRY_TRACE_LINK__alarm', expect.any(Object));
+    });
+
+    it('does not store span context when linkPreviousTrace is false', async () => {
+      vi.mocked(sentryCore.getActiveSpan).mockReturnValue({
+        spanContext: vi.fn().mockReturnValue({
+          traceId: 'current-trace-id-123456789012345678',
+          spanId: 'current-span-id',
+        }),
+      } as any);
+
+      const mockStorage = {
+        get: vi.fn().mockResolvedValue(undefined),
+        put: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const waitUntilPromises: Promise<void>[] = [];
+      const context = {
+        waitUntil: vi.fn((p: Promise<void>) => waitUntilPromises.push(p)),
+        originalStorage: mockStorage,
+      } as any;
+
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context,
+        startNewTrace: true,
+        linkPreviousTrace: false,
+        spanName: 'alarm',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      // Wait for all waitUntil promises to resolve
+      await Promise.all(waitUntilPromises);
+
+      // Should NOT store span context when linkPreviousTrace is false
+      expect(mockStorage.put).not.toHaveBeenCalledWith('__SENTRY_TRACE_LINK__alarm', expect.any(Object));
     });
   });
 

--- a/packages/cloudflare/test/wrapMethodWithSentry.test.ts
+++ b/packages/cloudflare/test/wrapMethodWithSentry.test.ts
@@ -147,7 +147,7 @@ describe('wrapMethodWithSentry', () => {
       expect(handler).toHaveBeenCalled();
     });
 
-    it('does not change sync/async behavior when linkPreviousTrace is true (links are set via waitUntil)', () => {
+    it('does not change sync/async behavior when startNewTrace is true (links are set via waitUntil)', () => {
       const handler = vi.fn().mockReturnValue('sync-result');
       const mockStorage = {
         get: vi.fn().mockResolvedValue(undefined),
@@ -164,13 +164,12 @@ describe('wrapMethodWithSentry', () => {
         context,
         spanName: 'alarm',
         startNewTrace: true,
-        linkPreviousTrace: true,
       };
 
       const wrapped = wrapMethodWithSentry(options, handler);
       const result = wrapped();
 
-      // linkPreviousTrace does not make the result async - links are set via waitUntil
+      // startNewTrace does not make the result async - links are set via waitUntil
       expect(result).not.toBeInstanceOf(Promise);
       expect(result).toBe('sync-result');
 
@@ -345,8 +344,8 @@ describe('wrapMethodWithSentry', () => {
     });
   });
 
-  describe('linkPreviousTrace option', () => {
-    it('retrieves stored span context when linkPreviousTrace is true', async () => {
+  describe('span linking', () => {
+    it('retrieves stored span context when startNewTrace is true', async () => {
       const storedContext = {
         traceId: 'previous-trace-id-1234567890123456',
         spanId: 'previous-span-id',
@@ -365,7 +364,6 @@ describe('wrapMethodWithSentry', () => {
         options: {},
         context,
         startNewTrace: true,
-        linkPreviousTrace: true,
         spanName: 'alarm',
       };
 
@@ -399,7 +397,6 @@ describe('wrapMethodWithSentry', () => {
         options: {},
         context,
         startNewTrace: true,
-        linkPreviousTrace: true,
         spanName: 'alarm',
       };
 
@@ -423,7 +420,7 @@ describe('wrapMethodWithSentry', () => {
       );
     });
 
-    it('stores span context after execution when linkPreviousTrace is true', async () => {
+    it('stores span context after execution when startNewTrace is true', async () => {
       vi.mocked(sentryCore.getActiveSpan).mockReturnValue({
         spanContext: vi.fn().mockReturnValue({
           traceId: 'current-trace-id-123456789012345678',
@@ -445,7 +442,6 @@ describe('wrapMethodWithSentry', () => {
         options: {},
         context,
         startNewTrace: true,
-        linkPreviousTrace: true,
         spanName: 'alarm',
       };
 
@@ -456,7 +452,7 @@ describe('wrapMethodWithSentry', () => {
       expect(mockStorage.put).toHaveBeenCalledWith('__SENTRY_TRACE_LINK__alarm', expect.any(Object));
     });
 
-    it('does not store span context when linkPreviousTrace is false', async () => {
+    it('does not store span context when startNewTrace is false', async () => {
       vi.mocked(sentryCore.getActiveSpan).mockReturnValue({
         spanContext: vi.fn().mockReturnValue({
           traceId: 'current-trace-id-123456789012345678',
@@ -479,8 +475,7 @@ describe('wrapMethodWithSentry', () => {
       const options = {
         options: {},
         context,
-        startNewTrace: true,
-        linkPreviousTrace: false,
+        startNewTrace: false,
         spanName: 'alarm',
       };
 
@@ -490,7 +485,7 @@ describe('wrapMethodWithSentry', () => {
       // Wait for all waitUntil promises to resolve
       await Promise.all(waitUntilPromises);
 
-      // Should NOT store span context when linkPreviousTrace is false
+      // Should NOT store span context when startNewTrace is false
       expect(mockStorage.put).not.toHaveBeenCalledWith('__SENTRY_TRACE_LINK__alarm', expect.any(Object));
     });
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -485,6 +485,7 @@ export type {
 } from './types-hoist/span';
 export type { SpanStatus } from './types-hoist/spanStatus';
 export type { Log, LogSeverityLevel } from './types-hoist/log';
+export type { SpanLink } from './types-hoist/link';
 export type {
   Metric,
   MetricType,


### PR DESCRIPTION
closes #19105 
closes [JS-1604](https://linear.app/getsentry/issue/JS-1604/cloudflare-alarm-split-in-different-traces)

closes #19453
closes [JS-1774](https://linear.app/getsentry/issue/JS-1774/cloudflare-instrument-alarm-api)

This actually splits up [alarms](https://developers.cloudflare.com/durable-objects/api/alarms/) into its own traces and binding them with [span links](https://develop.sentry.dev/sdk/telemetry/traces/span-links/). It also adds the `setAlarm`, `getAlarm` and `deleteAlarm` instrumentation, which is needed to make this work.

The logic works as following. When `setAlarm` is getting called it will store the alarm inside the durable object. Once the `alarm` is being executed the previous trace link will be retrieved via `ctx.storage.get` and then set as span link. Using the durable object itself as storage between alarms is even used on [Cloudflare's alarm page](https://developers.cloudflare.com/durable-objects/api/alarms/#scheduling-multiple-events-with-a-single-alarm).

Also it is worth to mention that only 1 alarm at a time can happen, so it is safe to use a fixed key for the previous trace. I implemented the trace links, so they could be reused in the future for other methods as well, so they are not exclusively for alarms.   

Example alarm that triggers 3 new alarms to show the span links: https://sentry-sdks.sentry.io/explore/traces/trace/1ef3f388601b425d96d1ed9de0d5b7b4/