### PR TITLE
fix(aws-serverless): Add timeout to _endSpan forceFlush to prevent Lambda hanging

### DIFF
--- a/packages/aws-serverless/src/integration/instrumentation-aws-lambda/instrumentation.ts
+++ b/packages/aws-serverless/src/integration/instrumentation-aws-lambda/instrumentation.ts
@@ -504,7 +504,18 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
       );
     }
 
-    Promise.all(flushers).then(callback, callback);
+    const FORCE_FLUSH_TIMEOUT_MS = 2000;
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const timeoutPromise = new Promise<void>(resolve => {
+      timeoutId = setTimeout(resolve, FORCE_FLUSH_TIMEOUT_MS);
+      timeoutId.unref();
+    });
+    Promise.race([Promise.all(flushers), timeoutPromise])
+      .catch(() => {})
+      .finally(() => {
+        clearTimeout(timeoutId);
+        callback();
+      });
   }
 
   /**

--- a/packages/aws-serverless/test/instrumentation.test.ts
+++ b/packages/aws-serverless/test/instrumentation.test.ts
@@ -1,0 +1,99 @@
+import { SpanStatusCode } from '@opentelemetry/api';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { AwsLambdaInstrumentation } from '../src/integration/instrumentation-aws-lambda/instrumentation';
+
+function createMockTracerProvider(forceFlushImpl: () => Promise<void>) {
+  return {
+    getTracer: () => ({
+      startSpan: vi.fn(),
+      startActiveSpan: vi.fn(),
+    }),
+    forceFlush: forceFlushImpl,
+  };
+}
+
+describe('AwsLambdaInstrumentation', () => {
+  describe('_endSpan', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test('callback fires even when tracerProvider.forceFlush() never resolves', async () => {
+      vi.useFakeTimers();
+
+      const instrumentation = new AwsLambdaInstrumentation();
+
+      const hangingProvider = createMockTracerProvider(() => new Promise<void>(() => {}));
+      instrumentation.setTracerProvider(hangingProvider as any);
+
+      const mockSpan = {
+        end: vi.fn(),
+        recordException: vi.fn(),
+        setStatus: vi.fn(),
+      };
+
+      const callback = vi.fn();
+
+      (instrumentation as any)._endSpan(mockSpan, undefined, callback);
+
+      // Advance past any reasonable timeout (e.g. 5s) — the callback should fire
+      // within a bounded time even if forceFlush() hangs forever.
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(mockSpan.end).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    test('callback fires promptly when tracerProvider.forceFlush() resolves', async () => {
+      const instrumentation = new AwsLambdaInstrumentation();
+
+      const normalProvider = createMockTracerProvider(() => Promise.resolve());
+      instrumentation.setTracerProvider(normalProvider as any);
+
+      const mockSpan = {
+        end: vi.fn(),
+        recordException: vi.fn(),
+        setStatus: vi.fn(),
+      };
+
+      const callback = vi.fn();
+
+      (instrumentation as any)._endSpan(mockSpan, undefined, callback);
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(mockSpan.end).toHaveBeenCalled();
+    });
+
+    test('error information is set on span before flush attempt', async () => {
+      const instrumentation = new AwsLambdaInstrumentation();
+
+      const normalProvider = createMockTracerProvider(() => Promise.resolve());
+      instrumentation.setTracerProvider(normalProvider as any);
+
+      const mockSpan = {
+        end: vi.fn(),
+        recordException: vi.fn(),
+        setStatus: vi.fn(),
+      };
+
+      const error = new Error('lambda failure');
+      const callback = vi.fn();
+
+      (instrumentation as any)._endSpan(mockSpan, error, callback);
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockSpan.recordException).toHaveBeenCalledWith(error);
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.ERROR,
+        message: 'lambda failure',
+      });
+      expect(mockSpan.end).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
The vendored `AwsLambdaInstrumentation._endSpan` calls `tracerProvider.forceFlush()` without any timeout.

Because `_endSpan` blocks the promise chain before `wrapHandler`'s `flush(2000)` can run, a hung `forceFlush()` prevents the Lambda from ever returning, causing it to sit idle until the runtime kills it at its configured timeout.

This was [reported by a user](https://discord.com/channels/621778831602221064/1488407219035701358) whose AppSync authorizer Lambda consistently timed out at 15s despite the handler completing in ~178ms.

The fix wraps the flush in a `Promise.race` with a 2s timeout, matching `wrapHandler`'s existing flush timeout.

closes #20063 