### PR TITLE
chore(aws-serverless): don't build lambda layer during build:dev

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -81,8 +81,9 @@
   "scripts": {
     "build": "run-p build:transpile build:types",
     "build:layer": "rimraf build/aws && rollup -c rollup.lambda-extension.config.mjs && yarn ts-node scripts/buildLambdaLayer.ts",
-    "build:dev": "run-p build:transpile build:types",
+    "build:dev": "run-p build:transpile:dev build:types",
     "build:transpile": "rollup -c rollup.npm.config.mjs && yarn build:layer",
+    "build:transpile:dev": "rollup -c rollup.npm.config.mjs",
     "build:types": "run-s build:types:core build:types:downlevel",
     "build:types:core": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "yarn downlevel-dts build/npm/types build/npm/types-ts3.8 --to ts3.8",


### PR DESCRIPTION
This PR updates `aws-serverless` dev build scripts to skip Lambda layer generation in `build:dev`.

## Why
`build:dev` is intended for faster local/dev iteration, but currently it triggers `build:layer` through `build:transpile`, which adds unnecessary work.

Related issue: #19587

## What changed
- Updated `build:dev` to use a dedicated dev transpile script.
- Added `build:transpile:dev` that only runs Rollup and does not build the Lambda layer.
- Kept `build:transpile` unchanged so production/full builds still include layer generation.

## Risk
Low. Script-only change scoped to `packages/aws-serverless` dev build path; no runtime behavior changes.