### PR TITLE
chore(ci): Bump actions/cache to v5 and actions/download-artifact to v7

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -18,7 +18,7 @@ runs:
       working-directory: ${{ inputs.cwd }}
 
     - name: Restore cached playwright binaries
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: playwright-cache
       with:
         path: |
@@ -43,7 +43,7 @@ runs:
 
     # Only store cache on develop branch
     - name: Store cached playwright binaries
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
       with:
         path: |

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -11,13 +11,13 @@ runs:
   steps:
     - name: Check dependency cache
       id: dep-cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ env.CACHED_DEPENDENCY_PATHS }}
         key: ${{ inputs.dependency_cache_key }}
 
     - name: Restore build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: build-output
 

--- a/.github/actions/restore-cache/action.yml
+++ b/.github/actions/restore-cache/action.yml
@@ -17,7 +17,7 @@ runs:
         key: ${{ inputs.dependency_cache_key }}
 
     - name: Restore build artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v7
       with:
         name: build-output
 


### PR DESCRIPTION
## Summary

- Upgrade `actions/cache/restore` and `actions/cache/save` from v4 to v5 in `install-playwright` and `restore-cache` composite actions
- Upgrade `actions/download-artifact` from v4 to **v7** in `restore-cache` composite action (v5 still ran on Node 20; v7 runs on Node 24 and matches `actions/upload-artifact@v7` elsewhere)
- This should fix warnings about Node 20 runner usage in CI

## Changelog

### `actions/cache` v4 → v5

- Only change is upgrading the Node.js runtime from 20 to 24
- No input/output parameter changes
- No behavioral differences
- Requires Actions Runner ≥ 2.327.1 (already satisfied by GitHub-hosted runners)

### `actions/download-artifact` v4 → v7

- **v7** updates the action runtime to Node.js 24 (`runs.using: node24`); v5 remained on Node 20, so it did not clear deprecation warnings for this step
- Requires Actions Runner ≥ 2.327.1 (same as cache v5; satisfied by GitHub-hosted runners)
- We download artifacts **by name** only; v5’s breaking changes around downloads **by ID** do not apply
- Aligns with `actions/upload-artifact@v7` already used in workflows

## Affected files

- `.github/actions/install-playwright/action.yml` — `cache/restore@v4` → `v5`, `cache/save@v4` → `v5`
- `.github/actions/restore-cache/action.yml` — `cache/restore@v4` → `v5`, `download-artifact@v4` → `v7`

## Test plan

- CI workflows pass (cache restore/save and artifact download work as before)
- No changes to action inputs/outputs for our usage, so downstream step references remain valid