### PR TITLE
chore(tanstackstart): Fix leftover formatting issue

### DIFF
--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -62,7 +62,6 @@ export function wrapFetchWithSentry(serverEntry: ServerEntry): ServerEntry {
             );
           }
 
-           
           return await target.apply(thisArg, args);
         } finally {
           await flushIfServerless();


### PR DESCRIPTION
No idea why this didn't trigger our linter.. but I keep getting this whenever I run `yarn fix` 🤔

Closes #19537 (added automatically)