### PR TITLE
ci(triage-skill): Allow `Write` and remove `rm` permission

### DIFF
--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -120,10 +120,10 @@ If the issue is complex or the fix is unclear, skip this section and instead not
 
   The script reads `LINEAR_CLIENT_ID` and `LINEAR_CLIENT_SECRET` from environment variables (set from GitHub Actions secrets), obtains an OAuth token, checks for duplicate triage comments, and posts the comment.
   1. **Write the report body to a file** using the Write tool (not Bash). This keeps markdown completely out of shell.
-     - **In CI:** Write to `triage_report.md` in the repository root. The CI sandbox only allows writes inside the working directory; `/tmp` and Bash output redirection are blocked.
-     - **Locally:** You may use `/tmp/triage_report.md` or `triage_report.md` in the repo root.
+     You may use `/tmp/triage_report.md` or `triage_report.md` in the repo root to write the file.
 
   2. **Run the script:**
+     Be aware that the directory structure and script path may differ between local and CI environments. Adjust accordingly.
 
      ```bash
      python3 .claude/skills/triage-issue/assets/post_linear_comment.py "JS-XXXX" "triage_report.md"
@@ -131,15 +131,14 @@ If the issue is complex or the fix is unclear, skip this section and instead not
 
      (Use the same path you wrote to: `triage_report.md` in CI, or `/tmp/triage_report.md` locally if you used that.)
 
-  If the script fails (non-zero exit), fall back to printing the full report to the terminal.
+     If the script fails (non-zero exit), fall back to printing the full report to the terminal. Print the current working directory so it's clear where the script was run.
 
-  Clean up after:
+  3. **Not CI? Cleanup**
+     When run locally, without `--ci` flag, clean up after:
 
-  ```bash
-  rm -f triage_report.md
-  ```
-
-  (In CI only `triage_report.md` in the repo root is writable; use that path for write, script, and rm.)
+     ```bash
+     rm -f tmp/triage_report.md
+     ```
 
 ## Important Rules
 

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -68,4 +68,4 @@ jobs:
             /triage-issue ${{ steps.parse-issue.outputs.issue_number }} --ci
             IMPORTANT: Do NOT wait for approval.
           claude_args: |
-            --max-turns 20 --allowedTools "Write(~/triage_report.md),Bash(gh api *),Bash(gh pr list *),Bash(python3 .claude/skills/triage-issue/assets/post_linear_comment.py *),Bash(rm -f triage_report.md)"
+            --max-turns 20 --allowedTools "Write,Bash(gh api *),Bash(gh pr list *),Bash(python3 .claude/skills/triage-issue/assets/post_linear_comment.py *)"


### PR DESCRIPTION
We can still adjust this further, but right now the CI has problems saving the file. It's fine to allow `Wrtie`. 


Closes #19398 (added automatically)