### PR TITLE
test(supabase-nextjs): Make E2E setup idempotent to stale Supabase containers

### DIFF
--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/package.json
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "clean": "npx rimraf node_modules pnpm-lock.yaml .next",
-    "start-local-supabase": "supabase init --force --workdir . && supabase start -o env && supabase db reset",
+    "start-local-supabase": "supabase init --force --workdir . && (supabase stop --no-backup || true) && supabase start -o env && supabase db reset",
     "test:prod": "TEST_ENV=production playwright test",
     "test:build": "pnpm install && pnpm start-local-supabase && pnpm build",
     "test:assert": "pnpm test:prod"


### PR DESCRIPTION
The `supabase-nextjs` E2E job failed on 2026-04-10 ([run](https://github.com/getsentry/sentry-javascript/actions/runs/24251102358/job/70812047044)) with:

```
failed to bind host port for 0.0.0.0:54322:172.18.0.2:5432/tcp: address already in use
```

Running `supabase stop --no-backup` before `supabase start` tears down any stale stack matching the project's id, freeing the ports. `|| true` makes it a no-op on a clean runner where nothing is running.

This will only help if the 

🤖 Generated with [Claude Code](https://claude.com/claude-code)