### PR TITLE
tests(langchain): Fix langchain v1 internal error tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/scenario-init-chat-model.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/scenario-init-chat-model.mjs
@@ -89,17 +89,17 @@ async function run() {
     ]);
 
     // Test 3: Error handling
-    //   try {
-    //     const errorModel = await initChatModel('error-model', {
-    //       modelProvider: 'openai',
-    //       configuration: {
-    //         baseURL: baseUrl,
-    //       },
-    //     });
-    //     await errorModel.invoke('This will fail');
-    //   } catch {
-    //     // Expected error
-    //   }
+    try {
+      const errorModel = await initChatModel('error-model', {
+        modelProvider: 'openai',
+        configuration: {
+          baseURL: baseUrl,
+        },
+      });
+      await errorModel.invoke('This will fail');
+    } catch {
+      // Expected error
+    }
   });
 
   await Sentry.flush(2000);

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/scenario.mjs
@@ -87,19 +87,19 @@ async function run() {
     ]);
 
     // Test 3: Error handling
-    //   const errorModel = new ChatAnthropic({
-    //     model: 'error-model',
-    //     apiKey: 'mock-api-key',
-    //     clientOptions: {
-    //       baseURL: baseUrl,
-    //     },
-    //   });
+    const errorModel = new ChatAnthropic({
+      model: 'error-model',
+      apiKey: 'mock-api-key',
+      clientOptions: {
+        baseURL: baseUrl,
+      },
+    });
 
-    //   try {
-    //     await errorModel.invoke('This will fail');
-    //   } catch {
-    //     // Expected error
-    //   }
+    try {
+      await errorModel.invoke('This will fail');
+    } catch {
+      // Expected error
+    }
   });
 
   await Sentry.flush(2000);

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/test.ts
@@ -78,19 +78,19 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
         status: 'ok',
       }),
       // Third span - error handling
-      // expect.objectContaining({
-      //   data: expect.objectContaining({
-      //     [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'chat',
-      //     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.chat',
-      //     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ai.langchain',
-      //     [GEN_AI_SYSTEM_ATTRIBUTE]: 'anthropic',
-      //     [GEN_AI_REQUEST_MODEL_ATTRIBUTE]: 'error-model',
-      //   }),
-      //   description: 'invoke_agent error-model',
-      //   op: 'gen_ai.chat',
-      //   origin: 'auto.ai.langchain',
-      //   status: 'internal_error',
-      // }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'chat',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.chat',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ai.langchain',
+          [GEN_AI_SYSTEM_ATTRIBUTE]: 'anthropic',
+          [GEN_AI_REQUEST_MODEL_ATTRIBUTE]: 'error-model',
+        }),
+        description: 'chat error-model',
+        op: 'gen_ai.chat',
+        origin: 'auto.ai.langchain',
+        status: 'internal_error',
+      }),
     ]),
   };
 
@@ -147,20 +147,20 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
         status: 'ok',
       }),
       // Third span - error handling with PII
-      // expect.objectContaining({
-      //   data: expect.objectContaining({
-      //     [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'chat',
-      //     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.chat',
-      //     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ai.langchain',
-      //     [GEN_AI_SYSTEM_ATTRIBUTE]: 'anthropic',
-      //     [GEN_AI_REQUEST_MODEL_ATTRIBUTE]: 'error-model',
-      //     [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: expect.any(String), // Should include messages when recordInputs: true
-      //   }),
-      //   description: 'invoke_agent error-model',
-      //   op: 'gen_ai.chat',
-      //   origin: 'auto.ai.langchain',
-      //   status: 'internal_error',
-      // }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'chat',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.chat',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ai.langchain',
+          [GEN_AI_SYSTEM_ATTRIBUTE]: 'anthropic',
+          [GEN_AI_REQUEST_MODEL_ATTRIBUTE]: 'error-model',
+          [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: expect.any(String), // Should include messages when recordInputs: true
+        }),
+        description: 'chat error-model',
+        op: 'gen_ai.chat',
+        origin: 'auto.ai.langchain',
+        status: 'internal_error',
+      }),
     ]),
   };
 
@@ -453,19 +453,19 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
         status: 'ok',
       }),
       // Third span - error handling
-      // expect.objectContaining({
-      //   data: expect.objectContaining({
-      //     [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'chat',
-      //     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.chat',
-      //     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ai.langchain',
-      //     [GEN_AI_SYSTEM_ATTRIBUTE]: 'openai',
-      //     [GEN_AI_REQUEST_MODEL_ATTRIBUTE]: 'error-model',
-      //   }),
-      //   description: 'invoke_agent error-model',
-      //   op: 'gen_ai.chat',
-      //   origin: 'auto.ai.langchain',
-      //   status: 'internal_error',
-      // }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'chat',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.chat',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ai.langchain',
+          [GEN_AI_SYSTEM_ATTRIBUTE]: 'openai',
+          [GEN_AI_REQUEST_MODEL_ATTRIBUTE]: 'error-model',
+        }),
+        description: 'chat error-model',
+        op: 'gen_ai.chat',
+        origin: 'auto.ai.langchain',
+        status: 'internal_error',
+      }),
     ]),
   };
 


### PR DESCRIPTION
The error tests for langchain v1 were commented out a while back, since they started failing for some reason. I had another look and after getting the attributes up to date they seem to work fine now, so I think we can put them back in.

Closes https://github.com/getsentry/sentry-javascript/issues/18835
