### PR TITLE
fix(ci): Update validate-pr action to remove draft enforcement

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: getsentry/github-workflows/validate-pr@4ff40ada546d4a31b852a4279828b989a6193497
+      - uses: getsentry/github-workflows/validate-pr@33c378e8d3aa1515164b62c16c210784cee35638
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
The validate-pr composite action's draft enforcement step was failing with:

```
API call failed: GraphQL: Resource not accessible by integration (convertPullRequestToDraft)
```

The SDK Maintainer Bot app lacks the permissions needed for the `convertPullRequestToDraft` GraphQL mutation. Rather than expanding the app's permissions, draft enforcement has been removed from the shared action in getsentry/github-workflows#159.

This bumps the pinned SHA to pick up that fix.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>