### PR TITLE
feat(core,cloudflare): Add dispose to the client for proper cleanup

### DIFF
--- a/packages/cloudflare/src/client.ts
+++ b/packages/cloudflare/src/client.ts
@@ -16,6 +16,9 @@ export class CloudflareClient extends ServerRuntimeClient {
   private _spanCompletionPromise: Promise<void> | null = null;
   private _resolveSpanCompletion: (() => void) | null = null;
 
+  private _unsubscribeSpanStart: (() => void) | null = null;
+  private _unsubscribeSpanEnd: (() => void) | null = null;
+
   /**
    * Creates a new Cloudflare SDK instance.
    * @param options Configuration options for this SDK.
@@ -37,7 +40,7 @@ export class CloudflareClient extends ServerRuntimeClient {
     this._flushLock = flushLock;
 
     // Track span lifecycle to know when to flush
-    this.on('spanStart', span => {
+    this._unsubscribeSpanStart = this.on('spanStart', span => {
       const spanId = span.spanContext().spanId;
       DEBUG_BUILD && debug.log('[CloudflareClient] Span started:', spanId);
       this._pendingSpans.add(spanId);
@@ -49,7 +52,7 @@ export class CloudflareClient extends ServerRuntimeClient {
       }
     });
 
-    this.on('spanEnd', span => {
+    this._unsubscribeSpanEnd = this.on('spanEnd', span => {
       const spanId = span.spanContext().spanId;
       DEBUG_BUILD && debug.log('[CloudflareClient] Span ended:', spanId);
       this._pendingSpans.delete(spanId);
@@ -97,6 +100,33 @@ export class CloudflareClient extends ServerRuntimeClient {
     }
 
     return super.flush(timeout);
+  }
+
+  /**
+   * Disposes of the client and releases all resources.
+   *
+   * This method clears all Cloudflare-specific state in addition to the base client cleanup.
+   * It unsubscribes from span lifecycle events and clears pending span tracking.
+   *
+   * Call this method after flushing to allow the client to be garbage collected.
+   * After calling dispose(), the client should not be used anymore.
+   */
+  public override dispose(): void {
+    DEBUG_BUILD && debug.log('[CloudflareClient] Disposing client...');
+
+    super.dispose();
+
+    if (this._unsubscribeSpanStart) {
+      this._unsubscribeSpanStart();
+      this._unsubscribeSpanStart = null;
+    }
+    if (this._unsubscribeSpanEnd) {
+      this._unsubscribeSpanEnd();
+      this._unsubscribeSpanEnd = null;
+    }
+
+    this._resetSpanCompletionPromise();
+    (this as unknown as { _flushLock: ReturnType<typeof makeFlushLock> | void })._flushLock = undefined;
   }
 
   /**

--- a/packages/cloudflare/src/flush.ts
+++ b/packages/cloudflare/src/flush.ts
@@ -1,4 +1,6 @@
 import type { ExecutionContext } from '@cloudflare/workers-types';
+import type { Client } from '@sentry/core';
+import { flush } from '@sentry/core';
 
 type FlushLock = {
   readonly ready: Promise<void>;
@@ -35,4 +37,17 @@ export function makeFlushLock(context: ExecutionContext): FlushLock {
       return allDone;
     },
   });
+}
+
+/**
+ * Flushes the client and then disposes of it to allow garbage collection.
+ * This should be called at the end of each request to prevent memory leaks.
+ *
+ * @param client - The CloudflareClient instance to flush and dispose
+ * @param timeout - Timeout in milliseconds for the flush operation
+ * @returns A promise that resolves when flush and dispose are complete
+ */
+export async function flushAndDispose(client: Client | undefined, timeout = 2000): Promise<void> {
+  await flush(timeout);
+  client?.dispose();
 }

--- a/packages/cloudflare/src/handler.ts
+++ b/packages/cloudflare/src/handler.ts
@@ -1,6 +1,5 @@
 import {
   captureException,
-  flush,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -9,6 +8,7 @@ import {
 } from '@sentry/core';
 import { setAsyncLocalStorageAsyncContextStrategy } from './async';
 import type { CloudflareOptions } from './client';
+import { flushAndDispose } from './flush';
 import { isInstrumented, markAsInstrumented } from './instrument';
 import { getHonoIntegration } from './integrations/hono';
 import { getFinalOptions } from './options';
@@ -113,7 +113,7 @@ export function withSentry<
                   captureException(e, { mechanism: { handled: false, type: 'auto.faas.cloudflare.scheduled' } });
                   throw e;
                 } finally {
-                  waitUntil(flush(2000));
+                  waitUntil(flushAndDispose(client));
                 }
               },
             );
