### PR TITLE
test(consola): Restructure tests (e.g. changing `cases.forEach()` to `it.each`)

### DIFF
--- a/packages/core/src/integrations/consola.ts
+++ b/packages/core/src/integrations/consola.ts
@@ -123,12 +123,19 @@ export interface ConsolaLogObject {
   /**
    * The raw arguments passed to the log method.
    *
-   * When `message` is not provided, these args are typically formatted into the final message.
+   * These args are typically formatted into the final `message`. In Consola reporters, `message` is not provided.
    *
    * @example
    * ```ts
    * consola.info('Hello', 'world', { user: 'john' });
    * // args = ['Hello', 'world', { user: 'john' }]
+   * ```
+   *
+   * @example
+   * ```ts
+   * // `message` is a reserved property in Consola
+   * consola.log({ message: 'Hello' });
+   * // args = ['Hello']
    * ```
    */
   args?: unknown[];

--- a/packages/core/test/lib/integrations/consola.test.ts
+++ b/packages/core/test/lib/integrations/consola.test.ts
@@ -112,7 +112,7 @@ describe('createConsolaReporter', () => {
       ['trace', 'trace'],
       ['fatal', 'fatal'],
     ] as const)('maps type "%s" to Sentry level "%s"', (type, expectedLevel) => {
-      sentryReporter.log({ type, message: `${type} message` });
+      sentryReporter.log({ type, args: [`${type} message`] });
 
       expect(_INTERNAL_captureLog).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -132,7 +132,7 @@ describe('createConsolaReporter', () => {
       ['log', 'info'],
       ['silent', 'trace'],
     ] as const)('maps consola type "%s" to Sentry level "%s"', (type, expectedLevel) => {
-      sentryReporter.log({ type, message: `Test ${type}` });
+      sentryReporter.log({ type, args: [`Test ${type}`] });
 
       expect(_INTERNAL_captureLog).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -149,7 +149,7 @@ describe('createConsolaReporter', () => {
     it('uses level number when type is missing', () => {
       sentryReporter.log({
         level: 0, // Fatal level
-        message: 'Fatal message',
+        args: ['Fatal message'],
       });
 
       expect(_INTERNAL_captureLog).toHaveBeenCalledWith(
@@ -174,21 +174,21 @@ describe('createConsolaReporter', () => {
       // Should capture error
       filteredReporter.log({
         type: 'error',
-        message: 'Error message',
+        args: ['Error message'],
       });
       expect(_INTERNAL_captureLog).toHaveBeenCalledTimes(1);
 
       // Should capture warn
       filteredReporter.log({
         type: 'warn',
-        message: 'Warn message',
+        args: ['Warn message'],
       });
       expect(_INTERNAL_captureLog).toHaveBeenCalledTimes(2);
 
       // Should not capture info
       filteredReporter.log({
         type: 'info',
-        message: 'Info message',
+        args: ['Info message'],
       });
       expect(_INTERNAL_captureLog).toHaveBeenCalledTimes(2);
     });
@@ -200,7 +200,7 @@ describe('createConsolaReporter', () => {
       ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(type => {
         defaultReporter.log({
           type,
-          message: `${type} message`,
+          args: [`${type} message`],
         });
       });
 


### PR DESCRIPTION
Some small refactoring to make test cases better readable. 

Part of this PR (to make things easier reviewable): https://github.com/getsentry/sentry-javascript/pull/18602

Closes #19518 (added automatically)