### PR TITLE
chore(test): Reduce unneeded `idleTimeout` test config

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/init.js
@@ -4,6 +4,11 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [Sentry.browserTracingIntegration({ idleTimeout: 3000, childSpanTimeout: 3000 })],
+  integrations: [
+    Sentry.browserTracingIntegration({
+      idleTimeout: 3000,
+      childSpanTimeout: 3000,
+    }),
+  ],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
       instrumentPageLoad: false,
       instrumentNavigation: false,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings-streamed/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 1000,
       _experiments: {
         enableHTTPTimings: true,
       },

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 1000,
       _experiments: {
         enableHTTPTimings: true,
       },

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
@@ -7,7 +7,6 @@ Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration({
       ignorePerformanceApiSpans: ['measure-ignore', /mark-i/],
-      idleTimeout: 9000,
     }),
   ],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 1000,
       enableLongTask: false,
       _experiments: {
         enableInteractions: true,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 1000,
       enableLongTask: false,
       _experiments: {
         enableInteractions: true,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation-streamed/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 2000,
       enableLongTask: false,
       enableLongAnimationFrame: true,
       instrumentPageLoad: false,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled-streamed/init.js
@@ -5,7 +5,10 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
-    Sentry.browserTracingIntegration({ enableLongTask: false, enableLongAnimationFrame: false, idleTimeout: 2000 }),
+    Sentry.browserTracingIntegration({
+      enableLongTask: false,
+      enableLongAnimationFrame: false,
+    }),
     Sentry.spanStreamingIntegration(),
   ],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled/init.js
@@ -5,7 +5,10 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
-    Sentry.browserTracingIntegration({ enableLongTask: false, enableLongAnimationFrame: false, idleTimeout: 9000 }),
+    Sentry.browserTracingIntegration({
+      enableLongTask: false,
+      enableLongAnimationFrame: false,
+    }),
   ],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled-streamed/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 2000,
       enableLongTask: false,
       enableLongAnimationFrame: true,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
       enableLongTask: false,
       enableLongAnimationFrame: true,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-non-chromium/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-non-chromium/init.js
@@ -5,7 +5,10 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
-    Sentry.browserTracingIntegration({ enableLongTask: true, enableLongAnimationFrame: true, idleTimeout: 9000 }),
+    Sentry.browserTracingIntegration({
+      enableLongTask: true,
+      enableLongAnimationFrame: true,
+    }),
   ],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled-streamed/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 2000,
       enableLongTask: true,
       enableLongAnimationFrame: true,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
       enableLongTask: true,
       enableLongAnimationFrame: true,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation-streamed/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 2000,
       enableLongAnimationFrame: false,
       instrumentPageLoad: false,
       instrumentNavigation: true,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
       enableLongAnimationFrame: false,
       instrumentPageLoad: false,
       instrumentNavigation: true,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled-streamed/init.js
@@ -5,7 +5,10 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
-    Sentry.browserTracingIntegration({ enableLongTask: false, enableLongAnimationFrame: false, idleTimeout: 2000 }),
+    Sentry.browserTracingIntegration({
+      enableLongTask: false,
+      enableLongAnimationFrame: false,
+    }),
     Sentry.spanStreamingIntegration(),
   ],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled/init.js
@@ -5,7 +5,10 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
-    Sentry.browserTracingIntegration({ enableLongTask: false, enableLongAnimationFrame: false, idleTimeout: 9000 }),
+    Sentry.browserTracingIntegration({
+      enableLongTask: false,
+      enableLongAnimationFrame: false,
+    }),
   ],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled-streamed/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 2000,
       enableLongAnimationFrame: false,
     }),
     Sentry.spanStreamingIntegration(),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
       enableLongAnimationFrame: false,
     }),
   ],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
       enableLongTask: true,
       enableLongAnimationFrame: false,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-aborting-pageload/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-aborting-pageload/init.js
