### PR TITLE
chore(svelte,sveltekit): Use version range for magic-string

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@sentry/browser": "10.40.0",
     "@sentry/core": "10.40.0",
-    "magic-string": "^0.30.0"
+    "magic-string": "~0.30.0"
   },
   "peerDependencies": {
     "svelte": "3.x || 4.x || 5.x"

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -53,7 +53,7 @@
     "@sentry/node": "10.40.0",
     "@sentry/svelte": "10.40.0",
     "@sentry/vite-plugin": "^5.1.0",
-    "magic-string": "0.30.7",
+    "magic-string": "~0.30.0",
     "recast": "0.23.11",
     "sorcery": "1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -21010,13 +21010,6 @@ magic-string@0.26.2:
   dependencies:
     sourcemap-codec "^1.4.8"
 
-magic-string@0.30.7:
-  version "0.30.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.7.tgz#0cecd0527d473298679da95a2d7aeb8c64048505"
-  integrity sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==
-  dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.15"
-
 magic-string@0.30.8:
   version "0.30.8"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.8.tgz#14e8624246d2bedba70d5462aa99ac9681844613"


### PR DESCRIPTION
closes #19510
closes [JS-1801](https://linear.app/getsentry/issue/JS-1801/magic-string-pinned-to-exact-versions-across-packages-preventing)

This is using a version range for `magic-string`. I moved the version range from `magic-string` in `@sentry/svelte` to a `~`, to actually prevent breaking changes in case something would break our SDK in `0.31.0`.