### PR TITLE
fix(deps): bump fast-xml-parser to 5.5.8 in @azure/core-xml chain

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -28223,12 +28223,7 @@ strnum@^1.0.5:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
   integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
-strnum@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.1.2.tgz#a5e00ba66ab25f9cafa3726b567ce7a49170937a"
-  integrity sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==
-
-strnum@^2.2.0:
+strnum@^2.1.2, strnum@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.1.tgz#d28f896b4ef9985212494ce8bcf7ca304fad8368"
   integrity sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==


### PR DESCRIPTION
Partially fixes Dependabot alert #1224. Updates the @azure/core-xml transitive dependency chain to fast-xml-parser 5.5.8 (patched for CVE-2026-33349). AWS SDK and Langchain chains require upstream updates.
