### PR TITLE
chore(build): Parallelize CDN bundle builds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,8 @@
   "[typescript]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },
-  "oxc.suppressProgramErrors": true
+  "oxc.suppressProgramErrors": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  }
 }

--- a/dev-packages/rollup-utils/bundleHelpers.mjs
+++ b/dev-packages/rollup-utils/bundleHelpers.mjs
@@ -136,54 +136,68 @@ export function makeBaseBundleConfig(options) {
 }
 
 /**
+ * @param {import('rollup').RollupOptions} baseConfig
+ * @param {string} variant
+ */
+function getVariantSpecificBundleConfig(baseConfig, variant) {
+  const baseEntryNames = baseConfig.output.entryFileNames;
+
+  switch (variant) {
+    case '.js':
+      return {
+        output: {
+          entryFileNames: chunkInfo => `${baseEntryNames(chunkInfo)}.js`,
+        },
+        plugins: [makeIsDebugBuildPlugin(true), makeSetSDKSourcePlugin('cdn')],
+      };
+    case '.min.js':
+      return {
+        output: {
+          entryFileNames: chunkInfo => `${baseEntryNames(chunkInfo)}.min.js`,
+        },
+        plugins: [makeIsDebugBuildPlugin(false), makeSetSDKSourcePlugin('cdn'), makeTerserPlugin()],
+      };
+    case '.debug.min.js':
+      return {
+        output: {
+          entryFileNames: chunkInfo => `${baseEntryNames(chunkInfo)}.debug.min.js`,
+        },
+        plugins: [makeIsDebugBuildPlugin(true), makeSetSDKSourcePlugin('cdn'), makeTerserPlugin()],
+      };
+    default:
+      throw new Error(`Unknown bundle variant requested: ${variant}`);
+  }
+}
+
+/**
  * Takes the CDN rollup config for a given package and produces three versions of it:
  *   - non-minified, including debug logging,
  *   - minified, including debug logging,
  *   - minified, with debug logging stripped
  *
- * @param baseConfig The rollup config shared by the entire package
- * @returns An array of versions of that config
+ * Pass `() => makeBaseBundleConfig({ ... })` so each variant gets a fresh base config (new plugin instances). That
+ * avoids sharing stateful Rollup plugins when `rollupParallel` runs multiple `rollup()` calls concurrently. Passing a
+ * plain config object is supported for backwards compatibility but only shallow-clones plugin shells.
+ *
+ * @param {(() => import('rollup').RollupOptions) | import('rollup').RollupOptions} getBaseConfigOrConfig
+ * @param {{ variants?: string[] }} [options]
  */
