### PR TITLE
fix(core): Avoid parse-time SyntaxError on Safari <16.4 in postgresjs

### DIFF
--- a/packages/core/src/integrations/postgresjs.ts
+++ b/packages/core/src/integrations/postgresjs.ts
@@ -378,7 +378,10 @@ export function _sanitizeSqlQuery(sqlQuery: string | undefined): string {
       .replace(/-?\b\d+\.?\d*[eE][+-]?\d+\b/g, '?') // Scientific notation
       .replace(/-?\b\d+\.\d+\b/g, '?') // Decimals
       .replace(/-?\.\d+\b/g, '?') // Decimals starting with dot
-      .replace(/(?<!\$)-?\b\d+\b/g, '?') // Integers (NOT $n placeholders)
+      // Constructed via `new RegExp` so the negative lookbehind is evaluated at
+      // runtime. As a literal, it is a parse-time SyntaxError on Safari <16.4 —
+      // which breaks any browser bundle that reaches this module via the core barrel.
+      .replace(new RegExp('(?<!\\$)-?\\b\\d+\\b', 'g'), '?') // Integers (NOT $n placeholders)
       // Collapse IN clauses for cardinality (both ? and $n variants)
       .replace(/\bIN\b\s*\(\s*\?(?:\s*,\s*\?)*\s*\)/gi, 'IN (?)')
       .replace(/\bIN\b\s*\(\s*\$\d+(?:\s*,\s*\$\d+)*\s*\)/gi, 'IN ($?)')

--- a/packages/core/src/integrations/postgresjs.ts
+++ b/packages/core/src/integrations/postgresjs.ts
@@ -342,6 +342,8 @@ export function _reconstructQuery(strings: string[] | undefined): string | undef
   return strings.reduce((acc, str, i) => (i === 0 ? str : `${acc}$${i}${str}`), '');
 }
 
+let integerLiteralRE: RegExp | undefined;
+
 /**
  * Sanitize SQL query as per the OTEL semantic conventions
  * https://opentelemetry.io/docs/specs/semconv/database/database-spans/#sanitization-of-dbquerytext
@@ -355,6 +357,11 @@ export function _sanitizeSqlQuery(sqlQuery: string | undefined): string {
   if (!sqlQuery) {
     return 'Unknown SQL Query';
   }
+
+  // Lazy init: constructing this at module scope would evaluate the lookbehind
+  // on import and crash Safari <16.4 browser bundles that reach this file via
+  // the core barrel. Building it on first call keeps the cost off the import path.
+  integerLiteralRE ??= new RegExp('(?<!\\$)-?\\b\\d+\\b', 'g');
 
   return (
     sqlQuery
@@ -378,10 +385,7 @@ export function _sanitizeSqlQuery(sqlQuery: string | undefined): string {
       .replace(/-?\b\d+\.?\d*[eE][+-]?\d+\b/g, '?') // Scientific notation
       .replace(/-?\b\d+\.\d+\b/g, '?') // Decimals
       .replace(/-?\.\d+\b/g, '?') // Decimals starting with dot
-      // Constructed via `new RegExp` so the negative lookbehind is evaluated at
-      // runtime. As a literal, it is a parse-time SyntaxError on Safari <16.4 —
-      // which breaks any browser bundle that reaches this module via the core barrel.
-      .replace(new RegExp('(?<!\\$)-?\\b\\d+\\b', 'g'), '?') // Integers (NOT $n placeholders)
+      .replace(integerLiteralRE, '?') // Integers (NOT $n placeholders)
       // Collapse IN clauses for cardinality (both ? and $n variants)
       .replace(/\bIN\b\s*\(\s*\?(?:\s*,\s*\?)*\s*\)/gi, 'IN (?)')
       .replace(/\bIN\b\s*\(\s*\$\d+(?:\s*,\s*\$\d+)*\s*\)/gi, 'IN ($?)')

--- a/packages/core/src/integrations/postgresjs.ts
+++ b/packages/core/src/integrations/postgresjs.ts
@@ -361,7 +361,9 @@ export function _sanitizeSqlQuery(sqlQuery: string | undefined): string {
   // Lazy init: constructing this at module scope would evaluate the lookbehind
   // on import and crash Safari <16.4 browser bundles that reach this file via
   // the core barrel. Building it on first call keeps the cost off the import path.
-  integerLiteralRE ??= new RegExp('(?<!\\$)-?\\b\\d+\\b', 'g');
+  if (!integerLiteralRE) {
+    integerLiteralRE = new RegExp('(?<!\\$)-?\\b\\d+\\b', 'g');
+  }
 
   return (
     sqlQuery


### PR DESCRIPTION
Bandaid fix for #20433. Constructs the negative-lookbehind regex via `new RegExp(...)` instead of a regex literal, so it is evaluated at runtime rather than at parse time.

[Safari <16.4 does not support lookbehind assertions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion) as a literal, this causes a parse-time `SyntaxError` that kills the entire script. 

As a constructor call with `new RegExp`, parsing succeeds;. Correctness in Safari doesn't matter here, we just don't want the file to fail to parse and it would never execute anyways.

The deeper issue is that server-only code from `@sentry/core` (postgresjs, express, trpc, mcp-server, the AI instrumentations, etc.) can end up in browser bundles because it seems like some bundlers can't tree-shake it out of the core barrel. We should be more disciplined about what the main `@sentry/core` entry re-exports so apps stop shipping server code that never executes.

I managed to reproduce this setup in a webpack with CJS app and noticed it didn't tree-shake the postgres integration. Vite seems to do it correctly.

Bringing this up next week, but we should not rely on tree-shaking to eliminate code-paths.