### PR TITLE
fix(craft): Add missing mainDocsUrl for @sentry/effect SDK

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -244,4 +244,5 @@ targets:
         name: 'Sentry Effect SDK'
         sdkName: 'sentry.javascript.effect'
         packageUrl: 'https://www.npmjs.com/package/@sentry/effect'
+        mainDocsUrl: 'https://docs.sentry.io/platforms/javascript/guides/effect/'
         onlyIfPresent: /^sentry-effect-\d.*\.tgz$/


### PR DESCRIPTION
## Problem

The @sentry/effect SDK was added to the release registry without the required `mainDocsUrl` field in the craft configuration. This causes a KeyError in the Sentry backend when trying to access SDK documentation URLs.

**Sentry Issue**: [SENTRY-5M6R](https://sentry.sentry.io/issues/7341944871/)
- **Error**: `KeyError: 'main_docs_url'` 
- **Impact**: 238,811 occurrences affecting 3,994 users
- **First seen**: March 17, 2026 at 16:50 UTC (shortly after Effect SDK was released at 16:44 UTC)

## Solution

This PR adds the missing `mainDocsUrl` field to the Effect SDK configuration in `.craft.yml`, following the same pattern as other JavaScript SDKs.

## Changes

- Added `mainDocsUrl: 'https://docs.sentry.io/platforms/javascript/guides/effect/'` to the Effect SDK registry configuration

## Testing

- [ ] Verified the URL format matches other JavaScript SDK documentation URLs
- [ ] Confirmed the field name matches the registry specification

## Impact

- Future releases of @sentry/effect will include the proper documentation URL in the release registry
- This prevents the KeyError from occurring in the Sentry backend

Fixes SENTRY-5M6R