### PR TITLE
chore(ci): Allow triage action to run on issues from external users

### DIFF
--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -57,6 +57,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: '*'
           settings: |
             {
               "env": {


### PR DESCRIPTION
The claude-code-action OIDC token exchange verifies that the triggering GitHub actor has write access to the repository. When an external user opens an issue, they are the actor and don't have write access, causing the action to fail with a 401 error.

Pass an explicit github_token and set allowed_non_write_users to '*' so the action skips the write-access check. This is safe because the workflow's GITHUB_TOKEN only has read permissions, and the existing prompt injection detection script guards against malicious issue content before any triage logic (including Linear writes) executes.

Following an example from anthropic [here](https://github.com/anthropics/claude-code-action/blob/3428ca8991d4611b464661a70b0725ae459c894d/examples/issue-triage.yml#L28)

Closes #19702 (added automatically)