### PR TITLE
test(nuxt): Make Nuxt 5 (nightly) E2E optional

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/package.json
@@ -31,6 +31,9 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
+  "sentryTest": {
+    "optional": true
+  },
   "volta": {
     "extends": "../../package.json",
     "node": "22.20.0"


### PR DESCRIPTION
Nuxt 5 is still in development and currently in a nightly version. The E2E tests might fail due to changes but this should not block CI as long as v5 is in nightly. 

This adds the `optional` label to the test.

E.g. unblocking this PR: https://github.com/getsentry/sentry-javascript/pull/20071
