### PR TITLE
chore(ci): Skip flaky issue creation for optional tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1147,7 +1147,7 @@ jobs:
               per_page: 100
             });
 
-            const failedJobs = jobs.filter(job => job.conclusion === 'failure');
+            const failedJobs = jobs.filter(job => job.conclusion === 'failure' && !job.name.includes('(optional)'));
 
             if (failedJobs.length === 0) {
               console.log('No failed jobs found');

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1127,13 +1127,11 @@ jobs:
       issues: write
     steps:
       - name: Check out current commit
-        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
       - name: Create issues for failed jobs
-        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1127,11 +1127,13 @@ jobs:
       issues: write
     steps:
       - name: Check out current commit
+        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
       - name: Create issues for failed jobs
+        if: github.ref == 'refs/heads/develop' && contains(needs.*.result, 'failure')
         uses: actions/github-script@v7
         with:
           script: |

--- a/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/tests/send-to-sentry.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/tests/send-to-sentry.test.ts
@@ -1,10 +1,5 @@
 import { expect, test } from '@playwright/test';
 
-// TEMPORARY: Guaranteed failure to verify optional test filtering in CI
-test('TEMPORARY - This optional test should fail without creating an issue', () => {
-  expect(true).toBe(false);
-});
-
 const EVENT_POLLING_TIMEOUT = 90_000;
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;

--- a/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/tests/send-to-sentry.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/tests/send-to-sentry.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+// TEMPORARY: Guaranteed failure to verify optional test filtering in CI
+test('TEMPORARY - This optional test should fail without creating an issue', () => {
+  expect(true).toBe(false);
+});
+
 const EVENT_POLLING_TIMEOUT = 90_000;
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;


### PR DESCRIPTION
Optional tests are usually optional for a reason. We shouldn't create a flaky test issue if an optional test fails on develop to reduce noise.

Closes https://github.com/getsentry/sentry-javascript/issues/20269
Closes https://github.com/getsentry/sentry-javascript/issues/20242
Closes https://github.com/getsentry/sentry-javascript/issues/20213
