### PR TITLE
fix(browser): enrich graphqlClient spans for relative URLs

### DIFF
--- a/packages/browser/src/integrations/graphqlClient.ts
+++ b/packages/browser/src/integrations/graphqlClient.ts
@@ -67,7 +67,14 @@ function _updateSpanWithGraphQLData(client: Client, options: GraphQLClientOption
       return;
     }
 
-    const httpUrl = spanAttributes[SEMANTIC_ATTRIBUTE_URL_FULL] || spanAttributes['http.url'];
+    // Fall back to the `url` attribute too: the fetch instrumentation only
+    // sets `url.full` / `http.url` for absolute URLs, but populates `url`
+    // for relative GraphQL endpoints. Without this fallback the integration
+    // silently skips relative endpoints. (#20292)
+    const httpUrl =
+      spanAttributes[SEMANTIC_ATTRIBUTE_URL_FULL] ||
+      spanAttributes['http.url'] ||
+      spanAttributes['url'];
     const httpMethod = spanAttributes[SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD] || spanAttributes['http.method'];
 
     if (!isString(httpUrl) || !isString(httpMethod)) {


### PR DESCRIPTION
Per #20292, `graphqlClientIntegration` silently skips spans for relative GraphQL endpoints because the fetch instrumentation only sets `url.full` / `http.url` for absolute URLs. For relative URLs it sets the `url` attribute instead, so the existing chain in `graphqlClient.ts` reads `undefined` and bails before enriching the span.

Fall back to `spanAttributes['url']` so relative GraphQL endpoints get enriched the same way as absolute ones.

Closes #20292