### PR TITLE
fix(core): fix 'occured' -> 'occurred' in gen-ai-attributes doc comment

### DIFF
--- a/packages/core/src/tracing/ai/gen-ai-attributes.ts
+++ b/packages/core/src/tracing/ai/gen-ai-attributes.ts
@@ -116,7 +116,7 @@ export const GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE = 'gen_ai.usage.total_tokens';
 export const GEN_AI_OPERATION_NAME_ATTRIBUTE = 'gen_ai.operation.name';
 
 /**
- * Original length of messages array, used to indicate truncations had occured
+ * Original length of messages array, used to indicate truncations had occurred
  */
 export const GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE = 'sentry.sdk_meta.gen_ai.input.messages.original_length';
 


### PR DESCRIPTION
Doc comment in `packages/core/src/tracing/ai/gen-ai-attributes.ts` line 119 reads `truncations had occured`. Fixed to `occurred`. Comment-only change.