### PR TITLE
test(nuxt): Fix flaky database error test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-3/tests/database.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/tests/database.test.ts
@@ -128,7 +128,9 @@ test.describe('database integration', () => {
 
   test('captures database error and marks span as failed', async ({ request }) => {
     const errorPromise = waitForError('nuxt-3', errorEvent => {
-      return !!errorEvent?.exception?.values?.[0]?.value?.includes('no such table');
+      return !!errorEvent?.exception?.values?.some(
+        value => value.mechanism?.type === 'auto.db.nuxt' && value.value?.includes('no such table'),
+      );
     });
 
     const transactionPromise = waitForTransaction('nuxt-3', transactionEvent => {
@@ -141,9 +143,11 @@ test.describe('database integration', () => {
 
     const [error, transaction] = await Promise.all([errorPromise, transactionPromise]);
 
-    expect(error).toBeDefined();
-    expect(error.exception?.values?.[0]?.value).toContain('no such table');
-    expect(error.exception?.values?.[0]?.mechanism).toEqual({
+    const dbException = error.exception?.values?.find(value => value.mechanism?.type === 'auto.db.nuxt');
+
+    expect(dbException).toBeDefined();
+    expect(dbException?.value).toContain('no such table');
+    expect(dbException?.mechanism).toEqual({
       handled: false,
       type: 'auto.db.nuxt',
     });

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/tests/database.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/tests/database.test.ts
@@ -128,7 +128,9 @@ test.describe('database integration', () => {
 
   test('captures database error and marks span as failed', async ({ request }) => {
     const errorPromise = waitForError('nuxt-4', errorEvent => {
-      return !!errorEvent?.exception?.values?.[0]?.value?.includes('no such table');
+      return !!errorEvent?.exception?.values?.some(
+        value => value.mechanism?.type === 'auto.db.nuxt' && value.value?.includes('no such table'),
+      );
     });
 
     const transactionPromise = waitForTransaction('nuxt-4', transactionEvent => {
@@ -141,9 +143,11 @@ test.describe('database integration', () => {
 
     const [error, transaction] = await Promise.all([errorPromise, transactionPromise]);
 
-    expect(error).toBeDefined();
-    expect(error.exception?.values?.[0]?.value).toContain('no such table');
-    expect(error.exception?.values?.[0]?.mechanism).toEqual({
+    const dbException = error.exception?.values?.find(value => value.mechanism?.type === 'auto.db.nuxt');
+
+    expect(dbException).toBeDefined();
+    expect(dbException?.value).toContain('no such table');
+    expect(dbException?.mechanism).toEqual({
       handled: false,
       type: 'auto.db.nuxt',
     });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/database.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/database.test.ts
@@ -128,7 +128,9 @@ test.describe('database integration', () => {
 
   test('captures database error and marks span as failed', async ({ request }) => {
     const errorPromise = waitForError('nuxt-5', errorEvent => {
-      return !!errorEvent?.exception?.values?.[0]?.value?.includes('no such table');
+      return !!errorEvent?.exception?.values?.some(
+        value => value.mechanism?.type === 'auto.db.nuxt' && value.value?.includes('no such table'),
+      );
     });
 
     const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
@@ -141,9 +143,11 @@ test.describe('database integration', () => {
 
     const [error, transaction] = await Promise.all([errorPromise, transactionPromise]);
 
-    expect(error).toBeDefined();
-    expect(error.exception?.values?.[0]?.value).toContain('no such table');
-    expect(error.exception?.values?.[0]?.mechanism).toEqual({
+    const dbException = error.exception?.values?.find(value => value.mechanism?.type === 'auto.db.nuxt');
+
+    expect(dbException).toBeDefined();
+    expect(dbException?.value).toContain('no such table');
+    expect(dbException?.mechanism).toEqual({
       handled: false,
       type: 'auto.db.nuxt',
     });


### PR DESCRIPTION
The test asserted on values[0], which flakes when the error arrives as a chained exception. Match by mechanism type instead, so the assertion holds regardless of ordering.

Closes #20446 