### PR TITLE
feat(effect): Use options in buildEffectLayer without overriding

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -256,10 +256,10 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
     // todo(v11): Remove the experimental flag
     // eslint-disable-next-line deprecation/deprecation
-    this._options.enableMetrics = this._options.enableMetrics ?? this._options._experiments?.enableMetrics ?? true;
+    const enableMetrics = this._options.enableMetrics ?? this._options._experiments?.enableMetrics ?? true;
 
     // Setup metric flushing with weight and timeout tracking
-    if (this._options.enableMetrics) {
+    if (enableMetrics) {
       setupWeightBasedFlushing(
         this,
         'afterCaptureMetric',

--- a/packages/effect/src/utils/buildEffectLayer.ts
+++ b/packages/effect/src/utils/buildEffectLayer.ts
@@ -27,15 +27,17 @@ export function buildEffectLayer<T extends EffectLayerBaseOptions>(
   }
 
   const clientOptions = client.getOptions();
+  const enableMetrics = clientOptions.enableMetrics ?? clientOptions._experiments?.enableMetrics ?? true;
+  const enableLogs = clientOptions.enableLogs ?? clientOptions._experiments?.enableLogs ?? false;
   const { enableEffectLogs = false, enableEffectMetrics = false } = options;
   let layer: EffectLayer.Layer<never, never, never> = SentryEffectTracerLayer;
 
-  if (enableEffectLogs && clientOptions.enableLogs) {
+  if (enableEffectLogs && enableLogs) {
     const effectLogger = replaceLogger(defaultLogger, SentryEffectLogger);
     layer = layer.pipe(provideMerge(effectLogger));
   }
 
-  if (enableEffectMetrics && clientOptions.enableMetrics) {
+  if (enableEffectMetrics && enableMetrics) {
     layer = layer.pipe(provideMerge(SentryEffectMetricsLayer));
   }
 


### PR DESCRIPTION
To not mess with `@sentry/core` while adding the new SDK this, the options are directly moved into the Effect SDK. The main reason why this is now moved is that mutating the options could lead to other issues, and this is why I want to keep this in a separate and smaller PR.