### PR TITLE
chore(e2e): Remove @tanstack/start-plugin-core override

### DIFF
--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
@@ -45,11 +45,6 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "pnpm": {
-    "overrides": {
-      "@tanstack/start-plugin-core": "1.167.35"
-    }
-  },
   "sentryTest": {
     "variants": [
       {


### PR DESCRIPTION
This PR removes the `@tanstack/start-plugin-core` override we added to work around transient breakage in `1.168.0` in #20482.

This is now no longer needed, and instead breaks because the subpath has changed.

Closes: #20508
