### PR TITLE
fix(supabase): Consider `sendDefaultPii` for supabase integration

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/supabase/db-operations/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/supabase/db-operations/init.js
@@ -9,6 +9,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration(), Sentry.supabaseIntegration({ supabaseClient })],
   tracesSampleRate: 1.0,
+  sendDefaultPii: true,
 });
 
 // Simulate database operations

--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/tests/performance.test.ts
@@ -57,37 +57,16 @@ test('Sends client-side Supabase db-operation spans and breadcrumbs to Sentry', 
 
   const transactionEvent = await pageloadTransactionPromise;
 
-  expect(transactionEvent.spans).toContainEqual(
-    expect.objectContaining({
-      description: 'select(*) filter(order, asc) from(todos)',
-      op: 'db',
-      data: expect.objectContaining({
-        'db.operation': 'select',
-        'db.query': ['select(*)', 'filter(order, asc)'],
-        'db.system': 'postgresql',
-        'sentry.op': 'db',
-        'sentry.origin': 'auto.db.supabase',
-      }),
-      parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
-      span_id: expect.stringMatching(/[a-f0-9]{16}/),
-      start_timestamp: expect.any(Number),
-      status: 'ok',
-      timestamp: expect.any(Number),
-      trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-      origin: 'auto.db.supabase',
-    }),
-  );
-
-  expect(transactionEvent.spans).toContainEqual({
+  // Client uses default sendDefaultPii: false — URL filters and bodies are not attached to spans/breadcrumbs.
+  const redactedSelectSpan = expect.objectContaining({
+    description: '[redacted] from(todos)',
+    op: 'db',
     data: expect.objectContaining({
       'db.operation': 'select',
-      'db.query': ['select(*)', 'filter(order, asc)'],
       'db.system': 'postgresql',
       'sentry.op': 'db',
       'sentry.origin': 'auto.db.supabase',
     }),
-    description: 'select(*) filter(order, asc) from(todos)',
-    op: 'db',
     parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
     span_id: expect.stringMatching(/[a-f0-9]{16}/),
     start_timestamp: expect.any(Number),
@@ -97,20 +76,26 @@ test('Sends client-side Supabase db-operation spans and breadcrumbs to Sentry', 
     origin: 'auto.db.supabase',
   });
 
+  expect(transactionEvent.spans).toContainEqual(redactedSelectSpan);
+
+  const selectSpan = transactionEvent.spans?.find(
+    (s: { description?: string }) => s.description === '[redacted] from(todos)',
+  );
+  expect(selectSpan).toBeDefined();
+  expect(selectSpan!.data).not.toHaveProperty('db.query');
+
   expect(transactionEvent.breadcrumbs).toContainEqual({
     timestamp: expect.any(Number),
     type: 'supabase',
     category: 'db.select',
-    message: 'select(*) filter(order, asc) from(todos)',
-    data: expect.any(Object),
+    message: '[redacted] from(todos)',
   });
 
   expect(transactionEvent.breadcrumbs).toContainEqual({
     timestamp: expect.any(Number),
     type: 'supabase',
     category: 'db.insert',
-    message: 'insert(...) select(*) from(todos)',
-    data: expect.any(Object),
+    message: 'insert(...) [redacted] from(todos)',
   });
 });
 

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-lines */
 import { addBreadcrumb } from '../breadcrumbs';
+import { getClient } from '../currentScopes';
 import { DEBUG_BUILD } from '../debug-build';
 import { captureException } from '../exports';
 import { defineIntegration } from '../integration';
@@ -361,12 +362,15 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
           }
         }
 
+        const sendDefaultPii = Boolean(getClient()?.getOptions().sendDefaultPii);
+
         // Adding operation to the beginning of the description if it's not a `select` operation
         // For example, it can be an `insert` or `update` operation but the query can be `select(...)`
         // For `select` operations, we don't need repeat it in the description
