### PR TITLE
fix(deno): Avoid inferring invalid span op from Deno tracer

### DIFF
--- a/dev-packages/e2e-tests/test-applications/deno/tests/ai.test.ts
+++ b/dev-packages/e2e-tests/test-applications/deno/tests/ai.test.ts
@@ -32,7 +32,7 @@ test('should create AI pipeline spans with Vercel AI SDK', async ({ baseURL }) =
     (span: any) =>
       span.op === 'gen_ai.invoke_agent' ||
       span.op === 'gen_ai.generate_content' ||
-      span.op === 'otel.span' ||
+      !span.op ||
       span.description?.includes('ai.generateText'),
   );
 

--- a/dev-packages/e2e-tests/test-applications/deno/tests/ai.test.ts
+++ b/dev-packages/e2e-tests/test-applications/deno/tests/ai.test.ts
@@ -28,13 +28,27 @@ test('should create AI pipeline spans with Vercel AI SDK', async ({ baseURL }) =
   // Due to the AI SDK monkey-patching limitation (https://github.com/vercel/ai/pull/6716),
   // only explicitly opted-in calls produce telemetry spans.
   // The explicitly enabled call (experimental_telemetry: { isEnabled: true }) should produce spans.
-  const aiSpans = spans.filter(
-    (span: any) =>
+  const aiSpans = spans.filter((span: any) => {
+    if (
       span.op === 'gen_ai.invoke_agent' ||
       span.op === 'gen_ai.generate_content' ||
-      !span.op ||
-      span.description?.includes('ai.generateText'),
-  );
+      span.op === 'gen_ai.execute_tool'
+    ) {
+      return true;
+    }
+    // Processed Vercel AI spans (incl. cases where OTel kind no longer maps to a generic `op`)
+    if (span.origin === 'auto.vercelai.otel') {
+      return true;
+    }
+    // Raw Vercel AI OTel span names / attributes before or without full Sentry mapping
+    if (typeof span.description === 'string' && span.description.startsWith('ai.')) {
+      return true;
+    }
+    if (span.data?.['ai.operationId'] != null || span.data?.['ai.pipeline.name'] != null) {
+      return true;
+    }
+    return false;
+  });
 
   // We expect at least one AI-related span from the explicitly enabled call
   expect(aiSpans.length).toBeGreaterThanOrEqual(1);

--- a/dev-packages/e2e-tests/test-applications/deno/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/deno/tests/transactions.test.ts
@@ -37,6 +37,11 @@ test('Sends transaction with OTel tracer.startSpan despite pre-existing provider
       }),
     ]),
   );
+
+  const otelSpan = transaction.spans!.find((s: any) => s.description === 'test-otel-span');
+  expect(otelSpan).toBeDefined();
+  // INTERNAL (and other unmapped) kinds must not get a synthetic `otel.span` op
+  expect(otelSpan!.op).toBeUndefined();
 });
 
 test('Sends transaction with OTel tracer.startActiveSpan', async ({ baseURL }) => {
@@ -56,6 +61,10 @@ test('Sends transaction with OTel tracer.startActiveSpan', async ({ baseURL }) =
       }),
     ]),
   );
+
+  const otelSpan = transaction.spans!.find((s: any) => s.description === 'test-otel-active-span');
+  expect(otelSpan).toBeDefined();
+  expect(otelSpan!.op).toBeUndefined();
 });
 
 test('OTel span appears as child of Sentry span (interop)', async ({ baseURL }) => {
@@ -84,4 +93,5 @@ test('OTel span appears as child of Sentry span (interop)', async ({ baseURL }) 
   const sentrySpan = transaction.spans!.find((s: any) => s.description === 'sentry-parent');
   const otelSpan = transaction.spans!.find((s: any) => s.description === 'otel-child');
   expect(otelSpan!.parent_span_id).toBe(sentrySpan!.span_id);
+  expect(otelSpan!.op).toBeUndefined();
 });

--- a/dev-packages/e2e-tests/test-applications/deno/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/deno/tests/transactions.test.ts
@@ -33,7 +33,6 @@ test('Sends transaction with OTel tracer.startSpan despite pre-existing provider
     expect.arrayContaining([
       expect.objectContaining({
         description: 'test-otel-span',
-        op: 'otel.span',
         origin: 'manual',
       }),
     ]),
@@ -53,7 +52,6 @@ test('Sends transaction with OTel tracer.startActiveSpan', async ({ baseURL }) =
     expect.arrayContaining([
       expect.objectContaining({
         description: 'test-otel-active-span',
-        op: 'otel.span',
         origin: 'manual',
       }),
     ]),
@@ -77,7 +75,6 @@ test('OTel span appears as child of Sentry span (interop)', async ({ baseURL }) 
       }),
       expect.objectContaining({
         description: 'otel-child',
-        op: 'otel.span',
         origin: 'manual',
       }),
     ]),

--- a/packages/deno/src/opentelemetry/tracer.ts
+++ b/packages/deno/src/opentelemetry/tracer.ts
@@ -43,7 +43,7 @@ class SentryDenoTracer implements Tracer {
       attributes: {
         ...options?.attributes,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
+        ...(op ? { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op } : {}),
         'sentry.deno_tracer': true,
       },
     });
@@ -77,7 +77,7 @@ class SentryDenoTracer implements Tracer {
       attributes: {
         ...opts.attributes,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
+        ...(op ? { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op } : {}),
         'sentry.deno_tracer': true,
       },
     };
@@ -96,7 +96,7 @@ class SentryDenoTracer implements Tracer {
     return startSpanManual(spanOpts, callback) as ReturnType<F>;
   }
 
-  private _mapSpanKindToOp(kind?: SpanKind): string {
+  private _mapSpanKindToOp(kind?: SpanKind): string | undefined {
     switch (kind) {
       case SpanKind.CLIENT:
         return 'http.client';
@@ -107,7 +107,7 @@ class SentryDenoTracer implements Tracer {
       case SpanKind.CONSUMER:
         return 'message.consume';
       default:
-        return 'otel.span';
+        return undefined;
     }
   }
 }


### PR DESCRIPTION
Looks like an invalid span op snuck into the Deno SDK when we pick up spans from Deno's tracer. We have a `_mapSpanKindToOp` helper in there which as a default value returned `otel.span`. This value does not align with our [definition](https://develop.sentry.dev/sdk/telemetry/traces/span-operations/#list-of-operations) of span ops. Instead, if we can't infer a span op, we should just not set one in the first place. 

(side-note: Long-term, we might need something more sophisticated here like `inferSpanData` in the Node SDK. But for now, I'd rather remove the invalid op and move on. Only came across this while working on #20127)