### PR TITLE
feat(core): Export `spanStreamingIntegration` from CDN bundles

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -276,7 +276,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: false,
     brotli: false,
-    limit: '255 KB',
+    limit: '255.5 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Logs, Metrics) - uncompressed',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -191,7 +191,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing)',
     path: createCDNPath('bundle.tracing.min.js'),
     gzip: true,
-    limit: '45 KB',
+    limit: '46.5 KB',
   },
   {
     name: 'CDN Bundle (incl. Logs, Metrics)',
@@ -203,7 +203,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Logs, Metrics)',
     path: createCDNPath('bundle.tracing.logs.metrics.min.js'),
     gzip: true,
-    limit: '47 KB',
+    limit: '47.5 KB',
   },
   {
     name: 'CDN Bundle (incl. Replay, Logs, Metrics)',
@@ -215,25 +215,25 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Replay)',
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: true,
-    limit: '82 KB',
+    limit: '83.5 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Logs, Metrics)',
     path: createCDNPath('bundle.tracing.replay.logs.metrics.min.js'),
     gzip: true,
-    limit: '83 KB',
+    limit: '84.5 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback)',
     path: createCDNPath('bundle.tracing.replay.feedback.min.js'),
     gzip: true,
-    limit: '88 KB',
+    limit: '89 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback, Logs, Metrics)',
     path: createCDNPath('bundle.tracing.replay.feedback.logs.metrics.min.js'),
     gzip: true,
