### PR TITLE
feat(core): Add `enableTruncation` option to Vercel AI integration

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-no-truncation.mjs
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  sendDefaultPii: true,
+  transport: loggingTransport,
+  integrations: [
+    Sentry.vercelAIIntegration({
+      recordInputs: true,
+      recordOutputs: true,
+      enableTruncation: false,
+    }),
+  ],
+});

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-streaming-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-streaming-with-truncation.mjs
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  sendDefaultPii: true,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+  integrations: [
+    Sentry.vercelAIIntegration({
+      enableTruncation: true,
+    }),
+  ],
+});

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-streaming.mjs
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  sendDefaultPii: true,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-no-truncation.mjs
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/node';
+import { generateText } from 'ai';
+import { MockLanguageModelV1 } from 'ai/test';
+
+async function run() {
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    // Multiple messages with long content (would normally be truncated and popped to last message only)
+    const longContent = 'A'.repeat(50_000);
+    await generateText({
+      experimental_telemetry: { isEnabled: true },
+      model: new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { promptTokens: 10, completionTokens: 5 },
+          text: 'Response',
+        }),
+      }),
+      messages: [
+        { role: 'user', content: longContent },
+        { role: 'assistant', content: 'Some reply' },
+        { role: 'user', content: 'Follow-up question' },
+      ],
+    });
+  });
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/scenario-streaming.mjs
@@ -1,0 +1,30 @@
+import * as Sentry from '@sentry/node';
+import { generateText } from 'ai';
+import { MockLanguageModelV1 } from 'ai/test';
+
+async function run() {
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    const longContent = 'A'.repeat(50_000);
+    await generateText({
+      experimental_telemetry: { isEnabled: true },
+      model: new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { promptTokens: 10, completionTokens: 5 },
+          text: 'Response',
+        }),
+      }),
+      messages: [
+        { role: 'user', content: longContent },
+        { role: 'assistant', content: 'Some reply' },
+        { role: 'user', content: 'Follow-up question' },
+      ],
+    });
+  });
+
+  // Flush is required when span streaming is enabled to ensure streamed spans are sent before the process exits
+  await Sentry.flush(2000);
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -983,4 +983,50 @@ describe('Vercel AI integration', () => {
       });
     },
   );
