### PR TITLE
fix(nextjs): Export captureRouterTransitionStart from server entry as noop

### DIFF
--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -151,3 +151,5 @@ export declare const openFeatureIntegration: typeof clientSdk.openFeatureIntegra
 export declare const OpenFeatureIntegrationHook: typeof clientSdk.OpenFeatureIntegrationHook;
 export declare const statsigIntegration: typeof clientSdk.statsigIntegration;
 export declare const unleashIntegration: typeof clientSdk.unleashIntegration;
+
+export declare const captureRouterTransitionStart: typeof clientSdk.captureRouterTransitionStart;

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -94,6 +94,13 @@ export function showReportDialog(): void {
 }
 
 /**
+ * Noop on the server - this is a client-only API to capture Next.js router transitions.
+ */
+export function captureRouterTransitionStart(_href: string, _navigationType: string): void {
+  return;
+}
+
+/**
  * Returns the runtime configuration for the SDK based on the environment.
  * When running on OpenNext/Cloudflare, returns cloudflare runtime config.
  */


### PR DESCRIPTION
## Summary
- Adds a server-side noop for `captureRouterTransitionStart` in `packages/nextjs/src/server/index.ts`, matching the existing pattern used for `showReportDialog`
- Adds an explicit re-export in `index.types.ts` to resolve the `export *` ambiguity between client and server

## Root Cause
Linters using `import/namespace` rules (eslint-plugin-import, oxlint) resolve `@sentry/nextjs` to the server entry point (`index.server.js`) via Node resolution, not the `types` condition. Since `captureRouterTransitionStart` was only exported from the client entry, linters reported it as missing from the namespace.

## Test plan
- [ ] Verify `yarn build:dev` passes
- [ ] Verify linters no longer report `captureRouterTransitionStart` as missing

Fixes #19939

🤖 Generated with [Claude Code](https://claude.com/claude-code)