### PR TITLE
docs(readme): Update usage instructions for binary scripts

### DIFF
--- a/packages/profiling-node/README.md
+++ b/packages/profiling-node/README.md
@@ -239,13 +239,19 @@ the binaries will be copied. This is wasteful as you will likely only need one o
 runtime.
 
 To prune the other libraries, profiling-node ships with a small utility script that helps you prune unused binaries. The
-script can be invoked via `sentry-prune-profiler-binaries`, use `--help` to see a list of available options or
-`--dry-run` if you want it to log the binaries that would have been deleted.
+script can be invoked via `sentry-prune-profiler-binaries`:
+
+```bash
+npx --package=@sentry/profiling-node sentry-prune-profiler-binaries
+```
+
+Use `--help` to see a list of available options or `--dry-run` if you want it to log the binaries that would have been
+deleted.
 
 Example of only preserving a binary to run node16 on linux x64 musl.
 
 ```bash
-sentry-prune-profiler-binaries --target_dir_path=./dist --target_platform=linux --target_node=16 --target_stdlib=musl --target_arch=x64
+npx --package=@sentry/profiling-node sentry-prune-profiler-binaries --target_dir_path=./dist --target_platform=linux --target_node=16 --target_stdlib=musl --target_arch=x64
 ```
 
 Which will output something like

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -122,8 +122,13 @@ Sentry.captureEvent({
 The Remix SDK provides a script that automatically creates a release and uploads sourcemaps. To generate sourcemaps with
 Remix, you need to call `remix build` with the `--sourcemap` option.
 
-On release, call `sentry-upload-sourcemaps` to upload source maps and create a release. To see more details on how to
-use the command, call `sentry-upload-sourcemaps --help`.
+On release, call `sentry-upload-sourcemaps` to upload source maps and create a release:
+
+```bash
+npx --package=@sentry/remix sentry-upload-sourcemaps
+```
+
+To see more details on how to use the command, call `npx --package=@sentry/remix sentry-upload-sourcemaps --help`.
 
 For more advanced configuration,
 [directly use `sentry-cli` to upload source maps.](https://github.com/getsentry/sentry-cli).


### PR DESCRIPTION
Adds `--package` to binary scripts so the usage invokes the correct script.

Closes https://github.com/getsentry/sentry-javascript/issues/20422
