### PR TITLE
test(node): Use docker-compose healthchecks for service readiness

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -63,6 +63,7 @@ Do not flag the issues below if they appear in tests.
   - Race conditions when waiting on multiple requests. Ensure that waiting checks are unique enough and don't depend on a hard order when there's a chance that telemetry can be sent in arbitrary order.
   - Timeouts or sleeps in tests. Instead suggest concrete events or other signals to wait on.
 - Flag usage of `getFirstEnvelope*`, `getMultipleEnvelope*` or related test helpers. These are NOT reliable anymore. Instead suggest helpers like `waitForTransaction`, `waitForError`, `waitForSpans`, etc.
+- Flag any new or modified `docker-compose.yml` under `dev-packages/node-integration-tests/suites/` or `dev-packages/node-core-integration-tests/suites/` where a service does not define a `healthcheck:`. The runner uses `docker compose up --wait` and relies on healthchecks to know when services are actually ready; without one the test will race the service's startup.
 
 ## Platform-safe code
 

--- a/dev-packages/node-integration-tests/suites/tracing/amqplib/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/amqplib/docker-compose.yml
@@ -10,6 +10,12 @@ services:
     ports:
       - '5672:5672'
       - '15672:15672'
+    healthcheck:
+      test: ['CMD-SHELL', 'rabbitmq-diagnostics -q ping']
+      interval: 2s
+      timeout: 10s
+      retries: 30
+      start_period: 15s
 
 networks:
   default:

