### PR TITLE
chore(triage-action): Fix JSON parsing

### DIFF
--- a/.claude/skills/triage-issue/scripts/write_job_summary.py
+++ b/.claude/skills/triage-issue/scripts/write_job_summary.py
@@ -6,8 +6,10 @@ to stdout as Markdown for GitHub Actions job summary (GITHUB_STEP_SUMMARY).
 Usage:
   python3 write_job_summary.py <path-to-claude-execution-output.json>
 
-Handles single JSON object or NDJSON (one JSON object per line).
-Uses the last object with type "result" when multiple are present.
+The execution file is written by anthropics/claude-code-action as a single
+JSON array of messages (JSON.stringify(messages, null, 2)) at
+$RUNNER_TEMP/claude-execution-output.json. We also support NDJSON (one
+object per line). Uses the last object with type "result" for metrics.
 
 Job summary has a ~1MB limit; raw JSON is truncated if needed to avoid job abort.
 """
@@ -52,17 +54,25 @@ def main() -> int:
             continue
         try:
             obj = json.loads(line)
-            if obj.get("type") == "result":
+            if isinstance(obj, dict) and obj.get("type") == "result":
                 results.append(obj)
+            elif isinstance(obj, list):
+                for item in obj:
+                    if isinstance(item, dict) and item.get("type") == "result":
+                        results.append(item)
         except json.JSONDecodeError:
             continue
 
     if not results:
-        # Try parsing whole content as single JSON
+        # Try parsing whole content as single JSON (object or array)
         try:
             obj = json.loads(content)
-            if obj.get("type") == "result":
+            if isinstance(obj, dict) and obj.get("type") == "result":
                 results = [obj]
+            elif isinstance(obj, list):
+                for item in obj:
+                    if isinstance(item, dict) and item.get("type") == "result":
+                        results.append(item)
         except json.JSONDecodeError:
             pass
 


### PR DESCRIPTION
The file is a single pretty-printed JSON array, `JSON.stringify(messages, null, 2)` ([source code](https://github.com/anthropics/claude-code-action/blob/edd85d61533cbba7b57ed0ca4af1750b1fdfd3c4/base-action/src/run-claude-sdk.ts#L183-L189)), not NDJSON. This script change (treating the parsed root as a list and collecting objects with type === "result") reads it correctly.


This is the the current error output:
```
Traceback (most recent call last):
  File "/home/runner/work/sentry-javascript/sentry-javascript/.claude/skills/triage-issue/scripts/write_job_summary.py", line 109, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/work/sentry-javascript/sentry-javascript/.claude/skills/triage-issue/scripts/write_job_summary.py", line 55, in main
    if obj.get("type") == "result":
       ^^^^^^^
```


Closes #19472 (added automatically)