### PR TITLE
fix(core): Correct GoogleGenAIIstrumentedMethod typo in type name

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -192,8 +192,10 @@ export type {
   GoogleGenAIClient,
   GoogleGenAIChat,
   GoogleGenAIOptions,
-  GoogleGenAIIstrumentedMethod,
+  GoogleGenAIInstrumentedMethod,
 } from './tracing/google-genai/types';
+// eslint-disable-next-line deprecation/deprecation
+export type { GoogleGenAIIstrumentedMethod } from './tracing/google-genai/types';
 
 export { SpanBuffer } from './tracing/spans/spanBuffer';
 export { hasSpanStreamingEnabled } from './tracing/spans/hasSpanStreamingEnabled';

--- a/packages/core/src/tracing/google-genai/types.ts
+++ b/packages/core/src/tracing/google-genai/types.ts
@@ -186,10 +186,14 @@ export interface GoogleGenAIChat {
   sendMessageStream: (...args: unknown[]) => Promise<AsyncGenerator<GenerateContentResponse, any, unknown>>;
 }
 
+export type GoogleGenAIInstrumentedMethod = keyof typeof GOOGLE_GENAI_METHOD_REGISTRY;
+
 /**
- * @deprecated This type is no longer used and will be removed in the next major version.
+ * @deprecated Use {@link GoogleGenAIInstrumentedMethod} instead. This alias
+ * preserves backwards compatibility with the misspelled name and will be
+ * removed in the next major version.
  */
-export type GoogleGenAIIstrumentedMethod = keyof typeof GOOGLE_GENAI_METHOD_REGISTRY;
+export type GoogleGenAIIstrumentedMethod = GoogleGenAIInstrumentedMethod;
 
 // Export the response type for use in instrumentation
 export type GoogleGenAIResponse = GenerateContentResponse;


### PR DESCRIPTION
## Description

Fixes a typo in the type exported from `@sentry/core` for Google Gen AI instrumentation: `GoogleGenAIIstrumentedMethod` (missing an `n`) -> `GoogleGenAIInstrumentedMethod`.

The misspelled name is preserved as a **deprecated type alias** that points at the correctly-spelled type, so existing code keeps working:

```ts
import type { GoogleGenAIInstrumentedMethod } from '@sentry/core';

/**
 * @deprecated Use {@link GoogleGenAIInstrumentedMethod} instead.
 */
export type GoogleGenAIIstrumentedMethod = GoogleGenAIInstrumentedMethod;
```

Noticed while wiring up the re-exports of the AI SDK manual instrumentation helpers from `@sentry/react-native` (getsentry/sentry-react-native#6028). The typo was blocking a clean re-export.

## Checklist

- [x] Added tests where applicable — existing `google-genai` tests still pass. No runtime behaviour changes; this is a type-only rename with a backwards-compat alias.
- [x] Code lints and the test suite passes — `yarn test google-genai` → 5/5 passing. Type emit for `packages/core` verified: both `GoogleGenAIInstrumentedMethod` and `GoogleGenAIIstrumentedMethod` appear in `build/types/index.d.ts`.
- [ ] No open issue — this is a follow-up to review feedback on getsentry/sentry-react-native#6028.



#skip-changelog
