### PR TITLE
fix(deps): bump next to 15.5.14 in nextjs-15 and nextjs-15-intl E2E test apps

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^18.19.1",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
-    "next": "15.5.13",
+    "next": "15.5.14",
     "next-intl": "^4.3.12",
     "react": "latest",
     "react-dom": "latest",

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
@@ -20,7 +20,7 @@
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
     "ai": "^3.0.0",
-    "next": "15.5.13",
+    "next": "15.5.14",
     "react": "latest",
     "react-dom": "latest",
     "typescript": "~5.0.0",


### PR DESCRIPTION

Fixes Dependabot alerts #1227 and #1228. Patches CVE-2026-27980 (unbounded next/image disk cache growth).
