### PR TITLE
feat(astro): Drop prerendered http.server filter via `ignoreSpans`

### DIFF
--- a/packages/astro/src/server/sdk.ts
+++ b/packages/astro/src/server/sdk.ts
@@ -1,5 +1,5 @@
 import { applySdkMetadata } from '@sentry/core';
-import type { Event, NodeClient, NodeOptions } from '@sentry/node';
+import type { NodeClient, NodeOptions } from '@sentry/node';
 import { init as initNodeSdk } from '@sentry/node';
 
 /**
@@ -13,28 +13,14 @@ export function init(options: NodeOptions): NodeClient | undefined {
 
   applySdkMetadata(opts, 'astro', ['astro', 'node']);
 
-  const client = initNodeSdk(opts);
+  opts.ignoreSpans = [
+    ...(opts.ignoreSpans || []),
+    // For http.server spans that did not go though the astro middleware,
+    // we want to drop them
+    // this is the case with http.server spans of prerendered pages
+    // we do not care about those, as they are effectively static
+    { op: 'http.server', attributes: { 'sentry.origin': 'auto.http.otel.http' } },
+  ];
 
-  client?.addEventProcessor(
-    Object.assign(
-      (event: Event) => {
-        // For http.server spans that did not go though the astro middleware,
-        // we want to drop them
-        // this is the case with http.server spans of prerendered pages
-        // we do not care about those, as they are effectively static
-        if (
-          event.type === 'transaction' &&
-          event.contexts?.trace?.op === 'http.server' &&
-          event.contexts?.trace?.origin === 'auto.http.otel.http'
-        ) {
-          return null;
-        }
-
-        return event;
-      },
-      { id: 'AstroHttpEventProcessor' },
-    ),
-  );
-
-  return client;
+  return initNodeSdk(opts);
 }

--- a/packages/astro/test/server/sdk.test.ts
+++ b/packages/astro/test/server/sdk.test.ts
@@ -41,5 +41,27 @@ describe('Sentry server SDK', () => {
     it('returns client from init', () => {
       expect(init({})).not.toBeUndefined();
     });
+
+    it('configures ignoreSpans to drop prerendered http.server spans', () => {
+      init({});
+
+      expect(nodeInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ignoreSpans: expect.arrayContaining([
+            { op: 'http.server', attributes: { 'sentry.origin': 'auto.http.otel.http' } },
+          ]),
+        }),
+      );
+    });
+
+    it('preserves user-provided ignoreSpans entries', () => {
+      init({ ignoreSpans: [/keep-me/] });
+
+      expect(nodeInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ignoreSpans: expect.arrayContaining([/keep-me/]),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
Migrates the Astro server pre-rendered route drop filter from an event processor to `ignoreSpans` so it also works in the streaming path. This only adds two unit tests, since the actual drop behavior is already tested by several astro e2e test apps.

Closes https://github.com/getsentry/sentry-javascript/issues/20375
