### PR TITLE
test: Fix flaky ANR test by increasing blocking duration

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/anr/app-path.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/app-path.mjs
@@ -25,7 +25,7 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);

--- a/dev-packages/node-core-integration-tests/suites/anr/basic-multiple.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic-multiple.mjs
@@ -21,7 +21,7 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);

--- a/dev-packages/node-core-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic-session.js
@@ -20,7 +20,7 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);

--- a/dev-packages/node-core-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic.js
@@ -22,7 +22,7 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);

--- a/dev-packages/node-core-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic.mjs
@@ -21,7 +21,7 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);

--- a/dev-packages/node-core-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/forked.js
@@ -21,7 +21,7 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);

--- a/dev-packages/node-core-integration-tests/suites/anr/isolated.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/isolated.mjs
@@ -18,7 +18,7 @@ setupOtel(client);
 async function longWork() {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);

--- a/dev-packages/node-core-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/stop-and-start.js
@@ -23,7 +23,7 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWorkIgnored() {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);
@@ -31,7 +31,7 @@ function longWorkIgnored() {
 }
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 50; i++) {
     const salt = crypto.randomBytes(128).toString('base64');
     const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
     assert.ok(hash);


### PR DESCRIPTION
Closes #20215
Closes [JS-2120](https://linear.app/getsentry/issue/JS-2120/flaky-ci-node-24-node-core-integration-tests)

Increase `longWork` iterations from 20 to 50 to ensure the blocking function is more likely to be captured in ANR stack sampling, reducing flakiness from sampling during timer processing.

A rerun solved it, but this would hopefully make it less flaky.