### PR TITLE
test(openai): Use multi-message scenario in no-truncation test

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/openai/scenario-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/scenario-no-truncation.mjs
@@ -60,11 +60,15 @@ async function run() {
       apiKey: 'mock-api-key',
     });
 
-    // Chat completion with long content (would normally be truncated)
+    // Multiple messages with long content (would normally be truncated and popped to last message only)
     const longContent = 'A'.repeat(50_000);
     await client.chat.completions.create({
       model: 'gpt-4',
-      messages: [{ role: 'user', content: longContent }],
+      messages: [
+        { role: 'user', content: longContent },
+        { role: 'assistant', content: 'Some reply' },
+        { role: 'user', content: 'Follow-up question' },
+      ],
     });
 
     // Responses API with long string input (would normally be truncated)

--- a/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
@@ -350,11 +350,15 @@ describe('OpenAI integration', () => {
   const EXPECTED_TRANSACTION_NO_TRUNCATION = {
     transaction: 'main',
     spans: expect.arrayContaining([
-      // Chat completion with long content should not be truncated
+      // Multiple messages should all be preserved (no popping to last message only)
       expect.objectContaining({
         data: expect.objectContaining({
-          [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: JSON.stringify([{ role: 'user', content: longContent }]),
-          [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: 1,
+          [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: JSON.stringify([
+            { role: 'user', content: longContent },
+            { role: 'assistant', content: 'Some reply' },
+            { role: 'user', content: 'Follow-up question' },
+          ]),
+          [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: 3,
         }),
       }),
       // Responses API long string input should not be truncated or wrapped in quotes


### PR DESCRIPTION
let's expand the no-truncation scenario here to use multiple input messages to ensure no message popping is applied to align this with other scenarios