### PR TITLE
fix(angular): Bump TypeScript to ~6.0.0 in angular-21 E2E test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/angular-21/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-21/package.json
@@ -44,7 +44,7 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.9.0"
+    "typescript": "~6.0.0"
   },
   "volta": {
     "node": "22.22.0",


### PR DESCRIPTION
Angular @next now requires TypeScript >=6.0.0, which caused the canary build to fail. Angular 21.2.x stable also supports TS 6.0.x (>=5.9 <6.1).

Closes: #20131
