### PR TITLE
chore(repo): Increase number of concurrently running nx tasks

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -65,5 +65,5 @@
   "tui": {
     "autoExit": true
   },
-  "parallel": 10
+  "parallel": 5
 }


### PR DESCRIPTION
After moving from lerna to nx, I noticed we run fewer tasks in parrallel. This PR sets the limit to ~10~ 5. previously, we used the [default value](https://nx.dev/docs/guides/tasks--caching/run-tasks-in-parallel) 3.

If reviewers prefer a different number than ~10~ 5, I'm happy to change it. On my local build this led to good results but mileage may vary.

UPDATE: I reduced the number from 10 to 5 because 10 concurrent tasks produced random test fails on CI. After a bit or research, this most likely relates to memory pressure or CPU starvation, due to many parallel running threads. Vitest and Playwright run tests in multiple threads, so if we multiply this with more concurrently running tests, this produceds a lot of threads, especially in resource-constrained CI runners. We could experiment further with a higher threshold but for now I'd keep 5. If we run into inexplicable test fails, this is the PR we need to revert.

Closes #19444 (added automatically)