### PR TITLE
chore(node-integration-tests): Remove unnecessary `file-type` dependency

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -91,7 +91,6 @@
     "@types/node-cron": "^3.0.11",
     "@types/node-schedule": "^2.1.7",
     "eslint-plugin-regexp": "^1.15.0",
-    "file-type": "^21.3.1",
     "globby": "11",
     "react": "^18.3.1",
     "zod": "^3.24.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17277,7 +17277,7 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-type@21.3.2, file-type@^21.3.1:
+file-type@21.3.2:
   version "21.3.2"
   resolved "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz"
   integrity sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==


### PR DESCRIPTION
It seems like we added `file-type` as a dependency in #16751 with the reason that yarn was complaining about a missing peer dependency. However, `file-type` is not a peer dependency but a dependency of `@nestjs/common`. So it should be installed anyway. Given CI passes, I'd rather remove it for now. 