### PR TITLE
test(react): Remove duplicated test mock

### DIFF
--- a/packages/react/test/reactrouter-cross-usage.test.tsx
+++ b/packages/react/test/reactrouter-cross-usage.test.tsx
@@ -64,15 +64,6 @@ vi.mock('@sentry/browser', async requireActual => {
 });
 
 vi.mock('@sentry/core', async requireActual => {
-  return {
-    ...(await requireActual()),
-    getRootSpan: () => {
-      return mockRootSpan;
-    },
-  };
-});
-
-vi.mock('@sentry/core', async requireActual => {
   const actual = (await requireActual()) as any;
   return {
     ...actual,
@@ -81,6 +72,8 @@ vi.mock('@sentry/core', async requireActual => {
     },
     getActiveSpan: () => {
       const span = actual.getActiveSpan();
+
+      if (!span) return undefined;
 
       span.updateName = mockNavigationSpan.updateName;
       span.setAttribute = mockNavigationSpan.setAttribute;


### PR DESCRIPTION
The `getActiveSpan` mock calls `actual.getActiveSpan()` and immediately assigns to the returned span without guarding
against `undefined`. When the router subscriber fires outside an active span context, `span` is `undefined` and the property assignment throws a TypeError. 

Additionally, there are two `vi.mock('@sentry/core')` declarations for the same module; the first (lines 66-73) is dead code since the second one overrides it.

Closes https://github.com/getsentry/sentry-javascript/issues/20199