### PR TITLE
test(nextjs): Unskip blocked cf tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -43,6 +43,10 @@
       {
         "build-command": "pnpm test:build-latest",
         "label": "nextjs-16-cf-workers (latest)"
+      },
+      {
+        "build-command": "pnpm test:build-canary",
+        "label": "nextjs-16-cf-workers (canary)"
       }
     ]
   }

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/cloudflare-runtime.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/cloudflare-runtime.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/test-utils';
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.describe.skip('Cloudflare Runtime', () => {
+test.describe('Cloudflare Runtime', () => {
   test('Should report cloudflare as the runtime in API route error events', async ({ request }) => {
     const errorEventPromise = waitForError('nextjs-16-cf-workers', errorEvent => {
       return !!errorEvent?.exception?.values?.some(value =>

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/isr-routes.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/isr-routes.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('should remove sentry-trace and baggage meta tags on ISR dynamic route page load', async ({ page }) => {
+test('should remove sentry-trace and baggage meta tags on ISR dynamic route page load', async ({ page }) => {
   // Navigate to ISR page
   await page.goto('/isr-test/laptop');
 
@@ -14,8 +13,7 @@ test.skip('should remove sentry-trace and baggage meta tags on ISR dynamic route
   await expect(page.locator('meta[name="baggage"]')).toHaveCount(0);
 });
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('should remove sentry-trace and baggage meta tags on ISR static route', async ({ page }) => {
+test('should remove sentry-trace and baggage meta tags on ISR static route', async ({ page }) => {
   // Navigate to ISR static page
   await page.goto('/isr-test/static');
 
@@ -27,8 +25,7 @@ test.skip('should remove sentry-trace and baggage meta tags on ISR static route'
   await expect(page.locator('meta[name="baggage"]')).toHaveCount(0);
 });
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('should remove meta tags for different ISR dynamic route values', async ({ page }) => {
+test('should remove meta tags for different ISR dynamic route values', async ({ page }) => {
   // Test with 'phone' (one of the pre-generated static params)
   await page.goto('/isr-test/phone');
   await expect(page.locator('#isr-product-id')).toHaveText('phone');
@@ -44,8 +41,7 @@ test.skip('should remove meta tags for different ISR dynamic route values', asyn
   await expect(page.locator('meta[name="baggage"]')).toHaveCount(0);
 });
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('should create unique transactions for ISR pages on each visit', async ({ page }) => {
+test('should create unique transactions for ISR pages on each visit', async ({ page }) => {
   const traceIds: string[] = [];
 
   // Load the same ISR page 5 times to ensure cached HTML meta tags are consistently removed
@@ -75,8 +71,7 @@ test.skip('should create unique transactions for ISR pages on each visit', async
   expect(uniqueTraceIds.size).toBe(5);
 });
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('ISR route should be identified correctly in the route manifest', async ({ page }) => {
+test('ISR route should be identified correctly in the route manifest', async ({ page }) => {
   const transactionPromise = waitForTransaction('nextjs-16-cf-workers', async transactionEvent => {
     return transactionEvent.transaction === '/isr-test/:product' && transactionEvent.contexts?.trace?.op === 'pageload';
   });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/parameterized-routes.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/parameterized-routes.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('should create a parameterized transaction when the `app` directory is used', async ({ page }) => {
+test('should create a parameterized transaction when the `app` directory is used', async ({ page }) => {
   const transactionPromise = waitForTransaction('nextjs-16-cf-workers', async transactionEvent => {
     return (
       transactionEvent.transaction === '/parameterized/:one' && transactionEvent.contexts?.trace?.op === 'pageload'
@@ -41,8 +40,7 @@ test.skip('should create a parameterized transaction when the `app` directory is
   });
 });
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('should create a static transaction when the `app` directory is used and the route is not parameterized', async ({
+test('should create a static transaction when the `app` directory is used and the route is not parameterized', async ({
   page,
 }) => {
   const transactionPromise = waitForTransaction('nextjs-16-cf-workers', async transactionEvent => {
@@ -83,8 +81,7 @@ test.skip('should create a static transaction when the `app` directory is used a
   });
 });
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('should create a partially parameterized transaction when the `app` directory is used', async ({ page }) => {
+test('should create a partially parameterized transaction when the `app` directory is used', async ({ page }) => {
   const transactionPromise = waitForTransaction('nextjs-16-cf-workers', async transactionEvent => {
     return (
       transactionEvent.transaction === '/parameterized/:one/beep' && transactionEvent.contexts?.trace?.op === 'pageload'
@@ -123,8 +120,7 @@ test.skip('should create a partially parameterized transaction when the `app` di
   });
 });
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('should create a nested parameterized transaction when the `app` directory is used.', async ({ page }) => {
+test('should create a nested parameterized transaction when the `app` directory is used.', async ({ page }) => {
   const transactionPromise = waitForTransaction('nextjs-16-cf-workers', async transactionEvent => {
     return (
       transactionEvent.transaction === '/parameterized/:one/beep/:two' &&

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/prefetch-spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/prefetch-spans.test.ts
@@ -2,8 +2,7 @@ import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 import { isDevMode } from './isDevMode';
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('Prefetch client spans should have a http.request.prefetch attribute', async ({ page }) => {
+test('Prefetch client spans should have a http.request.prefetch attribute', async ({ page }) => {
   test.skip(isDevMode, "Prefetch requests don't have the prefetch header in dev mode");
 
   const pageloadTransactionPromise = waitForTransaction('nextjs-16-cf-workers', async transactionEvent => {

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/streaming-rsc-error.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/streaming-rsc-error.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
 
-// TODO(https://github.com/opennextjs/opennextjs-cloudflare/issues/1141): Unskip once opennext supports prefetch-hints.json
-test.skip('Should capture errors for crashing streaming promises in server components when `Sentry.captureRequestError` is added to the `onRequestError` hook', async ({
+test('Should capture errors for crashing streaming promises in server components when `Sentry.captureRequestError` is added to the `onRequestError` hook', async ({
   page,
 }) => {
   const errorEventPromise = waitForError('nextjs-16-cf-workers', errorEvent => {


### PR DESCRIPTION
This was broken and blocked upstream.

closes https://github.com/getsentry/sentry-javascript/issues/19485