### PR TITLE
feat(core): Expose `rewriteSources` top level option 

### DIFF
--- a/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
+++ b/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
@@ -241,6 +241,19 @@ interface SourceMapsOptions {
    * The globbing patterns must follow the implementation of the `glob` package: https://www.npmjs.com/package/glob#glob-primer
    */
   filesToDeleteAfterUpload?: string | Array<string>;
+
+  /**
+   * Hook to rewrite the `sources` field inside the source map before being uploaded to Sentry. Does not modify the actual source map.
+   *
+   * The hook receives the following arguments:
+   * - `source` - the source file path from the source map's `sources` field
+   * - `map` - the source map object
+   * - `context` - an optional object containing `mapDir`, the absolute path to the directory of the source map file
+   *
+   * Defaults to making all sources relative to `process.cwd()` while building.
+   */
+  // oxlint-disable-next-line typescript-eslint/no-explicit-any -- matches the bundler plugin's RewriteSourcesHook type
+  rewriteSources?: (source: string, map: any, context?: { mapDir: string }) => string;
 }
 
 type AutoSetCommitsOptions = {

--- a/packages/nextjs/src/config/getBuildPluginOptions.ts
+++ b/packages/nextjs/src/config/getBuildPluginOptions.ts
@@ -326,7 +326,7 @@ export function getBuildPluginOptions({
     url: sentryBuildOptions.sentryUrl,
     sourcemaps: {
       disable: skipSourcemapsUpload ? true : (sentryBuildOptions.sourcemaps?.disable ?? false),
-      rewriteSources: rewriteWebpackSources,
+      rewriteSources: sentryBuildOptions.sourcemaps?.rewriteSources ?? rewriteWebpackSources,
       assets: sentryBuildOptions.sourcemaps?.assets ?? sourcemapUploadAssets,
       ignore: finalIgnorePatterns,
       filesToDeleteAfterUpload,

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -294,6 +294,21 @@ export type SentryBuildOptions = {
      * ```
      */
     filesToDeleteAfterUpload?: string | string[];
+
+    /**
+     * Hook to rewrite the `sources` field inside the source map before being uploaded to Sentry. Does not modify the actual source map.
+     *
+     * The hook receives the following arguments:
+     * - `source` - the source file path from the source map's `sources` field
+     * - `map` - the source map object
+     * - `context` - an optional object containing `mapDir`, the absolute path to the directory of the source map file
+     *
+     * If not provided, the SDK defaults to stripping webpack-specific prefixes (`webpack://_N_E/`).
+     *
+     * Defaults to making all sources relative to `process.cwd()` while building.
+     */
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any -- matches the bundler plugin's RewriteSourcesHook type
+    rewriteSources?: (source: string, map: any, context?: { mapDir: string }) => string;
   };
 
   /**

--- a/packages/nextjs/test/config/getBuildPluginOptions.test.ts
+++ b/packages/nextjs/test/config/getBuildPluginOptions.test.ts
@@ -692,6 +692,26 @@ describe('getBuildPluginOptions', () => {
         expect(rewriteSources('./components/Layout.tsx', {})).toBe('./components/Layout.tsx');
       }
     });
+
+    it('allows user to override rewriteSources', () => {
+      const customRewrite = (source: string) => source.replace(/^custom\//, '');
+      const sentryBuildOptions: SentryBuildOptions = {
+        org: 'test-org',
+        project: 'test-project',
+        sourcemaps: {
+          rewriteSources: customRewrite,
+        },
+      };
+
+      const result = getBuildPluginOptions({
+        sentryBuildOptions,
+        releaseName: mockReleaseName,
+        distDirAbsPath: mockDistDirAbsPath,
+        buildTool: 'webpack-client',
+      });
+
+      expect(result.sourcemaps?.rewriteSources).toBe(customRewrite);
+    });
   });
 
   describe('release configuration', () => {

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -216,7 +216,7 @@ export function getPluginOptions(
         : shouldDeleteFilesFallback?.server || shouldDeleteFilesFallback?.client
           ? fallbackFilesToDelete
           : undefined,
-      rewriteSources: sourcemapsOptions.rewriteSources ?? ((source: string) => normalizePath(source)),
+      rewriteSources: sourcemapsOptions.rewriteSources ?? normalizePath,
       ...moduleOptions?.unstable_sentryBundlerPluginOptions?.sourcemaps,
     },
   };

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -216,7 +216,7 @@ export function getPluginOptions(
         : shouldDeleteFilesFallback?.server || shouldDeleteFilesFallback?.client
           ? fallbackFilesToDelete
           : undefined,
-      rewriteSources: (source: string) => normalizePath(source),
+      rewriteSources: sourcemapsOptions.rewriteSources ?? ((source: string) => normalizePath(source)),
       ...moduleOptions?.unstable_sentryBundlerPluginOptions?.sourcemaps,
     },
   };

--- a/packages/nuxt/test/vite/sourceMaps.test.ts
+++ b/packages/nuxt/test/vite/sourceMaps.test.ts
@@ -118,6 +118,16 @@ describe('getPluginOptions', () => {
     expect(rewrite!('./local')).toBe('./local');
   });
 
+  it('allows user to override rewriteSources', () => {
+    const customRewrite = (source: string) => source.replace(/^src\//, 'custom/');
+    const options = getPluginOptions({
+      sourcemaps: {
+        rewriteSources: customRewrite,
+      },
+    } as SentryNuxtModuleOptions);
+    expect(options.sourcemaps?.rewriteSources).toBe(customRewrite);
+  });
+
   it('prioritizes new BuildTimeOptionsBase options over deprecated ones', () => {
     const options: SentryNuxtModuleOptions = {
       // New options

--- a/packages/tanstackstart-react/src/vite/sourceMaps.ts
+++ b/packages/tanstackstart-react/src/vite/sourceMaps.ts
@@ -65,6 +65,7 @@ export function makeAddSentryVitePlugin(options: BuildTimeOptionsBase): Plugin[]
       assets: sourcemaps?.assets,
       disable: sourcemaps?.disable,
       ignore: sourcemaps?.ignore,
+      rewriteSources: sourcemaps?.rewriteSources,
       filesToDeleteAfterUpload: filesToDeleteAfterUploadPromise,
     },
     telemetry: telemetry ?? true,

--- a/packages/tanstackstart-react/test/vite/sourceMaps.test.ts
+++ b/packages/tanstackstart-react/test/vite/sourceMaps.test.ts
@@ -195,6 +195,25 @@ describe('makeAddSentryVitePlugin()', () => {
     consoleSpy.mockRestore();
   });
 
+  it('passes rewriteSources to the vite plugin', () => {
+    const customRewrite = (source: string) => source.replace(/^src\//, '');
+    makeAddSentryVitePlugin({
+      org: 'my-org',
+      authToken: 'my-token',
+      sourcemaps: {
+        rewriteSources: customRewrite,
+      },
+    });
+
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourcemaps: expect.objectContaining({
+          rewriteSources: customRewrite,
+        }),
+      }),
+    );
+  });
+
   it('sets the correct metaFramework in telemetry options', () => {
     makeAddSentryVitePlugin({
       org: 'my-org',


### PR DESCRIPTION
- Adds `rewriteSources` to the base `SourceMapsOptions` interface so users can customize source path rewriting without the `unstable_*` escape hatch
- Wires up the option in Nuxt, Next.js, and TanStack Start (SvelteKit, Astro, React Router already pass it through via spread)
- Nuxt and Next.js preserve their default rewriting behavior when the option is not provided


bundler plugins ref https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/908
closes https://github.com/getsentry/sentry-javascript/issues/20028