### PR TITLE
fix(core): route replay events in multiplexed transport

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -221,7 +221,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Replay, Logs, Metrics)',
     path: createCDNPath('bundle.tracing.replay.logs.metrics.min.js'),
     gzip: true,
-    limit: '83 KB',
+    limit: '84 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback)',
@@ -283,7 +283,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '255 KB',
+    limit: '256 KB',
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback) - uncompressed',
@@ -297,7 +297,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.feedback.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '268 KB',
+    limit: '269 KB',
   },
   // Next.js SDK (ESM)
   {

--- a/packages/core/src/transports/multiplexed.ts
+++ b/packages/core/src/transports/multiplexed.ts
@@ -102,7 +102,7 @@ export function makeMultiplexedTransport<TO extends BaseTransportOptions>(
     const actualMatcher: Matcher =
       matcher ||
       (args => {
-        const event = args.getEvent();
+        const event = args.getEvent(['event', 'replay_event']);
         if (
           event?.extra?.[MULTIPLEXED_TRANSPORT_EXTRA_KEY] &&
           Array.isArray(event.extra[MULTIPLEXED_TRANSPORT_EXTRA_KEY])

--- a/packages/core/test/lib/transports/multiplexed.test.ts
+++ b/packages/core/test/lib/transports/multiplexed.test.ts
@@ -30,6 +30,7 @@ const TRANSACTION_ENVELOPE = createEnvelope<EventEnvelope>(
   { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' },
   [[{ type: 'transaction' }, TRANSACTION_EVENT] as EventItem],
 );
+const REPLAY_EVENT = { type: 'replay_event', event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2' };
 
 const DEFAULT_DISCARDED_EVENTS: ClientReport['discarded_events'] = [
   {
@@ -312,6 +313,36 @@ describe('makeMultiplexedTransport() with default matcher', () => {
           event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
           extra: {
             [MULTIPLEXED_TRANSPORT_EXTRA_KEY]: [],
+          },
+        },
+      ] as EventItem,
+    ]);
+
+    const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
+    await transport.send(envelope);
+  });
+
+  it('sends replay events to targets provided in event.extra[MULTIPLEXED_TRANSPORT_EXTRA_KEY]', async () => {
+    expect.assertions(2);
+
+    const makeTransport = makeMultiplexedTransport(
+      createTestTransport(
+        url => {
+          expect(url).toBe(DSN1_URL);
+        },
+        url => {
+          expect(url).toBe(DSN2_URL);
+        },
+      ),
+    );
+
+    const envelope = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' }, [
+      [
+        { type: 'replay_event' },
+        {
+          ...REPLAY_EVENT,
+          extra: {
+            [MULTIPLEXED_TRANSPORT_EXTRA_KEY]: [DSN1, DSN2],
           },
         },
       ] as EventItem,


### PR DESCRIPTION
This PR adds `replay_event` to the multiplex router matcher events so it can match against replay events, previously it used the plain `getEvent()` which defaulted to just `event` envelopes.

Closes #20346
