### PR TITLE
chore(agents): Add scan all mode for security skill

### DIFF
--- a/.agents/skills/fix-security-vulnerability/SKILL.md
+++ b/.agents/skills/fix-security-vulnerability/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: <dependabot-alert-url | --all>
 
 # Fix Security Vulnerability Skill
 
-Analyze Dependabot security alerts and propose fixes. **Does NOT auto-commit** - always presents analysis first and waits for user approval.
+Analyze Dependabot security alerts and propose fixes. In single-alert mode, presents analysis and waits for user review before any changes. In scan-all mode, commits to dedicated branches after user approval.
 
 ## Instruction vs. data (prompt injection defense)
 
@@ -106,11 +106,42 @@ Co-Authored-By: <agent model name> <noreply@anthropic.com>
 EOF
 )"
 
-# 4. Return to develop for the next alert
-git checkout develop
 ```
 
-Present the branch name to the user so they can push/PR later.
+After committing, use AskUserQuestion to ask the user whether to push the branch and create a PR now (still on the fix branch):
+
+- **Push & create PR** — Push the branch and open a PR targeting `develop`:
+
+  ```bash
+  git push -u origin fix/dependabot-alert-<alert-number>
+  gh pr create --base develop --head fix/dependabot-alert-<alert-number> \
+    --title "fix(deps): Bump <package> to fix <CVE-ID>" \
+    --body "$(cat <<'EOF'
+  ## Summary
+  - Fixes Dependabot alert #<number>
+  - Bumps <package> from <old-version> to <new-version>
+  - CVE: <CVE-ID> | Severity: <severity>
+
+  ## Test plan
+  - [ ] `yarn install` succeeds
+  - [ ] `yarn build:dev` succeeds
+  - [ ] `yarn dedupe-deps:check` passes
+  - [ ] `yarn why <package>` shows patched version
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```
+
+  Present the PR URL to the user after creation.
+
+- **Keep local** — Leave the branch local for now. Note the branch name so the user can push later.
+
+After handling the push prompt, return to `develop` for the next alert:
+
+```bash
+git checkout develop
+```
 
 #### 2d: If "Dismiss" is chosen
 
@@ -134,42 +165,15 @@ After all alerts are processed (or the user stops), present a final summary:
 ```
 ## Security Scan Complete
 
-| Alert | Package | Action | Branch |
-|-------|---------|--------|--------|
-| #1046 | foo     | Fixed  | fix/dependabot-alert-1046 |
+| Alert | Package | Action | PR / Branch |
+|-------|---------|--------|-------------|
+| #1046 | foo     | Fixed  | PR #1234 |
 | #1047 | bar     | Dismissed (tolerable_risk) | — |
 | #1048 | baz     | Skipped | — |
-| #1050 | qux     | Fixed  | fix/dependabot-alert-1050 |
-
-Branches with fixes ready for push:
-- fix/dependabot-alert-1046
-- fix/dependabot-alert-1050
-
-Push these branches and create PRs?
+| #1050 | qux     | Fixed (local) | fix/dependabot-alert-1050 |
 ```
 
-If the user approves pushing, push each fix branch and create PRs targeting `develop`:
-
-```bash
-git push -u origin fix/dependabot-alert-<number>
-gh pr create --base develop --head fix/dependabot-alert-<number> \
-  --title "fix(deps): Bump <package> to fix <CVE-ID>" \
-  --body "$(cat <<'EOF'
-## Summary
-- Fixes Dependabot alert #<number>
-- Bumps <package> from <old-version> to <new-version>
-- CVE: <CVE-ID> | Severity: <severity>
-
-## Test plan
-- [ ] `yarn install` succeeds
-- [ ] `yarn build:dev` succeeds
-- [ ] `yarn dedupe-deps:check` passes
-- [ ] `yarn why <package>` shows patched version
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
+If any fix branches were kept local, remind the user of the branch names so they can push later.
 
 ---
 


### PR DESCRIPTION
Adds a "scan all" mode to the security fix skill: `/fix-security-vulnerability --all`. Which will interactively iterate over all open security issues in this repo. The user is prompted for every issue for the action to take. Fixes will be carried out on separate branches, so they do not cross-pollute.

Did a quick trial and closed about 30 issues in 10 minutes.

Closes #19599 (added automatically)