### PR TITLE
chore(ci): Add `environment` to triage action

### DIFF
--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   triage-issue:
     runs-on: ubuntu-latest
+    environment: ci-triage
     permissions:
       contents: read
       issues: read


### PR DESCRIPTION
Adds environment to the action so the secret can be picked up correctly.

Closes #19376 (added automatically)