### PR TITLE
fix(astro): Do not inject withSentry into Cloudflare Pages

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -278,16 +278,15 @@ function isCloudflarePages(): boolean {
     const content = fs.readFileSync(configPath, 'utf-8');
 
     if (configFile.endsWith('.toml')) {
-      return content.includes('pages_build_output_dir');
+      // https://regex101.com/r/Uxe4p0/1
+      // Match pages_build_output_dir as a TOML key (at start of line, ignoring whitespace)
+      // This avoids false positives from comments (lines starting with #)
+      return /^\s*pages_build_output_dir\s*=/m.test(content);
     }
 
-    try {
-      // Strip comments from JSONC before parsing
-      const parsed = JSON.parse(content.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, ''));
-      return 'pages_build_output_dir' in parsed;
-    } catch {
-      return false;
-    }
+    // Match "pages_build_output_dir" as a JSON key (followed by :)
+    // This works for both .json and .jsonc without needing to strip comments
+    return /"pages_build_output_dir"\s*:/.test(content);
   }
 
   return false;

--- a/packages/astro/test/integration/cloudflare.test.ts
+++ b/packages/astro/test/integration/cloudflare.test.ts
@@ -150,6 +150,67 @@ describe('Cloudflare Pages vs Workers detection', () => {
       expect(baseConfigHookObject.logger.error).not.toHaveBeenCalled();
     });
 
+    it('correctly parses wrangler.json with URLs containing double slashes', async () => {
+      getWranglerConfig.mockReturnValue({
+        filename: 'wrangler.json',
+        content: JSON.stringify({
+          pages_build_output_dir: './dist',
+          vars: {
+            API_URL: 'https://api.example.com/v1',
+            ANOTHER_URL: 'http://localhost:3000',
+          },
+        }),
+      });
+
+      const integration = sentryAstro({});
+
+      // @ts-expect-error - the hook exists and we only need to pass what we actually use
+      await integration.hooks['astro:config:setup']({
+        ...baseConfigHookObject,
+        config: {
+          // @ts-expect-error - we only need to pass what we actually use
+          adapter: { name: '@astrojs/cloudflare' },
+        },
+        command: 'build',
+      });
+
+      expect(baseConfigHookObject.updateConfig).toHaveBeenCalledWith({
+        vite: expect.objectContaining({ plugins: ['sentryCloudflareNodeWarningPlugin'] }),
+      });
+    });
+
+    it('correctly parses wrangler.jsonc with URLs and comments', async () => {
+      getWranglerConfig.mockReturnValue({
+        filename: 'wrangler.jsonc',
+        content: `{
+          // API configuration
+          "pages_build_output_dir": "./dist",
+          "vars": {
+            "API_URL": "https://api.example.com/v1", // Production API
+            "WEBHOOK_URL": "https://hooks.example.com/callback"
+          }
+          /* Multi-line
+             comment */
+        }`,
+      });
+
+      const integration = sentryAstro({});
+
+      // @ts-expect-error - the hook exists and we only need to pass what we actually use
+      await integration.hooks['astro:config:setup']({
+        ...baseConfigHookObject,
+        config: {
+          // @ts-expect-error - we only need to pass what we actually use
+          adapter: { name: '@astrojs/cloudflare' },
+        },
+        command: 'build',
+      });
+
+      expect(baseConfigHookObject.updateConfig).toHaveBeenCalledWith({
+        vite: expect.objectContaining({ plugins: ['sentryCloudflareNodeWarningPlugin'] }),
+      });
+    });
+
     it('does not show warning for Pages project with wrangler.toml', async () => {
       getWranglerConfig.mockReturnValue({
         filename: 'wrangler.toml',
@@ -174,6 +235,40 @@ pages_build_output_dir = "./dist"
       expect(baseConfigHookObject.logger.error).not.toHaveBeenCalled();
     });
 
+    it('correctly identifies Workers when pages_build_output_dir appears only in comments', async () => {
+      getWranglerConfig.mockReturnValue({
+        filename: 'wrangler.toml',
+        content: `
+name = "my-astro-worker"
+# pages_build_output_dir is not used for Workers
+main = "dist/_worker.js/index.js"
+
+[assets]
+directory = "./dist"
+        `,
+      });
+
+      const integration = sentryAstro({});
+
+      // @ts-expect-error - the hook exists and we only need to pass what we actually use
+      await integration.hooks['astro:config:setup']({
+        ...baseConfigHookObject,
+        config: {
+          // @ts-expect-error - we only need to pass what we actually use
+          adapter: { name: '@astrojs/cloudflare' },
+        },
+        command: 'build',
+      });
+
+      // Workers should get both Cloudflare Vite plugins (including sentryCloudflareVitePlugin)
+      // This distinguishes it from Pages which only gets sentryCloudflareNodeWarningPlugin
+      expect(baseConfigHookObject.updateConfig).toHaveBeenCalledWith({
+        vite: expect.objectContaining({
+          plugins: ['sentryCloudflareNodeWarningPlugin', 'sentryCloudflareVitePlugin'],
+        }),
+      });
+    });
+
     it('does not add Cloudflare Vite plugins for Pages production build', async () => {
       getWranglerConfig.mockReturnValue({
         filename: 'wrangler.json',
@@ -195,9 +290,9 @@ pages_build_output_dir = "./dist"
       });
 
       // Check that sentryCloudflareVitePlugin is NOT in any of the calls
-      expect(baseConfigHookObject.updateConfig).toHaveBeenCalledWith(
-        { vite: expect.objectContaining({ plugins: ['sentryCloudflareNodeWarningPlugin'] }) },
-      );
+      expect(baseConfigHookObject.updateConfig).toHaveBeenCalledWith({
+        vite: expect.objectContaining({ plugins: ['sentryCloudflareNodeWarningPlugin'] }),
+      });
     });
 
     it('still adds SSR noExternal config for Pages in dev mode', async () => {


### PR DESCRIPTION
When running on Cloudflare Pages the `withSentry` function got bundled and wrapped into the `index.js`. This actually didn't cause any problems during the runtime, but it just added unnecessary code into the bundle. This removes now the automatic wrapping, which is required for Cloudflare Workers only.

By adding the plugin `sentryCloudflareNodeWarningPlugin` we also remove tons of warnings like following when building for Cloudflare Pages:

```
11:20:40 [WARN] [vite] [plugin vite:resolve] Automatically externalized node built-in module "node:diagnostics_channel" imported from "node_modules/.pnpm/@sentry+node@10.40.0/node_modules/@sentry/node/build/esm/integrations/tracing/fastify/index.js". Consider adding it to environments.ssr.external if it is intended.
11:20:40 [WARN] [vite] [plugin vite:resolve] Automatically externalized node built-in module "node:diagnostics_channel" imported from "node_modules/.pnpm/@sentry+node-core@10.40.0_@opentelemetry+api@1.9.0_@opentelemetry+context-async-hooks@2_feb79575758996d9eeb93d3eb9a5534b/node_modules/@sentry/node-core/build/esm/integrations/http/httpServerIntegration.js". Consider adding it to environments.ssr.external if it is intended.
```

Closes #19559 (added automatically)