### PR TITLE
fix(cloudflare): Use correct env types for withSentry

### DIFF
--- a/packages/cloudflare/src/withSentry.ts
+++ b/packages/cloudflare/src/withSentry.ts
@@ -1,12 +1,13 @@
+import type { env } from 'cloudflare:workers';
 import { setAsyncLocalStorageAsyncContextStrategy } from './async';
 import type { CloudflareOptions } from './client';
 import { isInstrumented, markAsInstrumented } from './instrument';
-import { getHonoIntegration } from './integrations/hono';
 import { instrumentExportedHandlerEmail } from './instrumentations/worker/instrumentEmail';
 import { instrumentExportedHandlerFetch } from './instrumentations/worker/instrumentFetch';
 import { instrumentExportedHandlerQueue } from './instrumentations/worker/instrumentQueue';
 import { instrumentExportedHandlerScheduled } from './instrumentations/worker/instrumentScheduled';
 import { instrumentExportedHandlerTail } from './instrumentations/worker/instrumentTail';
+import { getHonoIntegration } from './integrations/hono';
 
 /**
  * Wrapper for Cloudflare handlers.
@@ -20,7 +21,7 @@ import { instrumentExportedHandlerTail } from './instrumentations/worker/instrum
  * @returns The wrapped handler.
  */
 export function withSentry<
-  Env = unknown,
+  Env = typeof env,
   QueueHandlerMessage = unknown,
   CfHostMetadata = unknown,
   T extends ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata> = ExportedHandler<

--- a/packages/cloudflare/test/withSentry.test.ts
+++ b/packages/cloudflare/test/withSentry.test.ts
@@ -7,18 +7,21 @@ import { withSentry } from '../src/withSentry';
 import { markAsInstrumented } from '../src/instrument';
 import * as HonoIntegration from '../src/integrations/hono';
 
-type HonoLikeApp<Env = unknown, QueueHandlerMessage = unknown, CfHostMetadata = unknown> = ExportedHandler<
+declare global {
+  namespace Cloudflare {
+    interface Env {
+      SENTRY_DSN: string;
+    }
+  }
+}
+
+type HonoLikeApp<Env = Cloudflare.Env, QueueHandlerMessage = unknown, CfHostMetadata = unknown> = ExportedHandler<
   Env,
   QueueHandlerMessage,
   CfHostMetadata
 > & {
   onError?: () => void;
   errorHandler?: (err: Error) => Response;
-};
-
-const MOCK_ENV = {
-  SENTRY_DSN: 'https://public@dsn.ingest.sentry.io/1337',
-  SENTRY_RELEASE: '1.1.1',
 };
 
 describe('withSentry', () => {
@@ -33,7 +36,7 @@ describe('withSentry', () => {
       const handleHonoException = vi.fn();
       vi.spyOn(HonoIntegration, 'getHonoIntegration').mockReturnValue({ handleHonoException } as any);
 
-      const honoApp = {
+      const honoApp: HonoLikeApp = {
         fetch(_request, _env, _context) {
           return new Response('test');
         },
@@ -41,7 +44,7 @@ describe('withSentry', () => {
         errorHandler(err: Error) {
           return new Response(`Error: ${err.message}`, { status: 500 });
         },
-      } satisfies HonoLikeApp<typeof MOCK_ENV>;
+      };
 
       withSentry(env => ({ dsn: env.SENTRY_DSN }), honoApp);
 
@@ -59,13 +62,13 @@ describe('withSentry', () => {
 
       const error = new Error('test hono error');
 
-      const honoApp = {
+      const honoApp: HonoLikeApp = {
         fetch(_request, _env, _context) {
           return new Response('test');
         },
         onError() {},
         errorHandler: originalErrorHandlerSpy,
-      } satisfies HonoLikeApp<typeof MOCK_ENV>;
+      };
 
       withSentry(env => ({ dsn: env.SENTRY_DSN }), honoApp);
 
@@ -86,13 +89,13 @@ describe('withSentry', () => {
 
       markAsInstrumented(originalErrorHandler);
 
-      const honoApp = {
+      const honoApp: HonoLikeApp = {
         fetch(_request, _env, _context) {
           return new Response('test');
         },
         onError() {},
         errorHandler: originalErrorHandler,
-      } satisfies HonoLikeApp<typeof MOCK_ENV>;
+      };
 
       withSentry(env => ({ dsn: env.SENTRY_DSN }), honoApp);
 


### PR DESCRIPTION
closes #18294
closes [JS-1202](https://linear.app/getsentry/issue/JS-1202/cloudflare-types-for-env-no-longer-work)

By not using `unknown` but going directly to the `env` export of `cloudflare:workers`, this should resolve the typing issue, without changing the current generic API (as proposed in #18302).

The test proofs that when changing the Cloudflare globals, that this works OOTB now.