### PR TITLE
fix(core): Fix `withStreamedSpan` typing error add missing exports

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/beforeSendSpan-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/beforeSendSpan-streamed/init.js
@@ -21,7 +21,7 @@ Sentry.init({
         },
       ];
       span.attributes['sentry.custom_attribute'] = 'customAttributeValue';
-      span.status = 'something'
+      span.status = 'something';
     }
     return span;
   }),

--- a/dev-packages/browser-integration-tests/suites/public-api/beforeSendSpan-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/beforeSendSpan-streamed/init.js
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration(), Sentry.spanStreamingIntegration()],
+  tracesSampleRate: 1,
+  beforeSendSpan: Sentry.withStreamedSpan(span => {
+    if (span.attributes['sentry.op'] === 'pageload') {
+      span.name = 'customPageloadSpanName';
+      span.links = [
+        {
+          context: {
+            traceId: '123',
+            spanId: '456',
+          },
+          attributes: {
+            'sentry.link.type': 'custom_link',
+          },
+        },
+      ];
+      span.attributes['sentry.custom_attribute'] = 'customAttributeValue';
+      span.status = 'something'
+    }
+    return span;
+  }),
+});

--- a/dev-packages/browser-integration-tests/suites/public-api/beforeSendSpan-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/beforeSendSpan-streamed/test.ts
@@ -1,0 +1,35 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../utils/fixtures';
+import { shouldSkipTracingTest, testingCdnBundle } from '../../../utils/helpers';
+import { getSpanOp, waitForStreamedSpan } from '../../../utils/spanUtils';
+
+sentryTest('beforeSendSpan applies changes to streamed span', async ({ getLocalTestUrl, page }) => {
+  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  const pageloadSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'pageload');
+
+  await page.goto(url);
+
+  const pageloadSpan = await pageloadSpanPromise;
+
+  expect(pageloadSpan.name).toBe('customPageloadSpanName');
+  expect(pageloadSpan.links).toEqual([
+    {
+      context: {
+        traceId: '123',
+        spanId: '456',
+      },
+      attributes: {
+        'sentry.link.type': { type: 'string', value: 'custom_link' },
+      },
+    },
+  ]);
+  expect(pageloadSpan.attributes?.['sentry.custom_attribute']).toEqual({
+    type: 'string',
+    value: 'customAttributeValue',
+  });
+  // we allow overriding any kinds of fields on the span, so we have to expect invalid values
+  expect(pageloadSpan.status).toBe('something');
+});