--- a/dev-packages/node-integration-tests/suites/tracing/amqplib/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/amqplib/test.ts
@@ -34,7 +34,6 @@ describe('amqplib auto-instrumentation', () => {
       await createTestRunner()
         .withDockerCompose({
           workingDirectory: [__dirname],
-          readyMatches: ['Time to start RabbitMQ'],
         })
         .expect({
           transaction: (transaction: TransactionEvent) => {

--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/docker-compose.yml
@@ -5,3 +5,9 @@ services:
     container_name: integration-tests-kafka
     ports:
       - '9092:9092'
+    healthcheck:
+      test: ['CMD-SHELL', '/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092']
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 15s

--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
@@ -16,7 +16,6 @@ describe('kafkajs', () => {
       await createRunner()
         .withDockerCompose({
           workingDirectory: [__dirname],
-          readyMatches: ['9092'],
         })
         .expect({
           transaction: (transaction: TransactionEvent) => {

--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/docker-compose.yml
@@ -10,3 +10,9 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: docker
       MYSQL_DATABASE: tests
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -uroot -pdocker']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s

--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/test.ts
@@ -63,7 +63,7 @@ describe('knex auto instrumentation', () => {
         };
 
         await createRunner()
-          .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port: 3306'] })
+          .withDockerCompose({ workingDirectory: [__dirname] })
           .expect({ transaction: EXPECTED_TRANSACTION })
           .start()
           .completed();

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/docker-compose.yml
@@ -11,3 +11,9 @@ services:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test
       POSTGRES_DB: tests
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U test -d tests']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/test.ts
@@ -61,7 +61,7 @@ describe('knex auto instrumentation', () => {
         };
 
         await createRunner()
-          .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+          .withDockerCompose({ workingDirectory: [__dirname] })
           .expect({ transaction: EXPECTED_TRANSACTION })
           .start()
           .completed();

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       - '3306:3306'
     environment:
       MYSQL_ROOT_PASSWORD: password
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -uroot -ppassword']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2/test.ts
@@ -34,7 +34,7 @@ describe('mysql2 auto instrumentation', () => {
     };
 
     await createRunner(__dirname, 'scenario.js')
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port: 3306'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/docker-compose.yml
@@ -11,3 +11,9 @@ services:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test
       POSTGRES_DB: tests
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U test -d tests']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/test.ts
@@ -49,7 +49,6 @@ describe('postgres auto instrumentation', () => {
     await createRunner(__dirname, 'scenario.js')
       .withDockerCompose({
         workingDirectory: [__dirname],
-        readyMatches: ['port 5432'],
         setupCommand: 'yarn',
       })
       .expect({ transaction: EXPECTED_TRANSACTION })
@@ -61,7 +60,6 @@ describe('postgres auto instrumentation', () => {
     await createRunner(__dirname, 'scenario-ignoreConnect.js')
       .withDockerCompose({
         workingDirectory: [__dirname],
-        readyMatches: ['port 5432'],
         setupCommand: 'yarn',
       })
       .expect({
@@ -152,7 +150,6 @@ describe('postgres auto instrumentation', () => {
     await createRunner(__dirname, 'scenario-native.js')
       .withDockerCompose({
         workingDirectory: [__dirname],
-        readyMatches: ['port 5432'],
         setupCommand: 'yarn',
       })
       .expect({ transaction: EXPECTED_TRANSACTION })

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/docker-compose.yml
@@ -11,3 +11,9 @@ services:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test
       POSTGRES_DB: test_db
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U test -d test_db']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/test.ts
@@ -218,7 +218,7 @@ describe('postgresjs auto instrumentation', () => {
     };
 
     await createRunner(__dirname, 'scenario.js')
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .expect({ event: EXPECTED_ERROR_EVENT })
       .start()
@@ -438,7 +438,7 @@ describe('postgresjs auto instrumentation', () => {
 
     await createRunner(__dirname, 'scenario.mjs')
       .withFlags('--import', `${__dirname}/instrument.mjs`)
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .expect({ event: EXPECTED_ERROR_EVENT })
       .start()
@@ -532,7 +532,7 @@ describe('postgresjs auto instrumentation', () => {
 
     await createRunner(__dirname, 'scenario-requestHook.js')
       .withFlags('--require', `${__dirname}/instrument-requestHook.cjs`)
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();
@@ -625,7 +625,7 @@ describe('postgresjs auto instrumentation', () => {
 
     await createRunner(__dirname, 'scenario-requestHook.mjs')
       .withFlags('--import', `${__dirname}/instrument-requestHook.mjs`)
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();
@@ -706,7 +706,7 @@ describe('postgresjs auto instrumentation', () => {
     };
 
     await createRunner(__dirname, 'scenario-url.cjs')
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();
@@ -787,7 +787,7 @@ describe('postgresjs auto instrumentation', () => {
 
     await createRunner(__dirname, 'scenario-url.mjs')
       .withFlags('--import', `${__dirname}/instrument.mjs`)
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();
@@ -866,7 +866,7 @@ describe('postgresjs auto instrumentation', () => {
     };
 
     await createRunner(__dirname, 'scenario-unsafe.cjs')
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();
@@ -946,7 +946,7 @@ describe('postgresjs auto instrumentation', () => {
 
     await createRunner(__dirname, 'scenario-unsafe.mjs')
       .withFlags('--import', `${__dirname}/instrument.mjs`)
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port 5432'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/docker-compose.yml
@@ -11,3 +11,9 @@ services:
       POSTGRES_USER: prisma
       POSTGRES_PASSWORD: prisma
       POSTGRES_DB: tests
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U prisma -d tests']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -15,7 +15,6 @@ describe('Prisma ORM v5 Tests', () => {
         await createRunner()
           .withDockerCompose({
             workingDirectory: [cwd],
-            readyMatches: ['port 5432'],
             setupCommand: 'yarn prisma generate && yarn prisma migrate dev -n sentry-test',
           })
           .expect({

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/docker-compose.yml
@@ -11,3 +11,9 @@ services:
       POSTGRES_USER: prisma
       POSTGRES_PASSWORD: prisma
       POSTGRES_DB: tests
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U prisma -d tests']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -16,7 +16,6 @@ describe('Prisma ORM v6 Tests', () => {
         await createRunner()
           .withDockerCompose({
             workingDirectory: [cwd],
-            readyMatches: ['port 5432'],
             setupCommand: `yarn prisma generate --schema ${cwd}/prisma/schema.prisma && yarn prisma migrate dev -n sentry-test --schema ${cwd}/prisma/schema.prisma`,
           })
           .expect({

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/docker-compose.yml
@@ -11,3 +11,9 @@ services:
       POSTGRES_USER: prisma
       POSTGRES_PASSWORD: prisma
       POSTGRES_DB: tests
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U prisma -d tests']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
@@ -17,7 +17,6 @@ conditionalTest({ min: 20 })('Prisma ORM v7 Tests', () => {
         await createRunner()
           .withDockerCompose({
             workingDirectory: [cwd],
-            readyMatches: ['port 5432'],
             setupCommand: `yarn prisma generate --schema ${cwd}/prisma/schema.prisma && tsc -p ${cwd}/prisma/tsconfig.json && yarn prisma migrate dev -n sentry-test --schema ${cwd}/prisma/schema.prisma`,
           })
           .expect({

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/docker-compose.yml
@@ -4,6 +4,12 @@ services:
   db:
     image: redis:latest
     restart: always
-    container_name: integration-tests-redis
+    container_name: integration-tests-redis-cache
     ports:
       - '6379:6379'
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli ping | grep -q PONG']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/test.ts
@@ -38,7 +38,7 @@ describe('redis cache auto instrumentation', () => {
     };
 
     await createRunner(__dirname, 'scenario-ioredis.js')
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port=6379'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();
@@ -137,7 +137,7 @@ describe('redis cache auto instrumentation', () => {
     };
 
     await createRunner(__dirname, 'scenario-ioredis.js')
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port=6379'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();
@@ -228,7 +228,7 @@ describe('redis cache auto instrumentation', () => {
     };
 
     await createRunner(__dirname, 'scenario-redis-4.js')
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port=6379'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_REDIS_CONNECT })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()

--- a/dev-packages/node-integration-tests/suites/tracing/redis/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/redis/docker-compose.yml
@@ -7,3 +7,9 @@ services:
     container_name: integration-tests-redis
     ports:
       - '6379:6379'
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli ping | grep -q PONG']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/node-integration-tests/suites/tracing/redis/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/redis/test.ts
@@ -43,7 +43,7 @@ describe('redis auto instrumentation', () => {
       };
 
       await createRunner(__dirname, 'scenario-ioredis.js')
-        .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['port=6379'] })
+        .withDockerCompose({ workingDirectory: [__dirname] })
         .expect({ transaction: EXPECTED_TRANSACTION })
         .start()
         .completed();

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/docker-compose.yml
@@ -10,3 +10,9 @@ services:
     environment:
       ACCEPT_EULA: 'Y'
       MSSQL_SA_PASSWORD: 'TESTing123'
+    healthcheck:
+      test: ['CMD-SHELL', '/opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P "TESTing123" -C -Q "SELECT 1"']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 20s

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
@@ -42,7 +42,7 @@ describe.skip('tedious auto instrumentation', { timeout: 75_000 }, () => {
     };
 
     await createRunner(__dirname, 'scenario.js')
-      .withDockerCompose({ workingDirectory: [__dirname], readyMatches: ['1433'] })
+      .withDockerCompose({ workingDirectory: [__dirname] })
       .expect({ transaction: EXPECTED_TRANSACTION })
       .start()
       .completed();

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -79,7 +79,7 @@ interface DockerOptions {
  * healthcheck reports healthy. Each suite defines its healthcheck in its
  * own docker-compose.yml.
  *
- * Returns a function that can be called to docker compose down.
+ * Returns a function that can be called to docker compose down
  */
 async function runDockerCompose(options: DockerOptions): Promise<VoidFunction> {
   const cwd = join(...options.workingDirectory);

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -75,11 +75,11 @@ interface DockerOptions {
 }
 
 /**
- * Runs `docker compose up -d --wait`, which blocks until every service reports
- * its container `healthcheck` as `healthy` (see the `healthcheck:` stanza in
- * each suite's `docker-compose.yml`).
+ * Runs `docker compose up -d --wait`, which blocks until every service's
+ * healthcheck reports healthy. Each suite defines its healthcheck in its
+ * own docker-compose.yml.
  *
- * Returns a function that can be called to docker compose down
+ * Returns a function that can be called to docker compose down.
  */
 async function runDockerCompose(options: DockerOptions): Promise<VoidFunction> {
   const cwd = join(...options.workingDirectory);

--- a/dev-packages/node-integration-tests/utils/runner.ts
+++ b/dev-packages/node-integration-tests/utils/runner.ts
@@ -69,66 +69,57 @@ interface DockerOptions {
    */
   workingDirectory: string[];
   /**
-   * The strings to look for in the output to know that the docker compose is ready for the test to be run
-   */
-  readyMatches: string[];
-  /**
    * The command to run after docker compose is up
    */
   setupCommand?: string;
 }
 
 /**
- * Runs docker compose up and waits for the readyMatches to appear in the output
+ * Runs `docker compose up -d --wait`, which blocks until every service reports
+ * its container `healthcheck` as `healthy` (see the `healthcheck:` stanza in
+ * each suite's `docker-compose.yml`).
  *
  * Returns a function that can be called to docker compose down
  */
 async function runDockerCompose(options: DockerOptions): Promise<VoidFunction> {
-  return new Promise((resolve, reject) => {
-    const cwd = join(...options.workingDirectory);
-    const close = (): void => {
-      spawnSync('docker', ['compose', 'down', '--volumes'], {
-        cwd,
-        stdio: process.env.DEBUG ? 'inherit' : undefined,
-      });
-    };
+  const cwd = join(...options.workingDirectory);
+  const close = (): void => {
+    spawnSync('docker', ['compose', 'down', '--volumes'], {
+      cwd,
+      stdio: process.env.DEBUG ? 'inherit' : undefined,
+    });
+  };
 
-    // ensure we're starting fresh
-    close();
+  // ensure we're starting fresh
+  close();
 
-    const child = spawn('docker', ['compose', 'up'], { cwd });
-
-    const timeout = setTimeout(() => {
-      close();
-      reject(new Error('Timed out waiting for docker-compose'));
-    }, 75_000);
-
-    function newData(data: Buffer): void {
-      const text = data.toString('utf8');
-
-      if (process.env.DEBUG) log(text);
-
-      for (const match of options.readyMatches) {
-        if (text.includes(match)) {
-          child.stdout.removeAllListeners();
-          clearTimeout(timeout);
-          if (options.setupCommand) {
-            try {
-              // Prepend local node_modules/.bin to PATH so additionalDependencies binaries take precedence
-              const env = { ...process.env, PATH: `${cwd}/node_modules/.bin:${process.env.PATH}` };
-              execSync(options.setupCommand, { cwd, stdio: 'inherit', env });
-            } catch (e) {
-              log('Error running docker setup command', e);
-            }
-          }
-          resolve(close);
-        }
-      }
-    }
-
-    child.stdout.on('data', newData);
-    child.stderr.on('data', newData);
+  const result = spawnSync('docker', ['compose', 'up', '-d', '--wait'], {
+    cwd,
+    stdio: process.env.DEBUG ? 'inherit' : 'pipe',
   });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString() ?? '';
+    const stdout = result.stdout?.toString() ?? '';
+    // Surface container logs to make healthcheck failures easier to diagnose in CI
+    const logs = spawnSync('docker', ['compose', 'logs'], { cwd }).stdout?.toString() ?? '';
+    close();
+    throw new Error(
+      `docker compose up --wait failed (exit ${result.status})\n${stderr}${stdout}\n--- container logs ---\n${logs}`,
+    );
+  }
+
+  if (options.setupCommand) {
+    try {
+      // Prepend local node_modules/.bin to PATH so additionalDependencies binaries take precedence
+      const env = { ...process.env, PATH: `${cwd}/node_modules/.bin:${process.env.PATH}` };
+      execSync(options.setupCommand, { cwd, stdio: 'inherit', env });
+    } catch (e) {
+      log('Error running docker setup command', e);
+    }
+  }
+
+  return close;
 }
 
 type ExpectedEvent = Partial<Event> | ((event: Event) => void);


### PR DESCRIPTION
Replace the stdout `readyMatches` approach in the node-integration-tests runner with Docker native healthchecks + `docker compose up -d --wait`. The old approach matched log substrings like `'port 5432'`, which can fire too early when the server is not actually yet accepting connections resulting in flakes. Each `docker-compose.yml` now defines a proper healthcheck (e.g. pg_isready) and the runner blocks on `--wait` until every service reports healthy.

Also renames the redis-cache container to avoid collision with redis.

Closes https://github.com/getsentry/sentry-javascript/issues/20418
Closes https://github.com/getsentry/sentry-javascript/issues/20335
