### PR TITLE
feat(core): Automatically disable truncation when span streaming is enabled in LangChain integration

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-streaming-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-streaming-with-truncation.mjs
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  sendDefaultPii: true,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+  integrations: [
+    Sentry.langChainIntegration({
+      enableTruncation: true,
+    }),
+  ],
+});

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-streaming.mjs
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  sendDefaultPii: true,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
@@ -585,28 +585,23 @@ describe('LangChain integration', () => {
 
   const streamingLongContent = 'A'.repeat(50_000);
 
-  createEsmAndCjsTests(
-    __dirname,
-    'scenario-no-truncation.mjs',
-    'instrument-streaming.mjs',
-    (createRunner, test) => {
-      test('automatically disables truncation when span streaming is enabled', async () => {
-        await createRunner()
-          .expect({
-            span: container => {
-              const spans = container.items;
+  createEsmAndCjsTests(__dirname, 'scenario-no-truncation.mjs', 'instrument-streaming.mjs', (createRunner, test) => {
+    test('automatically disables truncation when span streaming is enabled', async () => {
+      await createRunner()
+        .expect({
+          span: container => {
+            const spans = container.items;
 
-              const chatSpan = spans.find(
-                s => s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes(streamingLongContent),
-              );
-              expect(chatSpan).toBeDefined();
-            },
-          })
-          .start()
-          .completed();
-      });
-    },
-  );
+            const chatSpan = spans.find(s =>
+              s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes(streamingLongContent),
+            );
+            expect(chatSpan).toBeDefined();
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
 
   createEsmAndCjsTests(
     __dirname,
@@ -621,8 +616,8 @@ describe('LangChain integration', () => {
 
               // With explicit enableTruncation: true, truncation keeps only the last message
               // and drops the long content. The result should NOT contain the full 50k 'A' string.
-              const chatSpan = spans.find(
-                s => s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Follow-up question'),
+              const chatSpan = spans.find(s =>
+                s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Follow-up question'),
               );
               expect(chatSpan).toBeDefined();
               expect(chatSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).not.toContain(streamingLongContent);

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
@@ -582,4 +582,55 @@ describe('LangChain integration', () => {
       });
     },
   );
+
+  const streamingLongContent = 'A'.repeat(50_000);
+
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-no-truncation.mjs',
+    'instrument-streaming.mjs',
+    (createRunner, test) => {
+      test('automatically disables truncation when span streaming is enabled', async () => {
+        await createRunner()
+          .expect({
+            span: container => {
+              const spans = container.items;
+
+              const chatSpan = spans.find(
+                s => s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes(streamingLongContent),
+              );
+              expect(chatSpan).toBeDefined();
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+  );
+
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-no-truncation.mjs',
+    'instrument-streaming-with-truncation.mjs',
+    (createRunner, test) => {
+      test('respects explicit enableTruncation: true even when span streaming is enabled', async () => {
+        await createRunner()
+          .expect({
+            span: container => {
+              const spans = container.items;
+
+              // With explicit enableTruncation: true, truncation keeps only the last message
+              // and drops the long content. The result should NOT contain the full 50k 'A' string.
+              const chatSpan = spans.find(
+                s => s.attributes?.[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Follow-up question'),
+              );
+              expect(chatSpan).toBeDefined();
+              expect(chatSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).not.toContain(streamingLongContent);
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+  );
 });

--- a/packages/core/src/tracing/ai/utils.ts
+++ b/packages/core/src/tracing/ai/utils.ts
@@ -3,6 +3,7 @@
  */
 import { captureException } from '../../exports';
 import { getClient } from '../../currentScopes';
+import { hasSpanStreamingEnabled } from '../spans/hasSpanStreamingEnabled';
 import type { Span } from '../../types-hoist/span';
 import { isThenable } from '../../utils/is';
 import {
@@ -54,6 +55,16 @@ export function resolveAIRecordingOptions<T extends AIRecordingOptions>(options?
     recordInputs: options?.recordInputs ?? sendDefaultPii,
     recordOutputs: options?.recordOutputs ?? sendDefaultPii,
   } as T & Required<AIRecordingOptions>;
+}
+
+/**
+ * Resolves whether truncation should be enabled.
+ * If the user explicitly set `enableTruncation`, that value is used.
+ * Otherwise, truncation is disabled when span streaming is active.
+ */
+export function shouldEnableTruncation(enableTruncation: boolean | undefined): boolean {
+  const client = getClient();
+  return enableTruncation ?? !(client && hasSpanStreamingEnabled(client));
 }
 
 /**

--- a/packages/core/src/tracing/langchain/index.ts
+++ b/packages/core/src/tracing/langchain/index.ts
@@ -10,7 +10,7 @@ import {
   GEN_AI_TOOL_NAME_ATTRIBUTE,
   GEN_AI_TOOL_OUTPUT_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
-import { resolveAIRecordingOptions } from '../ai/utils';
+import { resolveAIRecordingOptions, shouldEnableTruncation } from '../ai/utils';
 import { LANGCHAIN_ORIGIN } from './constants';
 import type {
   LangChainCallbackHandler,
@@ -34,7 +34,7 @@ import {
  */
 export function createLangChainCallbackHandler(options: LangChainOptions = {}): LangChainCallbackHandler {
   const { recordInputs, recordOutputs } = resolveAIRecordingOptions(options);
-  const enableTruncation = options.enableTruncation ?? true;
+  const enableTruncation = shouldEnableTruncation(options.enableTruncation);
 
   // Internal state - single instance tracks all spans
   const spanMap = new Map<string, Span>();


### PR DESCRIPTION
When span streaming is enabled, the `enableTruncation` option now defaults
to `false` unless the user has explicitly set it.

Closes: https://github.com/getsentry/sentry-javascript/issues/20224