### PR TITLE
feat(node-core,node): Add tracePropagation option to http and fetch integrations

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/instrument.mjs
+++ b/dev-packages/node-core-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/instrument.mjs
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/node-core';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import { setupOtel } from '../../../../utils/setupOtel.js';
+
+const client = Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  integrations: [Sentry.nativeNodeFetchIntegration({ tracePropagation: false })],
+  transport: loggingTransport,
+});
+
+setupOtel(client);

--- a/dev-packages/node-core-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/scenario.mjs
+++ b/dev-packages/node-core-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/scenario.mjs
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/node-core';
+
+async function run() {
+  Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+
+  await fetch(`${process.env.SERVER_URL}/api/v0`).then(res => res.text());
+  await fetch(`${process.env.SERVER_URL}/api/v1`).then(res => res.text());
+
+  Sentry.captureException(new Error('foo'));
+}
+
+run();

--- a/dev-packages/node-core-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/test.ts
@@ -1,0 +1,66 @@
+import { createTestServer } from '@sentry-internal/test-utils';
+import { describe, expect } from 'vitest';
+import { createEsmAndCjsTests } from '../../../../utils/runner';
+
+describe('outgoing fetch with tracePropagation disabled', () => {
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('does not inject trace headers but still creates breadcrumbs', async () => {
+      expect.assertions(5);
+
+      const [SERVER_URL, closeTestServer] = await createTestServer()
+        .get('/api/v0', headers => {
+          expect(headers['sentry-trace']).toBeUndefined();
+          expect(headers['baggage']).toBeUndefined();
+        })
+        .get('/api/v1', headers => {
+          expect(headers['sentry-trace']).toBeUndefined();
+          expect(headers['baggage']).toBeUndefined();
+        })
+        .start();
+
+      await createRunner()
+        .withEnv({ SERVER_URL })
+        .expect({
+          event: {
+            breadcrumbs: [
+              {
+                message: 'manual breadcrumb',
+                timestamp: expect.any(Number),
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v0`,
+                  status_code: 200,
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v1`,
+                  status_code: 200,
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+            ],
+            exception: {
+              values: [
+                {
+                  type: 'Error',
+                  value: 'foo',
+                },
+              ],
+            },
+          },
+        })
+        .start()
+        .completed();
+      closeTestServer();
+    });
+  });
+});

--- a/dev-packages/node-core-integration-tests/suites/tracing/requests/http-no-trace-propagation/instrument.mjs
+++ b/dev-packages/node-core-integration-tests/suites/tracing/requests/http-no-trace-propagation/instrument.mjs
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/node-core';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import { setupOtel } from '../../../../utils/setupOtel.js';
+
+const client = Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  integrations: [Sentry.httpIntegration({ tracePropagation: false, spans: false })],
+  transport: loggingTransport,
+});
+
+setupOtel(client);

--- a/dev-packages/node-core-integration-tests/suites/tracing/requests/http-no-trace-propagation/scenario.mjs
+++ b/dev-packages/node-core-integration-tests/suites/tracing/requests/http-no-trace-propagation/scenario.mjs
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/node-core';
+import * as http from 'http';
+
+async function run() {
+  Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v0`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v1`);
+
+  Sentry.captureException(new Error('foo'));
+}
+
+run();
+
+function makeHttpRequest(url) {
+  return new Promise(resolve => {
+    http
+      .request(url, httpRes => {
+        httpRes.on('data', () => {
+          // we don't care about data
+        });
+        httpRes.on('end', () => {
+          resolve();
+        });
+      })
+      .end();
+  });
+}

