### PR TITLE
fix : prevent bun response headers from leaking into transaction telemetry

### DIFF
--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -239,7 +239,6 @@ function wrapRequestHandler<T extends RouteHandler = RouteHandler>(
               if (response?.status) {
                 setHttpStatus(span, response.status);
                 isolationScope.setContext('response', {
-                  headers: response.headers.toJSON(),
                   status_code: response.status,
                 });
               }


### PR DESCRIPTION
- What: Stop storing Bun response headers on the isolation scope.

- Why: Response headers (including Set-Cookie) could leak into transaction telemetry.

- How: Only keep status_code in the Bun response context, no headers.

fix : #19790