### PR TITLE
chore(agents): Add nested `AGENTS.md` for nextjs

### DIFF
--- a/packages/nextjs/AGENTS.md
+++ b/packages/nextjs/AGENTS.md
@@ -19,6 +19,7 @@ Webpack builds use **loaders and templates** to wrap user code at compile time:
 4. **SentryWebpackPlugin** handles sourcemap upload and release management
 
 Template files and what they wrap:
+
 - `pageWrapperTemplate.ts` — Pages Router pages (`getInitialProps`, `getStaticProps`, `getServerSideProps`)
 - `apiWrapperTemplate.ts` — Pages Router API routes
 - `routeHandlerWrapperTemplate.ts` — App Router route handlers (GET, POST, etc.)
@@ -32,12 +33,14 @@ Config options that control wrapping: `autoInstrumentServerFunctions`, `autoInst
 Turbopack does **NOT** use the wrapping loader or templates. There is no build-time function wrapping.
 
 What turbopack **does** support:
+
 - **Value injection** via Turbopack rules (`src/config/turbopack/`) — injects the same globals as webpack
 - **Module metadata injection** (`moduleMetadataInjectionLoader.ts`) — enables `thirdPartyErrorFilterIntegration` (requires Next.js 16+ and `_experimental.turbopackApplicationKey`)
 - **Native debug IDs** for sourcemaps (Next.js 15.6+)
 - **`runAfterProductionCompile` hook** (enabled by default) for sourcemap upload
 
 What turbopack does **NOT** support:
+
 - Build-time wrapping of route handlers, API routes, pages, server components, or middleware
 - `autoInstrumentServerFunctions`, `autoInstrumentMiddleware`, `autoInstrumentAppDirectory` — these are no-ops
 - `excludeServerRoutes` — no-op since routes aren't wrapped
@@ -61,14 +64,14 @@ Routing logic: `src/config/withSentryConfig/getFinalConfigObject.ts`
 
 ## Key Directories
 
-| Path | Purpose |
-|------|---------|
-| `src/config/webpack.ts` | Webpack-specific config (loaders, rules, plugins) |
-| `src/config/turbopack/` | Turbopack-specific config (value injection rules) |
-| `src/config/loaders/` | Webpack loaders (wrapping, value injection, module metadata) |
-| `src/config/templates/` | Wrapper templates used by wrapping loader (webpack only) |
-| `src/config/manifest/` | Route manifest generation for transaction grouping |
-| `src/config/withSentryConfig/` | Main `withSentryConfig` entry point and bundler routing |
-| `src/client/` | Client-side SDK (browser) |
-| `src/server/` | Server-side SDK (Node.js) |
-| `src/edge/` | Edge runtime SDK |
+| Path                           | Purpose                                                      |
+| ------------------------------ | ------------------------------------------------------------ |
+| `src/config/webpack.ts`        | Webpack-specific config (loaders, rules, plugins)            |
+| `src/config/turbopack/`        | Turbopack-specific config (value injection rules)            |
+| `src/config/loaders/`          | Webpack loaders (wrapping, value injection, module metadata) |
+| `src/config/templates/`        | Wrapper templates used by wrapping loader (webpack only)     |
+| `src/config/manifest/`         | Route manifest generation for transaction grouping           |
+| `src/config/withSentryConfig/` | Main `withSentryConfig` entry point and bundler routing      |
+| `src/client/`                  | Client-side SDK (browser)                                    |
+| `src/server/`                  | Server-side SDK (Node.js)                                    |
+| `src/edge/`                    | Edge runtime SDK                                             |


### PR DESCRIPTION
Agents frequently misunderstand the bundling architecture, so adding this file should help to resolve this.

Closes #19557 (added automatically)