### PR TITLE
feat(core): Emit `no_parent_span` client outcomes for discarded spans requiring a parent

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -203,7 +203,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Logs, Metrics)',
     path: createCDNPath('bundle.tracing.logs.metrics.min.js'),
     gzip: true,
-    limit: '46 KB',
+    limit: '47 KB',
   },
   {
     name: 'CDN Bundle (incl. Replay, Logs, Metrics)',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -276,7 +276,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: false,
     brotli: false,
-    limit: '251 KB',
+    limit: '252 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Logs, Metrics) - uncompressed',
@@ -290,7 +290,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.feedback.min.js'),
     gzip: false,
     brotli: false,
-    limit: '264 KB',
+    limit: '265 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback, Logs, Metrics) - uncompressed',
@@ -324,7 +324,7 @@ module.exports = [
     import: createImport('init'),
     ignore: [...builtinModules, ...nodePrefixedBuiltinModules],
     gzip: true,
-    limit: '59 KB',
+    limit: '60 KB',
   },
   // Node SDK (ESM)
   {

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/init.js
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration({ instrumentPageLoad: false, instrumentNavigation: false }), Sentry.spanStreamingIntegration()],
+  tracesSampleRate: 1,
+  sendClientReports: true,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/init.js
@@ -4,7 +4,10 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [Sentry.browserTracingIntegration({ instrumentPageLoad: false, instrumentNavigation: false }), Sentry.spanStreamingIntegration()],
+  integrations: [
+    Sentry.browserTracingIntegration({ instrumentPageLoad: false, instrumentNavigation: false }),
+    Sentry.spanStreamingIntegration(),
+  ],
   tracesSampleRate: 1,
   sendClientReports: true,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/subject.js
@@ -1,0 +1,1 @@
+fetch('http://sentry-test-site.example/api/test');

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/test.ts
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test';
+import type { ClientReport } from '@sentry/core';
+import { sentryTest } from '../../../utils/fixtures';
+import {
+  envelopeRequestParser,
+  hidePage,
+  shouldSkipTracingTest,
+  testingCdnBundle,
+  waitForClientReportRequest,
+} from '../../../utils/helpers';
+
+sentryTest(
+  'records no_parent_span client report for fetch requests without an active span',
+  async ({ getLocalTestUrl, page }) => {
+    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+
+    await page.route('http://sentry-test-site.example/api/test', route => {
+      route.fulfill({
+        status: 200,
+        body: 'ok',
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    });
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const clientReportPromise = waitForClientReportRequest(page, report => {
+      return report.discarded_events.some(e => e.reason === 'no_parent_span');
+    });
+
+    await page.goto(url);
+
+    await hidePage(page);
+
+    const clientReport = envelopeRequestParser<ClientReport>(await clientReportPromise);
+
+    expect(clientReport.discarded_events).toEqual([
+      {
+        category: 'span',
+        quantity: 1,
+        reason: 'no_parent_span',
+      },
+    ]);
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/init.js
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.browserTracingIntegration({ instrumentPageLoad: false, instrumentNavigation: false })],
+  tracesSampleRate: 1,
+  sendClientReports: true,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/subject.js
@@ -1,2 +1,1 @@
 fetch('http://sentry-test-site.example/api/test');
-

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/subject.js
@@ -1,0 +1,2 @@
+fetch('http://sentry-test-site.example/api/test');
+

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/test.ts
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test';
+import type { ClientReport } from '@sentry/core';
+import { sentryTest } from '../../../utils/fixtures';
+import {
+  envelopeRequestParser,
+  hidePage,
+  shouldSkipTracingTest,
+  testingCdnBundle,
+  waitForClientReportRequest,
+} from '../../../utils/helpers';
+
+sentryTest(
+  'records no_parent_span client report for fetch requests without an active span',
+  async ({ getLocalTestUrl, page }) => {
+    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+
+    await page.route('http://sentry-test-site.example/api/test', route => {
+      route.fulfill({
+        status: 200,
+        body: 'ok',
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    });
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const clientReportPromise = waitForClientReportRequest(page, report => {
+      return report.discarded_events.some(e => e.reason === 'no_parent_span');
+    });
+
+    await page.goto(url);
+
+    await hidePage(page);
+
+    const clientReport = envelopeRequestParser<ClientReport>(await clientReportPromise);
+
+    expect(clientReport.discarded_events).toEqual([
+      {
+        category: 'span',
+        quantity: 1,
+        reason: 'no_parent_span',
+      },
+    ]);
+  },
+);

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report-streamed/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report-streamed/instrument.mjs
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+  clientReportFlushInterval: 1_000,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report-streamed/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report-streamed/scenario.mjs
@@ -1,0 +1,2 @@
+import http from 'http';
+http.get('http://localhost:9999/external', () => {}).on('error', () => {});

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report-streamed/test.ts
@@ -1,0 +1,29 @@
+import { afterAll, describe, expect } from 'vitest';
+import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+
+describe('no_parent_span client report (streaming)', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('records no_parent_span outcome for http.client span without a local parent', async () => {
+      const runner = createRunner()
+        .unignore('client_report')
+        .expect({
+          client_report: report => {
+            expect(report.discarded_events).toEqual([
+              {
+                category: 'span',
+                quantity: 1,
+                reason: 'no_parent_span',
+              },
+            ]);
+          },
+        })
+        .start();
+
+      await runner.completed();
+    });
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/instrument.mjs
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  clientReportFlushInterval: 1_000,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/scenario.mjs
@@ -1,0 +1,2 @@
+import http from 'http';
+http.get('http://localhost:9999/external', () => {}).on('error', () => {});

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/test.ts
@@ -1,0 +1,29 @@
+import { afterAll, describe, expect } from 'vitest';
+import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+
+describe('no_parent_span client report (streaming)', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('records no_parent_span outcome for http.client span without a local parent', async () => {
+      const runner = createRunner()
+        .unignore('client_report')
+        .expect({
+          client_report: report => {
+            expect(report.discarded_events).toEqual([
+              {
+                category: 'span',
+                quantity: 1,
+                reason: 'no_parent_span',
+              },
+            ]);
+          },
+        })
+        .start();
+
+      await runner.completed();
+    });
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect } from 'vitest';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
-describe('no_parent_span client report (streaming)', () => {
+describe('no_parent_span client report', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -404,6 +404,7 @@ function xhrCallback(
 
   const urlForSpanName = stripDataUrlContent(stripUrlQueryAndFragment(url));
 
+  const client = getClient();
   const hasParent = !!getActiveSpan();
 
   const span =
@@ -424,6 +425,10 @@ function xhrCallback(
         })
       : new SentryNonRecordingSpan();
 
+  if (shouldCreateSpanResult && !hasParent) {
+    client?.recordDroppedEvent('no_parent_span', 'span');
+  }
+
   xhr.__sentry_xhr_span_id__ = span.spanContext().spanId;
   spans[xhr.__sentry_xhr_span_id__] = span;
 
@@ -438,7 +443,6 @@ function xhrCallback(
     );
   }
 
-  const client = getClient();
   if (client) {
     client.emit('beforeOutgoingRequestSpan', span, handlerData as XhrHint);
   }

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -108,12 +108,17 @@ export function instrumentFetchRequest(
   const { spanOrigin = 'auto.http.browser', propagateTraceparent = false } =
     typeof spanOriginOrOptions === 'object' ? spanOriginOrOptions : { spanOrigin: spanOriginOrOptions };
 
+  const client = getClient();
   const hasParent = !!getActiveSpan();
 
   const span =
     shouldCreateSpanResult && hasParent
       ? startInactiveSpan(getSpanStartOptions(url, method, spanOrigin))
       : new SentryNonRecordingSpan();
+
+  if (shouldCreateSpanResult && !hasParent) {
+    client?.recordDroppedEvent('no_parent_span', 'span');
+  }
 
   handlerData.fetchData.__span = span.spanContext().spanId;
   spans[span.spanContext().spanId] = span;
@@ -140,8 +145,6 @@ export function instrumentFetchRequest(
       options.headers = headers;
     }
   }
-
-  const client = getClient();
 
   if (client) {
     const fetchHint = {

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -78,7 +78,6 @@ export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) =
             spanArguments,
             forceTransaction,
             scope,
-            client,
           });
 
       if (shouldSkipSpan) {
@@ -137,7 +136,6 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
     return wrapper(() => {
       const scope = getCurrentScope();
       const parentSpan = getParentSpan(scope, customParentSpan);
-      const client = getClient();
 
       const shouldSkipSpan = options.onlyIfParent && !parentSpan;
       const activeSpan = shouldSkipSpan
@@ -147,11 +145,10 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
             spanArguments,
             forceTransaction,
             scope,
-            client,
           });
 
       if (shouldSkipSpan) {
-        client?.recordDroppedEvent('no_parent_span', 'span');
+        getClient()?.recordDroppedEvent('no_parent_span', 'span');
       }
 
       // We don't set ignored child spans onto the scope because there likely is an active,
@@ -221,7 +218,6 @@ export function startInactiveSpan(options: StartSpanOptions): Span {
       spanArguments,
       forceTransaction,
       scope,
-      client,
     });
   });
 }
@@ -342,13 +338,11 @@ function createChildOrRootSpan({
   spanArguments,
   forceTransaction,
   scope,
-  client: clientArg,
 }: {
   parentSpan: SentrySpan | undefined;
   spanArguments: SentrySpanArguments;
   forceTransaction?: boolean;
   scope: Scope;
-  client?: Client;
 }): Span {
   if (!hasSpansEnabled()) {
     const span = new SentryNonRecordingSpan();
@@ -368,7 +362,7 @@ function createChildOrRootSpan({
     return span;
   }
 
-  const client = clientArg || getClient();
+  const client = getClient();
   if (_shouldIgnoreStreamedSpan(client, spanArguments)) {
     if (!_isTracingSuppressed(scope)) {
       // if tracing is actively suppressed (Sentry.suppressTracing(...)),

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -68,6 +68,7 @@ export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) =
     return wrapper(() => {
       const scope = getCurrentScope();
       const parentSpan = getParentSpan(scope, customParentSpan);
+      const client = getClient();
 
       const shouldSkipSpan = options.onlyIfParent && !parentSpan;
       const activeSpan = shouldSkipSpan
@@ -77,7 +78,12 @@ export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) =
             spanArguments,
             forceTransaction,
             scope,
+            client,
           });
+
+      if (shouldSkipSpan) {
+        client?.recordDroppedEvent('no_parent_span', 'span');
+      }
 
       // Ignored root spans still need to be set on scope so that `getActiveSpan()` returns them
       // and descendants are also non-recording. Ignored child spans don't need this because
@@ -131,6 +137,7 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
     return wrapper(() => {
       const scope = getCurrentScope();
       const parentSpan = getParentSpan(scope, customParentSpan);
+      const client = getClient();
 
       const shouldSkipSpan = options.onlyIfParent && !parentSpan;
       const activeSpan = shouldSkipSpan
@@ -140,7 +147,12 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
             spanArguments,
             forceTransaction,
             scope,
+            client,
           });
+
+      if (shouldSkipSpan) {
+        client?.recordDroppedEvent('no_parent_span', 'span');
+      }
 
       // We don't set ignored child spans onto the scope because there likely is an active,
       // unignored span on the scope already.
@@ -195,10 +207,12 @@ export function startInactiveSpan(options: StartSpanOptions): Span {
   return wrapper(() => {
     const scope = getCurrentScope();
     const parentSpan = getParentSpan(scope, customParentSpan);
+    const client = getClient();
 
     const shouldSkipSpan = options.onlyIfParent && !parentSpan;
 
     if (shouldSkipSpan) {
+      client?.recordDroppedEvent('no_parent_span', 'span');
       return new SentryNonRecordingSpan();
     }
 
@@ -207,6 +221,7 @@ export function startInactiveSpan(options: StartSpanOptions): Span {
       spanArguments,
       forceTransaction,
       scope,
+      client,
     });
   });
 }
@@ -327,11 +342,13 @@ function createChildOrRootSpan({
   spanArguments,
   forceTransaction,
   scope,
+  client: clientArg,
 }: {
   parentSpan: SentrySpan | undefined;
   spanArguments: SentrySpanArguments;
   forceTransaction?: boolean;
   scope: Scope;
+  client?: Client;
 }): Span {
   if (!hasSpansEnabled()) {
     const span = new SentryNonRecordingSpan();
@@ -351,7 +368,7 @@ function createChildOrRootSpan({
     return span;
   }
 
-  const client = getClient();
+  const client = clientArg || getClient();
   if (_shouldIgnoreStreamedSpan(client, spanArguments)) {
     if (!_isTracingSuppressed(scope)) {
       // if tracing is actively suppressed (Sentry.suppressTracing(...)),

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -70,8 +70,8 @@ export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) =
       const parentSpan = getParentSpan(scope, customParentSpan);
       const client = getClient();
 
-      const shouldSkipSpan = options.onlyIfParent && !parentSpan;
-      const activeSpan = shouldSkipSpan
+      const missingRequiredParent = options.onlyIfParent && !parentSpan;
+      const activeSpan = missingRequiredParent
         ? new SentryNonRecordingSpan()
         : createChildOrRootSpan({
             parentSpan,
@@ -80,7 +80,7 @@ export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) =
             scope,
           });
 
-      if (shouldSkipSpan) {
+      if (missingRequiredParent) {
         client?.recordDroppedEvent('no_parent_span', 'span');
       }
 
@@ -137,8 +137,8 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
       const scope = getCurrentScope();
       const parentSpan = getParentSpan(scope, customParentSpan);
 
-      const shouldSkipSpan = options.onlyIfParent && !parentSpan;
-      const activeSpan = shouldSkipSpan
+      const missingRequiredParent = options.onlyIfParent && !parentSpan;
+      const activeSpan = missingRequiredParent
         ? new SentryNonRecordingSpan()
         : createChildOrRootSpan({
             parentSpan,
@@ -147,7 +147,7 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
             scope,
           });
 
-      if (shouldSkipSpan) {
+      if (missingRequiredParent) {
         getClient()?.recordDroppedEvent('no_parent_span', 'span');
       }
 
@@ -206,9 +206,9 @@ export function startInactiveSpan(options: StartSpanOptions): Span {
     const parentSpan = getParentSpan(scope, customParentSpan);
     const client = getClient();
 
-    const shouldSkipSpan = options.onlyIfParent && !parentSpan;
+    const missingRequiredParent = options.onlyIfParent && !parentSpan;
 
-    if (shouldSkipSpan) {
+    if (missingRequiredParent) {
       client?.recordDroppedEvent('no_parent_span', 'span');
       return new SentryNonRecordingSpan();
     }

--- a/packages/core/src/types-hoist/clientreport.ts
+++ b/packages/core/src/types-hoist/clientreport.ts
@@ -11,7 +11,8 @@ export type EventDropReason =
   | 'internal_sdk_error'
   | 'buffer_overflow'
   | 'ignored'
-  | 'invalid';
+  | 'invalid'
+  | 'no_parent_span';
 
 export type Outcome = {
   reason: EventDropReason;

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -600,6 +600,16 @@ describe('startSpan', () => {
       expect(span).toBeInstanceOf(SentrySpan);
       expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
     });
+
+    it('does not record no_parent_span client report when onlyIfParent is not set', () => {
+      const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+      startSpan({ name: 'root span without onlyIfParent' }, span => {
+        return span;
+      });
+
+      expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+    });
   });
 
   describe('parentSpanIsAlwaysRootSpan', () => {
@@ -1220,6 +1230,17 @@ describe('startSpanManual', () => {
       expect(span).toBeInstanceOf(SentrySpan);
       expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
     });
+
+    it('does not record no_parent_span client report when onlyIfParent is not set', () => {
+      const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+      startSpanManual({ name: 'root span without onlyIfParent' }, span => {
+        span.end();
+        return span;
+      });
+
+      expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+    });
   });
 
   describe('parentSpanIsAlwaysRootSpan', () => {
@@ -1624,6 +1645,15 @@ describe('startInactiveSpan', () => {
 
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentrySpan);
+      expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+    });
+
+    it('does not record no_parent_span client report when onlyIfParent is not set', () => {
+      const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+      const span = startInactiveSpan({ name: 'root span without onlyIfParent' });
+      span.end();
+
       expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
     });
   });

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -572,7 +572,7 @@ describe('startSpan', () => {
   });
 
   describe('onlyIfParent', () => {
-    it('starts a non recording span if there is no parent', () => {
+    it('starts a non recording span and records no_parent_span client report if there is no parent', () => {
       const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
 
       const span = startSpan({ name: 'test span', onlyIfParent: true }, span => {
@@ -581,10 +581,13 @@ describe('startSpan', () => {
 
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentryNonRecordingSpan);
-      expect(spyOnDroppedEvent).not.toHaveBeenCalled();
+      expect(spyOnDroppedEvent).toHaveBeenCalledWith('no_parent_span', 'span');
+      expect(spyOnDroppedEvent).toHaveBeenCalledTimes(1);
     });
 
     it('creates a span if there is a parent', () => {
+      const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
       const span = startSpan({ name: 'parent span' }, () => {
         const span = startSpan({ name: 'test span', onlyIfParent: true }, span => {
           return span;
@@ -595,6 +598,7 @@ describe('startSpan', () => {
 
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentrySpan);
+      expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
     });
   });
 
@@ -1189,15 +1193,21 @@ describe('startSpanManual', () => {
   });
 
   describe('onlyIfParent', () => {
-    it('does not create a span if there is no parent', () => {
+    it('does not create a span and records no_parent_span client report if there is no parent', () => {
+      const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
       const span = startSpanManual({ name: 'test span', onlyIfParent: true }, span => {
         return span;
       });
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentryNonRecordingSpan);
+      expect(spyOnDroppedEvent).toHaveBeenCalledWith('no_parent_span', 'span');
+      expect(spyOnDroppedEvent).toHaveBeenCalledTimes(1);
     });
 
     it('creates a span if there is a parent', () => {
+      const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
       const span = startSpan({ name: 'parent span' }, () => {
         const span = startSpanManual({ name: 'test span', onlyIfParent: true }, span => {
           return span;
@@ -1208,6 +1218,7 @@ describe('startSpanManual', () => {
 
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentrySpan);
+      expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
     });
   });
 
@@ -1592,14 +1603,20 @@ describe('startInactiveSpan', () => {
   });
 
   describe('onlyIfParent', () => {
-    it('does not create a span if there is no parent', () => {
+    it('does not create a span and records no_parent_span client report if there is no parent', () => {
+      const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
       const span = startInactiveSpan({ name: 'test span', onlyIfParent: true });
 
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentryNonRecordingSpan);
+      expect(spyOnDroppedEvent).toHaveBeenCalledWith('no_parent_span', 'span');
+      expect(spyOnDroppedEvent).toHaveBeenCalledTimes(1);
     });
 
     it('creates a span if there is a parent', () => {
+      const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
       const span = startSpan({ name: 'parent span' }, () => {
         const span = startInactiveSpan({ name: 'test span', onlyIfParent: true });
         return span;
@@ -1607,6 +1624,7 @@ describe('startInactiveSpan', () => {
 
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentrySpan);
+      expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
     });
   });
 

--- a/packages/opentelemetry/src/sampler.ts
+++ b/packages/opentelemetry/src/sampler.ts
@@ -77,6 +77,7 @@ export class SentrySampler implements Sampler {
     // If we have a http.client span that has no local parent, we never want to sample it
     // but we want to leave downstream sampling decisions up to the server
     if (spanKind === SpanKind.CLIENT && maybeSpanHttpMethod && (!parentSpan || parentContext?.isRemote)) {
+      this._client.recordDroppedEvent('no_parent_span', 'span');
       return wrapSamplingDecision({ decision: undefined, context, spanAttributes });
     }
 

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -48,10 +48,10 @@ function _startSpan<T>(options: OpenTelemetrySpanContext, callback: (span: Span)
 
   return wrapper(() => {
     const activeCtx = getContext(options.scope, options.forceTransaction);
-    const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
-    const ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
+    const missingRequiredParent = options.onlyIfParent && !trace.getSpan(activeCtx);
+    const ctx = missingRequiredParent ? suppressTracing(activeCtx) : activeCtx;
 
-    if (shouldSkipSpan) {
+    if (missingRequiredParent) {
       getClient()?.recordDroppedEvent('no_parent_span', 'span');
     }
 
@@ -155,10 +155,10 @@ export function startInactiveSpan(options: OpenTelemetrySpanContext): Span {
 
   return wrapper(() => {
     const activeCtx = getContext(options.scope, options.forceTransaction);
-    const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
-    let ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
+    const missingRequiredParent = options.onlyIfParent && !trace.getSpan(activeCtx);
+    let ctx = missingRequiredParent ? suppressTracing(activeCtx) : activeCtx;
 
-    if (shouldSkipSpan) {
+    if (missingRequiredParent) {
       getClient()?.recordDroppedEvent('no_parent_span', 'span');
     }
 

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -51,6 +51,10 @@ function _startSpan<T>(options: OpenTelemetrySpanContext, callback: (span: Span)
     const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
     const ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
 
+    if (shouldSkipSpan) {
+      getClient()?.recordDroppedEvent('no_parent_span', 'span');
+    }
+
     const spanOptions = getSpanOptions(options);
 
     // If spans are not enabled, ensure we suppress tracing for the span creation
@@ -153,6 +157,10 @@ export function startInactiveSpan(options: OpenTelemetrySpanContext): Span {
     const activeCtx = getContext(options.scope, options.forceTransaction);
     const shouldSkipSpan = options.onlyIfParent && !trace.getSpan(activeCtx);
     let ctx = shouldSkipSpan ? suppressTracing(activeCtx) : activeCtx;
+
+    if (shouldSkipSpan) {
+      getClient()?.recordDroppedEvent('no_parent_span', 'span');
+    }
 
     const spanOptions = getSpanOptions(options);
 

--- a/packages/opentelemetry/test/sampler.test.ts
+++ b/packages/opentelemetry/test/sampler.test.ts
@@ -120,7 +120,7 @@ describe('SentrySampler', () => {
     spyOnDroppedEvent.mockReset();
   });
 
-  it('ignores local http client root spans', () => {
+  it('ignores local http client root spans and records no_parent_span client report', () => {
     const client = new TestClient(getDefaultTestClientOptions({ tracesSampleRate: 0 }));
     const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
     const sampler = new SentrySampler(client);
@@ -139,7 +139,8 @@ describe('SentrySampler', () => {
       decision: SamplingDecision.NOT_RECORD,
       traceState: new TraceState(),
     });
-    expect(spyOnDroppedEvent).toHaveBeenCalledTimes(0);
+    expect(spyOnDroppedEvent).toHaveBeenCalledTimes(1);
+    expect(spyOnDroppedEvent).toHaveBeenCalledWith('no_parent_span', 'span');
 
     spyOnDroppedEvent.mockReset();
   });

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -558,6 +558,32 @@ describe('trace', () => {
         expect(isSpan(span)).toBe(true);
         expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
       });
+
+      it('does not record no_parent_span client report when onlyIfParent is not set', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+        context.with(ROOT_CONTEXT, () => {
+          startSpan({ name: 'root span without onlyIfParent' }, span => {
+            return span;
+          });
+        });
+
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+      });
+
+      it('does not record no_parent_span client report when onlyIfParent is false even without a parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+        context.with(ROOT_CONTEXT, () => {
+          startSpan({ name: 'root span', onlyIfParent: false }, span => {
+            return span;
+          });
+        });
+
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+      });
     });
   });
 
@@ -855,6 +881,30 @@ describe('trace', () => {
         });
 
         expect(isSpan(span)).toBe(true);
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+      });
+
+      it('does not record no_parent_span client report when onlyIfParent is not set', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+        context.with(ROOT_CONTEXT, () => {
+          const span = startInactiveSpan({ name: 'root span without onlyIfParent' });
+          span.end();
+        });
+
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+      });
+
+      it('does not record no_parent_span client report when onlyIfParent is false even without a parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+        context.with(ROOT_CONTEXT, () => {
+          const span = startInactiveSpan({ name: 'root span', onlyIfParent: false });
+          span.end();
+        });
+
         expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
       });
     });
@@ -1236,6 +1286,34 @@ describe('trace', () => {
         });
 
         expect(isSpan(span)).toBe(true);
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+      });
+
+      it('does not record no_parent_span client report when onlyIfParent is not set', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+        context.with(ROOT_CONTEXT, () => {
+          startSpanManual({ name: 'root span without onlyIfParent' }, span => {
+            span.end();
+            return span;
+          });
+        });
+
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
+      });
+
+      it('does not record no_parent_span client report when onlyIfParent is false even without a parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
+        context.with(ROOT_CONTEXT, () => {
+          startSpanManual({ name: 'root span', onlyIfParent: false }, span => {
+            span.end();
+            return span;
+          });
+        });
+
         expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
       });
     });

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -530,15 +530,23 @@ describe('trace', () => {
     // TODO: propagation scope is not picked up by spans...
 
     describe('onlyIfParent', () => {
-      it('does not create a span if there is no parent', () => {
+      it('does not create a span and records no_parent_span client report if there is no parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
         const span = startSpan({ name: 'test span', onlyIfParent: true }, span => {
           return span;
         });
 
         expect(isSpan(span)).toBe(false);
+        expect(spyOnDroppedEvent).toHaveBeenCalledWith('no_parent_span', 'span');
+        expect(spyOnDroppedEvent).toHaveBeenCalledTimes(1);
       });
 
       it('creates a span if there is a parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
         const span = startSpan({ name: 'parent span' }, () => {
           const span = startSpan({ name: 'test span', onlyIfParent: true }, span => {
             return span;
@@ -548,6 +556,7 @@ describe('trace', () => {
         });
 
         expect(isSpan(span)).toBe(true);
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
       });
     });
   });
@@ -824,13 +833,21 @@ describe('trace', () => {
     });
 
     describe('onlyIfParent', () => {
-      it('does not create a span if there is no parent', () => {
+      it('does not create a span and records no_parent_span client report if there is no parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
         const span = startInactiveSpan({ name: 'test span', onlyIfParent: true });
 
         expect(isSpan(span)).toBe(false);
+        expect(spyOnDroppedEvent).toHaveBeenCalledWith('no_parent_span', 'span');
+        expect(spyOnDroppedEvent).toHaveBeenCalledTimes(1);
       });
 
       it('creates a span if there is a parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
         const span = startSpan({ name: 'parent span' }, () => {
           const span = startInactiveSpan({ name: 'test span', onlyIfParent: true });
 
@@ -838,6 +855,7 @@ describe('trace', () => {
         });
 
         expect(isSpan(span)).toBe(true);
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
       });
     });
 
@@ -1192,15 +1210,23 @@ describe('trace', () => {
     });
 
     describe('onlyIfParent', () => {
-      it('does not create a span if there is no parent', () => {
+      it('does not create a span and records no_parent_span client report if there is no parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
         const span = startSpanManual({ name: 'test span', onlyIfParent: true }, span => {
           return span;
         });
 
         expect(isSpan(span)).toBe(false);
+        expect(spyOnDroppedEvent).toHaveBeenCalledWith('no_parent_span', 'span');
+        expect(spyOnDroppedEvent).toHaveBeenCalledTimes(1);
       });
 
       it('creates a span if there is a parent', () => {
+        const client = getClient()!;
+        const spyOnDroppedEvent = vi.spyOn(client, 'recordDroppedEvent');
+
         const span = startSpan({ name: 'parent span' }, () => {
           const span = startSpanManual({ name: 'test span', onlyIfParent: true }, span => {
             return span;
@@ -1210,6 +1236,7 @@ describe('trace', () => {
         });
 
         expect(isSpan(span)).toBe(true);
+        expect(spyOnDroppedEvent).not.toHaveBeenCalledWith('no_parent_span', 'span');
       });
     });
   });


### PR DESCRIPTION
This PR adds reporting a client discard outcome for spans we skip because they require a parent span to be active. This happens when `onlyIfParent: true` is set when starting spans, or in custom logic for `http.client` spans. With this PR, we should now get a much clearer picture of how many spans users are missing out on.

In span streaming, we'll always emit them (see #17932) spans.

closes https://linear.app/getsentry/issue/SDK-1123/add-client-report-outcome-for-dropped-spans-because-of-missing-parent