### PR TITLE
chore(ci): Remove codecov steps from jobs that produce no coverage/JUnit data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -739,15 +739,6 @@ jobs:
         working-directory: dev-packages/node-integration-tests
         run: yarn test
 
-      - name: Parse and Upload Coverage
-        if: cancelled() == false
-        continue-on-error: true
-        uses: getsentry/codecov-action@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          directory: dev-packages/node-integration-tests
-          name: node-integration-${{ matrix.node }}${{ matrix.typescript && format('-ts{0}', matrix.typescript) || '' }}
-
   job_node_core_integration_tests:
     name:
       Node (${{ matrix.node }})${{ (matrix.typescript && format(' (TS {0})', matrix.typescript)) || '' }} Node-Core
@@ -788,16 +779,6 @@ jobs:
       - name: Run integration tests
         working-directory: dev-packages/node-core-integration-tests
         run: yarn test
-
-      - name: Parse and Upload Coverage
-        if: cancelled() == false
-        continue-on-error: true
-        uses: getsentry/codecov-action@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          directory: dev-packages/node-core-integration-tests
-          name:
-            node-core-integration-${{ matrix.node }}${{ matrix.typescript && format('-ts{0}', matrix.typescript) || ''}}
 
   job_cloudflare_integration_tests:
     name: Cloudflare Integration Tests
@@ -857,15 +838,6 @@ jobs:
         run: |
           cd packages/remix
           yarn test:integration:ci
-
-      - name: Parse and Upload Coverage
-        if: cancelled() == false
-        continue-on-error: true
-        uses: getsentry/codecov-action@main
-        with:
-          directory: packages/remix
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ matrix.node }}
 
   job_e2e_prepare:
     name: Prepare E2E tests
@@ -1054,15 +1026,6 @@ jobs:
           overwrite: true
           retention-days: 7
           if-no-files-found: ignore
-
-      - name: Parse and Upload Coverage
-        if: cancelled() == false
-        continue-on-error: true
-        uses: getsentry/codecov-action@main
-        with:
-          directory: dev-packages/e2e-tests
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: e2e-${{ matrix.test-application }}
 
   # - We skip optional tests on release branches
   job_optional_e2e_tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -605,6 +605,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           directory: dev-packages/browser-integration-tests
+          enable-coverage: false
           name:
             browser-playwright-${{ matrix.bundle }}-${{ matrix.project }}${{ matrix.shard && format('-{0}',
             matrix.shard) || '' }}
@@ -669,6 +670,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           directory: dev-packages/browser-integration-tests
+          enable-coverage: false
           name: browser-loader-${{ matrix.bundle }}
 
   job_check_for_faulty_dts:


### PR DESCRIPTION
## Summary

- Remove `getsentry/codecov-action` from CI jobs that don't produce coverage or JUnit XML files, eliminating noisy warnings in every CI run
- Disable coverage upload for Playwright browser integration tests that only produce JUnit XML

### Jobs cleaned up:

| Job | Issue | Fix |
|-----|-------|-----|
| Node Integration Tests | Coverage disabled in vitest config, custom reporters without JUnit | Removed codecov step entirely |
| Node-Core Integration Tests | Same as above | Removed codecov step entirely |
| E2E Tests | Uses ts-node/Playwright, not vitest | Removed codecov step entirely |
| Remix Tests | Custom vitest config without coverage/JUnit | Removed codecov step entirely |
| Playwright Browser Tests | No coverage files (Playwright, not vitest) | Added `enable-coverage: false` |
| PW Loader Tests | Same as above | Added `enable-coverage: false` |

### Warnings eliminated:

- `No coverage files found` (from integration tests, E2E, Remix, Playwright jobs)
- `No JUnit XML files found matching pattern: dev-packages/{node,node-core}-integration-tests/**/*.junit.xml`
- `No JUnit XML files found matching pattern: dev-packages/e2e-tests/**/*.junit.xml`
- `Please ensure your test framework is generating JUnit XML output`
- `Supported formats: clover, cobertura, jacoco, lcov, istanbul, go, codecov`

### Not addressed (upstream issue):

- `Entity expansion limit exceeded: 100X > 1000` on vitest JUnit XML files — this is a parser limitation in `getsentry/codecov-action` that affects large test suites (browser, core, node, nextjs, etc.)

## Test plan

- [ ] CI runs cleanly without the removed warnings
- [ ] Coverage still uploads correctly for Browser Unit Tests and Node Unit Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)