+
+  const streamingLongContent = 'A'.repeat(50_000);
+
+  createEsmAndCjsTests(__dirname, 'scenario-streaming.mjs', 'instrument-streaming.mjs', (createRunner, test) => {
+    test('automatically disables truncation when span streaming is enabled', async () => {
+      await createRunner()
+        .expect({
+          span: container => {
+            const spans = container.items;
+
+            const chatSpan = spans.find(s =>
+              s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes(streamingLongContent),
+            );
+            expect(chatSpan).toBeDefined();
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
+
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-streaming.mjs',
+    'instrument-streaming-with-truncation.mjs',
+    (createRunner, test) => {
+      test('respects explicit enableTruncation: true even when span streaming is enabled', async () => {
+        await createRunner()
+          .expect({
+            span: container => {
+              const spans = container.items;
+
+              // With explicit enableTruncation: true, truncation keeps only the last message
+              // and drops the long content. The result should NOT contain the full 50k 'A' string.
+              const chatSpan = spans.find(s =>
+                s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Follow-up question'),
+              );
+              expect(chatSpan).toBeDefined();
+              expect(chatSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).not.toContain(streamingLongContent);
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+  );
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -950,4 +950,37 @@ describe('Vercel AI integration', () => {
         .completed();
     });
   });
+
+  const longContent = 'A'.repeat(50_000);
+
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-no-truncation.mjs',
+    'instrument-no-truncation.mjs',
+    (createRunner, test) => {
+      test('does not truncate input messages when enableTruncation is false', async () => {
+        await createRunner()
+          .expect({
+            transaction: {
+              transaction: 'main',
+              spans: expect.arrayContaining([
+                // Multiple messages should all be preserved (no popping to last message only)
+                expect.objectContaining({
+                  data: expect.objectContaining({
+                    [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: JSON.stringify([
+                      { role: 'user', content: longContent },
+                      { role: 'assistant', content: 'Some reply' },
+                      { role: 'user', content: 'Follow-up question' },
+                    ]),
+                    [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: 3,
+                  }),
+                }),
+              ]),
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+  );
 });

--- a/packages/cloudflare/src/integrations/tracing/vercelai.ts
+++ b/packages/cloudflare/src/integrations/tracing/vercelai.ts
@@ -13,9 +13,18 @@ import { addVercelAiProcessors, defineIntegration } from '@sentry/core';
 
 const INTEGRATION_NAME = 'VercelAI';
 
-const _vercelAIIntegration = (() => {
+interface VercelAiOptions {
+  /**
+   * Enable or disable truncation of recorded input messages.
+   * Defaults to `true`.
+   */
+  enableTruncation?: boolean;
+}
+
+const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
+    options,
     setup(client) {
       addVercelAiProcessors(client);
     },

--- a/packages/core/src/tracing/ai/utils.ts
+++ b/packages/core/src/tracing/ai/utils.ts
@@ -3,6 +3,7 @@
  */
 import { captureException } from '../../exports';
 import { getClient } from '../../currentScopes';
+import { hasSpanStreamingEnabled } from '../spans/hasSpanStreamingEnabled';
 import type { Span } from '../../types-hoist/span';
 import { isThenable } from '../../utils/is';
 import {
@@ -54,6 +55,16 @@ export function resolveAIRecordingOptions<T extends AIRecordingOptions>(options?
     recordInputs: options?.recordInputs ?? sendDefaultPii,
     recordOutputs: options?.recordOutputs ?? sendDefaultPii,
   } as T & Required<AIRecordingOptions>;
+}
+
+/**
+ * Resolves whether truncation should be enabled.
+ * If the user explicitly set `enableTruncation`, that value is used.
+ * Otherwise, truncation is disabled when span streaming is active.
+ */
+export function shouldEnableTruncation(enableTruncation: boolean | undefined): boolean {
+  const client = getClient();
+  return enableTruncation ?? !(client && hasSpanStreamingEnabled(client));
 }
 
 /**

--- a/packages/core/src/tracing/vercel-ai/index.ts
+++ b/packages/core/src/tracing/vercel-ai/index.ts
@@ -94,7 +94,7 @@ function mapVercelAiOperationName(operationName: string): string {
  * Post-process spans emitted by the Vercel AI SDK.
  * This is supposed to be used in `client.on('spanStart', ...)
  */
-function onVercelAiSpanStart(span: Span, enableTruncation: boolean): void {
+function onVercelAiSpanStart(span: Span, client: Client): void {
   const { data: attributes, description: name } = spanToJSON(span);
 
   if (!name) {
@@ -113,6 +113,9 @@ function onVercelAiSpanStart(span: Span, enableTruncation: boolean): void {
   if (!attributes[AI_OPERATION_ID_ATTRIBUTE] && !name.startsWith('ai.')) {
     return;
   }
+
+  const integration = client.getIntegrationByName('VercelAI') as { options?: { enableTruncation?: boolean } } | undefined;
+  const enableTruncation = integration?.options?.enableTruncation ?? true;
 
   processGenerateSpan(span, name, attributes, enableTruncation);
 }
@@ -444,9 +447,8 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
 /**
  * Add event processors to the given client to process Vercel AI spans.
  */
-export function addVercelAiProcessors(client: Client, options?: { enableTruncation?: boolean }): void {
-  const enableTruncation = options?.enableTruncation ?? true;
-  client.on('spanStart', span => onVercelAiSpanStart(span, enableTruncation));
+export function addVercelAiProcessors(client: Client): void {
+  client.on('spanStart', span => onVercelAiSpanStart(span, client));
   // Note: We cannot do this on `spanEnd`, because the span cannot be mutated anymore at this point
   client.addEventProcessor(Object.assign(vercelAiEventProcessor, { id: 'VercelAiEventProcessor' }));
 }

--- a/packages/core/src/tracing/vercel-ai/index.ts
+++ b/packages/core/src/tracing/vercel-ai/index.ts
@@ -2,6 +2,7 @@
 import type { Client } from '../../client';
 import { getClient } from '../../currentScopes';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
+import { shouldEnableTruncation } from '../ai/utils';
 import type { Event } from '../../types-hoist/event';
 import type { Span, SpanAttributes, SpanAttributeValue, SpanJSON } from '../../types-hoist/span';
 import { spanToJSON } from '../../utils/spanUtils';
@@ -119,7 +120,7 @@ function onVercelAiSpanStart(span: Span): void {
   const integration = client?.getIntegrationByName('VercelAI') as
     | { options?: { enableTruncation?: boolean } }
     | undefined;
-  const enableTruncation = integration?.options?.enableTruncation ?? true;
+  const enableTruncation = shouldEnableTruncation(integration?.options?.enableTruncation);
 
   processGenerateSpan(span, name, attributes, enableTruncation);
 }

--- a/packages/core/src/tracing/vercel-ai/index.ts
+++ b/packages/core/src/tracing/vercel-ai/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import type { Client } from '../../client';
+import { getClient } from '../../currentScopes';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import type { Event } from '../../types-hoist/event';
 import type { Span, SpanAttributes, SpanAttributeValue, SpanJSON } from '../../types-hoist/span';
@@ -94,7 +95,7 @@ function mapVercelAiOperationName(operationName: string): string {
  * Post-process spans emitted by the Vercel AI SDK.
  * This is supposed to be used in `client.on('spanStart', ...)
  */
-function onVercelAiSpanStart(span: Span, client: Client): void {
+function onVercelAiSpanStart(span: Span): void {
   const { data: attributes, description: name } = spanToJSON(span);
 
   if (!name) {
@@ -114,7 +115,10 @@ function onVercelAiSpanStart(span: Span, client: Client): void {
     return;
   }
 
-  const integration = client.getIntegrationByName('VercelAI') as { options?: { enableTruncation?: boolean } } | undefined;
+  const client = getClient();
+  const integration = client?.getIntegrationByName('VercelAI') as
+    | { options?: { enableTruncation?: boolean } }
+    | undefined;
   const enableTruncation = integration?.options?.enableTruncation ?? true;
 
   processGenerateSpan(span, name, attributes, enableTruncation);
@@ -448,7 +452,7 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
  * Add event processors to the given client to process Vercel AI spans.
  */
 export function addVercelAiProcessors(client: Client): void {
-  client.on('spanStart', span => onVercelAiSpanStart(span, client));
+  client.on('spanStart', onVercelAiSpanStart);
   // Note: We cannot do this on `spanEnd`, because the span cannot be mutated anymore at this point
   client.addEventProcessor(Object.assign(vercelAiEventProcessor, { id: 'VercelAiEventProcessor' }));
 }

--- a/packages/core/src/tracing/vercel-ai/index.ts
+++ b/packages/core/src/tracing/vercel-ai/index.ts
@@ -94,7 +94,7 @@ function mapVercelAiOperationName(operationName: string): string {
  * Post-process spans emitted by the Vercel AI SDK.
  * This is supposed to be used in `client.on('spanStart', ...)
  */
-function onVercelAiSpanStart(span: Span): void {
+function onVercelAiSpanStart(span: Span, enableTruncation: boolean): void {
   const { data: attributes, description: name } = spanToJSON(span);
 
   if (!name) {
@@ -114,7 +114,7 @@ function onVercelAiSpanStart(span: Span): void {
     return;
   }
 
-  processGenerateSpan(span, name, attributes);
+  processGenerateSpan(span, name, attributes, enableTruncation);
 }
 
 function vercelAiEventProcessor(event: Event): Event {
@@ -396,7 +396,7 @@ function processToolCallSpan(span: Span, attributes: SpanAttributes): void {
   }
 }
 
-function processGenerateSpan(span: Span, name: string, attributes: SpanAttributes): void {
+function processGenerateSpan(span: Span, name: string, attributes: SpanAttributes, enableTruncation: boolean): void {
   span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.vercelai.otel');
 
   const nameWthoutAi = name.replace('ai.', '');
@@ -408,7 +408,7 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
     span.setAttribute('gen_ai.function_id', functionId);
   }
 
-  requestMessagesFromPrompt(span, attributes);
+  requestMessagesFromPrompt(span, attributes, enableTruncation);
 
   if (attributes[AI_MODEL_ID_ATTRIBUTE] && !attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]) {
     span.setAttribute(GEN_AI_RESPONSE_MODEL_ATTRIBUTE, attributes[AI_MODEL_ID_ATTRIBUTE]);
@@ -444,8 +444,9 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
 /**
  * Add event processors to the given client to process Vercel AI spans.
  */
-export function addVercelAiProcessors(client: Client): void {
-  client.on('spanStart', onVercelAiSpanStart);
+export function addVercelAiProcessors(client: Client, options?: { enableTruncation?: boolean }): void {
+  const enableTruncation = options?.enableTruncation ?? true;
+  client.on('spanStart', span => onVercelAiSpanStart(span, enableTruncation));
   // Note: We cannot do this on `spanEnd`, because the span cannot be mutated anymore at this point
   client.addEventProcessor(Object.assign(vercelAiEventProcessor, { id: 'VercelAiEventProcessor' }));
 }

--- a/packages/core/src/tracing/vercel-ai/utils.ts
+++ b/packages/core/src/tracing/vercel-ai/utils.ts
@@ -16,7 +16,7 @@ import {
   GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE,
   GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
-import { extractSystemInstructions, getTruncatedJsonString } from '../ai/utils';
+import { extractSystemInstructions, getJsonString, getTruncatedJsonString } from '../ai/utils';
 import { toolCallSpanContextMap } from './constants';
 import type { TokenSummary, ToolCallSpanContext } from './types';
 import { AI_PROMPT_ATTRIBUTE, AI_PROMPT_MESSAGES_ATTRIBUTE } from './vercel-ai-attributes';
@@ -227,7 +227,7 @@ export function convertUserInputToMessagesFormat(userInput: string): { role: str
  * Generate a request.messages JSON array from the prompt field in the
  * invoke_agent op
  */
-export function requestMessagesFromPrompt(span: Span, attributes: SpanAttributes): void {
+export function requestMessagesFromPrompt(span: Span, attributes: SpanAttributes, enableTruncation: boolean): void {
   if (
     typeof attributes[AI_PROMPT_ATTRIBUTE] === 'string' &&
     !attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE] &&
@@ -247,11 +247,13 @@ export function requestMessagesFromPrompt(span: Span, attributes: SpanAttributes
       }
 
       const filteredLength = Array.isArray(filteredMessages) ? filteredMessages.length : 0;
-      const truncatedMessages = getTruncatedJsonString(filteredMessages);
+      const messagesJson = enableTruncation
+        ? getTruncatedJsonString(filteredMessages)
+        : getJsonString(filteredMessages);
 
       span.setAttributes({
-        [AI_PROMPT_ATTRIBUTE]: truncatedMessages,
-        [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: truncatedMessages,
+        [AI_PROMPT_ATTRIBUTE]: messagesJson,
+        [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: messagesJson,
         [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: filteredLength,
       });
     }
@@ -268,11 +270,13 @@ export function requestMessagesFromPrompt(span: Span, attributes: SpanAttributes
         }
 
         const filteredLength = Array.isArray(filteredMessages) ? filteredMessages.length : 0;
-        const truncatedMessages = getTruncatedJsonString(filteredMessages);
+        const messagesJson = enableTruncation
+          ? getTruncatedJsonString(filteredMessages)
+          : getJsonString(filteredMessages);
 
         span.setAttributes({
-          [AI_PROMPT_MESSAGES_ATTRIBUTE]: truncatedMessages,
-          [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: truncatedMessages,
+          [AI_PROMPT_MESSAGES_ATTRIBUTE]: messagesJson,
+          [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: messagesJson,
           [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: filteredLength,
         });
       }

--- a/packages/deno/src/integrations/tracing/vercelai.ts
+++ b/packages/deno/src/integrations/tracing/vercelai.ts
@@ -7,9 +7,18 @@ import { addVercelAiProcessors, defineIntegration } from '@sentry/core';
 
 const INTEGRATION_NAME = 'VercelAI';
 
-const _vercelAIIntegration = (() => {
+interface VercelAiOptions {
+  /**
+   * Enable or disable truncation of recorded input messages.
+   * Defaults to `true`.
+   */
+  enableTruncation?: boolean;
+}
+
+const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
+    options,
     setup(client) {
       addVercelAiProcessors(client);
     },

--- a/packages/node/src/integrations/tracing/vercelai/index.ts
+++ b/packages/node/src/integrations/tracing/vercelai/index.ts
@@ -30,10 +30,11 @@ const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
       // Note that this can only be detected if the 'Modules' integration is available, and running in CJS mode
       const shouldForce = options.force ?? shouldForceIntegration(client);
 
+      const processorOptions = { enableTruncation: options.enableTruncation };
       if (shouldForce) {
-        addVercelAiProcessors(client);
+        addVercelAiProcessors(client, processorOptions);
       } else {
-        instrumentation?.callWhenPatched(() => addVercelAiProcessors(client));
+        instrumentation?.callWhenPatched(() => addVercelAiProcessors(client, processorOptions));
       }
     },
   };

--- a/packages/node/src/integrations/tracing/vercelai/index.ts
+++ b/packages/node/src/integrations/tracing/vercelai/index.ts
@@ -30,11 +30,10 @@ const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
       // Note that this can only be detected if the 'Modules' integration is available, and running in CJS mode
       const shouldForce = options.force ?? shouldForceIntegration(client);
 
-      const processorOptions = { enableTruncation: options.enableTruncation };
       if (shouldForce) {
-        addVercelAiProcessors(client, processorOptions);
+        addVercelAiProcessors(client);
       } else {
-        instrumentation?.callWhenPatched(() => addVercelAiProcessors(client, processorOptions));
+        instrumentation?.callWhenPatched(() => addVercelAiProcessors(client));
       }
     },
   };

--- a/packages/node/src/integrations/tracing/vercelai/types.ts
+++ b/packages/node/src/integrations/tracing/vercelai/types.ts
@@ -62,6 +62,12 @@ export interface VercelAiOptions {
    * If you want to register the span processors even when the ai package usage cannot be detected, you can set `force` to `true`.
    */
   force?: boolean;
+
+  /**
+   * Enable or disable truncation of recorded input messages.
+   * Defaults to `true`.
+   */
+  enableTruncation?: boolean;
 }
 
 export interface VercelAiIntegration extends Integration {

--- a/packages/vercel-edge/src/integrations/tracing/vercelai.ts
+++ b/packages/vercel-edge/src/integrations/tracing/vercelai.ts
@@ -13,9 +13,18 @@ import { addVercelAiProcessors, defineIntegration } from '@sentry/core';
 
 const INTEGRATION_NAME = 'VercelAI';
 
-const _vercelAIIntegration = (() => {
+interface VercelAiOptions {
+  /**
+   * Enable or disable truncation of recorded input messages.
+   * Defaults to `true`.
+   */
+  enableTruncation?: boolean;
+}
+
+const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
+    options,
     setup(client) {
       addVercelAiProcessors(client);
     },


### PR DESCRIPTION
This PR adds an enableTruncation option to the Vercel GenAI integration that allows users to disable input message truncation. It defaults to true to preserve existing behavior.

Closes https://github.com/getsentry/sentry-javascript/issues/20140
