### PR TITLE
chore(ci): Add `id-token: write` permission to triage workflow

### DIFF
--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -24,6 +24,7 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
+      id-token: write
     # Only run for Bug or Feature issues (automatic mode)
     if: |
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
The `claude-code-action@v1` requires OIDC token access to authenticate. Without the `id-token: write` permission, the workflow fails with "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable".


Closes #19383 (added automatically)