--- a/dev-packages/node-core-integration-tests/suites/public-api/beforeSendSpan-streamed/scenario.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/beforeSendSpan-streamed/scenario.ts
@@ -15,8 +15,7 @@ const client = Sentry.init({
         span.attributes = {};
       }
       span.attributes['sentry.custom_attribute'] = 'customAttributeValue';
-      // oxlint-disable-next-line typescript/ban-ts-comment
-      // @ts-expect-error - technically this is something we have to expect, despite types saying it's invalid
+      // @ts-ignore - technically this is something we have to expect, despite types saying it's invalid
       span.status = 'something';
       span.links = [
         {

--- a/dev-packages/node-core-integration-tests/suites/public-api/beforeSendSpan-streamed/scenario.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/beforeSendSpan-streamed/scenario.ts
@@ -1,0 +1,43 @@
+import * as Sentry from '@sentry/node-core';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+import { setupOtel } from '../../../utils/setupOtel';
+
+const client = Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  tracesSampleRate: 1.0,
+  traceLifecycle: 'stream',
+  transport: loggingTransport,
+  release: '1.0.0',
+  beforeSendSpan: Sentry.withStreamedSpan(span => {
+    if (span.name === 'test-child-span') {
+      span.name = 'customChildSpanName';
+      if (!span.attributes) {
+        span.attributes = {};
+      }
+      span.attributes['sentry.custom_attribute'] = 'customAttributeValue';
+      // oxlint-disable-next-line typescript/ban-ts-comment
+      // @ts-expect-error - technically this is something we have to expect, despite types saying it's invalid
+      span.status = 'something';
+      span.links = [
+        {
+          trace_id: '123',
+          span_id: '456',
+          attributes: {
+            'sentry.link.type': 'custom_link',
+          },
+        },
+      ];
+    }
+    return span;
+  }),
+});
+
+setupOtel(client);
+
+Sentry.startSpan({ name: 'test-span', op: 'test' }, () => {
+  Sentry.startSpan({ name: 'test-child-span', op: 'test-child' }, () => {
+    // noop
+  });
+});
+
+void Sentry.flush();

--- a/dev-packages/node-core-integration-tests/suites/public-api/beforeSendSpan-streamed/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/beforeSendSpan-streamed/test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest';
+import { createRunner } from '../../../utils/runner';
+
+test('beforeSendSpan applies changes to streamed span', async () => {
+  await createRunner(__dirname, 'scenario.ts')
+    .expect({
+      span: container => {
+        const spans = container.items;
+        expect(spans.length).toBe(2);
+
+        const customChildSpan = spans.find(s => s.name === 'customChildSpanName');
+
+        expect(customChildSpan).toBeDefined();
+        expect(customChildSpan!.attributes?.['sentry.custom_attribute']).toEqual({
+          type: 'string',
+          value: 'customAttributeValue',
+        });
+        expect(customChildSpan!.status).toBe('something');
+        expect(customChildSpan!.links).toEqual([
+          {
+            trace_id: '123',
+            span_id: '456',
+            attributes: {
+              'sentry.link.type': { type: 'string', value: 'custom_link' },
+            },
+          },
+        ]);
+      },
+    })
+    .start()
+    .completed();
+});

--- a/dev-packages/node-integration-tests/suites/tracing/ignoreSpans-streamed/children/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/ignoreSpans-streamed/children/instrument.mjs
@@ -7,6 +7,6 @@ Sentry.init({
   tracesSampleRate: 1.0,
   transport: loggingTransport,
   traceLifecycle: 'stream',
-  ignoreSpans: ['middleware - expressInit', /custom-to-drop/, { op: 'ignored-op' }],
+  ignoreSpans: ['expressInit', /custom-to-drop/, { op: 'ignored-op' }],
   clientReportFlushInterval: 1_000,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/ignoreSpans-streamed/children/server.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/ignoreSpans-streamed/children/server.mjs
@@ -38,6 +38,12 @@ app.get('/test/express', (_req, res) => {
     () => {},
   );
   res.send({ response: 'response 1' });
+
+  setTimeout(() => {
+    // flush to avoid waiting for the span buffer timeout to send spans
+    // but defer it to the next tick to let the SDK finish the http.server span first.
+    Sentry.flush();
+  });
 });
 
 Sentry.setupExpressErrorHandler(app);

--- a/dev-packages/node-integration-tests/suites/tracing/ignoreSpans-streamed/segments/server.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/ignoreSpans-streamed/segments/server.mjs
@@ -13,6 +13,11 @@ app.get('/health', (_req, res) => {
 
 app.get('/ok', (_req, res) => {
   res.send({ status: 'ok' });
+  setTimeout(() => {
+    // flush to avoid waiting for the span buffer timeout to send spans
+    // but defer it to the next tick to let the SDK finish the http.server span first.
+    Sentry.flush();
+  });
 });
 
 Sentry.setupExpressErrorHandler(app);

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -82,11 +82,3 @@ function checkAndSetAngularVersion(): void {
     setContext('angular', { version: angularVersion });
   }
 }
-
-init({
-  dsn: '__DSN__',
-  traceLifecycle: 'stream',
-  beforeSendSpan: span => {
-    return span;
-  },
-});

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -82,3 +82,11 @@ function checkAndSetAngularVersion(): void {
     setContext('angular', { version: angularVersion });
   }
 }
+
+init({
+  dsn: '__DSN__',
+  traceLifecycle: 'stream',
+  beforeSendSpan: span => {
+    return span;
+  },
+});

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -174,6 +174,7 @@ export {
   unleashIntegration,
   growthbookIntegration,
   spanStreamingIntegration,
+  withStreamedSpan,
   metrics,
 } from '@sentry/node';
 

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -21,6 +21,7 @@ export declare function init(options: Options | clientSdk.BrowserOptions | NodeO
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -161,6 +161,7 @@ export {
   growthbookIntegration,
   metrics,
   spanStreamingIntegration,
+  withStreamedSpan,
 } from '@sentry/node';
 
 export {

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -70,6 +70,7 @@ export {
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,
+  withStreamedSpan,
   metrics,
 } from '@sentry/core';
 

--- a/packages/browser/src/integrations/spanstreaming.ts
+++ b/packages/browser/src/integrations/spanstreaming.ts
@@ -19,7 +19,7 @@ export const spanStreamingIntegration = defineIntegration(() => {
       // This avoids the classic double-opt-in problem we'd otherwise have in the browser SDK.
       const clientOptions = client.getOptions();
       if (!clientOptions.traceLifecycle) {
-        DEBUG_BUILD && debug.warn('[SpanStreaming] set `traceLifecycle` to "stream"');
+        DEBUG_BUILD && debug.log('[SpanStreaming] set `traceLifecycle` to "stream"');
         clientOptions.traceLifecycle = 'stream';
       }
     },

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -179,6 +179,7 @@ export {
   unleashIntegration,
   metrics,
   spanStreamingIntegration,
+  withStreamedSpan,
 } from '@sentry/node';
 
 export {

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -107,6 +107,7 @@ export {
   growthbookIntegration,
   logger,
   metrics,
+  withStreamedSpan,
   instrumentLangGraph,
 } from '@sentry/core';
 

--- a/packages/core/src/tracing/spans/beforeSendSpan.ts
+++ b/packages/core/src/tracing/spans/beforeSendSpan.ts
@@ -37,8 +37,6 @@ export function withStreamedSpan(
  * @param callback - The `beforeSendSpan` callback to check.
  * @returns `true` if the callback was wrapped with {@link withStreamedSpan}.
  */
-export function isStreamedBeforeSendSpanCallback(
-  callback: (ClientOptions['beforeSendSpan'] & { _streamed?: true }) | unknown,
-): callback is BeforeSendStreamedSpanCallback {
+export function isStreamedBeforeSendSpanCallback(callback: unknown): callback is BeforeSendStreamedSpanCallback {
   return !!callback && typeof callback === 'function' && '_streamed' in callback && !!callback._streamed;
 }

--- a/packages/core/src/tracing/spans/beforeSendSpan.ts
+++ b/packages/core/src/tracing/spans/beforeSendSpan.ts
@@ -1,6 +1,9 @@
-import type { BeforeSendStramedSpanCallback, ClientOptions } from '../../types-hoist/options';
+import type { CoreOptions } from '../../types-hoist/options';
+import type { BeforeSendStreamedSpanCallback, ClientOptions } from '../../types-hoist/options';
 import type { StreamedSpanJSON } from '../../types-hoist/span';
 import { addNonEnumerableProperty } from '../../utils/object';
+
+type StaticBeforeSendSpanCallback = CoreOptions['beforeSendSpan'];
 
 /**
  * A wrapper to use the new span format in your `beforeSendSpan` callback.
@@ -23,9 +26,9 @@ import { addNonEnumerableProperty } from '../../utils/object';
  */
 export function withStreamedSpan(
   callback: (span: StreamedSpanJSON) => StreamedSpanJSON,
-): BeforeSendStramedSpanCallback {
+): StaticBeforeSendSpanCallback & { _streamed: true } {
   addNonEnumerableProperty(callback, '_streamed', true);
-  return callback;
+  return callback as unknown as StaticBeforeSendSpanCallback & { _streamed: true };
 }
 
 /**
@@ -35,7 +38,7 @@ export function withStreamedSpan(
  * @returns `true` if the callback was wrapped with {@link withStreamedSpan}.
  */
 export function isStreamedBeforeSendSpanCallback(
-  callback: ClientOptions['beforeSendSpan'],
-): callback is BeforeSendStramedSpanCallback {
-  return !!callback && '_streamed' in callback && !!callback._streamed;
+  callback: (ClientOptions['beforeSendSpan'] & { _streamed?: true }) | unknown,
+): callback is BeforeSendStreamedSpanCallback {
+  return !!callback && typeof callback === 'function' && '_streamed' in callback && !!callback._streamed;
 }

--- a/packages/core/src/tracing/spans/beforeSendSpan.ts
+++ b/packages/core/src/tracing/spans/beforeSendSpan.ts
@@ -1,5 +1,5 @@
 import type { CoreOptions } from '../../types-hoist/options';
-import type { BeforeSendStreamedSpanCallback, ClientOptions } from '../../types-hoist/options';
+import type { BeforeSendStreamedSpanCallback } from '../../types-hoist/options';
 import type { StreamedSpanJSON } from '../../types-hoist/span';
 import { addNonEnumerableProperty } from '../../utils/object';
 

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -594,7 +594,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    *
    * @returns The modified span payload that will be sent.
    */
-  beforeSendSpan?: ((span: SpanJSON) => SpanJSON) | BeforeSendStramedSpanCallback;
+  beforeSendSpan?: ((span: SpanJSON) => SpanJSON) & { _streamed?: true };
 
   /**
    * An event-processing callback for transaction events, guaranteed to be invoked after all other event
@@ -631,7 +631,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
  *
  * @see {@link StreamedSpanJSON} for the streamed span format used with `traceLifecycle: 'stream'`
  */
-export type BeforeSendStramedSpanCallback = ((span: StreamedSpanJSON) => StreamedSpanJSON) & {
+export type BeforeSendStreamedSpanCallback = ((span: StreamedSpanJSON) => StreamedSpanJSON) & {
   /**
    * When true, indicates this callback is designed to handle the {@link StreamedSpanJSON} format
    * used with `traceLifecycle: 'stream'`. Set this by wrapping your callback with `withStreamedSpan`.

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -94,6 +94,7 @@ export {
   wrapMcpServerWithSentry,
   featureFlagsIntegration,
   metrics,
+  withStreamedSpan,
   logger,
   consoleLoggingIntegration,
 } from '@sentry/core';

--- a/packages/effect/src/index.types.ts
+++ b/packages/effect/src/index.types.ts
@@ -22,6 +22,7 @@ export declare function init(options: Options | clientSdk.BrowserOptions | serve
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 export declare const logger: typeof clientSdk.logger | typeof serverSdk.logger;

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -155,6 +155,8 @@ export {
   statsigIntegration,
   unleashIntegration,
   metrics,
+  spanStreamingIntegration,
+  withStreamedSpan,
   bunServerIntegration,
   makeFetchTransport,
 } from '@sentry/bun';

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -161,6 +161,7 @@ export {
   unleashIntegration,
   metrics,
   spanStreamingIntegration,
+  withStreamedSpan,
 } from '@sentry/node';
 
 export {

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -24,6 +24,7 @@ export declare function init(
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 
 // Different implementation in server and worker
 export declare const vercelAIIntegration: typeof serverSdk.vercelAIIntegration;

--- a/packages/node-core/src/common-exports.ts
+++ b/packages/node-core/src/common-exports.ts
@@ -121,6 +121,7 @@ export {
   wrapMcpServerWithSentry,
   featureFlagsIntegration,
   spanStreamingIntegration,
+  withStreamedSpan,
   metrics,
   envToBool,
 } from '@sentry/core';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -205,5 +205,6 @@ export {
   cron,
   NODE_VERSION,
   validateOpenTelemetrySetup,
+  withStreamedSpan,
   _INTERNAL_normalizeCollectionInterval,
 } from '@sentry/node-core';

--- a/packages/nuxt/src/index.types.ts
+++ b/packages/nuxt/src/index.types.ts
@@ -17,6 +17,7 @@ export declare function init(options: Options | SentryNuxtClientOptions | Sentry
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -48,5 +48,7 @@ export { SentrySampler, wrapSamplingDecision } from './sampler';
 
 export { openTelemetrySetupCheck } from './utils/setupCheck';
 
+export { withStreamedSpan } from '@sentry/core';
+
 // Legacy
 export { getClient } from '@sentry/core';

--- a/packages/react-router/src/index.types.ts
+++ b/packages/react-router/src/index.types.ts
@@ -17,6 +17,7 @@ export declare function init(options: Options | clientSdk.BrowserOptions | serve
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 export declare const defaultStackParser: StackParser;
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 

--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -114,5 +114,6 @@ export {
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,
+  withStreamedSpan,
   featureFlagsIntegration,
 } from '@sentry/core';

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -19,6 +19,7 @@ export declare const browserTracingIntegration: typeof clientSdk.browserTracingI
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -132,6 +132,7 @@ export {
   createConsolaReporter,
   createSentryWinstonTransport,
   spanStreamingIntegration,
+  withStreamedSpan,
 } from '@sentry/node';
 
 // Keeping the `*` exports for backwards compatibility and types

--- a/packages/solidstart/src/index.types.ts
+++ b/packages/solidstart/src/index.types.ts
@@ -19,6 +19,7 @@ export declare function init(options: Options | clientSdk.BrowserOptions | serve
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -131,6 +131,7 @@ export {
   createConsolaReporter,
   createSentryWinstonTransport,
   spanStreamingIntegration,
+  withStreamedSpan,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -48,6 +48,7 @@ export declare function wrapLoadWithSentry<T extends (...args: any) => any>(orig
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 
 // Different implementation in server and worker
 export declare const vercelAIIntegration: typeof serverSdk.vercelAIIntegration;

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -136,6 +136,7 @@ export {
   vercelAIIntegration,
   metrics,
   spanStreamingIntegration,
+  withStreamedSpan,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -80,6 +80,7 @@ export {
   withIsolationScope,
   withMonitor,
   withScope,
+  withStreamedSpan,
   supabaseIntegration,
   instrumentSupabaseClient,
   zodErrorsIntegration,

--- a/packages/tanstackstart-react/src/index.types.ts
+++ b/packages/tanstackstart-react/src/index.types.ts
@@ -19,6 +19,7 @@ export declare function init(options: Options | clientSdk.BrowserOptions | serve
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
+export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 
 export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -102,6 +102,7 @@ export {
   featureFlagsIntegration,
   logger,
   metrics,
+  withStreamedSpan,
 } from '@sentry/core';
 
 export { VercelEdgeClient } from './client';


### PR DESCRIPTION
This PR makes some changes to the span streaming `beforeSendSpan` implementation:

Previously `beforeSendSpan` was typed via discriminated union. While I initially thought this would work, it would break type checking for user-provided static `beforeSendSpan` callbacks because TS couldn't infer if the callback received a `SpanJSON` or a `StreamedSpanJSON`. So it defaulted to `unknown`. Now, we "pretend" that every `beforeSendSpan` callback receives and returns a `SpanJSON`. Since we instruct users for span streaming to use the `withStreamedSpan` helper anyway, they will get correct typing within the wrapper function (i.e. a callback receiving and returning `StreamedSpanJSON`.

Other changes:
- added missing exports for the `withStreamedSpan` helper from every SDK
- added integration tests to demonstrate it being used
- downleveled the debug log from `warn` to `log` that the browser `spanStreamingIntegration` automatically sets `traceLifecycle: 'stream'`. This is expected behaviour and we'll instruct users to only set `spanStreamingIntegration` to avoid a double-opt-in situation. 