### PR TITLE
feat(core): Automatically disable truncation when span streaming is enabled in OpenAI integration

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-streaming-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-streaming-with-truncation.mjs
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  sendDefaultPii: true,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+  integrations: [
+    Sentry.openAIIntegration({
+      enableTruncation: true,
+    }),
+  ],
+});

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-streaming.mjs
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  sendDefaultPii: true,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/openai/scenario-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/scenario-no-truncation.mjs
@@ -75,6 +75,8 @@ async function run() {
     });
   });
 
+  // Flush is required when span streaming is enabled to ensure streamed spans are sent before the process exits
+  await Sentry.flush();
   server.close();
 }
 

--- a/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
@@ -1019,4 +1019,58 @@ describe('OpenAI integration', () => {
         .completed();
     });
   });
+
+  const streamingLongContent = 'A'.repeat(50_000);
+  const streamingLongString = 'B'.repeat(50_000);
+
+  createEsmAndCjsTests(__dirname, 'scenario-no-truncation.mjs', 'instrument-streaming.mjs', (createRunner, test) => {
+    test('automatically disables truncation when span streaming is enabled', async () => {
+      await createRunner()
+        .expect({
+          span: container => {
+            const spans = container.items;
+
+            const chatSpan = spans.find(s =>
+              s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes(streamingLongContent),
+            );
+            expect(chatSpan).toBeDefined();
+
+            const responsesSpan = spans.find(s =>
+              s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes(streamingLongString),
+            );
+            expect(responsesSpan).toBeDefined();
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
+
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-no-truncation.mjs',
+    'instrument-streaming-with-truncation.mjs',
+    (createRunner, test) => {
+      test('respects explicit enableTruncation: true even when span streaming is enabled', async () => {
+        await createRunner()
+          .expect({
+            span: container => {
+              const spans = container.items;
+
+              // With explicit enableTruncation: true, content should be truncated despite streaming.
+              // Find the chat span by matching the start of the truncated content (the 'A' repeated messages).
+              const chatSpan = spans.find(s =>
+                s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.startsWith('[{"role":"user","content":"AAAA'),
+              );
+              expect(chatSpan).toBeDefined();
+              expect(chatSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value.length).toBeLessThan(
+                streamingLongContent.length,
+              );
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+  );
 });

--- a/packages/core/src/tracing/ai/utils.ts
+++ b/packages/core/src/tracing/ai/utils.ts
@@ -3,6 +3,7 @@
  */
 import { captureException } from '../../exports';
 import { getClient } from '../../currentScopes';
+import { hasSpanStreamingEnabled } from '../spans/hasSpanStreamingEnabled';
 import type { Span } from '../../types-hoist/span';
 import { isThenable } from '../../utils/is';
 import {
@@ -54,6 +55,16 @@ export function resolveAIRecordingOptions<T extends AIRecordingOptions>(options?
     recordInputs: options?.recordInputs ?? sendDefaultPii,
     recordOutputs: options?.recordOutputs ?? sendDefaultPii,
   } as T & Required<AIRecordingOptions>;
+}
+
+/**
+ * Resolves whether truncation should be enabled.
+ * If the user explicitly set `enableTruncation`, that value is used.
+ * Otherwise, truncation is disabled when span streaming is active.
+ */
+export function shouldEnableTruncation(enableTruncation: boolean | undefined): boolean {
+  const client = getClient();
+  return enableTruncation ?? !(client && hasSpanStreamingEnabled(client));
 }
 
 /**

--- a/packages/core/src/tracing/openai/index.ts
+++ b/packages/core/src/tracing/openai/index.ts
@@ -1,4 +1,3 @@
-import { getClient } from '../../currentScopes';
 import { DEBUG_BUILD } from '../../debug-build';
 import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
@@ -23,9 +22,9 @@ import {
   getJsonString,
   getTruncatedJsonString,
   resolveAIRecordingOptions,
+  shouldEnableTruncation,
   wrapPromiseWithMethods,
 } from '../ai/utils';
-import { hasSpanStreamingEnabled } from '../spans/hasSpanStreamingEnabled';
 import { OPENAI_METHOD_REGISTRY } from './constants';
 import { instrumentStream } from './streaming';
 import type { ChatCompletionChunk, OpenAiOptions, OpenAIStream, ResponseStreamingEvent } from './types';
@@ -172,9 +171,7 @@ function instrumentMethod<T extends unknown[], R>(
         originalResult = originalMethod.apply(context, args);
 
         if (options.recordInputs && params) {
-          const client = getClient();
-          const enableTruncation = options.enableTruncation ?? !(client && hasSpanStreamingEnabled(client));
-          addRequestAttributes(span, params, operationName, enableTruncation);
+          addRequestAttributes(span, params, operationName, shouldEnableTruncation(options.enableTruncation));
         }
 
         // Return async processing
@@ -212,9 +209,7 @@ function instrumentMethod<T extends unknown[], R>(
       originalResult = originalMethod.apply(context, args);
 
       if (options.recordInputs && params) {
-        const client = getClient();
-        const enableTruncation = options.enableTruncation ?? !(client && hasSpanStreamingEnabled(client));
-        addRequestAttributes(span, params, operationName, enableTruncation);
+        addRequestAttributes(span, params, operationName, shouldEnableTruncation(options.enableTruncation));
       }
 
       return originalResult.then(

--- a/packages/core/src/tracing/openai/index.ts
+++ b/packages/core/src/tracing/openai/index.ts
@@ -1,3 +1,4 @@
+import { getClient } from '../../currentScopes';
 import { DEBUG_BUILD } from '../../debug-build';
 import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
@@ -24,6 +25,7 @@ import {
   resolveAIRecordingOptions,
   wrapPromiseWithMethods,
 } from '../ai/utils';
+import { hasSpanStreamingEnabled } from '../spans/hasSpanStreamingEnabled';
 import { OPENAI_METHOD_REGISTRY } from './constants';
 import { instrumentStream } from './streaming';
 import type { ChatCompletionChunk, OpenAiOptions, OpenAIStream, ResponseStreamingEvent } from './types';
@@ -170,7 +172,9 @@ function instrumentMethod<T extends unknown[], R>(
         originalResult = originalMethod.apply(context, args);
 
         if (options.recordInputs && params) {
-          addRequestAttributes(span, params, operationName, options.enableTruncation ?? true);
+          const client = getClient();
+          const enableTruncation = options.enableTruncation ?? !(client && hasSpanStreamingEnabled(client));
+          addRequestAttributes(span, params, operationName, enableTruncation);
         }
 
         // Return async processing
@@ -208,7 +212,9 @@ function instrumentMethod<T extends unknown[], R>(
       originalResult = originalMethod.apply(context, args);
 
       if (options.recordInputs && params) {
-        addRequestAttributes(span, params, operationName, options.enableTruncation ?? true);
+        const client = getClient();
+        const enableTruncation = options.enableTruncation ?? !(client && hasSpanStreamingEnabled(client));
+        addRequestAttributes(span, params, operationName, enableTruncation);
       }
 
       return originalResult.then(


### PR DESCRIPTION
When span streaming is enabled, the `enableTruncation` option now defaults to `false` unless the user has explicitly set it.

Closes: #20221