### PR TITLE
feat(core): Backfill otel attributes on streamed spans

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -212,7 +212,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing)',
     path: createCDNPath('bundle.tracing.min.js'),
     gzip: true,
-    limit: '46.5 KB',
+    limit: '47 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
@@ -226,7 +226,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Logs, Metrics)',
     path: createCDNPath('bundle.tracing.logs.metrics.min.js'),
     gzip: true,
-    limit: '47.5 KB',
+    limit: '48 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
@@ -240,14 +240,14 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Replay)',
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: true,
-    limit: '83.5 KB',
+    limit: '84 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
     name: 'CDN Bundle (incl. Tracing, Replay, Logs, Metrics)',
     path: createCDNPath('bundle.tracing.replay.logs.metrics.min.js'),
     gzip: true,
-    limit: '84.5 KB',
+    limit: '85 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
@@ -278,7 +278,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.min.js'),
     gzip: false,
     brotli: false,
-    limit: '139 KB',
+    limit: '140 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
@@ -294,7 +294,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '142 KB',
+    limit: '143 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
@@ -310,7 +310,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: false,
     brotli: false,
-    limit: '256 KB',
+    limit: '257 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
@@ -318,7 +318,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '260 KB',
+    limit: '260.5 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic-streamed/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic-streamed/scenario.ts
@@ -1,0 +1,20 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  traceLifecycle: 'stream',
+  transport: loggingTransport,
+});
+
+async function run(): Promise<void> {
+  await Sentry.startSpan({ name: 'test_transaction' }, async () => {
+    await fetch(`${process.env.SERVER_URL}/api/v0`);
+  });
+
+  await Sentry.flush();
+}
+
+void run();

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic-streamed/test.ts
@@ -1,0 +1,30 @@
+import { createTestServer } from '@sentry-internal/test-utils';
+import { expect, test } from 'vitest';
+import { createRunner } from '../../../../utils/runner';
+
+test('captures streamed spans with sentry.op for outgoing fetch requests', async () => {
+  expect.assertions(2);
+
+  const [SERVER_URL, closeTestServer] = await createTestServer()
+    .get('/api/v0', () => {
+      // Just ensure we're called
+      expect(true).toBe(true);
+    })
+    .start();
+
+  await createRunner(__dirname, 'scenario.ts')
+    .withEnv({ SERVER_URL })
+    .expect({
+      span: container => {
+        const httpClientSpan = container.items.find(
+          item =>
+            item.attributes?.['sentry.op']?.type === 'string' && item.attributes['sentry.op'].value === 'http.client',
+        );
+
+        expect(httpClientSpan).toBeDefined();
+      },
+    })
+    .start()
+    .completed();
+  closeTestServer();
+});

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic-streamed/test.ts
@@ -2,8 +2,8 @@ import { createTestServer } from '@sentry-internal/test-utils';
 import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('infers sentry.op, name, and source for streamed outgoing fetch spans', async () => {
-  expect.assertions(4);
+test('infers sentry.op for streamed outgoing fetch spans', async () => {
+  expect.assertions(2);
 
   const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', () => {
@@ -21,8 +21,6 @@ test('infers sentry.op, name, and source for streamed outgoing fetch spans', asy
         );
 
         expect(httpClientSpan).toBeDefined();
-        expect(httpClientSpan?.name).toMatch(/^GET /);
-        expect(httpClientSpan?.attributes?.['sentry.source']).toEqual({ type: 'string', value: 'url' });
       },
     })
     .start()

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic-streamed/test.ts
@@ -2,12 +2,11 @@ import { createTestServer } from '@sentry-internal/test-utils';
 import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
 
-test('captures streamed spans with sentry.op for outgoing fetch requests', async () => {
-  expect.assertions(2);
+test('infers sentry.op, name, and source for streamed outgoing fetch spans', async () => {
+  expect.assertions(4);
 
   const [SERVER_URL, closeTestServer] = await createTestServer()
     .get('/api/v0', () => {
-      // Just ensure we're called
       expect(true).toBe(true);
     })
     .start();
@@ -22,6 +21,8 @@ test('captures streamed spans with sentry.op for outgoing fetch requests', async
         );
 
         expect(httpClientSpan).toBeDefined();
+        expect(httpClientSpan?.name).toMatch(/^GET /);
+        expect(httpClientSpan?.attributes?.['sentry.source']).toEqual({ type: 'string', value: 'url' });
       },
     })
     .start()

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/instrument.mjs
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/server.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/server.mjs
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/node';
+import { startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
+import cors from 'cors';
+import express from 'express';
+
+const app = express();
+
+app.use(cors());
+
+app.get('/test', (_req, res) => {
+  res.send({ response: 'ok' });
+});
+
+Sentry.setupExpressErrorHandler(app);
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/test.ts
@@ -1,0 +1,31 @@
+import { afterAll, describe, expect } from 'vitest';
+import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+
+describe('httpIntegration-streamed', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  createEsmAndCjsTests(__dirname, 'server.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('infers sentry.op http.server on streamed server spans', async () => {
+      const runner = createRunner()
+        .expect({
+          span: container => {
+            const serverSpan = container.items.find(
+              item =>
+                item.attributes?.['sentry.op']?.type === 'string' &&
+                item.attributes['sentry.op'].value === 'http.server',
+            );
+
+            expect(serverSpan).toBeDefined();
+            expect(serverSpan?.is_segment).toBe(true);
+          },
+        })
+        .start();
+
+      await runner.makeRequest('get', '/test');
+
+      await runner.completed();
+    });
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/test.ts
@@ -7,7 +7,7 @@ describe('httpIntegration-streamed', () => {
   });
 
   createEsmAndCjsTests(__dirname, 'server.mjs', 'instrument.mjs', (createRunner, test) => {
-    test('infers sentry.op http.server on streamed server spans', async () => {
+    test('infers sentry.op, name, and source for streamed server spans', async () => {
       const runner = createRunner()
         .expect({
           span: container => {
@@ -19,6 +19,8 @@ describe('httpIntegration-streamed', () => {
 
             expect(serverSpan).toBeDefined();
             expect(serverSpan?.is_segment).toBe(true);
+            expect(serverSpan?.name).toBe('GET /test');
+            expect(serverSpan?.attributes?.['sentry.source']).toEqual({ type: 'string', value: 'route' });
           },
         })
         .start();

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration-streamed/test.ts
@@ -21,6 +21,7 @@ describe('httpIntegration-streamed', () => {
             expect(serverSpan?.is_segment).toBe(true);
             expect(serverSpan?.name).toBe('GET /test');
             expect(serverSpan?.attributes?.['sentry.source']).toEqual({ type: 'string', value: 'route' });
+            expect(serverSpan?.attributes?.['sentry.span.source']).toEqual({ type: 'string', value: 'route' });
           },
         })
         .start();

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -3,6 +3,7 @@ import type { Client } from '../../client';
 import type { ScopeData } from '../../scope';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
@@ -79,6 +80,17 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
     });
   }
 
+  // Backfill sentry.op from span attributes when not explicitly set.
+  // OTel-originated spans don't have sentry.op set — we infer it from semantic conventions.
+  if (!processedSpan.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP]) {
+    const inferredOp = inferOpFromAttributes(processedSpan.attributes);
+    if (inferredOp) {
+      safeSetSpanJSONAttributes(processedSpan, {
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: inferredOp,
+      });
+    }
+  }
+
   return {
     ...streamedSpanJsonToSerializedSpan(processedSpan),
     _segmentSpan: segmentSpan,
@@ -149,4 +161,30 @@ export function safeSetSpanJSONAttributes(
       originalAttributes[key] = value;
     }
   });
+}
+
+/**
+ * Infer `sentry.op` from span attributes based on OTel semantic conventions.
+ * This is needed because OTel-originated spans don't set `sentry.op` — the non-streamed
+ * path infers it in the `SentrySpanExporter`, but streamed spans skip the exporter entirely.
+ */
+function inferOpFromAttributes(attributes?: RawAttributes<Record<string, unknown>>): string | undefined {
+  if (!attributes) {
+    return undefined;
+  }
+
+  const httpMethod = attributes['http.request.method'] || attributes['http.method'];
+  if (httpMethod) {
+    // Determine client vs server from the span's parent:
+    // - Spans with a server address are outgoing (client) requests
+    // - The `sentry.origin` attribute can also indicate the direction
+    return attributes['server.address'] || attributes['net.peer.name'] ? 'http.client' : 'http.server';
+  }
+
+  const dbSystem = attributes['db.system.name'] || attributes['db.system'];
+  if (dbSystem) {
+    return 'db';
+  }
+
+  return undefined;
 }

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -228,11 +228,15 @@ function inferHttpSpanData(
   }
   safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: opParts.join('.') });
 
-  // If the user already set a custom name or source, don't overwrite
-  if (
-    attributes[SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME] ||
-    attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom'
-  ) {
+  // If the user set a custom span name via updateSpanName(), apply it — OTel instrumentation
+  // may have overwritten span.name after the user set it, so we restore from the attribute.
+  const customName = attributes[SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME];
+  if (typeof customName === 'string') {
+    spanJSON.name = customName;
+    return;
+  }
+
+  if (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom') {
     return;
   }
 
@@ -249,10 +253,14 @@ function inferHttpSpanData(
 function inferDbSpanData(spanJSON: StreamedSpanJSON, attributes: RawAttributes<Record<string, unknown>>): void {
   safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db' });
 
-  if (
-    attributes[SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME] ||
-    attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom'
-  ) {
+  // If the user set a custom span name via updateSpanName(), apply it.
+  const customName = attributes[SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME];
+  if (typeof customName === 'string') {
+    spanJSON.name = customName;
+    return;
+  }
+
+  if (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom') {
     return;
   }
 

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -82,8 +82,11 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
 
   // Backfill sentry.op from span attributes when not explicitly set.
   // OTel-originated spans don't have sentry.op set — we infer it from semantic conventions.
+  // The non-streamed path infers this in the SentrySpanExporter, but streamed spans skip the exporter.
   if (!processedSpan.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP]) {
-    const inferredOp = inferOpFromAttributes(processedSpan.attributes);
+    // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type
+    const spanKind = (span as { kind?: number }).kind;
+    const inferredOp = inferOpFromAttributes(processedSpan.attributes, spanKind);
     if (inferredOp) {
       safeSetSpanJSONAttributes(processedSpan, {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: inferredOp,
@@ -163,22 +166,32 @@ export function safeSetSpanJSONAttributes(
   });
 }
 
+// OTel SpanKind values (we use the numeric values to avoid importing from @opentelemetry/api)
+const SPAN_KIND_CLIENT = 2;
+const SPAN_KIND_SERVER = 1;
+
 /**
- * Infer `sentry.op` from span attributes based on OTel semantic conventions.
+ * Infer `sentry.op` from span attributes and kind based on OTel semantic conventions.
  * This is needed because OTel-originated spans don't set `sentry.op` — the non-streamed
  * path infers it in the `SentrySpanExporter`, but streamed spans skip the exporter entirely.
  */
-function inferOpFromAttributes(attributes?: RawAttributes<Record<string, unknown>>): string | undefined {
+function inferOpFromAttributes(
+  attributes?: RawAttributes<Record<string, unknown>>,
+  spanKind?: number,
+): string | undefined {
   if (!attributes) {
     return undefined;
   }
 
   const httpMethod = attributes['http.request.method'] || attributes['http.method'];
   if (httpMethod) {
-    // Determine client vs server from the span's parent:
-    // - Spans with a server address are outgoing (client) requests
-    // - The `sentry.origin` attribute can also indicate the direction
-    return attributes['server.address'] || attributes['net.peer.name'] ? 'http.client' : 'http.server';
+    if (spanKind === SPAN_KIND_CLIENT) {
+      return 'http.client';
+    }
+    if (spanKind === SPAN_KIND_SERVER) {
+      return 'http.server';
+    }
+    return 'http';
   }
 
   const dbSystem = attributes['db.system.name'] || attributes['db.system'];

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -60,6 +60,14 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
     client.emit('processSegmentSpan', spanJSON);
   }
 
+  // Backfill span data from OTel semantic conventions when not explicitly set.
+  // OTel-originated spans don't have sentry.op, description, etc. — the non-streamed path
+  // infers these in the SentrySpanExporter, but streamed spans skip the exporter entirely.
+  // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type.
+  // This must run before hooks and beforeSendSpan so that user callbacks can see and override inferred values.
+  const spanKind = (span as { kind?: number }).kind;
+  inferSpanDataFromOtelAttributes(spanJSON, spanKind);
+
   // This allows hook subscribers to mutate the span JSON
   // This also invokes the `processSpan` hook of all integrations
   client.emit('processSpan', spanJSON);
@@ -69,14 +77,6 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
     beforeSendSpan && isStreamedBeforeSendSpanCallback(beforeSendSpan)
       ? applyBeforeSendSpanCallback(spanJSON, beforeSendSpan)
       : spanJSON;
-
-  // Backfill span data from OTel semantic conventions when not explicitly set.
-  // OTel-originated spans don't have sentry.op, description, etc. — the non-streamed path
-  // infers these in the SentrySpanExporter, but streamed spans skip the exporter entirely.
-  // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type.
-  // This must run before the sentry.span.source backfill below, so that inferred sentry.source is picked up.
-  const spanKind = (span as { kind?: number }).kind;
-  inferSpanDataFromOtelAttributes(processedSpan, spanKind);
 
   // Backfill sentry.span.source from sentry.source. Only `sentry.span.source` is respected by Sentry.
   // TODO(v11): Remove this backfill once we renamed SEMANTIC_ATTRIBUTE_SENTRY_SOURCE to sentry.span.source

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -5,7 +5,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
@@ -17,7 +16,6 @@ import {
   SEMANTIC_ATTRIBUTE_USER_IP_ADDRESS,
   SEMANTIC_ATTRIBUTE_USER_USERNAME,
 } from '../../semanticAttributes';
-import { getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from '../../utils/url';
 import type { SerializedStreamedSpan, Span, StreamedSpanJSON } from '../../types-hoist/span';
 import { getCombinedScopeData } from '../../utils/scopeData';
 import {
@@ -234,39 +232,13 @@ function inferHttpSpanData(
     return;
   }
 
-  // Infer name and source from URL attributes
+  // Only overwrite the span name when we have an explicit http.route — it's more specific than
+  // what OTel instrumentation sets as the span name. For all other cases (url.full, http.target),
+  // the OTel-set name is already good enough and we'd risk producing a worse name (e.g. full URL).
   const httpRoute = attributes['http.route'];
-  const httpTarget = attributes['http.target'];
-  const httpUrl = attributes['url.full'] || attributes['http.url'];
-  const parsedUrl = typeof httpUrl === 'string' ? parseUrl(httpUrl) : undefined;
-  const sanitizedUrl = parsedUrl ? getSanitizedUrlString(parsedUrl) : undefined;
-
-  let urlPath: string | undefined;
-  let source: string | undefined;
-
   if (typeof httpRoute === 'string') {
-    urlPath = httpRoute;
-    source = 'route';
-  } else if (spanKind === SPAN_KIND_SERVER && typeof httpTarget === 'string') {
-    urlPath = stripUrlQueryAndFragment(httpTarget);
-    source = 'url';
-  } else if (sanitizedUrl) {
-    urlPath = sanitizedUrl;
-    source = 'url';
-  } else if (typeof httpTarget === 'string') {
-    urlPath = stripUrlQueryAndFragment(httpTarget);
-    source = 'url';
-  }
-
-  if (urlPath) {
-    const isClientOrServer = spanKind === SPAN_KIND_CLIENT || spanKind === SPAN_KIND_SERVER;
-    const origin = attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] || 'manual';
-    const isAutoSpan = `${origin}`.startsWith('auto');
-
-    if (isClientOrServer || isAutoSpan) {
-      spanJSON.name = `${httpMethod} ${urlPath}`;
-      safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source });
-    }
+    spanJSON.name = `${httpMethod} ${httpRoute}`;
+    safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route' });
   }
 }
 

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -186,7 +186,10 @@ function inferSpanDataFromOtelAttributes(spanJSON: StreamedSpanJSON, spanKind?: 
   }
 
   const dbSystem = attributes['db.system.name'] || attributes['db.system'];
-  if (dbSystem) {
+  const opIsCache =
+    typeof attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'string' &&
+    `${attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]}`.startsWith('cache.');
+  if (dbSystem && !opIsCache) {
     inferDbSpanData(spanJSON, attributes);
     return;
   }

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -2,8 +2,10 @@ import type { RawAttributes } from '../../attributes';
 import type { Client } from '../../client';
 import type { ScopeData } from '../../scope';
 import {
+  SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION,
@@ -15,6 +17,7 @@ import {
   SEMANTIC_ATTRIBUTE_USER_IP_ADDRESS,
   SEMANTIC_ATTRIBUTE_USER_USERNAME,
 } from '../../semanticAttributes';
+import { getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from '../../utils/url';
 import type { SerializedStreamedSpan, Span, StreamedSpanJSON } from '../../types-hoist/span';
 import { getCombinedScopeData } from '../../utils/scopeData';
 import {
@@ -168,6 +171,7 @@ const SPAN_KIND_CLIENT = 2;
  * This mirrors what the `SentrySpanExporter` does for non-streamed spans via `getSpanData`/`inferSpanData`.
  * Streamed spans skip the exporter, so we do the inference here during capture.
  *
+ * Backfills: `sentry.op`, `sentry.source`, and `name` (description).
  * Uses `safeSetSpanJSONAttributes` so explicitly set attributes are never overwritten.
  */
 function inferSpanDataFromOtelAttributes(spanJSON: StreamedSpanJSON, spanKind?: number): void {
@@ -178,49 +182,107 @@ function inferSpanDataFromOtelAttributes(spanJSON: StreamedSpanJSON, spanKind?: 
 
   const httpMethod = attributes['http.request.method'] || attributes['http.method'];
   if (httpMethod) {
-    const opParts = ['http'];
-    if (spanKind === SPAN_KIND_CLIENT) {
-      opParts.push('client');
-    } else if (spanKind === SPAN_KIND_SERVER) {
-      opParts.push('server');
-    }
-
-    if (attributes['sentry.http.prefetch']) {
-      opParts.push('prefetch');
-    }
-
-    safeSetSpanJSONAttributes(spanJSON, {
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: opParts.join('.'),
-    });
+    inferHttpSpanData(spanJSON, attributes, spanKind, httpMethod);
     return;
   }
 
   const dbSystem = attributes['db.system.name'] || attributes['db.system'];
   if (dbSystem) {
-    safeSetSpanJSONAttributes(spanJSON, {
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
-    });
+    inferDbSpanData(spanJSON, attributes);
     return;
   }
 
   if (attributes['rpc.service']) {
-    safeSetSpanJSONAttributes(spanJSON, {
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'rpc',
-    });
+    safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'rpc' });
     return;
   }
 
   if (attributes['messaging.system']) {
-    safeSetSpanJSONAttributes(spanJSON, {
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'message',
-    });
+    safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'message' });
     return;
   }
 
   const faasTrigger = attributes['faas.trigger'];
   if (faasTrigger) {
-    safeSetSpanJSONAttributes(spanJSON, {
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: `${faasTrigger}`,
-    });
+    safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: `${faasTrigger}` });
+  }
+}
+
+function inferHttpSpanData(
+  spanJSON: StreamedSpanJSON,
+  attributes: RawAttributes<Record<string, unknown>>,
+  spanKind: number | undefined,
+  httpMethod: unknown,
+): void {
+  // Infer op: http.client, http.server, or just http
+  const opParts = ['http'];
+  if (spanKind === SPAN_KIND_CLIENT) {
+    opParts.push('client');
+  } else if (spanKind === SPAN_KIND_SERVER) {
+    opParts.push('server');
+  }
+  if (attributes['sentry.http.prefetch']) {
+    opParts.push('prefetch');
+  }
+  safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: opParts.join('.') });
+
+  // If the user already set a custom name or source, don't overwrite
+  if (
+    attributes[SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME] ||
+    attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom'
+  ) {
+    return;
+  }
+
+  // Infer name and source from URL attributes
+  const httpRoute = attributes['http.route'];
+  const httpTarget = attributes['http.target'];
+  const httpUrl = attributes['url.full'] || attributes['http.url'];
+  const parsedUrl = typeof httpUrl === 'string' ? parseUrl(httpUrl) : undefined;
+  const sanitizedUrl = parsedUrl ? getSanitizedUrlString(parsedUrl) : undefined;
+
+  let urlPath: string | undefined;
+  let source: string | undefined;
+
+  if (typeof httpRoute === 'string') {
+    urlPath = httpRoute;
+    source = 'route';
+  } else if (spanKind === SPAN_KIND_SERVER && typeof httpTarget === 'string') {
+    urlPath = stripUrlQueryAndFragment(httpTarget);
+    source = 'url';
+  } else if (sanitizedUrl) {
+    urlPath = sanitizedUrl;
+    source = 'url';
+  } else if (typeof httpTarget === 'string') {
+    urlPath = stripUrlQueryAndFragment(httpTarget);
+    source = 'url';
+  }
+
+  if (urlPath) {
+    const isClientOrServer = spanKind === SPAN_KIND_CLIENT || spanKind === SPAN_KIND_SERVER;
+    const origin = attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] || 'manual';
+    const isAutoSpan = `${origin}`.startsWith('auto');
+
+    if (isClientOrServer || isAutoSpan) {
+      spanJSON.name = `${httpMethod} ${urlPath}`;
+      safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source });
+    }
+  }
+}
+
+function inferDbSpanData(spanJSON: StreamedSpanJSON, attributes: RawAttributes<Record<string, unknown>>): void {
+  safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db' });
+
+  if (
+    attributes[SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME] ||
+    attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom'
+  ) {
+    return;
+  }
+
+  const statement = attributes['db.statement'];
+  if (statement) {
+    spanJSON.name = `${statement}`;
+    safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task' });
   }
 }

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -53,20 +53,20 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
 
   applyCommonSpanAttributes(spanJSON, serializedSegmentSpan, client, finalScopeData);
 