-    limit: '89 KB',
+    limit: '90 KB',
   },
   // browser CDN bundles (non-gzipped)
   {
@@ -248,7 +248,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.min.js'),
     gzip: false,
     brotli: false,
-    limit: '135 KB',
+    limit: '138 KB',
   },
   {
     name: 'CDN Bundle (incl. Logs, Metrics) - uncompressed',
@@ -262,7 +262,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '138 KB',
+    limit: '141.5 KB',
   },
   {
     name: 'CDN Bundle (incl. Replay, Logs, Metrics) - uncompressed',
@@ -276,28 +276,28 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: false,
     brotli: false,
-    limit: '252 KB',
+    limit: '255 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Logs, Metrics) - uncompressed',
     path: createCDNPath('bundle.tracing.replay.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '255 KB',
+    limit: '258.5 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback) - uncompressed',
     path: createCDNPath('bundle.tracing.replay.feedback.min.js'),
     gzip: false,
     brotli: false,
-    limit: '265 KB',
+    limit: '268 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback, Logs, Metrics) - uncompressed',
     path: createCDNPath('bundle.tracing.replay.feedback.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '268 KB',
+    limit: '271.5 KB',
   },
   // Next.js SDK (ESM)
   {

--- a/dev-packages/browser-integration-tests/suites/integrations/cultureContext-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/cultureContext-streamed/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { getSpanOp, waitForStreamedSpans } from '../../../utils/spanUtils';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../utils/helpers';
 
 sentryTest('cultureContextIntegration captures locale, timezone, and calendar', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const spansPromise = waitForStreamedSpans(page, spans => spans.some(s => getSpanOp(s) === 'pageload'));

--- a/dev-packages/browser-integration-tests/suites/public-api/beforeSendSpan-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/beforeSendSpan-streamed/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../utils/spanUtils';
 
 sentryTest('beforeSendSpan applies changes to streamed span', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
@@ -11,13 +11,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { waitForStreamedSpanEnvelope } from '../../../../utils/spanUtils';
 
 sentryTest(
   'sends a streamed span envelope if spanStreamingIntegration is enabled',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const spanEnvelopePromise = waitForStreamedSpanEnvelope(page);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-pageload-streamed/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../utils/spanUtils';
 
 sentryTest('finishes streamed pageload span when the page goes background', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
   const url = await getLocalTestUrl({ testDir: __dirname });
   const pageloadSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'pageload');
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings-streamed/test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
@@ -8,7 +8,7 @@ sentryTest(
   async ({ browserName, getLocalTestUrl, page }) => {
     const supportedBrowsers = ['chromium', 'firefox'];
 
-    sentryTest.skip(shouldSkipTracingTest() || !supportedBrowsers.includes(browserName) || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest() || !supportedBrowsers.includes(browserName));
 
     await page.route('http://sentry-test-site.example/*', async route => {
       const request = route.request();

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
@@ -99,7 +99,7 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
   });
 
   const loAFSpans = interactionSpanTree.filter(span => getSpanOp(span)?.startsWith('ui.long-animation-frame'));
-  expect(loAFSpans).toHaveLength(1);
+  expect(loAFSpans).toHaveLength(browserName === 'chromium' ? 1 : 0);
 
   const interactionSpan = interactionSpanTree.find(span => getSpanOp(span) === 'ui.interaction.click');
   expect(interactionSpan).toEqual({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
@@ -11,13 +11,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest('captures streamed interaction span tree. @firefox', async ({ browserName, getLocalTestUrl, page }) => {
   const supportedBrowsers = ['chromium', 'firefox'];
 
-  sentryTest.skip(shouldSkipTracingTest() || !supportedBrowsers.includes(browserName) || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest() || !supportedBrowsers.includes(browserName));
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const interactionSpansPromise = waitForStreamedSpans(page, spans =>

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/default/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/default/test.ts
@@ -1,12 +1,12 @@
 import { expect } from '@playwright/test';
 import { extractTraceparentData, parseBaggageHeader, SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE } from '@sentry/core';
 import { sentryTest } from '../../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle, waitForTracingHeadersOnUrl } from '../../../../../../utils/helpers';
+import { shouldSkipTracingTest, waitForTracingHeadersOnUrl } from '../../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpanEnvelope } from '../../../../../../utils/spanUtils';
 
 sentryTest.describe('When `consistentTraceSampling` is `true`', () => {
   sentryTest('continues sampling decision from initial pageload span', async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -80,7 +80,7 @@ sentryTest.describe('When `consistentTraceSampling` is `true`', () => {
   });
 
   sentryTest('Propagates continued sampling decision to outgoing requests', async ({ page, getLocalTestUrl }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/meta-negative/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/meta-negative/test.ts
@@ -7,7 +7,6 @@ import {
   envelopeRequestParser,
   hidePage,
   shouldSkipTracingTest,
-  testingCdnBundle,
   waitForClientReportRequest,
   waitForTracingHeadersOnUrl,
 } from '../../../../../../utils/helpers';
@@ -21,7 +20,7 @@ sentryTest.describe('When `consistentTraceSampling` is `true` and page contains 
   sentryTest(
     'Continues negative sampling decision from meta tag across all traces and downstream propagations',
     async ({ getLocalTestUrl, page }) => {
-      sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+      sentryTest.skip(shouldSkipTracingTest());
 
       const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/meta-precedence/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/meta-precedence/test.ts
@@ -6,7 +6,6 @@ import {
   envelopeRequestParser,
   hidePage,
   shouldSkipTracingTest,
-  testingCdnBundle,
   waitForClientReportRequest,
   waitForTracingHeadersOnUrl,
 } from '../../../../../../utils/helpers';
@@ -21,7 +20,7 @@ sentryTest.describe('When `consistentTraceSampling` is `true` and page contains 
   sentryTest(
     'meta tag decision has precedence over sampling decision from previous trace in session storage',
     async ({ getLocalTestUrl, page }) => {
-      sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+      sentryTest.skip(shouldSkipTracingTest());
 
       const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/meta/test.ts
@@ -5,7 +5,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_PREVIOUS_TRACE_SAMPLE_RATE,
 } from '@sentry/core';
 import { sentryTest } from '../../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle, waitForTracingHeadersOnUrl } from '../../../../../../utils/helpers';
+import { shouldSkipTracingTest, waitForTracingHeadersOnUrl } from '../../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpanEnvelope } from '../../../../../../utils/spanUtils';
 
 const metaTagSampleRand = 0.051121;
@@ -13,7 +13,7 @@ const metaTagSampleRate = 0.2;
 
 sentryTest.describe('When `consistentTraceSampling` is `true` and page contains <meta> tags', () => {
   sentryTest('Continues sampling decision across all traces from meta tag', async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -96,7 +96,7 @@ sentryTest.describe('When `consistentTraceSampling` is `true` and page contains 
   sentryTest(
     'Propagates continued <meta> tag sampling decision to outgoing requests',
     async ({ page, getLocalTestUrl }) => {
-      sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+      sentryTest.skip(shouldSkipTracingTest());
 
       const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/tracesSampler-precedence/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/tracesSampler-precedence/test.ts
@@ -7,7 +7,6 @@ import {
   envelopeRequestParser,
   hidePage,
   shouldSkipTracingTest,
-  testingCdnBundle,
   waitForClientReportRequest,
 } from '../../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpanEnvelope } from '../../../../../../utils/spanUtils';
@@ -19,7 +18,7 @@ import { getSpanOp, waitForStreamedSpanEnvelope } from '../../../../../../utils/
  */
 sentryTest.describe('When `consistentTraceSampling` is `true`', () => {
   sentryTest('explicit sampling decisions in `tracesSampler` have precedence', async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/custom-trace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/custom-trace/test.ts
@@ -1,11 +1,11 @@
 import { expect } from '@playwright/test';
 import { SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 sentryTest('manually started custom traces are linked correctly in the chain', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/default/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/default/test.ts
@@ -1,11 +1,11 @@
 import { expect } from '@playwright/test';
 import { SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 sentryTest("navigation spans link back to previous trace's root span", async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -71,7 +71,7 @@ sentryTest("navigation spans link back to previous trace's root span", async ({ 
 });
 
 sentryTest("doesn't link between hard page reloads by default", async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/interaction-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/interaction-spans/test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 /*
@@ -13,7 +13,7 @@ import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 sentryTest(
   'only the first root spans in the trace link back to the previous trace',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/meta/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/meta/test.ts
@@ -1,13 +1,13 @@
 import { expect } from '@playwright/test';
 import { SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 sentryTest(
   "links back to previous trace's local root span if continued from meta tags",
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/negatively-sampled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/negatively-sampled/test.ts
@@ -1,11 +1,11 @@
 import { expect } from '@playwright/test';
 import { SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 sentryTest('includes a span link to a previously negatively sampled span', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/session-storage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/session-storage/test.ts
@@ -1,11 +1,11 @@
 import { expect } from '@playwright/test';
 import { SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 sentryTest('adds link between hard page reloads when opting into sessionStorage', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation-streamed/test.ts
@@ -1,13 +1,13 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
   "doesn't capture long animation frame that starts before a navigation.",
   async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
-    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled-streamed/test.ts
@@ -1,14 +1,14 @@
 import type { Route } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
   'does not capture long animation frame when flag is disabled.',
   async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
-    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
 
     await page.route('**/path/to/script.js', (route: Route) =>
       route.fulfill({ path: `${__dirname}/assets/script.js` }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled-streamed/test.ts
@@ -3,14 +3,14 @@ import { expect } from '@playwright/test';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/browser';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
   'captures long animation frame span for top-level script.',
   async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
-    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
 
     await page.route('**/path/to/script.js', (route: Route) =>
       route.fulfill({ path: `${__dirname}/assets/script.js` }),
@@ -62,7 +62,7 @@ sentryTest(
 
 sentryTest('captures long animation frame span for event listener.', async ({ browserName, getLocalTestUrl, page }) => {
   // Long animation frames only work on chrome
-  sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
 
   await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled-streamed/test.ts
@@ -3,14 +3,14 @@ import { expect } from '@playwright/test';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/browser';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
   'captures long animation frame span for top-level script.',
   async ({ browserName, getLocalTestUrl, page }) => {
     // Long animation frames only work on chrome
-    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
 
     // Long animation frame should take priority over long tasks
 
@@ -64,7 +64,7 @@ sentryTest(
 
 sentryTest('captures long animation frame span for event listener.', async ({ browserName, getLocalTestUrl, page }) => {
   // Long animation frames only work on chrome
-  sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
 
   await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation-streamed/test.ts
@@ -1,13 +1,13 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
   "doesn't capture long task spans starting before a navigation in the navigation transaction",
   async ({ browserName, getLocalTestUrl, page }) => {
     // Long tasks only work on chrome
-    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
     const url = await getLocalTestUrl({ testDir: __dirname });
 
     await page.route('**/path/to/script.js', route => route.fulfill({ path: `${__dirname}/assets/script.js` }));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled-streamed/test.ts
@@ -1,12 +1,12 @@
 import type { Route } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest("doesn't capture long task spans when flag is disabled.", async ({ browserName, getLocalTestUrl, page }) => {
   // Long tasks only work on chrome
-  sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
 
   await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled-streamed/test.ts
@@ -1,12 +1,12 @@
 import type { Route } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest('captures long task.', async ({ browserName, getLocalTestUrl, page }) => {
   // Long tasks only work on chrome
-  sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium' || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest() || browserName !== 'chromium');
 
   await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -15,7 +15,7 @@ import {
   waitForStreamedSpanEnvelope,
 } from '../../../../utils/spanUtils';
 
-sentryTest('starts a streamed navigation span on page navigation', async ({ getLocalTestUrl, page }) => {
+sentryTest('starts a streamed navigation span on page navigation', async ({ browserName, getLocalTestUrl, page }) => {
   sentryTest.skip(shouldSkipTracingTest());
 
   const pageloadSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'pageload');
@@ -81,18 +81,20 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ getL
         type: 'string',
         value: expect.any(String),
       },
-      'network.connection.effective_type': {
-        type: 'string',
-        value: expect.any(String),
-      },
       'device.processor_count': {
         type: expect.stringMatching(/^(integer)|(double)$/),
         value: expect.any(Number),
       },
-      'network.connection.rtt': {
-        type: expect.stringMatching(/^(integer)|(double)$/),
-        value: expect.any(Number),
-      },
+      ...(browserName !== 'webkit' && {
+        'network.connection.effective_type': {
+          type: 'string',
+          value: expect.any(String),
+        },
+        'network.connection.rtt': {
+          type: expect.stringMatching(/^(integer)|(double)$/),
+          value: expect.any(Number),
+        },
+      }),
       'sentry.idle_span_finish_reason': {
         type: 'string',
         value: 'idleTimeout',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -7,7 +7,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import {
   getSpanOp,
   getSpansFromEnvelope,
@@ -16,7 +16,7 @@ import {
 } from '../../../../utils/spanUtils';
 
 sentryTest('starts a streamed navigation span on page navigation', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const pageloadSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'pageload');
   const navigationSpanEnvelopePromise = waitForStreamedSpanEnvelope(
@@ -162,7 +162,7 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ getL
 });
 
 sentryTest('handles pushState with full URL', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -11,13 +11,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, getSpansFromEnvelope, waitForStreamedSpanEnvelope } from '../../../../utils/spanUtils';
 
 sentryTest(
   'creates a pageload streamed span envelope with url as pageload span name source',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const spanEnvelopePromise = waitForStreamedSpanEnvelope(
       page,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -16,7 +16,7 @@ import { getSpanOp, getSpansFromEnvelope, waitForStreamedSpanEnvelope } from '..
 
 sentryTest(
   'creates a pageload streamed span envelope with url as pageload span name source',
-  async ({ getLocalTestUrl, page }) => {
+  async ({ browserName, getLocalTestUrl, page }) => {
     sentryTest.skip(shouldSkipTracingTest());
 
     const spanEnvelopePromise = waitForStreamedSpanEnvelope(
@@ -74,11 +74,6 @@ sentryTest(
           type: 'string',
           value: expect.any(String),
         },
-        // formerly known as 'effectiveConnectionType'
-        'network.connection.effective_type': {
-          type: 'string',
-          value: expect.any(String),
-        },
         // formerly known as 'hardwareConcurrency'
         'device.processor_count': {
           type: expect.stringMatching(/^(integer)|(double)$/),
@@ -92,18 +87,25 @@ sentryTest(
           type: expect.stringMatching(/^(integer)|(double)$/),
           value: expect.any(Number),
         },
-        'network.connection.rtt': {
-          type: expect.stringMatching(/^(integer)|(double)$/),
-          value: expect.any(Number),
-        },
         'browser.web_vital.ttfb.request_time': {
           type: expect.stringMatching(/^(integer)|(double)$/),
           value: expect.any(Number),
         },
-        'browser.web_vital.ttfb.value': {
-          type: expect.stringMatching(/^(integer)|(double)$/),
-          value: expect.any(Number),
-        },
+        ...(browserName !== 'webkit' && {
+          // formerly known as 'effectiveConnectionType'
+          'network.connection.effective_type': {
+            type: 'string',
+            value: expect.any(String),
+          },
+          'network.connection.rtt': {
+            type: expect.stringMatching(/^(integer)|(double)$/),
+            value: expect.any(Number),
+          },
+          'browser.web_vital.ttfb.value': {
+            type: expect.stringMatching(/^(integer)|(double)$/),
+            value: expect.any(Number),
+          },
+        }),
         'sentry.idle_span_finish_reason': {
           type: 'string',
           value: 'idleTimeout',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded-streamed/default/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded-streamed/default/test.ts
@@ -7,13 +7,13 @@ import {
 } from '@sentry/browser';
 import { SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 sentryTest(
   'waits for Sentry.reportPageLoaded() to be called when `enableReportPageLoaded` is true',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded-streamed/finalTimeout/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded-streamed/finalTimeout/test.ts
@@ -6,13 +6,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/browser';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 sentryTest(
   'final timeout cancels the pageload span even if `enableReportPageLoaded` is true',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded-streamed/navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded-streamed/navigation/test.ts
@@ -6,13 +6,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/browser';
 import { sentryTest } from '../../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../../utils/spanUtils';
 
 sentryTest(
   'starting a navigation span cancels the pageload span even if `enableReportPageLoaded` is true',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans-streamed/child/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans-streamed/child/test.ts
@@ -4,14 +4,13 @@ import {
   envelopeRequestParser,
   hidePage,
   shouldSkipTracingTest,
-  testingCdnBundle,
   waitForClientReportRequest,
 } from '../../../../utils/helpers';
 import { waitForStreamedSpans } from '../../../../utils/spanUtils';
 import type { ClientReport } from '@sentry/core';
 
 sentryTest('ignored child spans are dropped and their children are reparented', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const spansPromise = waitForStreamedSpans(page, spans => !!spans?.find(s => s.name === 'parent-span'));
 

--- a/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans-streamed/segment/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans-streamed/segment/test.ts
@@ -4,14 +4,13 @@ import {
   envelopeRequestParser,
   hidePage,
   shouldSkipTracingTest,
-  testingCdnBundle,
   waitForClientReportRequest,
 } from '../../../../utils/helpers';
 import { observeStreamedSpan, waitForStreamedSpans } from '../../../../utils/spanUtils';
 import type { ClientReport } from '@sentry/core';
 
 sentryTest('ignored segment span drops entire trace', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/linking-addLink-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/linking-addLink-streamed/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../utils/helpers';
 import { waitForStreamedSpan, waitForStreamedSpans } from '../../../utils/spanUtils';
 
 sentryTest('links spans with addLink() in trace context', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const rootSpan1Promise = waitForStreamedSpan(page, s => s.name === 'rootSpan1' && !!s.is_segment);
   const rootSpan2Promise = waitForStreamedSpan(page, s => s.name === 'rootSpan2' && !!s.is_segment);
@@ -29,7 +29,7 @@ sentryTest('links spans with addLink() in trace context', async ({ getLocalTestU
 });
 
 sentryTest('links spans with addLink() in nested startSpan() calls', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const rootSpan1Promise = waitForStreamedSpan(page, s => s.name === 'rootSpan1' && !!s.is_segment);
   const rootSpan3SpansPromise = waitForStreamedSpans(page, spans =>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-streamed-spans/test.ts
@@ -1,11 +1,11 @@
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { hidePage, shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { hidePage, shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../utils/spanUtils';
 
 sentryTest.beforeEach(async ({ browserName, page }) => {
-  if (shouldSkipTracingTest() || testingCdnBundle() || browserName !== 'chromium') {
+  if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-streamed-spans/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { hidePage, shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { hidePage, shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../utils/spanUtils';
 
 sentryTest.beforeEach(async ({ browserName }) => {
-  if (shouldSkipTracingTest() || testingCdnBundle() || browserName !== 'chromium') {
+  if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
@@ -1,11 +1,11 @@
 import type { Route } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { hidePage, shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { hidePage, shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../utils/spanUtils';
 
 sentryTest.beforeEach(async ({ browserName, page }) => {
-  if (shouldSkipTracingTest() || testingCdnBundle() || browserName !== 'chromium') {
+  if (shouldSkipTracingTest() || browserName !== 'chromium') {
     sentryTest.skip();
   }
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-ttfb-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-ttfb-streamed/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { hidePage, shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { hidePage, shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../utils/spanUtils';
 
 sentryTest.beforeEach(async ({ page }) => {
-  if (shouldSkipTracingTest() || testingCdnBundle()) {
+  if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
 

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report-streamed/test.ts
@@ -5,14 +5,13 @@ import {
   envelopeRequestParser,
   hidePage,
   shouldSkipTracingTest,
-  testingCdnBundle,
   waitForClientReportRequest,
 } from '../../../utils/helpers';
 
 sentryTest(
   'records no_parent_span client report for fetch requests without an active span',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     await page.route('http://sentry-test-site.example/api/test', route => {
       route.fulfill({

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed/test.ts
@@ -19,7 +19,11 @@ sentryTest('creates spans for fetch requests', async ({ getLocalTestUrl, page })
 
   const allSpans = await spansPromise;
   const pageloadSpan = allSpans.find(s => getSpanOp(s) === 'pageload');
-  const requestSpans = allSpans.filter(s => getSpanOp(s) === 'http.client');
+  const requestSpans = allSpans
+    .filter(s => getSpanOp(s) === 'http.client')
+    .sort((a, b) =>
+      (a.attributes!['http.url']!.value as string).localeCompare(b.attributes!['http.url']!.value as string),
+    );
 
   expect(requestSpans).toHaveLength(3);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest('creates spans for fetch requests', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   await page.route('http://sentry-test-site.example/*', route => route.fulfill({ body: 'ok' }));
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-streamed/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest('creates spans for XHR requests', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   await page.route('http://sentry-test-site.example/*', route => route.fulfill({ body: 'ok' }));
 

--- a/dev-packages/browser-integration-tests/suites/tracing/setSpanActive-streamed/default/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/setSpanActive-streamed/default/test.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest('sets an inactive span active and adds child spans to it', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const spansPromise = waitForStreamedSpans(page, spans => spans.some(s => s.name === 'checkout-flow' && s.is_segment));
 

--- a/dev-packages/browser-integration-tests/suites/tracing/setSpanActive-streamed/nested-parentAlwaysRoot/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/setSpanActive-streamed/nested-parentAlwaysRoot/test.ts
@@ -1,12 +1,12 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
   'nested calls to setActiveSpanInBrowser with parentSpanIsAlwaysRootSpan=false result in correct parenting',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const checkoutSpansPromise = waitForStreamedSpans(page, spans =>
       spans.some(s => s.name === 'checkout-flow' && s.is_segment),

--- a/dev-packages/browser-integration-tests/suites/tracing/setSpanActive-streamed/nested/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/setSpanActive-streamed/nested/test.ts
@@ -1,12 +1,12 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
   'nested calls to setActiveSpanInBrowser still parent to root span by default',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const checkoutSpansPromise = waitForStreamedSpans(page, spans =>
       spans.some(s => s.name === 'checkout-flow' && s.is_segment),

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/navigation-streamed/test.ts
@@ -7,12 +7,11 @@ import {
   getFirstSentryEnvelopeRequest,
   shouldSkipFeedbackTest,
   shouldSkipTracingTest,
-  testingCdnBundle,
 } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan, waitForStreamedSpanEnvelope } from '../../../../utils/spanUtils';
 
 sentryTest('creates a new trace and sample_rand on each navigation', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -76,7 +75,7 @@ sentryTest('creates a new trace and sample_rand on each navigation', async ({ ge
 });
 
 sentryTest('error after navigation has navigation traceId', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -138,7 +137,7 @@ sentryTest('error after navigation has navigation traceId', async ({ getLocalTes
 });
 
 sentryTest('error during navigation has new navigation traceId', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -188,7 +187,7 @@ sentryTest('error during navigation has new navigation traceId', async ({ getLoc
 sentryTest(
   'outgoing fetch request during navigation has navigation traceId in headers',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -232,7 +231,7 @@ sentryTest(
 sentryTest(
   'outgoing XHR request during navigation has navigation traceId in headers',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -276,7 +275,7 @@ sentryTest(
 sentryTest(
   'user feedback event after navigation has navigation traceId in headers',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || shouldSkipFeedbackTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest() || shouldSkipFeedbackTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname, handleLazyLoadedFeedback: true });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/pageload-streamed/test.ts
@@ -7,12 +7,11 @@ import {
   getFirstSentryEnvelopeRequest,
   shouldSkipFeedbackTest,
   shouldSkipTracingTest,
-  testingCdnBundle,
 } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan, waitForStreamedSpanEnvelope } from '../../../../utils/spanUtils';
 
 sentryTest('creates a new trace for a navigation after the initial pageload', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const pageloadSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'pageload');
   const navigationSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'navigation');
@@ -41,7 +40,7 @@ sentryTest('creates a new trace for a navigation after the initial pageload', as
 });
 
 sentryTest('error after pageload has pageload traceId', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const pageloadSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'pageload');
 
@@ -83,7 +82,7 @@ sentryTest('error after pageload has pageload traceId', async ({ getLocalTestUrl
 });
 
 sentryTest('error during pageload has pageload traceId', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -126,7 +125,7 @@ sentryTest('error during pageload has pageload traceId', async ({ getLocalTestUr
 sentryTest(
   'outgoing fetch request during pageload has pageload traceId in headers',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -165,7 +164,7 @@ sentryTest(
 sentryTest(
   'outgoing XHR request during pageload has pageload traceId in headers',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
@@ -202,7 +201,7 @@ sentryTest(
 );
 
 sentryTest('user feedback event after pageload has pageload traceId in headers', async ({ getLocalTestUrl, page }) => {
-  sentryTest.skip(shouldSkipTracingTest() || shouldSkipFeedbackTest() || testingCdnBundle());
+  sentryTest.skip(shouldSkipTracingTest() || shouldSkipFeedbackTest());
 
   const url = await getLocalTestUrl({ testDir: __dirname, handleLazyLoadedFeedback: true });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTrace-streamed/test.ts
@@ -1,12 +1,12 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { shouldSkipTracingTest, testingCdnBundle } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../utils/spanUtils';
 
 sentryTest(
   'creates a new trace if `startNewTrace` is called and leaves old trace valid outside the callback',
   async ({ getLocalTestUrl, page }) => {
-    sentryTest.skip(shouldSkipTracingTest() || testingCdnBundle());
+    sentryTest.skip(shouldSkipTracingTest());
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -136,6 +136,10 @@ export function makeTerserPlugin() {
           '_resolveFilename',
           // Set on e.g. the shim feedbackIntegration to be able to detect it
           '_isShim',
+          // Set by `withStreamedSpan()` and checked by `isStreamedBeforeSendSpanCallback()` -
+          // since the setter passes the name as a string to `addNonEnumerableProperty`, terser
+          // cannot mangle it there, so we must keep the reader side unmangled too.
+          '_streamed',
           // This is used in metadata integration
           '_sentryModuleMetadata',
         ],

--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -136,9 +136,7 @@ export function makeTerserPlugin() {
           '_resolveFilename',
           // Set on e.g. the shim feedbackIntegration to be able to detect it
           '_isShim',
-          // Set by `withStreamedSpan()` and checked by `isStreamedBeforeSendSpanCallback()` -
-          // since the setter passes the name as a string to `addNonEnumerableProperty`, terser
-          // cannot mangle it there, so we must keep the reader side unmangled too.
+          // Marker set by `withStreamedSpan()` to tag streamed `beforeSendSpan` callbacks
           '_streamed',
           // This is used in metadata integration
           '_sentryModuleMetadata',

--- a/packages/browser/src/index.bundle.feedback.ts
+++ b/packages/browser/src/index.bundle.feedback.ts
@@ -4,6 +4,7 @@ import {
   elementTimingIntegrationShim,
   loggerShim,
   replayIntegrationShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { feedbackAsyncIntegration } from './feedbackAsync';
 
@@ -20,4 +21,5 @@ export {
   feedbackAsyncIntegration as feedbackAsyncIntegration,
   feedbackAsyncIntegration as feedbackIntegration,
   replayIntegrationShim as replayIntegration,
+  spanStreamingIntegrationShim as spanStreamingIntegration,
 };

--- a/packages/browser/src/index.bundle.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.logs.metrics.ts
@@ -2,6 +2,7 @@ import {
   browserTracingIntegrationShim,
   feedbackIntegrationShim,
   replayIntegrationShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
@@ -16,4 +17,5 @@ export {
   feedbackIntegrationShim as feedbackAsyncIntegration,
   feedbackIntegrationShim as feedbackIntegration,
   replayIntegrationShim as replayIntegration,
+  spanStreamingIntegrationShim as spanStreamingIntegration,
 };

--- a/packages/browser/src/index.bundle.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.replay.feedback.ts
@@ -3,6 +3,7 @@ import {
   consoleLoggingIntegrationShim,
   elementTimingIntegrationShim,
   loggerShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { feedbackAsyncIntegration } from './feedbackAsync';
 
@@ -18,6 +19,7 @@ export {
   elementTimingIntegrationShim as elementTimingIntegration,
   feedbackAsyncIntegration as feedbackAsyncIntegration,
   feedbackAsyncIntegration as feedbackIntegration,
+  spanStreamingIntegrationShim as spanStreamingIntegration,
 };
 
 export { replayIntegration, getReplay } from '@sentry-internal/replay';

--- a/packages/browser/src/index.bundle.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.replay.logs.metrics.ts
@@ -1,4 +1,8 @@
-import { browserTracingIntegrationShim, feedbackIntegrationShim } from '@sentry-internal/integration-shims';
+import {
+  browserTracingIntegrationShim,
+  feedbackIntegrationShim,
+  spanStreamingIntegrationShim,
+} from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
 
@@ -13,4 +17,5 @@ export {
   browserTracingIntegrationShim as browserTracingIntegration,
   feedbackIntegrationShim as feedbackAsyncIntegration,
   feedbackIntegrationShim as feedbackIntegration,
+  spanStreamingIntegrationShim as spanStreamingIntegration,
 };

--- a/packages/browser/src/index.bundle.replay.ts
+++ b/packages/browser/src/index.bundle.replay.ts
@@ -4,6 +4,7 @@ import {
   elementTimingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
@@ -18,4 +19,5 @@ export {
   elementTimingIntegrationShim as elementTimingIntegration,
   feedbackIntegrationShim as feedbackAsyncIntegration,
   feedbackIntegrationShim as feedbackIntegration,
+  spanStreamingIntegrationShim as spanStreamingIntegration,
 };

--- a/packages/browser/src/index.bundle.tracing.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.logs.metrics.ts
@@ -30,6 +30,8 @@ export { elementTimingIntegration } from '@sentry-internal/browser-utils';
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
+export { spanStreamingIntegration } from './integrations/spanstreaming';
+
 export {
   feedbackIntegrationShim as feedbackAsyncIntegration,
   feedbackIntegrationShim as feedbackIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
@@ -30,6 +30,8 @@ export { elementTimingIntegration } from '@sentry-internal/browser-utils';
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
+export { spanStreamingIntegration } from './integrations/spanstreaming';
+
 export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
 
 export { feedbackAsyncIntegration as feedbackAsyncIntegration, feedbackAsyncIntegration as feedbackIntegration };

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -36,6 +36,8 @@ export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 
+export { spanStreamingIntegration } from './integrations/spanstreaming';
+
 export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
 
 export { feedbackAsyncIntegration as feedbackAsyncIntegration, feedbackAsyncIntegration as feedbackIntegration };

--- a/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
@@ -30,6 +30,8 @@ export { elementTimingIntegration } from '@sentry-internal/browser-utils';
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
+export { spanStreamingIntegration } from './integrations/spanstreaming';
+
 export { feedbackIntegrationShim as feedbackAsyncIntegration, feedbackIntegrationShim as feedbackIntegration };
 
 export { replayIntegration, getReplay } from '@sentry-internal/replay';

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -35,6 +35,8 @@ export { elementTimingIntegrationShim as elementTimingIntegration };
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
+export { spanStreamingIntegration } from './integrations/spanstreaming';
+
 export { feedbackIntegrationShim as feedbackAsyncIntegration, feedbackIntegrationShim as feedbackIntegration };
 
 export { replayIntegration, getReplay } from '@sentry-internal/replay';

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -37,6 +37,8 @@ export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 
+export { spanStreamingIntegration } from './integrations/spanstreaming';
+
 export {
   feedbackIntegrationShim as feedbackAsyncIntegration,
   feedbackIntegrationShim as feedbackIntegration,

--- a/packages/browser/src/index.bundle.ts
+++ b/packages/browser/src/index.bundle.ts
@@ -5,6 +5,7 @@ import {
   feedbackIntegrationShim,
   loggerShim,
   replayIntegrationShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
@@ -18,4 +19,5 @@ export {
   feedbackIntegrationShim as feedbackAsyncIntegration,
   feedbackIntegrationShim as feedbackIntegration,
   replayIntegrationShim as replayIntegration,
+  spanStreamingIntegrationShim as spanStreamingIntegration,
 };

--- a/packages/browser/test/index.bundle.feedback.test.ts
+++ b/packages/browser/test/index.bundle.feedback.test.ts
@@ -3,6 +3,7 @@ import {
   consoleLoggingIntegrationShim,
   loggerShim,
   replayIntegrationShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
 import { feedbackAsyncIntegration } from '../src';
@@ -14,6 +15,7 @@ describe('index.bundle.feedback', () => {
     expect(FeedbackBundle.feedbackAsyncIntegration).toBe(feedbackAsyncIntegration);
     expect(FeedbackBundle.feedbackIntegration).toBe(feedbackAsyncIntegration);
     expect(FeedbackBundle.replayIntegration).toBe(replayIntegrationShim);
+    expect(FeedbackBundle.spanStreamingIntegration).toBe(spanStreamingIntegrationShim);
 
     expect(FeedbackBundle.logger).toBe(loggerShim);
     expect(FeedbackBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/index.bundle.logs.metrics.test.ts
+++ b/packages/browser/test/index.bundle.logs.metrics.test.ts
@@ -1,4 +1,5 @@
 import { logger as coreLogger, metrics as coreMetrics } from '@sentry/core';
+import { spanStreamingIntegrationShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
 import * as LogsMetricsBundle from '../src/index.bundle.logs.metrics';
 
@@ -6,5 +7,6 @@ describe('index.bundle.logs.metrics', () => {
   it('has correct exports', () => {
     expect(LogsMetricsBundle.logger).toBe(coreLogger);
     expect(LogsMetricsBundle.metrics).toBe(coreMetrics);
+    expect(LogsMetricsBundle.spanStreamingIntegration).toBe(spanStreamingIntegrationShim);
   });
 });

--- a/packages/browser/test/index.bundle.replay.feedback.test.ts
+++ b/packages/browser/test/index.bundle.replay.feedback.test.ts
@@ -2,6 +2,7 @@ import {
   browserTracingIntegrationShim,
   consoleLoggingIntegrationShim,
   loggerShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
 import { feedbackAsyncIntegration, replayIntegration } from '../src';
@@ -13,6 +14,7 @@ describe('index.bundle.replay.feedback', () => {
     expect(ReplayFeedbackBundle.feedbackAsyncIntegration).toBe(feedbackAsyncIntegration);
     expect(ReplayFeedbackBundle.feedbackIntegration).toBe(feedbackAsyncIntegration);
     expect(ReplayFeedbackBundle.replayIntegration).toBe(replayIntegration);
+    expect(ReplayFeedbackBundle.spanStreamingIntegration).toBe(spanStreamingIntegrationShim);
 
     expect(ReplayFeedbackBundle.logger).toBe(loggerShim);
     expect(ReplayFeedbackBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/index.bundle.replay.logs.metrics.test.ts
+++ b/packages/browser/test/index.bundle.replay.logs.metrics.test.ts
@@ -1,5 +1,9 @@
 import { logger as coreLogger, metrics as coreMetrics } from '@sentry/core';
-import { browserTracingIntegrationShim, feedbackIntegrationShim } from '@sentry-internal/integration-shims';
+import {
+  browserTracingIntegrationShim,
+  feedbackIntegrationShim,
+  spanStreamingIntegrationShim,
+} from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
 import { replayIntegration } from '../src';
 import * as ReplayLogsMetricsBundle from '../src/index.bundle.replay.logs.metrics';
@@ -10,6 +14,7 @@ describe('index.bundle.replay.logs.metrics', () => {
     expect(ReplayLogsMetricsBundle.feedbackAsyncIntegration).toBe(feedbackIntegrationShim);
     expect(ReplayLogsMetricsBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(ReplayLogsMetricsBundle.replayIntegration).toBe(replayIntegration);
+    expect(ReplayLogsMetricsBundle.spanStreamingIntegration).toBe(spanStreamingIntegrationShim);
 
     expect(ReplayLogsMetricsBundle.logger).toBe(coreLogger);
     expect(ReplayLogsMetricsBundle.metrics).toBe(coreMetrics);

--- a/packages/browser/test/index.bundle.replay.test.ts
+++ b/packages/browser/test/index.bundle.replay.test.ts
@@ -3,6 +3,7 @@ import {
   consoleLoggingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
 import { replayIntegration } from '../src';
@@ -14,6 +15,7 @@ describe('index.bundle.replay', () => {
     expect(ReplayBundle.feedbackAsyncIntegration).toBe(feedbackIntegrationShim);
     expect(ReplayBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(ReplayBundle.replayIntegration).toBe(replayIntegration);
+    expect(ReplayBundle.spanStreamingIntegration).toBe(spanStreamingIntegrationShim);
 
     expect(ReplayBundle.logger).toBe(loggerShim);
     expect(ReplayBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/index.bundle.test.ts
+++ b/packages/browser/test/index.bundle.test.ts
@@ -4,6 +4,7 @@ import {
   feedbackIntegrationShim,
   loggerShim,
   replayIntegrationShim,
+  spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
 import * as Bundle from '../src/index.bundle';
@@ -14,6 +15,7 @@ describe('index.bundle', () => {
     expect(Bundle.feedbackAsyncIntegration).toBe(feedbackIntegrationShim);
     expect(Bundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(Bundle.replayIntegration).toBe(replayIntegrationShim);
+    expect(Bundle.spanStreamingIntegration).toBe(spanStreamingIntegrationShim);
 
     expect(Bundle.logger).toBe(loggerShim);
     expect(Bundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/index.bundle.tracing.logs.metrics.test.ts
+++ b/packages/browser/test/index.bundle.tracing.logs.metrics.test.ts
@@ -1,7 +1,7 @@
 import { logger as coreLogger, metrics as coreMetrics } from '@sentry/core';
 import { feedbackIntegrationShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration } from '../src';
+import { browserTracingIntegration, spanStreamingIntegration } from '../src';
 import * as TracingLogsMetricsBundle from '../src/index.bundle.tracing.logs.metrics';
 
 describe('index.bundle.tracing.logs.metrics', () => {
@@ -10,6 +10,7 @@ describe('index.bundle.tracing.logs.metrics', () => {
     expect(TracingLogsMetricsBundle.feedbackAsyncIntegration).toBe(feedbackIntegrationShim);
     expect(TracingLogsMetricsBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(TracingLogsMetricsBundle.replayIntegration).toBe(replayIntegrationShim);
+    expect(TracingLogsMetricsBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
 
     expect(TracingLogsMetricsBundle.logger).toBe(coreLogger);
     expect(TracingLogsMetricsBundle.metrics).toBe(coreMetrics);

--- a/packages/browser/test/index.bundle.tracing.replay.feedback.logs.metrics.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.feedback.logs.metrics.test.ts
@@ -1,6 +1,11 @@
 import { logger as coreLogger, metrics as coreMetrics } from '@sentry/core';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, feedbackAsyncIntegration, replayIntegration } from '../src';
+import {
+  browserTracingIntegration,
+  feedbackAsyncIntegration,
+  replayIntegration,
+  spanStreamingIntegration,
+} from '../src';
 import * as TracingReplayFeedbackLogsMetricsBundle from '../src/index.bundle.tracing.replay.feedback.logs.metrics';
 
 describe('index.bundle.tracing.replay.feedback.logs.metrics', () => {
@@ -9,6 +14,7 @@ describe('index.bundle.tracing.replay.feedback.logs.metrics', () => {
     expect(TracingReplayFeedbackLogsMetricsBundle.feedbackAsyncIntegration).toBe(feedbackAsyncIntegration);
     expect(TracingReplayFeedbackLogsMetricsBundle.feedbackIntegration).toBe(feedbackAsyncIntegration);
     expect(TracingReplayFeedbackLogsMetricsBundle.replayIntegration).toBe(replayIntegration);
+    expect(TracingReplayFeedbackLogsMetricsBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
 
     expect(TracingReplayFeedbackLogsMetricsBundle.logger).toBe(coreLogger);
     expect(TracingReplayFeedbackLogsMetricsBundle.metrics).toBe(coreMetrics);

--- a/packages/browser/test/index.bundle.tracing.replay.feedback.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.feedback.test.ts
@@ -1,6 +1,11 @@
 import { consoleLoggingIntegrationShim, loggerShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, feedbackAsyncIntegration, replayIntegration, spanStreamingIntegration } from '../src';
+import {
+  browserTracingIntegration,
+  feedbackAsyncIntegration,
+  replayIntegration,
+  spanStreamingIntegration,
+} from '../src';
 import * as TracingReplayFeedbackBundle from '../src/index.bundle.tracing.replay.feedback';
 
 describe('index.bundle.tracing.replay.feedback', () => {

--- a/packages/browser/test/index.bundle.tracing.replay.feedback.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.feedback.test.ts
@@ -1,6 +1,6 @@
 import { consoleLoggingIntegrationShim, loggerShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, feedbackAsyncIntegration, replayIntegration } from '../src';
+import { browserTracingIntegration, feedbackAsyncIntegration, replayIntegration, spanStreamingIntegration } from '../src';
 import * as TracingReplayFeedbackBundle from '../src/index.bundle.tracing.replay.feedback';
 
 describe('index.bundle.tracing.replay.feedback', () => {
@@ -9,6 +9,7 @@ describe('index.bundle.tracing.replay.feedback', () => {
     expect(TracingReplayFeedbackBundle.feedbackAsyncIntegration).toBe(feedbackAsyncIntegration);
     expect(TracingReplayFeedbackBundle.feedbackIntegration).toBe(feedbackAsyncIntegration);
     expect(TracingReplayFeedbackBundle.replayIntegration).toBe(replayIntegration);
+    expect(TracingReplayFeedbackBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
 
     expect(TracingReplayFeedbackBundle.logger).toBe(loggerShim);
     expect(TracingReplayFeedbackBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/index.bundle.tracing.replay.logs.metrics.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.logs.metrics.test.ts
@@ -1,7 +1,7 @@
 import { logger as coreLogger, metrics as coreMetrics } from '@sentry/core';
 import { feedbackIntegrationShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, replayIntegration } from '../src';
+import { browserTracingIntegration, replayIntegration, spanStreamingIntegration } from '../src';
 import * as TracingReplayLogsMetricsBundle from '../src/index.bundle.tracing.replay.logs.metrics';
 
 describe('index.bundle.tracing.replay.logs.metrics', () => {
@@ -10,6 +10,7 @@ describe('index.bundle.tracing.replay.logs.metrics', () => {
     expect(TracingReplayLogsMetricsBundle.feedbackAsyncIntegration).toBe(feedbackIntegrationShim);
     expect(TracingReplayLogsMetricsBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(TracingReplayLogsMetricsBundle.replayIntegration).toBe(replayIntegration);
+    expect(TracingReplayLogsMetricsBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
 
     expect(TracingReplayLogsMetricsBundle.logger).toBe(coreLogger);
     expect(TracingReplayLogsMetricsBundle.metrics).toBe(coreMetrics);

--- a/packages/browser/test/index.bundle.tracing.replay.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.test.ts
@@ -1,6 +1,6 @@
 import { consoleLoggingIntegrationShim, feedbackIntegrationShim, loggerShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, replayIntegration } from '../src';
+import { browserTracingIntegration, replayIntegration, spanStreamingIntegration } from '../src';
 import * as TracingReplayBundle from '../src/index.bundle.tracing.replay';
 
 describe('index.bundle.tracing.replay', () => {
@@ -9,6 +9,7 @@ describe('index.bundle.tracing.replay', () => {
     expect(TracingReplayBundle.feedbackAsyncIntegration).toBe(feedbackIntegrationShim);
     expect(TracingReplayBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(TracingReplayBundle.replayIntegration).toBe(replayIntegration);
+    expect(TracingReplayBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
 
     expect(TracingReplayBundle.logger).toBe(loggerShim);
     expect(TracingReplayBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/index.bundle.tracing.test.ts
+++ b/packages/browser/test/index.bundle.tracing.test.ts
@@ -5,7 +5,7 @@ import {
   replayIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration } from '../src';
+import { browserTracingIntegration, spanStreamingIntegration } from '../src';
 import * as TracingBundle from '../src/index.bundle.tracing';
 
 describe('index.bundle.tracing', () => {
@@ -14,6 +14,7 @@ describe('index.bundle.tracing', () => {
     expect(TracingBundle.feedbackAsyncIntegration).toBe(feedbackIntegrationShim);
     expect(TracingBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(TracingBundle.replayIntegration).toBe(replayIntegrationShim);
+    expect(TracingBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
 
     expect(TracingBundle.logger).toBe(loggerShim);
     expect(TracingBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/integration-shims/src/SpanStreaming.ts
+++ b/packages/integration-shims/src/SpanStreaming.ts
@@ -8,7 +8,7 @@ import { consoleSandbox, defineIntegration } from '@sentry/core';
 export const spanStreamingIntegrationShim = defineIntegration(() => {
   consoleSandbox(() => {
     // eslint-disable-next-line no-console
-    console.warn('You are using spanStreamingIntegration() even though this bundle does not include span streaming.');
+    console.warn('You are using spanStreamingIntegration() even though this bundle does not include tracing.');
   });
 
   return {

--- a/packages/integration-shims/src/SpanStreaming.ts
+++ b/packages/integration-shims/src/SpanStreaming.ts
@@ -1,0 +1,17 @@
+import { consoleSandbox, defineIntegration } from '@sentry/core';
+
+/**
+ * This is a shim for the SpanStreaming integration.
+ * It is needed in order for the CDN bundles to continue working when users add/remove span streaming
+ * from it, without changing their config. This is necessary for the loader mechanism.
+ */
+export const spanStreamingIntegrationShim = defineIntegration(() => {
+  consoleSandbox(() => {
+    // eslint-disable-next-line no-console
+    console.warn('You are using spanStreamingIntegration() even though this bundle does not include span streaming.');
+  });
+
+  return {
+    name: 'SpanStreaming',
+  };
+});

--- a/packages/integration-shims/src/index.ts
+++ b/packages/integration-shims/src/index.ts
@@ -4,3 +4,4 @@ export { browserTracingIntegrationShim } from './BrowserTracing';
 export { launchDarklyIntegrationShim, buildLaunchDarklyFlagUsedHandlerShim } from './launchDarkly';
 export { elementTimingIntegrationShim } from './ElementTiming';
 export { loggerShim, consoleLoggingIntegrationShim } from './logs';
+export { spanStreamingIntegrationShim } from './SpanStreaming';


### PR DESCRIPTION
- Export the integration from all CDN tracing bundles and shim for non-tracing bundles.
- Remove the CDN test skips in the browser integration tests since this should work now.
- Reserve `_streamed` in the terser mangler so `withStreamedSpan`'s marker survives minification in CDN bundles.
- Some additional test changes were needed to make CI happy. Mostly cases where certain browsers don't emit some attributes but we check for strict equality with `toEqual`.

Closes https://github.com/getsentry/sentry-javascript/issues/20273
