### PR TITLE
feat(cloudflare): Instrument async KV API

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers/src/index.ts
@@ -20,17 +20,26 @@ class MyDurableObjectBase extends DurableObject<Env> {
   }
 
   async fetch(request: Request) {
-    const { pathname } = new URL(request.url);
-    switch (pathname) {
+    const url = new URL(request.url);
+    switch (url.pathname) {
       case '/throwException': {
         await this.throwException();
         break;
       }
-      case '/ws':
+      case '/ws': {
         const webSocketPair = new WebSocketPair();
         const [client, server] = Object.values(webSocketPair);
         this.ctx.acceptWebSocket(server);
         return new Response(null, { status: 101, webSocket: client });
+      }
+      case '/storage/put': {
+        await this.ctx.storage.put('test-key', 'test-value');
+        return new Response('Stored');
+      }
+      case '/storage/get': {
+        const value = await this.ctx.storage.get('test-key');
+        return new Response(`Got: ${value}`);
+      }
     }
     return new Response('DO is fine');
   }

--- a/packages/cloudflare/src/instrumentations/instrumentDurableObjectStorage.ts
+++ b/packages/cloudflare/src/instrumentations/instrumentDurableObjectStorage.ts
@@ -1,0 +1,50 @@
+import type { DurableObjectStorage } from '@cloudflare/workers-types';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+
+const STORAGE_METHODS_TO_INSTRUMENT = ['get', 'put', 'delete', 'list'] as const;
+
+type StorageMethod = (typeof STORAGE_METHODS_TO_INSTRUMENT)[number];
+
+/**
+ * Instruments DurableObjectStorage methods with Sentry spans.
+ *
+ * Wraps the following async methods:
+ * - get, put, delete, list (KV API)
+ *
+ * @param storage - The DurableObjectStorage instance to instrument
+ * @returns An instrumented DurableObjectStorage instance
+ */
+export function instrumentDurableObjectStorage(storage: DurableObjectStorage): DurableObjectStorage {
+  return new Proxy(storage, {
+    get(target, prop, receiver) {
+      const original = Reflect.get(target, prop, receiver);
+
+      if (typeof original !== 'function') {
+        return original;
+      }
+
+      const methodName = prop as string;
+      if (!STORAGE_METHODS_TO_INSTRUMENT.includes(methodName as StorageMethod)) {
+        return (original as (...args: unknown[]) => unknown).bind(target);
+      }
+
+      return function (this: unknown, ...args: unknown[]) {
+        return startSpan(
+          {
+            // Use underscore naming to match Cloudflare's native instrumentation (e.g., "durable_object_storage_get")
+            name: `durable_object_storage_${methodName}`,
+            op: 'db',
+            attributes: {
+              [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
+              'db.system.name': 'cloudflare.durable_object.storage',
+              'db.operation.name': methodName,
+            },
+          },
+          () => {
+            return (original as (...args: unknown[]) => unknown).apply(target, args);
+          },
+        );
+      };
+    },
+  });
+}

--- a/packages/cloudflare/test/instrumentContext.test.ts
+++ b/packages/cloudflare/test/instrumentContext.test.ts
@@ -46,6 +46,57 @@ describe('instrumentContext', () => {
     const instrumented = instrumentContext(context);
     expect(instrumented[s]).toBe(context[s]);
   });
+
+  describe('DurableObjectState storage instrumentation', () => {
+    it('instruments storage property', () => {
+      const mockStorage = createMockStorage();
+      const context = makeDurableObjectStateMock(mockStorage);
+      const instrumented = instrumentContext(context);
+
+      // The storage property should be instrumented (wrapped)
+      expect(instrumented.storage).toBeDefined();
+      // The instrumented storage should not be the same reference
+      expect(instrumented.storage).not.toBe(mockStorage);
+    });
+
+    it('exposes originalStorage as the uninstrumented storage', () => {
+      const mockStorage = createMockStorage();
+      const context = makeDurableObjectStateMock(mockStorage);
+      const instrumented = instrumentContext(context);
+
+      // originalStorage should be the original uninstrumented storage
+      expect(instrumented.originalStorage).toBe(mockStorage);
+    });
+
+    it('originalStorage is not enumerable', () => {
+      const mockStorage = createMockStorage();
+      const context = makeDurableObjectStateMock(mockStorage);
+      const instrumented = instrumentContext(context);
+
+      // originalStorage should not appear in Object.keys
+      expect(Object.keys(instrumented)).not.toContain('originalStorage');
+    });
+
+    it('returns instrumented storage lazily', () => {
+      const mockStorage = createMockStorage();
+      const context = makeDurableObjectStateMock(mockStorage);
+      const instrumented = instrumentContext(context);
+
+      // Access storage twice to ensure memoization
+      const storage1 = instrumented.storage;
+      const storage2 = instrumented.storage;
+
+      expect(storage1).toBe(storage2);
+    });
+
+    it('handles context without storage property', () => {
+      const context = makeExecutionContextMock();
+      const instrumented = instrumentContext(context) as any;
+
+      // Should not have originalStorage if no storage property
+      expect(instrumented.originalStorage).toBeUndefined();
+    });
+  });
 });
 
 function makeExecutionContextMock<T extends ExecutionContext>() {
@@ -53,4 +104,40 @@ function makeExecutionContextMock<T extends ExecutionContext>() {
     waitUntil: vi.fn(),
     passThroughOnException: vi.fn(),
   } as unknown as Mocked<T>;
+}
+
+function makeDurableObjectStateMock(storage?: any) {
+  return {
+    waitUntil: vi.fn(),
+    blockConcurrencyWhile: vi.fn(),
+    id: { toString: () => 'test-id', equals: vi.fn(), name: 'test' },
+    storage: storage || createMockStorage(),
+    acceptWebSocket: vi.fn(),
+    getWebSockets: vi.fn().mockReturnValue([]),
+    setWebSocketAutoResponse: vi.fn(),
+    getWebSocketAutoResponse: vi.fn(),
+    getWebSocketAutoResponseTimestamp: vi.fn(),
+    setHibernatableWebSocketEventTimeout: vi.fn(),
+    getHibernatableWebSocketEventTimeout: vi.fn(),
+    getTags: vi.fn().mockReturnValue([]),
+    abort: vi.fn(),
+  } as any;
+}
+
+function createMockStorage(): any {
+  return {
+    get: vi.fn().mockResolvedValue(undefined),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(false),
+    list: vi.fn().mockResolvedValue(new Map()),
+    getAlarm: vi.fn().mockResolvedValue(null),
+    setAlarm: vi.fn().mockResolvedValue(undefined),
+    deleteAlarm: vi.fn().mockResolvedValue(undefined),
+    deleteAll: vi.fn().mockResolvedValue(undefined),
+    sync: vi.fn().mockResolvedValue(undefined),
+    transaction: vi.fn().mockImplementation(async (cb: () => unknown) => cb()),
+    sql: {
+      exec: vi.fn(),
+    },
+  };
 }

