### PR TITLE
fix(deps): bump hono to 4.12.5 to fix multiple vulnerabilities

### DIFF
--- a/dev-packages/cloudflare-integration-tests/package.json
+++ b/dev-packages/cloudflare-integration-tests/package.json
@@ -16,7 +16,7 @@
     "@langchain/langgraph": "^1.0.1",
     "@sentry/cloudflare": "10.42.0",
     "@sentry/hono": "10.42.0",
-    "hono": "^4.11.10"
+    "hono": "^4.12.5"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250922.0",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@sentry/cloudflare": "latest || *",
-    "hono": "4.11.10"
+    "hono": "4.12.5"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8.31",

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -56,7 +56,7 @@
     "generic-pool": "^3.9.0",
     "graphql": "^16.11.0",
     "graphql-tag": "^2.12.6",
-    "hono": "^4.11.10",
+    "hono": "^4.12.5",
     "http-terminator": "^3.2.0",
     "ioredis": "^5.4.1",
     "kafkajs": "2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18604,10 +18604,10 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hono@^4.11.10:
-  version "4.11.10"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.11.10.tgz#0cb40d3d8e2ff764c761b4267b99e3c7a6edf6a0"
-  integrity sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==
+hono@^4.12.5:
+  version "4.12.5"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.5.tgz#8c16209b35040025d3f110d18f3b821de6cab00f"
+  integrity sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==
 
 hookable@^5.5.3:
   version "5.5.3"
@@ -28096,7 +28096,6 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
-  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"


### PR DESCRIPTION
Fixes Dependabot alerts #1125, #1126, #1127, #1128, #1129, #1130.
- CVE-2026-29045: Arbitrary file access via serveStatic (high)
- Cookie Attribute Injection via setCookie() (medium)
- SSE Control Field Injection via writeSSE() (medium)

@s1gr1d feel free to close this one if you want, but pls dismiss the alerts accordingly if this is the case