### PR TITLE
chore(ci): Replace pr-labels-action with native GitHub expressions

### DIFF
--- a/.github/workflows/ci-metadata.yml
+++ b/.github/workflows/ci-metadata.yml
@@ -82,8 +82,8 @@ jobs:
       # When merging into master, or from master
       is_gitflow_sync: ${{ github.head_ref == 'master' || github.ref == 'refs/heads/master' }}
       has_gitflow_label:
-        ${{ github.event_name == 'pull_request' && contains(toJSON(github.event.pull_request.labels.*.name),
-        'Gitflow') }}
+        ${{ github.event_name == 'pull_request' && contains(toJSON(github.event.pull_request.labels.*.name), 'Gitflow')
+        }}
       force_skip_cache:
         ${{ github.event_name == 'schedule' || (github.event_name == 'pull_request' &&
         contains(toJSON(github.event.pull_request.labels.*.name), 'ci-skip-cache')) }}

--- a/.github/workflows/ci-metadata.yml
+++ b/.github/workflows/ci-metadata.yml
@@ -70,10 +70,6 @@ jobs:
             any_code:
               - '!**/*.md'
 
-      - name: Get PR labels
-        id: pr-labels
-        uses: mydea/pr-labels-action@fn/bump-node20
-
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
       # Note: These next three have to be checked as strings ('true'/'false')!
@@ -86,7 +82,8 @@ jobs:
       # When merging into master, or from master
       is_gitflow_sync: ${{ github.head_ref == 'master' || github.ref == 'refs/heads/master' }}
       has_gitflow_label:
-        ${{ github.event_name == 'pull_request' && contains(steps.pr-labels.outputs.labels, ' Gitflow ') }}
+        ${{ github.event_name == 'pull_request' && contains(toJSON(github.event.pull_request.labels.*.name),
+        'Gitflow') }}
       force_skip_cache:
         ${{ github.event_name == 'schedule' || (github.event_name == 'pull_request' &&
-        contains(steps.pr-labels.outputs.labels, ' ci-skip-cache ')) }}
+        contains(toJSON(github.event.pull_request.labels.*.name), 'ci-skip-cache')) }}


### PR DESCRIPTION
## Summary

- Replace the custom fork `mydea/pr-labels-action@fn/bump-node20` with built-in GitHub Actions expressions
- Zero external dependencies needed — uses `github.event.pull_request.labels.*.name` directly

### Before
```yaml
- name: Get PR labels
  id: pr-labels
  uses: mydea/pr-labels-action@fn/bump-node20

# ...
contains(steps.pr-labels.outputs.labels, ' Gitflow ')
contains(steps.pr-labels.outputs.labels, ' ci-skip-cache ')
```

### After
```yaml
# No action step needed

# ...
contains(toJSON(github.event.pull_request.labels.*.name), 'Gitflow')
contains(toJSON(github.event.pull_request.labels.*.name), 'ci-skip-cache')
```

Both usages already gate on `github.event_name == 'pull_request'`, so the labels context is always available when needed. This also eliminates the Node.js 20 deprecation warning that `mydea/pr-labels-action` was causing.

## Test plan

- [ ] CI metadata job runs successfully
- [ ] Gitflow label detection still works on PRs with the `Gitflow` label
- [ ] `ci-skip-cache` label detection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)