### PR TITLE
fix(gatsby): Fix errorHandler signature to match bundler-plugin-core API

### DIFF
--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -41,7 +41,7 @@ exports.onCreateWebpackConfig = ({ getConfig, actions }, options) => {
           },
           // Handle sentry-cli configuration errors when the user has not done it not to break
           // the build.
-          errorHandler(err, invokeErr) {
+          errorHandler(err) {
             const message = (err.message && err.message.toLowerCase()) || '';
             if (message.includes('organization slug is required') || message.includes('project slug is required')) {
               // eslint-disable-next-line no-console
@@ -55,7 +55,7 @@ exports.onCreateWebpackConfig = ({ getConfig, actions }, options) => {
               console.warn('Sentry [Warn]: Cannot upload source maps due to missing SENTRY_AUTH_TOKEN env variable.');
               return;
             }
-            invokeErr(err);
+            throw err;
           },
         }),
       ],

--- a/packages/gatsby/test/gatsby-node.test.ts
+++ b/packages/gatsby/test/gatsby-node.test.ts
@@ -65,6 +65,47 @@ describe('onCreateWebpackConfig', () => {
     expect(actions.setWebpackConfig).toHaveBeenCalledTimes(0);
   });
 
+  describe('errorHandler', () => {
+    function getErrorHandler(): (err: Error) => void {
+      const actions = { setWebpackConfig: vi.fn() };
+      const getConfig = vi.fn().mockReturnValue({ devtool: 'source-map' });
+
+      onCreateWebpackConfig({ actions, getConfig }, {});
+
+      const pluginOptions = sentryWebpackPlugin.mock.calls[0][0];
+      return pluginOptions.errorHandler;
+    }
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('accepts a single error argument (bundler-plugin-core v5 API)', () => {
+      const errorHandler = getErrorHandler();
+      expect(() => errorHandler(new Error('some error'))).toThrow('some error');
+    });
+
+    it('does not throw for missing organization slug', () => {
+      const errorHandler = getErrorHandler();
+      expect(() => errorHandler(new Error('Organization slug is required'))).not.toThrow();
+    });
+
+    it('does not throw for missing project slug', () => {
+      const errorHandler = getErrorHandler();
+      expect(() => errorHandler(new Error('Project slug is required'))).not.toThrow();
+    });
+
+    it('does not throw for missing auth token', () => {
+      const errorHandler = getErrorHandler();
+      expect(() => errorHandler(new Error('Authentication credentials were not provided'))).not.toThrow();
+    });
+
+    it('re-throws unknown errors', () => {
+      const errorHandler = getErrorHandler();
+      expect(() => errorHandler(new Error('Something unexpected'))).toThrow('Something unexpected');
+    });
+  });
+
   describe('delete source maps after upload', () => {
     beforeEach(() => {
       vi.clearAllMocks();


### PR DESCRIPTION
closes #20043
closes [JS-2024](https://linear.app/getsentry/issue/JS-2024/sentrygatsby-build-can-fail-with-typeerror-invokeerr-is-not-a-function)

The `@sentry/bundler-plugin-core` was updated to call `errorHandler` with only a single `Error` argument, but the Gatsby plugin's `errorHandler` still expected two arguments `(err, invokeErr)`. This caused builds to fail with "TypeError: invokeErr is not a function" when a Sentry error occurred during source map upload.

It was originally added in #4064, where we still had v1 of the `@senrty/webpack-plugin` (where the type still existed: https://github.com/getsentry/sentry-webpack-plugin/blob/cb854281eb409c5c14f6a0d1042429240644a48d/index.d.ts#L112). With v2, and the move to [our new repo](https://github.com/getsentry/sentry-javascript-bundler-plugins), this option got removed and is no longer part of it. So `invokeErr` is safe to remove, and should have been already with this PR #11292