### PR TITLE
fix(v8/profiling-node): Restore install script to build binaries from source

### DIFF
--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -50,6 +50,7 @@
     "/scripts/prune-profiler-binaries.js"
   ],
   "scripts": {
+    "install": "node scripts/check-build.js",
     "clean": "rm -rf build && rm -rf lib",
     "lint": "yarn lint:eslint && yarn lint:clang",
     "lint:eslint": "eslint . --format stylish",
@@ -63,6 +64,8 @@
     "build:types:downlevel": "yarn downlevel-dts lib/types lib/types-ts3.8 --to ts3.8",
     "build:types": "tsc -p tsconfig.types.json && yarn build:types:downlevel",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
+    "build:bindings:configure": "node-gyp configure",
+    "build:bindings": "node-gyp build && node scripts/copy-target.js",
     "build:copy-bindings": "cp -r compiled-bindings/ lib/",
     "build:dev": "yarn clean && yarn build",
     "build:transpile:watch": "rollup -c rollup.npm.config.mjs --watch",

--- a/packages/profiling-node/scripts/check-build.js
+++ b/packages/profiling-node/scripts/check-build.js
@@ -11,7 +11,7 @@ function clean(err) {
 
 function recompileFromSource() {
   console.log('@sentry/profiling-node: Compiling from source...');
-  let spawn = child_process.spawnSync('npm', ['run', 'build:bindings:configure'], {
+  let spawn = child_process.spawnSync('npm run build:bindings:configure', {
     stdio: ['inherit', 'inherit', 'pipe'],
     env: process.env,
     shell: true,
@@ -23,7 +23,7 @@ function recompileFromSource() {
     return;
   }
 
-  spawn = child_process.spawnSync('npm', ['run', 'build:bindings'], {
+  spawn = child_process.spawnSync('npm run build:bindings', {
     stdio: ['inherit', 'inherit', 'pipe'],
     env: process.env,
     shell: true,

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -430,7 +430,7 @@ export const _nodeProfilingIntegration = ((): ProfilingIntegration<NodeClient> =
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
       console.warn(
-        `[Sentry Profiling] You are using a Node.js version that does not have prebuilt binaries (${NODE_VERSION}).`,
+        `[Sentry Profiling] You are using a Node.js version that does not have prebuilt binaries (${NODE_VERSION.major}.${NODE_VERSION.minor}.${NODE_VERSION.patch}).`,
         'The @sentry/profiling-node package only has prebuilt support for the following LTS versions of Node.js: 16, 18, 20, 22.',
         'To use the @sentry/profiling-node package with this version of Node.js, you will need to compile the native addon from source.',
         'See: https://github.com/getsentry/sentry-javascript/tree/develop/packages/profiling-node#building-the-package-from-source',


### PR DESCRIPTION
This PR adds the `install` script back compiles bindings from source if precompiled binaries are not found.

We removed this in `8.55.1` when we fixed our CI to run on this legacy branch but v8 does not ship with a precompiled Node 24 binary. Users on Node 24 crash with `Cannot find module` errors.

It also fixes deprecation warnings for `spawnSync` calls and an interpolation error in the profiling integration console warning.

Closes: #20501

