### PR TITLE
feat(hono): Support middleware spans defined in app groups

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hono-4/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/playwright.config.ts
@@ -1,8 +1,5 @@
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
-
-type Runtime = 'cloudflare' | 'node' | 'bun';
-
-const RUNTIME = (process.env.RUNTIME || 'cloudflare') as Runtime;
+import { RUNTIME, type Runtime } from './tests/constants';
 
 const testEnv = process.env.TEST_ENV;
 

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/route-groups/test-middleware.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/route-groups/test-middleware.ts
@@ -1,10 +1,29 @@
 import { Hono } from 'hono';
+import { failingMiddleware, middlewareA, middlewareB } from '../middleware';
 
-const testMiddleware = new Hono();
+const middlewareRoutes = new Hono();
 
-testMiddleware.get('/named', c => c.json({ middleware: 'named' }));
-testMiddleware.get('/anonymous', c => c.json({ middleware: 'anonymous' }));
-testMiddleware.get('/multi', c => c.json({ middleware: 'multi' }));
-testMiddleware.get('/error', c => c.text('should not reach'));
+middlewareRoutes.get('/named', c => c.json({ middleware: 'named' }));
+middlewareRoutes.get('/anonymous', c => c.json({ middleware: 'anonymous' }));
+middlewareRoutes.get('/multi', c => c.json({ middleware: 'multi' }));
+middlewareRoutes.get('/error', c => c.text('should not reach'));
 
-export { testMiddleware };
+const subAppWithMiddleware = new Hono();
+
+subAppWithMiddleware.use('/named/*', middlewareA);
+subAppWithMiddleware.use('/anonymous/*', async (c, next) => {
+  c.header('X-Custom', 'anonymous');
+  await next();
+});
+subAppWithMiddleware.use('/multi/*', middlewareA, middlewareB);
+subAppWithMiddleware.use('/error/*', failingMiddleware);
+
+// .all() produces the same method:'ALL' as .use() in Hono's route record.
+// Wrapping it is harmless (onlyIfParent:true) — this route exists to prove that.
+subAppWithMiddleware.all('/all-handler', async function allCatchAll(c) {
+  return c.json({ handler: 'all' });
+});
+
+subAppWithMiddleware.route('/', middlewareRoutes);
+
+export { middlewareRoutes, subAppWithMiddleware };

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/route-groups/test-middleware.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/route-groups/test-middleware.ts
@@ -8,6 +8,7 @@ middlewareRoutes.get('/anonymous', c => c.json({ middleware: 'anonymous' }));
 middlewareRoutes.get('/multi', c => c.json({ middleware: 'multi' }));
 middlewareRoutes.get('/error', c => c.text('should not reach'));
 
