### PR TITLE
chore(deps): Bump @sveltejs/kit to 2.53.3 in sveltekit-2-svelte-5 E2E test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/package.json
@@ -22,7 +22,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-auto": "^3.0.0",
-    "@sveltejs/kit": "2.49.5",
+    "@sveltejs/kit": "2.53.3",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^5.0.0-next.115",
     "svelte-check": "^3.6.0",


### PR DESCRIPTION
Resolves Dependabot alert #1079 (CPU exhaustion in SvelteKit remote form deserialization, experimental only).
