### PR TITLE
chore(ci): Vendor nx-affected-list action, drop dkhunt27 dependency

### DIFF
--- a/.github/actions/nx-affected-list/action.yml
+++ b/.github/actions/nx-affected-list/action.yml
@@ -20,14 +20,17 @@ runs:
     - name: Get affected Nx projects
       id: affected
       shell: bash
+      env:
+        INPUT_BASE: ${{ inputs.base }}
+        INPUT_HEAD: ${{ inputs.head }}
       run: |
         set -euo pipefail
-        ARGS=""
-        if [ -n "${{ inputs.base }}" ]; then ARGS="$ARGS --base=${{ inputs.base }}"; fi
-        if [ -n "${{ inputs.head }}" ]; then ARGS="$ARGS --head=${{ inputs.head }}"; fi
+        extra_args=()
+        if [ -n "${INPUT_BASE:-}" ]; then extra_args+=(--base="$INPUT_BASE"); fi
+        if [ -n "${INPUT_HEAD:-}" ]; then extra_args+=(--head="$INPUT_HEAD"); fi
 
         # Fail the step on nx/git errors so empty output cannot skip integration jobs silently.
-        AFFECTED=$(./node_modules/.bin/nx show projects --affected $ARGS | tr '\n' ' ' | xargs)
+        AFFECTED=$(./node_modules/.bin/nx show projects --affected "${extra_args[@]}" | tr '\n' ' ' | xargs)
         echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
 
         if [ -n "$AFFECTED" ]; then

--- a/.github/actions/nx-affected-list/action.yml
+++ b/.github/actions/nx-affected-list/action.yml
@@ -21,11 +21,13 @@ runs:
       id: affected
       shell: bash
       run: |
+        set -euo pipefail
         ARGS=""
         if [ -n "${{ inputs.base }}" ]; then ARGS="$ARGS --base=${{ inputs.base }}"; fi
         if [ -n "${{ inputs.head }}" ]; then ARGS="$ARGS --head=${{ inputs.head }}"; fi
 
-        AFFECTED=$(./node_modules/.bin/nx show projects --affected $ARGS 2>/dev/null | tr '\n' ' ' | xargs) || true
+        # Fail the step on nx/git errors so empty output cannot skip integration jobs silently.
+        AFFECTED=$(./node_modules/.bin/nx show projects --affected $ARGS | tr '\n' ' ' | xargs)
         echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
 
         if [ -n "$AFFECTED" ]; then

--- a/.github/actions/nx-affected-list/action.yml
+++ b/.github/actions/nx-affected-list/action.yml
@@ -1,0 +1,35 @@
+name: 'Nx Affected List'
+description: 'Outputs a space-separated list of Nx projects affected by changes between base and head commits.'
+
+inputs:
+  base:
+    description: 'Base commit SHA'
+    required: false
+  head:
+    description: 'Head commit SHA'
+    required: false
+
+outputs:
+  affected:
+    description: 'Space-separated list of affected project names'
+    value: ${{ steps.affected.outputs.affected }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get affected Nx projects
+      id: affected
+      shell: bash
+      run: |
+        ARGS=""
+        if [ -n "${{ inputs.base }}" ]; then ARGS="$ARGS --base=${{ inputs.base }}"; fi
+        if [ -n "${{ inputs.head }}" ]; then ARGS="$ARGS --head=${{ inputs.head }}"; fi
+
+        AFFECTED=$(./node_modules/.bin/nx show projects --affected $ARGS 2>/dev/null | tr '\n' ' ' | xargs) || true
+        echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
+
+        if [ -n "$AFFECTED" ]; then
+          echo "Affected projects: $AFFECTED"
+        else
+          echo "No affected projects found"
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         id: install_dependencies
 
       - name: Check for Affected Nx Projects
-        uses: dkhunt27/action-nx-affected-list@v6.1
+        uses: ./.github/actions/nx-affected-list
         id: checkForAffected
         if: github.event_name == 'pull_request'
         with:


### PR DESCRIPTION
## Summary

Replace the third-party `dkhunt27/action-nx-affected-list@v6.1` with a vendored composite action at `.github/actions/nx-affected-list/`.

**Why:**
- The external action is outdated (last release Sep 2024) and uses Node.js 20 (GHA deprecation warning)
- It's a heavy wrapper (~200 lines of compiled JS) around a single command: `nx show projects --affected`
- Third-party CI dependencies are a supply chain risk

**What the external action did:**
1. `nx --version` + `nx reset` (prep)
2. `nx show projects --affected --base=X --head=Y` (core logic)
3. Parse output into a list, set as action output

**What the vendored action does:**
- Runs `nx show projects --affected` directly in bash (~15 lines)
- Outputs space-separated project names (compatible with existing `contains()` checks)
- No Node.js runtime dependency, no `nx reset` (unnecessary in our setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)