### PR TITLE
chore(nuxt): Pin nuxt-nightly canary to working version

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
@@ -12,7 +12,7 @@
     "clean": "npx nuxi cleanup",
     "test": "playwright test",
     "test:build": "pnpm install && pnpm build",
-    "test:build-canary": "pnpm add nuxt@npm:nuxt-nightly@3x && pnpm add nitropack@npm:nitropack-nightly@latest && pnpm install --force && pnpm build",
+    "test:build-canary": "pnpm add nuxt@npm:nuxt-nightly@3.21.3-29561591.46bcd990 && pnpm install --force && pnpm build",
     "test:assert": "pnpm test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Pin `nuxt-nightly` to `3.21.3-29561591.46bcd990` (March 16) in the nuxt-3 canary e2e test
- Remove separate `nitropack-nightly` override (`latest` now resolves to Nitro v2, incompatible with Nuxt 3.x nightly)

The latest `nuxt-nightly@3x` (`3.21.3-29571421.a222917b`, published today) ships a broken `@nuxt/nitro-server-nightly` missing `dist/runtime/h3-compat`, causing the server to crash on startup. This is an upstream nuxt nightly regression, once fixed, we can switch back to `@3x`.
