### PR TITLE
fix(bun): Consume fetch response body to prevent memory leak

### DIFF
--- a/packages/bun/src/transports/index.ts
+++ b/packages/bun/src/transports/index.ts
@@ -17,7 +17,9 @@ export function makeFetchTransport(options: BaseTransportOptions): Transport {
         return fetch(options.url, requestOptions).then(response => {
           // Drain response body to prevent Bun from retaining the backing ArrayBuffer.
           // See: https://github.com/oven-sh/bun/issues/10763, https://github.com/oven-sh/bun/issues/27358
-          void response.text().catch(() => {});
+          // try/catch: guards against synchronous TypeError if response.text is not a function.
+          // .catch(): handles async rejection if body read fails mid-stream (prevents unhandled promise rejection).
+          try { void response.text().catch(() => {}); } catch {} // eslint-disable-line no-empty
 
           return {
             statusCode: response.status,

--- a/packages/bun/src/transports/index.ts
+++ b/packages/bun/src/transports/index.ts
@@ -14,7 +14,18 @@ export function makeFetchTransport(options: BaseTransportOptions): Transport {
 
     try {
       return suppressTracing(() => {
-        return fetch(options.url, requestOptions).then(response => {
+        return fetch(options.url, requestOptions).then(async response => {
+          // Consume the response body to prevent memory leaks in Bun's fetch implementation.
+          // Bun retains the backing ArrayBuffer of unconsumed response bodies indefinitely,
+          // causing memory to accumulate when sending many Sentry envelopes.
+          // See: https://github.com/getsentry/sentry-javascript/issues/18534
+          try {
+            await response.text();
+          } catch {
+            // We don't care about the response body, but consuming it is necessary
+            // to prevent memory leaks in Bun's fetch implementation
+          }
+
           return {
             statusCode: response.status,
             headers: {

--- a/packages/bun/src/transports/index.ts
+++ b/packages/bun/src/transports/index.ts
@@ -14,17 +14,10 @@ export function makeFetchTransport(options: BaseTransportOptions): Transport {
 
     try {
       return suppressTracing(() => {
-        return fetch(options.url, requestOptions).then(async response => {
-          // Consume the response body to prevent memory leaks in Bun's fetch implementation.
-          // Bun retains the backing ArrayBuffer of unconsumed response bodies indefinitely,
-          // causing memory to accumulate when sending many Sentry envelopes.
-          // See: https://github.com/getsentry/sentry-javascript/issues/18534
-          try {
-            await response.text();
-          } catch {
-            // We don't care about the response body, but consuming it is necessary
-            // to prevent memory leaks in Bun's fetch implementation
-          }
+        return fetch(options.url, requestOptions).then(response => {
+          // Drain response body to prevent Bun from retaining the backing ArrayBuffer.
+          // See: https://github.com/oven-sh/bun/issues/10763, https://github.com/oven-sh/bun/issues/27358
+          void response.text().catch(() => {});
 
           return {
             statusCode: response.status,

--- a/packages/bun/test/transport.test.ts
+++ b/packages/bun/test/transport.test.ts
@@ -1,0 +1,154 @@
+import type { EventEnvelope, EventItem } from '@sentry/core';
+import { createEnvelope, serializeEnvelope } from '@sentry/core';
+import { afterAll, describe, expect, it, mock } from 'bun:test';
+import { makeFetchTransport } from '../src/transports';
+
+const DEFAULT_TRANSPORT_OPTIONS = {
+  url: 'https://sentry.io/api/42/store/?sentry_key=123&sentry_version=7',
+  recordDroppedEvent: () => undefined,
+};
+
+const ERROR_ENVELOPE = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' }, [
+  [{ type: 'event' }, { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2' }] as EventItem,
+]);
+
+const mockFetch = mock();
+
+const oldFetch = globalThis.fetch;
+globalThis.fetch = mockFetch as typeof fetch;
+
+afterAll(() => {
+  globalThis.fetch = oldFetch;
+});
+
+describe('Bun Fetch Transport', () => {
+  it('calls fetch with the given URL', async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        headers: new Headers(),
+        status: 200,
+        text: () => Promise.resolve(''),
+      }),
+    );
+
+    const transport = makeFetchTransport(DEFAULT_TRANSPORT_OPTIONS);
+
+    expect(mockFetch).toHaveBeenCalledTimes(0);
+    await transport.send(ERROR_ENVELOPE);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenLastCalledWith(DEFAULT_TRANSPORT_OPTIONS.url, {
+      body: serializeEnvelope(ERROR_ENVELOPE),
+      method: 'POST',
+      headers: undefined,
+    });
+  });
+
+  it('sets rate limit headers', async () => {
+    const headers = {
+      get: mock((key: string) => {
+        if (key === 'X-Sentry-Rate-Limits') return 'rate-limit-value';
+        if (key === 'Retry-After') return '42';
+        return null;
+      }),
+    };
+
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        headers,
+        status: 200,
+        text: () => Promise.resolve(''),
+      }),
+    );
+
+    const transport = makeFetchTransport(DEFAULT_TRANSPORT_OPTIONS);
+
+    const result = await transport.send(ERROR_ENVELOPE);
+
+    expect(headers.get).toHaveBeenCalledTimes(2);
+    expect(headers.get).toHaveBeenCalledWith('X-Sentry-Rate-Limits');
+    expect(headers.get).toHaveBeenCalledWith('Retry-After');
+    expect(result).toEqual({
+      statusCode: 200,
+      headers: {
+        'x-sentry-rate-limits': 'rate-limit-value',
+        'retry-after': '42',
+      },
+    });
+  });
+
+  describe('Response body consumption (issue #18534)', () => {
+    it('consumes the response body to prevent memory leaks in Bun', async () => {
+      const textMock = mock(() => Promise.resolve('OK'));
+      const headers = {
+        get: mock(() => null),
+      };
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          headers,
+          status: 200,
+          text: textMock,
+        }),
+      );
+
+      const transport = makeFetchTransport(DEFAULT_TRANSPORT_OPTIONS);
+
+      await transport.send(ERROR_ENVELOPE);
+
+      expect(textMock).toHaveBeenCalledTimes(1);
+      expect(headers.get).toHaveBeenCalledTimes(2);
+      expect(headers.get).toHaveBeenCalledWith('X-Sentry-Rate-Limits');
+      expect(headers.get).toHaveBeenCalledWith('Retry-After');
+    });
+
+    it('handles response body consumption errors gracefully', async () => {
+      const textMock = mock(() => Promise.reject(new Error('Body read error')));
+      const headers = {
+        get: mock(() => null),
+      };
+
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          headers,
+          status: 200,
+          text: textMock,
+        }),
+      );
+
+      const transport = makeFetchTransport(DEFAULT_TRANSPORT_OPTIONS);
+
+      // Should not throw even though text() rejects
+      const result = await transport.send(ERROR_ENVELOPE);
+
+      expect(result).toBeDefined();
+      expect(textMock).toHaveBeenCalledTimes(1);
+      expect(headers.get).toHaveBeenCalledTimes(2);
+      expect(headers.get).toHaveBeenCalledWith('X-Sentry-Rate-Limits');
+      expect(headers.get).toHaveBeenCalledWith('Retry-After');
+    });
+
+    it('handles a response without a text method', async () => {
+      const headers = {
+        get: mock(() => null),
+      };
+
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          headers,
+          status: 200,
+          // No text method on the response
+        }),
+      );
+
+      const transport = makeFetchTransport(DEFAULT_TRANSPORT_OPTIONS);
+
+      // Should not throw even without text()
+      const result = await transport.send(ERROR_ENVELOPE);
+
+      expect(result).toBeDefined();
+      expect(headers.get).toHaveBeenCalledTimes(2);
+      expect(headers.get).toHaveBeenCalledWith('X-Sentry-Rate-Limits');
+      expect(headers.get).toHaveBeenCalledWith('Retry-After');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Bun's `fetch` retains the backing `ArrayBuffer` of unconsumed response bodies indefinitely. The Bun transport's `makeFetchTransport` calls `fetch()` but never consumes the response body, causing a memory leak when sending Sentry envelopes.

This is the same class of bug that was fixed for the Cloudflare transport in #18545. We improve on that fix by using `void response.text().catch(() => {})` instead of `await response.text()`: the `void` approach drains the body asynchronously, adding zero latency to Sentry envelope sends. We don't need the response content, just need to trigger the drain so Bun releases the backing ArrayBuffer.

## Bun fetch memory leak: documented and ongoing

Bun has a well-documented history of fetch response bodies not being garbage collected. Despite multiple fixes across releases, the core problem persists for the simplest case (unconsumed bodies):

### Merged fixes (proving the problem exists)

| PR | Description | Date |
|---|---|---|
| [oven-sh/bun#10933](https://github.com/oven-sh/bun/pull/10933) | `fix(fetch): allow Response to be GC'd before all request body received` | Jun 2024 |
| [oven-sh/bun#23313](https://github.com/oven-sh/bun/pull/23313) | `refactor(Response): isolate body usage` (fetch memory leak fix) | 2025 |
| [oven-sh/bun#25846](https://github.com/oven-sh/bun/pull/25846) | `fix(fetch): fix ReadableStream memory leak when using stream body` | Jan 2026 |
| [oven-sh/bun#25965](https://github.com/oven-sh/bun/pull/25965) | `fix(http): fix Strong reference leak in server response streaming` | Jan 2026 |
| [oven-sh/bun#27191](https://github.com/oven-sh/bun/pull/27191) | `fix: release ReadableStream Strong ref on fetch body cancel` (260KB leaked per cancelled request) | Feb 2026 |

### Still-open issues

| Issue | Description |
|---|---|
| [oven-sh/bun#20912](https://github.com/oven-sh/bun/issues/20912) | Large fetch request count causes RSS to grow to 2.46GB then crash |
| [oven-sh/bun#27358](https://github.com/oven-sh/bun/issues/27358) | RSS retention on Bun 1.3.9/1.3.10 with fetch + TLS |
| [oven-sh/bun#10763](https://github.com/oven-sh/bun/issues/10763) | Partially-read fetch response bodies leak when `cancel()` is not called |

Root cause (from [#10763](https://github.com/oven-sh/bun/issues/10763)): Bun holds a strong reference to the ReadableStream backing the response body. If never consumed, the strong ref prevents GC.

## Improvement over the Cloudflare transport fix (#18545)

The Cloudflare transport fix in #18545 used `await response.text()`, which blocks the transport until the body is fully read. This adds unnecessary latency to every Sentry envelope send.

Our fix uses `void response.text().catch(() => {})` instead:
- **No added latency**: the transport returns immediately with status code and headers
- **Body still drains**: the promise runs in the background, releasing the ArrayBuffer once complete
- **No `async` needed**: the `.then()` callback stays synchronous, matching the original signature
- **Defensive `.catch(() => {})`**: if the drain fails for any reason, it doesn't crash the transport

This is a strictly better pattern for any transport where we don't need the response body content.

## Production evidence (heap snapshots)

We observed this leak in production on a Bun service running `@sentry/bun`:

| Metric | Value |
|---|---|
| ArrayBuffers accumulated (4h) | 130,389 (1,055 MB) |
| ArrayBuffer size | ~8 KB each (Bun's Buffer.poolSize) |
| RSS growth | 776 MB (t=0) -> 2,693 MB (t=4.84h) |
| CPU: `get buffer` accessor | 5% (t=0) -> 47% (t=4h), GC thrashing |
| OOM kills | Every ~5h, hitting 4GB container limit |

After applying this fix, the leak was eliminated.

## Reproduction

```js
// repro.js — run with: bun run repro.js
// Watch RSS grow unboundedly because response bodies are never consumed

const server = Bun.serve({
  port: 3456,
  fetch() {
    return new Response("x".repeat(8192));
  },
});

let i = 0;
setInterval(async () => {
  const res = await fetch("http://localhost:3456");
  // NOT consuming res.text() or res.arrayBuffer() — just discard
  void res;
  if (++i % 100 === 0) {
    Bun.gc(true);
    console.log(
      `Requests: ${i}, RSS: ${(process.memoryUsage.rss() / 1024 / 1024).toFixed(1)}MB`
    );
  }
}, 10);
```

Expected: RSS stays flat. Observed on Bun 1.3.x: RSS grows linearly.

---

> This PR was generated with the assistance of Claude Code and reviewed by a human.
