### PR TITLE
feat(browser): Add support for streamed spans in `cultureContextIntegration`

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -241,14 +241,14 @@ module.exports = [
     path: createCDNPath('bundle.min.js'),
     gzip: false,
     brotli: false,
-    limit: '83.5 KB',
+    limit: '84 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing) - uncompressed',
     path: createCDNPath('bundle.tracing.min.js'),
     gzip: false,
     brotli: false,
-    limit: '134 KB',
+    limit: '135 KB',
   },
   {
     name: 'CDN Bundle (incl. Logs, Metrics) - uncompressed',
@@ -269,14 +269,14 @@ module.exports = [
     path: createCDNPath('bundle.replay.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '211 KB',
+    limit: '212 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay) - uncompressed',
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: false,
     brotli: false,
-    limit: '251 KB',
+    limit: '252 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Logs, Metrics) - uncompressed',
@@ -290,7 +290,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.feedback.min.js'),
     gzip: false,
     brotli: false,
-    limit: '264 KB',
+    limit: '265 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback, Logs, Metrics) - uncompressed',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -155,7 +155,7 @@ module.exports = [
     import: createImport('init', 'ErrorBoundary', 'reactRouterV6BrowserTracingIntegration'),
     ignore: ['react/jsx-runtime'],
     gzip: true,
-    limit: '46 KB',
+    limit: '47 KB',
   },
   // Vue SDK (ESM)
   {

--- a/dev-packages/browser-integration-tests/suites/integrations/cultureContext-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/cultureContext-streamed/init.js
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [Sentry.spanStreamingIntegration(), Sentry.browserTracingIntegration()],
+  tracesSampleRate: 1.0,
+});

--- a/dev-packages/browser-integration-tests/suites/integrations/cultureContext-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/cultureContext-streamed/test.ts
@@ -1,0 +1,21 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../utils/fixtures';
+import { getSpanOp, waitForStreamedSpans } from '../../../utils/spanUtils';
+import { shouldSkipTracingTest, testingCdnBundle } from '../../../utils/helpers';
+
+sentryTest('cultureContextIntegration captures locale, timezone, and calendar', async ({ getLocalTestUrl, page }) => {
+  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  const spansPromise = waitForStreamedSpans(page, spans => spans.some(s => getSpanOp(s) === 'pageload'));
+
+  await page.goto(url);
+
+  const spans = await spansPromise;
+
+  const pageloadSpan = spans.find(s => getSpanOp(s) === 'pageload');
+
+  expect(pageloadSpan!.attributes?.['culture.locale']).toEqual({ type: 'string', value: expect.any(String) });
+  expect(pageloadSpan!.attributes?.['culture.timezone']).toEqual({ type: 'string', value: expect.any(String) });
+  expect(pageloadSpan!.attributes?.['culture.calendar']).toEqual({ type: 'string', value: expect.any(String) });
+});

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
@@ -167,6 +167,18 @@ sentryTest(
       },
       {
         attributes: {
+          'culture.calendar': {
+            type: 'string',
+            value: expect.any(String),
+          },
+          'culture.locale': {
+            type: 'string',
+            value: expect.any(String),
+          },
+          'culture.timezone': {
+            type: 'string',
+            value: expect.any(String),
+          },
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: {
             type: 'string',
             value: 'test',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
@@ -40,6 +40,18 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
 
   expect(interactionSegmentSpan).toEqual({
     attributes: {
+      'culture.calendar': {
+        type: 'string',
+        value: expect.any(String),
+      },
+      'culture.locale': {
+        type: 'string',
+        value: expect.any(String),
+      },
+      'culture.timezone': {
+        type: 'string',
+        value: expect.any(String),
+      },
       [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: {
         type: 'string',
         value: 'idleTimeout',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -69,6 +69,18 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ getL
 
   expect(navigationSpan).toEqual({
     attributes: {
+      'culture.calendar': {
+        type: 'string',
+        value: expect.any(String),
+      },
+      'culture.locale': {
+        type: 'string',
+        value: expect.any(String),
+      },
+      'culture.timezone': {
+        type: 'string',
+        value: expect.any(String),
+      },
       'network.connection.effective_type': {
         type: 'string',
         value: expect.any(String),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -62,6 +62,18 @@ sentryTest(
 
     expect(pageloadSpan).toEqual({
       attributes: {
+        'culture.calendar': {
+          type: 'string',
+          value: expect.any(String),
+        },
+        'culture.locale': {
+          type: 'string',
+          value: expect.any(String),
+        },
+        'culture.timezone': {
+          type: 'string',
+          value: expect.any(String),
+        },
         // formerly known as 'effectiveConnectionType'
         'network.connection.effective_type': {
           type: 'string',

--- a/packages/browser/src/integrations/culturecontext.ts
+++ b/packages/browser/src/integrations/culturecontext.ts
@@ -17,6 +17,19 @@ const _cultureContextIntegration = (() => {
         };
       }
     },
+    processSegmentSpan(span) {
+      const culture = getCultureContext();
+
+      if (culture) {
+        span.attributes = {
+          'culture.locale': culture.locale,
+          'culture.timezone': culture.timezone,
+          'culture.calendar': culture.calendar,
+          xxxDeleteMe: undefined,
+          ...span.attributes,
+        };
+      }
+    },
   };
 }) satisfies IntegrationFn;
 

--- a/packages/browser/src/integrations/culturecontext.ts
+++ b/packages/browser/src/integrations/culturecontext.ts
@@ -25,7 +25,6 @@ const _cultureContextIntegration = (() => {
           'culture.locale': culture.locale,
           'culture.timezone': culture.timezone,
           'culture.calendar': culture.calendar,
-          xxxDeleteMe: undefined,
           ...span.attributes,
         };
       }

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -4,7 +4,7 @@ import { DEBUG_BUILD } from './debug-build';
 import type { Event, EventHint } from './types-hoist/event';
 import type { Integration, IntegrationFn } from './types-hoist/integration';
 import type { CoreOptions } from './types-hoist/options';
-import { StreamedSpanJSON } from './types-hoist/span';
+import type { StreamedSpanJSON } from './types-hoist/span';
 import { debug } from './utils/debug-logger';
 
 export const installedIntegrations: string[] = [];

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -138,6 +138,16 @@ export function setupIntegration(client: Client, integration: Integration, integ
     client.addEventProcessor(processor);
   }
 
+  if (typeof integration.processSpan === 'function') {
+    const callback = integration.processSpan.bind(integration) as typeof integration.processSpan;
+    client.on('processSpan', span => callback(span, client));
+  }
+
+  if (typeof integration.processSegmentSpan === 'function') {
+    const callback = integration.processSegmentSpan.bind(integration) as typeof integration.processSegmentSpan;
+    client.on('processSegmentSpan', span => callback(span, client));
+  }
+
   DEBUG_BUILD && debug.log(`Integration installed: ${integration.name}`);
 }
 

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -4,6 +4,7 @@ import { DEBUG_BUILD } from './debug-build';
 import type { Event, EventHint } from './types-hoist/event';
 import type { Integration, IntegrationFn } from './types-hoist/integration';
 import type { CoreOptions } from './types-hoist/options';
+import { StreamedSpanJSON } from './types-hoist/span';
 import { debug } from './utils/debug-logger';
 
 export const installedIntegrations: string[] = [];
@@ -138,15 +139,14 @@ export function setupIntegration(client: Client, integration: Integration, integ
     client.addEventProcessor(processor);
   }
 
-  if (typeof integration.processSpan === 'function') {
-    const callback = integration.processSpan.bind(integration) as typeof integration.processSpan;
-    client.on('processSpan', span => callback(span, client));
-  }
-
-  if (typeof integration.processSegmentSpan === 'function') {
-    const callback = integration.processSegmentSpan.bind(integration) as typeof integration.processSegmentSpan;
-    client.on('processSegmentSpan', span => callback(span, client));
-  }
+  (['processSpan', 'processSegmentSpan'] as const).forEach(hook => {
+    const callback = integration[hook];
+    if (typeof callback === 'function') {
+      // The cast is needed because TS can't resolve overloads when the discriminant is a union type.
+      // Both overloads have the same callback signature so this is safe.
+      client.on(hook as 'processSpan', (span: StreamedSpanJSON) => callback.call(integration, span, client));
+    }
+  });
 
   DEBUG_BUILD && debug.log(`Integration installed: ${integration.name}`);
 }

--- a/packages/core/src/integrations/requestdata.ts
+++ b/packages/core/src/integrations/requestdata.ts
@@ -1,5 +1,4 @@
 import { defineIntegration } from '../integration';
-import { hasSpanStreamingEnabled } from '../tracing/spans/hasSpanStreamingEnabled';
 import type { Event } from '../types-hoist/event';
 import type { IntegrationFn } from '../types-hoist/integration';
 import type { RequestEventData } from '../types-hoist/request';

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -54,10 +54,12 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
   if (spanJSON.is_segment) {
     applyScopeToSegmentSpan(spanJSON, finalScopeData);
     // Allow hook subscribers to mutate the segment span JSON
+    // This also invokes the `processSegmentSpan` hook of all integrations
     client.emit('processSegmentSpan', spanJSON);
   }
 
-  // Allow hook subscribers to mutate the span JSON
+  // This allows hook subscribers to mutate the span JSON
+  // This also invokes the `processSpan` hook of all integrations
   client.emit('processSpan', spanJSON);
 
   const { beforeSendSpan } = client.getOptions();

--- a/packages/core/src/types-hoist/integration.ts
+++ b/packages/core/src/types-hoist/integration.ts
@@ -1,5 +1,6 @@
 import type { Client } from '../client';
 import type { Event, EventHint } from './event';
+import { StreamedSpanJSON } from './span';
 
 /** Integration interface */
 export interface Integration {
@@ -50,6 +51,20 @@ export interface Integration {
    * This receives the client that the integration was installed for as third argument.
    */
   processEvent?(event: Event, hint: EventHint, client: Client): Event | null | PromiseLike<Event | null>;
+
+  /**
+   * An optional hook that allows modifications to a span. This hook runs after the span is ended,
+   * during `captureSpan` and before the span is passed to users' `beforeSendSpan` callback.
+   * Use this hook to modify a span in-place.
+   */
+  processSpan?(span: StreamedSpanJSON, client: Client): void;
+
+  /**
+   * An optional hook that allows modifications to a segment span. This hook runs after the segment span is ended,
+   * during `captureSpan` and before the segment span is passed to users' `beforeSendSpan` callback.
+   * Use this hook to modify a segment span in-place.
+   */
+  processSegmentSpan?(span: StreamedSpanJSON, client: Client): void;
 }
 
 /**

--- a/packages/core/src/types-hoist/integration.ts
+++ b/packages/core/src/types-hoist/integration.ts
@@ -1,6 +1,6 @@
 import type { Client } from '../client';
 import type { Event, EventHint } from './event';
-import { StreamedSpanJSON } from './span';
+import type { StreamedSpanJSON } from './span';
 
 /** Integration interface */
 export interface Integration {


### PR DESCRIPTION
This PR adds span processing support for the `cultureContextIntegration` plus a few integration API additions to make span processing on an integration level easier:

- `Integration::processSegmentSpan`
- `Integration::processSpan`
- register a `processSegmentSpan` callback on `cultureContextIntegration` that adds the attributes. All attributes are already registered in sentry conventions: https://getsentry.github.io/sentry-conventions/attributes/culture/
- adds a span streaming-specific integration test in addition to the already existing error/event-based integration test

closes https://github.com/getsentry/sentry-javascript/issues/20353
closes https://github.com/getsentry/sentry-javascript/issues/20354