### PR TITLE
test(nextjs): Deactivate canary test for cf-workers

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -44,12 +44,6 @@
         "build-command": "pnpm test:build-latest",
         "label": "nextjs-16-cf-workers (latest)"
       }
-    ],
-    "optionalVariants": [
-      {
-        "build-command": "pnpm test:build-canary",
-        "label": "nextjs-16-cf-workers (canary)"
-      }
     ]
   }
 }


### PR DESCRIPTION
Deactivating this test for noise removal until this gets resolved upstream.

Closes #19484 (added automatically)

ref https://github.com/getsentry/sentry-javascript/issues/19485 for re-activating