### PR TITLE
fix(nestjs): Add `node` to nest metadata

### DIFF
--- a/packages/nestjs/src/sdk.ts
+++ b/packages/nestjs/src/sdk.ts
@@ -18,7 +18,7 @@ export function init(options: NodeOptions | undefined = {}): NodeClient | undefi
     ...options,
   };
 
-  applySdkMetadata(opts, 'nestjs');
+  applySdkMetadata(opts, 'nestjs', ['nestjs', 'node']);
 
   const client = nodeInit(opts);
 

--- a/packages/nestjs/test/sdk.test.ts
+++ b/packages/nestjs/test/sdk.test.ts
@@ -20,7 +20,10 @@ describe('Initialize Nest SDK', () => {
       _metadata: {
         sdk: {
           name: 'sentry.javascript.nestjs',
-          packages: [{ name: 'npm:@sentry/nestjs', version: SDK_VERSION }],
+          packages: [
+            { name: 'npm:@sentry/nestjs', version: SDK_VERSION },
+            { name: 'npm:@sentry/node', version: SDK_VERSION },
+          ],
           version: SDK_VERSION,
         },
       },


### PR DESCRIPTION
Just saw that we missed to pass the underlying node sdk metadata.

Closes #19876 (added automatically)