### PR TITLE
fix(core): set span.status to error when MCP tool returns JSON-RPC error response

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express-v5/src/mcp.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/src/mcp.ts
@@ -47,6 +47,10 @@ server.prompt('echo', { message: z.string() }, ({ message }, extra) => ({
   ],
 }));
 
+server.tool('always-error', {}, async () => {
+  throw new Error('intentional error for span status testing');
+});
+
 const transports: Record<string, SSEServerTransport> = {};
 
 mcpRouter.get('/sse', async (_, res) => {

--- a/dev-packages/e2e-tests/test-applications/node-express-v5/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/tests/mcp.test.ts
@@ -120,6 +120,23 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
 
     // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
   });
+
+  await test.step('error tool sets span status to internal_error', async () => {
+    const toolTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
+      return transactionEvent.transaction === 'tools/call always-error';
+    });
+
+    try {
+      await client.callTool({ name: 'always-error', arguments: {} });
+    } catch {
+      // Expected: MCP SDK throws when the tool returns a JSON-RPC error
+    }
+
+    const toolTransaction = await toolTransactionPromise;
+    expect(toolTransaction).toBeDefined();
+    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
+    expect(toolTransaction.contexts?.trace?.status).toEqual('internal_error');
+  });
 });
 
 /**

--- a/dev-packages/e2e-tests/test-applications/node-express/src/mcp.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/mcp.ts
@@ -47,6 +47,10 @@ server.prompt('echo', { message: z.string() }, ({ message }, extra) => ({
   ],
 }));
 
+server.tool('always-error', {}, async () => {
+  throw new Error('intentional error for span status testing');
+});
+
 const transports: Record<string, SSEServerTransport> = {};
 
 mcpRouter.get('/sse', async (_, res) => {

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/mcp.test.ts
@@ -126,6 +126,23 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
     expect(promptTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('prompts/get');
     // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
   });
+
+  await test.step('error tool sets span status to internal_error', async () => {
+    const toolTransactionPromise = waitForTransaction('node-express', transactionEvent => {
+      return transactionEvent.transaction === 'tools/call always-error';
+    });
+
+    try {
+      await client.callTool({ name: 'always-error', arguments: {} });
+    } catch {
+      // Expected: MCP SDK throws when the tool returns a JSON-RPC error
+    }
+
+    const toolTransaction = await toolTransactionPromise;
+    expect(toolTransaction).toBeDefined();
+    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
+    expect(toolTransaction.contexts?.trace?.status).toEqual('internal_error');
+  });
 });
 
 /**

--- a/dev-packages/e2e-tests/test-applications/tsx-express/src/mcp.ts
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/src/mcp.ts
@@ -47,6 +47,10 @@ server.prompt('echo', { message: z.string() }, ({ message }, extra) => ({
   ],
 }));
 
+server.tool('always-error', {}, async () => {
+  throw new Error('intentional error for span status testing');
+});
+
 const transports: Record<string, SSEServerTransport> = {};
 
 mcpRouter.get('/sse', async (_, res) => {

--- a/dev-packages/e2e-tests/test-applications/tsx-express/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/tests/mcp.test.ts
@@ -123,6 +123,23 @@ test('Records transactions for mcp handlers', async ({ baseURL }) => {
 
     // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
   });
+
+  await test.step('error tool sets span status to internal_error', async () => {
+    const toolTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
+      return transactionEvent.transaction === 'tools/call always-error';
+    });
+
+    try {
+      await client.callTool({ name: 'always-error', arguments: {} });
+    } catch {
+      // Expected: MCP SDK throws when the tool returns a JSON-RPC error
+    }
+
+    const toolTransaction = await toolTransactionPromise;
+    expect(toolTransaction).toBeDefined();
+    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
+    expect(toolTransaction.contexts?.trace?.status).toEqual('internal_error');
+  });
 });
 
 /**

--- a/packages/core/src/integrations/mcp-server/correlation.ts
+++ b/packages/core/src/integrations/mcp-server/correlation.ts
@@ -81,19 +81,23 @@ export function storeSpanForRequest(transport: MCPTransport, requestId: RequestI
  * @param requestId - Request identifier
  * @param result - Execution result for attribute extraction
  * @param options - Resolved MCP options
+ * @param hasError - Whether the JSON-RPC response contained an error
  */
 export function completeSpanWithResults(
   transport: MCPTransport,
   requestId: RequestId,
   result: unknown,
   options: ResolvedMcpOptions,
+  hasError = false,
 ): void {
   const spanMap = getOrCreateSpanMap(transport);
   const spanData = spanMap.get(requestId);
   if (spanData) {
     const { span, method } = spanData;
 
-    if (method === 'initialize') {
+    if (hasError) {
+      span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+    } else if (method === 'initialize') {
       const sessionData = extractSessionDataFromInitializeResponse(result);
       const serverAttributes = buildServerAttributesFromInfo(sessionData.serverInfo);
 

--- a/packages/core/src/integrations/mcp-server/transport.ts
+++ b/packages/core/src/integrations/mcp-server/transport.ts
@@ -121,7 +121,7 @@ export function wrapTransportSend(transport: MCPTransport, options: ResolvedMcpO
               }
             }
 
-            completeSpanWithResults(this, message.id, message.result, options);
+            completeSpanWithResults(this, message.id, message.result, options, !!message.error);
           }
         }
 

--- a/packages/core/test/lib/integrations/mcp-server/transportInstrumentation.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/transportInstrumentation.test.ts
@@ -182,6 +182,68 @@ describe('MCP Server Transport Instrumentation', () => {
       // Trigger onclose - should not throw
       expect(() => mockTransport.onclose?.()).not.toThrow();
     });
+
+    it('should set span status to error when JSON-RPC error response is sent', async () => {
+      const mockSpan = {
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        end: vi.fn(),
+        isRecording: vi.fn().mockReturnValue(true),
+      };
+      startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+
+      await wrappedMcpServer.connect(mockTransport);
+
+      // Simulate an incoming tools/call request
+      const jsonRpcRequest = {
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        id: 'req-err-1',
+        params: { name: 'always-error' },
+      };
+      mockTransport.onmessage?.(jsonRpcRequest, {});
+
+      // Simulate the MCP SDK sending back a JSON-RPC error response
+      const jsonRpcErrorResponse = {
+        jsonrpc: '2.0',
+        id: 'req-err-1',
+        error: { code: -32603, message: 'Internal error: tool threw an exception' },
+      };
+      await mockTransport.send?.(jsonRpcErrorResponse as any);
+
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 2, message: 'internal_error' });
+      expect(mockSpan.end).toHaveBeenCalled();
+    });
+
+    it('should not set error span status for successful JSON-RPC responses', async () => {
+      const mockSpan = {
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        end: vi.fn(),
+        isRecording: vi.fn().mockReturnValue(true),
+      };
+      startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+
+      await wrappedMcpServer.connect(mockTransport);
+
+      const jsonRpcRequest = {
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        id: 'req-ok-1',
+        params: { name: 'echo' },
+      };
+      mockTransport.onmessage?.(jsonRpcRequest, {});
+
+      const jsonRpcSuccessResponse = {
+        jsonrpc: '2.0',
+        id: 'req-ok-1',
+        result: { content: [{ type: 'text', text: 'hello' }] },
+      };
+      await mockTransport.send?.(jsonRpcSuccessResponse as any);
+
+      expect(mockSpan.setStatus).not.toHaveBeenCalled();
+      expect(mockSpan.end).toHaveBeenCalled();
+    });
   });
 
   describe('Stdio Transport Tests', () => {


### PR DESCRIPTION
When an MCP tool returns a JSON-RPC error response (i.e. the response has an `error` field instead of `result`), the span was being ended with `status=ok`. This meant `failure_rate()` read 0% in the MCP insights dashboard even when tools were consistently failing.

## Root cause

`completeSpanWithResults` always ended the span without checking whether the response was an error. The `captureError` path uses `getActiveSpan()`, which returns `null` outside a `withActiveSpan()` context — so errors were never reflected in span status.

## Fix

Pass `!!message.error` as a `hasError` flag to `completeSpanWithResults`. When `true`, set `SPAN_STATUS_ERROR` with `message: 'internal_error'` directly on the stored span before ending it.

## Changes

- `correlation.ts` — `completeSpanWithResults` accepts optional `hasError` param; sets error status when true
- `transport.ts` — passes `!!message.error` when completing spans on outgoing send
- `transportInstrumentation.test.ts` — two new tests: error response sets error status; success response does not

Closes #20083