### PR TITLE
ref(browser): Use `safeSetSpanJSONAttributes` in cultureContext integration

### DIFF
--- a/packages/browser/src/integrations/culturecontext.ts
+++ b/packages/browser/src/integrations/culturecontext.ts
@@ -1,5 +1,5 @@
 import type { CultureContext, IntegrationFn } from '@sentry/core';
-import { defineIntegration } from '@sentry/core';
+import { defineIntegration, safeSetSpanJSONAttributes } from '@sentry/core';
 import { WINDOW } from '../helpers';
 
 const INTEGRATION_NAME = 'CultureContext';
@@ -21,12 +21,11 @@ const _cultureContextIntegration = (() => {
       const culture = getCultureContext();
 
       if (culture) {
-        span.attributes = {
+        safeSetSpanJSONAttributes(span, {
           'culture.locale': culture.locale,
           'culture.timezone': culture.timezone,
           'culture.calendar': culture.calendar,
-          ...span.attributes,
-        };
+        });
       }
     },
   };


### PR DESCRIPTION
Applies the same `safeSetSpanJSONAttributes` refactor from #20464 to the `cultureContext` integration's `processSegmentSpan` hook. This gives us in-place mutation instead of spread-and-reassign and nullish values are skipped (these get dropped during serialization anyways but doesn't hurt to just not assign them in the first place).