### PR TITLE
fix(core): Do not remove promiseBuffer entirely

### DIFF
--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -4,6 +4,7 @@ import { getIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { Scope } from './scope';
 import { registerSpanErrorInstrumentation } from './tracing';
+import { DEFAULT_TRANSPORT_BUFFER_SIZE } from './transports/base';
 import { addUserAgentToTransportHeaders } from './transports/userAgent';
 import type { CheckIn, MonitorConfig, SerializedCheckIn } from './types-hoist/checkin';
 import type { Event, EventHint } from './types-hoist/event';
@@ -14,7 +15,7 @@ import type { BaseTransportOptions, Transport } from './types-hoist/transport';
 import { debug } from './utils/debug-logger';
 import { eventFromMessage, eventFromUnknownInput } from './utils/eventbuilder';
 import { uuid4 } from './utils/misc';
-import type { PromiseBuffer } from './utils/promisebuffer';
+import { makePromiseBuffer } from './utils/promisebuffer';
 import { resolvedSyncPromise } from './utils/syncpromise';
 import { _getTraceInfoFromScope } from './utils/trace-info';
 
@@ -176,7 +177,7 @@ export class ServerRuntimeClient<
     this._integrations = {};
     this._outcomes = {};
     (this as unknown as { _transport?: Transport })._transport = undefined;
-    (this as unknown as { _promiseBuffer?: PromiseBuffer<unknown> })._promiseBuffer = undefined;
+    this._promiseBuffer = makePromiseBuffer(DEFAULT_TRANSPORT_BUFFER_SIZE);
   }
 
   /**

--- a/packages/core/test/lib/server-runtime-client.test.ts
+++ b/packages/core/test/lib/server-runtime-client.test.ts
@@ -301,4 +301,24 @@ describe('ServerRuntimeClient', () => {
       );
     });
   });
+
+  describe('dispose', () => {
+    it('resets _promiseBuffer to a new empty buffer instead of undefined', () => {
+      const options = getDefaultClientOptions({ dsn: PUBLIC_DSN });
+      client = new ServerRuntimeClient(options);
+
+      // Access the private _promiseBuffer before dispose
+      const originalBuffer = client['_promiseBuffer'];
+      expect(originalBuffer).toBeDefined();
+
+      client.dispose();
+
+      // After dispose, _promiseBuffer should still be defined (not undefined)
+      const bufferAfterDispose = client['_promiseBuffer'];
+      expect(bufferAfterDispose).toBeDefined();
+      expect(bufferAfterDispose).not.toBe(originalBuffer);
+      // Verify it's a fresh buffer with no pending items
+      expect(bufferAfterDispose.$).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
closes #19589
closes [JS-1839](https://linear.app/getsentry/issue/JS-1839/flushanddispose-in-10410-crashes-when-workerentrypoint-rpc-methods-use)

It seems that there are way to rely on the memory leak on Cloudflare. When that is the case the promise buffer is set to undefined and would fail in a latter step. Creating a new promise buffer would release everything we had before and mark with that it would be ready to be released by the garbage collector.

The transport above is ok to be set to undefined, as it is readonly on TypeScript level.