### PR TITLE
feat(core): Emit `sentry.sdk.integrations` on streamed segment spans

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
@@ -4,6 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID,
@@ -208,6 +209,10 @@ sentryTest(
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION]: {
             type: 'string',
             value: SDK_VERSION,
+          },
+          [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+            type: 'array',
+            value: expect.arrayContaining(['SpanStreaming']),
           },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: {
             type: 'string',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
@@ -4,6 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID,
@@ -79,6 +80,10 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
       [SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION]: {
         type: 'string',
         value: SDK_VERSION,
+      },
+      [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+        type: 'array',
+        value: expect.arrayContaining(['BrowserTracing', 'SpanStreaming']),
       },
       [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: {
         type: 'string',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -4,6 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
@@ -130,6 +131,10 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ brow
       'sentry.sdk.version': {
         type: 'string',
         value: SDK_VERSION,
+      },
+      [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+        type: 'array',
+        value: expect.arrayContaining(['BrowserTracing', 'SpanStreaming']),
       },
       'sentry.segment.id': {
         type: 'string',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -4,6 +4,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID,
@@ -137,6 +138,10 @@ sentryTest(
         [SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION]: {
           type: 'string',
           value: SDK_VERSION,
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+          type: 'array',
+          value: expect.arrayContaining(['BrowserTracing', 'SpanStreaming']),
         },
         [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: {
           type: 'string',

--- a/dev-packages/cloudflare-integration-tests/suites/public-api/startSpan-streamed/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/public-api/startSpan-streamed/test.ts
@@ -2,13 +2,14 @@ import type { Envelope, SerializedStreamedSpanContainer } from '@sentry/core';
 import {
   SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
 import { expect, it } from 'vitest';
@@ -175,6 +176,7 @@ it('sends a streamed span envelope with correct spans for a manually started spa
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME]: { type: 'string', value: CLOUDFLARE_SDK },
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION]: { type: 'string', value: SDK_VERSION },
+          [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: { type: 'array', value: expect.arrayContaining(['SpanStreaming']) },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'auto.http.cloudflare' },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },

--- a/dev-packages/cloudflare-integration-tests/suites/public-api/startSpan-streamed/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/public-api/startSpan-streamed/test.ts
@@ -176,7 +176,10 @@ it('sends a streamed span envelope with correct spans for a manually started spa
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME]: { type: 'string', value: CLOUDFLARE_SDK },
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION]: { type: 'string', value: SDK_VERSION },
-          [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: { type: 'array', value: expect.arrayContaining(['SpanStreaming']) },
+          [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+            type: 'array',
+            value: expect.arrayContaining(['SpanStreaming']),
+          },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'auto.http.cloudflare' },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },

--- a/dev-packages/e2e-tests/test-applications/deno-streamed/tests/spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-streamed/tests/spans.test.ts
@@ -95,6 +95,10 @@ const SEGMENT_SPAN = {
       type: 'string',
       value: expect.any(String),
     },
+    'sentry.sdk.integrations': {
+      type: 'array',
+      value: expect.arrayContaining(['SpanStreaming']),
+    },
     'sentry.segment.id': {
       type: 'string',
       value: expect.stringMatching(/^[\da-f]{16}$/),

--- a/dev-packages/node-core-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
@@ -3,6 +3,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID,
@@ -128,6 +129,10 @@ test('sends a streamed span envelope with correct spans for a manually started s
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: { type: 'integer', value: 1 },
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME]: { type: 'string', value: 'sentry.javascript.node-core' },
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION]: { type: 'string', value: SDK_VERSION },
+          [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+            type: 'array',
+            value: expect.arrayContaining(['SpanStreaming']),
+          },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
@@ -3,6 +3,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID,
@@ -128,6 +129,10 @@ test('sends a streamed span envelope with correct spans for a manually started s
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: { type: 'integer', value: 1 },
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME]: { type: 'string', value: 'sentry.javascript.node' },
           [SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION]: { type: 'string', value: SDK_VERSION },
+          [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+            type: 'array',
+            value: expect.arrayContaining(['SpanStreaming']),
+          },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },

--- a/packages/browser/test/integrations/spanstreaming.test.ts
+++ b/packages/browser/test/integrations/spanstreaming.test.ts
@@ -1,5 +1,5 @@
 import * as SentryCore from '@sentry/core/browser';
-import { debug } from '@sentry/core/browser';
+import { debug, SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS } from '@sentry/core/browser';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BrowserClient, spanStreamingIntegration } from '../../src';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
@@ -144,6 +144,10 @@ describe('spanStreamingIntegration', () => {
         'sentry.sdk.version': {
           type: 'string',
           value: expect.any(String),
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+          type: 'array',
+          value: ['SpanStreaming'],
         },
         'sentry.segment.id': {
           type: 'string',

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -501,6 +501,13 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   }
 
   /**
+   * Returns the names of all installed integrations.
+   */
+  public getIntegrationNames(): string[] {
+    return Object.keys(this._integrations);
+  }
+
+  /**
    * Add an integration to the client.
    * This can be used to e.g. lazy load integrations.
    * In most cases, this should not be necessary,
@@ -1302,8 +1309,8 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     isolationScope: Scope,
   ): PromiseLike<Event | null> {
     const options = this.getOptions();
-    const integrations = Object.keys(this._integrations);
-    if (!hint.integrations && integrations?.length) {
+    const integrations = this.getIntegrationNames();
+    if (!hint.integrations && integrations.length) {
       hint.integrations = integrations;
     }
 

--- a/packages/core/src/semanticAttributes.ts
+++ b/packages/core/src/semanticAttributes.ts
@@ -52,6 +52,8 @@ export const SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID = 'sentry.segment.id';
 export const SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME = 'sentry.sdk.name';
 /** The version of the Sentry SDK */
 export const SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION = 'sentry.sdk.version';
+/** The list of integrations enabled in the Sentry SDK (e.g., ["InboundFilters", "BrowserTracing"]) */
+export const SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS = 'sentry.sdk.integrations';
 
 /** The user ID */
 export const SEMANTIC_ATTRIBUTE_USER_ID = 'user.id';

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -6,6 +6,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID,
@@ -64,6 +65,7 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
 
   if (spanJSON.is_segment) {
     applyScopeToSegmentSpan(spanJSON, finalScopeData);
+    applySdkMetadataToSegmentSpan(spanJSON, client);
     // Allow hook subscribers to mutate the segment span JSON
     // This also invokes the `processSegmentSpan` hook of all integrations
     client.emit('processSegmentSpan', spanJSON);
@@ -115,6 +117,15 @@ export function safeSetSpanJSONAttributes(
     if (value != null && !(key in originalAttributes)) {
       originalAttributes[key] = value;
     }
+  });
+}
+
+function applySdkMetadataToSegmentSpan(segmentSpanJSON: StreamedSpanJSON, client: Client): void {
+  const integrationNames = client.getOptions().integrations.map(i => i.name);
+  if (!integrationNames.length) return;
+
+  safeSetSpanJSONAttributes(segmentSpanJSON, {
+    [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: integrationNames,
   });
 }
 

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -120,8 +120,15 @@ export function safeSetSpanJSONAttributes(
   });
 }
 
+const integrationNamesCache = new WeakMap<Client, string[]>();
+
 function applySdkMetadataToSegmentSpan(segmentSpanJSON: StreamedSpanJSON, client: Client): void {
-  const integrationNames = client.getOptions().integrations.map(i => i.name);
+  let integrationNames = integrationNamesCache.get(client);
+  if (!integrationNames) {
+    integrationNames = client.getOptions().integrations.map(i => i.name);
+    integrationNamesCache.set(client, integrationNames);
+  }
+
   if (!integrationNames.length) return;
 
   safeSetSpanJSONAttributes(segmentSpanJSON, {

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -120,15 +120,8 @@ export function safeSetSpanJSONAttributes(
   });
 }
 
-const integrationNamesCache = new WeakMap<Client, string[]>();
-
 function applySdkMetadataToSegmentSpan(segmentSpanJSON: StreamedSpanJSON, client: Client): void {
-  let integrationNames = integrationNamesCache.get(client);
-  if (!integrationNames) {
-    integrationNames = client.getOptions().integrations.map(i => i.name);
-    integrationNamesCache.set(client, integrationNames);
-  }
-
+  const integrationNames = client.getIntegrationNames();
   if (!integrationNames.length) return;
 
   safeSetSpanJSONAttributes(segmentSpanJSON, {

--- a/packages/core/test/lib/tracing/spans/captureSpan.test.ts
+++ b/packages/core/test/lib/tracing/spans/captureSpan.test.ts
@@ -7,6 +7,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
   SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID,
@@ -228,6 +229,86 @@ describe('captureSpan', () => {
       },
       _segmentSpan: span,
     });
+  });
+
+  it('adds sentry.sdk.integrations to segment spans as an array attribute', () => {
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://dsn@ingest.f00.f00/1',
+        tracesSampleRate: 1,
+        release: '1.0.0',
+        environment: 'staging',
+        integrations: [
+          { name: 'InboundFilters', setupOnce: () => {} },
+          { name: 'BrowserTracing', setupOnce: () => {} },
+        ],
+        _metadata: {
+          sdk: {
+            name: 'sentry.javascript.browser',
+            version: '9.0.0',
+          },
+        },
+      }),
+    );
+
+    const span = withScope(scope => {
+      scope.setClient(client);
+      const span = startInactiveSpan({ name: 'my-span', attributes: { 'sentry.op': 'http.client' } });
+      span.end();
+      return span;
+    });
+
+    expect(captureSpan(span, client)).toStrictEqual({
+      span_id: expect.stringMatching(/^[\da-f]{16}$/),
+      trace_id: expect.stringMatching(/^[\da-f]{32}$/),
+      parent_span_id: undefined,
+      links: undefined,
+      start_timestamp: expect.any(Number),
+      name: 'my-span',
+      end_timestamp: expect.any(Number),
+      status: 'ok',
+      is_segment: true,
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'http.client' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'manual' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: { type: 'integer', value: 1 },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { value: 'my-span', type: 'string' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { value: span.spanContext().spanId, type: 'string' },
+        'sentry.span.source': { value: 'custom', type: 'string' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: { value: 'custom', type: 'string' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { value: '1.0.0', type: 'string' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { value: 'staging', type: 'string' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME]: { value: 'sentry.javascript.browser', type: 'string' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION]: { value: '9.0.0', type: 'string' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
+          type: 'array',
+          value: ['InboundFilters', 'BrowserTracing'],
+        },
+      },
+      _segmentSpan: span,
+    });
+  });
+
+  it('does not add sentry.sdk.integrations to non-segment child spans', () => {
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://dsn@ingest.f00.f00/1',
+        tracesSampleRate: 1,
+        integrations: [{ name: 'InboundFilters', setupOnce: () => {} }],
+      }),
+    );
+
+    const serializedChild = withScope(scope => {
+      scope.setClient(client);
+      return startSpan({ name: 'segment' }, () => {
+        const childSpan = startInactiveSpan({ name: 'child' });
+        childSpan.end();
+        return captureSpan(childSpan, client);
+      });
+    });
+
+    expect(serializedChild.is_segment).toBe(false);
+    expect(serializedChild.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]).toBeUndefined();
   });
 
   describe('client hooks', () => {

--- a/packages/core/test/lib/tracing/spans/captureSpan.test.ts
+++ b/packages/core/test/lib/tracing/spans/captureSpan.test.ts
@@ -250,6 +250,7 @@ describe('captureSpan', () => {
         },
       }),
     );
+    client.init();
 
     const span = withScope(scope => {
       scope.setClient(client);
@@ -297,6 +298,7 @@ describe('captureSpan', () => {
         integrations: [{ name: 'InboundFilters', setupOnce: () => {} }],
       }),
     );
+    client.init();
 
     const serializedChild = withScope(scope => {
       scope.setClient(client);


### PR DESCRIPTION
In the classic (non-streaming) pipeline, SDK integrations are sets on the transaction event wrapper via `event.sdk.integrations`. In the streaming path this metadata is currently missing. This PR sets `sentry.sdk.integrations` on streamed segment spans.
