### PR TITLE
style: Auto changes made from "yarn fix"

### DIFF
--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -27,7 +27,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const packageDotJSON = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), './package.json'), { encoding: 'utf8' }));
 
-const ignoreSideEffects = /[\\\/]debug-build\.ts$/;
+const ignoreSideEffects = /[\\/]debug-build\.ts$/;
 
 export function makeBaseNPMConfig(options = {}) {
   const {


### PR DESCRIPTION
I ran `yarn fix` on `develop` and there was a change. 

Does that mean that the CI doesn't fail when the files are not formatted correctly?!

Closes #19711 (added automatically)