+  // Backfill span data from OTel semantic conventions when not explicitly set.
+  // OTel-originated spans don't have sentry.op, description, etc. — the non-streamed path
+  // infers these in the SentrySpanExporter, but streamed spans skip the exporter entirely.
+  // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type.
+  // This must run before all hooks and beforeSendSpan so that user callbacks can see and override inferred values.
+  const spanKind = (span as { kind?: number }).kind;
+  inferSpanDataFromOtelAttributes(spanJSON, spanKind);
+
   if (spanJSON.is_segment) {
     applyScopeToSegmentSpan(spanJSON, finalScopeData);
     // Allow hook subscribers to mutate the segment span JSON
     // This also invokes the `processSegmentSpan` hook of all integrations
     client.emit('processSegmentSpan', spanJSON);
   }
-
-  // Backfill span data from OTel semantic conventions when not explicitly set.
-  // OTel-originated spans don't have sentry.op, description, etc. — the non-streamed path
-  // infers these in the SentrySpanExporter, but streamed spans skip the exporter entirely.
-  // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type.
-  // This must run before hooks and beforeSendSpan so that user callbacks can see and override inferred values.
-  const spanKind = (span as { kind?: number }).kind;
-  inferSpanDataFromOtelAttributes(spanJSON, spanKind);
 
   // This allows hook subscribers to mutate the span JSON
   // This also invokes the `processSpan` hook of all integrations

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -248,6 +248,11 @@ function inferHttpSpanData(
   if (typeof httpRoute === 'string') {
     spanJSON.name = `${httpMethod} ${httpRoute}`;
     safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route' });
+  } else {
+    // Fallback: set source to 'url' for HTTP spans without a route.
+    // The spec requires sentry.span.source on segment spans, and the non-streamed exporter
+    // always sets this — so we need to ensure it's present for streamed spans too.
+    safeSetSpanJSONAttributes(spanJSON, { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url' });
   }
 }
 

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -173,7 +173,8 @@ const SPAN_KIND_CLIENT = 2;
  * Backfills: `sentry.op`, `sentry.source`, and `name` (description).
  * Uses `safeSetSpanJSONAttributes` so explicitly set attributes are never overwritten.
  */
-function inferSpanDataFromOtelAttributes(spanJSON: StreamedSpanJSON, spanKind?: number): void {
+/** Exported only for tests. */
+export function inferSpanDataFromOtelAttributes(spanJSON: StreamedSpanJSON, spanKind?: number): void {
   const attributes = spanJSON.attributes;
   if (!attributes) {
     return;

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -80,19 +80,12 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
     });
   }
 
-  // Backfill sentry.op from span attributes when not explicitly set.
-  // OTel-originated spans don't have sentry.op set — we infer it from semantic conventions.
-  // The non-streamed path infers this in the SentrySpanExporter, but streamed spans skip the exporter.
-  if (!processedSpan.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP]) {
-    // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type
-    const spanKind = (span as { kind?: number }).kind;
-    const inferredOp = inferOpFromAttributes(processedSpan.attributes, spanKind);
-    if (inferredOp) {
-      safeSetSpanJSONAttributes(processedSpan, {
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: inferredOp,
-      });
-    }
-  }
+  // Backfill span data from OTel semantic conventions when not explicitly set.
+  // OTel-originated spans don't have sentry.op, description, etc. — the non-streamed path
+  // infers these in the SentrySpanExporter, but streamed spans skip the exporter entirely.
+  // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type.
+  const spanKind = (span as { kind?: number }).kind;
+  inferSpanDataFromOtelAttributes(processedSpan, spanKind);
 
   return {
     ...streamedSpanJsonToSerializedSpan(processedSpan),
@@ -166,38 +159,68 @@ export function safeSetSpanJSONAttributes(
   });
 }
 