-export function makeBundleConfigVariants(baseConfig, options = {}) {
+export function makeBundleConfigVariants(getBaseConfigOrConfig, options = {}) {
   const { variants = BUNDLE_VARIANTS } = options;
-
-  const includeDebuggingPlugin = makeIsDebugBuildPlugin(true);
-  const stripDebuggingPlugin = makeIsDebugBuildPlugin(false);
-  const terserPlugin = makeTerserPlugin();
-  const setSdkSourcePlugin = makeSetSDKSourcePlugin('cdn');
-
-  // The additional options to use for each variant we're going to create.
-  const variantSpecificConfigMap = {
-    '.js': {
-      output: {
-        entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.js`,
-      },
-      plugins: [includeDebuggingPlugin, setSdkSourcePlugin],
-    },
-
-    '.min.js': {
-      output: {
-        entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.min.js`,
-      },
-      plugins: [stripDebuggingPlugin, setSdkSourcePlugin, terserPlugin],
-    },
-
-    '.debug.min.js': {
-      output: {
-        entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.debug.min.js`,
-      },
-      plugins: [includeDebuggingPlugin, setSdkSourcePlugin, terserPlugin],
-    },
-  };
+  const resolveBase = typeof getBaseConfigOrConfig === 'function' ? getBaseConfigOrConfig : () => getBaseConfigOrConfig;
 
   return variants.map(variant => {
     if (!BUNDLE_VARIANTS.includes(variant)) {
       throw new Error(`Unknown bundle variant requested: ${variant}`);
     }
-    return deepMerge(baseConfig, variantSpecificConfigMap[variant], {
+    const baseConfig = resolveBase();
+    const merged = deepMerge(baseConfig, getVariantSpecificBundleConfig(baseConfig, variant), {
       // Merge the plugin arrays and make sure the end result is in the correct order. Everything else can use the
       // default merge strategy.
       customMerge: key => (key === 'plugins' ? mergePlugins : undefined),
     });
+    return {
+      ...merged,
+    };
   });
 }

--- a/dev-packages/rollup-utils/bundleHelpers.mjs
+++ b/dev-packages/rollup-utils/bundleHelpers.mjs
@@ -196,8 +196,7 @@ export function makeBundleConfigVariants(getBaseConfigOrConfig, options = {}) {
       // default merge strategy.
       customMerge: key => (key === 'plugins' ? mergePlugins : undefined),
     });
-    return {
-      ...merged,
-    };
+
+    return merged;
   });
 }

--- a/dev-packages/rollup-utils/rollupParallel.mjs
+++ b/dev-packages/rollup-utils/rollupParallel.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 /**
  * Runs rollup builds in parallel for configs that export an array.
  * Usage: node rollupParallel.mjs <config-path>
@@ -21,7 +23,7 @@ let done = 0;
 async function worker() {
   while (queue.length > 0) {
     const config = queue.shift();
-    const bundle = await rollup({ ...config, onwarn: () => {} });
+    const bundle = await rollup({ ...config, onwarn: console.warn });
     await bundle.write(config.output);
     await bundle.close();
     done++;

--- a/dev-packages/rollup-utils/rollupParallel.mjs
+++ b/dev-packages/rollup-utils/rollupParallel.mjs
@@ -4,7 +4,7 @@
  * Runs rollup builds in parallel for configs that export an array.
  * Usage: node rollupParallel.mjs <config-path>
  */
-import { cpus } from 'os';
+import { availableParallelism } from 'os';
 import { pathToFileURL } from 'url';
 import { resolve } from 'path';
 import { rollup } from 'rollup';
@@ -16,7 +16,7 @@ if (!configPath) {
 }
 
 const { default: configs } = await import(pathToFileURL(resolve(configPath)).href);
-const concurrency = cpus().length;
+const concurrency = availableParallelism();
 const queue = [...configs];
 let done = 0;
 

--- a/dev-packages/rollup-utils/rollupParallel.mjs
+++ b/dev-packages/rollup-utils/rollupParallel.mjs
@@ -1,0 +1,34 @@
+/**
+ * Runs rollup builds in parallel for configs that export an array.
+ * Usage: node rollupParallel.mjs <config-path>
+ */
+import { cpus } from 'os';
+import { pathToFileURL } from 'url';
+import { resolve } from 'path';
+import { rollup } from 'rollup';
+
+const configPath = process.argv[2];
+if (!configPath) {
+  console.error('Usage: node rollupParallel.mjs <config-path>');
+  process.exit(1);
+}
+
+const { default: configs } = await import(pathToFileURL(resolve(configPath)).href);
+const concurrency = cpus().length;
+const queue = [...configs];
+let done = 0;
+
+async function worker() {
+  while (queue.length > 0) {
+    const config = queue.shift();
+    const bundle = await rollup({ ...config, onwarn: () => {} });
+    await bundle.write(config.output);
+    await bundle.close();
+    done++;
+    process.stdout.write(`\r  [${done}/${configs.length}] builds completed`);
+  }
+}
+
+console.log(`Running ${configs.length} rollup builds (concurrency: ${concurrency})...`);
+await Promise.all(Array.from({ length: concurrency }, worker));
+console.log('\nDone.');

--- a/docs/adding-cdn-bundle.md
+++ b/docs/adding-cdn-bundle.md
@@ -130,18 +130,18 @@ describe('index.bundle.{FEATURE_COMBO}', () => {
 Add bundle config before `builds.push(...)`:
 
 ```javascript
-const {featureCombo}BaseBundleConfig = makeBaseBundleConfig({
+const {featureCombo}BaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.{FEATURE_COMBO}.ts'],
   licenseTitle: '@sentry/browser ({Human Readable Feature List})',
   outputFileBase: () => 'bundles/bundle.{FEATURE_COMBO}',
-});
+};
 ```
 
 Add to `builds.push(...)`:
 
 ```javascript
-...makeBundleConfigVariants({featureCombo}BaseBundleConfig),
+...makeBundleConfigVariants(() => makeBaseBundleConfig({featureCombo}BaseBundleOptions)),
 ```
 
 ### 4. `.size-limit.js`

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "build": "run-p build:transpile build:bundle build:types",
     "build:dev": "run-p build:transpile build:types",
-    "build:bundle": "rollup -c rollup.bundle.config.mjs",
+    "build:bundle": "node ../../dev-packages/rollup-utils/rollupParallel.mjs rollup.bundle.config.mjs",
     "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "run-s build:types:core build:types:downlevel",
     "build:types:core": "tsc -p tsconfig.types.json",

--- a/packages/browser/rollup.bundle.config.mjs
+++ b/packages/browser/rollup.bundle.config.mjs
@@ -22,31 +22,35 @@ const reexportedPluggableIntegrationFiles = [
 ];
 
 browserPluggableIntegrationFiles.forEach(integrationName => {
-  const integrationsBundleConfig = makeBaseBundleConfig({
-    bundleType: 'addon',
-    entrypoints: [`src/integrations/${integrationName}.ts`],
-    licenseTitle: `@sentry/browser - ${integrationName}`,
-    outputFileBase: () => `bundles/${integrationName}`,
-  });
-
-  builds.push(...makeBundleConfigVariants(integrationsBundleConfig));
+  builds.push(
+    ...makeBundleConfigVariants(() =>
+      makeBaseBundleConfig({
+        bundleType: 'addon',
+        entrypoints: [`src/integrations/${integrationName}.ts`],
+        licenseTitle: `@sentry/browser - ${integrationName}`,
+        outputFileBase: () => `bundles/${integrationName}`,
+      }),
+    ),
+  );
 });
 
 reexportedPluggableIntegrationFiles.forEach(integrationName => {
-  const integrationsBundleConfig = makeBaseBundleConfig({
-    bundleType: 'addon',
-    entrypoints: [`src/integrations-bundle/index.${integrationName}.ts`],
-    licenseTitle: `@sentry/browser - ${integrationName}`,
-    outputFileBase: () => `bundles/${integrationName}`,
-  });
-
-  builds.push(...makeBundleConfigVariants(integrationsBundleConfig));
+  builds.push(
+    ...makeBundleConfigVariants(() =>
+      makeBaseBundleConfig({
+        bundleType: 'addon',
+        entrypoints: [`src/integrations-bundle/index.${integrationName}.ts`],
+        licenseTitle: `@sentry/browser - ${integrationName}`,
+        outputFileBase: () => `bundles/${integrationName}`,
+      }),
+    ),
+  );
 });
 
 // Bundle config for additional exports we don't want to include in the main SDK bundle
 // if we need more of these, we can generalize the config as for pluggable integrations
 builds.push(
-  ...makeBundleConfigVariants(
+  ...makeBundleConfigVariants(() =>
     makeBaseBundleConfig({
       bundleType: 'addon',
       entrypoints: ['src/pluggable-exports-bundle/index.multiplexedtransport.ts'],
@@ -56,104 +60,104 @@ builds.push(
   ),
 );
 
-const baseBundleConfig = makeBaseBundleConfig({
+const baseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.ts'],
   licenseTitle: '@sentry/browser',
   outputFileBase: () => 'bundles/bundle',
-});
+};
 
-const feedbackBaseBundleConfig = makeBaseBundleConfig({
+const feedbackBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.feedback.ts'],
   licenseTitle: '@sentry/browser & @sentry/feedback',
   outputFileBase: () => 'bundles/bundle.feedback',
-});
+};
 
-const logsMetricsBaseBundleConfig = makeBaseBundleConfig({
+const logsMetricsBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.logs.metrics.ts'],
   licenseTitle: '@sentry/browser (Logs and Metrics)',
   outputFileBase: () => 'bundles/bundle.logs.metrics',
-});
+};
 
-const replayBaseBundleConfig = makeBaseBundleConfig({
+const replayBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.replay.ts'],
   licenseTitle: '@sentry/browser (Replay)',
   outputFileBase: () => 'bundles/bundle.replay',
-});
+};
 
-const replayFeedbackBaseBundleConfig = makeBaseBundleConfig({
+const replayFeedbackBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.replay.feedback.ts'],
   licenseTitle: '@sentry/browser (Replay, and Feedback)',
   outputFileBase: () => 'bundles/bundle.replay.feedback',
-});
+};
 
-const replayLogsMetricsBaseBundleConfig = makeBaseBundleConfig({
+const replayLogsMetricsBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.replay.logs.metrics.ts'],
   licenseTitle: '@sentry/browser (Replay, Logs, and Metrics)',
   outputFileBase: () => 'bundles/bundle.replay.logs.metrics',
-});
+};
 
 // Tracing
-const tracingBaseBundleConfig = makeBaseBundleConfig({
+const tracingBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.tracing.ts'],
   licenseTitle: '@sentry/browser (Performance Monitoring)',
   outputFileBase: () => 'bundles/bundle.tracing',
-});
+};
 
-const tracingLogsMetricsBaseBundleConfig = makeBaseBundleConfig({
+const tracingLogsMetricsBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.tracing.logs.metrics.ts'],
   licenseTitle: '@sentry/browser (Performance Monitoring, Logs, and Metrics)',
   outputFileBase: () => 'bundles/bundle.tracing.logs.metrics',
-});
+};
 
-const tracingReplayBaseBundleConfig = makeBaseBundleConfig({
+const tracingReplayBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.tracing.replay.ts'],
   licenseTitle: '@sentry/browser (Performance Monitoring and Replay)',
   outputFileBase: () => 'bundles/bundle.tracing.replay',
-});
+};
 
-const tracingReplayLogsMetricsBaseBundleConfig = makeBaseBundleConfig({
+const tracingReplayLogsMetricsBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.tracing.replay.logs.metrics.ts'],
   licenseTitle: '@sentry/browser (Performance Monitoring, Replay, Logs, and Metrics)',
   outputFileBase: () => 'bundles/bundle.tracing.replay.logs.metrics',
-});
+};
 
-const tracingReplayFeedbackBaseBundleConfig = makeBaseBundleConfig({
+const tracingReplayFeedbackBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.tracing.replay.feedback.ts'],
   licenseTitle: '@sentry/browser (Performance Monitoring, Replay, and Feedback)',
   outputFileBase: () => 'bundles/bundle.tracing.replay.feedback',
-});
+};
 
-const tracingReplayFeedbackLogsMetricsBaseBundleConfig = makeBaseBundleConfig({
+const tracingReplayFeedbackLogsMetricsBaseBundleOptions = {
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.tracing.replay.feedback.logs.metrics.ts'],
   licenseTitle: '@sentry/browser (Performance Monitoring, Replay, Feedback, Logs, and Metrics)',
   outputFileBase: () => 'bundles/bundle.tracing.replay.feedback.logs.metrics',
-});
+};
 
 builds.push(
-  ...makeBundleConfigVariants(baseBundleConfig),
-  ...makeBundleConfigVariants(feedbackBaseBundleConfig),
-  ...makeBundleConfigVariants(logsMetricsBaseBundleConfig),
-  ...makeBundleConfigVariants(replayBaseBundleConfig),
-  ...makeBundleConfigVariants(replayFeedbackBaseBundleConfig),
-  ...makeBundleConfigVariants(replayLogsMetricsBaseBundleConfig),
-  ...makeBundleConfigVariants(tracingBaseBundleConfig),
-  ...makeBundleConfigVariants(tracingLogsMetricsBaseBundleConfig),
-  ...makeBundleConfigVariants(tracingReplayBaseBundleConfig),
-  ...makeBundleConfigVariants(tracingReplayLogsMetricsBaseBundleConfig),
-  ...makeBundleConfigVariants(tracingReplayFeedbackBaseBundleConfig),
-  ...makeBundleConfigVariants(tracingReplayFeedbackLogsMetricsBaseBundleConfig),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(baseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(feedbackBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(logsMetricsBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(replayBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(replayFeedbackBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(replayLogsMetricsBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(tracingBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(tracingLogsMetricsBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(tracingReplayBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(tracingReplayLogsMetricsBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(tracingReplayFeedbackBaseBundleOptions)),
+  ...makeBundleConfigVariants(() => makeBaseBundleConfig(tracingReplayFeedbackLogsMetricsBaseBundleOptions)),
 );
 
 export default builds;

--- a/packages/feedback/rollup.bundle.config.mjs
+++ b/packages/feedback/rollup.bundle.config.mjs
@@ -3,7 +3,7 @@ import { makeBaseBundleConfig, makeBundleConfigVariants } from '@sentry-internal
 export default [
   // The core `feedback` bundle is built in the browser package
   // Sub-bundles are built here
-  ...makeBundleConfigVariants(
+  ...makeBundleConfigVariants(() =>
     makeBaseBundleConfig({
       bundleType: 'addon',
       entrypoints: ['src/screenshot/integration.ts'],
@@ -19,7 +19,7 @@ export default [
       },
     }),
   ),
-  ...makeBundleConfigVariants(
+  ...makeBundleConfigVariants(() =>
     makeBaseBundleConfig({
       bundleType: 'addon',
       entrypoints: ['src/modal/integration.tsx'],

--- a/packages/replay-canvas/rollup.bundle.config.mjs
+++ b/packages/replay-canvas/rollup.bundle.config.mjs
@@ -1,12 +1,12 @@
 import { makeBaseBundleConfig, makeBundleConfigVariants } from '@sentry-internal/rollup-utils';
 
-const baseBundleConfig = makeBaseBundleConfig({
+const baseBundleOptions = {
   bundleType: 'addon',
   entrypoints: ['src/index.ts'],
   licenseTitle: '@sentry-internal/replay-canvas',
   outputFileBase: () => 'bundles/replay-canvas',
-});
+};
 
-const builds = makeBundleConfigVariants(baseBundleConfig);
+const builds = makeBundleConfigVariants(() => makeBaseBundleConfig(baseBundleOptions));
 
 export default builds;

--- a/packages/replay-internal/rollup.bundle.config.mjs
+++ b/packages/replay-internal/rollup.bundle.config.mjs
@@ -1,12 +1,12 @@
 import { makeBaseBundleConfig, makeBundleConfigVariants } from '@sentry-internal/rollup-utils';
 
-const baseBundleConfig = makeBaseBundleConfig({
+const baseBundleOptions = {
   bundleType: 'addon',
   entrypoints: ['src/index.ts'],
   licenseTitle: '@sentry-internal/replay',
   outputFileBase: () => 'bundles/replay',
-});
+};
 
-const builds = makeBundleConfigVariants(baseBundleConfig);
+const builds = makeBundleConfigVariants(() => makeBaseBundleConfig(baseBundleOptions));
 
 export default builds;

--- a/packages/wasm/rollup.bundle.config.mjs
+++ b/packages/wasm/rollup.bundle.config.mjs
@@ -1,10 +1,10 @@
 import { makeBaseBundleConfig, makeBundleConfigVariants } from '@sentry-internal/rollup-utils';
 
-const baseBundleConfig = makeBaseBundleConfig({
+const baseBundleOptions = {
   bundleType: 'addon',
   entrypoints: ['src/index.ts'],
   licenseTitle: '@sentry/wasm',
   outputFileBase: () => 'bundles/wasm',
-});
+};
 
-export default makeBundleConfigVariants(baseBundleConfig);
+export default makeBundleConfigVariants(() => makeBaseBundleConfig(baseBundleOptions));


### PR DESCRIPTION
Previously, running `yarn build:bundles` for the browser package is one of the biggest blocker for build time. This is because this builds ~90 bundles in series via rollup. This PR adds a small script to run multiple rollup builds in parallel, hopefully speeding this up significantly. Locally I saw an improvement from ~150s to ~70s.

It turns out this is a bit harder than expected because we were kind of incorrectly relying on shared rollup plugin instances for our builds, which seems not to be recommended. So I (or cursor, actually) rewrote this to instead generate a standalone plugin instance for each build so they cannot conflict.

## Summary

- Adds `dev-packages/rollup-utils/rollupParallel.mjs` — a ~30 line script that runs rollup config arrays concurrently using the rollup JS API (concurrency = CPU count)
- Uses it for `@sentry/browser`'s `build:bundle`, which builds 93 rollup configs (31 entrypoints × 3 variants: `.js`, `.min.js`, `.debug.min.js`)

Rollup processes config arrays sequentially. This was the critical path for `yarn build` — the browser bundle step alone took **~175s**. With parallel execution it completes in **~65s** (~2.6x speedup).

The other packages with `build:bundle` (replay, feedback, replay-canvas, wasm) only have 3-6 configs each, so the overhead isn't worth it there.

## Test plan

- [x] `yarn build` in `packages/browser` produces all 93 bundles + sourcemaps
- [x] Bundle sizes match sequential build output
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)