### PR TITLE
fix(e2e): Pin @opentelemetry/api to 1.9.0 in ts3.8 test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/generic-ts3.8/package.json
+++ b/dev-packages/e2e-tests/test-applications/generic-ts3.8/package.json
@@ -20,6 +20,11 @@
     "@sentry-internal/replay": "latest || *",
     "@sentry/wasm": "latest || *"
   },
+  "pnpm": {
+    "overrides": {
+      "@opentelemetry/api": "1.9.0"
+    }
+  },
   "volta": {
     "extends": "../../package.json"
   }


### PR DESCRIPTION
## Summary

- `@opentelemetry/api@1.9.1` was released on Mar 25 and introduced `export { Foo, type Bar }` syntax (inline type modifiers) in its `.d.ts` files, which requires TypeScript 4.5+
- The `generic-ts3.8` E2E test runs with `skipLibCheck: false` and TypeScript 3.8, so it tries to parse OTel's types and fails
- This pins `@opentelemetry/api` to `1.9.0` in the ts3.8 test app via `pnpm.overrides`
- We can't pin repo-wide in published packages because OTel uses a global singleton pattern — version mismatches with `@opentelemetry/sdk-trace-base` cause the tracer to become a no-op
- Our published `.d.ts` files are unaffected — only OTel's own types use the incompatible syntax

## Test plan

- [x] Verified locally: `yarn test:run generic-ts3.8` passes with the pin
- [ ] CI `E2E generic-ts3.8 Test` should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #19998 (added automatically)