### PR TITLE
fix(nextjs): skip custom browser tracing setup for bot user agents

### DIFF
--- a/packages/browser/src/index.bundle.tracing.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.logs.metrics.ts
@@ -22,6 +22,7 @@ export {
 
 export {
   browserTracingIntegration,
+  isBotUserAgent,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from './tracing/browserTracingIntegration';

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
@@ -22,6 +22,7 @@ export {
 
 export {
   browserTracingIntegration,
+  isBotUserAgent,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from './tracing/browserTracingIntegration';

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -27,6 +27,7 @@ export {
 
 export {
   browserTracingIntegration,
+  isBotUserAgent,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from './tracing/browserTracingIntegration';

--- a/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
@@ -22,6 +22,7 @@ export {
 
 export {
   browserTracingIntegration,
+  isBotUserAgent,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from './tracing/browserTracingIntegration';

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -27,6 +27,7 @@ export {
 
 export {
   browserTracingIntegration,
+  isBotUserAgent,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from './tracing/browserTracingIntegration';

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -28,6 +28,7 @@ export {
 
 export {
   browserTracingIntegration,
+  isBotUserAgent,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from './tracing/browserTracingIntegration';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -36,6 +36,7 @@ export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
 export { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './tracing/request';
 export {
   browserTracingIntegration,
+  isBotUserAgent,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from './tracing/browserTracingIntegration';

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -62,7 +62,7 @@ export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 const BOT_USER_AGENT_RE =
   /Googlebot|Google-InspectionTool|Storebot-Google|Bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Facebot|facebookexternalhit|LinkedInBot|Twitterbot|Applebot/i;
 
-function _isBotUserAgent(): boolean {
+export function isBotUserAgent(): boolean {
   const nav = WINDOW.navigator as Navigator | undefined;
   if (!nav?.userAgent) {
     return false;
@@ -405,7 +405,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
     ...options,
   };
 
-  const _isBot = _isBotUserAgent();
+  const _isBot = isBotUserAgent();
 
   let _collectWebVitals: undefined | (() => void);
   let lastInteractionTimestamp: number | undefined;

--- a/packages/nextjs/src/client/browserTracingIntegration.ts
+++ b/packages/nextjs/src/client/browserTracingIntegration.ts
@@ -1,5 +1,5 @@
 import type { Integration } from '@sentry/core';
-import { browserTracingIntegration as originalBrowserTracingIntegration } from '@sentry/react';
+import { browserTracingIntegration as originalBrowserTracingIntegration, isBotUserAgent } from '@sentry/react';
 import { nextRouterInstrumentNavigation, nextRouterInstrumentPageLoad } from './routing/nextRoutingInstrumentation';
 
 /**
@@ -29,6 +29,10 @@ export function browserTracingIntegration(
   return {
     ...browserTracingIntegrationInstance,
     afterAllSetup(client) {
+      if (isBotUserAgent()) {
+        return;
+      }
+
       // We need to run the navigation span instrumentation before the `afterAllSetup` hook on the normal browser
       // tracing integration because we need to ensure the order of execution is as follows:
       // Instrumentation to start span on RSC fetch request runs -> Instrumentation to put tracing headers from active span on fetch runs

--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -19,6 +19,7 @@ Object.defineProperty(global, 'addEventListener', { value: () => undefined, writ
 
 const originalGlobalDocument = WINDOW.document;
 const originalGlobalLocation = WINDOW.location;
+const originalNavigator = WINDOW.navigator;
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const originalGlobalAddEventListener = WINDOW.addEventListener;
 
@@ -26,6 +27,7 @@ afterAll(() => {
   // Clean up JSDom
   Object.defineProperty(WINDOW, 'document', { value: originalGlobalDocument });
   Object.defineProperty(WINDOW, 'location', { value: originalGlobalLocation });
+  Object.defineProperty(WINDOW, 'navigator', { value: originalNavigator, writable: true, configurable: true });
   Object.defineProperty(WINDOW, 'addEventListener', { value: originalGlobalAddEventListener });
 });
 
@@ -43,6 +45,7 @@ describe('Client init()', () => {
     getIsolationScope().clear();
     getCurrentScope().clear();
     getCurrentScope().setClient(undefined);
+    Object.defineProperty(WINDOW, 'navigator', { value: originalNavigator, writable: true, configurable: true });
   });
 
   it('inits the React SDK', () => {
@@ -159,6 +162,25 @@ describe('Client init()', () => {
 
         // @ts-expect-error Test setup for build-time flag
         delete globalThis.__SENTRY_TRACING__;
+      });
+
+      it("doesn't run Next.js router instrumentation for bot user agents", () => {
+        Object.defineProperty(WINDOW, 'navigator', {
+          value: {
+            userAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+          },
+          writable: true,
+          configurable: true,
+        });
+
+        const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+        init({
+          dsn: TEST_DSN,
+          tracesSampleRate: 1.0,
+        });
+
+        expect(setIntervalSpy).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
Exposes `isBotUserAgent()` from the browser tracing integration to use it in the Next.js browser tracing wrapper so bot user agents also skip Next.js-specific router instrumentation which adds its own interval timer.

This is intentionally the smallest change to test whether this fixes the Googlebot rendering issue.

Longer term, we probably want a more general mechanism for integrations to skip their own setup, with a skip decision that can be downstreamed easily through wrappers and integration variants instead of checking the bot predicate ad hoc in each package.

closes #19670 