### PR TITLE
fix(tests): Remove nitro canary test job

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -120,9 +120,6 @@ jobs:
           - test-application: 'nestjs-microservices'
             build-command: 'test:build-latest'
             label: 'nestjs-microservices (latest)'
-          - test-application: 'nitro-3'
-            build-command: 'test:build-canary'
-            label: 'nitro-3 (canary)'
 
     steps:
       - name: Check out current commit


### PR DESCRIPTION
There is no stable stream of Nitro 3 canary builds yet, so no point in having this. I will add it back once we have a stable stream of builds, likely after the full v3 release.

I probably had it at one point then didn't remove it properly before merging https://github.com/getsentry/sentry-javascript/pull/19224

Closes #20472 
