### PR TITLE
chore(ci): Bump pnpm/action-setup to v5 and pin to commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -922,7 +922,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.HEAD_COMMIT }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 9.15.9
       - name: Set up Node
@@ -1054,7 +1054,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.HEAD_COMMIT }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 9.15.9
       - name: Set up Node

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.HEAD_COMMIT }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 9.15.9
       - name: Set up Node


### PR DESCRIPTION
## Summary

- Bump `pnpm/action-setup` from v4 to v5.0.0
- Pin to exact commit SHA ([`fc06bc1257f339d1d5d8b3a19a8cae5388b55320`](https://github.com/pnpm/action-setup/commit/fc06bc1257f339d1d5d8b3a19a8cae5388b55320)) instead of a mutable version tag for supply chain security

Updated in `build.yml` (2 occurrences) and `canary.yml` (1 occurrence).

### Changelog (v4 → v5)

**v5.0.0** — Updated the action to use Node.js 24 (resolves GHA deprecation warning for Node.js 20 actions).

**v4.4.0** — Updated the action to use Node.js 24.

**v4.3.0** — Store caching support, docs fixes, dependency cleanup.

**v4.2.0** — Respects `.npmrc` registry configuration when fetching pnpm.

**v4.1.0** — Added support for `package.yaml`.

Full changelog: https://github.com/pnpm/action-setup/compare/v4.0.0...v5.0.0

## Test plan

- [ ] CI passes — E2E tests use pnpm for package installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)