@@ -4,7 +4,11 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [Sentry.browserTracingIntegration({ idleTimeout: 2000, detectRedirects: false })],
+  integrations: [
+    Sentry.browserTracingIntegration({
+      detectRedirects: false,
+    }),
+  ],
   tracesSampleRate: 1,
 });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/on-request-span-end/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/on-request-span-end/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 1000,
       onRequestSpanEnd(span, { headers }) {
         if (headers) {
           span.setAttribute('hook.called.response-type', headers.get('x-response-type'));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/on-request-span-start/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/on-request-span-start/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 1000,
       onRequestSpanStart(span, { headers }) {
         if (headers) {
           span.setAttribute('hook.called.headers', headers.get('foo'));

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/resource-spans-ignored/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/resource-spans-ignored/init.js
@@ -7,7 +7,6 @@ Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration({
       ignoreResourceSpans: ['resource.script'],
-      idleTimeout: 9000,
     }),
   ],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt/test.ts
@@ -15,14 +15,14 @@ async function createSessionWithLatency(page: Page, latency: number) {
   await session.send('Network.emulateNetworkConditions', {
     offline: false,
     latency: latency,
-    downloadThroughput: (25 * 1024) / 8,
+    downloadThroughput: (100 * 1024) / 8,
     uploadThroughput: (5 * 1024) / 8,
   });
 
   return session;
 }
 
-sentryTest('should capture a `connection.rtt` metric.', async ({ getLocalTestUrl, page }) => {
+sentryTest('should capture a `connection.rtt` metric. xxx', async ({ getLocalTestUrl, page }) => {
   const url = await getLocalTestUrl({ testDir: __dirname });
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/init.js
@@ -4,10 +4,6 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [
-    Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
-    }),
-  ],
+  integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans-domexception-details/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans-domexception-details/init.js
@@ -23,11 +23,7 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [
-    Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
-    }),
-  ],
+  integrations: [Sentry.browserTracingIntegration({})],
   tracesSampleRate: 1,
 });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans/init.js
@@ -11,10 +11,6 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [
-    Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
-    }),
-  ],
+  integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-standalone-spans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-standalone-spans/init.js
@@ -6,12 +6,11 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
+      idleTimeout: 5000,
       _experiments: {
         enableStandaloneClsSpans: true,
       },
     }),
   ],
   tracesSampleRate: 1,
-  debug: true,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls/init.js
@@ -6,10 +6,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      enableLongTask: false,
-      enableLongAnimationFrame: true,
-      instrumentPageLoad: false,
-      enableInp: false,
+      idleTimeout: 5000,
     }),
   ],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 1000,
       enableLongTask: false,
       enableInp: true,
       instrumentPageLoad: false,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/init.js
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 1000,
       enableLongTask: false,
       enableInp: true,
       instrumentPageLoad: false,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-streamed-spans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-streamed-spans/init.js
@@ -5,6 +5,11 @@ window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [Sentry.browserTracingIntegration({ idleTimeout: 4000 }), Sentry.spanStreamingIntegration()],
+  integrations: [
+    Sentry.browserTracingIntegration({
+      idleTimeout: 5000,
+    }),
+    Sentry.spanStreamingIntegration(),
+  ],
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-standalone-spans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-standalone-spans/init.js
@@ -6,7 +6,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({
-      idleTimeout: 9000,
+      idleTimeout: 5000,
       _experiments: {
         enableStandaloneLcpSpans: true,
       },


### PR DESCRIPTION
After looking a bit at what the slowest browser-integration-tests are, I found an easy-to-fix pattern in our tests - we had _a lot_ of tests there that set some arbitrary `idleTimeout` to the `browserIntegrationTest`. This massively made these tests slower as it takes much longer to flush any pageload span. Many test runtimes reduced from 10-20s to 1-5s due to this change. A few places remain where this seems to be necessary, but there are way fewer now. 

FYI 1000ms is the default, we also had some defining this for some reason, I also removed those to be more consistent.