### PR TITLE
fix(profiling-node): Fix NODE_VERSION rendered as [object Object] in warning

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -15,7 +15,7 @@ import {
 import type { NodeClient, NodeOptions } from '@sentry/node';
 import { CpuProfilerBindings, ProfileFormat, type RawThreadCpuProfile } from '@sentry-internal/node-cpu-profiler';
 import { DEBUG_BUILD } from './debug-build';
-import { NODE_MAJOR, NODE_VERSION } from './nodeVersion';
+import { NODE_MAJOR } from './nodeVersion';
 import { MAX_PROFILE_DURATION_MS, maybeProfileSpan, stopSpanProfile } from './spanProfileUtils';
 import {
   addProfilesToEnvelope,
@@ -634,7 +634,7 @@ export const _nodeProfilingIntegration = ((): ProfilingIntegration<NodeClient> =
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
       console.warn(
-        `[Sentry Profiling] You are using a Node.js version that does not have prebuilt binaries (${NODE_VERSION}).`,
+        `[Sentry Profiling] You are using a Node.js version that does not have prebuilt binaries (${NODE_MAJOR}).`,
         'The @sentry/profiling-node package only has prebuilt support for the following LTS versions of Node.js: 16, 18, 20, 22, 24.',
         'To use the @sentry/profiling-node package with this version of Node.js, you will need to compile the native addon from source.',
         'See: https://github.com/getsentry/sentry-javascript/tree/develop/packages/profiling-node#building-the-package-from-source',

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -5,6 +5,7 @@ import type { NodeClientOptions } from '@sentry/node/build/types/types';
 import { CpuProfilerBindings } from '@sentry-internal/node-cpu-profiler';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { _nodeProfilingIntegration } from '../src/integration';
+import { NODE_VERSION } from '../src/nodeVersion';
 
 function makeLegacySpanProfilingClient(): [Sentry.NodeClient, Transport] {
   const integration = _nodeProfilingIntegration();
@@ -981,6 +982,16 @@ describe('ProfilingIntegration', () => {
         });
       });
     });
+  });
+});
+
+describe('NODE_VERSION', () => {
+  it('is a plain object without a custom toString', () => {
+    // NODE_VERSION is a SemVer object from parseSemver — it has no custom toString().
+    // Code should never interpolate it directly in a template literal.
+    // Use process.versions.node or format the components manually instead.
+    expect(`${NODE_VERSION}`).toBe('[object Object]');
+    expect(`${NODE_VERSION.major}.${NODE_VERSION.minor}.${NODE_VERSION.patch}`).toMatch(/^\d+\.\d+\.\d+$/);
   });
 });
 


### PR DESCRIPTION
I found this while working on `no-base-to-string` rule, this is the only valid violation, the rest are buggy.

## Summary

- `NODE_VERSION` is a `SemVer` object (`{ major, minor, patch }`) from `parseSemver()` with no custom `toString()`. Interpolating it in a template literal produced `[object Object]` instead of the actual version number.
- Since the surrounding check is `![16, 18, 20, 22, 24].includes(NODE_MAJOR)`, it makes more sense to log `NODE_MAJOR` (a number) in the warning message anyway.
- Added a test verifying that `NODE_VERSION` has no custom `toString()` to prevent future misuse.

## Test plan
- [x] Added unit test confirming `NODE_VERSION` stringifies as `[object Object]`
- [x] Existing profiling-node tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #19789 (added automatically)