### PR TITLE
chore(ci): Fix "Gatbsy" typo in issue package label workflow

### DIFF
--- a/.github/workflows/issue-package-label.yml
+++ b/.github/workflows/issue-package-label.yml
@@ -57,7 +57,7 @@ jobs:
                 "label": "Ember"
               },
               "@sentry.gatsby": {
-                "label": "Gatbsy"
+                "label": "Gatsby"
               },
               "@sentry.google-cloud-serverless": {
                 "label": "Google Cloud Functions"


### PR DESCRIPTION
The workflow that auto-labels issues based on SDK package name had a typo mapping @sentry/gatsby to "Gatbsy" instead of "Gatsby".



Closes #19906 (added automatically)