### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,5 +31,18 @@
       "Bash(mv:*)"
     ],
     "deny": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing permissions configuration.

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently skips pre-commit, commit-msg, and pre-push hooks. `block-no-verify` detects the flag and exits 2 to block. The existing configuration is preserved unchanged.

Closes #19895

---

_Disclosure: I am the author and maintainer of `block-no-verify`._