-// OTel SpanKind values (we use the numeric values to avoid importing from @opentelemetry/api)
-const SPAN_KIND_CLIENT = 2;
+// OTel SpanKind values (numeric to avoid importing from @opentelemetry/api)
 const SPAN_KIND_SERVER = 1;
+const SPAN_KIND_CLIENT = 2;
 
 /**
- * Infer `sentry.op` from span attributes and kind based on OTel semantic conventions.
- * This is needed because OTel-originated spans don't set `sentry.op` — the non-streamed
- * path infers it in the `SentrySpanExporter`, but streamed spans skip the exporter entirely.
+ * Infer and backfill span data from OTel semantic conventions.
+ * This mirrors what the `SentrySpanExporter` does for non-streamed spans via `getSpanData`/`inferSpanData`.
+ * Streamed spans skip the exporter, so we do the inference here during capture.
+ *
+ * Uses `safeSetSpanJSONAttributes` so explicitly set attributes are never overwritten.
  */
-function inferOpFromAttributes(
-  attributes?: RawAttributes<Record<string, unknown>>,
-  spanKind?: number,
-): string | undefined {
+function inferSpanDataFromOtelAttributes(spanJSON: StreamedSpanJSON, spanKind?: number): void {
+  const attributes = spanJSON.attributes;
   if (!attributes) {
-    return undefined;
+    return;
   }
 
   const httpMethod = attributes['http.request.method'] || attributes['http.method'];
   if (httpMethod) {
+    const opParts = ['http'];
     if (spanKind === SPAN_KIND_CLIENT) {
-      return 'http.client';
+      opParts.push('client');
+    } else if (spanKind === SPAN_KIND_SERVER) {
+      opParts.push('server');
     }
-    if (spanKind === SPAN_KIND_SERVER) {
-      return 'http.server';
+
+    if (attributes['sentry.http.prefetch']) {
+      opParts.push('prefetch');
     }
-    return 'http';
+
+    safeSetSpanJSONAttributes(spanJSON, {
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: opParts.join('.'),
+    });
+    return;
   }
 
   const dbSystem = attributes['db.system.name'] || attributes['db.system'];
   if (dbSystem) {
-    return 'db';
+    safeSetSpanJSONAttributes(spanJSON, {
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+    });
+    return;
   }
 
-  return undefined;
+  if (attributes['rpc.service']) {
+    safeSetSpanJSONAttributes(spanJSON, {
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'rpc',
+    });
+    return;
+  }
+
+  if (attributes['messaging.system']) {
+    safeSetSpanJSONAttributes(spanJSON, {
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'message',
+    });
+    return;
+  }
+
+  const faasTrigger = attributes['faas.trigger'];
+  if (faasTrigger) {
+    safeSetSpanJSONAttributes(spanJSON, {
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: `${faasTrigger}`,
+    });
+  }
 }

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -70,6 +70,14 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
       ? applyBeforeSendSpanCallback(spanJSON, beforeSendSpan)
       : spanJSON;
 
+  // Backfill span data from OTel semantic conventions when not explicitly set.
+  // OTel-originated spans don't have sentry.op, description, etc. — the non-streamed path
+  // infers these in the SentrySpanExporter, but streamed spans skip the exporter entirely.
+  // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type.
+  // This must run before the sentry.span.source backfill below, so that inferred sentry.source is picked up.
+  const spanKind = (span as { kind?: number }).kind;
+  inferSpanDataFromOtelAttributes(processedSpan, spanKind);
+
   // Backfill sentry.span.source from sentry.source. Only `sentry.span.source` is respected by Sentry.
   // TODO(v11): Remove this backfill once we renamed SEMANTIC_ATTRIBUTE_SENTRY_SOURCE to sentry.span.source
   const spanNameSource = processedSpan.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
@@ -80,13 +88,6 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
       'sentry.span.source': spanNameSource,
     });
   }
