### PR TITLE
fix(e2e/tanstackstart-react): pin @tanstack/start-plugin-core to unblock CI

### DIFF
--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
@@ -45,6 +45,11 @@
   "volta": {
     "extends": "../../package.json"
   },
+  "pnpm": {
+    "overrides": {
+      "@tanstack/start-plugin-core": "1.167.35"
+    }
+  },
   "sentryTest": {
     "variants": [
       {


### PR DESCRIPTION
`@tanstack/start-plugin-core@1.168.0` was published at `2026-04-24T01:28Z` and broke the `tanstackstart-react` E2E build on every branch 😡 

I had a clanker pin it temporarily, to unblock the current branches.