@@ -157,7 +157,7 @@ export function withSentry<
                   captureException(e, { mechanism: { handled: false, type: 'auto.faas.cloudflare.email' } });
                   throw e;
                 } finally {
-                  waitUntil(flush(2000));
+                  waitUntil(flushAndDispose(client));
                 }
               },
             );
@@ -209,7 +209,7 @@ export function withSentry<
                   captureException(e, { mechanism: { handled: false, type: 'auto.faas.cloudflare.queue' } });
                   throw e;
                 } finally {
-                  waitUntil(flush(2000));
+                  waitUntil(flushAndDispose(client));
                 }
               },
             );
@@ -243,7 +243,7 @@ export function withSentry<
               captureException(e, { mechanism: { handled: false, type: 'auto.faas.cloudflare.tail' } });
               throw e;
             } finally {
-              waitUntil(flush(2000));
+              waitUntil(flushAndDispose(client));
             }
           });
         },

--- a/packages/cloudflare/src/request.ts
+++ b/packages/cloudflare/src/request.ts
@@ -2,7 +2,6 @@ import type { ExecutionContext, IncomingRequestCfProperties } from '@cloudflare/
 import {
   captureException,
   continueTrace,
-  flush,
   getClient,
   getHttpSpanDetailsFromUrlObject,
   httpHeadersToSpanAttributes,
@@ -14,6 +13,7 @@ import {
   withIsolationScope,
 } from '@sentry/core';
 import type { CloudflareOptions } from './client';
+import { flushAndDispose } from './flush';
 import { addCloudResourceContext, addCultureContext, addRequest } from './scope-utils';
 import { init } from './sdk';
 import { classifyResponseStreaming } from './utils/streaming';
@@ -95,7 +95,7 @@ export function wrapRequestHandler(
         }
         throw e;
       } finally {
-        waitUntil?.(flush(2000));
+        waitUntil?.(flushAndDispose(client));
       }
     }
 
@@ -122,7 +122,7 @@ export function wrapRequestHandler(
             if (captureErrors) {
               captureException(e, { mechanism: { handled: false, type: 'auto.http.cloudflare' } });
             }
-            waitUntil?.(flush(2000));
+            waitUntil?.(flushAndDispose(client));
             throw e;
           }
 
@@ -149,7 +149,7 @@ export function wrapRequestHandler(
                 } finally {
                   reader.releaseLock();
                   span.end();
-                  waitUntil?.(flush(2000));
+                  waitUntil?.(flushAndDispose(client));
                 }
               })();
 
@@ -165,14 +165,22 @@ export function wrapRequestHandler(
             } catch (e) {
               // tee() failed (e.g stream already locked) - fall back to non-streaming handling
               span.end();
-              waitUntil?.(flush(2000));
+              waitUntil?.(flushAndDispose(client));
               return res;
             }
           }
 
           // Non-streaming response - end span immediately and return original
           span.end();
-          waitUntil?.(flush(2000));
+
+          // Don't dispose for protocol upgrades (101 Switching Protocols) - the connection stays alive.
+          // This includes WebSocket upgrades where webSocketMessage/webSocketClose handlers
+          // will still be called and may need the client to capture errors.
+          if (res.status === 101) {
+            waitUntil?.(client?.flush(2000));
+          } else {
+            waitUntil?.(flushAndDispose(client));
+          }
           return res;
         });
       },

--- a/packages/cloudflare/src/workflows.ts
+++ b/packages/cloudflare/src/workflows.ts
@@ -20,6 +20,7 @@ import type {
 } from 'cloudflare:workers';
 import { setAsyncLocalStorageAsyncContextStrategy } from './async';
 import type { CloudflareOptions } from './client';
+import { flushAndDispose } from './flush';
 import { addCloudResourceContext } from './scope-utils';
 import { init } from './sdk';
 import { instrumentContext } from './utils/instrumentContext';
@@ -186,7 +187,7 @@ export function instrumentWorkflowWithSentry<
                       new WrappedWorkflowStep(event.instanceId, context, options, step),
                     );
                   } finally {
-                    context.waitUntil(flush(2000));
+                    context.waitUntil(flushAndDispose(client));
                   }
                 });
               });

