### PR TITLE
chore(ci): Do not build AWS lambda layer in build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,18 +38,14 @@ env:
 
   # DEPENDENCY_CACHE_KEY: can't be set here because we don't have access to yarn.lock
 
-  # WARNING: this disables cross os caching as ~ and
-  # github.workspace evaluate to differents paths
-  # packages/utils/cjs and packages/utils/esm: Symlinks to the folders inside of `build`, needed for tests
-  CACHED_BUILD_PATHS: |
+  BUILD_PATHS: |
     ${{ github.workspace }}/dev-packages/*/build
     ${{ github.workspace }}/packages/*/build
     ${{ github.workspace }}/packages/*/lib
     ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/gatsby/*.d.ts
 
-  # Upload/download this directory only (no globs): must match pnpm link .../build/aws/dist-serverless/ in aws-serverless E2E.
-  CACHED_BUILD_LAYER_ARTIFACT_PATH: ${{ github.workspace }}/packages/aws-serverless/build/aws/dist-serverless
+  BUILD_LAYER_PATH: ${{ github.workspace }}/packages/aws-serverless/build/aws/dist-serverless
 
   BUILD_CACHE_TARBALL_KEY: tarball-${{ github.event.inputs.commit || github.sha }}
 
@@ -136,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-output
-          path: ${{ env.CACHED_BUILD_PATHS }}
+          path: ${{ env.BUILD_PATHS }}
           retention-days: 4
           compression-level: 6
           overwrite: true
@@ -197,7 +193,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-layer-output
-          path: ${{ env.CACHED_BUILD_LAYER_ARTIFACT_PATH }}
+          path: ${{ env.BUILD_LAYER_PATH }}
           retention-days: 4
           compression-level: 6
           overwrite: true
@@ -357,7 +353,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: build-layer-output
-          path: ${{ env.CACHED_BUILD_LAYER_ARTIFACT_PATH }}
+          path: ${{ env.BUILD_LAYER_PATH }}
 
       - name: Pack tarballs
         run: yarn build:tarball
@@ -996,7 +992,7 @@ jobs:
         if: matrix.test-application == 'aws-serverless'
         with:
           name: build-layer-output
-          path: ${{ env.CACHED_BUILD_LAYER_ARTIFACT_PATH }}
+          path: ${{ env.BUILD_LAYER_PATH }}
 
       - name: Restore tarball cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,9 @@ env:
     ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/gatsby/*.d.ts
 
+  # Avoid '*' here: upload-artifact flattens paths after the first wildcard (drops the packages/ prefix).
   CACHED_BUILD_LAYER_PATHS: |
-    ${{ github.workspace }}/packages/*/build/aws
+    ${{ github.workspace }}/packages/aws-serverless/build/aws
 
   BUILD_CACHE_TARBALL_KEY: tarball-${{ github.event.inputs.commit || github.sha }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,10 +167,14 @@ jobs:
       changed_browser_integration:
         ${{ needs.job_get_metadata.outputs.changed_ci == 'true' || contains(steps.checkForAffected.outputs.affected,
         '@sentry-internal/browser-integration-tests') }}
+      changed_aws_serverless:
+        ${{ needs.job_get_metadata.outputs.changed_ci == 'true' || contains(steps.checkForAffected.outputs.affected,
+        '@sentry/aws-serverless') }}
 
   job_build_layer:
     name: Build Lambda layer
     needs: [job_get_metadata, job_build]
+    if: needs.job_build.outputs.changed_aws_serverless == 'true' || github.event_name != 'pull_request'
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ env:
     ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/gatsby/*.d.ts
 
+  CACHED_BUILD_LAYER_PATHS: |
+    ${{ github.workspace }}/packages/*/build/aws
+
   BUILD_CACHE_TARBALL_KEY: tarball-${{ github.event.inputs.commit || github.sha }}
 
   # GH will use the first restore-key it finds that matches
@@ -165,8 +168,8 @@ jobs:
         ${{ needs.job_get_metadata.outputs.changed_ci == 'true' || contains(steps.checkForAffected.outputs.affected,
         '@sentry-internal/browser-integration-tests') }}
 
-  job_verify_build_layer:
-    name: Verify Lambda layer build
+  job_build_layer:
+    name: Build Lambda layer
     needs: [job_get_metadata, job_build]
     timeout-minutes: 10
     runs-on: ubuntu-24.04
@@ -185,6 +188,15 @@ jobs:
           dependency_cache_key: ${{ needs.job_build.outputs.dependency_cache_key }}
       - name: Build Lambda layer
         run: yarn build:layer
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-layer-output
+          path: ${{ env.CACHED_BUILD_LAYER_PATHS }}
+          retention-days: 4
+          compression-level: 6
+          overwrite: true
 
   job_check_branches:
     name: Check PR branches
@@ -319,7 +331,7 @@ jobs:
 
   job_artifacts:
     name: Upload Artifacts
-    needs: [job_get_metadata, job_build]
+    needs: [job_get_metadata, job_build, job_build_layer]
     runs-on: ubuntu-24.04
     # Build artifacts are only needed for releasing workflow.
     if: needs.job_get_metadata.outputs.is_release == 'true'
@@ -337,11 +349,13 @@ jobs:
         with:
           dependency_cache_key: ${{ needs.job_build.outputs.dependency_cache_key }}
 
+      - name: Restore build layer artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: build-layer-output
+
       - name: Pack tarballs
         run: yarn build:tarball
-
-      - name: Build Lambda layer
-        run: yarn build:layer
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v7
@@ -926,7 +940,7 @@ jobs:
     # See: https://github.com/actions/runner/issues/2205
     if:
       always() && needs.job_e2e_prepare.result == 'success' && needs.job_e2e_prepare.outputs.matrix != '{"include":[]}'
-    needs: [job_get_metadata, job_build, job_e2e_prepare]
+    needs: [job_get_metadata, job_build, job_build_layer, job_e2e_prepare]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
@@ -971,6 +985,12 @@ jobs:
         uses: ./.github/actions/restore-cache
         with:
           dependency_cache_key: ${{ needs.job_build.outputs.dependency_cache_key }}
+
+      - name: Restore build layer artifacts
+        uses: actions/download-artifact@v7
+        if: matrix.test-application == 'aws-serverless'
+        with:
+          name: build-layer-output
 
       - name: Restore tarball cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1178,7 +1178,7 @@ jobs:
         job_check_lockfile,
         job_check_format,
         job_circular_dep_check,
-        job_verify_build_layer,
+        job_build_layer,
         job_size_check,
       ]
     # Always run this, even if a dependent job failed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,8 @@ env:
     ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/gatsby/*.d.ts
 
-  # Avoid '*' here: upload-artifact flattens paths after the first wildcard (drops the packages/ prefix).
-  CACHED_BUILD_LAYER_PATHS: |
-    ${{ github.workspace }}/packages/aws-serverless/build/aws
+  # Upload/download this directory only (no globs): must match pnpm link .../build/aws/dist-serverless/ in aws-serverless E2E.
+  CACHED_BUILD_LAYER_ARTIFACT_PATH: ${{ github.workspace }}/packages/aws-serverless/build/aws/dist-serverless
 
   BUILD_CACHE_TARBALL_KEY: tarball-${{ github.event.inputs.commit || github.sha }}
 
@@ -198,7 +197,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-layer-output
-          path: ${{ env.CACHED_BUILD_LAYER_PATHS }}
+          path: ${{ env.CACHED_BUILD_LAYER_ARTIFACT_PATH }}
           retention-days: 4
           compression-level: 6
           overwrite: true
@@ -358,6 +357,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: build-layer-output
+          path: ${{ env.CACHED_BUILD_LAYER_ARTIFACT_PATH }}
 
       - name: Pack tarballs
         run: yarn build:tarball
@@ -996,6 +996,7 @@ jobs:
         if: matrix.test-application == 'aws-serverless'
         with:
           name: build-layer-output
+          path: ${{ env.CACHED_BUILD_LAYER_ARTIFACT_PATH }}
 
       - name: Restore tarball cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,27 @@ jobs:
         ${{ needs.job_get_metadata.outputs.changed_ci == 'true' || contains(steps.checkForAffected.outputs.affected,
         '@sentry-internal/browser-integration-tests') }}
 
+  job_verify_build_layer:
+    name: Verify Lambda layer build
+    needs: [job_get_metadata, job_build]
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.HEAD_COMMIT }}
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: 'package.json'
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        with:
+          dependency_cache_key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Build Lambda layer
+        run: yarn build:layer
+
   job_check_branches:
     name: Check PR branches
     needs: job_get_metadata
@@ -318,6 +339,9 @@ jobs:
 
       - name: Pack tarballs
         run: yarn build:tarball
+
+      - name: Build Lambda layer
+        run: yarn build:layer
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v7
@@ -1134,6 +1158,7 @@ jobs:
         job_check_lockfile,
         job_check_format,
         job_circular_dep_check,
+        job_verify_build_layer,
         job_size_check,
       ]
     # Always run this, even if a dependent job failed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,6 @@ env:
   BUILD_PATHS: |
     ${{ github.workspace }}/dev-packages/*/build
     ${{ github.workspace }}/packages/*/build
-    ${{ github.workspace }}/packages/*/lib
-    ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/gatsby/*.d.ts
 
   BUILD_LAYER_PATH: ${{ github.workspace }}/packages/aws-serverless/build/aws/dist-serverless

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "private": true,
   "scripts": {
-    "build": "node ./scripts/verify-packages-versions.js && nx run-many -t build:transpile build:types build:bundle build:layer",
+    "build": "node ./scripts/verify-packages-versions.js && nx run-many -t build:transpile build:types build:bundle",
     "build:bundle": "nx run-many -t build:bundle",
+    "build:layer": "nx run-many -t build:layer",
     "build:dev": "nx run-many -t build:types build:transpile",
     "build:dev:filter": "nx run-many -t build:dev -p",
     "build:transpile": "nx run-many -t build:transpile",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "node ./scripts/verify-packages-versions.js && nx run-many -t build:transpile build:types build:bundle",
+    "build": "node ./scripts/verify-packages-versions.js && nx run-many -t build:transpile build:types build:bundle build:extension",
     "build:bundle": "nx run-many -t build:bundle",
     "build:layer": "nx run-many -t build:layer",
     "build:dev": "nx run-many -t build:types build:transpile",

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -83,7 +83,7 @@
     "build": "run-p build:transpile build:types build:extension",
     "build:extension": "rollup -c rollup.lambda-extension.config.mjs && yarn ts-node scripts/buildLambdaExtension.ts",
     "build:layer": "rimraf build/aws && yarn ts-node scripts/buildLambdaLayer.ts",
-    "build:dev": "run-p build:transpile build:types build:extension",
+    "build:dev": "run-p build:transpile build:types",
     "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "run-s build:types:core build:types:downlevel",
     "build:types:core": "tsc -p tsconfig.types.json",

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -145,6 +145,23 @@
           "{projectRoot}/build/aws"
         ],
         "cache": true
+      },
+      "build:tarball": {
+        "inputs": [
+          "production",
+          "^production"
+        ],
+        "dependsOn": [
+          "build:transpile",
+          "^build:transpile",
+          "build:types",
+          "^build:types",
+          "build:extension"
+        ],
+        "outputs": [
+          "{projectRoot}/*.tgz"
+        ],
+        "cache": true
       }
     }
   }

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -80,9 +80,9 @@
     "@vercel/nft": "^1.3.0"
   },
   "scripts": {
-    "build": "run-p build:transpile build:types build:extension && run-s build:layer",
+    "build": "run-p build:transpile build:types",
     "build:extension": "rollup -c rollup.lambda-extension.config.mjs && yarn ts-node scripts/buildLambdaExtension.ts",
-    "build:layer": "rimraf build/aws && yarn ts-node scripts/buildLambdaLayer.ts",
+    "build:layer": "rimraf build/aws && yarn build:extension && yarn ts-node scripts/buildLambdaLayer.ts",
     "build:dev": "run-p build:transpile build:types",
     "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "run-s build:types:core build:types:downlevel",

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -80,10 +80,10 @@
     "@vercel/nft": "^1.3.0"
   },
   "scripts": {
-    "build": "run-p build:transpile build:types",
+    "build": "run-p build:transpile build:types build:extension",
     "build:extension": "rollup -c rollup.lambda-extension.config.mjs && yarn ts-node scripts/buildLambdaExtension.ts",
-    "build:layer": "rimraf build/aws && yarn build:extension && yarn ts-node scripts/buildLambdaLayer.ts",
-    "build:dev": "run-p build:transpile build:types",
+    "build:layer": "rimraf build/aws && yarn ts-node scripts/buildLambdaLayer.ts",
+    "build:dev": "run-p build:transpile build:types build:extension",
     "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "run-s build:types:core build:types:downlevel",
     "build:types:core": "tsc -p tsconfig.types.json",

--- a/packages/aws-serverless/scripts/buildLambdaLayer.ts
+++ b/packages/aws-serverless/scripts/buildLambdaLayer.ts
@@ -2,7 +2,6 @@
 import { nodeFileTrace } from '@vercel/nft';
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { version } from '../package.json';
 
@@ -22,21 +21,14 @@ function run(cmd: string, options?: childProcess.ExecSyncOptions): string {
  */
 async function buildLambdaLayer(): Promise<void> {
   console.log('Building Lambda layer.');
-  buildPackageJson();
-  console.log('Installing local @sentry/aws-serverless into build/aws/dist-serverless/nodejs.');
-  // Use a temporary cache folder to avoid stale cache references to local file: packages.
-  // Yarn's global cache can contain outdated references to build artifacts from other
-  // @sentry/* packages (e.g., build/node_modules paths that no longer exist), causing
-  // ENOENT errors during file copying.
-  // The cache folder must be outside the monorepo to avoid recursive nesting when Yarn
-  // follows file: links and copies package directories.
-  const cacheFolder = path.join(os.tmpdir(), `sentry-lambda-build-cache-${Date.now()}`);
-  run(`yarn install --prod --cwd ./build/aws/dist-serverless/nodejs --cache-folder "${cacheFolder}"`);
+  const tarballDir = buildTarballsAndPackageJson();
+  console.log('Installing @sentry/aws-serverless from tarballs into build/aws/dist-serverless/nodejs.');
+  run('yarn install --prod --cwd ./build/aws/dist-serverless/nodejs');
 
   await pruneNodeModules();
   fs.rmSync('./build/aws/dist-serverless/nodejs/package.json', { force: true });
   fs.rmSync('./build/aws/dist-serverless/nodejs/yarn.lock', { force: true });
-  fs.rmSync(cacheFolder, { recursive: true, force: true });
+  fs.rmSync(tarballDir, { recursive: true, force: true });
 
   // The layer also includes `awslambda-auto.js`, a helper file which calls `Sentry.init()` and wraps the lambda
   // handler. It gets run when Node is launched inside the lambda, using the environment variable
@@ -170,43 +162,90 @@ function getAllFiles(dir: string): string[] {
   return files;
 }
 
-function buildPackageJson(): void {
-  console.log('Building package.json');
+/**
+ * Pack @sentry/* packages into tarballs and generate a package.json that references them.
+ *
+ * Using tarballs instead of `file:` directory references avoids stale yarn cache issues
+ * (where yarn's global cache retains outdated build artifact paths from previous builds)
+ * and allows us to use yarn's global cache for faster installs.
+ *
+ * Only packs packages that are transitive dependencies of @sentry/aws-serverless to keep
+ * the packing step fast.
+ */
+function buildTarballsAndPackageJson(): string {
+  const tarballDir = path.resolve('./build/aws/tarballs');
+  fsForceMkdirSync(tarballDir);
+
   const packagesDir = path.resolve(__dirname, '../..');
-  const packageDirs = fs
-    .readdirSync(packagesDir, { withFileTypes: true })
-    .filter(dirent => dirent.isDirectory())
-    .map(dirent => dirent.name)
-    .filter(name => !name.startsWith('.')) // Skip hidden directories
-    .sort();
+  const sentryPackages = collectSentryDependencies(packagesDir);
+
+  console.log(`Packing ${sentryPackages.size} @sentry/* packages into tarballs.`);
 
   const resolutions: Record<string, string> = {};
 
-  for (const packageDir of packageDirs) {
-    const packageJsonPath = path.join(packagesDir, packageDir, 'package.json');
-    if (fs.existsSync(packageJsonPath)) {
-      try {
-        const packageContent = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as { name?: string };
-        const packageName = packageContent.name;
-        if (typeof packageName === 'string' && packageName) {
-          resolutions[packageName] = `file:../../../../../../packages/${packageDir}`;
-        }
-      } catch {
-        console.warn(`Warning: Could not read package.json for ${packageDir}`);
-      }
-    }
+  for (const [packageName, packageDir] of sentryPackages) {
+    run(`npm pack --pack-destination "${tarballDir}"`, {
+      cwd: path.join(packagesDir, packageDir),
+      stdio: 'pipe',
+    });
+    const tarballName = `${packageName.replace('@', '').replace('/', '-')}-${version}.tgz`;
+    resolutions[packageName] = `file:${path.join(tarballDir, tarballName)}`;
+  }
+
+  const awsServerlessTarball = resolutions['@sentry/aws-serverless'];
+  if (!awsServerlessTarball) {
+    throw new Error('Failed to pack @sentry/aws-serverless');
   }
 
   const packageJson = {
     dependencies: {
-      '@sentry/aws-serverless': 'file:../../../../../../packages/aws-serverless',
+      '@sentry/aws-serverless': awsServerlessTarball,
     },
     resolutions,
   };
 
   fsForceMkdirSync('./build/aws/dist-serverless/nodejs');
-  const packageJsonPath = './build/aws/dist-serverless/nodejs/package.json';
-  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  fs.writeFileSync('./build/aws/dist-serverless/nodejs/package.json', JSON.stringify(packageJson, null, 2));
+
+  return tarballDir;
+}
+
+/**
+ * Collect all @sentry/* and @sentry-internal/* packages that are transitive
+ * dependencies of @sentry/aws-serverless.
+ * Returns a Map of packageName -> directory name.
+ */
+function collectSentryDependencies(packagesDir: string): Map<string, string> {
+  const result = new Map<string, string>();
+
+  // Build a lookup of package name -> directory name
+  const nameToDir = new Map<string, string>();
+  for (const dirent of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!dirent.isDirectory() || dirent.name.startsWith('.')) continue;
+    const pkgPath = path.join(packagesDir, dirent.name, 'package.json');
+    if (!fs.existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { name?: string };
+    if (pkg.name) {
+      nameToDir.set(pkg.name, dirent.name);
+    }
+  }
+
+  function collect(packageName: string): void {
+    if (result.has(packageName)) return;
+    const dir = nameToDir.get(packageName);
+    if (!dir) return;
+    result.set(packageName, dir);
+    const pkgPath = path.join(packagesDir, dir, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { dependencies?: Record<string, string> };
+    for (const dep of Object.keys(pkg.dependencies || {})) {
+      if (dep.startsWith('@sentry/') || dep.startsWith('@sentry-internal/')) {
+        collect(dep);
+      }
+    }
+  }
+
+  collect('@sentry/aws-serverless');
+  return result;
 }
 
 function replaceSDKSource(): void {

--- a/packages/aws-serverless/scripts/buildLambdaLayer.ts
+++ b/packages/aws-serverless/scripts/buildLambdaLayer.ts
@@ -2,6 +2,7 @@
 import { nodeFileTrace } from '@vercel/nft';
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { version } from '../package.json';
 
@@ -21,14 +22,21 @@ function run(cmd: string, options?: childProcess.ExecSyncOptions): string {
  */
 async function buildLambdaLayer(): Promise<void> {
   console.log('Building Lambda layer.');
-  const tarballDir = buildTarballsAndPackageJson();
-  console.log('Installing @sentry/aws-serverless from tarballs into build/aws/dist-serverless/nodejs.');
-  run('yarn install --prod --cwd ./build/aws/dist-serverless/nodejs');
+  buildPackageJson();
+  console.log('Installing local @sentry/aws-serverless into build/aws/dist-serverless/nodejs.');
+  // Use a temporary cache folder to avoid stale cache references to local file: packages.
+  // Yarn's global cache can contain outdated references to build artifacts from other
+  // @sentry/* packages (e.g., build/node_modules paths that no longer exist), causing
+  // ENOENT errors during file copying.
+  // The cache folder must be outside the monorepo to avoid recursive nesting when Yarn
+  // follows file: links and copies package directories.
+  const cacheFolder = path.join(os.tmpdir(), `sentry-lambda-build-cache-${Date.now()}`);
+  run(`yarn install --prod --cwd ./build/aws/dist-serverless/nodejs --cache-folder "${cacheFolder}"`);
 
   await pruneNodeModules();
   fs.rmSync('./build/aws/dist-serverless/nodejs/package.json', { force: true });
   fs.rmSync('./build/aws/dist-serverless/nodejs/yarn.lock', { force: true });
-  fs.rmSync(tarballDir, { recursive: true, force: true });
+  fs.rmSync(cacheFolder, { recursive: true, force: true });
 
   // The layer also includes `awslambda-auto.js`, a helper file which calls `Sentry.init()` and wraps the lambda
   // handler. It gets run when Node is launched inside the lambda, using the environment variable
@@ -162,90 +170,43 @@ function getAllFiles(dir: string): string[] {
   return files;
 }
 
-/**
- * Pack @sentry/* packages into tarballs and generate a package.json that references them.
- *
- * Using tarballs instead of `file:` directory references avoids stale yarn cache issues
- * (where yarn's global cache retains outdated build artifact paths from previous builds)
- * and allows us to use yarn's global cache for faster installs.
- *
- * Only packs packages that are transitive dependencies of @sentry/aws-serverless to keep
- * the packing step fast.
- */
-function buildTarballsAndPackageJson(): string {
-  const tarballDir = path.resolve('./build/aws/tarballs');
-  fsForceMkdirSync(tarballDir);
-
+function buildPackageJson(): void {
+  console.log('Building package.json');
   const packagesDir = path.resolve(__dirname, '../..');
-  const sentryPackages = collectSentryDependencies(packagesDir);
-
-  console.log(`Packing ${sentryPackages.size} @sentry/* packages into tarballs.`);
+  const packageDirs = fs
+    .readdirSync(packagesDir, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name)
+    .filter(name => !name.startsWith('.')) // Skip hidden directories
+    .sort();
 
   const resolutions: Record<string, string> = {};
 
-  for (const [packageName, packageDir] of sentryPackages) {
-    run(`npm pack --pack-destination "${tarballDir}"`, {
-      cwd: path.join(packagesDir, packageDir),
-      stdio: 'pipe',
-    });
-    const tarballName = `${packageName.replace('@', '').replace('/', '-')}-${version}.tgz`;
-    resolutions[packageName] = `file:${path.join(tarballDir, tarballName)}`;
-  }
-
-  const awsServerlessTarball = resolutions['@sentry/aws-serverless'];
-  if (!awsServerlessTarball) {
-    throw new Error('Failed to pack @sentry/aws-serverless');
+  for (const packageDir of packageDirs) {
+    const packageJsonPath = path.join(packagesDir, packageDir, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      try {
+        const packageContent = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as { name?: string };
+        const packageName = packageContent.name;
+        if (typeof packageName === 'string' && packageName) {
+          resolutions[packageName] = `file:../../../../../../packages/${packageDir}`;
+        }
+      } catch {
+        console.warn(`Warning: Could not read package.json for ${packageDir}`);
+      }
+    }
   }
 
   const packageJson = {
     dependencies: {
-      '@sentry/aws-serverless': awsServerlessTarball,
+      '@sentry/aws-serverless': 'file:../../../../../../packages/aws-serverless',
     },
     resolutions,
   };
 
   fsForceMkdirSync('./build/aws/dist-serverless/nodejs');
-  fs.writeFileSync('./build/aws/dist-serverless/nodejs/package.json', JSON.stringify(packageJson, null, 2));
-
-  return tarballDir;
-}
-
-/**
- * Collect all @sentry/* and @sentry-internal/* packages that are transitive
- * dependencies of @sentry/aws-serverless.
- * Returns a Map of packageName -> directory name.
- */
-function collectSentryDependencies(packagesDir: string): Map<string, string> {
-  const result = new Map<string, string>();
-
-  // Build a lookup of package name -> directory name
-  const nameToDir = new Map<string, string>();
-  for (const dirent of fs.readdirSync(packagesDir, { withFileTypes: true })) {
-    if (!dirent.isDirectory() || dirent.name.startsWith('.')) continue;
-    const pkgPath = path.join(packagesDir, dirent.name, 'package.json');
-    if (!fs.existsSync(pkgPath)) continue;
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { name?: string };
-    if (pkg.name) {
-      nameToDir.set(pkg.name, dirent.name);
-    }
-  }
-
-  function collect(packageName: string): void {
-    if (result.has(packageName)) return;
-    const dir = nameToDir.get(packageName);
-    if (!dir) return;
-    result.set(packageName, dir);
-    const pkgPath = path.join(packagesDir, dir, 'package.json');
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { dependencies?: Record<string, string> };
-    for (const dep of Object.keys(pkg.dependencies || {})) {
-      if (dep.startsWith('@sentry/') || dep.startsWith('@sentry-internal/')) {
-        collect(dep);
-      }
-    }
-  }
-
-  collect('@sentry/aws-serverless');
-  return result;
+  const packageJsonPath = './build/aws/dist-serverless/nodejs/package.json';
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
 }
 
 function replaceSDKSource(): void {


### PR DESCRIPTION
To slightly improve build times, I figured we can actually skip building the AWS lambda layer all the time in our `build` step, as, AFAIK, we don't really need this for any tests etc. Instead, we only need this when uploading artifacts for publishing, so I moved this into that step. To ensure we do not accidentally regress this, I also added a standalone job that can run in parallel that verifies that building this still works.