### PR TITLE
test(node-core): Fix minute-boundary race in session-aggregate tests

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/sessions/errored-session-aggregate/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/sessions/errored-session-aggregate/test.ts
@@ -10,14 +10,17 @@ test('should aggregate successful, crashed and erroneous sessions', async () => 
     .ignore('transaction', 'event')
     .unignore('sessions')
     .expect({
-      sessions: {
-        aggregates: [
-          {
-            started: expect.any(String),
-            exited: 2,
-            errored: 1,
-          },
-        ],
+      sessions: agg => {
+        // Sessions are bucketed by minute; tolerate splits across a minute boundary by summing.
+        const totals = agg.aggregates.reduce(
+          (acc, b) => ({
+            exited: acc.exited + (b.exited ?? 0),
+            errored: acc.errored + (b.errored ?? 0),
+            crashed: acc.crashed + (b.crashed ?? 0),
+          }),
+          { exited: 0, errored: 0, crashed: 0 },
+        );
+        expect(totals).toEqual({ exited: 2, errored: 1, crashed: 0 });
       },
     })
     .start();

--- a/dev-packages/node-core-integration-tests/suites/sessions/exited-session-aggregate/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/sessions/exited-session-aggregate/test.ts
@@ -10,13 +10,17 @@ test('should aggregate successful sessions', async () => {
     .ignore('transaction', 'event')
     .unignore('sessions')
     .expect({
-      sessions: {
-        aggregates: [
-          {
-            started: expect.any(String),
-            exited: 3,
-          },
-        ],
+      sessions: agg => {
+        // Sessions are bucketed by minute; tolerate splits across a minute boundary by summing.
+        const totals = agg.aggregates.reduce(
+          (acc, b) => ({
+            exited: acc.exited + (b.exited ?? 0),
+            errored: acc.errored + (b.errored ?? 0),
+            crashed: acc.crashed + (b.crashed ?? 0),
+          }),
+          { exited: 0, errored: 0, crashed: 0 },
+        );
+        expect(totals).toEqual({ exited: 3, errored: 0, crashed: 0 });
       },
     })
     .start();

--- a/dev-packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
@@ -10,14 +10,17 @@ test('should aggregate successful and crashed sessions', async () => {
     .ignore('transaction', 'event')
     .unignore('sessions')
     .expect({
-      sessions: {
-        aggregates: [
-          {
-            started: expect.any(String),
-            exited: 2,
-            crashed: 1,
-          },
-        ],
+      sessions: agg => {
+        // Sessions are bucketed by minute; tolerate splits across a minute boundary by summing.
+        const totals = agg.aggregates.reduce(
+          (acc, b) => ({
+            exited: acc.exited + (b.exited ?? 0),
+            errored: acc.errored + (b.errored ?? 0),
+            crashed: acc.crashed + (b.crashed ?? 0),
+          }),
+          { exited: 0, errored: 0, crashed: 0 },
+        );
+        expect(totals).toEqual({ exited: 2, errored: 0, crashed: 1 });
       },
     })
     .start();

--- a/dev-packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
@@ -10,15 +10,17 @@ test('should aggregate successful, crashed and erroneous sessions', async () => 
     .ignore('transaction', 'event')
     .unignore('sessions')
     .expect({
-      sessions: {
-        aggregates: [
-          {
-            started: expect.any(String),
-            exited: 1,
-            crashed: 1,
-            errored: 1,
-          },
-        ],
+      sessions: agg => {
+        // Sessions are bucketed by minute; tolerate splits across a minute boundary by summing.
+        const totals = agg.aggregates.reduce(
+          (acc, b) => ({
+            exited: acc.exited + (b.exited ?? 0),
+            errored: acc.errored + (b.errored ?? 0),
+            crashed: acc.crashed + (b.crashed ?? 0),
+          }),
+          { exited: 0, errored: 0, crashed: 0 },
+        );
+        expect(totals).toEqual({ exited: 1, errored: 1, crashed: 1 });
       },
     })
     .start();

--- a/dev-packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
@@ -10,13 +10,17 @@ test('should aggregate successful sessions', async () => {
     .ignore('transaction', 'event')
     .unignore('sessions')
     .expect({
-      sessions: {
-        aggregates: [
-          {
-            started: expect.any(String),
-            exited: 3,
-          },
-        ],
+      sessions: agg => {
+        // Sessions are bucketed by minute; tolerate splits across a minute boundary by summing.
+        const totals = agg.aggregates.reduce(
+          (acc, b) => ({
+            exited: acc.exited + (b.exited ?? 0),
+            errored: acc.errored + (b.errored ?? 0),
+            crashed: acc.crashed + (b.crashed ?? 0),
+          }),
+          { exited: 0, errored: 0, crashed: 0 },
+        );
+        expect(totals).toEqual({ exited: 3, errored: 0, crashed: 0 });
       },
     })
     .start();


### PR DESCRIPTION
The SDK buckets sessions by minute-rounded timestamp. When a test's sequential requests run across a minute boundary, the payload splits across two `aggregates` buckets and the existing single-bucket assertion fails. To resolve this, this PR replaces the single bucket check with a sum across all returned buckets to ensure the total count is correct even if events are split across buckets.

The same pattern exists in our `node-core` and `node` integration tests.

Closes #20283
Closes #20436