### PR TITLE
feat(core): support registerTool/registerResource/registerPrompt in MCP integration

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express-v5/src/mcp.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/src/mcp.ts
@@ -35,6 +35,14 @@ server.tool('echo', { message: z.string() }, async ({ message }, rest) => {
   };
 });
 
+server.registerTool(
+  'echo-register',
+  { description: 'Echo tool (register API)', inputSchema: { message: z.string() } },
+  async ({ message }) => ({
+    content: [{ type: 'text', text: `registerTool echo: ${message}` }],
+  }),
+);
+
 server.prompt('echo', { message: z.string() }, ({ message }, extra) => ({
   messages: [
     {
@@ -102,6 +110,14 @@ streamableServer.tool('echo', { message: z.string() }, async ({ message }) => {
     content: [{ type: 'text', text: `Tool echo: ${message}` }],
   };
 });
+
+streamableServer.registerTool(
+  'echo-register',
+  { description: 'Echo tool (register API)', inputSchema: { message: z.string() } },
+  async ({ message }) => ({
+    content: [{ type: 'text', text: `registerTool echo: ${message}` }],
+  }),
+);
 
 streamableServer.prompt('echo', { message: z.string() }, ({ message }) => ({
   messages: [

--- a/dev-packages/e2e-tests/test-applications/node-express/src/mcp.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/mcp.ts
@@ -35,6 +35,14 @@ server.tool('echo', { message: z.string() }, async ({ message }, rest) => {
   };
 });
 
+server.registerTool(
+  'echo-register',
+  { description: 'Echo tool (register API)', inputSchema: { message: z.string() } },
+  async ({ message }) => ({
+    content: [{ type: 'text', text: `registerTool echo: ${message}` }],
+  }),
+);
+
 server.prompt('echo', { message: z.string() }, ({ message }, extra) => ({
   messages: [
     {
@@ -102,6 +110,14 @@ streamableServer.tool('echo', { message: z.string() }, async ({ message }) => {
     content: [{ type: 'text', text: `Tool echo: ${message}` }],
   };
 });
+
+streamableServer.registerTool(
+  'echo-register',
+  { description: 'Echo tool (register API)', inputSchema: { message: z.string() } },
+  async ({ message }) => ({
+    content: [{ type: 'text', text: `registerTool echo: ${message}` }],
+  }),
+);
 
 streamableServer.prompt('echo', { message: z.string() }, ({ message }) => ({
   messages: [

--- a/dev-packages/e2e-tests/test-applications/tsx-express/src/mcp.ts
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/src/mcp.ts
@@ -35,6 +35,14 @@ server.tool('echo', { message: z.string() }, async ({ message }, rest) => {
   };
 });
 
+server.registerTool(
+  'echo-register',
+  { description: 'Echo tool (register API)', inputSchema: { message: z.string() } },
+  async ({ message }) => ({
+    content: [{ type: 'text', text: `registerTool echo: ${message}` }],
+  }),
+);
+
 server.prompt('echo', { message: z.string() }, ({ message }, extra) => ({
   messages: [
     {
@@ -102,6 +110,14 @@ streamableServer.tool('echo', { message: z.string() }, async ({ message }) => {
     content: [{ type: 'text', text: `Tool echo: ${message}` }],
   };
 });
+
+streamableServer.registerTool(
+  'echo-register',
+  { description: 'Echo tool (register API)', inputSchema: { message: z.string() } },
+  async ({ message }) => ({
+    content: [{ type: 'text', text: `registerTool echo: ${message}` }],
+  }),
+);
 
 streamableServer.prompt('echo', { message: z.string() }, ({ message }) => ({
   messages: [

--- a/packages/core/src/integrations/mcp-server/handlers.ts
+++ b/packages/core/src/integrations/mcp-server/handlers.ts
@@ -96,7 +96,7 @@ function captureHandlerError(error: Error, methodName: keyof MCPServerInstance, 
   try {
     const extraData: Record<string, unknown> = {};
 
-    if (methodName === 'tool') {
+    if (methodName === 'tool' || methodName === 'registerTool') {
       extraData.tool_name = handlerName;
 
       if (
@@ -114,10 +114,10 @@ function captureHandlerError(error: Error, methodName: keyof MCPServerInstance, 
       } else {
         captureError(error, 'tool_execution', extraData);
       }
-    } else if (methodName === 'resource') {
+    } else if (methodName === 'resource' || methodName === 'registerResource') {
       extraData.resource_uri = handlerName;
       captureError(error, 'resource_execution', extraData);
-    } else if (methodName === 'prompt') {
+    } else if (methodName === 'prompt' || methodName === 'registerPrompt') {
       extraData.prompt_name = handlerName;
       captureError(error, 'prompt_execution', extraData);
     }
@@ -127,31 +127,39 @@ function captureHandlerError(error: Error, methodName: keyof MCPServerInstance, 
 }
 
 /**
- * Wraps tool handlers to associate them with request spans
+ * Wraps tool handlers to associate them with request spans.
+ * Instruments both `tool` (legacy API) and `registerTool` (new API) if present.
  * @param serverInstance - MCP server instance
  */
 export function wrapToolHandlers(serverInstance: MCPServerInstance): void {
-  wrapMethodHandler(serverInstance, 'tool');
+  if (typeof serverInstance.tool === 'function') wrapMethodHandler(serverInstance, 'tool');
+  if (typeof serverInstance.registerTool === 'function') wrapMethodHandler(serverInstance, 'registerTool');
 }
 
 /**
- * Wraps resource handlers to associate them with request spans
+ * Wraps resource handlers to associate them with request spans.
+ * Instruments both `resource` (legacy API) and `registerResource` (new API) if present.
  * @param serverInstance - MCP server instance
  */
 export function wrapResourceHandlers(serverInstance: MCPServerInstance): void {
-  wrapMethodHandler(serverInstance, 'resource');
+  if (typeof serverInstance.resource === 'function') wrapMethodHandler(serverInstance, 'resource');
+  if (typeof serverInstance.registerResource === 'function') wrapMethodHandler(serverInstance, 'registerResource');
 }
 
 /**
- * Wraps prompt handlers to associate them with request spans
+ * Wraps prompt handlers to associate them with request spans.
+ * Instruments both `prompt` (legacy API) and `registerPrompt` (new API) if present.
  * @param serverInstance - MCP server instance
  */
 export function wrapPromptHandlers(serverInstance: MCPServerInstance): void {
-  wrapMethodHandler(serverInstance, 'prompt');
+  if (typeof serverInstance.prompt === 'function') wrapMethodHandler(serverInstance, 'prompt');
+  if (typeof serverInstance.registerPrompt === 'function') wrapMethodHandler(serverInstance, 'registerPrompt');
 }
 
 /**
- * Wraps all MCP handler types (tool, resource, prompt) for span correlation
+ * Wraps all MCP handler types for span correlation.
+ * Supports both the legacy API (`tool`, `resource`, `prompt`) and the newer API
+ * (`registerTool`, `registerResource`, `registerPrompt`), instrumenting whichever methods are present.
  * @param serverInstance - MCP server instance
  */
 export function wrapAllMCPHandlers(serverInstance: MCPServerInstance): void {

--- a/packages/core/src/integrations/mcp-server/index.ts
+++ b/packages/core/src/integrations/mcp-server/index.ts
@@ -14,7 +14,8 @@ const wrappedMcpServerInstances = new WeakSet();
 /**
  * Wraps a MCP Server instance from the `@modelcontextprotocol/sdk` package with Sentry instrumentation.
  *
- * Compatible with versions `^1.9.0` of the `@modelcontextprotocol/sdk` package.
+ * Compatible with versions `^1.9.0` of the `@modelcontextprotocol/sdk` package (legacy `tool`/`resource`/`prompt` API)
+ * and versions that expose the newer `registerTool`/`registerResource`/`registerPrompt` API (introduced in 1.x, sole API in 2.x).
  * Automatically instruments transport methods and handler functions for comprehensive monitoring.
  *
  * @example

--- a/packages/core/src/integrations/mcp-server/types.ts
+++ b/packages/core/src/integrations/mcp-server/types.ts
@@ -87,17 +87,29 @@ export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcRespo
 
 /**
  * MCP server instance interface
- * @description MCP server methods for registering handlers
+ * @description MCP server methods for registering handlers.
+ * Supports both the legacy API (`tool`, `resource`, `prompt`) used in SDK 1.x
+ * and the newer API (`registerTool`, `registerResource`, `registerPrompt`) introduced in SDK 1.x
+ * and made the only option in SDK 2.x.
  */
 export interface MCPServerInstance {
-  /** Register a resource handler */
-  resource: (name: string, ...args: unknown[]) => void;
+  /** Register a resource handler (legacy API) */
+  resource?: (name: string, ...args: unknown[]) => void;
 
-  /** Register a tool handler */
-  tool: (name: string, ...args: unknown[]) => void;
+  /** Register a tool handler (legacy API) */
+  tool?: (name: string, ...args: unknown[]) => void;
 
-  /** Register a prompt handler */
-  prompt: (name: string, ...args: unknown[]) => void;
+  /** Register a prompt handler (legacy API) */
+  prompt?: (name: string, ...args: unknown[]) => void;
+
+  /** Register a resource handler (new API, SDK >=1.x / 2.x) */
+  registerResource?: (name: string, ...args: unknown[]) => void;
+
+  /** Register a tool handler (new API, SDK >=1.x / 2.x) */
+  registerTool?: (name: string, ...args: unknown[]) => void;
+
+  /** Register a prompt handler (new API, SDK >=1.x / 2.x) */
+  registerPrompt?: (name: string, ...args: unknown[]) => void;
 
   /** Connect the server to a transport */
   connect(transport: MCPTransport): Promise<void>;

--- a/packages/core/src/integrations/mcp-server/validation.ts
+++ b/packages/core/src/integrations/mcp-server/validation.ts
@@ -57,7 +57,10 @@ export function isJsonRpcResponse(message: unknown): message is JsonRpcResponse 
 }
 
 /**
- * Validates MCP server instance with type checking
+ * Validates MCP server instance with type checking.
+ * Accepts both the legacy API (`tool`, `resource`, `prompt`) used in SDK 1.x
+ * and the newer API (`registerTool`, `registerResource`, `registerPrompt`) introduced
+ * alongside the legacy API in SDK 1.x and made the only option in SDK 2.x.
  * @param instance - Object to validate as MCP server instance
  * @returns True if instance has required MCP server methods
  */
@@ -65,10 +68,9 @@ export function validateMcpServerInstance(instance: unknown): boolean {
   if (
     typeof instance === 'object' &&
     instance !== null &&
-    'resource' in instance &&
-    'tool' in instance &&
-    'prompt' in instance &&
-    'connect' in instance
+    'connect' in instance &&
+    (('tool' in instance && 'resource' in instance && 'prompt' in instance) ||
+      ('registerTool' in instance && 'registerResource' in instance && 'registerPrompt' in instance))
   ) {
     return true;
   }

--- a/packages/core/test/lib/integrations/mcp-server/mcpServerWrapper.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/mcpServerWrapper.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as currentScopes from '../../../../src/currentScopes';
 import { wrapMcpServerWithSentry } from '../../../../src/integrations/mcp-server';
 import * as tracingModule from '../../../../src/tracing';
-import { createMockMcpServer } from './testUtils';
+import { createMockMcpServer, createMockMcpServerWithRegisterApi } from './testUtils';
 
 describe('wrapMcpServerWithSentry', () => {
   const startSpanSpy = vi.spyOn(tracingModule, 'startSpan');
@@ -45,6 +45,19 @@ describe('wrapMcpServerWithSentry', () => {
     expect(startInactiveSpanSpy).not.toHaveBeenCalled();
   });
 
+  it('should accept a server with only the new register* API (no legacy methods)', () => {
+    const mockServer = createMockMcpServerWithRegisterApi();
+    const result = wrapMcpServerWithSentry(mockServer);
+    expect(result).toBe(mockServer);
+  });
+
+  it('should reject a server with neither legacy nor register* methods', () => {
+    const invalidServer = { connect: vi.fn() };
+    const result = wrapMcpServerWithSentry(invalidServer);
+    expect(result).toBe(invalidServer);
+    expect(startSpanSpy).not.toHaveBeenCalled();
+  });
+
   it('should not wrap the same instance twice', () => {
     const mockMcpServer = createMockMcpServer();
 
@@ -75,6 +88,19 @@ describe('wrapMcpServerWithSentry', () => {
     expect(wrappedMcpServer.tool).not.toBe(originalTool);
     expect(wrappedMcpServer.resource).not.toBe(originalResource);
     expect(wrappedMcpServer.prompt).not.toBe(originalPrompt);
+  });
+
+  it('should wrap handler methods (registerTool, registerResource, registerPrompt)', () => {
+    const mockServer = createMockMcpServerWithRegisterApi();
+    const originalRegisterTool = mockServer.registerTool;
+    const originalRegisterResource = mockServer.registerResource;
+    const originalRegisterPrompt = mockServer.registerPrompt;
+
+    const wrapped = wrapMcpServerWithSentry(mockServer);
+
+    expect(wrapped.registerTool).not.toBe(originalRegisterTool);
+    expect(wrapped.registerResource).not.toBe(originalRegisterResource);
+    expect(wrapped.registerPrompt).not.toBe(originalRegisterPrompt);
   });
 
   describe('Handler Wrapping', () => {
@@ -115,6 +141,40 @@ describe('wrapMcpServerWithSentry', () => {
 
       expect(() => {
         wrappedMcpServer.tool('test-tool', nonFunctionArg, 'other-arg');
+      }).not.toThrow();
+    });
+  });
+
+  describe('Handler Wrapping (register* API)', () => {
+    let mockServer: ReturnType<typeof createMockMcpServerWithRegisterApi>;
+    let wrappedServer: ReturnType<typeof createMockMcpServerWithRegisterApi>;
+
+    beforeEach(() => {
+      mockServer = createMockMcpServerWithRegisterApi();
+      wrappedServer = wrapMcpServerWithSentry(mockServer);
+    });
+
+    it('should register tool handlers via registerTool without throwing errors', () => {
+      const toolHandler = vi.fn();
+
+      expect(() => {
+        wrappedServer.registerTool('test-tool', {}, toolHandler);
+      }).not.toThrow();
+    });
+
+    it('should register resource handlers via registerResource without throwing errors', () => {
+      const resourceHandler = vi.fn();
+
+      expect(() => {
+        wrappedServer.registerResource('test-resource', 'res://test', {}, resourceHandler);
+      }).not.toThrow();
+    });
+
+    it('should register prompt handlers via registerPrompt without throwing errors', () => {
+      const promptHandler = vi.fn();
+
+      expect(() => {
+        wrappedServer.registerPrompt('test-prompt', {}, promptHandler);
       }).not.toThrow();
     });
   });

--- a/packages/core/test/lib/integrations/mcp-server/testUtils.ts
+++ b/packages/core/test/lib/integrations/mcp-server/testUtils.ts
@@ -1,13 +1,28 @@
 import { vi } from 'vitest';
 
 /**
- * Create a mock MCP server instance for testing
+ * Create a mock MCP server instance for testing (legacy API: tool/resource/prompt)
  */
 export function createMockMcpServer() {
   return {
     resource: vi.fn(),
     tool: vi.fn(),
     prompt: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    server: {
+      setRequestHandler: vi.fn(),
+    },
+  };
+}
+
+/**
+ * Create a mock MCP server instance using the new register* API (SDK >=1.x / 2.x)
+ */
+export function createMockMcpServerWithRegisterApi() {
+  return {
+    registerResource: vi.fn(),
+    registerTool: vi.fn(),
+    registerPrompt: vi.fn(),
     connect: vi.fn().mockResolvedValue(undefined),
     server: {
       setRequestHandler: vi.fn(),


### PR DESCRIPTION
The `@modelcontextprotocol/sdk` introduced `registerTool`, `registerResource`, and `registerPrompt` as a new API in 1.x, and in 2.x these are the *only* methods available — the old `tool`/`resource`/`prompt` names are gone.

Before this change, servers using the new API would silently get no instrumentation: `validateMcpServerInstance` would reject them (it only checked for the old names), so `wrapMcpServerWithSentry` would return the unwrapped instance. The cloudflare-mcp e2e app already used `registerTool` and was affected by this.

## Changes

- `MCPServerInstance` type now includes optional `registerTool?`, `registerResource?`, `registerPrompt?` alongside the legacy methods (also made legacy ones optional since 2.x doesn't have them)
- `validateMcpServerInstance` now accepts instances with either `tool+resource+prompt+connect` or `registerTool+registerResource+registerPrompt+connect`
- `wrapAllMCPHandlers` conditionally wraps whichever set of methods exists on the instance
- `captureHandlerError` maps `registerTool` → `tool_execution`, `registerResource` → `resource_execution`, `registerPrompt` → `prompt_execution`
- Unit tests added for validation and wrapping of the new method names
- `registerTool` handlers added to the node-express, node-express-v5, and tsx-express e2e apps

The existing `wrapMethodHandler` logic (intercepts the last argument as the callback) works identically for both old and new signatures, so no changes were needed there.

- [ ] Tests added
- [ ] Lints and test suite passes

Closes #16666