-
-  // Backfill span data from OTel semantic conventions when not explicitly set.
-  // OTel-originated spans don't have sentry.op, description, etc. — the non-streamed path
-  // infers these in the SentrySpanExporter, but streamed spans skip the exporter entirely.
-  // Access `kind` via duck-typing — OTel span objects have this property but it's not on Sentry's Span type.
-  const spanKind = (span as { kind?: number }).kind;
-  inferSpanDataFromOtelAttributes(processedSpan, spanKind);
 
   return {
     ...streamedSpanJsonToSerializedSpan(processedSpan),

--- a/packages/core/test/lib/tracing/spans/captureSpan.test.ts
+++ b/packages/core/test/lib/tracing/spans/captureSpan.test.ts
@@ -21,7 +21,7 @@ import {
   withScope,
   withStreamedSpan,
 } from '../../../../src';
-import { safeSetSpanJSONAttributes } from '../../../../src/tracing/spans/captureSpan';
+import { inferSpanDataFromOtelAttributes, safeSetSpanJSONAttributes } from '../../../../src/tracing/spans/captureSpan';
 import { getDefaultTestClientOptions, TestClient } from '../../../mocks/client';
 
 describe('captureSpan', () => {
@@ -481,5 +481,159 @@ describe('safeSetSpanJSONAttributes', () => {
     safeSetSpanJSONAttributes(spanJSON, { a: undefined, b: null });
 
     expect(spanJSON.attributes).toEqual({});
+  });
+});
+
+describe('inferSpanDataFromOtelAttributes', () => {
+  function makeSpanJSON(name: string, attributes: Record<string, unknown>): StreamedSpanJSON {
+    return {
+      name,
+      span_id: 'abc123',
+      trace_id: 'def456',
+      start_timestamp: 0,
+      end_timestamp: 1,
+      status: 'ok',
+      is_segment: false,
+      attributes,
+    };
+  }
+
+  describe('http spans', () => {
+    it('infers http.client op for CLIENT kind', () => {
+      const spanJSON = makeSpanJSON('GET', { 'http.request.method': 'GET' });
+      inferSpanDataFromOtelAttributes(spanJSON, 2); // SPAN_KIND_CLIENT
+      expect(spanJSON.attributes?.['sentry.op']).toBe('http.client');
+    });
+
+    it('infers http.server op for SERVER kind', () => {
+      const spanJSON = makeSpanJSON('GET', { 'http.request.method': 'GET' });
+      inferSpanDataFromOtelAttributes(spanJSON, 1); // SPAN_KIND_SERVER
+      expect(spanJSON.attributes?.['sentry.op']).toBe('http.server');
+    });
+
+    it('infers http op when kind is unknown', () => {
+      const spanJSON = makeSpanJSON('GET', { 'http.request.method': 'GET' });
+      inferSpanDataFromOtelAttributes(spanJSON);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('http');
+    });
+
+    it('appends prefetch to op', () => {
+      const spanJSON = makeSpanJSON('GET', { 'http.request.method': 'GET', 'sentry.http.prefetch': true });
+      inferSpanDataFromOtelAttributes(spanJSON, 2);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('http.client.prefetch');
+    });
+
+    it('sets name and source from http.route', () => {
+      const spanJSON = makeSpanJSON('GET', { 'http.request.method': 'GET', 'http.route': '/users/:id' });
+      inferSpanDataFromOtelAttributes(spanJSON, 1);
+      expect(spanJSON.name).toBe('GET /users/:id');
+      expect(spanJSON.attributes?.['sentry.source']).toBe('route');
+    });
+
+    it('does not overwrite name when no http.route', () => {
+      const spanJSON = makeSpanJSON('GET', { 'http.request.method': 'GET', 'url.full': 'http://example.com/api' });
+      inferSpanDataFromOtelAttributes(spanJSON, 2);
+      expect(spanJSON.name).toBe('GET');
+    });
+
+    it('does not overwrite sentry.op if already set', () => {
+      const spanJSON = makeSpanJSON('GET', { 'http.request.method': 'GET', 'sentry.op': 'http.client.custom' });
+      inferSpanDataFromOtelAttributes(spanJSON, 2);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('http.client.custom');
+    });
+
+    it('restores custom span name from sentry.custom_span_name', () => {
+      const spanJSON = makeSpanJSON('overwritten-by-otel', {
+        'http.request.method': 'GET',
+        'sentry.custom_span_name': 'my-custom-name',
+        'sentry.source': 'custom',
+        'http.route': '/users/:id',
+      });
+      inferSpanDataFromOtelAttributes(spanJSON, 1);
+      expect(spanJSON.name).toBe('my-custom-name');
+    });
+
+    it('does not overwrite name when sentry.source is custom', () => {
+      const spanJSON = makeSpanJSON('my-name', {
+        'http.request.method': 'GET',
+        'sentry.source': 'custom',
+        'http.route': '/users/:id',
+      });
+      inferSpanDataFromOtelAttributes(spanJSON, 1);
+      expect(spanJSON.name).toBe('my-name');
+    });
+
+    it('supports legacy http.method attribute', () => {
+      const spanJSON = makeSpanJSON('GET', { 'http.method': 'GET' });
+      inferSpanDataFromOtelAttributes(spanJSON, 2);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('http.client');
+    });
+  });
+
+  describe('db spans', () => {
+    it('infers db op', () => {
+      const spanJSON = makeSpanJSON('redis', { 'db.system': 'redis' });
+      inferSpanDataFromOtelAttributes(spanJSON);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('db');
+    });
+
+    it('sets name from db.statement', () => {
+      const spanJSON = makeSpanJSON('mysql', { 'db.system': 'mysql', 'db.statement': 'SELECT * FROM users' });
+      inferSpanDataFromOtelAttributes(spanJSON);
+      expect(spanJSON.name).toBe('SELECT * FROM users');
+      expect(spanJSON.attributes?.['sentry.source']).toBe('task');
+    });
+
+    it('skips db inference for cache spans', () => {
+      const spanJSON = makeSpanJSON('cache-get', { 'db.system': 'redis', 'sentry.op': 'cache.get_item' });
+      inferSpanDataFromOtelAttributes(spanJSON);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('cache.get_item');
+      expect(spanJSON.name).toBe('cache-get');
+    });
+
+    it('restores custom span name from sentry.custom_span_name', () => {
+      const spanJSON = makeSpanJSON('overwritten', {
+        'db.system': 'mysql',
+        'db.statement': 'SELECT 1',
+        'sentry.custom_span_name': 'my-db-span',
+        'sentry.source': 'custom',
+      });
+      inferSpanDataFromOtelAttributes(spanJSON);
+      expect(spanJSON.name).toBe('my-db-span');
+    });
+  });
+
+  describe('other span types', () => {
+    it('infers rpc op', () => {
+      const spanJSON = makeSpanJSON('grpc', { 'rpc.service': 'UserService' });
+      inferSpanDataFromOtelAttributes(spanJSON);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('rpc');
+    });
+
+    it('infers message op', () => {
+      const spanJSON = makeSpanJSON('kafka', { 'messaging.system': 'kafka' });
+      inferSpanDataFromOtelAttributes(spanJSON);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('message');
+    });
+
+    it('infers faas op from trigger', () => {
+      const spanJSON = makeSpanJSON('lambda', { 'faas.trigger': 'http' });
+      inferSpanDataFromOtelAttributes(spanJSON);
+      expect(spanJSON.attributes?.['sentry.op']).toBe('http');
+    });
+  });
+
+  it('does nothing when attributes are missing', () => {
+    const spanJSON = makeSpanJSON('test', undefined as unknown as Record<string, unknown>);
+    spanJSON.attributes = undefined;
+    inferSpanDataFromOtelAttributes(spanJSON, 2);
+    expect(spanJSON.attributes).toBeUndefined();
+  });
+
+  it('does nothing for spans without recognizable attributes', () => {
+    const spanJSON = makeSpanJSON('test', { 'custom.attr': 'value' });
+    inferSpanDataFromOtelAttributes(spanJSON);
+    expect(spanJSON.attributes?.['sentry.op']).toBeUndefined();
+    expect(spanJSON.name).toBe('test');
   });
 });

--- a/packages/core/test/lib/tracing/spans/captureSpan.test.ts
+++ b/packages/core/test/lib/tracing/spans/captureSpan.test.ts
@@ -530,10 +530,11 @@ describe('inferSpanDataFromOtelAttributes', () => {
       expect(spanJSON.attributes?.['sentry.source']).toBe('route');
     });
 
-    it('does not overwrite name when no http.route', () => {
+    it('does not overwrite name when no http.route but sets source to url', () => {
       const spanJSON = makeSpanJSON('GET', { 'http.request.method': 'GET', 'url.full': 'http://example.com/api' });
       inferSpanDataFromOtelAttributes(spanJSON, 2);
       expect(spanJSON.name).toBe('GET');
+      expect(spanJSON.attributes?.['sentry.source']).toBe('url');
     });
 
     it('does not overwrite sentry.op if already set', () => {


### PR DESCRIPTION
The streaming path skips the `SentrySpanExporter`, which is why we backfill span data (`sentry.op`, `name`, `sentry.source`) in `captureSpan` now. Some of the inference logic is duplicated from the otel package — which we can likely drop once we move away from otel.

closes https://github.com/getsentry/sentry-javascript/issues/20425