### PR TITLE
fix: update prisma v7 spans descriptions

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
@@ -37,7 +37,6 @@ conditionalTest({ min: 20 })('Prisma ORM v7 Tests', () => {
               expect(spanDescriptions).toContain('prisma:client:operation');
               expect(spanDescriptions).toContain('prisma:client:serialize');
               expect(spanDescriptions).toContain('prisma:client:connect');
-              expect(spanDescriptions).toContain('prisma:client:db_query');
 
               // Verify the create operation has correct metadata
               const createSpan = prismaSpans.find(
@@ -48,11 +47,17 @@ conditionalTest({ min: 20 })('Prisma ORM v7 Tests', () => {
               );
               expect(createSpan).toBeDefined();
 
-              // Verify db_query span has system info and correct op (v7 uses db.system.name)
-              const dbQuerySpan = prismaSpans.find(span => span.description === 'prisma:client:db_query');
+              // Verify db_query span has system info and correct op (v7 uses db.system.name).
+              // The SDK should rewrite the span name to the actual SQL text (same as v5/v6
+              // `prisma:engine:db_query`), so we find it via op/origin rather than description.
+              const dbQuerySpan = prismaSpans.find(
+                span => span.data?.['sentry.op'] === 'db' && span.data?.['db.query.text'],
+              );
+              expect(dbQuerySpan).toBeDefined();
               expect(dbQuerySpan?.data?.['db.system.name']).toBe('postgresql');
-              expect(dbQuerySpan?.data?.['sentry.op']).toBe('db');
               expect(dbQuerySpan?.op).toBe('db');
+              expect(dbQuerySpan?.description).toBe(dbQuerySpan?.data?.['db.query.text']);
+              expect(dbQuerySpan?.description).not.toBe('prisma:client:db_query');
             },
           })
           .start()

--- a/packages/node/src/integrations/tracing/prisma.ts
+++ b/packages/node/src/integrations/tracing/prisma.ts
@@ -224,8 +224,12 @@ export const prismaIntegration = defineIntegration((options?: PrismaOptions) => 
           span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.prisma');
         }
 
-        // Make sure we use the query text as the span name, for ex. SELECT * FROM "User" WHERE "id" = $1
-        if (spanJSON.description === 'prisma:engine:db_query' && spanJSON.data['db.query.text']) {
+        // Make sure we use the query text as the span name, for ex. SELECT * FROM "User" WHERE "id" = $1.
+        // v5/v6 emit `prisma:engine:db_query`; v7 inlined the engine and emits `prisma:client:db_query`.
+        if (
+          (spanJSON.description === 'prisma:engine:db_query' || spanJSON.description === 'prisma:client:db_query') &&
+          spanJSON.data['db.query.text']
+        ) {
           span.updateName(spanJSON.data['db.query.text'] as string);
         }
 


### PR DESCRIPTION
Applies the same fix as in #19924

closes #18797
