### PR TITLE
fix(deps): bump hono 4.12.5 to 4.12.7 in cloudflare-hono E2E test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@sentry/cloudflare": "latest || *",
-    "hono": "4.12.5"
+    "hono": "4.12.7"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8.31",


### PR DESCRIPTION
Fixes Dependabot alert #1138 (prototype pollution via parseBody).
