### PR TITLE
test(node): Test runName parameter in handleChainStart for langchain

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/langchain/scenario-chain.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/scenario-chain.mjs
@@ -1,0 +1,63 @@
+import { ChatAnthropic } from '@langchain/anthropic';
+import { RunnableLambda, RunnableSequence } from '@langchain/core/runnables';
+import { createLangChainCallbackHandler } from '@sentry/core';
+import * as Sentry from '@sentry/node';
+import express from 'express';
+
+function startMockAnthropicServer() {
+  const app = express();
+  app.use(express.json());
+
+  app.post('/v1/messages', (req, res) => {
+    res.json({
+      id: 'msg_chain_test',
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'The weather is sunny.' }],
+      model: req.body.model,
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+  });
+
+  return new Promise(resolve => {
+    const server = app.listen(0, () => {
+      resolve(server);
+    });
+  });
+}
+
+async function run() {
+  const server = await startMockAnthropicServer();
+  const baseUrl = `http://localhost:${server.address().port}`;
+
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    const model = new ChatAnthropic({
+      model: 'claude-3-5-sonnet-20241022',
+      temperature: 0,
+      maxTokens: 50,
+      apiKey: 'mock-api-key',
+      clientOptions: { baseURL: baseUrl },
+    });
+
+    const formatStep = RunnableLambda.from(input => `Tell me about: ${input.topic}`).withConfig({
+      runName: 'format_prompt',
+    });
+
+    const parseStep = RunnableLambda.from(output => output.content[0].text).withConfig({
+      runName: 'parse_output',
+    });
+
+    const chain = RunnableSequence.from([formatStep, model, parseStep]);
+
+    const handler = createLangChainCallbackHandler();
+
+    await chain.invoke({ topic: 'weather' }, { callbacks: [handler] });
+  });
+
+  await Sentry.flush(2000);
+  server.close();
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
@@ -376,4 +376,41 @@ describe('LangChain integration', () => {
       });
     },
   );
+
+  createEsmAndCjsTests(__dirname, 'scenario-chain.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('uses runName for chain spans instead of unknown_chain', async () => {
+      await createRunner()
+        .ignore('event')
+        .expect({
+          transaction: {
+            transaction: 'main',
+            spans: expect.arrayContaining([
+              expect.objectContaining({
+                description: 'chain format_prompt',
+                op: 'gen_ai.invoke_agent',
+                origin: 'auto.ai.langchain',
+                data: expect.objectContaining({
+                  'langchain.chain.name': 'format_prompt',
+                }),
+              }),
+              expect.objectContaining({
+                description: 'chain parse_output',
+                op: 'gen_ai.invoke_agent',
+                origin: 'auto.ai.langchain',
+                data: expect.objectContaining({
+                  'langchain.chain.name': 'parse_output',
+                }),
+              }),
+              expect.objectContaining({
+                description: 'chat claude-3-5-sonnet-20241022',
+                op: 'gen_ai.chat',
+                origin: 'auto.ai.langchain',
+              }),
+            ]),
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a test for langchain where handleChainStart uses runName for the span description and attribute instead of falling back to unknown_chain.

Closes #19563 (added automatically)