### PR TITLE
chore: Ignore claude worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ packages/**/*.junit.xml
 
 # Local Claude Code settings that should not be committed
 .claude/settings.local.json
+.claude/worktrees
 
 # Triage report
 **/triage_report.md


### PR DESCRIPTION
When creating worktrees within Claude Code they are created within `.claude/worktrees`. That PR ignores this folder