--- a/packages/cloudflare/src/wrapMethodWithSentry.ts
+++ b/packages/cloudflare/src/wrapMethodWithSentry.ts
@@ -1,7 +1,6 @@
 import type { DurableObjectStorage } from '@cloudflare/workers-types';
 import {
   captureException,
-  flush,
   getClient,
   isThenable,
   type Scope,
@@ -12,6 +11,7 @@ import {
   withScope,
 } from '@sentry/core';
 import type { CloudflareOptions } from './client';
+import { flushAndDispose } from './flush';
 import { isInstrumented, markAsInstrumented } from './instrument';
 import { init } from './sdk';
 
@@ -74,6 +74,8 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
           scope.setClient(client);
         }
 
+        const clientToDispose = currentClient || scope.getClient();
+
         if (!wrapperOptions.spanName) {
           try {
             if (callback) {
@@ -84,7 +86,7 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
             if (isThenable(result)) {
               return result.then(
                 (res: unknown) => {
-                  waitUntil?.(flush(2000));
+                  waitUntil?.(flushAndDispose(clientToDispose));
                   return res;
                 },
                 (e: unknown) => {
@@ -94,12 +96,12 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
                       handled: false,
                     },
                   });
-                  waitUntil?.(flush(2000));
+                  waitUntil?.(flushAndDispose(clientToDispose));
                   throw e;
                 },
               );
             } else {
-              waitUntil?.(flush(2000));
+              waitUntil?.(flushAndDispose(clientToDispose));
               return result;
             }
           } catch (e) {
@@ -109,7 +111,7 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
                 handled: false,
               },
             });
-            waitUntil?.(flush(2000));
+            waitUntil?.(flushAndDispose(clientToDispose));
             throw e;
           }
         }
@@ -128,7 +130,7 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
             if (isThenable(result)) {
               return result.then(
                 (res: unknown) => {
-                  waitUntil?.(flush(2000));
+                  waitUntil?.(flushAndDispose(clientToDispose));
                   return res;
                 },
                 (e: unknown) => {
@@ -138,12 +140,12 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
                       handled: false,
                     },
                   });
-                  waitUntil?.(flush(2000));
+                  waitUntil?.(flushAndDispose(clientToDispose));
                   throw e;
                 },
               );
             } else {
-              waitUntil?.(flush(2000));
+              waitUntil?.(flushAndDispose(clientToDispose));
               return result;
             }
           } catch (e) {
@@ -153,7 +155,7 @@ export function wrapMethodWithSentry<T extends OriginalMethod>(
                 handled: false,
               },
             });
-            waitUntil?.(flush(2000));
+            waitUntil?.(flushAndDispose(clientToDispose));
             throw e;
           }
         });

