### PR TITLE
chore(remix): Replace glob with native recursive fs walk

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -72,7 +72,6 @@
     "@sentry/core": "10.45.0",
     "@sentry/node": "10.45.0",
     "@sentry/react": "10.45.0",
-    "glob": "^13.0.6",
     "yargs": "^17.6.0"
   },
   "devDependencies": {

--- a/packages/remix/scripts/deleteSourcemaps.js
+++ b/packages/remix/scripts/deleteSourcemaps.js
@@ -2,13 +2,49 @@
 const fs = require('fs');
 const path = require('path');
 
-const { globSync } = require('glob');
+/**
+ * Recursively walks a directory and returns relative paths of all files
+ * matching the given extension.
+ *
+ * Uses manual recursion instead of `fs.readdirSync({ recursive: true, withFileTypes: true })`
+ * to avoid a bug in Node 18.17–18.18 where `withFileTypes` returns incorrect `parentPath` values
+ * when combined with `recursive: true`.
+ *
+ * @param {string} rootDir - The root directory to start walking from.
+ * @param {string} extension - The file extension to match (e.g. '.map').
+ * @returns {string[]} Relative file paths from rootDir.
+ */
+function walkDirectory(rootDir, extension) {
+  const results = [];
+
+  function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.name.endsWith(extension)) {
+        results.push(path.relative(rootDir, fullPath));
+      }
+    }
+  }
+
+  walk(rootDir);
+  return results;
+}
 
 function deleteSourcemaps(buildPath) {
   console.info(`[sentry] Deleting sourcemaps from ${buildPath}`);
 
   // Delete all .map files in the build folder and its subfolders
-  const mapFiles = globSync('**/*.map', { cwd: buildPath });
+  const mapFiles = walkDirectory(buildPath, '.map');
 
   mapFiles.forEach(file => {
     fs.unlinkSync(path.join(buildPath, file));

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -39,9 +39,6 @@
     "@vanilla-extract/css": "1.13.0",
     "@vanilla-extract/integration": "6.2.4",
     "@types/mime": "^3.0.0",
-    "@sentry/remix/glob": "<10.4.3",
-    "jackspeak": "<3.4.1",
-    "**/path-scurry/lru-cache": "10.2.0",
     "vite": "^6.0.0"
   },
   "engines": {


### PR DESCRIPTION
Replaces the `glob` dependency in `@sentry/remix` with a simple recursive `fs.readdirSync` walk for finding `.map` files to delete after source map upload.

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [ ] Link an issue if there is one related to your pull request. If no issue is linked, one will be auto-generated and linked.

Ref #19447

## What this does

Replaces `glob.sync('**/*.map', { cwd: buildPath })` in `deleteSourcemaps.js` with a manual recursive directory walk using native `fs.readdirSync`. This removes the `glob` package and its transitive dependency tree (minimatch, brace-expansion, balanced-match, minipass, jackspeak, path-scurry, foreground-child) from `@sentry/remix`.

Also cleans up orphaned `glob`/`jackspeak`/`path-scurry` resolution overrides in the integration test `package.json`.

## Why manual recursion instead of `fs.readdirSync({recursive: true})`

`fs.readdirSync(dir, { recursive: true, withFileTypes: true })` silently drops entries on Node 18.17-18.18 due to a known Node.js bug. Since `@sentry/remix` supports Node >= 18, a manual recursive walk avoids this edge case entirely.

## Behavioral notes

- The walk returns relative paths from `buildPath`, matching `glob.sync`'s `{ cwd }` output shape
- Non-existent directories return `[]` gracefully (matching glob behavior)
- The walk includes dotfiles (glob excludes by default with `dot: false`), but this has zero practical impact since Remix build output never produces `.map` dotfiles

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>