### PR TITLE
chore(bugbot): Add rules to flag test-flake-provoking patterns

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -62,6 +62,7 @@ Do not flag the issues below if they appear in tests.
   - Only waiting for a request, after an action is performed. Instead, start waiting, perform action, await request promise.
   - Race conditions when waiting on multiple requests. Ensure that waiting checks are unique enough and don't depend on a hard order when there's a chance that telemetry can be sent in arbitrary order.
   - Timeouts or sleeps in tests. Instead suggest concrete events or other signals to wait on.
+- Flag usage of `getFirstEnvelope*`, `getMultipleEnvelope*` or related test helpers. These are NOT reliable anymore. Instead suggest helpers like `waitForTransaction`, `waitForError`, `waitForSpans`, etc.
 
 ## Platform-safe code
 

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -58,6 +58,10 @@ Do not flag the issues below if they appear in tests.
 - Flag usage of `expect.objectContaining` and other relaxed assertions, when a test expects something NOT to be included in a payload but there's no respective assertion.
 - Flag usage of conditionals in one test and recommend splitting up the test for the different paths.
 - Flag usage of loops testing multiple scenarios in one test and recommend using `(it)|(test).each` instead.
+- Flag tests that are likely to introduce flakes. In our case this usually means we wait for some telemetry requests sent from an SDK. Patterns to look out for:
+  - Only waiting for a request, after an action is performed. Instead, start waiting, perform action, await request promise.
+  - Race conditions when waiting on multiple requests. Ensure that waiting checks are unique enough and don't depend on a hard order when there's a chance that telemetry can be sent in arbitrary order.
+  - Timeouts or sleeps in tests. Instead suggest concrete events or other signals to wait on.
 
 ## Platform-safe code
 


### PR DESCRIPTION
We need to get a grip on our test flake situation again. Currently, CI flakes on almost every initial run, which is especially painful when cutting releases. This PR adds a few rules for bug bot to look out for anti patterns that are likely to introduce new test flakes. 