### PR TITLE
fix(tanstackstart-react): remove misleading `workerd`/`worker` export conditions

### DIFF
--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -19,14 +19,6 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./build/types/index.types.d.ts",
-      "workerd": {
-        "import": "./build/esm/index.server.js",
-        "require": "./build/cjs/index.server.js"
-      },
-      "worker": {
-        "import": "./build/esm/index.server.js",
-        "require": "./build/cjs/index.server.js"
-      },
       "browser": {
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"


### PR DESCRIPTION
## Summary

Removes the `workerd` and `worker` export conditions from `@sentry/tanstackstart-react`'s `package.json`. These conditions currently resolve to `index.server.js` — the same entry as `node` — which re-exports `@sentry/node`. This falsely signals Cloudflare Workers compatibility and causes silent Worker crashes when bundlers resolve the `workerd` condition.

**What changed:** Deleted the `workerd` and `worker` blocks from the `"."` exports map. Workers bundlers will now fall through to `browser` → `index.client.js` (which uses `@sentry/browser`, safe for Workers).

**Caveats (for the team to evaluate):**
- Fallback to `browser` depends on the bundler's condition set including `browser`. Adding a `default` condition pointing to the client entry would be more robust ([Node docs](https://nodejs.org/api/packages.html#conditional-exports)), but that's a broader design decision.
- The `browser`/client entry does not export `wrapFetchWithSentry`, so Workers consumers using that import would get a build error. In practice this is an improvement — a build error is far better than the current silent runtime crash.

**Longer-term:** Proper Workers support would need a dedicated entry using `@sentry/cloudflare` instead of `@sentry/node` — multiple server source files (`sdk.ts`, `wrapFetchWithSentry.ts`, `middleware.ts`) import `@sentry/node` directly, not just the barrel. This is tracked in #18669.

Fixes #20038

## References

- Issue: #20038
- Related: #18669, #18843, #14931, #16130