### PR TITLE
fix(deps): update lockfile to resolve h3@1.15.10

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18501,9 +18501,9 @@ h3@1.15.3:
     uncrypto "^0.1.3"
 
 h3@^1.10.0, h3@^1.12.0, h3@^1.15.3, h3@^1.15.5:
-  version "1.15.5"
-  resolved "https://registry.yarnpkg.com/h3/-/h3-1.15.5.tgz#e2f28d4a66a249973bb050eaddb06b9ab55506f8"
-  integrity sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==
+  version "1.15.10"
+  resolved "https://registry.yarnpkg.com/h3/-/h3-1.15.10.tgz#defe650df7b70cf585d2020c4146fb580cfb0d42"
+  integrity sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==
   dependencies:
     cookie-es "^1.2.2"
     crossws "^0.3.5"


### PR DESCRIPTION
Fixes Dependabot alerts #1236 (SSE Event Injection) and #1237 (Path Traversal via Double Decoding) by updating the yarn.lock resolution for h3 from 1.15.5 to 1.15.10.

Easier fix than https://github.com/getsentry/sentry-javascript/pull/19910 as Nuxt 3.21.x introduced breaking type changes (removed nitro from NuxtOptions and nitro:config from NuxtHooks).