### PR TITLE
fix(Prisma): update span description for Prisma v7+

### DIFF
--- a/packages/node/src/integrations/tracing/prisma.ts
+++ b/packages/node/src/integrations/tracing/prisma.ts
@@ -225,7 +225,7 @@ export const prismaIntegration = defineIntegration((options?: PrismaOptions) => 
         }
 
         // Make sure we use the query text as the span name, for ex. SELECT * FROM "User" WHERE "id" = $1
-        if (spanJSON.description === 'prisma:engine:db_query' && spanJSON.data['db.query.text']) {
+        if ((spanJSON.description === 'prisma:engine:db_query' || spanJSON.description === 'prisma:client:db_query') && spanJSON.data['db.query.text']) {
           span.updateName(spanJSON.data['db.query.text'] as string);
         }
 


### PR DESCRIPTION
This pull request makes a small but important update to the Prisma tracing integration. The change ensures that both engine-level and client-level database queries are properly named in tracing spans, improving visibility and debugging for Prisma queries.

* Updated the span naming logic in `prismaIntegration` to also cover `prisma:client:db_query` events (v7+), in addition to `prisma:engine:db_query`, ensuring that the query text is used as the span name for both types of database queries. (`packages/node/src/integrations/tracing/prisma.ts`)

Relates to #18797