### PR TITLE
chore(skills): Add `bump-size-limit` skill

### DIFF
--- a/.agents/skills/bump-size-limit/SKILL.md
+++ b/.agents/skills/bump-size-limit/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: bump-size-limit
+description: Bump size limits in .size-limit.js when the size-limit CI check is failing. Use when the user mentions size limit failures, bundle size checks failing, CI size check errors, or needs to update size-limit thresholds. Also use when the user says "bumpSizeLimit", "fix size limit", "size check failing", or "update bundle size limits".
+---
+
+# Bump Size Limit
+
+When the size-limit GitHub Action fails, it means one or more bundle scenarios exceed their configured byte thresholds in `.size-limit.js`. This skill walks through building, measuring, and bumping only the limits that need it.
+
+## Workflow
+
+### Step 1: Build all packages (including CDN bundles)
+
+A full build is required because size-limit measures the actual compiled artifacts.
+
+```bash
+yarn build
+```
+
+This takes a few minutes. CDN bundles in `packages/browser/build/bundles/` must be up to date — a dev build is not sufficient.
+
+### Step 2: Run the size check in JSON mode
+
+```bash
+yarn test:size-limit
+```
+
+The JSON output is an array of objects. Each object has:
+
+- `name` — the scenario label
+- `passed` — whether it's within the limit
+- `size` — actual size in bytes
+- `sizeLimit` — configured limit in bytes
+
+### Step 3: Identify failed scenarios
+
+Filter for entries where `"passed": false`. These are the only ones that need bumping.
+
+### Step 4: Calculate new limits
+
+For each failed scenario, round the actual size **up to the next full KB** (1 KB = 1000 bytes in this context, matching how size-limit interprets the limits in `.size-limit.js`).
+
+**Example:** If actual size is `129,127` bytes, the new limit is `130 KB` (i.e. 130,000 bytes).
+
+The heuristic is intentionally conservative — it gives just enough headroom without inflating limits unnecessarily.
+
+### Step 5: Update `.size-limit.js`
+
+Open `.size-limit.js` at the repository root and update the `limit` field for each failed scenario. Limits are strings like `'130 KB'`.
+
+Only change limits for scenarios that actually failed. Do not touch passing scenarios.
+
+### Step 6: Verify the fix
+
+Re-run size-limit to confirm everything passes:
+
+```bash
+yarn test:size-limit
+```
+
+If any scenario still fails (e.g., due to rounding edge cases), bump that specific limit by another 1 KB and re-run.

--- a/agents.toml
+++ b/agents.toml
@@ -43,6 +43,10 @@ name = "upgrade-dep"
 source = "path:.agents/skills/upgrade-dep"
 
 [[skills]]
+name = "bump-size-limit"
+source = "path:.agents/skills/bump-size-limit"
+
+[[skills]]
 name = "upgrade-otel"
 source = "path:.agents/skills/upgrade-otel"
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:ci:browser": "UNIT_TEST_ENV=browser ts-node ./scripts/ci-unit-tests.ts",
     "test:ci:node": "UNIT_TEST_ENV=node ts-node ./scripts/ci-unit-tests.ts",
     "test:ci:bun": "nx run-many -t test -p @sentry/bun",
+    "test:size-limit": "yarn size-limit --json",
     "yalc:publish": "nx run-many -t yalc:publish"
   },
   "volta": {


### PR DESCRIPTION
As a "manual but less manual than editing `.size-limit.js`" alternative to #19690, this PR adds a skill that takes care of bumping size limits. I also added a `test:size-limit` script for convenience since we didn't document elsewhere how to manually run the `size-limit` CLI. 