--- a/dev-packages/node-core-integration-tests/suites/tracing/requests/http-no-trace-propagation/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/tracing/requests/http-no-trace-propagation/test.ts
@@ -1,0 +1,66 @@
+import { createTestServer } from '@sentry-internal/test-utils';
+import { describe, expect } from 'vitest';
+import { createEsmAndCjsTests } from '../../../../utils/runner';
+
+describe('outgoing http with tracePropagation disabled', () => {
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('does not inject trace headers but still creates breadcrumbs', async () => {
+      expect.assertions(5);
+
+      const [SERVER_URL, closeTestServer] = await createTestServer()
+        .get('/api/v0', headers => {
+          expect(headers['sentry-trace']).toBeUndefined();
+          expect(headers['baggage']).toBeUndefined();
+        })
+        .get('/api/v1', headers => {
+          expect(headers['sentry-trace']).toBeUndefined();
+          expect(headers['baggage']).toBeUndefined();
+        })
+        .start();
+
+      await createRunner()
+        .withEnv({ SERVER_URL })
+        .expect({
+          event: {
+            breadcrumbs: [
+              {
+                message: 'manual breadcrumb',
+                timestamp: expect.any(Number),
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v0`,
+                  status_code: 200,
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v1`,
+                  status_code: 200,
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+            ],
+            exception: {
+              values: [
+                {
+                  type: 'Error',
+                  value: 'foo',
+                },
+              ],
+            },
+          },
+        })
+        .start()
+        .completed();
+      closeTestServer();
+    });
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/instrument.mjs
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  integrations: [Sentry.nativeNodeFetchIntegration({ tracePropagation: false })],
+  transport: loggingTransport,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/scenario.mjs
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/node';
+
+async function run() {
+  Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+
+  await fetch(`${process.env.SERVER_URL}/api/v0`).then(res => res.text());
+  await fetch(`${process.env.SERVER_URL}/api/v1`).then(res => res.text());
+
+  Sentry.captureException(new Error('foo'));
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/test.ts
@@ -1,0 +1,66 @@
+import { createTestServer } from '@sentry-internal/test-utils';
+import { describe, expect } from 'vitest';
+import { createEsmAndCjsTests } from '../../../../utils/runner';
+
+describe('outgoing fetch with tracePropagation disabled', () => {
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('does not inject trace headers but still creates breadcrumbs', async () => {
+      expect.assertions(5);
+
+      const [SERVER_URL, closeTestServer] = await createTestServer()
+        .get('/api/v0', headers => {
+          expect(headers['sentry-trace']).toBeUndefined();
+          expect(headers['baggage']).toBeUndefined();
+        })
+        .get('/api/v1', headers => {
+          expect(headers['sentry-trace']).toBeUndefined();
+          expect(headers['baggage']).toBeUndefined();
+        })
+        .start();
+
+      await createRunner()
+        .withEnv({ SERVER_URL })
+        .expect({
+          event: {
+            breadcrumbs: [
+              {
+                message: 'manual breadcrumb',
+                timestamp: expect.any(Number),
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v0`,
+                  status_code: 200,
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v1`,
+                  status_code: 200,
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+            ],
+            exception: {
+              values: [
+                {
+                  type: 'Error',
+                  value: 'foo',
+                },
+              ],
+            },
+          },
+        })
+        .start()
+        .completed();
+      closeTestServer();
+    });
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/instrument.mjs
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  integrations: [Sentry.httpIntegration({ tracePropagation: false, spans: false })],
+  transport: loggingTransport,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/scenario.mjs
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/node';
+import * as http from 'http';
+
+async function run() {
+  Sentry.addBreadcrumb({ message: 'manual breadcrumb' });
+
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v0`);
+  await makeHttpRequest(`${process.env.SERVER_URL}/api/v1`);
+
+  Sentry.captureException(new Error('foo'));
+}
+
+run();
+
+function makeHttpRequest(url) {
+  return new Promise(resolve => {
+    http
+      .request(url, httpRes => {
+        httpRes.on('data', () => {
+          // we don't care about data
+        });
+        httpRes.on('end', () => {
+          resolve();
+        });
+      })
+      .end();
+  });
+}

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/test.ts
@@ -1,0 +1,66 @@
+import { createTestServer } from '@sentry-internal/test-utils';
+import { describe, expect } from 'vitest';
+import { createEsmAndCjsTests } from '../../../../utils/runner';
+
+describe('outgoing http with tracePropagation disabled', () => {
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('does not inject trace headers but still creates breadcrumbs', async () => {
+      expect.assertions(5);
+
+      const [SERVER_URL, closeTestServer] = await createTestServer()
+        .get('/api/v0', headers => {
+          expect(headers['sentry-trace']).toBeUndefined();
+          expect(headers['baggage']).toBeUndefined();
+        })
+        .get('/api/v1', headers => {
+          expect(headers['sentry-trace']).toBeUndefined();
+          expect(headers['baggage']).toBeUndefined();
+        })
+        .start();
+
+      await createRunner()
+        .withEnv({ SERVER_URL })
+        .expect({
+          event: {
+            breadcrumbs: [
+              {
+                message: 'manual breadcrumb',
+                timestamp: expect.any(Number),
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v0`,
+                  status_code: 200,
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+              {
+                category: 'http',
+                data: {
+                  'http.method': 'GET',
+                  url: `${SERVER_URL}/api/v1`,
+                  status_code: 200,
+                },
+                timestamp: expect.any(Number),
+                type: 'http',
+              },
+            ],
+            exception: {
+              values: [
+                {
+                  type: 'Error',
+                  value: 'foo',
+                },
+              ],
+            },
+          },
+        })
+        .start()
+        .completed();
+      closeTestServer();
+    });
+  });
+});

