### PR TITLE
chore(e2e): Pin @embroider/macros to 1.19.7 in ember test apps

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-classic/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/package.json
@@ -78,6 +78,11 @@
     "@babel/traverse": "~7.25.9",
     "clean-css": "^5.3.0"
   },
+  "pnpm": {
+    "overrides": {
+      "@embroider/macros": "1.19.7"
+    }
+  },
   "ember": {
     "edition": "octane"
   },

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -66,6 +66,11 @@
   "ember": {
     "edition": "octane"
   },
+  "pnpm": {
+    "overrides": {
+      "@embroider/macros": "1.19.7"
+    }
+  },
   "volta": {
     "extends": "../../package.json"
   }


### PR DESCRIPTION
Yesterday's `@embroider/macros` 1.20.0 release breaks our CI. Looks like the dynamic import of `@sentry/browser` is causing issues. Not really sure why yet tho but it leads to no pageload/navigation transactions in our e2e tests.

Pinning to the previous version to unblock us for now.

Closes #19516 (added automatically)