+// Self-contained sub-app registering its own middleware
 const subAppWithMiddleware = new Hono();
 
 subAppWithMiddleware.use('/named/*', middlewareA);

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/routes.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/routes.ts
@@ -1,7 +1,7 @@
 import type { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import { testMiddleware } from './route-groups/test-middleware';
-import { middlewareA, middlewareB, failingMiddleware } from './middleware';
+import { failingMiddleware, middlewareA, middlewareB } from './middleware';
+import { middlewareRoutes, subAppWithMiddleware } from './route-groups/test-middleware';
 
 export function addRoutes(app: Hono<{ Bindings?: { E2E_TEST_DSN: string } }>): void {
   app.get('/', c => {
@@ -24,9 +24,7 @@ export function addRoutes(app: Hono<{ Bindings?: { E2E_TEST_DSN: string } }>): v
     throw new HTTPException(code, { message: `HTTPException ${code}` });
   });
 
-  // === Middleware ===
-  // Middleware is registered on the main app (the patched instance) via `app.use()`
-  // TODO: In the future, we may want to support middleware registration on sub-apps (route groups)
+  // Root-app middleware: registered on the patched main app instance
   app.use('/test-middleware/named/*', middlewareA);
   app.use('/test-middleware/anonymous/*', async (c, next) => {
     c.header('X-Custom', 'anonymous');
@@ -34,6 +32,8 @@ export function addRoutes(app: Hono<{ Bindings?: { E2E_TEST_DSN: string } }>): v
   });
   app.use('/test-middleware/multi/*', middlewareA, middlewareB);
   app.use('/test-middleware/error/*', failingMiddleware);
+  app.route('/test-middleware', middlewareRoutes);
 
-  app.route('/test-middleware', testMiddleware);
+  // Sub-app middleware: registered on the sub-app, wrapped at mount time by route() patching
+  app.route('/test-subapp-middleware', subAppWithMiddleware);
 }

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/constants.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/constants.ts
@@ -1,0 +1,6 @@
+export type Runtime = 'cloudflare' | 'node' | 'bun';
+
+export const RUNTIME = (process.env.RUNTIME || 'cloudflare') as Runtime;
+export const isNode = RUNTIME === 'node';
+
+export const APP_NAME = 'hono-4';

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/errors.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/test-utils';
-
-const APP_NAME = 'hono-4';
+import { APP_NAME } from './constants';
 
 test('captures error thrown in route handler', async ({ baseURL }) => {
   const errorWaiter = waitForError(APP_NAME, event => {

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
@@ -28,7 +28,7 @@ const SCENARIOS = [
     prefix: '/test-subapp-middleware',
     origin: isNode ? OTEL_ORIGIN : MIDDLEWARE_ORIGIN,
   },
-];
+] as const;
 
 for (const { name, prefix, origin } of SCENARIOS) {
   test.describe(name, () => {
@@ -83,7 +83,12 @@ for (const { name, prefix, origin } of SCENARIOS) {
       );
     });
 
-    test.only('multiple middleware are sibling spans under the same parent', async ({ baseURL }) => {
+    test('multiple middleware are sibling spans under the same parent', async ({ baseURL }) => {
+      test.skip(
+        isNode,
+        'Node double-instruments middleware (too many spans) - TODO: fix this in the SDK and re-enable the test',
+      );
+
       const transactionPromise = waitForTransaction(APP_NAME, event => {
         return event.contexts?.trace?.op === 'http.server' && event.transaction === `GET ${prefix}/multi`;
       });
@@ -94,9 +99,8 @@ for (const { name, prefix, origin } of SCENARIOS) {
       const transaction = await transactionPromise;
       const spans = transaction.spans || [];
 
-  // Sort spans because they are in a different order in Node/Bun (OTel-based)
-  const middlewareSpans = spans
-    .sort((a, b) => (a.start_timestamp ?? 0) - (b.start_timestamp ?? 0));
+      // Sort spans because they are in a different order in Node/Bun (OTel-based)
+      const middlewareSpans = spans.sort((a, b) => (a.start_timestamp ?? 0) - (b.start_timestamp ?? 0));
 
       expect(middlewareSpans).toHaveLength(2);
       expect(middlewareSpans[0]?.description).toBe('middlewareA');

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
@@ -69,7 +69,6 @@ test('multiple middleware are sibling spans under the same parent', async ({ bas
 
   // Sort spans because they are in a different order in Node/Bun (OTel-based)
   const middlewareSpans = spans
-    .filter((span: SpanJSON) => span.op === 'middleware.hono' && span.origin === 'auto.middleware.hono')
     .sort((a, b) => (a.start_timestamp ?? 0) - (b.start_timestamp ?? 0));
 
   expect(middlewareSpans).toHaveLength(2);

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
@@ -1,142 +1,219 @@
 import { expect, test } from '@playwright/test';
 import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
 import { type SpanJSON } from '@sentry/core';
+import { APP_NAME, isNode } from './constants';
 
-const APP_NAME = 'hono-4';
+// In Node, @sentry/node/preload eagerly activates the OTel HonoInstrumentation,
+// which wraps all Hono instance methods at construction time via WrappedHono.
+//
+// For the *root app*, patchAppUse's Proxy wraps handlers before OTel does
+// (Proxy → OTel → Hono internals), so the inner Sentry span preserves the
+// original function name and has origin 'auto.middleware.hono'.
+//
+// For *sub-apps*, OTel wraps handlers at registration time (inside WrappedHono
+// constructor) before patchRoute runs at mount time. So patchRoute sees anonymous
+// OTel wrappers. The OTel spans carry the correct function names with origin
+// 'auto.http.otel.hono'.
+const MIDDLEWARE_ORIGIN = 'auto.middleware.hono';
+const OTEL_ORIGIN = 'auto.http.otel.hono';
 
-test('creates a span for named middleware', async ({ baseURL }) => {
-  const transactionPromise = waitForTransaction(APP_NAME, event => {
-    return event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /test-middleware/named';
-  });
+const SCENARIOS = [
+  {
+    name: 'root app middleware',
+    prefix: '/test-middleware',
+    origin: MIDDLEWARE_ORIGIN,
+  },
+  {
+    name: 'sub-app middleware (route group)',
+    prefix: '/test-subapp-middleware',
+    origin: isNode ? OTEL_ORIGIN : MIDDLEWARE_ORIGIN,
+  },
+];
 
-  const response = await fetch(`${baseURL}/test-middleware/named`);
-  expect(response.status).toBe(200);
+for (const { name, prefix, origin } of SCENARIOS) {
+  test.describe(name, () => {
+    test('creates a span for named middleware', async ({ baseURL }) => {
+      const transactionPromise = waitForTransaction(APP_NAME, event => {
+        return event.contexts?.trace?.op === 'http.server' && event.transaction === `GET ${prefix}/named`;
+      });
 
-  const transaction = await transactionPromise;
-  const spans = transaction.spans || [];
+      const response = await fetch(`${baseURL}${prefix}/named`);
+      expect(response.status).toBe(200);
 
-  const middlewareSpan = spans.find(
-    (span: { description?: string; op?: string }) =>
-      span.op === 'middleware.hono' && span.description === 'middlewareA',
-  );
+      const transaction = await transactionPromise;
+      const spans = transaction.spans || [];
 
-  expect(middlewareSpan).toEqual(
-    expect.objectContaining({
-      description: 'middlewareA',
-      op: 'middleware.hono',
-      origin: 'auto.middleware.hono',
-      status: 'ok',
-    }),
-  );
+      const middlewareSpan = spans.find(
+        (span: { description?: string; op?: string }) =>
+          span.op === 'middleware.hono' && span.description === 'middlewareA',
+      );
 
-  // The middleware has a 50ms delay, so the span duration should be at least 50ms (0.05s)
-  // @ts-expect-error timestamp is defined
-  const durationMs = (middlewareSpan?.timestamp - middlewareSpan?.start_timestamp) * 1000;
-  expect(durationMs).toBeGreaterThanOrEqual(49);
-});
+      expect(middlewareSpan).toEqual(
+        expect.objectContaining({
+          description: 'middlewareA',
+          op: 'middleware.hono',
+          origin,
+          status: 'ok',
+        }),
+      );
 
-test('creates a span for anonymous middleware', async ({ baseURL }) => {
-  const transactionPromise = waitForTransaction(APP_NAME, event => {
-    return event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /test-middleware/anonymous';
-  });
+      // @ts-expect-error timestamp is defined
+      const durationMs = (middlewareSpan?.timestamp - middlewareSpan?.start_timestamp) * 1000;
+      expect(durationMs).toBeGreaterThanOrEqual(49);
+    });
 
-  const response = await fetch(`${baseURL}/test-middleware/anonymous`);
-  expect(response.status).toBe(200);
+    test('creates a span for anonymous middleware', async ({ baseURL }) => {
+      const transactionPromise = waitForTransaction(APP_NAME, event => {
+        return event.contexts?.trace?.op === 'http.server' && event.transaction === `GET ${prefix}/anonymous`;
+      });
 
-  const transaction = await transactionPromise;
-  const spans = transaction.spans || [];
+      const response = await fetch(`${baseURL}${prefix}/anonymous`);
+      expect(response.status).toBe(200);
 
-  expect(spans).toContainEqual(
-    expect.objectContaining({
-      description: '<anonymous>',
-      op: 'middleware.hono',
-      origin: 'auto.middleware.hono',
-      status: 'ok',
-    }),
-  );
-});
+      const transaction = await transactionPromise;
+      const spans = transaction.spans || [];
 
-test('multiple middleware are sibling spans under the same parent', async ({ baseURL }) => {
-  const transactionPromise = waitForTransaction(APP_NAME, event => {
-    return event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /test-middleware/multi';
-  });
+      expect(spans).toContainEqual(
+        expect.objectContaining({
+          description: '<anonymous>',
+          op: 'middleware.hono',
+          origin: MIDDLEWARE_ORIGIN,
+          status: 'ok',
+        }),
+      );
+    });
 
-  const response = await fetch(`${baseURL}/test-middleware/multi`);
-  expect(response.status).toBe(200);
+    test.only('multiple middleware are sibling spans under the same parent', async ({ baseURL }) => {
+      const transactionPromise = waitForTransaction(APP_NAME, event => {
+        return event.contexts?.trace?.op === 'http.server' && event.transaction === `GET ${prefix}/multi`;
+      });
 
-  const transaction = await transactionPromise;
-  const spans = transaction.spans || [];
+      const response = await fetch(`${baseURL}${prefix}/multi`);
+      expect(response.status).toBe(200);
+
+      const transaction = await transactionPromise;
+      const spans = transaction.spans || [];
 
   // Sort spans because they are in a different order in Node/Bun (OTel-based)
   const middlewareSpans = spans
     .sort((a, b) => (a.start_timestamp ?? 0) - (b.start_timestamp ?? 0));
 
-  expect(middlewareSpans).toHaveLength(2);
-  expect(middlewareSpans[0]?.description).toBe('middlewareA');
-  expect(middlewareSpans[1]?.description).toBe('middlewareB');
+      expect(middlewareSpans).toHaveLength(2);
+      expect(middlewareSpans[0]?.description).toBe('middlewareA');
+      expect(middlewareSpans[1]?.description).toBe('middlewareB');
 
-  // Both middleware spans share the same parent (siblings, not nested)
-  expect(middlewareSpans[0]?.parent_span_id).toBe(middlewareSpans[1]?.parent_span_id);
+      expect(middlewareSpans[0]?.parent_span_id).toBe(middlewareSpans[1]?.parent_span_id);
 
-  // middlewareA has a 50ms delay, middlewareB has a 60ms delay
-  // @ts-expect-error timestamp is defined
-  const middlewareADuration = (middlewareSpans[0]?.timestamp - middlewareSpans[0]?.start_timestamp) * 1000;
-  // @ts-expect-error timestamp is defined
-  const middlewareBDuration = (middlewareSpans[1]?.timestamp - middlewareSpans[1]?.start_timestamp) * 1000;
-  expect(middlewareADuration).toBeGreaterThanOrEqual(49);
-  expect(middlewareBDuration).toBeGreaterThanOrEqual(59);
-});
+      // middlewareA has a 50ms delay, middlewareB has a 60ms delay
+      // @ts-expect-error timestamp is defined
+      const aDurationMs = (middlewareSpans[0]?.timestamp - middlewareSpans[0]?.start_timestamp) * 1000;
+      // @ts-expect-error timestamp is defined
+      const bDurationMs = (middlewareSpans[1]?.timestamp - middlewareSpans[1]?.start_timestamp) * 1000;
+      expect(aDurationMs).toBeGreaterThanOrEqual(49);
+      expect(bDurationMs).toBeGreaterThanOrEqual(59);
+    });
 
-test('captures error thrown in middleware', async ({ baseURL }) => {
-  const errorPromise = waitForError(APP_NAME, event => {
-    return event.exception?.values?.[0]?.value === 'Middleware error';
+    test('captures error thrown in middleware', async ({ baseURL }) => {
+      const errorPromise = waitForError(APP_NAME, event => {
+        return (
+          event.exception?.values?.[0]?.value === 'Middleware error' &&
+          event.exception?.values?.[0]?.mechanism?.type === 'auto.middleware.hono'
+        );
+      });
+
+      const response = await fetch(`${baseURL}${prefix}/error`);
+      expect(response.status).toBe(500);
+
+      const errorEvent = await errorPromise;
+      expect(errorEvent.exception?.values?.[0]?.value).toBe('Middleware error');
+      expect(errorEvent.exception?.values?.[0]?.mechanism).toEqual(
+        expect.objectContaining({
+          handled: false,
+          type: 'auto.middleware.hono',
+        }),
+      );
+    });
+
+    test('sets error status on middleware span when middleware throws', async ({ baseURL }) => {
+      const transactionPromise = waitForTransaction(APP_NAME, event => {
+        return event.contexts?.trace?.op === 'http.server' && event.transaction === `GET ${prefix}/error/*`;
+      });
+
+      await fetch(`${baseURL}${prefix}/error`);
+
+      const transaction = await transactionPromise;
+      const spans = transaction.spans || [];
+
+      // On the /error path only one middleware (failingMiddleware) is registered,
+      // so we can find the error span by status alone. On Node for sub-apps, the
+      // OTel layer wraps before patchRoute, so the function name may be lost in
+      // the patchRoute span — but the error status is always set.
+      const failingSpan = spans.find(
+        (span: SpanJSON) => span.op === 'middleware.hono' && span.status === 'internal_error',
+      );
+
+      expect(failingSpan).toBeDefined();
+      expect(failingSpan?.status).toBe('internal_error');
+    });
+
+    test('includes request data on error events from middleware', async ({ baseURL }) => {
+      const errorPromise = waitForError(APP_NAME, event => {
+        return event.exception?.values?.[0]?.value === 'Middleware error' && !!event.request?.url?.includes(prefix);
+      });
+
+      await fetch(`${baseURL}${prefix}/error`);
+
+      const errorEvent = await errorPromise;
+      expect(errorEvent.request).toEqual(
+        expect.objectContaining({
+          method: 'GET',
+          url: expect.stringContaining(`${prefix}/error`),
+        }),
+      );
+    });
   });
+}
 
-  const response = await fetch(`${baseURL}/test-middleware/error`);
-  expect(response.status).toBe(500);
+test.describe('.all() handler on sub-app (method ALL edge case)', () => {
+  test('.all() handler is instrumented and produces a span', async ({ baseURL }) => {
+    const transactionPromise = waitForTransaction(APP_NAME, event => {
+      return (
+        event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /test-subapp-middleware/all-handler'
+      );
+    });
 
-  const errorEvent = await errorPromise;
-  expect(errorEvent.exception?.values?.[0]?.value).toBe('Middleware error');
-  expect(errorEvent.exception?.values?.[0]?.mechanism).toEqual(
-    expect.objectContaining({
-      handled: false,
-      type: 'auto.middleware.hono',
-    }),
-  );
-});
+    const response = await fetch(`${baseURL}/test-subapp-middleware/all-handler`);
+    expect(response.status).toBe(200);
 
-test('sets error status on middleware span when middleware throws', async ({ baseURL }) => {
-  const transactionPromise = waitForTransaction(APP_NAME, event => {
-    return event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /test-middleware/error/*';
+    const body = await response.json();
+    expect(body).toEqual({ handler: 'all' });
+
+    const transaction = await transactionPromise;
+    const spans = transaction.spans || [];
+
+    if (isNode) {
+      // On Node, OTel wraps .all() at construction time. Since the handler
+      // returns a Response, OTel classifies it as 'request_handler' (not
+      // middleware). patchRoute also wraps it but sees the anonymous OTel wrapper.
+      // Either way, the handler IS instrumented — verify any hono span exists.
+      const honoSpan = spans.find((span: SpanJSON) => span.op?.endsWith('.hono'));
+      expect(honoSpan).toBeDefined();
+    } else {
+      // On Bun/Cloudflare, patchRoute is the sole wrapper and sees the original
+      // function name. It wraps .all() handlers identically to .use() middleware
+      // because both produce method:'ALL' in Hono's route record.
+      const allHandlerSpan = spans.find(
+        (span: SpanJSON) => span.op === 'middleware.hono' && span.description === 'allCatchAll',
+      );
+
+      expect(allHandlerSpan).toEqual(
+        expect.objectContaining({
+          description: 'allCatchAll',
+          op: 'middleware.hono',
+          origin: MIDDLEWARE_ORIGIN,
+          status: 'ok',
+        }),
+      );
+    }
   });
-
-  await fetch(`${baseURL}/test-middleware/error`);
-
-  const transaction = await transactionPromise;
-  const spans = transaction.spans || [];
-
-  const failingSpan = spans.find(
-    (span: { description?: string; op?: string }) =>
-      span.op === 'middleware.hono' && span.description === 'failingMiddleware',
-  );
-
-  expect(failingSpan).toBeDefined();
-  expect(failingSpan?.status).toBe('internal_error');
-  expect(failingSpan?.origin).toBe('auto.middleware.hono');
-});
-
-test('includes request data on error events from middleware', async ({ baseURL }) => {
-  const errorPromise = waitForError(APP_NAME, event => {
-    return event.exception?.values?.[0]?.value === 'Middleware error';
-  });
-
-  await fetch(`${baseURL}/test-middleware/error`);
-
-  const errorEvent = await errorPromise;
-  expect(errorEvent.request).toEqual(
-    expect.objectContaining({
-      method: 'GET',
-      url: expect.stringContaining('/test-middleware/error'),
-    }),
-  );
 });

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
@@ -170,7 +170,9 @@ for (const { name, prefix, origin } of SCENARIOS) {
 }
 
 test.describe('.all() handler on sub-app (method ALL edge case)', () => {
-  test('.all() handler is instrumented and produces a span', async ({ baseURL }) => {
+  test('Node: OTel wraps .all() and produces a hono span', async ({ baseURL }) => {
+    test.skip(!isNode, 'Node-specific: OTel wraps .all() at construction time');
+
     const transactionPromise = waitForTransaction(APP_NAME, event => {
       return (
         event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /test-subapp-middleware/all-handler'
@@ -186,29 +188,46 @@ test.describe('.all() handler on sub-app (method ALL edge case)', () => {
     const transaction = await transactionPromise;
     const spans = transaction.spans || [];
 
-    if (isNode) {
-      // On Node, OTel wraps .all() at construction time. Since the handler
-      // returns a Response, OTel classifies it as 'request_handler' (not
-      // middleware). patchRoute also wraps it but sees the anonymous OTel wrapper.
-      // Either way, the handler IS instrumented — verify any hono span exists.
-      const honoSpan = spans.find((span: SpanJSON) => span.op?.endsWith('.hono'));
-      expect(honoSpan).toBeDefined();
-    } else {
-      // On Bun/Cloudflare, patchRoute is the sole wrapper and sees the original
-      // function name. It wraps .all() handlers identically to .use() middleware
-      // because both produce method:'ALL' in Hono's route record.
-      const allHandlerSpan = spans.find(
-        (span: SpanJSON) => span.op === 'middleware.hono' && span.description === 'allCatchAll',
-      );
+    // On Node, OTel wraps .all() at construction time. Since the handler
+    // returns a Response, OTel classifies it as 'request_handler' (not
+    // middleware). patchRoute also wraps it but sees the anonymous OTel wrapper.
+    // Either way, the handler IS instrumented — verify any hono span exists.
+    const honoSpan = spans.find((span: SpanJSON) => span.op?.endsWith('.hono'));
+    expect(honoSpan).toBeDefined();
+  });
 
-      expect(allHandlerSpan).toEqual(
-        expect.objectContaining({
-          description: 'allCatchAll',
-          op: 'middleware.hono',
-          origin: MIDDLEWARE_ORIGIN,
-          status: 'ok',
-        }),
+  test('Bun/Cloudflare: patchRoute wraps .all() as middleware span', async ({ baseURL }) => {
+    test.skip(isNode, 'Bun/Cloudflare-specific: patchRoute is the sole wrapper');
+
+    const transactionPromise = waitForTransaction(APP_NAME, event => {
+      return (
+        event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /test-subapp-middleware/all-handler'
       );
-    }
+    });
+
+    const response = await fetch(`${baseURL}/test-subapp-middleware/all-handler`);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toEqual({ handler: 'all' });
+
+    const transaction = await transactionPromise;
+    const spans = transaction.spans || [];
+
+    // On Bun/Cloudflare, patchRoute is the sole wrapper and sees the original
+    // function name. It wraps .all() handlers identically to .use() middleware
+    // because both produce method:'ALL' in Hono's route record.
+    const allHandlerSpan = spans.find(
+      (span: SpanJSON) => span.op === 'middleware.hono' && span.description === 'allCatchAll',
+    );
+
+    expect(allHandlerSpan).toEqual(
+      expect.objectContaining({
+        description: 'allCatchAll',
+        op: 'middleware.hono',
+        origin: MIDDLEWARE_ORIGIN,
+        status: 'ok',
+      }),
+    );
   });
 });

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
@@ -5,15 +5,6 @@ import { APP_NAME, isNode } from './constants';
 
 // In Node, @sentry/node/preload eagerly activates the OTel HonoInstrumentation,
 // which wraps all Hono instance methods at construction time via WrappedHono.
-//
-// For the *root app*, patchAppUse's Proxy wraps handlers before OTel does
-// (Proxy → OTel → Hono internals), so the inner Sentry span preserves the
-// original function name and has origin 'auto.middleware.hono'.
-//
-// For *sub-apps*, OTel wraps handlers at registration time (inside WrappedHono
-// constructor) before patchRoute runs at mount time. So patchRoute sees anonymous
-// OTel wrappers. The OTel spans carry the correct function names with origin
-// 'auto.http.otel.hono'.
 const MIDDLEWARE_ORIGIN = 'auto.middleware.hono';
 const OTEL_ORIGIN = 'auto.http.otel.hono';
 

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
-
-const APP_NAME = 'hono-4';
+import { APP_NAME } from './constants';
 
 test('sends a transaction for the index route', async ({ baseURL }) => {
   const transactionWaiter = waitForTransaction(APP_NAME, event => {

--- a/packages/hono/src/bun/middleware.ts
+++ b/packages/hono/src/bun/middleware.ts
@@ -1,8 +1,8 @@
 import { type BaseTransportOptions, debug, type Options } from '@sentry/core';
 import { init } from './sdk';
 import type { Hono, MiddlewareHandler } from 'hono';
-import { patchAppUse } from '../shared/patchAppUse';
 import { requestHandler, responseHandler } from '../shared/middlewareHandlers';
+import { applyPatches } from '../shared/applyPatches';
 
 export interface HonoBunOptions extends Options<BaseTransportOptions> {}
 
@@ -16,7 +16,7 @@ export const sentry = (app: Hono, options: HonoBunOptions): MiddlewareHandler =>
 
   init(options);
 
-  patchAppUse(app);
+  applyPatches(app);
 
   return async (context, next) => {
     requestHandler(context);

--- a/packages/hono/src/cloudflare/middleware.ts
+++ b/packages/hono/src/cloudflare/middleware.ts
@@ -3,7 +3,7 @@ import { applySdkMetadata, type BaseTransportOptions, debug, type Options } from
 import type { Env, Hono, MiddlewareHandler } from 'hono';
 import { buildFilteredIntegrations } from '../shared/buildFilteredIntegrations';
 import { requestHandler, responseHandler } from '../shared/middlewareHandlers';
-import { patchAppUse } from '../shared/patchAppUse';
+import { applyPatches } from '../shared/applyPatches';
 
 export interface HonoCloudflareOptions extends Options<BaseTransportOptions> {}
 
@@ -33,7 +33,7 @@ export function sentry<E extends Env>(
     app as unknown as ExportedHandler<unknown>,
   );
 
-  patchAppUse(app);
+  applyPatches(app);
 
   return async (context, next) => {
     requestHandler(context);

--- a/packages/hono/src/node/middleware.ts
+++ b/packages/hono/src/node/middleware.ts
@@ -1,8 +1,8 @@
 import { type BaseTransportOptions, debug, type Options } from '@sentry/core';
 import { init } from './sdk';
 import type { Hono, MiddlewareHandler } from 'hono';
-import { patchAppUse } from '../shared/patchAppUse';
 import { requestHandler, responseHandler } from '../shared/middlewareHandlers';
+import { applyPatches } from '../shared/applyPatches';
 
 export interface HonoNodeOptions extends Options<BaseTransportOptions> {}
 
@@ -16,7 +16,7 @@ export const sentry = (app: Hono, options: HonoNodeOptions): MiddlewareHandler =
 
   init(options);
 
-  patchAppUse(app);
+  applyPatches(app);
 
   return async (context, next) => {
     requestHandler(context);

--- a/packages/hono/src/shared/applyPatches.ts
+++ b/packages/hono/src/shared/applyPatches.ts
@@ -1,0 +1,14 @@
+import type { Env, Hono } from 'hono';
+import { patchAppUse } from '../shared/patchAppUse';
+import { patchRoute } from '../shared/patchRoute';
+
+/**
+ * Applies necessary patches to the Hono app to ensure that Sentry can properly trace middleware and route handlers.
+ */
+export function applyPatches<E extends Env>(app: Hono<E>): void {
+  // `app.use` (instance own property) — wraps middleware at registration time on this instance.
+  patchAppUse(app);
+
+  //`HonoBase.prototype.route` — wraps sub-app middleware at mount time so that route groups (`app.route('/prefix', subApp)`) are also instrumented.
+  patchRoute(app);
+}

--- a/packages/hono/src/shared/patchAppUse.ts
+++ b/packages/hono/src/shared/patchAppUse.ts
@@ -1,28 +1,8 @@
-import {
-  captureException,
-  getActiveSpan,
-  getRootSpan,
-  getOriginalFunction,
-  markFunctionWrapped,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SPAN_STATUS_ERROR,
-  SPAN_STATUS_OK,
-  startInactiveSpan,
-} from '@sentry/core';
-import type { WrappedFunction } from '@sentry/core';
+import { wrapMiddlewareWithSpan } from './wrapMiddlewareSpan';
 import type { Env, Hono, MiddlewareHandler } from 'hono';
-import { patchRoute } from './patchRoute';
-
-const MIDDLEWARE_ORIGIN = 'auto.middleware.hono';
 
 /**
  * Patches the Hono app so that middleware is automatically traced as Sentry spans.
- *
- * Two things are patched:
- * 1. `app.use` (instance own property) — wraps middleware at registration time on this instance.
- * 2. `HonoBase.prototype.route` — wraps sub-app middleware at mount time so that
- *    route groups (`app.route('/prefix', subApp)`) are also instrumented.
  */
 export function patchAppUse<E extends Env>(app: Hono<E>): void {
   app.use = new Proxy(app.use, {
@@ -38,50 +18,4 @@ export function patchAppUse<E extends Env>(app: Hono<E>): void {
       return Reflect.apply(target, thisArg, allHandlers);
     },
   });
-
-  patchRoute(app);
-}
-
-/**
- * Wraps a Hono middleware handler so that its execution is traced as a Sentry span.
- * Explicitly parents each span under the root (transaction) span so that all middleware
- * spans are siblings — even when OTel instrumentation introduces nested active contexts
- * (onion order: A → B → handler → B → A would otherwise nest B under A).
- */
-export function wrapMiddlewareWithSpan(handler: MiddlewareHandler): MiddlewareHandler {
-  if (getOriginalFunction(handler as unknown as WrappedFunction)) {
-    return handler;
-  }
-
-  const wrapped: MiddlewareHandler = async function sentryTracedMiddleware(context, next) {
-    const activeSpan = getActiveSpan();
-    const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
-    const span = startInactiveSpan({
-      name: handler.name || '<anonymous>',
-      op: 'middleware.hono',
-      onlyIfParent: true,
-      parentSpan: rootSpan,
-      attributes: {
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'middleware.hono',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: MIDDLEWARE_ORIGIN,
-      },
-    });
-
-    try {
-      const result = await handler(context, next);
-      span.setStatus({ code: SPAN_STATUS_OK });
-      return result;
-    } catch (error) {
-      span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-      captureException(error, {
-        mechanism: { handled: false, type: MIDDLEWARE_ORIGIN },
-      });
-      throw error;
-    } finally {
-      span.end();
-    }
-  };
-
-  markFunctionWrapped(wrapped as unknown as WrappedFunction, handler as unknown as WrappedFunction);
-  return wrapped;
 }

--- a/packages/hono/src/shared/patchAppUse.ts
+++ b/packages/hono/src/shared/patchAppUse.ts
@@ -2,19 +2,27 @@ import {
   captureException,
   getActiveSpan,
   getRootSpan,
+  getOriginalFunction,
+  markFunctionWrapped,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
   startInactiveSpan,
 } from '@sentry/core';
+import type { WrappedFunction } from '@sentry/core';
 import type { Env, Hono, MiddlewareHandler } from 'hono';
+import { patchRoute } from './patchRoute';
 
 const MIDDLEWARE_ORIGIN = 'auto.middleware.hono';
 
 /**
- * Patches `app.use` so that every middleware registered through it is automatically
- * wrapped in a Sentry span. Supports both forms: `app.use(...handlers)` and `app.use(path, ...handlers)`.
+ * Patches the Hono app so that middleware is automatically traced as Sentry spans.
+ *
+ * Two things are patched:
+ * 1. `app.use` (instance own property) — wraps middleware at registration time on this instance.
+ * 2. `HonoBase.prototype.route` — wraps sub-app middleware at mount time so that
+ *    route groups (`app.route('/prefix', subApp)`) are also instrumented.
  */
 export function patchAppUse<E extends Env>(app: Hono<E>): void {
   app.use = new Proxy(app.use, {
@@ -30,6 +38,8 @@ export function patchAppUse<E extends Env>(app: Hono<E>): void {
       return Reflect.apply(target, thisArg, allHandlers);
     },
   });
+
+  patchRoute(app);
 }
 
 /**
@@ -38,11 +48,14 @@ export function patchAppUse<E extends Env>(app: Hono<E>): void {
  * spans are siblings — even when OTel instrumentation introduces nested active contexts
  * (onion order: A → B → handler → B → A would otherwise nest B under A).
  */
-function wrapMiddlewareWithSpan(handler: MiddlewareHandler): MiddlewareHandler {
-  return async function sentryTracedMiddleware(context, next) {
+export function wrapMiddlewareWithSpan(handler: MiddlewareHandler): MiddlewareHandler {
+  if (getOriginalFunction(handler as unknown as WrappedFunction)) {
+    return handler;
+  }
+
+  const wrapped: MiddlewareHandler = async function sentryTracedMiddleware(context, next) {
     const activeSpan = getActiveSpan();
     const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
-
     const span = startInactiveSpan({
       name: handler.name || '<anonymous>',
       op: 'middleware.hono',
@@ -68,4 +81,7 @@ function wrapMiddlewareWithSpan(handler: MiddlewareHandler): MiddlewareHandler {
       span.end();
     }
   };
+
+  markFunctionWrapped(wrapped as unknown as WrappedFunction, handler as unknown as WrappedFunction);
+  return wrapped;
 }

--- a/packages/hono/src/shared/patchRoute.ts
+++ b/packages/hono/src/shared/patchRoute.ts
@@ -1,41 +1,21 @@
 import { getOriginalFunction, markFunctionWrapped } from '@sentry/core';
 import type { WrappedFunction } from '@sentry/core';
 import type { Env, Hono } from 'hono';
-import { wrapMiddlewareWithSpan } from './patchAppUse';
+import { wrapMiddlewareWithSpan } from './wrapMiddlewareSpan';
 
 /**
- * Hono stores every route as `{ method, path, handler }` in `app.routes`.
- * Internally, `app.use()` always registers with `method: 'ALL'` (via the
- * constant `METHOD_NAME_ALL`), while `app.get()` / `.post()` / etc. use
- * their respective uppercase method name.
+ * Patches `HonoBase.prototype.route` so that when a sub-app is mounted via `app.route('/prefix', subApp)`, its middleware handlers
+ * are retroactively wrapped in Sentry spans before the parent copies them.
  *
- * `app.all()` also produces `method: 'ALL'`, making it indistinguishable
- * from middleware in the route record.  Wrapping those handlers is harmless
- * because the resulting span uses `onlyIfParent: true` — it only materialises
- * when there is already an active transaction, and adds negligible overhead.
+ * `route` lives on the prototype (unlike `use` which is a class field)
  */
-const HONO_METHOD_ALL = 'ALL';
-
-/**
- * Patches `HonoBase.prototype.route` so that when a sub-app is mounted via
- * `app.route('/prefix', subApp)`, its middleware handlers are retroactively
- * wrapped in Sentry spans *before* Hono copies them into the parent router.
- *
- * `route` lives on the prototype (unlike `use`, `get`, `all`, etc. which
- * are own properties assigned in the HonoBase constructor).
- */
-interface HonoBaseProto {
-  // oxlint-disable-next-line typescript/no-explicit-any
-  route: (path: string, app: Hono<any>) => Hono<any>;
-}
-
 export function patchRoute<E extends Env>(app: Hono<E>): void {
-  const honoBaseProto = Object.getPrototypeOf(Object.getPrototypeOf(app)) as HonoBaseProto | null;
+  const honoBaseProto = Object.getPrototypeOf(Object.getPrototypeOf(app));
   if (!honoBaseProto || typeof honoBaseProto.route !== 'function') {
     return;
   }
 
-  if (getOriginalFunction(honoBaseProto.route as unknown as WrappedFunction)) {
+  if (getOriginalFunction(honoBaseProto.route as WrappedFunction)) {
     return;
   }
 
@@ -44,9 +24,13 @@ export function patchRoute<E extends Env>(app: Hono<E>): void {
   // oxlint-disable-next-line typescript/no-explicit-any
   const patchedRoute = function (this: Hono<any>, path: string, subApp: Hono<any>): Hono<any> {
     if (subApp && Array.isArray(subApp.routes)) {
-      for (const r of subApp.routes) {
-        if (r.method === HONO_METHOD_ALL && typeof r.handler === 'function') {
-          r.handler = wrapMiddlewareWithSpan(r.handler);
+      for (const route of subApp.routes) {
+        /* Internally, `app.use()` always registers with `method: 'ALL'` (via the constant `METHOD_NAME_ALL`),
+         * while `app.get()` / `.post()` / etc. use their respective uppercase method name.
+         * https://github.com/honojs/hono/blob/18fe604c8cefc2628240651b1af219692e1918c1/src/hono-base.ts#L156-L168
+         */
+        if (route.method === 'ALL' && typeof route.handler === 'function') {
+          route.handler = wrapMiddlewareWithSpan(route.handler);
         }
       }
     }

--- a/packages/hono/src/shared/patchRoute.ts
+++ b/packages/hono/src/shared/patchRoute.ts
@@ -1,0 +1,58 @@
+import { getOriginalFunction, markFunctionWrapped } from '@sentry/core';
+import type { WrappedFunction } from '@sentry/core';
+import type { Env, Hono } from 'hono';
+import { wrapMiddlewareWithSpan } from './patchAppUse';
+
+/**
+ * Hono stores every route as `{ method, path, handler }` in `app.routes`.
+ * Internally, `app.use()` always registers with `method: 'ALL'` (via the
+ * constant `METHOD_NAME_ALL`), while `app.get()` / `.post()` / etc. use
+ * their respective uppercase method name.
+ *
+ * `app.all()` also produces `method: 'ALL'`, making it indistinguishable
+ * from middleware in the route record.  Wrapping those handlers is harmless
+ * because the resulting span uses `onlyIfParent: true` — it only materialises
+ * when there is already an active transaction, and adds negligible overhead.
+ */
+const HONO_METHOD_ALL = 'ALL';
+
+/**
+ * Patches `HonoBase.prototype.route` so that when a sub-app is mounted via
+ * `app.route('/prefix', subApp)`, its middleware handlers are retroactively
+ * wrapped in Sentry spans *before* Hono copies them into the parent router.
+ *
+ * `route` lives on the prototype (unlike `use`, `get`, `all`, etc. which
+ * are own properties assigned in the HonoBase constructor).
+ */
+interface HonoBaseProto {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  route: (path: string, app: Hono<any>) => Hono<any>;
+}
+
+export function patchRoute<E extends Env>(app: Hono<E>): void {
+  const honoBaseProto = Object.getPrototypeOf(Object.getPrototypeOf(app)) as HonoBaseProto | null;
+  if (!honoBaseProto || typeof honoBaseProto.route !== 'function') {
+    return;
+  }
+
+  if (getOriginalFunction(honoBaseProto.route as unknown as WrappedFunction)) {
+    return;
+  }
+
+  const originalRoute = honoBaseProto.route;
+
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const patchedRoute = function (this: Hono<any>, path: string, subApp: Hono<any>): Hono<any> {
+    if (subApp && Array.isArray(subApp.routes)) {
+      for (const r of subApp.routes) {
+        if (r.method === HONO_METHOD_ALL && typeof r.handler === 'function') {
+          r.handler = wrapMiddlewareWithSpan(r.handler);
+        }
+      }
+    }
+    return originalRoute.call(this, path, subApp);
+  };
+
+  markFunctionWrapped(patchedRoute as unknown as WrappedFunction, originalRoute as unknown as WrappedFunction);
+  honoBaseProto.route = patchedRoute;
+}

--- a/packages/hono/src/shared/patchRoute.ts
+++ b/packages/hono/src/shared/patchRoute.ts
@@ -3,6 +3,11 @@ import type { WrappedFunction } from '@sentry/core';
 import type { Env, Hono } from 'hono';
 import { wrapMiddlewareWithSpan } from './wrapMiddlewareSpan';
 
+interface HonoBaseProto {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  route: (path: string, app: Hono<any>) => Hono<any>;
+}
+
 /**
  * Patches `HonoBase.prototype.route` so that when a sub-app is mounted via `app.route('/prefix', subApp)`, its middleware handlers
  * are retroactively wrapped in Sentry spans before the parent copies them.
@@ -10,8 +15,8 @@ import { wrapMiddlewareWithSpan } from './wrapMiddlewareSpan';
  * `route` lives on the prototype (unlike `use` which is a class field)
  */
 export function patchRoute<E extends Env>(app: Hono<E>): void {
-  const honoBaseProto = Object.getPrototypeOf(Object.getPrototypeOf(app));
-  if (!honoBaseProto || typeof honoBaseProto.route !== 'function') {
+  const honoBaseProto = Object.getPrototypeOf(Object.getPrototypeOf(app)) as HonoBaseProto;
+  if (!honoBaseProto || typeof honoBaseProto?.route !== 'function') {
     return;
   }
 

--- a/packages/hono/src/shared/wrapMiddlewareSpan.ts
+++ b/packages/hono/src/shared/wrapMiddlewareSpan.ts
@@ -1,0 +1,60 @@
+import {
+  captureException,
+  getActiveSpan,
+  getRootSpan,
+  getOriginalFunction,
+  markFunctionWrapped,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SPAN_STATUS_ERROR,
+  SPAN_STATUS_OK,
+  startInactiveSpan,
+  type WrappedFunction,
+} from '@sentry/core';
+import { type MiddlewareHandler } from 'hono';
+
+const MIDDLEWARE_ORIGIN = 'auto.middleware.hono';
+
+/**
+ * Wraps a Hono middleware handler so that its execution is traced as a Sentry span.
+ * Explicitly parents each span under the root (transaction) span so that all middleware
+ * spans are siblings — even when OTel instrumentation introduces nested active contexts
+ * (onion order: A → B → handler → B → A would otherwise nest B under A).
+ */
+export function wrapMiddlewareWithSpan(handler: MiddlewareHandler): MiddlewareHandler {
+  if (getOriginalFunction(handler as unknown as WrappedFunction)) {
+    return handler;
+  }
+
+  const wrapped: MiddlewareHandler = async function sentryTracedMiddleware(context, next) {
+    const activeSpan = getActiveSpan();
+    const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
+    const span = startInactiveSpan({
+      name: handler.name || '<anonymous>',
+      op: 'middleware.hono',
+      onlyIfParent: true,
+      parentSpan: rootSpan,
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'middleware.hono',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: MIDDLEWARE_ORIGIN,
+      },
+    });
+
+    try {
+      const result = await handler(context, next);
+      span.setStatus({ code: SPAN_STATUS_OK });
+      return result;
+    } catch (error) {
+      span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+      captureException(error, {
+        mechanism: { handled: false, type: MIDDLEWARE_ORIGIN },
+      });
+      throw error;
+    } finally {
+      span.end();
+    }
+  };
+
+  markFunctionWrapped(wrapped as unknown as WrappedFunction, handler as unknown as WrappedFunction);
+  return wrapped;
+}

--- a/packages/hono/test/shared/patchAppUse.test.ts
+++ b/packages/hono/test/shared/patchAppUse.test.ts
@@ -2,6 +2,7 @@ import * as SentryCore from '@sentry/core';
 import { Hono } from 'hono';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { patchAppUse } from '../../src/shared/patchAppUse';
+import { patchRoute } from '../../src/shared/patchRoute';
 
 vi.mock('@sentry/core', async () => {
   const actual = await vi.importActual('@sentry/core');
@@ -164,9 +165,14 @@ describe('patchAppUse (middleware spans)', () => {
   });
 
   describe('route() patching (sub-app / route group support)', () => {
+    beforeEach(() => {
+      honoBaseProto.route = originalRoute;
+    });
+
     it('wraps middleware on sub-apps mounted via route()', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       const subApp = new Hono();
       subApp.use(async function subMiddleware(_c: unknown, next: () => Promise<void>) {
@@ -184,6 +190,7 @@ describe('patchAppUse (middleware spans)', () => {
     it('does not wrap route handlers (only method ALL from use())', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       const subApp = new Hono();
       subApp.get('/', () => new Response('sub'));
@@ -198,6 +205,7 @@ describe('patchAppUse (middleware spans)', () => {
     it('does not double-wrap handlers already wrapped by patchAppUse on the main app', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       app.use(async function mainMiddleware(_c: unknown, next: () => Promise<void>) {
         await next();
@@ -214,21 +222,21 @@ describe('patchAppUse (middleware spans)', () => {
       expect(startInactiveSpanMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'mainMiddleware' }));
     });
 
-    it('does not patch route() twice when patchAppUse is called multiple times', () => {
+    it('does not patch route() twice when patchRoute is called multiple times', () => {
       const app1 = new Hono();
-      patchAppUse(app1);
+      patchRoute(app1);
 
       const patchedRoute = honoBaseProto.route;
 
       const app2 = new Hono();
-      patchAppUse(app2);
+      patchRoute(app2);
 
       expect(honoBaseProto.route).toBe(patchedRoute);
     });
 
     it('stores the original route via __sentry_original__ for other libraries to unwrap', () => {
       const app = new Hono();
-      patchAppUse(app);
+      patchRoute(app);
 
       // oxlint-disable-next-line typescript/no-explicit-any
       const sentryOriginal = (honoBaseProto.route as any).__sentry_original__;
@@ -238,6 +246,7 @@ describe('patchAppUse (middleware spans)', () => {
     it('wraps path-targeted .use("/path", handler) on sub-apps', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       const subApp = new Hono();
       subApp.use('/admin/*', async function adminAuth(_c: unknown, next: () => Promise<void>) {
@@ -254,6 +263,7 @@ describe('patchAppUse (middleware spans)', () => {
     it('also wraps .all() handlers on sub-apps (same method: ALL in route record)', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       const subApp = new Hono();
       subApp.all('/catch-all', async function allHandler() {
@@ -269,6 +279,7 @@ describe('patchAppUse (middleware spans)', () => {
     it('wraps mixed .use() and .all() handlers on the same sub-app', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       const subApp = new Hono();
       subApp.use(async function mw(_c: unknown, next: () => Promise<void>) {
@@ -290,6 +301,7 @@ describe('patchAppUse (middleware spans)', () => {
     it('does not wrap .get()/.post()/.put()/.delete() handlers on sub-apps', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       const subApp = new Hono();
       subApp.get('/resource', async function getHandler() {
@@ -308,6 +320,7 @@ describe('patchAppUse (middleware spans)', () => {
     it('wraps middleware in nested sub-apps (sub-app mounting another sub-app)', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       const innerSub = new Hono();
       innerSub.use(async function innerMiddleware(_c: unknown, next: () => Promise<void>) {
@@ -332,6 +345,7 @@ describe('patchAppUse (middleware spans)', () => {
     it('handles sub-app with multiple path-targeted middleware for different paths', async () => {
       const app = new Hono();
       patchAppUse(app);
+      patchRoute(app);
 
       const subApp = new Hono();
       subApp.use('/a/*', async function mwForA(_c: unknown, next: () => Promise<void>) {

--- a/packages/hono/test/shared/patchAppUse.test.ts
+++ b/packages/hono/test/shared/patchAppUse.test.ts
@@ -1,6 +1,6 @@
 import * as SentryCore from '@sentry/core';
 import { Hono } from 'hono';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { patchAppUse } from '../../src/shared/patchAppUse';
 
 vi.mock('@sentry/core', async () => {
@@ -18,9 +18,16 @@ vi.mock('@sentry/core', async () => {
 const startInactiveSpanMock = SentryCore.startInactiveSpan as ReturnType<typeof vi.fn>;
 const captureExceptionMock = SentryCore.captureException as ReturnType<typeof vi.fn>;
 
+const honoBaseProto = Object.getPrototypeOf(Object.getPrototypeOf(new Hono()));
+const originalRoute = honoBaseProto.route;
+
 describe('patchAppUse (middleware spans)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    honoBaseProto.route = originalRoute;
   });
 
   it('wraps handlers in app.use(handler) so startInactiveSpan is called when middleware runs', async () => {
@@ -156,22 +163,199 @@ describe('patchAppUse (middleware spans)', () => {
     expect(fakeApp._capturedThis).toBe(fakeApp);
   });
 
-  // todo: support sub-app (Hono route groups) patching in the future
-  it('does not wrap middleware on sub-apps (instance-level patching limitation)', async () => {
-    const app = new Hono();
-    patchAppUse(app);
+  describe('route() patching (sub-app / route group support)', () => {
+    it('wraps middleware on sub-apps mounted via route()', async () => {
+      const app = new Hono();
+      patchAppUse(app);
 
-    // Route Grouping: https://hono.dev/docs/api/routing#grouping
-    const subApp = new Hono();
-    subApp.use(async function subMiddleware(_c: unknown, next: () => Promise<void>) {
-      await next();
+      const subApp = new Hono();
+      subApp.use(async function subMiddleware(_c: unknown, next: () => Promise<void>) {
+        await next();
+      });
+      subApp.get('/', () => new Response('sub'));
+
+      app.route('/sub', subApp);
+
+      await app.fetch(new Request('http://localhost/sub'));
+
+      expect(startInactiveSpanMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'subMiddleware' }));
     });
-    subApp.get('/', () => new Response('sub'));
 
-    app.route('/sub', subApp);
+    it('does not wrap route handlers (only method ALL from use())', async () => {
+      const app = new Hono();
+      patchAppUse(app);
 
-    await app.fetch(new Request('http://localhost/sub'));
+      const subApp = new Hono();
+      subApp.get('/', () => new Response('sub'));
 
-    expect(startInactiveSpanMock).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'subMiddleware' }));
+      app.route('/sub', subApp);
+
+      await app.fetch(new Request('http://localhost/sub'));
+
+      expect(startInactiveSpanMock).not.toHaveBeenCalled();
+    });
+
+    it('does not double-wrap handlers already wrapped by patchAppUse on the main app', async () => {
+      const app = new Hono();
+      patchAppUse(app);
+
+      app.use(async function mainMiddleware(_c: unknown, next: () => Promise<void>) {
+        await next();
+      });
+      app.get('/', () => new Response('ok'));
+
+      // Mount the main app as a sub-app of another app (contrived but tests the guard)
+      const parent = new Hono();
+      parent.route('/', app);
+
+      await parent.fetch(new Request('http://localhost/'));
+
+      expect(startInactiveSpanMock).toHaveBeenCalledTimes(1);
+      expect(startInactiveSpanMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'mainMiddleware' }));
+    });
+
+    it('does not patch route() twice when patchAppUse is called multiple times', () => {
+      const app1 = new Hono();
+      patchAppUse(app1);
+
+      const patchedRoute = honoBaseProto.route;
+
+      const app2 = new Hono();
+      patchAppUse(app2);
+
+      expect(honoBaseProto.route).toBe(patchedRoute);
+    });
+
+    it('stores the original route via __sentry_original__ for other libraries to unwrap', () => {
+      const app = new Hono();
+      patchAppUse(app);
+
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const sentryOriginal = (honoBaseProto.route as any).__sentry_original__;
+      expect(sentryOriginal).toBe(originalRoute);
+    });
+
+    it('wraps path-targeted .use("/path", handler) on sub-apps', async () => {
+      const app = new Hono();
+      patchAppUse(app);
+
+      const subApp = new Hono();
+      subApp.use('/admin/*', async function adminAuth(_c: unknown, next: () => Promise<void>) {
+        await next();
+      });
+      subApp.get('/admin/dashboard', () => new Response('dashboard'));
+
+      app.route('/api', subApp);
+      await app.fetch(new Request('http://localhost/api/admin/dashboard'));
+
+      expect(startInactiveSpanMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'adminAuth' }));
+    });
+
+    it('also wraps .all() handlers on sub-apps (same method: ALL in route record)', async () => {
+      const app = new Hono();
+      patchAppUse(app);
+
+      const subApp = new Hono();
+      subApp.all('/catch-all', async function allHandler() {
+        return new Response('catch-all');
+      });
+
+      app.route('/api', subApp);
+      await app.fetch(new Request('http://localhost/api/catch-all'));
+
+      expect(startInactiveSpanMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'allHandler' }));
+    });
+
+    it('wraps mixed .use() and .all() handlers on the same sub-app', async () => {
+      const app = new Hono();
+      patchAppUse(app);
+
+      const subApp = new Hono();
+      subApp.use(async function mw(_c: unknown, next: () => Promise<void>) {
+        await next();
+      });
+      subApp.all('/wildcard', async function allRoute() {
+        return new Response('wildcard');
+      });
+      subApp.get('/specific', () => new Response('specific'));
+
+      app.route('/mixed', subApp);
+      await app.fetch(new Request('http://localhost/mixed/wildcard'));
+
+      const spanNames = startInactiveSpanMock.mock.calls.map((c: unknown[]) => (c[0] as { name: string }).name);
+      expect(spanNames).toContain('mw');
+      expect(spanNames).toContain('allRoute');
+    });
+
+    it('does not wrap .get()/.post()/.put()/.delete() handlers on sub-apps', async () => {
+      const app = new Hono();
+      patchAppUse(app);
+
+      const subApp = new Hono();
+      subApp.get('/resource', async function getHandler() {
+        return new Response('get');
+      });
+      subApp.post('/resource', async function postHandler() {
+        return new Response('post');
+      });
+
+      app.route('/api', subApp);
+      await app.fetch(new Request('http://localhost/api/resource'));
+
+      expect(startInactiveSpanMock).not.toHaveBeenCalled();
+    });
+
+    it('wraps middleware in nested sub-apps (sub-app mounting another sub-app)', async () => {
+      const app = new Hono();
+      patchAppUse(app);
+
+      const innerSub = new Hono();
+      innerSub.use(async function innerMiddleware(_c: unknown, next: () => Promise<void>) {
+        await next();
+      });
+      innerSub.get('/', () => new Response('inner'));
+
+      const outerSub = new Hono();
+      outerSub.use(async function outerMiddleware(_c: unknown, next: () => Promise<void>) {
+        await next();
+      });
+      outerSub.route('/inner', innerSub);
+
+      app.route('/outer', outerSub);
+      await app.fetch(new Request('http://localhost/outer/inner'));
+
+      const spanNames = startInactiveSpanMock.mock.calls.map((c: unknown[]) => (c[0] as { name: string }).name);
+      expect(spanNames).toContain('outerMiddleware');
+      expect(spanNames).toContain('innerMiddleware');
+    });
+
+    it('handles sub-app with multiple path-targeted middleware for different paths', async () => {
+      const app = new Hono();
+      patchAppUse(app);
+
+      const subApp = new Hono();
+      subApp.use('/a/*', async function mwForA(_c: unknown, next: () => Promise<void>) {
+        await next();
+      });
+      subApp.use('/b/*', async function mwForB(_c: unknown, next: () => Promise<void>) {
+        await next();
+      });
+      subApp.get('/a/test', () => new Response('a'));
+      subApp.get('/b/test', () => new Response('b'));
+
+      app.route('/sub', subApp);
+
+      // Hit path /a — only mwForA should fire
+      await app.fetch(new Request('http://localhost/sub/a/test'));
+      expect(startInactiveSpanMock).toHaveBeenCalledTimes(1);
+      expect(startInactiveSpanMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'mwForA' }));
+
+      startInactiveSpanMock.mockClear();
+
+      // Hit path /b — only mwForB should fire
+      await app.fetch(new Request('http://localhost/sub/b/test'));
+      expect(startInactiveSpanMock).toHaveBeenCalledTimes(1);
+      expect(startInactiveSpanMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'mwForB' }));
+    });
   });
 });


### PR DESCRIPTION
Patches `app.route` to also support middleware defined in Hono route groups.

The Node instrumentation still produces too many spans, this will be fixed in another PR - one test is skipped for now.

Closes https://github.com/getsentry/sentry-javascript/issues/20449