--- a/packages/node-core/src/integrations/http/index.ts
+++ b/packages/node-core/src/integrations/http/index.ts
@@ -42,6 +42,16 @@ interface HttpOptions {
   sessionFlushingDelayMS?: number;
 
   /**
+   * Whether to inject trace propagation headers (sentry-trace, baggage, traceparent) into outgoing HTTP requests.
+   *
+   * When set to `false`, Sentry will not inject any trace propagation headers, but will still create breadcrumbs
+   * (if `breadcrumbs` is enabled).
+   *
+   * @default `true`
+   */
+  tracePropagation?: boolean;
+
+  /**
    * Do not capture spans or breadcrumbs for outgoing HTTP requests to URLs where the given callback returns `true`.
    * This controls both span & breadcrumb creation - spans will be non recording if tracing is disabled.
    *
@@ -141,7 +151,7 @@ export const httpIntegration = defineIntegration((options: HttpOptions = {}) => 
 
   const httpInstrumentationOptions: SentryHttpInstrumentationOptions = {
     breadcrumbs: options.breadcrumbs,
-    propagateTraceInOutgoingRequests: true,
+    propagateTraceInOutgoingRequests: options.tracePropagation ?? true,
     ignoreOutgoingRequests: options.ignoreOutgoingRequests,
   };
 

--- a/packages/node-core/src/integrations/node-fetch/SentryNodeFetchInstrumentation.ts
+++ b/packages/node-core/src/integrations/node-fetch/SentryNodeFetchInstrumentation.ts
@@ -21,6 +21,17 @@ export type SentryNodeFetchInstrumentationOptions = InstrumentationConfig & {
   breadcrumbs?: boolean;
 
   /**
+   * Whether to inject trace propagation headers (sentry-trace, baggage, traceparent) into outgoing fetch requests.
+   *
+   * When set to `false`, Sentry will not inject any trace propagation headers, but will still create breadcrumbs
+   * (if `breadcrumbs` is enabled). This is useful when `skipOpenTelemetrySetup: true` is configured and you want
+   * to avoid duplicate trace headers being injected by both Sentry and OpenTelemetry's UndiciInstrumentation.
+   *
+   * @default `true`
+   */
+  tracePropagation?: boolean;
+
+  /**
    * Do not capture breadcrumbs or inject headers for outgoing fetch requests to URLs where the given callback returns `true`.
    * The same option can be passed to the top-level httpIntegration where it controls both, breadcrumb and
    * span creation.
@@ -118,7 +129,9 @@ export class SentryNodeFetchInstrumentation extends InstrumentationBase<SentryNo
       return;
     }
 
-    addTracePropagationHeadersToFetchRequest(request, this._propagationDecisionMap);
+    if (config.tracePropagation !== false) {
+      addTracePropagationHeadersToFetchRequest(request, this._propagationDecisionMap);
+    }
   }
 
   /**

--- a/packages/node-core/src/integrations/node-fetch/index.ts
+++ b/packages/node-core/src/integrations/node-fetch/index.ts
@@ -13,6 +13,13 @@ interface NodeFetchOptions {
   breadcrumbs?: boolean;
 
   /**
+   * Whether to inject trace propagation headers (sentry-trace, baggage, traceparent) into outgoing fetch requests.
+   *
+   * @default `true`
+   */
+  tracePropagation?: boolean;
+
+  /**
    * Do not capture spans or breadcrumbs for outgoing fetch requests to URLs where the given callback returns `true`.
    * This controls both span & breadcrumb creation - spans will be non recording if tracing is disabled.
    */

--- a/packages/node-core/src/light/integrations/httpIntegration.ts
+++ b/packages/node-core/src/light/integrations/httpIntegration.ts
@@ -61,6 +61,16 @@ export interface HttpIntegrationOptions {
   breadcrumbs?: boolean;
 
   /**
+   * Whether to inject trace propagation headers (sentry-trace, baggage, traceparent) into outgoing HTTP requests.
+   *
+   * When set to `false`, Sentry will not inject any trace propagation headers, but will still create breadcrumbs
+   * (if `breadcrumbs` is enabled).
+   *
+   * @default `true`
+   */
+  tracePropagation?: boolean;
+
+  /**
    * Do not capture breadcrumbs or propagate trace headers for outgoing HTTP requests to URLs
    * where the given callback returns `true`.
    *
@@ -75,6 +85,7 @@ const _httpIntegration = ((options: HttpIntegrationOptions = {}) => {
     maxRequestBodySize: options.maxRequestBodySize ?? 'medium',
     ignoreRequestBody: options.ignoreRequestBody,
     breadcrumbs: options.breadcrumbs ?? true,
+    tracePropagation: options.tracePropagation ?? true,
     ignoreOutgoingRequests: options.ignoreOutgoingRequests,
   };
 
@@ -212,7 +223,7 @@ function instrumentServer(
 
 function onOutgoingRequestCreated(
   request: ClientRequest,
-  options: { ignoreOutgoingRequests?: (url: string, request: RequestOptions) => boolean },
+  options: { tracePropagation: boolean; ignoreOutgoingRequests?: (url: string, request: RequestOptions) => boolean },
   propagationDecisionMap: LRUMap<string, boolean>,
   ignoreOutgoingRequestsMap: WeakMap<ClientRequest, boolean>,
 ): void {
@@ -223,7 +234,9 @@ function onOutgoingRequestCreated(
     return;
   }
 
-  addTracePropagationHeadersToOutgoingRequest(request, propagationDecisionMap);
+  if (options.tracePropagation) {
+    addTracePropagationHeadersToOutgoingRequest(request, propagationDecisionMap);
+  }
 }
 
 function onOutgoingRequestFinish(

--- a/packages/node-core/src/light/integrations/nativeNodeFetchIntegration.ts
+++ b/packages/node-core/src/light/integrations/nativeNodeFetchIntegration.ts
@@ -20,6 +20,16 @@ export interface NativeNodeFetchIntegrationOptions {
   breadcrumbs?: boolean;
 
   /**
+   * Whether to inject trace propagation headers (sentry-trace, baggage, traceparent) into outgoing fetch requests.
+   *
+   * When set to `false`, Sentry will not inject any trace propagation headers, but will still create breadcrumbs
+   * (if `breadcrumbs` is enabled).
+   *
+   * @default `true`
+   */
+  tracePropagation?: boolean;
+
+  /**
    * Do not capture breadcrumbs or inject headers for outgoing fetch requests to URLs
    * where the given callback returns `true`.
    *
@@ -31,6 +41,7 @@ export interface NativeNodeFetchIntegrationOptions {
 const _nativeNodeFetchIntegration = ((options: NativeNodeFetchIntegrationOptions = {}) => {
   const _options = {
     breadcrumbs: options.breadcrumbs ?? true,
+    tracePropagation: options.tracePropagation ?? true,
     ignoreOutgoingRequests: options.ignoreOutgoingRequests,
   };
 
@@ -69,7 +80,7 @@ export const nativeNodeFetchIntegration = _nativeNodeFetchIntegration as (
 
 function onUndiciRequestCreated(
   request: UndiciRequest,
-  options: { ignoreOutgoingRequests?: (url: string) => boolean },
+  options: { tracePropagation: boolean; ignoreOutgoingRequests?: (url: string) => boolean },
   propagationDecisionMap: LRUMap<string, boolean>,
   ignoreOutgoingRequestsMap: WeakMap<UndiciRequest, boolean>,
 ): void {
@@ -80,7 +91,9 @@ function onUndiciRequestCreated(
     return;
   }
 
-  addTracePropagationHeadersToFetchRequest(request, propagationDecisionMap);
+  if (options.tracePropagation) {
+    addTracePropagationHeadersToFetchRequest(request, propagationDecisionMap);
+  }
 }
 
 function onUndiciResponseHeaders(

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -58,6 +58,17 @@ interface HttpOptions {
   sessionFlushingDelayMS?: number;
 
   /**
+   * Whether to inject trace propagation headers (sentry-trace, baggage, traceparent) into outgoing HTTP requests.
+   *
+   * When set to `false`, Sentry will not inject any trace propagation headers, but will still create breadcrumbs
+   * (if `breadcrumbs` is enabled). This is useful when `skipOpenTelemetrySetup: true` is configured and you want
+   * to avoid duplicate trace headers being injected by both Sentry and OpenTelemetry's HttpInstrumentation.
+   *
+   * @default `true`
+   */
+  tracePropagation?: boolean;
+
+  /**
    * Do not capture spans or breadcrumbs for outgoing HTTP requests to URLs where the given callback returns `true`.
    * This controls both span & breadcrumb creation - spans will be non recording if tracing is disabled.
    *
@@ -246,7 +257,8 @@ export const httpIntegration = defineIntegration((options: HttpOptions = {}) => 
 
       const sentryHttpInstrumentationOptions = {
         breadcrumbs: options.breadcrumbs,
-        propagateTraceInOutgoingRequests: !useOtelHttpInstrumentation,
+        propagateTraceInOutgoingRequests:
+          typeof options.tracePropagation === 'boolean' ? options.tracePropagation : !useOtelHttpInstrumentation,
         ignoreOutgoingRequests: options.ignoreOutgoingRequests,
       } satisfies SentryHttpInstrumentationOptions;
 

--- a/packages/node/src/integrations/node-fetch.ts
+++ b/packages/node/src/integrations/node-fetch.ts
@@ -33,6 +33,17 @@ interface NodeFetchOptions extends Pick<UndiciInstrumentationConfig, 'requestHoo
   spans?: boolean;
 
   /**
+   * Whether to inject trace propagation headers (sentry-trace, baggage, traceparent) into outgoing fetch requests.
+   *
+   * When set to `false`, Sentry will not inject any trace propagation headers, but will still create breadcrumbs
+   * (if `breadcrumbs` is enabled). This is useful when `skipOpenTelemetrySetup: true` is configured and you want
+   * to avoid duplicate trace headers being injected by both Sentry and OpenTelemetry's UndiciInstrumentation.
+   *
+   * @default `true`
+   */
+  tracePropagation?: boolean;
+
+  /**
    * Do not capture spans or breadcrumbs for outgoing fetch requests to URLs where the given callback returns `true`.
    * This controls both span & breadcrumb creation - spans will be non recording if tracing is disabled.
    */


### PR DESCRIPTION
Add a `tracePropagation` option to `httpIntegration` and `nativeNodeFetchIntegration` that allows disabling Sentry's trace header injection (sentry-trace, baggage, traceparent) while still creating breadcrumbs. This is useful when `skipOpenTelemetrySetup: true` is configured and an external OTel setup handles trace propagation, avoiding duplicate headers.

Closes: #19689