--- a/packages/cloudflare/test/client.test.ts
+++ b/packages/cloudflare/test/client.test.ts
@@ -1,0 +1,312 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setAsyncLocalStorageAsyncContextStrategy } from '../src/async';
+import { CloudflareClient, type CloudflareClientOptions } from '../src/client';
+import { makeFlushLock } from '../src/flush';
+
+const MOCK_CLIENT_OPTIONS: CloudflareClientOptions = {
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  stackParser: () => [],
+  integrations: [],
+  transport: () => ({
+    send: vi.fn().mockResolvedValue({}),
+    flush: vi.fn().mockResolvedValue(true),
+  }),
+};
+
+describe('CloudflareClient', () => {
+  beforeAll(() => {
+    setAsyncLocalStorageAsyncContextStrategy();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('dispose()', () => {
+    it('unsubscribes from span lifecycle events', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      // Access the private unsubscribe functions to verify they exist
+      const privateClient = client as unknown as {
+        _unsubscribeSpanStart: (() => void) | null;
+        _unsubscribeSpanEnd: (() => void) | null;
+      };
+
+      expect(privateClient._unsubscribeSpanStart).not.toBeNull();
+      expect(privateClient._unsubscribeSpanEnd).not.toBeNull();
+
+      client.dispose();
+
+      expect(privateClient._unsubscribeSpanStart).toBeNull();
+      expect(privateClient._unsubscribeSpanEnd).toBeNull();
+    });
+
+    it('clears pending spans tracking', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      const privateClient = client as unknown as {
+        _pendingSpans: Set<string>;
+        _spanCompletionPromise: Promise<void> | null;
+        _resolveSpanCompletion: (() => void) | null;
+      };
+
+      // Add some pending spans
+      privateClient._pendingSpans.add('span1');
+      privateClient._pendingSpans.add('span2');
+      privateClient._spanCompletionPromise = new Promise(() => {});
+      privateClient._resolveSpanCompletion = () => {};
+
+      expect(privateClient._pendingSpans.size).toBe(2);
+
+      client.dispose();
+
+      expect(privateClient._pendingSpans.size).toBe(0);
+      expect(privateClient._spanCompletionPromise).toBeNull();
+      expect(privateClient._resolveSpanCompletion).toBeNull();
+    });
+
+    it('clears flushLock reference', () => {
+      const mockContext = {
+        waitUntil: vi.fn(),
+        passThroughOnException: vi.fn(),
+      };
+      const flushLock = makeFlushLock(mockContext as any);
+
+      const client = new CloudflareClient({
+        ...MOCK_CLIENT_OPTIONS,
+        flushLock,
+      });
+
+      const privateClient = client as unknown as {
+        _flushLock: ReturnType<typeof makeFlushLock> | void;
+      };
+
+      expect(privateClient._flushLock).toBeDefined();
+
+      client.dispose();
+
+      expect(privateClient._flushLock).toBeUndefined();
+    });
+
+    it('clears hooks', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      // Add a hook
+      const hookCallback = vi.fn();
+      client.on('beforeEnvelope', hookCallback);
+
+      const privateClient = client as unknown as {
+        _hooks: Record<string, Set<unknown> | undefined>;
+      };
+
+      // Verify hook was registered - check that there are hooks with actual Sets
+      const hooksWithSets = Object.values(privateClient._hooks).filter(v => v instanceof Set);
+      expect(hooksWithSets.length).toBeGreaterThan(0);
+
+      client.dispose();
+
+      // All hooks should be cleared (set to undefined)
+      const hooksWithSetsAfter = Object.values(privateClient._hooks).filter(v => v instanceof Set);
+      expect(hooksWithSetsAfter.length).toBe(0);
+    });
+
+    it('clears event processors', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      // Add an event processor
+      client.addEventProcessor(event => event);
+
+      const privateClient = client as unknown as {
+        _eventProcessors: unknown[];
+      };
+
+      // SDK adds some default processors, so length should be >= 1
+      const initialLength = privateClient._eventProcessors.length;
+      expect(initialLength).toBeGreaterThan(0);
+
+      client.dispose();
+
+      expect(privateClient._eventProcessors.length).toBe(0);
+    });
+
+    it('clears integrations', () => {
+      const mockIntegration = {
+        name: 'MockIntegration',
+        setupOnce: vi.fn(),
+      };
+
+      const client = new CloudflareClient({
+        ...MOCK_CLIENT_OPTIONS,
+        integrations: [mockIntegration],
+      });
+
+      // Need to call init() to setup integrations
+      client.init();
+
+      const privateClient = client as unknown as {
+        _integrations: Record<string, unknown | undefined>;
+      };
+
+      // Integration should be registered
+      expect(privateClient._integrations['MockIntegration']).toBeDefined();
+      expect(privateClient._integrations['MockIntegration']).not.toBeUndefined();
+
+      client.dispose();
+
+      // Integration reference should be cleared (set to undefined)
+      expect(privateClient._integrations['MockIntegration']).toBeUndefined();
+    });
+
+    it('clears transport reference', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      const privateClient = client as unknown as {
+        _transport?: unknown;
+      };
+
+      expect(privateClient._transport).toBeDefined();
+
+      client.dispose();
+
+      expect(privateClient._transport).toBeUndefined();
+    });
+
+    it('clears outcomes tracking', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      const privateClient = client as unknown as {
+        _outcomes: Record<string, number | undefined>;
+      };
+
+      // Add some outcomes
+      privateClient._outcomes['reason:error:outcome1'] = 5;
+      privateClient._outcomes['reason:error:outcome2'] = 10;
+
+      // Verify we have actual values
+      const validOutcomes = Object.values(privateClient._outcomes).filter(v => v !== undefined);
+      expect(validOutcomes.length).toBe(2);
+
+      client.dispose();
+
+      // All outcomes should be set to undefined
+      const validOutcomesAfter = Object.values(privateClient._outcomes).filter(v => v !== undefined);
+      expect(validOutcomesAfter.length).toBe(0);
+    });
+
+    it('can be called multiple times safely', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      // Should not throw when called multiple times
+      expect(() => {
+        client.dispose();
+        client.dispose();
+        client.dispose();
+      }).not.toThrow();
+    });
+
+    it('does not break event emission after spanStart unsubscribe', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      // Dispose which unsubscribes from span events
+      client.dispose();
+
+      // Should not throw when emitting span events after dispose
+      expect(() => {
+        client.emit('spanStart', {} as any);
+        client.emit('spanEnd', {} as any);
+      }).not.toThrow();
+    });
+  });
+
+  describe('span lifecycle tracking', () => {
+    it('tracks pending spans when spanStart is emitted', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      const privateClient = client as unknown as {
+        _pendingSpans: Set<string>;
+        _spanCompletionPromise: Promise<void> | null;
+      };
+
+      expect(privateClient._pendingSpans.size).toBe(0);
+      expect(privateClient._spanCompletionPromise).toBeNull();
+
+      // Emit spanStart
+      const mockSpan = {
+        spanContext: () => ({ spanId: 'test-span-id' }),
+      };
+      client.emit('spanStart', mockSpan as any);
+
+      expect(privateClient._pendingSpans.has('test-span-id')).toBe(true);
+      expect(privateClient._spanCompletionPromise).not.toBeNull();
+    });
+
+    it('removes pending span when spanEnd is emitted', async () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      const privateClient = client as unknown as {
+        _pendingSpans: Set<string>;
+        _spanCompletionPromise: Promise<void> | null;
+      };
+
+      const mockSpan = {
+        spanContext: () => ({ spanId: 'test-span-id' }),
+      };
+
+      // Start span
+      client.emit('spanStart', mockSpan as any);
+      expect(privateClient._pendingSpans.has('test-span-id')).toBe(true);
+
+      // End span
+      client.emit('spanEnd', mockSpan as any);
+      expect(privateClient._pendingSpans.has('test-span-id')).toBe(false);
+    });
+
+    it('resolves completion promise when all spans end', async () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      const privateClient = client as unknown as {
+        _pendingSpans: Set<string>;
+        _spanCompletionPromise: Promise<void> | null;
+      };
+
+      const mockSpan1 = { spanContext: () => ({ spanId: 'span-1' }) };
+      const mockSpan2 = { spanContext: () => ({ spanId: 'span-2' }) };
+
+      // Start both spans
+      client.emit('spanStart', mockSpan1 as any);
+      client.emit('spanStart', mockSpan2 as any);
+
+      const completionPromise = privateClient._spanCompletionPromise;
+      expect(completionPromise).not.toBeNull();
+
+      // End first span - promise should still exist
+      client.emit('spanEnd', mockSpan1 as any);
+      expect(privateClient._pendingSpans.size).toBe(1);
+
+      // End second span - promise should be resolved and reset
+      client.emit('spanEnd', mockSpan2 as any);
+      expect(privateClient._pendingSpans.size).toBe(0);
+
+      // The original promise should resolve
+      await expect(completionPromise).resolves.toBeUndefined();
+    });
+
+    it('does not track spans after dispose', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      client.dispose();
+
+      const privateClient = client as unknown as {
+        _pendingSpans: Set<string>;
+      };
+
+      const mockSpan = {
+        spanContext: () => ({ spanId: 'test-span-id' }),
+      };
+
+      // Emit spanStart after dispose - should not be tracked
+      client.emit('spanStart', mockSpan as any);
+      expect(privateClient._pendingSpans.has('test-span-id')).toBe(false);
+    });
+  });
+});

