### PR TITLE
feat(feedback): allow error messages to be customized

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -103,7 +103,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/prod/index.js',
     import: createImport('init', 'feedbackIntegration'),
     gzip: true,
-    limit: '43 KB',
+    limit: '44 KB',
   },
   {
     name: '@sentry/browser (incl. sendFeedback)',
@@ -233,7 +233,7 @@ module.exports = [
     name: 'CDN Bundle (incl. Tracing, Replay, Feedback, Logs, Metrics)',
     path: createCDNPath('bundle.tracing.replay.feedback.logs.metrics.min.js'),
     gzip: true,
-    limit: '90 KB',
+    limit: '91 KB',
   },
   // browser CDN bundles (non-gzipped)
   {
@@ -297,7 +297,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.feedback.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '272 KB',
+    limit: '273 KB',
   },
   // Next.js SDK (ESM)
   {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -453,6 +453,8 @@ export type {
   ReplayStopReason,
 } from './types-hoist/replay';
 export type {
+  FeedbackErrorCode,
+  FeedbackErrorMessages,
   FeedbackEvent,
   FeedbackFormData,
   FeedbackInternalOptions,

--- a/packages/core/src/types-hoist/feedback/config.ts
+++ b/packages/core/src/types-hoist/feedback/config.ts
@@ -191,6 +191,31 @@ export interface FeedbackTextConfiguration {
    * The label for the button that removed a highlight/hidden section of the screenshot.
    */
   removeHighlightText: string;
+
+  /**
+   * Error text shown when feedback submission is attempted with an empty message
+   */
+  errorEmptyMessageText: string;
+
+  /**
+   * Error text shown when the Sentry client is not set up
+   */
+  errorNoClientText: string;
+
+  /**
+   * Error text shown when the feedback submission times out (after 30s)
+   */
+  errorTimeoutText: string;
+
+  /**
+   * Error text shown when the feedback submission is blocked because the domain is not allowed (HTTP 403)
+   */
+  errorForbiddenText: string;
+
+  /**
+   * Error text shown when the feedback submission fails for any other reason (e.g. network error, ad-blocker)
+   */
+  errorGenericText: string;
 }
 
 /**

--- a/packages/core/src/types-hoist/feedback/index.ts
+++ b/packages/core/src/types-hoist/feedback/index.ts
@@ -6,10 +6,17 @@ import type {
   FeedbackTextConfiguration,
   FeedbackThemeConfiguration,
 } from './config';
-import type { FeedbackEvent, SendFeedback, SendFeedbackParams, UserFeedback } from './sendFeedback';
+import type {
+  FeedbackErrorCode,
+  FeedbackErrorMessages,
+  FeedbackEvent,
+  SendFeedback,
+  SendFeedbackParams,
+  UserFeedback,
+} from './sendFeedback';
 
 export type { FeedbackFormData } from './form';
-export type { FeedbackEvent, UserFeedback, SendFeedback, SendFeedbackParams };
+export type { FeedbackErrorCode, FeedbackErrorMessages, FeedbackEvent, SendFeedback, SendFeedbackParams, UserFeedback };
 
 /**
  * The integration's internal `options` member where every value should be set

--- a/packages/core/src/types-hoist/feedback/sendFeedback.ts
+++ b/packages/core/src/types-hoist/feedback/sendFeedback.ts
@@ -47,7 +47,16 @@ export interface SendFeedbackParams {
   tags?: { [key: string]: Primitive };
 }
 
+export type FeedbackErrorCode =
+  | 'ERROR_EMPTY_MESSAGE'
+  | 'ERROR_NO_CLIENT'
+  | 'ERROR_TIMEOUT'
+  | 'ERROR_FORBIDDEN'
+  | 'ERROR_GENERIC';
+
+export type FeedbackErrorMessages = Partial<Record<FeedbackErrorCode, string>>;
+
 export type SendFeedback = (
   params: SendFeedbackParams,
-  hint?: EventHint & { includeReplay?: boolean },
+  hint?: EventHint & { includeReplay?: boolean; errorMessages?: FeedbackErrorMessages },
 ) => Promise<string>;

--- a/packages/feedback/src/constants/index.ts
+++ b/packages/feedback/src/constants/index.ts
@@ -26,7 +26,7 @@ export const HIGHLIGHT_TOOL_TEXT = 'Highlight';
 export const HIDE_TOOL_TEXT = 'Hide';
 export const REMOVE_HIGHLIGHT_TEXT = 'Remove';
 
-export const ERROR_EMPTY_MESSAGE_TEXT = 'Unable to submit feedback with an empty message';
+export const ERROR_EMPTY_MESSAGE_TEXT = 'Unable to submit feedback with empty message';
 export const ERROR_NO_CLIENT_TEXT = 'No client setup, cannot send feedback.';
 export const ERROR_TIMEOUT_TEXT = 'Unable to determine if Feedback was correctly sent.';
 export const ERROR_FORBIDDEN_TEXT =

--- a/packages/feedback/src/constants/index.ts
+++ b/packages/feedback/src/constants/index.ts
@@ -26,7 +26,7 @@ export const HIGHLIGHT_TOOL_TEXT = 'Highlight';
 export const HIDE_TOOL_TEXT = 'Hide';
 export const REMOVE_HIGHLIGHT_TEXT = 'Remove';
 
-export const ERROR_EMPTY_MESSAGE_TEXT = 'Unable to submit feedback with empty message';
+export const ERROR_EMPTY_MESSAGE_TEXT = 'Unable to submit feedback with an empty message';
 export const ERROR_NO_CLIENT_TEXT = 'No client setup, cannot send feedback.';
 export const ERROR_TIMEOUT_TEXT = 'Unable to determine if Feedback was correctly sent.';
 export const ERROR_FORBIDDEN_TEXT =

--- a/packages/feedback/src/constants/index.ts
+++ b/packages/feedback/src/constants/index.ts
@@ -26,6 +26,14 @@ export const HIGHLIGHT_TOOL_TEXT = 'Highlight';
 export const HIDE_TOOL_TEXT = 'Hide';
 export const REMOVE_HIGHLIGHT_TEXT = 'Remove';
 
+export const ERROR_EMPTY_MESSAGE_TEXT = 'Unable to submit feedback with empty message';
+export const ERROR_NO_CLIENT_TEXT = 'No client setup, cannot send feedback.';
+export const ERROR_TIMEOUT_TEXT = 'Unable to determine if Feedback was correctly sent.';
+export const ERROR_FORBIDDEN_TEXT =
+  'Unable to send feedback. This could be because this domain is not in your list of allowed domains.';
+export const ERROR_GENERIC_TEXT =
+  'Unable to send feedback. This could be because of network issues, or because you are using an ad-blocker.';
+
 export const FEEDBACK_WIDGET_SOURCE = 'widget';
 export const FEEDBACK_API_SOURCE = 'api';
 

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+/* eslint-disable complexity */
 
 import type {
   FeedbackInternalOptions,
@@ -15,6 +16,11 @@ import {
   DOCUMENT,
   EMAIL_LABEL,
   EMAIL_PLACEHOLDER,
+  ERROR_EMPTY_MESSAGE_TEXT,
+  ERROR_FORBIDDEN_TEXT,
+  ERROR_GENERIC_TEXT,
+  ERROR_NO_CLIENT_TEXT,
+  ERROR_TIMEOUT_TEXT,
   FORM_TITLE,
   HIDE_TOOL_TEXT,
   HIGHLIGHT_TOOL_TEXT,
@@ -119,6 +125,11 @@ export const buildFeedbackIntegration = ({
     highlightToolText = HIGHLIGHT_TOOL_TEXT,
     hideToolText = HIDE_TOOL_TEXT,
     removeHighlightText = REMOVE_HIGHLIGHT_TEXT,
+    errorEmptyMessageText = ERROR_EMPTY_MESSAGE_TEXT,
+    errorNoClientText = ERROR_NO_CLIENT_TEXT,
+    errorTimeoutText = ERROR_TIMEOUT_TEXT,
+    errorForbiddenText = ERROR_FORBIDDEN_TEXT,
+    errorGenericText = ERROR_GENERIC_TEXT,
 
     // FeedbackCallbacks
     onFormOpen,
@@ -164,6 +175,11 @@ export const buildFeedbackIntegration = ({
       highlightToolText,
       hideToolText,
       removeHighlightText,
+      errorEmptyMessageText,
+      errorNoClientText,
+      errorTimeoutText,
+      errorForbiddenText,
+      errorGenericText,
 
       onFormClose,
       onFormOpen,

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -2,11 +2,13 @@
 /* eslint-disable complexity */
 
 import type {
+  FeedbackErrorMessages,
   FeedbackInternalOptions,
   FeedbackModalIntegration,
   FeedbackScreenshotIntegration,
   Integration,
   IntegrationFn,
+  SendFeedback,
 } from '@sentry/core';
 import { addIntegration, debug, isBrowser } from '@sentry/core';
 import {
@@ -246,6 +248,16 @@ export const buildFeedbackIntegration = ({
           debug.error('[Feedback] Missing feedback screenshot integration. Proceeding without screenshots.');
       }
 
+      const errorMessages: FeedbackErrorMessages = {
+        ERROR_EMPTY_MESSAGE: options.errorEmptyMessageText,
+        ERROR_NO_CLIENT: options.errorNoClientText,
+        ERROR_TIMEOUT: options.errorTimeoutText,
+        ERROR_FORBIDDEN: options.errorForbiddenText,
+        ERROR_GENERIC: options.errorGenericText,
+      };
+      const wrappedSendFeedback: SendFeedback = (params, hint) =>
+        sendFeedback(params, { includeReplay: true, ...hint, errorMessages });
+
       const dialog = modalIntegration.createDialog({
         options: {
           ...options,
@@ -259,7 +271,7 @@ export const buildFeedbackIntegration = ({
           },
         },
         screenshotIntegration,
-        sendFeedback,
+        sendFeedback: wrappedSendFeedback,
         shadow: _createShadow(options),
       });
 

--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -1,6 +1,8 @@
 import type { Event, EventHint, SendFeedback, SendFeedbackParams, TransportMakeRequestResponse } from '@sentry/core';
 import { captureFeedback, getClient, getCurrentScope, getLocationHref } from '@sentry/core';
 import { FEEDBACK_API_SOURCE } from '../constants';
+import type { FeedbackErrorCode } from '../util/createFeedbackError';
+import { createFeedbackError } from '../util/createFeedbackError';
 
 /**
  * Public API to send a Feedback item to Sentry
@@ -10,14 +12,14 @@ export const sendFeedback: SendFeedback = (
   hint: EventHint & { includeReplay?: boolean } = { includeReplay: true },
 ): Promise<string> => {
   if (!params.message) {
-    throw new Error('Unable to submit feedback with empty message');
+    throw createFeedbackError('ERROR_EMPTY_MESSAGE');
   }
 
   // We want to wait for the feedback to be sent (or not)
   const client = getClient();
 
   if (!client) {
-    throw new Error('No client setup, cannot send feedback.');
+    throw createFeedbackError('ERROR_NO_CLIENT');
   }
 
   if (params.tags && Object.keys(params.tags).length) {
@@ -35,7 +37,7 @@ export const sendFeedback: SendFeedback = (
   // We want to wait for the feedback to be sent (or not)
   return new Promise<string>((resolve, reject) => {
     // After 30s, we want to clear anyhow
-    const timeout = setTimeout(() => reject('Unable to determine if Feedback was correctly sent.'), 30_000);
+    const timeout = setTimeout(() => reject('ERROR_TIMEOUT' satisfies FeedbackErrorCode), 30_000);
 
     const cleanup = client.on('afterSendEvent', (event: Event, response: TransportMakeRequestResponse) => {
       if (event.event_id !== eventId) {
@@ -51,14 +53,10 @@ export const sendFeedback: SendFeedback = (
       }
 
       if (response?.statusCode === 403) {
-        return reject(
-          'Unable to send feedback. This could be because this domain is not in your list of allowed domains.',
-        );
+        return reject('ERROR_FORBIDDEN' satisfies FeedbackErrorCode);
       }
 
-      return reject(
-        'Unable to send feedback. This could be because of network issues, or because you are using an ad-blocker.',
-      );
+      return reject('ERROR_GENERIC' satisfies FeedbackErrorCode);
     });
   });
 };

--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -37,7 +37,10 @@ export const sendFeedback: SendFeedback = (
   // We want to wait for the feedback to be sent (or not)
   return new Promise<string>((resolve, reject) => {
     // After 30s, we want to clear anyhow
-    const timeout = setTimeout(() => reject('ERROR_TIMEOUT' satisfies FeedbackErrorCode), 30_000);
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject('ERROR_TIMEOUT' satisfies FeedbackErrorCode);
+    }, 30_000);
 
     const cleanup = client.on('afterSendEvent', (event: Event, response: TransportMakeRequestResponse) => {
       if (event.event_id !== eventId) {

--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -1,25 +1,33 @@
-import type { Event, EventHint, SendFeedback, SendFeedbackParams, TransportMakeRequestResponse } from '@sentry/core';
+import type {
+  Event,
+  EventHint,
+  FeedbackErrorMessages,
+  SendFeedback,
+  SendFeedbackParams,
+  TransportMakeRequestResponse,
+} from '@sentry/core';
 import { captureFeedback, getClient, getCurrentScope, getLocationHref } from '@sentry/core';
 import { FEEDBACK_API_SOURCE } from '../constants';
-import type { FeedbackErrorCode } from '../util/createFeedbackError';
-import { createFeedbackError } from '../util/createFeedbackError';
+import { createFeedbackError, resolveFeedbackErrorMessage } from '../util/createFeedbackError';
 
 /**
  * Public API to send a Feedback item to Sentry
  */
 export const sendFeedback: SendFeedback = (
   params: SendFeedbackParams,
-  hint: EventHint & { includeReplay?: boolean } = { includeReplay: true },
+  hint: EventHint & { includeReplay?: boolean; errorMessages?: FeedbackErrorMessages } = { includeReplay: true },
 ): Promise<string> => {
+  const errorMessages = hint.errorMessages;
+
   if (!params.message) {
-    throw createFeedbackError('ERROR_EMPTY_MESSAGE');
+    throw createFeedbackError('ERROR_EMPTY_MESSAGE', errorMessages);
   }
 
   // We want to wait for the feedback to be sent (or not)
   const client = getClient();
 
   if (!client) {
-    throw createFeedbackError('ERROR_NO_CLIENT');
+    throw createFeedbackError('ERROR_NO_CLIENT', errorMessages);
   }
 
   if (params.tags && Object.keys(params.tags).length) {
@@ -39,7 +47,7 @@ export const sendFeedback: SendFeedback = (
     // After 30s, we want to clear anyhow
     const timeout = setTimeout(() => {
       cleanup();
-      reject('ERROR_TIMEOUT' satisfies FeedbackErrorCode);
+      reject(resolveFeedbackErrorMessage('ERROR_TIMEOUT', errorMessages));
     }, 30_000);
 
     const cleanup = client.on('afterSendEvent', (event: Event, response: TransportMakeRequestResponse) => {
@@ -56,10 +64,10 @@ export const sendFeedback: SendFeedback = (
       }
 
       if (response?.statusCode === 403) {
-        return reject('ERROR_FORBIDDEN' satisfies FeedbackErrorCode);
+        return reject(resolveFeedbackErrorMessage('ERROR_FORBIDDEN', errorMessages));
       }
 
-      return reject('ERROR_GENERIC' satisfies FeedbackErrorCode);
+      return reject(resolveFeedbackErrorMessage('ERROR_GENERIC', errorMessages));
     });
   });
 };

--- a/packages/feedback/src/modal/components/Form.tsx
+++ b/packages/feedback/src/modal/components/Form.tsx
@@ -9,7 +9,6 @@ import type { JSX, VNode } from 'preact';
 import { h } from 'preact'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { useCallback, useState } from 'preact/hooks';
 import { FEEDBACK_WIDGET_SOURCE } from '../../constants';
-import type { FeedbackErrorCode } from '../../util/createFeedbackError';
 import { DEBUG_BUILD } from '../../util/debug-build';
 import { getMissingFields } from '../../util/validate';
 
@@ -60,20 +59,7 @@ export function Form({
     namePlaceholder,
     submitButtonLabel,
     isRequiredLabel,
-    errorEmptyMessageText,
-    errorNoClientText,
-    errorTimeoutText,
-    errorForbiddenText,
-    errorGenericText,
   } = options;
-
-  const errorTextByCode: Record<FeedbackErrorCode, string> = {
-    ERROR_EMPTY_MESSAGE: errorEmptyMessageText,
-    ERROR_NO_CLIENT: errorNoClientText,
-    ERROR_TIMEOUT: errorTimeoutText,
-    ERROR_FORBIDDEN: errorForbiddenText,
-    ERROR_GENERIC: errorGenericText,
-  };
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   // TODO: set a ref on the form, and whenever an input changes call processForm() and setError()
   const [error, setError] = useState<null | string>(null);
@@ -146,7 +132,7 @@ export function Form({
         } catch (error) {
           DEBUG_BUILD && debug.error(error);
           const err = error instanceof Error ? error : new Error(String(error));
-          setError(errorTextByCode[err.message as FeedbackErrorCode] ?? errorGenericText);
+          setError(err.message);
           onSubmitError(err);
         }
       } finally {

--- a/packages/feedback/src/modal/components/Form.tsx
+++ b/packages/feedback/src/modal/components/Form.tsx
@@ -146,7 +146,7 @@ export function Form({
         } catch (error) {
           DEBUG_BUILD && debug.error(error);
           const err = error instanceof Error ? error : new Error(String(error));
-          setError(errorTextByCode[err.message as FeedbackErrorCode] || errorGenericText);
+          setError(errorTextByCode[err.message as FeedbackErrorCode] ?? errorGenericText);
           onSubmitError(err);
         }
       } finally {

--- a/packages/feedback/src/modal/components/Form.tsx
+++ b/packages/feedback/src/modal/components/Form.tsx
@@ -9,6 +9,7 @@ import type { JSX, VNode } from 'preact';
 import { h } from 'preact'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { useCallback, useState } from 'preact/hooks';
 import { FEEDBACK_WIDGET_SOURCE } from '../../constants';
+import type { FeedbackErrorCode } from '../../util/createFeedbackError';
 import { DEBUG_BUILD } from '../../util/debug-build';
 import { getMissingFields } from '../../util/validate';
 
@@ -59,7 +60,20 @@ export function Form({
     namePlaceholder,
     submitButtonLabel,
     isRequiredLabel,
+    errorEmptyMessageText,
+    errorNoClientText,
+    errorTimeoutText,
+    errorForbiddenText,
+    errorGenericText,
   } = options;
+
+  const errorTextByCode: Record<FeedbackErrorCode, string> = {
+    ERROR_EMPTY_MESSAGE: errorEmptyMessageText,
+    ERROR_NO_CLIENT: errorNoClientText,
+    ERROR_TIMEOUT: errorTimeoutText,
+    ERROR_FORBIDDEN: errorForbiddenText,
+    ERROR_GENERIC: errorGenericText,
+  };
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   // TODO: set a ref on the form, and whenever an input changes call processForm() and setError()
   const [error, setError] = useState<null | string>(null);
@@ -131,8 +145,9 @@ export function Form({
           onSubmitSuccess(data, eventId);
         } catch (error) {
           DEBUG_BUILD && debug.error(error);
-          setError(error as string);
-          onSubmitError(error as Error);
+          const err = error instanceof Error ? error : new Error(String(error));
+          setError(errorTextByCode[err.message as FeedbackErrorCode] || errorGenericText);
+          onSubmitError(err);
         }
       } finally {
         setIsSubmitting(false);

--- a/packages/feedback/src/util/createFeedbackError.ts
+++ b/packages/feedback/src/util/createFeedbackError.ts
@@ -1,0 +1,10 @@
+export type FeedbackErrorCode =
+  | 'ERROR_EMPTY_MESSAGE'
+  | 'ERROR_NO_CLIENT'
+  | 'ERROR_TIMEOUT'
+  | 'ERROR_FORBIDDEN'
+  | 'ERROR_GENERIC';
+
+export function createFeedbackError(reason: FeedbackErrorCode): Error {
+  return new Error(reason);
+}

--- a/packages/feedback/src/util/createFeedbackError.ts
+++ b/packages/feedback/src/util/createFeedbackError.ts
@@ -1,10 +1,24 @@
-export type FeedbackErrorCode =
-  | 'ERROR_EMPTY_MESSAGE'
-  | 'ERROR_NO_CLIENT'
-  | 'ERROR_TIMEOUT'
-  | 'ERROR_FORBIDDEN'
-  | 'ERROR_GENERIC';
+import type { FeedbackErrorCode, FeedbackErrorMessages } from '@sentry/core';
+import {
+  ERROR_EMPTY_MESSAGE_TEXT,
+  ERROR_FORBIDDEN_TEXT,
+  ERROR_GENERIC_TEXT,
+  ERROR_NO_CLIENT_TEXT,
+  ERROR_TIMEOUT_TEXT,
+} from '../constants';
 
-export function createFeedbackError(reason: FeedbackErrorCode): Error {
-  return new Error(reason);
+const DEFAULT_MESSAGES: Record<FeedbackErrorCode, string> = {
+  ERROR_EMPTY_MESSAGE: ERROR_EMPTY_MESSAGE_TEXT,
+  ERROR_NO_CLIENT: ERROR_NO_CLIENT_TEXT,
+  ERROR_TIMEOUT: ERROR_TIMEOUT_TEXT,
+  ERROR_FORBIDDEN: ERROR_FORBIDDEN_TEXT,
+  ERROR_GENERIC: ERROR_GENERIC_TEXT,
+};
+
+export function resolveFeedbackErrorMessage(code: FeedbackErrorCode, messages?: FeedbackErrorMessages): string {
+  return messages?.[code] ?? DEFAULT_MESSAGES[code];
+}
+
+export function createFeedbackError(code: FeedbackErrorCode, messages?: FeedbackErrorMessages): Error {
+  return new Error(resolveFeedbackErrorMessage(code, messages));
 }

--- a/packages/feedback/test/core/sendFeedback.test.ts
+++ b/packages/feedback/test/core/sendFeedback.test.ts
@@ -269,7 +269,7 @@ describe('sendFeedback', () => {
 
   it('throws when message is empty', () => {
     mockSdk();
-    expect(() => sendFeedback({ message: '' })).toThrow('Unable to submit feedback with an empty message');
+    expect(() => sendFeedback({ message: '' })).toThrow('Unable to submit feedback with empty message');
   });
 
   it('throws when no client is set up', async () => {

--- a/packages/feedback/test/core/sendFeedback.test.ts
+++ b/packages/feedback/test/core/sendFeedback.test.ts
@@ -293,6 +293,20 @@ describe('sendFeedback', () => {
     ).rejects.toMatch('custom forbidden text');
   });
 
+  it('falls back to default messages for codes not in errorMessages', async () => {
+    mockSdk();
+    vi.spyOn(getClient()!.getTransport()!, 'send').mockImplementation(() => {
+      return Promise.resolve({ statusCode: 400 });
+    });
+
+    // Only override ERROR_FORBIDDEN — a 400 should still use the default generic message.
+    await expect(
+      sendFeedback({ message: 'mi' }, { errorMessages: { ERROR_FORBIDDEN: 'custom forbidden text' } }),
+    ).rejects.toMatch(
+      'Unable to send feedback. This could be because of network issues, or because you are using an ad-blocker.',
+    );
+  });
+
   it('handles 400 transport error', async () => {
     mockSdk();
     vi.spyOn(getClient()!.getTransport()!, 'send').mockImplementation(() => {

--- a/packages/feedback/test/core/sendFeedback.test.ts
+++ b/packages/feedback/test/core/sendFeedback.test.ts
@@ -279,9 +279,7 @@ describe('sendFeedback', () => {
         email: 're@example.org',
         message: 'mi',
       }),
-    ).rejects.toMatch(
-      'Unable to send feedback. This could be because of network issues, or because you are using an ad-blocker.',
-    );
+    ).rejects.toMatch('ERROR_GENERIC');
   });
 
   it('handles 0 transport error', async () => {
@@ -296,9 +294,7 @@ describe('sendFeedback', () => {
         email: 're@example.org',
         message: 'mi',
       }),
-    ).rejects.toMatch(
-      'Unable to send feedback. This could be because of network issues, or because you are using an ad-blocker.',
-    );
+    ).rejects.toMatch('ERROR_GENERIC');
   });
 
   it('handles 403 transport error', async () => {
@@ -313,9 +309,7 @@ describe('sendFeedback', () => {
         email: 're@example.org',
         message: 'mi',
       }),
-    ).rejects.toMatch(
-      'Unable to send feedback. This could be because this domain is not in your list of allowed domains.',
-    );
+    ).rejects.toMatch('ERROR_FORBIDDEN');
   });
 
   it('handles 200 transport response', async () => {
@@ -349,7 +343,7 @@ describe('sendFeedback', () => {
 
     vi.advanceTimersByTime(30_000);
 
-    await expect(promise).rejects.toMatch('Unable to determine if Feedback was correctly sent.');
+    await expect(promise).rejects.toMatch('ERROR_TIMEOUT');
 
     vi.useRealTimers();
   });

--- a/packages/feedback/test/core/sendFeedback.test.ts
+++ b/packages/feedback/test/core/sendFeedback.test.ts
@@ -267,6 +267,21 @@ describe('sendFeedback', () => {
     ]);
   });
 
+  it('throws when message is empty', () => {
+    mockSdk();
+    expect(() => sendFeedback({ message: '' })).toThrow('ERROR_EMPTY_MESSAGE');
+  });
+
+  it('throws when no client is set up', async () => {
+    // Isolate in its own scope so the client set up by other tests doesn't bleed in.
+    // `getClient` reads from the current scope; resetting it here leaves no client.
+    const { getGlobalScope } = await import('@sentry/core');
+    getGlobalScope().setClient(undefined);
+    getCurrentScope().setClient(undefined);
+    getIsolationScope().setClient(undefined);
+    expect(() => sendFeedback({ message: 'mi' })).toThrow('ERROR_NO_CLIENT');
+  });
+
   it('handles 400 transport error', async () => {
     mockSdk();
     vi.spyOn(getClient()!.getTransport()!, 'send').mockImplementation(() => {

--- a/packages/feedback/test/core/sendFeedback.test.ts
+++ b/packages/feedback/test/core/sendFeedback.test.ts
@@ -269,7 +269,7 @@ describe('sendFeedback', () => {
 
   it('throws when message is empty', () => {
     mockSdk();
-    expect(() => sendFeedback({ message: '' })).toThrow('ERROR_EMPTY_MESSAGE');
+    expect(() => sendFeedback({ message: '' })).toThrow('Unable to submit feedback with an empty message');
   });
 
   it('throws when no client is set up', async () => {
@@ -279,7 +279,18 @@ describe('sendFeedback', () => {
     getGlobalScope().setClient(undefined);
     getCurrentScope().setClient(undefined);
     getIsolationScope().setClient(undefined);
-    expect(() => sendFeedback({ message: 'mi' })).toThrow('ERROR_NO_CLIENT');
+    expect(() => sendFeedback({ message: 'mi' })).toThrow('No client setup, cannot send feedback.');
+  });
+
+  it('uses provided errorMessages overrides', async () => {
+    mockSdk();
+    vi.spyOn(getClient()!.getTransport()!, 'send').mockImplementation(() => {
+      return Promise.resolve({ statusCode: 403 });
+    });
+
+    await expect(
+      sendFeedback({ message: 'mi' }, { errorMessages: { ERROR_FORBIDDEN: 'custom forbidden text' } }),
+    ).rejects.toMatch('custom forbidden text');
   });
 
   it('handles 400 transport error', async () => {
@@ -294,7 +305,9 @@ describe('sendFeedback', () => {
         email: 're@example.org',
         message: 'mi',
       }),
-    ).rejects.toMatch('ERROR_GENERIC');
+    ).rejects.toMatch(
+      'Unable to send feedback. This could be because of network issues, or because you are using an ad-blocker.',
+    );
   });
 
   it('handles 0 transport error', async () => {
@@ -309,7 +322,9 @@ describe('sendFeedback', () => {
         email: 're@example.org',
         message: 'mi',
       }),
-    ).rejects.toMatch('ERROR_GENERIC');
+    ).rejects.toMatch(
+      'Unable to send feedback. This could be because of network issues, or because you are using an ad-blocker.',
+    );
   });
 
   it('handles 403 transport error', async () => {
@@ -324,7 +339,9 @@ describe('sendFeedback', () => {
         email: 're@example.org',
         message: 'mi',
       }),
-    ).rejects.toMatch('ERROR_FORBIDDEN');
+    ).rejects.toMatch(
+      'Unable to send feedback. This could be because this domain is not in your list of allowed domains.',
+    );
   });
 
   it('handles 200 transport response', async () => {
@@ -358,7 +375,7 @@ describe('sendFeedback', () => {
 
     vi.advanceTimersByTime(30_000);
 
-    await expect(promise).rejects.toMatch('ERROR_TIMEOUT');
+    await expect(promise).rejects.toMatch('Unable to determine if Feedback was correctly sent.');
 
     vi.useRealTimers();
   });


### PR DESCRIPTION
Adds text options to `FeedbackTextConfiguration` to allow customizing the widget's error messages (for i18n and other purposes).

`sendFeedback` now accepts optional `errorMessages` overrides via its `hint` argument, defaulting to the original English strings. The widget wraps `sendFeedback` to inject the configured text options before the form displays them.

Standalone `sendFeedback` consumers see the same English messages as before — no observable behavior change.

Closes #14687