### PR TITLE
test(cloudflare): Skip flaky durableobject-spans test

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-spans/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-spans/test.ts
@@ -6,7 +6,8 @@ import { createRunner } from '../../../runner';
 // must appear as children of the DO transaction. The first invocation always worked;
 // the second invocation on the same DO instance previously lost its child spans
 // because the client was disposed after the first call.
-it('sends child spans on repeated Durable Object calls', async ({ signal }) => {
+// TODO: unskip - this test is flaky, timing out in CI
+it.skip('sends child spans on repeated Durable Object calls', async ({ signal }) => {
   function assertDoWorkEnvelope(envelope: unknown): void {
     const transactionEvent = (envelope as any)[1]?.[0]?.[1];
 


### PR DESCRIPTION
The test is timing out intermittently in CI, causing spurious failures. This will be fixed as part of #20208
