### PR TITLE
chore(lint): Remove junit report file

### DIFF
--- a/dev-packages/browser-integration-tests/.gitignore
+++ b/dev-packages/browser-integration-tests/.gitignore
@@ -1,2 +1,3 @@
 test-results
 tmp
+*.junit.xml

--- a/dev-packages/browser-integration-tests/results.junit.xml
+++ b/dev-packages/browser-integration-tests/results.junit.xml
@@ -1,6 +1,0 @@
-<testsuites id="" name="" tests="1" failures="0" skipped="0" errors="0" time="3.3956">
-<testsuite name="suites/replay/privacyBlock/test.ts" timestamp="2026-02-13T20:07:07.731Z" hostname="chromium" tests="1" failures="0" skipped="0" time="1.969" errors="0">
-<testcase name="should allow to manually block elements" classname="suites/replay/privacyBlock/test.ts" time="1.969">
-</testcase>
-</testsuite>
-</testsuites>


### PR DESCRIPTION
I think this was accidentally committed in https://github.com/getsentry/sentry-javascript/pull/19311



Closes #19492 (added automatically)