### PR TITLE
feat(nuxt): Exclude tracing meta tags on cached pages in Nuxt 5

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.cached-html.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.cached-html.test.ts
@@ -14,13 +14,11 @@ test.describe('Rendering Modes with Cached HTML', () => {
     await testChangingTracingMetaTagsOnISRPage(page, '/rendering-modes/isr-1h-cached-page', 'ISR 1h Cached Page');
   });
 
-  // TODO: Make test work with Nuxt 5
-  test.skip('exclude tracing meta tags on SWR-cached page', async ({ page }) => {
+  test('exclude tracing meta tags on SWR-cached page', async ({ page }) => {
     await testExcludeTracingMetaTagsOnCachedPage(page, '/rendering-modes/swr-cached-page', 'SWR Cached Page');
   });
 
-  // TODO: Make test work with Nuxt 5
-  test.skip('exclude tracing meta tags on SWR 1h cached page', async ({ page }) => {
+  test('exclude tracing meta tags on SWR 1h cached page', async ({ page }) => {
     await testExcludeTracingMetaTagsOnCachedPage(page, '/rendering-modes/swr-1h-cached-page', 'SWR 1h Cached Page');
   });
 

--- a/packages/nuxt/src/runtime/plugins/sentry.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry.server.ts
@@ -21,7 +21,9 @@ export default (nitroApp => {
       !!(event as any).res?.headers?.has?.('x-nitro-prerender');
 
     // oxlint-disable-next-line typescript-oxlint/no-unsafe-member-access
-    const isSWRCachedPage = event?.context?.cache?.options?.swr as boolean | undefined;
+    const isSWRCachedPage = /* Nitro v2 */ (event?.context?.cache?.options?.swr ||
+      // oxlint-disable-next-line typescript-oxlint/no-unsafe-member-access
+      /* Nitro v3 */ event?.context?.routeRules?.swr) as boolean;
 
     if (!isPreRenderedPage && !isSWRCachedPage) {
       addSentryTracingMetaTags(html.head);


### PR DESCRIPTION
To know whether a page is SWR cached, can now be found in `event.context.routeRules.swr` (Nitro v3) instead of `event.context.cache.options.swr` (Nitro v2).

closes https://github.com/getsentry/sentry-javascript/issues/20169