### PR TITLE
fix(triage-issue): Fix Linear idempotency check to match actual report header

### DIFF
--- a/.claude/skills/triage-issue/scripts/post_linear_comment.py
+++ b/.claude/skills/triage-issue/scripts/post_linear_comment.py
@@ -84,7 +84,7 @@ data = graphql(token,
 )
 comments = data.get("data", {}).get("issue", {}).get("comments", {}).get("nodes", [])
 for c in comments:
-    if c.get("body", "").startswith("## Automated Triage Report"):
+    if c.get("body", "").startswith("## Issue Triage:"):
         print(f"Triage comment already exists on {identifier}, skipping")
         sys.exit(0)
 


### PR DESCRIPTION
The duplicate-comment guard in `post_linear_comment.py` was checking for comments starting with `## Automated Triage Report`, but the triage report template (`triage-report.md`) generates headers in the format `## Issue Triage: #<number>`.

Closes #19493 (added automatically)