### PR TITLE
chore: prevent test from creating zombie process

### DIFF
--- a/dev-packages/node-integration-tests/suites/vercel/sigterm-flush/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/vercel/sigterm-flush/scenario.ts
@@ -33,4 +33,7 @@ Sentry.captureMessage('SIGTERM flush message');
 console.log('READY');
 
 // Keep the process alive so the integration test can send SIGTERM.
-setInterval(() => undefined, 1_000);
+const interval = setInterval(() => undefined, 10_000);
+
+// allow graceful exit once the SIGTERM arrives.
+process.once('SIGTERM', () => clearInterval(interval));


### PR DESCRIPTION
An interval is set to keep the scenario file running in the vercel/sigterm-flush integration test.

Ensure that the interval is cleared once the SIGTERM signal arrives, so that the scenario process can exit normally.
