### PR TITLE
chore: Add separate dependabot config for packages and dev-packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,10 @@ updates:
       prefix: ci
       prefix-development: ci
       include: scope
+
   - package-ecosystem: 'npm'
-    directory: '/'
+    directories:
+      - '/packages/*'
     schedule:
       interval: 'weekly'
     ignore:
@@ -27,6 +29,21 @@ updates:
     commit-message:
       prefix: feat
       prefix-development: chore
+      include: scope
+
+  - package-ecosystem: 'npm'
+    directories:
+      - '/'
+      - '/dev-packages/*'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: '@opentelemetry/instrumentation'
+      - dependency-name: '@opentelemetry/instrumentation-*'
+      - dependency-name: 'typescript'
+    versioning-strategy: increase
+    commit-message:
+      prefix: chore
       include: scope
     exclude-paths:
       - 'dev-packages/e2e-tests/test-applications/**'


### PR DESCRIPTION
To be honest, I'm not sure if we tried this before or if it works as intended. Would appreciate a review from someone who has more context on dependabot. 

For now the main change is that any PR opened by dependabot in `dev-packages` is prefixed with `chore`. We can probably do more specific configs with this as well (?)