### PR TITLE
fix(nestjs): treat WsException as expected error

### DIFF
--- a/packages/nestjs/src/helpers.ts
+++ b/packages/nestjs/src/helpers.ts
@@ -2,6 +2,8 @@
  * Determines if the exception is an expected NestJS control flow error.
  * - HttpException have getStatus and getResponse methods: https://github.com/nestjs/nest/blob/master/packages/microservices/exceptions/rpc-exception.ts
  * - RpcException have getError and initMessage methods: https://github.com/nestjs/nest/blob/master/packages/common/exceptions/http.exception.ts
+ * - WsException has getError and initMessage in current Nest versions, but we also accept a WsException-shaped fallback
+ *   identified by constructor name to avoid reporting control-flow websocket exceptions.
  *
  * We cannot use `instanceof HttpException` here because this file is imported
  * from the main entry point (via decorators.ts), and importing @nestjs/common at that
@@ -25,8 +27,13 @@ export function isExpectedError(exception: unknown): boolean {
     return true;
   }
 
-  // RpcException
+  // RpcException / WsException (current Nest versions)
   if (typeof ex.getError === 'function' && typeof ex.initMessage === 'function') {
+    return true;
+  }
+
+  // WsException fallback (older/custom variants may not expose initMessage)
+  if (typeof ex.getError === 'function' && ex.constructor?.name === 'WsException') {
     return true;
   }
 

--- a/packages/nestjs/test/helpers.test.ts
+++ b/packages/nestjs/test/helpers.test.ts
@@ -15,6 +15,14 @@ describe('isExpectedError', () => {
     expect(isExpectedError(rpcLike)).toBe(true);
   });
 
+  it('should return true for WsException-like objects without initMessage', () => {
+    const wsLike = {
+      getError: () => 'some error',
+      constructor: { name: 'WsException' },
+    };
+    expect(isExpectedError(wsLike)).toBe(true);
+  });
+
   it('should return false for plain Error', () => {
     expect(isExpectedError(new Error('test'))).toBe(false);
   });


### PR DESCRIPTION
This PR updates NestJS expected-error detection to avoid reporting `WsException` control-flow errors to Sentry.

## Why
Issue #19631 notes that `WsException` should be treated similarly to `HttpException` and `RpcException` (control-flow exceptions thrown by user code), and should not be captured as errors.

## What changed
- Updated `isExpectedError` in `packages/nestjs/src/helpers.ts`:
  - Keep existing `getError + initMessage` detection (covers current `RpcException`/`WsException` shapes).
  - Add a `WsException` fallback for variants that expose `getError` but not `initMessage`, detected via `constructor.name === 'WsException'`.
- Added test coverage in `packages/nestjs/test/helpers.test.ts` for a `WsException`-like object without `initMessage`.

## Risk
Low. The change is scoped to NestJS control-flow exception classification and does not alter event pipeline behavior outside this filter.

## Validation
- Added unit test for the new `WsException` fallback case.
- Note: Full test execution was not run in this environment because `yarn` is unavailable.
