### PR TITLE
fix(node): Prevent duplicate LangChain spans from double module patching

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
@@ -169,6 +169,23 @@ describe('LangChain integration', () => {
         .start()
         .completed();
     });
+
+    test('does not create duplicate spans from double module patching', async () => {
+      await createRunner()
+        .ignore('event')
+        .expect({
+          transaction: event => {
+            const spans = event.spans || [];
+            const genAiChatSpans = spans.filter(span => span.op === 'gen_ai.chat');
+            // The scenario makes 3 LangChain calls (2 successful + 1 error).
+            // Without the dedup guard, the file-level and module-level hooks
+            // both patch the same prototype, producing 6 spans instead of 3.
+            expect(genAiChatSpans).toHaveLength(3);
+          },
+        })
+        .start()
+        .completed();
+    });
   });
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {

--- a/packages/node/src/integrations/tracing/langchain/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/langchain/instrumentation.ts
@@ -228,6 +228,12 @@ export class SentryLangChainInstrumentation extends InstrumentationBase<LangChai
     // Patch directly on chatModelClass.prototype
     const targetProto = chatModelClass.prototype as Record<string, unknown>;
 
+    // Skip if already patched (both file-level and module-level hooks resolve to the same prototype)
+    if (targetProto.__sentry_patched__) {
+      return;
+    }
+    targetProto.__sentry_patched__ = true;
+
     // Patch the methods (invoke, stream, batch)
     // All chat model instances will inherit these patched methods
     const methodsToPatch = ['invoke', 'stream', 'batch'] as const;


### PR DESCRIPTION
The LangChain instrumentation registers both a module-level and a file-level hook for each provider package (e.g. `@langchain/openai`). Both hooks call _patch, which wraps the same prototype methods (invoke, stream, batch) with a new  
  proxy and callback handler. This results in every LangChain call producing duplicate gen_ai.chat spans. The fix adds a `__sentry_patched__` guard on the prototype to skip patching if it's already been done.


Closes #19685 (added automatically)