### PR TITLE
fix(opentelemetry): Convert seconds timestamps in span.end() to milliseconds

### DIFF
--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -1,4 +1,4 @@
-import type { Context, Span, SpanContext, SpanOptions, Tracer } from '@opentelemetry/api';
+import type { Context, Span, SpanContext, SpanOptions, TimeInput, Tracer } from '@opentelemetry/api';
 import { context, SpanStatusCode, trace, TraceFlags } from '@opentelemetry/api';
 import { isTracingSuppressed, suppressTracing } from '@opentelemetry/core';
 import type {
@@ -60,6 +60,7 @@ function _startSpan<T>(options: OpenTelemetrySpanContext, callback: (span: Span)
 
       return context.with(suppressedCtx, () => {
         return tracer.startActiveSpan(name, spanOptions, suppressedCtx, span => {
+          patchSpanEnd(span);
           // Restore the original unsuppressed context for the callback execution
           // so that custom OpenTelemetry spans maintain the correct context.
           // We use activeCtx (not ctx) because ctx may be suppressed when onlyIfParent is true
@@ -82,6 +83,7 @@ function _startSpan<T>(options: OpenTelemetrySpanContext, callback: (span: Span)
     }
 
     return tracer.startActiveSpan(name, spanOptions, ctx, span => {
+      patchSpanEnd(span);
       return handleCallbackErrors(
         () => callback(span),
         () => {
@@ -155,7 +157,9 @@ export function startInactiveSpan(options: OpenTelemetrySpanContext): Span {
       ctx = isTracingSuppressed(ctx) ? ctx : suppressTracing(ctx);
     }
 
-    return tracer.startSpan(name, spanOptions, ctx);
+    const span = tracer.startSpan(name, spanOptions, ctx);
+    patchSpanEnd(span);
+    return span;
   });
 }
 
@@ -200,6 +204,17 @@ function getSpanOptions(options: OpenTelemetrySpanContext): SpanOptions {
 function ensureTimestampInMilliseconds(timestamp: number): number {
   const isMs = timestamp < 9999999999;
   return isMs ? timestamp * 1000 : timestamp;
+}
+
+/**
+ * Wraps the span's `end()` method so that numeric timestamps passed in seconds
+ * are converted to milliseconds before reaching OTel's native `Span.end()`.
+ */
+function patchSpanEnd(span: Span): void {
+  const originalEnd = span.end.bind(span);
+  span.end = (endTime?: TimeInput) => {
+    return originalEnd(typeof endTime === 'number' ? ensureTimestampInMilliseconds(endTime) : endTime);
+  };
 }
 
 function getContext(scope: Scope | undefined, forceTransaction: boolean | undefined): Context {

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -2005,6 +2005,94 @@ describe('suppressTracing', () => {
   });
 });
 
+describe('span.end() timestamp conversion', () => {
+  beforeEach(() => {
+    mockSdkInit({ tracesSampleRate: 1 });
+  });
+
+  afterEach(async () => {
+    await cleanupOtel();
+  });
+
+  it('converts seconds to milliseconds for startInactiveSpan', () => {
+    // Use a timestamp in seconds that is after the span start (i.e. in the future)
+    // OTel resets endTime to startTime if endTime < startTime
+    const nowSec = Math.floor(Date.now() / 1000) + 1;
+    const span = startInactiveSpan({ name: 'test' });
+    span.end(nowSec);
+
+    const endTime = getSpanEndTime(span);
+    // ensureTimestampInMilliseconds converts seconds (< 9999999999) to ms by * 1000
+    // OTel then converts ms to HrTime [seconds, nanoseconds]
+    expect(endTime![0]).toBe(nowSec);
+    expect(endTime![1]).toBe(0);
+  });
+
+  it('keeps milliseconds as-is for startInactiveSpan', () => {
+    // Timestamp already in milliseconds (> 9999999999 threshold)
+    const nowMs = Date.now() + 1000;
+    const nowSec = Math.floor(nowMs / 1000);
+    const span = startInactiveSpan({ name: 'test' });
+    span.end(nowMs);
+
+    const endTime = getSpanEndTime(span);
+    expect(endTime![0]).toBe(nowSec);
+  });
+
+  it('handles Date input for startInactiveSpan', () => {
+    const nowMs = Date.now() + 1000;
+    const nowSec = Math.floor(nowMs / 1000);
+    const span = startInactiveSpan({ name: 'test' });
+    span.end(new Date(nowMs));
+
+    const endTime = getSpanEndTime(span);
+    expect(endTime![0]).toBe(nowSec);
+  });
+
+  it('handles no-arg end for startInactiveSpan', () => {
+    const span = startInactiveSpan({ name: 'test' });
+    span.end();
+
+    const endTime = getSpanEndTime(span);
+    expect(endTime).toBeDefined();
+    expect(endTime![0]).not.toBe(0);
+  });
+
+  it('handles HrTime input for startInactiveSpan', () => {
+    const nowSec = Math.floor(Date.now() / 1000) + 1;
+    const span = startInactiveSpan({ name: 'test' });
+    span.end([nowSec, 500000000] as [number, number]);
+
+    const endTime = getSpanEndTime(span);
+    expect(endTime![0]).toBe(nowSec);
+    expect(endTime![1]).toBe(500000000);
+  });
+
+  it('converts seconds to milliseconds for startSpanManual callback span', () => {
+    const nowSec = Math.floor(Date.now() / 1000) + 1;
+    startSpanManual({ name: 'test' }, span => {
+      span.end(nowSec);
+
+      const endTime = getSpanEndTime(span);
+      expect(endTime![0]).toBe(nowSec);
+      expect(endTime![1]).toBe(0);
+    });
+  });
+
+  it('converts seconds to milliseconds for startSpan child span', () => {
+    const nowSec = Math.floor(Date.now() / 1000) + 1;
+    let capturedEndTime: [number, number] | undefined;
+    startSpan({ name: 'outer' }, () => {
+      const innerSpan = startInactiveSpan({ name: 'inner' });
+      innerSpan.end(nowSec);
+      capturedEndTime = getSpanEndTime(innerSpan);
+    });
+
+    expect(capturedEndTime![0]).toBe(nowSec);
+    expect(capturedEndTime![1]).toBe(0);
+  });
+});
+
 function getSpanName(span: AbstractSpan): string | undefined {
   return spanHasName(span) ? span.name : undefined;
 }


### PR DESCRIPTION
## Summary

- Patches OTel span's `end()` method to run numeric timestamps through `ensureTimestampInMilliseconds()` before reaching OTel's native implementation
- `startTime` already had this conversion, but `span.end(timestamp)` passed values directly to OTel which expects milliseconds — passing seconds (the Sentry convention) produced garbage timestamps
- Applied in all three span creation paths: both code paths in `_startSpan()` and `startInactiveSpan()`

Closes #18697