### PR TITLE
fix(browser-tests): Pin axios to 1.13.5 to avoid compromised 1.14.1

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -62,7 +62,7 @@
     "@sentry-internal/rrweb": "2.34.0",
     "@sentry/browser": "10.46.0",
     "@supabase/supabase-js": "2.49.3",
-    "axios": "^1.12.2",
+    "axios": "1.13.5",
     "babel-loader": "^10.1.1",
     "fflate": "0.8.2",
     "html-webpack-plugin": "^5.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11868,7 +11868,7 @@ aws-ssl-profiles@^1.1.2:
   resolved "https://registry.yarnpkg.com/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz#157dd77e9f19b1d123678e93f120e6f193022641"
   integrity sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==
 
-axios@^1.12.0, axios@^1.12.2:
+axios@1.13.5, axios@^1.12.0:
   version "1.13.5"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
   integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==


### PR DESCRIPTION
axios 1.14.1 contains a supply chain attack via the plain-crypto-js dependency. 

This PR pins to 1.13.5 to prevent accidental upgrades.

See: https://x.com/feross/status/2038807290422370479
