### PR TITLE
fix(react-router): Disable debug ID injection in Vite plugin to prevent double injection

### DIFF
--- a/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
+++ b/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
@@ -42,7 +42,7 @@ export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuil
     },
     // will be handled in buildEnd hook
     sourcemaps: {
-      disable: 'disable-upload',
+      disable: true,
       ...unstable_sentryVitePluginOptions?.sourcemaps,
     },
     ...unstable_sentryVitePluginOptions,

--- a/packages/react-router/test/vite/makeCustomSentryVitePlugins.test.ts
+++ b/packages/react-router/test/vite/makeCustomSentryVitePlugins.test.ts
@@ -54,13 +54,13 @@ describe('makeCustomSentryVitePlugins', () => {
     expect(plugins?.[0]?.name).toBe('sentry-vite-plugin');
   });
 
-  it('should disable sourcemap upload with "disable-upload" by default', async () => {
+  it('should disable sourcemap upload by default', async () => {
     await makeCustomSentryVitePlugins({});
 
     expect(sentryVitePlugin).toHaveBeenCalledWith(
       expect.objectContaining({
         sourcemaps: expect.objectContaining({
-          disable: 'disable-upload',
+          disable: true,
         }),
       }),
     );


### PR DESCRIPTION
The `makeCustomSentryVitePlugins` function was passing `sourcemaps: { disable: 'disable-upload' }` to the Sentry Vite plugin. However, the underlying Rollup plugin checks `disable !== true`, so the string value `'disable-upload'` did not actually disable debug ID injection.

This caused double injection: once by the Vite plugin (during build), and again by `sentryOnBuildEnd` via `sentry-cli sourcemaps inject`. Each injection assigned a different UUID to the same file, breaking source map resolution.

Fix: change `disable` from `'disable-upload'` to `true` so the Rollup plugin correctly skips debug ID injection, leaving the full injection pass to `sentryOnBuildEnd`.

Closes #19874