-        const description = `${operation === 'select' ? '' : `${operation}${body ? '(...) ' : ''}`}${queryItems.join(
-          ' ',
-        )} from(${table})`;
+        const mutationPart = operation === 'select' ? '' : `${operation}${Object.keys(body).length ? '(...) ' : ''}`;
+        const queryPart = sendDefaultPii ? queryItems.join(' ') : queryItems.length > 0 ? '[redacted]' : '';
+        const descriptionMiddle = [mutationPart.trimEnd(), queryPart].filter(Boolean).join(' ');
+        const description = descriptionMiddle ? `${descriptionMiddle} from(${table})` : `from(${table})`;
 
         const attributes: Record<string, any> = {
           'db.table': table,
@@ -379,11 +383,11 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
         };
 
-        if (queryItems.length) {
+        if (queryItems.length && sendDefaultPii) {
           attributes['db.query'] = queryItems;
         }
 
-        if (Object.keys(body).length) {
+        if (Object.keys(body).length && sendDefaultPii) {
           attributes['db.body'] = body;
         }
 
@@ -413,10 +417,10 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
                     }
 
                     const supabaseContext: Record<string, any> = {};
-                    if (queryItems.length) {
+                    if (queryItems.length && sendDefaultPii) {
                       supabaseContext.query = queryItems;
                     }
-                    if (Object.keys(body).length) {
+                    if (Object.keys(body).length && sendDefaultPii) {
                       supabaseContext.body = body;
                     }
 
@@ -444,11 +448,11 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
 
                   const data: Record<string, unknown> = {};
 
-                  if (queryItems.length) {
+                  if (queryItems.length && sendDefaultPii) {
                     data.query = queryItems;
                   }
 
-                  if (Object.keys(body).length) {
+                  if (Object.keys(body).length && sendDefaultPii) {
                     data.body = body;
                   }
 

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -150,6 +150,25 @@ function isInstrumented<T>(fn: T): boolean | undefined {
 }
 
 /**
+ * Plain-object bodies are copied into `plainBody`; array inserts (and other non-plain shapes) stay only on `rawBody`.
+ * Returns a payload suitable for span attributes / breadcrumbs when the client has `sendDefaultPii` enabled.
+ */
+function getMutationBodyPayloadForTelemetry(rawBody: unknown, plainBody: Record<string, unknown>): unknown | undefined {
+  if (Object.keys(plainBody).length > 0) {
+    return plainBody;
+  }
+  if (Array.isArray(rawBody) && rawBody.length > 0) {
+    return rawBody;
+  }
+  return undefined;
+}
+
+/** True when the PostgREST builder carries a mutation body (for `insert(...)`, etc. in span descriptions). */
+function hasMutationBodyForDescription(rawBody: unknown, plainBody: Record<string, unknown>): boolean {
+  return getMutationBodyPayloadForTelemetry(rawBody, plainBody) !== undefined;
+}
+
+/**
  * Extracts the database operation type from the HTTP method and headers
  * @param method - The HTTP method of the request
  * @param headers - The request headers
@@ -363,11 +382,15 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
         }
 
         const sendDefaultPii = Boolean(getClient()?.getOptions().sendDefaultPii);
+        const bodyPayload = getMutationBodyPayloadForTelemetry(typedThis.body, body);
 
         // Adding operation to the beginning of the description if it's not a `select` operation
         // For example, it can be an `insert` or `update` operation but the query can be `select(...)`
         // For `select` operations, we don't need repeat it in the description
-        const mutationPart = operation === 'select' ? '' : `${operation}${Object.keys(body).length ? '(...) ' : ''}`;
+        const mutationPart =
+          operation === 'select'
+            ? ''
+            : `${operation}${hasMutationBodyForDescription(typedThis.body, body) ? '(...) ' : ''}`;
         const queryPart = sendDefaultPii ? queryItems.join(' ') : queryItems.length > 0 ? '[redacted]' : '';
         const descriptionMiddle = [mutationPart.trimEnd(), queryPart].filter(Boolean).join(' ');
         const description = descriptionMiddle ? `${descriptionMiddle} from(${table})` : `from(${table})`;
@@ -387,8 +410,8 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
           attributes['db.query'] = queryItems;
         }
 
-        if (Object.keys(body).length && sendDefaultPii) {
-          attributes['db.body'] = body;
+        if (bodyPayload !== undefined && sendDefaultPii) {
+          attributes['db.body'] = bodyPayload;
         }
 
         return startSpan(
@@ -420,8 +443,8 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
                     if (queryItems.length && sendDefaultPii) {
                       supabaseContext.query = queryItems;
                     }
-                    if (Object.keys(body).length && sendDefaultPii) {
-                      supabaseContext.body = body;
+                    if (bodyPayload !== undefined && sendDefaultPii) {
+                      supabaseContext.body = bodyPayload;
                     }
 
                     captureException(err, scope => {
@@ -452,8 +475,8 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
                     data.query = queryItems;
                   }
 
-                  if (Object.keys(body).length && sendDefaultPii) {
-                    data.body = body;
+                  if (bodyPayload !== undefined && sendDefaultPii) {
+                    data.body = bodyPayload;
                   }
 
                   if (Object.keys(data).length) {

--- a/packages/core/test/lib/integrations/supabase.test.ts
+++ b/packages/core/test/lib/integrations/supabase.test.ts
@@ -310,4 +310,38 @@ describe('Supabase Integration', () => {
       expect(contexts.supabase).toEqual({});
     });
   });
+
+  describe('array insert body', () => {
+    beforeEach(() => {
+      vi.spyOn(breadcrumbModule, 'addBreadcrumb').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('includes insert(...) in span description and db.body when payload is a non-empty array', async () => {
+      tracingMocks.startSpan.mockClear();
+      const client = createMockSupabaseClient(
+        { status: 200 },
+        {
+          method: 'POST',
+          url: 'https://example.supabase.co/rest/v1/todos?columns=',
+          body: [{ title: 'Test Todo' }],
+          sendDefaultPii: true,
+        },
+      );
+      instrumentSupabaseClient(client);
+
+      await (client as any).from('todos').insert({}).then();
+
+      const spanOptions = tracingMocks.startSpan.mock.calls[0]![0] as {
+        name: string;
+        attributes: Record<string, unknown>;
+      };
+      expect(spanOptions.name).toMatch(/^insert\(\.\.\.\)/);
+      expect(spanOptions.name).toContain('from(todos)');
+      expect(spanOptions.attributes['db.body']).toEqual([{ title: 'Test Todo' }]);
+    });
+  });
 });

--- a/packages/core/test/lib/integrations/supabase.test.ts
+++ b/packages/core/test/lib/integrations/supabase.test.ts
@@ -8,21 +8,113 @@ import {
 } from '../../../src/integrations/supabase';
 import type { PostgRESTQueryBuilder, SupabaseClientInstance } from '../../../src/integrations/supabase';
 
-// Mock tracing to avoid needing full SDK setup
-vi.mock('../../../src/tracing', () => ({
-  startSpan: (_opts: any, cb: (span: any) => any) => {
+const tracingMocks = vi.hoisted(() => ({
+  startSpan: vi.fn((_opts: unknown, cb: (span: unknown) => unknown) => {
     const mockSpan = {
       setStatus: vi.fn(),
       end: vi.fn(),
     };
     return cb(mockSpan);
-  },
+  }),
+}));
+
+const currentScopesMocks = vi.hoisted(() => ({
+  getClient: vi.fn(),
+}));
+
+// Mock tracing to avoid needing full SDK setup
+vi.mock('../../../src/tracing', () => ({
+  startSpan: tracingMocks.startSpan,
   setHttpStatus: vi.fn(),
   SPAN_STATUS_OK: 1,
   SPAN_STATUS_ERROR: 2,
 }));
 
+vi.mock('../../../src/currentScopes', () => ({
+  getClient: currentScopesMocks.getClient,
+}));
+
+type CreateMockSupabaseClientOptions = {
+  method?: string;
+  url?: URL | string;
+  body?: unknown;
+  /** When set, configures the mocked Sentry client `sendDefaultPii`. Omit to leave `getClient` to the test file `beforeEach`. */
+  sendDefaultPii?: boolean;
+};
+
+const DEFAULT_MOCK_SUPABASE_REST_URL = 'https://example.supabase.co/rest/v1/todos';
+
+/** Shared PATCH + query string + body shape for `sendDefaultPii` tests. */
+const MOCK_SUPABASE_PII_SCENARIO: Pick<CreateMockSupabaseClientOptions, 'method' | 'url' | 'body'> = {
+  method: 'PATCH',
+  url: 'https://example.supabase.co/rest/v1/users?email=eq.secret%40example.com&select=id',
+  body: { full_name: 'Jane Doe', phone: '555-0100' },
+};
+
+function createMockSupabaseClient(resolveWith: unknown, options?: CreateMockSupabaseClientOptions): unknown {
+  if (options?.sendDefaultPii !== undefined) {
+    currentScopesMocks.getClient.mockReturnValue({
+      getOptions: () => ({ sendDefaultPii: options.sendDefaultPii }),
+    } as any);
+  }
+
+  const method = options?.method ?? 'GET';
+  const requestUrl =
+    options?.url !== undefined
+      ? options.url instanceof URL
+        ? options.url
+        : new URL(options.url)
+      : new URL(DEFAULT_MOCK_SUPABASE_REST_URL);
+  const body = options?.body;
+
+  class MockPostgRESTFilterBuilder {
+    method = method;
+    headers: Record<string, string> = { 'X-Client-Info': 'supabase-js/2.0.0' };
+    url = requestUrl;
+    schema = 'public';
+    body = body;
+
+    then(onfulfilled?: (value: any) => any, onrejected?: (reason: any) => any): Promise<any> {
+      return Promise.resolve(resolveWith).then(onfulfilled, onrejected);
+    }
+  }
+
+  class MockPostgRESTQueryBuilder {
+    select() {
+      return new MockPostgRESTFilterBuilder();
+    }
+    insert() {
+      return new MockPostgRESTFilterBuilder();
+    }
+    upsert() {
+      return new MockPostgRESTFilterBuilder();
+    }
+    update() {
+      return new MockPostgRESTFilterBuilder();
+    }
+    delete() {
+      return new MockPostgRESTFilterBuilder();
+    }
+  }
+
+  class MockSupabaseClient {
+    auth = {
+      admin: {} as any,
+    } as SupabaseClientInstance['auth'];
+
+    from(_table: string): PostgRESTQueryBuilder {
+      return new MockPostgRESTQueryBuilder() as unknown as PostgRESTQueryBuilder;
+    }
+  }
+
+  return new MockSupabaseClient();
+}
+
 describe('Supabase Integration', () => {
+  beforeEach(() => {
+    currentScopesMocks.getClient.mockReturnValue(undefined);
+  });
+
   describe('extractOperation', () => {
     it('returns select for GET', () => {
       expect(extractOperation('GET')).toBe('select');
@@ -71,52 +163,6 @@ describe('Supabase Integration', () => {
     afterEach(() => {
       vi.restoreAllMocks();
     });
-
-    function createMockSupabaseClient(resolveWith: unknown): unknown {
-      // Create a PostgRESTFilterBuilder-like class
-      class MockPostgRESTFilterBuilder {
-        method = 'GET';
-        headers: Record<string, string> = { 'X-Client-Info': 'supabase-js/2.0.0' };
-        url = new URL('https://example.supabase.co/rest/v1/todos');
-        schema = 'public';
-        body = undefined;
-
-        then(onfulfilled?: (value: any) => any, onrejected?: (reason: any) => any): Promise<any> {
-          return Promise.resolve(resolveWith).then(onfulfilled, onrejected);
-        }
-      }
-
-      class MockPostgRESTQueryBuilder {
-        select() {
-          return new MockPostgRESTFilterBuilder();
-        }
-        insert() {
-          return new MockPostgRESTFilterBuilder();
-        }
-        upsert() {
-          return new MockPostgRESTFilterBuilder();
-        }
-        update() {
-          return new MockPostgRESTFilterBuilder();
-        }
-        delete() {
-          return new MockPostgRESTFilterBuilder();
-        }
-      }
-
-      // Create a mock SupabaseClient constructor
-      class MockSupabaseClient {
-        auth = {
-          admin: {} as any,
-        } as SupabaseClientInstance['auth'];
-
-        from(_table: string): PostgRESTQueryBuilder {
-          return new MockPostgRESTQueryBuilder() as unknown as PostgRESTQueryBuilder;
-        }
-      }
-
-      return new MockSupabaseClient();
-    }
 
     it('handles undefined response without throwing', async () => {
       const client = createMockSupabaseClient(undefined);
@@ -174,6 +220,94 @@ describe('Supabase Integration', () => {
       await builder.select('*');
 
       expect(captureExceptionSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('sendDefaultPii', () => {
+    let captureExceptionSpy: ReturnType<typeof vi.spyOn>;
+    let addBreadcrumbSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      captureExceptionSpy = vi.spyOn(exportsModule, 'captureException').mockImplementation(() => '');
+      addBreadcrumbSpy = vi.spyOn(breadcrumbModule, 'addBreadcrumb').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('omits db.query, db.body, and breadcrumb query/body when sendDefaultPii is false', async () => {
+      const client = createMockSupabaseClient(
+        { status: 200 },
+        { ...MOCK_SUPABASE_PII_SCENARIO, sendDefaultPii: false },
+      );
+      instrumentSupabaseClient(client);
+
+      await (client as any).from('users').update({}).then();
+
+      const spanOptions = tracingMocks.startSpan.mock.calls[0]![0] as {
+        name: string;
+        attributes: Record<string, unknown>;
+      };
+      expect(spanOptions.name).toContain('[redacted]');
+      expect(spanOptions.name).not.toContain('secret');
+      expect(spanOptions.attributes['db.query']).toBeUndefined();
+      expect(spanOptions.attributes['db.body']).toBeUndefined();
+
+      const breadcrumb = addBreadcrumbSpy.mock.calls[0]![0] as { data?: unknown };
+      expect(breadcrumb).not.toHaveProperty('data');
+    });
+
+    it('includes db.query, db.body, and breadcrumb query/body when sendDefaultPii is true', async () => {
+      const client = createMockSupabaseClient({ status: 200 }, { ...MOCK_SUPABASE_PII_SCENARIO, sendDefaultPii: true });
+      instrumentSupabaseClient(client);
+
+      await (client as any).from('users').update({}).then();
+
+      const spanOptions = tracingMocks.startSpan.mock.calls[0]![0] as {
+        name: string;
+        attributes: Record<string, unknown>;
+      };
+      expect(spanOptions.name).toContain('eq(email, secret@example.com)');
+      expect(spanOptions.attributes['db.query']).toEqual(
+        expect.arrayContaining([expect.stringContaining('secret@example.com')]),
+      );
+      expect(spanOptions.attributes['db.body']).toEqual(
+        expect.objectContaining({ full_name: 'Jane Doe', phone: '555-0100' }),
+      );
+
+      expect(addBreadcrumbSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            query: expect.any(Array),
+            body: expect.objectContaining({ full_name: 'Jane Doe' }),
+          }),
+        }),
+      );
+    });
+
+    it('omits supabase error context query/body when sendDefaultPii is false', async () => {
+      const client = createMockSupabaseClient(
+        { status: 400, error: { message: 'Bad request', code: '400' } },
+        { ...MOCK_SUPABASE_PII_SCENARIO, sendDefaultPii: false },
+      );
+      instrumentSupabaseClient(client);
+
+      await (client as any).from('users').update({}).then();
+
+      expect(captureExceptionSpy).toHaveBeenCalled();
+      const scopeCallback = captureExceptionSpy.mock.calls[0]![1] as (scope: {
+        addEventProcessor: (fn: (e: unknown) => unknown) => void;
+        setContext: (key: string, ctx: Record<string, unknown>) => void;
+      }) => unknown;
+      const contexts: Record<string, Record<string, unknown>> = {};
+      scopeCallback({
+        addEventProcessor: () => {},
+        setContext(key: string, ctx: Record<string, unknown>) {
+          contexts[key] = ctx;
+        },
+      } as any);
+      expect(contexts.supabase).toEqual({});
     });
   });
 });


### PR DESCRIPTION
We did not consider `sendDefaultPii` for the supabase integration. However:

> The Supabase integration captures the full request body of POST/PATCH/PUT/DELETE operations (database mutations) and attaches it as the 'db.body' span attribute (line 387). This body contains the actual data being inserted or updated in Supabase tables, which commonly includes PII such as user emails, names, addresses, and other sensitive fields. Unlike other integrations (e.g., the MCP server integration which checks sendDefaultPii), the Supabase integration performs no sendDefaultPii check and applies no filtering or redaction to the captured body. Additionally, query filter values from URL search parameters are captured at lines 351-355, which can also contain PII used in WHERE clauses.

This PR fixes this.