### PR TITLE
ref(node): use replaceExports core utility for openai/anthropic client patching

### DIFF
--- a/packages/node/src/integrations/tracing/anthropic-ai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/anthropic-ai/instrumentation.ts
@@ -9,6 +9,7 @@ import {
   _INTERNAL_shouldSkipAiProviderWrapping,
   ANTHROPIC_AI_INTEGRATION_NAME,
   instrumentAnthropicAiClient,
+  replaceExports,
   SDK_VERSION,
 } from '@sentry/core';
 
@@ -76,36 +77,8 @@ export class SentryAnthropicAiInstrumentation extends InstrumentationBase<Anthro
       }
     }
 
-    // Constructor replacement - handle read-only properties
-    // The Anthropic property might have only a getter, so use defineProperty
-    try {
-      exports.Anthropic = WrappedAnthropic;
-    } catch {
-      // If direct assignment fails, override the property descriptor
-      Object.defineProperty(exports, 'Anthropic', {
-        value: WrappedAnthropic,
-        writable: true,
-        configurable: true,
-        enumerable: true,
-      });
-    }
-
-    // Wrap the default export if it points to the original constructor
-    // Constructor replacement - handle read-only properties
-    // The Anthropic property might have only a getter, so use defineProperty
-    if (exports.default === Original) {
-      try {
-        exports.default = WrappedAnthropic;
-      } catch {
-        // If direct assignment fails, override the property descriptor
-        Object.defineProperty(exports, 'default', {
-          value: WrappedAnthropic,
-          writable: true,
-          configurable: true,
-          enumerable: true,
-        });
-      }
-    }
+    // Replace exports with the wrapped constructor
+    replaceExports(exports, 'Anthropic', WrappedAnthropic);
     return exports;
   }
 }

--- a/packages/node/src/integrations/tracing/google-genai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/google-genai/instrumentation.ts
@@ -93,7 +93,7 @@ export class SentryGoogleGenAiInstrumentation extends InstrumentationBase<Google
       }
     }
 
-    // Replace google genai exports with the wrapped constructor
+    // Replace exports with the wrapped constructor
     replaceExports(exports, 'GoogleGenAI', WrappedGoogleGenAI);
 
     return exports;

--- a/packages/node/src/integrations/tracing/openai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/openai/instrumentation.ts
@@ -9,6 +9,7 @@ import {
   _INTERNAL_shouldSkipAiProviderWrapping,
   instrumentOpenAiClient,
   OPENAI_INTEGRATION_NAME,
+  replaceExports,
   SDK_VERSION,
 } from '@sentry/core';
 
@@ -90,36 +91,8 @@ export class SentryOpenAiInstrumentation extends InstrumentationBase<OpenAiInstr
       }
     }
 
-    // Constructor replacement - handle read-only properties
-    // The OpenAI property might have only a getter, so use defineProperty
-    try {
-      exports[exportKey] = WrappedOpenAI;
-    } catch {
-      // If direct assignment fails, override the property descriptor
-      Object.defineProperty(exports, exportKey, {
-        value: WrappedOpenAI,
-        writable: true,
-        configurable: true,
-        enumerable: true,
-      });
-    }
-
-    // Wrap the default export if it points to the original constructor
-    // Constructor replacement - handle read-only properties
-    // The OpenAI property might have only a getter, so use defineProperty
-    if (exports.default === Original) {
-      try {
-        exports.default = WrappedOpenAI;
-      } catch {
-        // If direct assignment fails, override the property descriptor
-        Object.defineProperty(exports, 'default', {
-          value: WrappedOpenAI,
-          writable: true,
-          configurable: true,
-          enumerable: true,
-        });
-      }
-    }
+    // Replace exports with the wrapped constructor
+    replaceExports(exports, exportKey, WrappedOpenAI);
     return exports;
   }
 }


### PR DESCRIPTION
We have a core utility `replaceExports` that does exactly what we need here, which we also already use in the `google-genai` instrumentation, so we should use it for `openai` and `anthropic` as well.