### PR TITLE
fix(react-router): preserve sourcemaps.disable override

### DIFF
--- a/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
+++ b/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
@@ -19,6 +19,7 @@ export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuil
   } = options;
 
   const sentryVitePlugins = sentryVitePlugin({
+    ...unstable_sentryVitePluginOptions,
     authToken: authToken ?? process.env.SENTRY_AUTH_TOKEN,
     bundleSizeOptimizations,
     debug: debug ?? false,
@@ -26,15 +27,16 @@ export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuil
     project: project ?? process.env.SENTRY_PROJECT,
     telemetry: telemetry ?? true,
     _metaOptions: {
+      ...unstable_sentryVitePluginOptions?._metaOptions,
       telemetry: {
+        ...unstable_sentryVitePluginOptions?._metaOptions?.telemetry,
         metaFramework: 'react-router',
       },
-      ...unstable_sentryVitePluginOptions?._metaOptions,
     },
     reactComponentAnnotation: {
+      ...unstable_sentryVitePluginOptions?.reactComponentAnnotation,
       enabled: reactComponentAnnotation?.enabled ?? undefined,
       ignoredComponents: reactComponentAnnotation?.ignoredComponents ?? undefined,
-      ...unstable_sentryVitePluginOptions?.reactComponentAnnotation,
     },
     release: {
       ...unstable_sentryVitePluginOptions?.release,
@@ -42,10 +44,9 @@ export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuil
     },
     // will be handled in buildEnd hook
     sourcemaps: {
-      disable: true,
       ...unstable_sentryVitePluginOptions?.sourcemaps,
+      disable: true,
     },
-    ...unstable_sentryVitePluginOptions,
   }) as Plugin[];
 
   return sentryVitePlugins;

--- a/packages/react-router/test/vite/makeCustomSentryVitePlugins.test.ts
+++ b/packages/react-router/test/vite/makeCustomSentryVitePlugins.test.ts
@@ -66,7 +66,7 @@ describe('makeCustomSentryVitePlugins', () => {
     );
   });
 
-  it('should allow overriding sourcemaps via unstable_sentryVitePluginOptions', async () => {
+  it('should merge sourcemaps options from unstable_sentryVitePluginOptions', async () => {
     await makeCustomSentryVitePlugins({
       unstable_sentryVitePluginOptions: {
         sourcemaps: {
@@ -75,12 +75,12 @@ describe('makeCustomSentryVitePlugins', () => {
       },
     });
 
-    // unstable_sentryVitePluginOptions is spread last, so it fully overrides sourcemaps
     expect(sentryVitePlugin).toHaveBeenCalledWith(
       expect.objectContaining({
-        sourcemaps: {
+        sourcemaps: expect.objectContaining({
+          disable: true,
           assets: ['dist/**'],
-        },
+        }),
       }),
     );
   });


### PR DESCRIPTION
Ensure unstable vite plugin options don't overwrite sourcemaps.disable=true and update test expectations accordingly.

Before submitting a pull request, please take a look at our

Small issue found by cursor in #19890 right before it got merged.