### PR TITLE
fix(tanstackstart-react): Add workerd and worker export conditions

### DIFF
--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -19,6 +19,14 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./build/types/index.types.d.ts",
+      "workerd": {
+        "import": "./build/esm/index.server.js",
+        "require": "./build/cjs/index.server.js"
+      },
+      "worker": {
+        "import": "./build/esm/index.server.js",
+        "require": "./build/cjs/index.server.js"
+      },
       "browser": {
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"


### PR DESCRIPTION
## Problem

When deploying a TanStack Start application to Cloudflare Workers, importing `@sentry/tanstackstart-react` causes a build failure.

The `@cloudflare/vite-plugin` configures resolve conditions as `["workerd", "worker", "module", "browser"]` for the SSR environment. Since this package only defines `browser` and `node` conditions, the resolver falls through to `browser`, which points to `index.client.js`. TanStack Start's import-protection plugin denies files matching `**/*.client.*` in the server environment, causing the build to fail.

Related: https://github.com/TanStack/router/pull/6688

## Solution

Add `workerd` and `worker` export conditions to the `.` entry in `package.json`, pointing to `index.server.js` (the same target as the `node` condition). This ensures that bundlers targeting Workers runtimes resolve to the server entry rather than falling through to the `browser` condition.

Users deploying to Cloudflare Workers will need `nodejs_compat` enabled in their wrangler configuration for `@sentry/node` to function correctly at runtime.

A dedicated Cloudflare entrypoint (without `@sentry/node` dependency) will be addressed in a follow-up PR.

## Changed files

| File | Change |
|---|---|
| `packages/tanstackstart-react/package.json` | Add `workerd` and `worker` export conditions pointing to `index.server.js` |