--- a/packages/cloudflare/test/instrumentDurableObjectStorage.test.ts
+++ b/packages/cloudflare/test/instrumentDurableObjectStorage.test.ts
@@ -1,0 +1,212 @@
+import * as sentryCore from '@sentry/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { instrumentDurableObjectStorage } from '../src/instrumentations/instrumentDurableObjectStorage';
+
+vi.mock('@sentry/core', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    startSpan: vi.fn((opts, callback) => callback()),
+    getActiveSpan: vi.fn(),
+  };
+});
+
+describe('instrumentDurableObjectStorage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('get', () => {
+    it('instruments get with single key', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.get('myKey');
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_get',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'get',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+
+    it('instruments get with array of keys', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.get(['key1', 'key2', 'key3']);
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_get',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'get',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('put', () => {
+    it('instruments put with single key', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.put('myKey', 'myValue');
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_put',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'put',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+
+    it('instruments put with object entries', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.put({ key1: 'val1', key2: 'val2' });
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_put',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'put',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('instruments delete with single key', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.delete('myKey');
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_delete',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'delete',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+
+    it('instruments delete with array of keys', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.delete(['key1', 'key2']);
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_delete',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'delete',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('list', () => {
+    it('instruments list', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.list();
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        {
+          name: 'durable_object_storage_list',
+          op: 'db',
+          attributes: expect.objectContaining({
+            'db.operation.name': 'list',
+          }),
+        },
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('non-instrumented methods', () => {
+    it('does not instrument alarm methods', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.getAlarm();
+      await instrumented.setAlarm(Date.now() + 1000);
+      await instrumented.deleteAlarm();
+
+      expect(sentryCore.startSpan).not.toHaveBeenCalled();
+    });
+
+    it('does not instrument deleteAll, sync, transaction', async () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await instrumented.deleteAll();
+      await instrumented.sync();
+      await instrumented.transaction(async txn => txn);
+
+      expect(sentryCore.startSpan).not.toHaveBeenCalled();
+    });
+
+    it('does not instrument sql property', () => {
+      const mockStorage = createMockStorage();
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      // sql is a property, not a method we instrument
+      expect(instrumented.sql).toBe(mockStorage.sql);
+    });
+  });
+
+  describe('error handling', () => {
+    it('propagates errors from storage operations', async () => {
+      const mockStorage = createMockStorage();
+      mockStorage.get = vi.fn().mockRejectedValue(new Error('Storage error'));
+      const instrumented = instrumentDurableObjectStorage(mockStorage);
+
+      await expect(instrumented.get('myKey')).rejects.toThrow('Storage error');
+    });
+  });
+});
+
+function createMockStorage(): any {
+  return {
+    get: vi.fn().mockResolvedValue(undefined),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(false),
+    list: vi.fn().mockResolvedValue(new Map()),
+    getAlarm: vi.fn().mockResolvedValue(null),
+    setAlarm: vi.fn().mockResolvedValue(undefined),
+    deleteAlarm: vi.fn().mockResolvedValue(undefined),
+    deleteAll: vi.fn().mockResolvedValue(undefined),
+    sync: vi.fn().mockResolvedValue(undefined),
+    transaction: vi.fn().mockImplementation(async (cb: () => unknown) => cb()),
+    sql: {
+      exec: vi.fn(),
+    },
+  };
+}

--- a/packages/cloudflare/test/wrapMethodWithSentry.test.ts
+++ b/packages/cloudflare/test/wrapMethodWithSentry.test.ts
@@ -1,0 +1,308 @@
+import * as sentryCore from '@sentry/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isInstrumented } from '../src/instrument';
+import { wrapMethodWithSentry } from '../src/wrapMethodWithSentry';
+
+// Mock the SDK init to avoid actual SDK initialization
+vi.mock('../src/sdk', () => ({
+  init: vi.fn(() => ({
+    getOptions: () => ({}),
+    on: vi.fn(),
+  })),
+}));
+
+// Mock sentry/core functions
+vi.mock('@sentry/core', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getClient: vi.fn(),
+    withIsolationScope: vi.fn((callback: (scope: any) => any) => callback(createMockScope())),
+    withScope: vi.fn((callback: (scope: any) => any) => callback(createMockScope())),
+    startSpan: vi.fn((opts, callback) => callback(createMockSpan())),
+    captureException: vi.fn(),
+    flush: vi.fn().mockResolvedValue(true),
+    getActiveSpan: vi.fn(),
+  };
+});
+
+function createMockScope() {
+  return {
+    getClient: vi.fn(),
+    setClient: vi.fn(),
+  };
+}
+
+function createMockSpan() {
+  return {
+    setAttribute: vi.fn(),
+    setAttributes: vi.fn(),
+    spanContext: vi.fn().mockReturnValue({
+      traceId: 'test-trace-id-12345678901234567890',
+      spanId: 'test-span-id',
+    }),
+  };
+}
+
+function createMockContext(options: { hasStorage?: boolean; hasWaitUntil?: boolean } = {}) {
+  const mockStorage = {
+    get: vi.fn().mockResolvedValue(undefined),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(false),
+  };
+
+  return {
+    waitUntil: options.hasWaitUntil !== false ? vi.fn() : undefined,
+    storage: options.hasStorage !== false ? mockStorage : undefined,
+    originalStorage: options.hasStorage !== false ? mockStorage : undefined,
+  } as any;
+}
+
+describe('wrapMethodWithSentry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('basic wrapping', () => {
+    it('wraps a sync method and returns its result', () => {
+      const handler = vi.fn().mockReturnValue('sync-result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      wrapped();
+
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it('wraps an async method and returns a promise', async () => {
+      const handler = vi.fn().mockResolvedValue('async-result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it('marks handler as instrumented', () => {
+      const handler = vi.fn();
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      expect(isInstrumented(handler)).toBeUndefined();
+
+      wrapMethodWithSentry(options, handler);
+
+      expect(isInstrumented(handler)).toBe(true);
+    });
+
+    it('does not re-wrap already instrumented handler', () => {
+      const handler = vi.fn();
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped1 = wrapMethodWithSentry(options, handler);
+      const wrapped2 = wrapMethodWithSentry(options, wrapped1);
+
+      // Should return the same wrapped function
+      expect(wrapped2).toBe(wrapped1);
+    });
+
+    it('does not mark handler when noMark is true', () => {
+      const handler = vi.fn();
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      wrapMethodWithSentry(options, handler, undefined, true);
+
+      expect(isInstrumented(handler)).toBeFalsy();
+    });
+  });
+
+  describe('span creation', () => {
+    it('creates span with spanName when provided', async () => {
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+        spanName: 'test-span',
+        spanOp: 'test-op',
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      expect(sentryCore.startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'test-span',
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('does not create span when spanName is not provided', async () => {
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      // startSpan should not be called when no spanName is provided
+      expect(sentryCore.startSpan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('captures exceptions from sync methods', async () => {
+      const error = new Error('Test sync error');
+      const handler = vi.fn().mockImplementation(() => {
+        throw error;
+      });
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+
+      await expect(async () => wrapped()).rejects.toThrow('Test sync error');
+      expect(sentryCore.captureException).toHaveBeenCalledWith(error, {
+        mechanism: {
+          type: 'auto.faas.cloudflare.durable_object',
+          handled: false,
+        },
+      });
+    });
+
+    it('captures exceptions from async methods', async () => {
+      const error = new Error('Test async error');
+      const handler = vi.fn().mockRejectedValue(error);
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+
+      await expect(wrapped()).rejects.toThrow('Test async error');
+      expect(sentryCore.captureException).toHaveBeenCalledWith(error, {
+        mechanism: {
+          type: 'auto.faas.cloudflare.durable_object',
+          handled: false,
+        },
+      });
+    });
+  });
+
+  describe('callback execution', () => {
+    it('executes callback before handler', async () => {
+      const callOrder: string[] = [];
+      const handler = vi.fn().mockImplementation(() => {
+        callOrder.push('handler');
+        return 'result';
+      });
+      const callback = vi.fn().mockImplementation(() => {
+        callOrder.push('callback');
+      });
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler, callback);
+      await wrapped('arg1', 'arg2');
+
+      expect(callback).toHaveBeenCalledWith('arg1', 'arg2');
+      expect(callOrder).toEqual(['callback', 'handler']);
+    });
+  });
+
+  describe('waitUntil flush', () => {
+    it('calls waitUntil with flush when context has waitUntil', async () => {
+      const waitUntil = vi.fn();
+      const context = {
+        waitUntil,
+        originalStorage: undefined,
+      } as any;
+
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context,
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped();
+
+      expect(waitUntil).toHaveBeenCalled();
+      expect(sentryCore.flush).toHaveBeenCalledWith(2000);
+    });
+
+    it('handles missing waitUntil gracefully', async () => {
+      const context = {
+        originalStorage: undefined,
+      } as any;
+
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context,
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+
+      // Should not throw
+      await expect(wrapped()).resolves.toBeDefined();
+    });
+  });
+
+  describe('argument passing', () => {
+    it('passes arguments to handler', async () => {
+      const handler = vi.fn().mockResolvedValue('result');
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped('arg1', 'arg2', { key: 'value' });
+
+      expect(handler).toHaveBeenCalledWith('arg1', 'arg2', { key: 'value' });
+    });
+
+    it('preserves this context', async () => {
+      const thisArg = { name: 'test-context' };
+      const handler = vi.fn(function (this: any) {
+        return this.name;
+      });
+      const options = {
+        options: {},
+        context: createMockContext(),
+      };
+
+      const wrapped = wrapMethodWithSentry(options, handler);
+      await wrapped.call(thisArg);
+
+      expect(handler.mock.instances[0]).toBe(thisArg);
+    });
+  });
+});


### PR DESCRIPTION
closes #19384
closes [JS-1744](https://linear.app/getsentry/issue/JS-1744/cloudflare-instrument-async-kv-api)

With that we start to instrument DO objects starting with the Async KV API.

Cloudflare is instrumenting these with underlines between: `durable_object_storage_get`, without any more information to it. 

In the future to make them a little more useful we could store the keys as span attributes on it with `db.cloudflare.durable_object.storage.key` or `db.cloudflare.durable_object.storage.keys`. First we have to add them to our [semantic conventions](https://getsentry.github.io/sentry-conventions/attributes/) though