--- a/packages/cloudflare/test/wrapMethodWithSentry.test.ts
+++ b/packages/cloudflare/test/wrapMethodWithSentry.test.ts
@@ -8,6 +8,7 @@ vi.mock('../src/sdk', () => ({
   init: vi.fn(() => ({
     getOptions: () => ({}),
     on: vi.fn(),
+    dispose: vi.fn(),
   })),
 }));
 
@@ -237,7 +238,7 @@ describe('wrapMethodWithSentry', () => {
   });
 
   describe('waitUntil flush', () => {
-    it('calls waitUntil with flush when context has waitUntil', async () => {
+    it('calls waitUntil with flushAndDispose when context has waitUntil', async () => {
       const waitUntil = vi.fn();
       const context = {
         waitUntil,
@@ -254,6 +255,7 @@ describe('wrapMethodWithSentry', () => {
       await wrapped();
 
       expect(waitUntil).toHaveBeenCalled();
+      // flushAndDispose calls flush internally
       expect(sentryCore.flush).toHaveBeenCalledWith(2000);
     });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -203,12 +203,12 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   protected _eventProcessors: EventProcessor[];
 
   /** Holds flushable  */
-  private _outcomes: { [key: string]: number };
+  protected _outcomes: { [key: string]: number };
 
   // eslint-disable-next-line @typescript-eslint/ban-types
-  private _hooks: Record<string, Set<Function>>;
+  protected _hooks: Record<string, Set<Function>>;
 
-  private _promiseBuffer: PromiseBuffer<unknown>;
+  protected _promiseBuffer: PromiseBuffer<unknown>;
 
   /**
    * Initializes this client instance.
@@ -1096,6 +1096,16 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
     DEBUG_BUILD && debug.error('Transport disabled');
     return {};
+  }
+
+  /**
+   * Disposes of the client and releases all resources.
+   *
+   * Subclasses should override this method to clean up their own resources.
+   * After calling dispose(), the client should not be used anymore.
+   */
+  public dispose(): void {
+    // Base class has no cleanup logic - subclasses implement their own
   }
 
   /* eslint-enable @typescript-eslint/unified-signatures */

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -10,10 +10,11 @@ import type { Event, EventHint } from './types-hoist/event';
 import type { ClientOptions } from './types-hoist/options';
 import type { ParameterizedString } from './types-hoist/parameterize';
 import type { SeverityLevel } from './types-hoist/severity';
-import type { BaseTransportOptions } from './types-hoist/transport';
+import type { BaseTransportOptions, Transport } from './types-hoist/transport';
 import { debug } from './utils/debug-logger';
 import { eventFromMessage, eventFromUnknownInput } from './utils/eventbuilder';
 import { uuid4 } from './utils/misc';
+import type { PromiseBuffer } from './utils/promisebuffer';
 import { resolvedSyncPromise } from './utils/syncpromise';
 import { _getTraceInfoFromScope } from './utils/trace-info';
 
@@ -150,6 +151,32 @@ export class ServerRuntimeClient<
     this.sendEnvelope(envelope);
 
     return id;
+  }
+
+  /**
+   * Disposes of the client and releases all resources.
+   *
+   * This method clears all internal state to allow the client to be garbage collected.
+   * It clears hooks, event processors, integrations, transport, and other internal references.
+   *
+   * Call this method after flushing to allow the client to be garbage collected.
+   * After calling dispose(), the client should not be used anymore.
+   *
+   * Subclasses should override this method to clean up their own resources and call `super.dispose()`.
+   */
+  public override dispose(): void {
+    DEBUG_BUILD && debug.log('Disposing client...');
+
+    for (const hookName of Object.keys(this._hooks)) {
+      this._hooks[hookName]?.clear();
+    }
+
+    this._hooks = {};
+    this._eventProcessors.length = 0;
+    this._integrations = {};
+    this._outcomes = {};
+    (this as unknown as { _transport?: Transport })._transport = undefined;
+    (this as unknown as { _promiseBuffer?: PromiseBuffer<unknown> })._promiseBuffer = undefined;
   }
 
   /**


### PR DESCRIPTION
closes #19475
closes [JS-1785](https://linear.app/getsentry/issue/JS-1785/investigate-memory-leaks-in-cloudflare)

This is a way to dispose the client entirely. Every request in Cloudflare Workers create their own client. Once the request is done the client would stay in memory forever, unless we `dispose` it after every request. We also have to wait until all `waitUntil`s are finished, otherwise we would loose these traces. 

The `dispose()` method got added on purpose into the core client, as the `getCurrentClient()` would return a `Client`. The `dispose()` method actually only has functionality inside the `ServerRuntimeClient`, as only the server would need this functionality. 

There is still a leak in one of the default integrations, but when running load tests against [the reproduction repo](https://github.com/JPeer264/temp-cloudflare-leak) and setting `defaultIntegrations: false`, then no leak is happening.

FWIW there will be a separate PR for adding a MemoryProfiler as seen in #19364, to prevent this memory leak in the future. 