### PR TITLE
chore(ci): Bump dorny/paths-filter from v3.0.1 to v4.0.1

### DIFF
--- a/.github/workflows/ci-metadata.yml
+++ b/.github/workflows/ci-metadata.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Most changed packages are determined in job_build via Nx
       - name: Determine changed packages
-        uses: dorny/paths-filter@v3.0.1
+        uses: dorny/paths-filter@v4
         id: changed
         with:
           filters: |

--- a/.github/workflows/ci-metadata.yml
+++ b/.github/workflows/ci-metadata.yml
@@ -61,7 +61,7 @@ jobs:
 
       # Most changed packages are determined in job_build via Nx
       - name: Determine changed packages
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@v4.0.1
         id: changed
         with:
           filters: |

--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -55,7 +55,7 @@ jobs:
           browsers: 'chromium'
 
       - name: Determine changed tests
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@v4.0.1
         id: changed
         with:
           list-files: json

--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -55,7 +55,7 @@ jobs:
           browsers: 'chromium'
 
       - name: Determine changed tests
-        uses: dorny/paths-filter@v3.0.1
+        uses: dorny/paths-filter@v4
         id: changed
         with:
           list-files: json


### PR DESCRIPTION
## Summary

- Upgrade `dorny/paths-filter` from v3.0.1 to v4.0.1 in `ci-metadata` and `flaky-test-detector` workflows
- The v4 major bump was solely for the Node.js runtime upgrade from node20 to node24 — no functional breaking changes

## Changelog (v3.0.1 → v4.0.1)

- **v3.0.2/v3.0.3**: Added `predicate-quantifier` parameter (not used by us)
- **v4.0.0**: Upgraded action runtime from `node20` to `node24` (the only breaking change)
- **v4.0.1**: Added `merge_group` event support (not used by us)

## Usage verification

Our usage relies on:
- `filters` input with glob patterns → unchanged in v4
- `list-files: json` input → unchanged in v4
- `outputs.<filter_name>` (string `'true'`/`'false'`) → unchanged in v4
- `outputs.<filter_name>_files` (JSON file list) → unchanged in v4

No configuration changes needed — drop-in replacement.

## Test plan

- [ ] CI workflows pass with the updated action
- [ ] `ci-metadata` job correctly detects changed packages
- [ ] `flaky-test-detector` job correctly detects changed test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)