### PR TITLE
docs(new-release): Update docs based on new Craft flow

### DIFF
--- a/docs/new-sdk-release-checklist.md
+++ b/docs/new-sdk-release-checklist.md
@@ -81,21 +81,22 @@ order**. Note that you can prepare the PRs at any time but the **merging oder** 
     includeNames: /^sentry-[yourPackage]-\d.*\.tgz$/
   ```
 - [ ] 3. Add a `registry` target in `craft.yml` for the new package.
-         For new packages, Craft will automatically create the required directory structure and initial manifest in the Sentry Release Registry ([Craft Docs](https://craft.sentry.dev/targets/registry/#creating-new-packages)).
+     For new packages, Craft will automatically create the required directory structure and initial manifest in the Sentry Release Registry ([Craft Docs](https://craft.sentry.dev/targets/registry/#creating-new-packages)).
   ```yml
-    name: 'Sentry [Package] SDK'
-    packageUrl: 'https://www.npmjs.com/package/@sentry/[package]'
-    mainDocsUrl: 'https://docs.sentry.io/platforms/javascript/guides/[package]/'
-    onlyIfPresent: /^sentry-[package]-\d.*\.tgz$/
+  name: 'Sentry [Package] SDK'
+  packageUrl: 'https://www.npmjs.com/package/@sentry/[package]'
+  mainDocsUrl: 'https://docs.sentry.io/platforms/javascript/guides/[package]/'
+  onlyIfPresent: /^sentry-[package]-\d.*\.tgz$/
   ```
 - [ ] 4. Cut a new release (as usual, see
-      [Publishing Release](https://github.com/getsentry/sentry-javascript/blob/develop/docs/publishing-a-release.md))
+     [Publishing Release](https://github.com/getsentry/sentry-javascript/blob/develop/docs/publishing-a-release.md))
 
 ### After the Release
 
 - [ ] 1. Check that the package was in fact published to NPM
-- [ ] 2. Check that the SDK is added to the Sentry Release Registry [npm Packages](https://github.com/getsentry/sentry-release-registry/tree/master/packages/npm/%40sentry) and [SDK symlinks](https://github.com/getsentry/sentry-release-registry/tree/master/sdks)
+- [ ] 2. Check that the SDK is added to the Sentry Release Registry [npm packages](https://github.com/getsentry/sentry-release-registry/tree/master/packages/npm/%40sentry) and [SDK symlinks](https://github.com/getsentry/sentry-release-registry/tree/master/sdks)
 - [ ] 3. In case the package is missing anywhere, add the missing content. Instructions on how to do this can be found [here](https://github.com/getsentry/sentry-release-registry#adding-new-sdks)
+     [Example PR](https://github.com/getsentry/sentry-release-registry/pull/80) from the Svelte SDK.
 
 ## Follow-up Tasks
 


### PR DESCRIPTION
We don't need to create PRs to add new packages to the registry. Craft can now do this automatically.

Documented here: https://craft.sentry.dev/targets/registry/#creating-new-packages


Closes #19732 (added automatically)