### PR TITLE
chore: Add oxlint migration commits to blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -27,3 +27,9 @@ c88ff463a5566194a454b58bc555f183cf9ee813
 
 # chore: Unignore HTML files and reformat with oxfmt (#19311)
 b1d25bb2462feb02defcdb28221759e26c115d99
+
+# chore: migrate to oxlint (#19134)
+413041a34e748582af38c90067cd573f15c85add
+
+# chore(lint): Rule adjustments and fix warnings (#19612)
+a0c7d4029bc6f1100ea7e901e78fb5374dc308e8


### PR DESCRIPTION
## Summary
- Add oxlint migration commit (`413041a34e` — #19134) to `.git-blame-ignore-revs` (212 files changed)
- Add lint warning fixes commit (`a0c7d4029b` — #19612) to `.git-blame-ignore-revs` (65 files changed)

These are mechanical lint changes that aren't useful in `git blame` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)