### PR TITLE
fix(aws-serverless): guard against negative timeout warning delay

### DIFF
--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -124,6 +124,10 @@ function setupTimeoutWarning(context: Context, options: WrapperOptions): NodeJS.
   if (options.captureTimeoutWarning) {
     const timeoutWarningDelay = tryGetRemainingTimeInMillis(context) - options.timeoutWarningLimit;
 
+    if (timeoutWarningDelay < 1) {
+      return undefined;
+    }
+
     return setTimeout(() => {
       withScope(scope => {
         scope.setTag('timeout', humanReadableTimeout);

--- a/packages/aws-serverless/test/sdk.test.ts
+++ b/packages/aws-serverless/test/sdk.test.ts
@@ -44,7 +44,7 @@ vi.mock('@sentry/node', async () => {
 });
 
 // Default `timeoutWarningLimit` is 500ms so leaving some space for it to trigger when necessary
-const DEFAULT_EXECUTION_TIME = 100;
+const DEFAULT_EXECUTION_TIME = 1000;
 let fakeEvent: { [key: string]: unknown };
 const fakeContext = {
   callbackWaitsForEmptyEventLoop: false,
@@ -76,7 +76,7 @@ function expectScopeSettings() {
       function_name: 'functionName',
       function_version: 'functionVersion',
       invoked_function_arn: 'invokedFunctionArn',
-      remaining_time_in_millis: 100,
+      remaining_time_in_millis: DEFAULT_EXECUTION_TIME,
     }),
   );
 
@@ -167,6 +167,21 @@ describe('AWSLambda', () => {
 
       expect(mockCaptureMessage).toBeCalled();
       expect(mockScope.setTag).toBeCalledWith('timeout', '1m40s');
+    });
+
+    test('captureTimeoutWarning skipped when timeoutWarningLimit exceeds remaining time', async () => {
+      const handler: Handler = (_event, _context, callback) => {
+        setTimeout(() => {
+          callback(null, 42);
+        }, DEFAULT_EXECUTION_TIME);
+      };
+      const wrappedHandler = wrapHandler(handler, {
+        timeoutWarningLimit: 100000,
+      });
+      await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
+
+      expect(mockCaptureMessage).not.toBeCalled();
+      expect(mockScope.setTag).not.toBeCalledWith('timeout', expect.anything());
     });
 
     test('captureAllSettledReasons disabled (default)', async () => {


### PR DESCRIPTION
Node 24 warns if a negative timeout is set. This is possible if `tryGetRemainingTimeInMillis` returns `0` (fallback) and `options.timeoutWarningLimit` is set. Less likely, but could also happen with very high `timeoutWarningLimit` value. In this scenario the timeout warning is pointless and therefore should be skipped

```
(node:5825) TimeoutNegativeWarning: -500 is a negative number.
Timeout duration was set to 1.
    at new Timeout (node:internal/timers:194:17)
    at setTimeout (node:timers:117:19)
    at setupTimeoutWarning
```