### PR TITLE
chore(test): Remove empty variant tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-core-light-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-core-light-express/package.json
@@ -25,12 +25,5 @@
   },
   "volta": {
     "node": "22.18.0"
-  },
-  "sentryTest": {
-    "variants": [
-      {
-        "label": "node 22 (light mode, requires Node 22+ for diagnostics_channel)"
-      }
-    ]
   }
 }

--- a/dev-packages/e2e-tests/test-applications/node-core-light-otlp/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-core-light-otlp/package.json
@@ -29,12 +29,5 @@
   },
   "volta": {
     "node": "22.18.0"
-  },
-  "sentryTest": {
-    "variants": [
-      {
-        "label": "node 22 (light mode + OTLP integration)"
-      }
-    ]
   }
 }


### PR DESCRIPTION
I noticed we have two e2e tests with variants that have no build/assert command. This will essentially run the same test twice, once normally and once with a different label. So just removing the variant cuts down two e2e tests.