### PR TITLE
feat(nuxt): Add middleware instrumentation compatibility for Nuxt 5

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-5/server/middleware/04.hooks.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/server/middleware/04.hooks.ts
@@ -2,16 +2,18 @@ import { defineHandler } from 'nitro';
 import { getQuery } from 'nitro/h3';
 
 export default defineHandler({
-  onRequest: async event => {
-    // Set a header to indicate the onRequest hook ran
-    event.res?.headers.set('x-hooks-onrequest', 'executed');
+  middleware: [
+    async event => {
+      // Set a header to indicate the middleware ran
+      event.res?.headers.set('x-hooks-middleware', 'executed');
 
-    // Check if we should throw an error in onRequest
-    const query = getQuery(event);
-    if (query.throwOnRequestError === 'true') {
-      throw new Error('OnRequest hook error');
-    }
-  },
+      // Check if we should throw an error in middleware
+      const query = getQuery(event);
+      if (query.throwOnRequestError === 'true') {
+        throw new Error('OnRequest hook error');
+      }
+    },
+  ],
 
   handler: async event => {
     // Set a header to indicate the main handler ran
@@ -21,17 +23,6 @@ export default defineHandler({
     const query = getQuery(event);
     if (query.throwHandlerError === 'true') {
       throw new Error('Handler error');
-    }
-  },
-
-  onBeforeResponse: async (event, response) => {
-    // Set a header to indicate the onBeforeResponse hook ran
-    event.res?.headers.set('x-hooks-onbeforeresponse', 'executed');
-
-    // Check if we should throw an error in onBeforeResponse
-    const query = getQuery(event);
-    if (query.throwOnBeforeResponseError === 'true') {
-      throw new Error('OnBeforeResponse hook error');
     }
   },
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/server/middleware/05.array-hooks.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/server/middleware/05.array-hooks.ts
@@ -2,10 +2,10 @@ import { defineHandler } from 'nitro';
 import { getQuery } from 'nitro/h3';
 
 export default defineHandler({
-  // Array of onRequest handlers
-  onRequest: [
+  // Array of middleware handlers (replaces onRequest in h3 v2)
+  middleware: [
     async event => {
-      event.res?.headers.set('x-array-onrequest-0', 'executed');
+      event.res?.headers.set('x-array-middleware-0', 'executed');
 
       const query = getQuery(event);
       if (query.throwOnRequest0Error === 'true') {
@@ -13,7 +13,7 @@ export default defineHandler({
       }
     },
     async event => {
-      event.res?.headers.set('x-array-onrequest-1', 'executed');
+      event.res?.headers.set('x-array-middleware-1', 'executed');
 
       const query = getQuery(event);
       if (query.throwOnRequest1Error === 'true') {
@@ -25,24 +25,4 @@ export default defineHandler({
   handler: async event => {
     event.res?.headers.set('x-array-handler', 'executed');
   },
-
-  // Array of onBeforeResponse handlers
-  onBeforeResponse: [
-    async (event, response) => {
-      event.res?.headers.set('x-array-onbeforeresponse-0', 'executed');
-
-      const query = getQuery(event);
-      if (query.throwOnBeforeResponse0Error === 'true') {
-        throw new Error('OnBeforeResponse[0] hook error');
-      }
-    },
-    async (event, response) => {
-      event.res?.headers.set('x-array-onbeforeresponse-1', 'executed');
-
-      const query = getQuery(event);
-      if (query.throwOnBeforeResponse1Error === 'true') {
-        throw new Error('OnBeforeResponse[1] hook error');
-      }
-    },
-  ],
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/middleware.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { waitForTransaction, waitForError } from '@sentry-internal/test-utils';
 
 // TODO: Skipped for Nuxt 5 as the SDK is not yet updated for that
-test.describe.skip('Server Middleware Instrumentation', () => {
+test.describe('Server Middleware Instrumentation', () => {
   test('should create separate spans for each server middleware', async ({ request }) => {
     const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
       return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
@@ -20,8 +20,8 @@ test.describe.skip('Server Middleware Instrumentation', () => {
     // Verify that we have spans for each middleware
     const middlewareSpans = serverTxnEvent.spans?.filter(span => span.op === 'middleware.nuxt') || [];
 
-    // 3 simple + 3 hooks (onRequest+handler+onBeforeResponse) + 5 array hooks (2 onRequest + 1 handler + 2 onBeforeResponse
-    expect(middlewareSpans).toHaveLength(11);
+    // 3 simple + 2 hooks (middleware+handler) + 3 array hooks (2 middleware + 1 handler)
+    expect(middlewareSpans).toHaveLength(8);
 
     // Check for specific middleware spans
     const firstMiddlewareSpan = middlewareSpans.find(span => span.data?.['nuxt.middleware.name'] === '01.first');
@@ -60,8 +60,8 @@ test.describe.skip('Server Middleware Instrumentation', () => {
     // Verify spans have different span IDs (each middleware gets its own span)
     const spanIds = middlewareSpans.map(span => span.span_id);
     const uniqueSpanIds = new Set(spanIds);
-    // 3 simple + 3 hooks (onRequest+handler+onBeforeResponse) + 5 array hooks (2 onRequest + 1 handler + 2 onBeforeResponse)
-    expect(uniqueSpanIds.size).toBe(11);
+    // 3 simple + 2 hooks (middleware+handler) + 3 array hooks (2 middleware + 1 handler)
+    expect(uniqueSpanIds.size).toBe(8);
 
     // Verify spans share the same trace ID
     const traceIds = middlewareSpans.map(span => span.trace_id);
@@ -128,7 +128,7 @@ test.describe.skip('Server Middleware Instrumentation', () => {
     );
   });
 
-  test('should create spans for onRequest and onBeforeResponse hooks', async ({ request }) => {
+  test('should create spans for middleware and handler hooks', async ({ request }) => {
     const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
       return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
     });
@@ -143,42 +143,35 @@ test.describe.skip('Server Middleware Instrumentation', () => {
     // Find spans for the hooks middleware
     const hooksSpans = middlewareSpans.filter(span => span.data?.['nuxt.middleware.name'] === '04.hooks');
 
-    // Should have spans for onRequest, handler, and onBeforeResponse
-    expect(hooksSpans).toHaveLength(3);
+    // Should have spans for middleware and handler (h3 v2 no longer has onBeforeResponse)
+    expect(hooksSpans).toHaveLength(2);
 
     // Find specific hook spans
-    const onRequestSpan = hooksSpans.find(span => span.data?.['nuxt.middleware.hook.name'] === 'onRequest');
+    const middlewareSpan = hooksSpans.find(span => span.data?.['nuxt.middleware.hook.name'] === 'middleware');
     const handlerSpan = hooksSpans.find(span => span.data?.['nuxt.middleware.hook.name'] === 'handler');
-    const onBeforeResponseSpan = hooksSpans.find(
-      span => span.data?.['nuxt.middleware.hook.name'] === 'onBeforeResponse',
-    );
 
-    expect(onRequestSpan).toBeDefined();
+    expect(middlewareSpan).toBeDefined();
     expect(handlerSpan).toBeDefined();
-    expect(onBeforeResponseSpan).toBeDefined();
 
     // Verify span names include hook types
-    expect(onRequestSpan?.description).toBe('04.hooks.onRequest');
+    expect(middlewareSpan?.description).toBe('04.hooks.middleware');
     expect(handlerSpan?.description).toBe('04.hooks');
-    expect(onBeforeResponseSpan?.description).toBe('04.hooks.onBeforeResponse');
 
     // Verify all spans have correct middleware name (without hook suffix)
-    [onRequestSpan, handlerSpan, onBeforeResponseSpan].forEach(span => {
+    [middlewareSpan, handlerSpan].forEach(span => {
       expect(span?.data?.['nuxt.middleware.name']).toBe('04.hooks');
     });
 
     // Verify hook-specific attributes
-    expect(onRequestSpan?.data?.['nuxt.middleware.hook.name']).toBe('onRequest');
+    expect(middlewareSpan?.data?.['nuxt.middleware.hook.name']).toBe('middleware');
     expect(handlerSpan?.data?.['nuxt.middleware.hook.name']).toBe('handler');
-    expect(onBeforeResponseSpan?.data?.['nuxt.middleware.hook.name']).toBe('onBeforeResponse');
 
-    // Verify no index attributes for single hooks
-    expect(onRequestSpan?.data).not.toHaveProperty('nuxt.middleware.hook.index');
+    // Verify middleware has index (middleware is always an array in h3 v2)
+    expect(middlewareSpan?.data?.['nuxt.middleware.hook.index']).toBe(0);
     expect(handlerSpan?.data).not.toHaveProperty('nuxt.middleware.hook.index');
-    expect(onBeforeResponseSpan?.data).not.toHaveProperty('nuxt.middleware.hook.index');
   });
 
-  test('should create spans with index attributes for array hooks', async ({ request }) => {
+  test('should create spans with index attributes for array middleware', async ({ request }) => {
     const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
       return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
     });
@@ -193,48 +186,35 @@ test.describe.skip('Server Middleware Instrumentation', () => {
     // Find spans for the array hooks middleware
     const arrayHooksSpans = middlewareSpans.filter(span => span.data?.['nuxt.middleware.name'] === '05.array-hooks');
 
-    // Should have spans for 2 onRequest + 1 handler + 2 onBeforeResponse = 5 spans
-    expect(arrayHooksSpans).toHaveLength(5);
+    // Should have spans for 2 middleware + 1 handler = 3 spans (h3 v2 no longer has onBeforeResponse)
+    expect(arrayHooksSpans).toHaveLength(3);
 
-    // Find onRequest array spans
-    const onRequestSpans = arrayHooksSpans.filter(span => span.data?.['nuxt.middleware.hook.name'] === 'onRequest');
-    expect(onRequestSpans).toHaveLength(2);
-
-    // Find onBeforeResponse array spans
-    const onBeforeResponseSpans = arrayHooksSpans.filter(
-      span => span.data?.['nuxt.middleware.hook.name'] === 'onBeforeResponse',
+    // Find middleware array spans
+    const middlewareArraySpans = arrayHooksSpans.filter(
+      span => span.data?.['nuxt.middleware.hook.name'] === 'middleware',
     );
-    expect(onBeforeResponseSpans).toHaveLength(2);
+    expect(middlewareArraySpans).toHaveLength(2);
 
     // Find handler span
     const handlerSpan = arrayHooksSpans.find(span => span.data?.['nuxt.middleware.hook.name'] === 'handler');
     expect(handlerSpan).toBeDefined();
 
-    // Verify index attributes for onRequest array
-    const onRequest0Span = onRequestSpans.find(span => span.data?.['nuxt.middleware.hook.index'] === 0);
-    const onRequest1Span = onRequestSpans.find(span => span.data?.['nuxt.middleware.hook.index'] === 1);
+    // Verify index attributes for middleware array
+    const middleware0Span = middlewareArraySpans.find(span => span.data?.['nuxt.middleware.hook.index'] === 0);
+    const middleware1Span = middlewareArraySpans.find(span => span.data?.['nuxt.middleware.hook.index'] === 1);
 
-    expect(onRequest0Span).toBeDefined();
-    expect(onRequest1Span).toBeDefined();
+    expect(middleware0Span).toBeDefined();
+    expect(middleware1Span).toBeDefined();
 
-    // Verify index attributes for onBeforeResponse array
-    const onBeforeResponse0Span = onBeforeResponseSpans.find(span => span.data?.['nuxt.middleware.hook.index'] === 0);
-    const onBeforeResponse1Span = onBeforeResponseSpans.find(span => span.data?.['nuxt.middleware.hook.index'] === 1);
-
-    expect(onBeforeResponse0Span).toBeDefined();
-    expect(onBeforeResponse1Span).toBeDefined();
-
-    // Verify span names for array handlers
-    expect(onRequest0Span?.description).toBe('05.array-hooks.onRequest');
-    expect(onRequest1Span?.description).toBe('05.array-hooks.onRequest');
-    expect(onBeforeResponse0Span?.description).toBe('05.array-hooks.onBeforeResponse');
-    expect(onBeforeResponse1Span?.description).toBe('05.array-hooks.onBeforeResponse');
+    // Verify span names for array middleware handlers
+    expect(middleware0Span?.description).toBe('05.array-hooks.middleware');
+    expect(middleware1Span?.description).toBe('05.array-hooks.middleware');
 
     // Verify handler has no index
     expect(handlerSpan?.data).not.toHaveProperty('nuxt.middleware.hook.index');
   });
 
-  test('should handle errors in onRequest hooks', async ({ request }) => {
+  test('should handle errors in middleware hooks', async ({ request }) => {
     const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
       return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
     });
@@ -243,54 +223,26 @@ test.describe.skip('Server Middleware Instrumentation', () => {
       return errorEvent?.exception?.values?.[0]?.value === 'OnRequest hook error';
     });
 
-    // Make request with query param to trigger error in onRequest
+    // Make request with query param to trigger error in middleware
     const response = await request.get('/api/middleware-test?throwOnRequestError=true');
     expect(response.status()).toBe(500);
 
     const [serverTxnEvent, errorEvent] = await Promise.all([serverTxnEventPromise, errorEventPromise]);
 
-    // Find the onRequest span that should have error status
-    const onRequestSpan = serverTxnEvent.spans?.find(
+    // Find the middleware span that should have error status
+    const middlewareSpan = serverTxnEvent.spans?.find(
       span =>
         span.op === 'middleware.nuxt' &&
         span.data?.['nuxt.middleware.name'] === '04.hooks' &&
-        span.data?.['nuxt.middleware.hook.name'] === 'onRequest',
+        span.data?.['nuxt.middleware.hook.name'] === 'middleware',
     );
 
-    expect(onRequestSpan).toBeDefined();
-    expect(onRequestSpan?.status).toBe('internal_error');
+    expect(middlewareSpan).toBeDefined();
+    expect(middlewareSpan?.status).toBe('internal_error');
     expect(errorEvent.exception?.values?.[0]?.value).toBe('OnRequest hook error');
   });
 
-  test('should handle errors in onBeforeResponse hooks', async ({ request }) => {
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
-    });
-
-    const errorEventPromise = waitForError('nuxt-5', errorEvent => {
-      return errorEvent?.exception?.values?.[0]?.value === 'OnBeforeResponse hook error';
-    });
-
-    // Make request with query param to trigger error in onBeforeResponse
-    const response = await request.get('/api/middleware-test?throwOnBeforeResponseError=true');
-    expect(response.status()).toBe(500);
-
-    const [serverTxnEvent, errorEvent] = await Promise.all([serverTxnEventPromise, errorEventPromise]);
-
-    // Find the onBeforeResponse span that should have error status
-    const onBeforeResponseSpan = serverTxnEvent.spans?.find(
-      span =>
-        span.op === 'middleware.nuxt' &&
-        span.data?.['nuxt.middleware.name'] === '04.hooks' &&
-        span.data?.['nuxt.middleware.hook.name'] === 'onBeforeResponse',
-    );
-
-    expect(onBeforeResponseSpan).toBeDefined();
-    expect(onBeforeResponseSpan?.status).toBe('internal_error');
-    expect(errorEvent.exception?.values?.[0]?.value).toBe('OnBeforeResponse hook error');
-  });
-
-  test('should handle errors in array hooks with proper index attribution', async ({ request }) => {
+  test('should handle errors in array middleware with proper index attribution', async ({ request }) => {
     const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
       return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
     });
@@ -299,35 +251,35 @@ test.describe.skip('Server Middleware Instrumentation', () => {
       return errorEvent?.exception?.values?.[0]?.value === 'OnRequest[1] hook error';
     });
 
-    // Make request with query param to trigger error in second onRequest handler
+    // Make request with query param to trigger error in second middleware handler
     const response = await request.get('/api/middleware-test?throwOnRequest1Error=true');
     expect(response.status()).toBe(500);
 
     const [serverTxnEvent, errorEvent] = await Promise.all([serverTxnEventPromise, errorEventPromise]);
 
-    // Find the second onRequest span that should have error status
-    const onRequest1Span = serverTxnEvent.spans?.find(
+    // Find the second middleware span that should have error status
+    const middleware1Span = serverTxnEvent.spans?.find(
       span =>
         span.op === 'middleware.nuxt' &&
         span.data?.['nuxt.middleware.name'] === '05.array-hooks' &&
-        span.data?.['nuxt.middleware.hook.name'] === 'onRequest' &&
+        span.data?.['nuxt.middleware.hook.name'] === 'middleware' &&
         span.data?.['nuxt.middleware.hook.index'] === 1,
     );
 
-    expect(onRequest1Span).toBeDefined();
-    expect(onRequest1Span?.status).toBe('internal_error');
+    expect(middleware1Span).toBeDefined();
+    expect(middleware1Span?.status).toBe('internal_error');
     expect(errorEvent.exception?.values?.[0]?.value).toBe('OnRequest[1] hook error');
 
-    // Verify the first onRequest handler still executed successfully
-    const onRequest0Span = serverTxnEvent.spans?.find(
+    // Verify the first middleware handler still executed successfully
+    const middleware0Span = serverTxnEvent.spans?.find(
       span =>
         span.op === 'middleware.nuxt' &&
         span.data?.['nuxt.middleware.name'] === '05.array-hooks' &&
-        span.data?.['nuxt.middleware.hook.name'] === 'onRequest' &&
+        span.data?.['nuxt.middleware.hook.name'] === 'middleware' &&
         span.data?.['nuxt.middleware.hook.index'] === 0,
     );
 
-    expect(onRequest0Span).toBeDefined();
-    expect(onRequest0Span?.status).not.toBe('internal_error');
+    expect(middleware0Span).toBeDefined();
+    expect(middleware0Span?.status).not.toBe('internal_error');
   });
 });

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -166,7 +166,7 @@ export default defineNuxtModule<ModuleOptions>({
         return;
       }
 
-      if (serverConfigFile && !isNitroV3) {
+      if (serverConfigFile) {
         addMiddlewareInstrumentation(nitro);
       }
 

--- a/packages/nuxt/src/runtime/hooks/wrapMiddlewareHandler.ts
+++ b/packages/nuxt/src/runtime/hooks/wrapMiddlewareHandler.ts
@@ -21,6 +21,19 @@ import type {
   H3Event,
 } from 'h3';
 
+type RequestMiddleware = (event: H3Event<EventHandlerRequest>) => void | Promise<void>;
+type HookName = 'onRequest' | 'onBeforeResponse' | 'middleware';
+
+// Broader handler object type covering both h3 v1 and h3 v2 shapes.
+type EventHandlerObjectH3 = EventHandlerObject & {
+  // h3 v1 (Nitro v2): onRequest, onBeforeResponse, handler (required)
+  onRequest?: RequestMiddleware | RequestMiddleware[];
+  onBeforeResponse?: ResponseMiddleware | ResponseMiddleware[];
+
+  // h3 v2 (Nitro v3): middleware[], handler (optional), fetch, meta
+  middleware?: EventHandler[];
+};
+
 /**
  * Wraps a middleware handler with Sentry instrumentation.
  *
@@ -35,36 +48,41 @@ export function wrapMiddlewareHandlerWithSentry<THandler extends EventHandler | 
     return wrapEventHandler(handler, fileName) as THandler;
   }
 
-  const handlerObj = {
-    ...handler,
-    handler: wrapEventHandler(handler.handler, fileName),
+  const handlerObj = handler as EventHandlerObjectH3;
+
+  const result: EventHandlerObjectH3 = {
+    ...handlerObj,
+    ...(handlerObj.handler && { handler: wrapEventHandler(handlerObj.handler, fileName) }),
   };
 
-  if (handlerObj.onRequest) {
-    handlerObj.onRequest = normalizeHandlers(handlerObj.onRequest, (h, index) =>
-      wrapEventHandler(h, fileName, 'onRequest', index),
+  // h3 v1 (Nitro v2): onRequest and response hooks
+  if (result.onRequest) {
+    result.onRequest = normalizeHandlers(result.onRequest, (h, index) =>
+      wrapEventHandler(h as EventHandler, fileName, 'onRequest', index),
     );
   }
 
-  if (handlerObj.onBeforeResponse) {
-    handlerObj.onBeforeResponse = normalizeHandlers(handlerObj.onBeforeResponse, (h, index) =>
+  if (result.onBeforeResponse) {
+    result.onBeforeResponse = normalizeHandlers(result.onBeforeResponse, (h, index) =>
       wrapResponseHandler(h, fileName, index),
     );
   }
 
-  return handlerObj;
+  // h3 v2 (Nitro v3): middleware array replaces onRequest/onBeforeResponse
+  if (result.middleware?.length) {
+    result.middleware = result.middleware.map((h, index) => wrapEventHandler(h, fileName, 'middleware', index));
+  }
+
+  return result as THandler;
 }
 
 /**
  * Wraps a callable event handler with Sentry instrumentation.
- *
- * @param handler The event handler.
- * @param handlerName The name of the event handler to be used for the span name and logging.
  */
 function wrapEventHandler(
   handler: EventHandler,
   middlewareName: string,
-  hookName?: 'onRequest',
+  hookName?: HookName,
   index?: number,
 ): EventHandler {
   return async (event: H3Event<EventHandlerRequest>) => {
@@ -77,7 +95,7 @@ function wrapEventHandler(
 }
 
 /**
- * Wraps a middleware response handler with Sentry instrumentation.
+ * Wraps a middleware response handler with Sentry instrumentation (h3 v1 only).
  */
 function wrapResponseHandler(handler: ResponseMiddleware, middlewareName: string, index?: number): ResponseMiddleware {
   return async (event: H3Event<EventHandlerRequest>, response: EventHandlerResponse) => {
@@ -96,7 +114,7 @@ function withSpan<TResult>(
   handler: () => TResult | Promise<TResult>,
   attributes: SpanAttributes,
   middlewareName: string,
-  hookName?: 'handler' | 'onRequest' | 'onBeforeResponse',
+  hookName?: HookName | 'handler',
 ): Promise<TResult> {
   const spanName = hookName && hookName !== 'handler' ? `${middlewareName}.${hookName}` : middlewareName;
 
@@ -132,10 +150,7 @@ function withSpan<TResult>(
 /**
  * Takes a list of handlers and wraps them with the normalizer function.
  */
-function normalizeHandlers<T extends EventHandler | ResponseMiddleware>(
-  handlers: T | T[],
-  normalizer: (h: T, index?: number) => T,
-): T | T[] {
+function normalizeHandlers<T>(handlers: T | T[], normalizer: (h: T, index?: number) => T): T | T[] {
   return Array.isArray(handlers) ? handlers.map((handler, index) => normalizer(handler, index)) : normalizer(handlers);
 }
 
@@ -145,7 +160,7 @@ function normalizeHandlers<T extends EventHandler | ResponseMiddleware>(
 function getSpanAttributes(
   event: H3Event<EventHandlerRequest>,
   middlewareName: string,
-  hookName?: 'handler' | 'onRequest' | 'onBeforeResponse',
+  hookName?: HookName | 'handler',
   index?: number,
 ): SpanAttributes {
   const attributes: SpanAttributes = {
@@ -161,18 +176,31 @@ function getSpanAttributes(
     attributes['nuxt.middleware.hook.index'] = index;
   }
 
-  // Add HTTP method
-  if (event.method) {
-    attributes['http.request.method'] = event.method;
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const eventH3v2 = event as any;
+  // oxlint-disable-next-line @typescript-oxlint/no-unsafe-member-access
+  const method = event.method ?? eventH3v2?.req?.method;
+  // oxlint-disable-next-line @typescript-oxlint/no-unsafe-member-access
+  const path = event.path ?? eventH3v2?.url?.pathname;
+
+  if (method) {
+    attributes['http.request.method'] = method;
   }
 
-  // Add route information
-  if (event.path) {
-    attributes['http.route'] = event.path;
+  if (path) {
+    attributes['http.route'] = path;
   }
 
-  // Get headers from the Node.js request object
-  const headers = event.node?.req?.headers || {};
+  // h3 v1 (Nuxt 4): headers are on event.node.req.headers
+  // h3 v2 (Nuxt 5): headers are on event.req.headers
+  let headers: Record<string, string | string[] | undefined> = event.node?.req?.headers || {};
+
+  // oxlint-disable-next-line @typescript-oxlint/no-unsafe-member-access
+  if (!Object.keys(headers).length && eventH3v2?.req?.headers instanceof Headers) {
+    // oxlint-disable-next-line @typescript-oxlint/no-unsafe-member-access
+    headers = Object.fromEntries(eventH3v2?.req.headers.entries());
+  }
+
   const headerAttributes = httpHeadersToSpanAttributes(headers, getClient()?.getOptions().sendDefaultPii ?? false);
 
   // Merge header attributes with existing attributes
@@ -182,7 +210,7 @@ function getSpanAttributes(
 }
 
 /**
- * Checks if the handler is an event handler, util for type narrowing.
+ * Checks if the handler is an event handler object, util for type narrowing.
  */
 function isEventHandlerObject(handler: EventHandler | EventHandlerObject): handler is EventHandlerObject {
   return typeof handler !== 'function';

--- a/packages/nuxt/src/vite/middlewareConfig.ts
+++ b/packages/nuxt/src/vite/middlewareConfig.ts
@@ -90,8 +90,13 @@ function instrumentedEventHandler(handlerOrObject) {
   return eventHandler(wrapMiddlewareHandlerWithSentry(handlerOrObject, '${cleanFileName}'));
 }
 
+function defineInstrumentedHandler(handlerOrObject) {
+  return defineHandler(wrapMiddlewareHandlerWithSentry(handlerOrObject, '${cleanFileName}'));
+}
+
 ${originalCode
   .replace(/defineEventHandler\(/g, 'defineInstrumentedEventHandler(')
-  .replace(/eventHandler\(/g, 'instrumentedEventHandler(')}
+  .replace(/eventHandler\(/g, 'instrumentedEventHandler(')
+  .replace(/defineHandler\(/g, 'defineInstrumentedHandler(')}
 `;
 }

--- a/packages/nuxt/test/runtime/hooks/wrapMiddlewareHandler.test.ts
+++ b/packages/nuxt/test/runtime/hooks/wrapMiddlewareHandler.test.ts
@@ -468,6 +468,99 @@ describe('wrapMiddlewareHandlerWithSentry', () => {
     });
   });
 
+  describe('h3 v2 (Nitro v3) middleware array wrapping', () => {
+    it('should wrap middleware array handlers correctly', async () => {
+      const baseHandler: EventHandler = vi.fn().mockResolvedValue('handler-result');
+      const middlewareHandler1 = vi.fn().mockResolvedValue(undefined);
+      const middlewareHandler2 = vi.fn().mockResolvedValue(undefined);
+      const handlerObject = {
+        handler: baseHandler,
+        middleware: [middlewareHandler1, middlewareHandler2],
+      };
+
+      const wrapped = wrapMiddlewareHandlerWithSentry(handlerObject as any, 'v2-middleware');
+
+      expect(wrapped).toHaveProperty('middleware');
+      expect(Array.isArray((wrapped as any).middleware)).toBe(true);
+      expect((wrapped as any).middleware).toHaveLength(2);
+
+      await (wrapped as any).middleware[0](mockEvent);
+      await (wrapped as any).middleware[1](mockEvent);
+
+      expect(middlewareHandler1).toHaveBeenCalledWith(mockEvent);
+      expect(middlewareHandler2).toHaveBeenCalledWith(mockEvent);
+
+      expect(SentryCore.startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'v2-middleware.middleware',
+          attributes: expect.objectContaining({
+            [SentryCore.SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'middleware.nuxt',
+            'nuxt.middleware.name': 'v2-middleware',
+            'nuxt.middleware.hook.name': 'middleware',
+            'nuxt.middleware.hook.index': 0,
+          }),
+        }),
+        expect.any(Function),
+      );
+      expect(SentryCore.startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'v2-middleware.middleware',
+          attributes: expect.objectContaining({
+            'nuxt.middleware.hook.name': 'middleware',
+            'nuxt.middleware.hook.index': 1,
+          }),
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('should wrap single-element middleware array with index', async () => {
+      const baseHandler: EventHandler = vi.fn().mockResolvedValue('handler-result');
+      const middlewareHandler = vi.fn().mockResolvedValue(undefined);
+      const handlerObject = {
+        handler: baseHandler,
+        middleware: [middlewareHandler],
+      };
+
+      const wrapped = wrapMiddlewareHandlerWithSentry(handlerObject as any, 'v2-single-middleware');
+
+      await (wrapped as any).middleware[0](mockEvent);
+
+      expect(middlewareHandler).toHaveBeenCalledWith(mockEvent);
+
+      const spanCall = (SentryCore.startSpan as any).mock.calls.find(
+        (call: any) => call[0]?.attributes?.['nuxt.middleware.hook.name'] === 'middleware',
+      );
+      expect(spanCall[0].attributes['nuxt.middleware.hook.index']).toBe(0);
+    });
+
+    it('should handle h3 v2 object without middleware property', async () => {
+      const baseHandler: EventHandler = vi.fn().mockResolvedValue('v2-result');
+      const handlerObject = { handler: baseHandler };
+
+      const wrapped = wrapMiddlewareHandlerWithSentry(handlerObject as any, 'v2-handler-only');
+
+      const result = await (wrapped as any).handler(mockEvent);
+      expect(result).toBe('v2-result');
+      expect(baseHandler).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('should propagate errors from middleware array handlers', async () => {
+      const baseHandler: EventHandler = vi.fn().mockResolvedValue('success');
+      const error = new Error('Middleware error');
+      const failingMiddleware = vi.fn().mockRejectedValue(error);
+      const handlerObject = {
+        handler: baseHandler,
+        middleware: [failingMiddleware],
+      };
+
+      const wrapped = wrapMiddlewareHandlerWithSentry(handlerObject as any, 'failing-v2-middleware');
+
+      await expect((wrapped as any).middleware[0](mockEvent)).rejects.toThrow('Middleware error');
+      expect(SentryCore.captureException).toHaveBeenCalledWith(error, expect.any(Object));
+    });
+  });
+
   describe('Sentry API integration', () => {
     it('should call Sentry APIs with correct parameters', async () => {
       const userHandler: EventHandler = vi.fn().mockResolvedValue('api-test-result');


### PR DESCRIPTION
Nitro v3 (used by Nuxt 5) ships with h3 v2, which restructures the `EventHandlerObject` type ([old](https://github.com/h3js/h3/blob/b72bb57060cf68e627575e0c350742f4fa8206fa/src/types/index.ts#L81-L92) / [new](https://github.com/h3js/h3/blob/7c2bc9b96ab9bc25f5ca02b0c15a81b8d079e159/src/types/handler.ts#L20-L28)). The previous `onRequest`/`onBeforeResponse` lifecycle hooks are replaced by a single middleware array, and `handler` is now optional.

This PR updates the Nuxt SDK's middleware instrumentation to handle both shapes transparently: h3 v1 (`onRequest`, `onBeforeResponse`, required `handler`) for Nuxt 4 / Nitro v2, and h3 v2 (`middleware[]`, optional `handler`) for Nuxt 5 / Nitro v3.

The Nuxt 5 test app middleware files are updated to match the new h3 v2 API, and unit/E2E test assertions are adjusted accordingly.

Closes https://github.com/getsentry/sentry-javascript/issues/19954
