### PR TITLE
chore(claude): Enable Claude Code Intelligence (LSP)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "env": { "ENABLE_LSP_TOOL": "1" },
   "permissions": {
     "allow": [
       "Bash(find:*)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,19 @@ Monorepo with 40+ packages in `@sentry/*`, managed with Yarn workspaces and Nx.
 - After cloning: `yarn install && yarn build`
 - Never change Volta, Yarn, or package manager versions unless explicitly asked
 
+### Code Intelligence
+
+Prefer LSP over Grep/Read for code navigation — it's faster, precise, and avoids reading entire files:
+
+- `workspaceSymbol` to find where something is defined
+- `findReferences` to see all usages across the codebase
+- `goToDefinition` / `goToImplementation` to jump to source
+- `hover` for type info without reading the file
+
+Use Grep only when LSP isn't available or for text/pattern searches (comments, strings, config).
+
+After writing or editing code, check LSP diagnostics and fix errors before proceeding.
+
 ## Package Manager
 
 Use **yarn**: `yarn install`, `yarn build:dev`, `yarn test`, `yarn lint`


### PR DESCRIPTION
Code intelligence plugins enable Claude Code’s built-in LSP tool, giving Claude the ability to jump to definitions, find references, and see type errors immediately after edits.

## Instructions

1. Install TS language server: `npm i -g typescript-language-server typescript`
2. Update Claude catalog: `claude plugin marketplace update claude-plugins-official`
3. Install Claude plugin: `claude plugin install typescript-lsp`
4. Verify: `claude plugin list`

### References

- Claude Code Intelligence Docs: https://code.claude.com/docs/en/discover-plugins#code-intelligence
- Blog article: https://karanbansal.in/blog/claude-code-lsp/
- Reddit thread: https://www.reddit.com/r/ClaudeCode/comments/1rh5pcm/enable_lsp_in_claude_code_code_navigation_goes/
- Claude Code PR (with undocumented env `ENABLE_LSP_TOOL`: https://github.com/anthropics/claude-code/issues/15619



Closes #19931 (added automatically)