### PR TITLE
fix(core): Only attach `flags` context to error events

### DIFF
--- a/packages/core/src/utils/featureFlags.ts
+++ b/packages/core/src/utils/featureFlags.ts
@@ -28,6 +28,12 @@ const SPAN_FLAG_ATTRIBUTE_PREFIX = 'flag.evaluation.';
  * Copies feature flags that are in current scope context to the event context
  */
 export function _INTERNAL_copyFlagsFromScopeToEvent(event: Event): Event {
+  if (event.type) {
+    // No need to add the flags context to transaction events.
+    // Spans already get the flag.evaluation attributes.
+    return event;
+  }
+
   const scope = getCurrentScope();
   const flagContext = scope.getScopeData().contexts.flags;
   const flagBuffer = flagContext ? flagContext.values : [];

--- a/packages/core/test/lib/utils/featureFlags.test.ts
+++ b/packages/core/test/lib/utils/featureFlags.test.ts
@@ -164,7 +164,30 @@ describe('flags', () => {
 
       const result = _INTERNAL_copyFlagsFromScopeToEvent(event);
 
-      expect(result).toEqual(event);
+      expect(result).toEqual({
+        contexts: {
+          flags: {
+            values: [
+              {
+                flag: 'feat1',
+                result: true,
+              },
+              {
+                flag: 'feat2',
+                result: false,
+              },
+            ],
+          },
+        },
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'error message',
+            },
+          ],
+        },
+      });
       expect(getCurrentScope).toHaveBeenCalled();
     });
   });

--- a/packages/core/test/lib/utils/featureFlags.test.ts
+++ b/packages/core/test/lib/utils/featureFlags.test.ts
@@ -2,10 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getCurrentScope } from '../../../src/currentScopes';
 import { debug } from '../../../src/utils/debug-logger';
 import {
+  _INTERNAL_copyFlagsFromScopeToEvent,
   _INTERNAL_insertFlagToScope,
   _INTERNAL_insertToFlagBuffer,
   type FeatureFlag,
 } from '../../../src/utils/featureFlags';
+
+import * as currentScopeModule from '../../../src/currentScopes';
+import type { Event } from '../../../src/types-hoist/event';
 
 describe('flags', () => {
   describe('insertFlagToScope()', () => {
@@ -107,6 +111,61 @@ describe('flags', () => {
         { flag: 'feat1', result: true },
         { flag: 'feat2', result: true },
       ]);
+    });
+  });
+
+  describe('copyFlagsFromScopeToEvent()', () => {
+    it.each(['transaction', 'replay_event', 'feedback', 'profile'])('does not add flags context to %s events', type => {
+      vi.spyOn(currentScopeModule, 'getCurrentScope').mockReturnValue({
+        // @ts-expect-error - only returning partial scope data
+        getScopeData: () => ({
+          contexts: {
+            flags: { values: [{ flag: 'feat1', result: true }] },
+          },
+        }),
+      });
+
+      const event = {
+        type: type,
+        spans: [],
+      } as Event;
+
+      const result = _INTERNAL_copyFlagsFromScopeToEvent(event);
+
+      expect(result).toEqual(event);
+      expect(getCurrentScope).not.toHaveBeenCalled();
+    });
+
+    it('adds add flags context to error events', () => {
+      vi.spyOn(currentScopeModule, 'getCurrentScope').mockReturnValue({
+        // @ts-expect-error - only returning partial scope data
+        getScopeData: () => ({
+          contexts: {
+            flags: {
+              values: [
+                { flag: 'feat1', result: true },
+                { flag: 'feat2', result: false },
+              ],
+            },
+          },
+        }),
+      });
+
+      const event: Event = {
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'error message',
+            },
+          ],
+        },
+      };
+
+      const result = _INTERNAL_copyFlagsFromScopeToEvent(event);
+
+      expect(result).toEqual(event);
+      expect(getCurrentScope).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
While looking into feature flags for span streaming, we noticed that the SDK currently attaches the `flags` context to all outgoing event types, including transactions (h/t @mjq). The [develop spec](https://develop.sentry.dev/sdk/foundations/client/integrations/feature-flags/#tracking-feature-flag-evaluations:~:text=Feature%20flags%20can%20be%20attached%20to%20error%20events%20or%20to%20span%20events) specifies that feature flags should be added to 
- errors via the `flags` context
- spans via span attributes

This PR ensures that the event processor adding the context is scoped to error events only. 