### PR TITLE
fix(node-core,vercel-edge): Use HEROKU_BUILD_COMMIT env var for default release

### DIFF
--- a/packages/node-core/src/sdk/api.ts
+++ b/packages/node-core/src/sdk/api.ts
@@ -66,7 +66,9 @@ export function getSentryRelease(fallback?: string): string | undefined {
     process.env['FC_GIT_COMMIT_SHA'] ||
     // Heroku #1 https://devcenter.heroku.com/articles/heroku-ci
     process.env['HEROKU_TEST_RUN_COMMIT_VERSION'] ||
-    // Heroku #2 https://docs.sentry.io/product/integrations/deployment/heroku/#configure-releases
+    // Heroku #2 https://devcenter.heroku.com/articles/dyno-metadata#dyno-metadata
+    process.env['HEROKU_BUILD_COMMIT'] ||
+    // Heroku #3 (deprecated by Heroku, kept for backward compatibility)
     process.env['HEROKU_SLUG_COMMIT'] ||
     // Railway - https://docs.railway.app/reference/variables#git-variables
     process.env['RAILWAY_GIT_COMMIT_SHA'] ||

--- a/packages/node-core/test/sdk/getSentryRelease.test.ts
+++ b/packages/node-core/test/sdk/getSentryRelease.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getSentryRelease } from '../../src/sdk/api';
+
+// Higher-priority env vars that may be set on CI (e.g. GITHUB_SHA on GitHub Actions)
+// and would take precedence over the Heroku vars we're testing.
+const HIGHER_PRIORITY_ENV_VARS = [
+  'SENTRY_RELEASE',
+  'GITHUB_SHA',
+  'CI_MERGE_REQUEST_SOURCE_BRANCH_SHA',
+  'CI_BUILD_REF',
+  'CI_COMMIT_SHA',
+  'BITBUCKET_COMMIT',
+];
+
+beforeEach(() => {
+  for (const key of HIGHER_PRIORITY_ENV_VARS) {
+    vi.stubEnv(key, '');
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('getSentryRelease', () => {
+  it('uses HEROKU_BUILD_COMMIT env var', () => {
+    vi.stubEnv('HEROKU_BUILD_COMMIT', 'heroku-build-commit-sha');
+
+    expect(getSentryRelease()).toBe('heroku-build-commit-sha');
+  });
+
+  it('falls back to HEROKU_SLUG_COMMIT if HEROKU_BUILD_COMMIT is not set', () => {
+    vi.stubEnv('HEROKU_SLUG_COMMIT', 'heroku-slug-commit-sha');
+
+    expect(getSentryRelease()).toBe('heroku-slug-commit-sha');
+  });
+
+  it('prefers HEROKU_BUILD_COMMIT over HEROKU_SLUG_COMMIT', () => {
+    vi.stubEnv('HEROKU_BUILD_COMMIT', 'heroku-build-commit-sha');
+    vi.stubEnv('HEROKU_SLUG_COMMIT', 'heroku-slug-commit-sha');
+
+    expect(getSentryRelease()).toBe('heroku-build-commit-sha');
+  });
+});

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -265,7 +265,9 @@ export function getSentryRelease(fallback?: string): string | undefined {
     process.env['FC_GIT_COMMIT_SHA'] ||
     // Heroku #1 https://devcenter.heroku.com/articles/heroku-ci
     process.env['HEROKU_TEST_RUN_COMMIT_VERSION'] ||
-    // Heroku #2 https://docs.sentry.io/product/integrations/deployment/heroku/#configure-releases
+    // Heroku #2 https://devcenter.heroku.com/articles/dyno-metadata#dyno-metadata
+    process.env['HEROKU_BUILD_COMMIT'] ||
+    // Heroku #3 (deprecated by Heroku, kept for backward compatibility)
     process.env['HEROKU_SLUG_COMMIT'] ||
     // Railway - https://docs.railway.app/reference/variables#git-variables
     process.env['RAILWAY_GIT_COMMIT_SHA'] ||


### PR DESCRIPTION
Add `HEROKU_BUILD_COMMIT` as the primary env var for detecting the release on Heroku, keeping `HEROKU_SLUG_COMMIT` as a fallback since it is deprecated by Heroku.

Closes: #19615
