### PR TITLE
feat(cloudflare): Support tracing for queue producer

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -437,7 +437,7 @@ module.exports = [
     ignore: [...builtinModules, ...nodePrefixedBuiltinModules],
     gzip: false,
     brotli: false,
-    limit: '414 KiB',
+    limit: '420 KiB',
     disablePlugins: ['@size-limit/webpack'],
     webpack: false,
     modifyEsbuildConfig: function (config) {

--- a/dev-packages/cloudflare-integration-tests/suites/queue/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/queue/index.ts
@@ -1,0 +1,47 @@
+import type { MessageBatch, Queue } from '@cloudflare/workers-types';
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+  MY_QUEUE: Queue<{ trigger?: 'error'; payload?: string }>;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1,
+  }),
+  {
+    async fetch(request, env) {
+      const url = new URL(request.url);
+
+      if (url.pathname === '/enqueue/error') {
+        await env.MY_QUEUE.send({ trigger: 'error' });
+        return new Response('enqueued error');
+      }
+
+      if (url.pathname === '/enqueue/ok') {
+        await env.MY_QUEUE.send({ payload: 'hello' });
+        return new Response('enqueued ok');
+      }
+
+      if (url.pathname === '/enqueue/batch') {
+        await env.MY_QUEUE.sendBatch([
+          { body: { payload: 'one' } },
+          { body: { payload: 'two' } },
+          { body: { payload: 'three' } },
+        ]);
+        return new Response('enqueued batch');
+      }
+
+      return new Response('not found', { status: 404 });
+    },
+    async queue(batch: MessageBatch<{ trigger?: 'error'; payload?: string }>) {
+      for (const message of batch.messages) {
+        if (message.body.trigger === 'error') {
+          throw new Error('Boom from queue handler');
+        }
+      }
+    },
+  } as ExportedHandler<Env>,
+);

--- a/dev-packages/cloudflare-integration-tests/suites/queue/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/queue/test.ts
@@ -1,0 +1,128 @@
+import type { Envelope } from '@sentry/core';
+import { expect, it } from 'vitest';
+import { createRunner } from '../../runner';
+
+function envelopeItemType(envelope: Envelope): string | undefined {
+  return envelope[1][0]?.[0]?.type as string | undefined;
+}
+
+function envelopeItem(envelope: Envelope): Record<string, unknown> {
+  return envelope[1][0]![1] as Record<string, unknown>;
+}
+
+function findPublishSpan(envelope: Envelope): Record<string, unknown> | undefined {
+  if (envelopeItemType(envelope) !== 'transaction') return undefined;
+  const tx = envelopeItem(envelope);
+  const spans = (tx.spans as Array<Record<string, unknown>>) || [];
+  return spans.find(s => (s.op as string) === 'queue.publish');
+}
+
+function isConsumerTransaction(envelope: Envelope): boolean {
+  if (envelopeItemType(envelope) !== 'transaction') return false;
+  const tx = envelopeItem(envelope);
+  return tx.transaction === 'process test-queue';
+}
+
+it('captures errors thrown by the queue handler with the correct mechanism', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .ignore('transaction')
+    .expect((envelope: Envelope) => {
+      expect(envelopeItemType(envelope)).toBe('event');
+      const event = envelopeItem(envelope);
+      expect(event).toMatchObject({
+        level: 'error',
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Boom from queue handler',
+              mechanism: { type: 'auto.faas.cloudflare.queue', handled: false },
+            },
+          ],
+        },
+      });
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/enqueue/error');
+  await runner.completed();
+});
+
+it('emits a queue.publish span on env.MY_QUEUE.send and a queue.process transaction on the consumer', async ({
+  signal,
+}) => {
+  const runner = createRunner(__dirname)
+    .unordered()
+    .expect((envelope: Envelope) => {
+      // Producer transaction must contain a queue.publish child span
+      const publishSpan = findPublishSpan(envelope);
+      expect(publishSpan).toBeDefined();
+      expect(publishSpan).toMatchObject({
+        op: 'queue.publish',
+        description: 'send MY_QUEUE',
+        data: expect.objectContaining({
+          'messaging.system': 'cloudflare',
+          'messaging.destination.name': 'MY_QUEUE',
+          'messaging.operation.type': 'send',
+          'messaging.operation.name': 'send',
+          'sentry.origin': 'auto.faas.cloudflare.queue',
+        }),
+      });
+    })
+    .expect((envelope: Envelope) => {
+      expect(isConsumerTransaction(envelope)).toBe(true);
+      const tx = envelopeItem(envelope);
+      const trace = (tx.contexts as Record<string, Record<string, unknown>>).trace as Record<string, unknown>;
+      expect(trace).toMatchObject({
+        op: 'queue.process',
+        origin: 'auto.faas.cloudflare.queue',
+        data: expect.objectContaining({
+          'messaging.system': 'cloudflare',
+          'messaging.destination.name': 'test-queue',
+          'messaging.operation.type': 'process',
+          'messaging.operation.name': 'process',
+          'messaging.batch.message_count': 1,
+          'faas.trigger': 'pubsub',
+        }),
+      });
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/enqueue/ok');
+  await runner.completed();
+});
+
+it('emits a queue.publish span with batch attributes on env.MY_QUEUE.sendBatch', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .unordered()
+    .expect((envelope: Envelope) => {
+      const publishSpan = findPublishSpan(envelope);
+      expect(publishSpan).toBeDefined();
+      expect(publishSpan).toMatchObject({
+        op: 'queue.publish',
+        description: 'send MY_QUEUE',
+        data: expect.objectContaining({
+          'messaging.system': 'cloudflare',
+          'messaging.destination.name': 'MY_QUEUE',
+          'messaging.operation.type': 'send',
+          'messaging.operation.name': 'send',
+          'messaging.batch.message_count': 3,
+          'sentry.origin': 'auto.faas.cloudflare.queue',
+        }),
+      });
+    })
+    .expect((envelope: Envelope) => {
+      expect(isConsumerTransaction(envelope)).toBe(true);
+      const tx = envelopeItem(envelope);
+      const trace = (tx.contexts as Record<string, Record<string, unknown>>).trace as Record<string, unknown>;
+      expect(trace).toMatchObject({
+        data: expect.objectContaining({
+          'messaging.batch.message_count': 3,
+        }),
+      });
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/enqueue/batch');
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/queue/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/queue/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "name": "worker-name",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+  "queues": {
+    "producers": [
+      {
+        "queue": "test-queue",
+        "binding": "MY_QUEUE",
+      },
+    ],
+    "consumers": [
+      {
+        "queue": "test-queue",
+        "max_batch_size": 10,
+        "max_batch_timeout": 1,
+        "max_retries": 0,
+      },
+    ],
+  },
+}

--- a/packages/cloudflare/src/instrumentations/worker/instrumentEnv.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentEnv.ts
@@ -1,9 +1,10 @@
 import type { CloudflareOptions } from '../../client';
-import { isDurableObjectNamespace, isJSRPC } from '../../utils/isBinding';
+import { isDurableObjectNamespace, isJSRPC, isQueue } from '../../utils/isBinding';
 import { appendRpcMeta } from '../../utils/rpcMeta';
 import { getEffectiveRpcPropagation } from '../../utils/rpcOptions';
 import { instrumentDurableObjectNamespace, STUB_NON_RPC_METHODS } from '../instrumentDurableObjectNamespace';
 import { instrumentFetcher } from './instrumentFetcher';
+import { instrumentQueueProducer } from './instrumentQueueProducer';
 
 function isProxyable(item: unknown): item is object {
   return item !== null && (typeof item === 'object' || typeof item === 'function');
@@ -17,9 +18,10 @@ const instrumentedBindings = new WeakMap<object, unknown>();
  *
  * Currently detects:
  * - DurableObjectNamespace (via `idFromName` duck-typing)
- * - Service bindings / JSRPC proxies (wraps `fetch` for trace propagation)
+ * - Service bindings / JSRPC proxies
+ * - Queue producers (via `send` + `sendBatch` duck-typing)
  *
- * Extensible for future binding types (KV, D1, Queue, etc.).
+ * Extensible for future binding types (KV, D1, etc.).
  *
  * @param env - The Cloudflare env object to instrument
  * @param options - Optional CloudflareOptions to control RPC trace propagation
@@ -30,12 +32,6 @@ export function instrumentEnv<Env extends Record<string, unknown>>(env: Env, opt
   }
 
   const rpcPropagation = options ? getEffectiveRpcPropagation(options) : false;
-
-  // As of now only trace propagation is used for the instrumentEnv
-  // so this is an optimization to avoid wrapping the env in a proxy if trace propagation is disabled
-  if (!rpcPropagation) {
-    return env;
-  }
 
   return new Proxy(env, {
     get(target, prop, receiver) {
@@ -49,6 +45,17 @@ export function instrumentEnv<Env extends Record<string, unknown>>(env: Env, opt
 
       if (cached) {
         return cached;
+      }
+
+      if (isQueue(item)) {
+        const bindingName = typeof prop === 'string' ? prop : String(prop);
+        const instrumented = instrumentQueueProducer(item, bindingName);
+        instrumentedBindings.set(item, instrumented);
+        return instrumented;
+      }
+
+      if (!rpcPropagation) {
+        return item;
       }
 
       if (isDurableObjectNamespace(item)) {

--- a/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
@@ -42,6 +42,8 @@ function wrapQueueHandler(
           'faas.trigger': 'pubsub',
           'messaging.destination.name': batch.queue,
           'messaging.system': 'cloudflare',
+          'messaging.operation.type': 'process',
+          'messaging.operation.name': 'process',
           'messaging.batch.message_count': batch.messages.length,
           'messaging.message.retry.count': batch.messages.reduce((acc, message) => acc + message.attempts - 1, 0),
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'queue.process',

--- a/packages/cloudflare/src/instrumentations/worker/instrumentQueueProducer.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentQueueProducer.ts
@@ -84,10 +84,13 @@ export function instrumentQueueProducer<T extends Queue>(queue: T, bindingName: 
           options?: QueueSendBatchOptions,
         ): Promise<void> {
           const messageArray = Array.from(messages);
-          const totalBodySize = messageArray.reduce<number>((acc, m) => {
+          const totalBodySize = messageArray.reduce<number | undefined>((acc, m) => {
             const size = getBodySize(m.body);
-            return size === undefined ? acc : acc + size;
-          }, 0);
+            if (size === undefined) {
+              return acc;
+            }
+            return (acc ?? 0) + size;
+          }, undefined);
 
           return startPublishSpan({ bindingName, bodySize: totalBodySize, messageCount: messageArray.length }, () =>
             Reflect.apply(original, target, [messageArray, options]),

--- a/packages/cloudflare/src/instrumentations/worker/instrumentQueueProducer.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentQueueProducer.ts
@@ -1,0 +1,101 @@
+import type { MessageSendRequest, Queue, QueueSendBatchOptions, QueueSendOptions } from '@cloudflare/workers-types';
+import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+
+const ORIGIN = 'auto.faas.cloudflare.queue';
+
+function startPublishSpan<T>(
+  options: {
+    bindingName: string;
+    bodySize: number | undefined;
+    messageCount?: number;
+  },
+  callback: () => T,
+): T {
+  const { bindingName, bodySize, messageCount } = options;
+
+  return startSpan(
+    {
+      op: 'queue.publish',
+      name: `send ${bindingName}`,
+      attributes: {
+        'messaging.system': 'cloudflare',
+        'messaging.destination.name': bindingName,
+        'messaging.operation.type': 'send',
+        'messaging.operation.name': 'send',
+        ...(messageCount !== undefined && { 'messaging.batch.message_count': messageCount }),
+        'messaging.message.body.size': bodySize,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'queue.publish',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+      },
+    },
+    callback,
+  );
+}
+
+function getBodySize(body: unknown): number | undefined {
+  if (body == null) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return new TextEncoder().encode(body).byteLength;
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return body.byteLength;
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return body.byteLength;
+  }
+
+  try {
+    return new TextEncoder().encode(JSON.stringify(body)).byteLength;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Wraps a Queue producer binding to create `queue.publish` spans on
+ * `send` and `sendBatch` calls.
+ *
+ * The queue's own name is not available on the binding object, so we use
+ * the env binding key (e.g. `MY_QUEUE`) as `messaging.destination.name`.
+ */
+export function instrumentQueueProducer<T extends Queue>(queue: T, bindingName: string): T {
+  return new Proxy(queue, {
+    get(target, prop, receiver) {
+      if (prop === 'send') {
+        const original = Reflect.get(target, prop, receiver) as Queue['send'];
+
+        return function (this: unknown, message: unknown, options?: QueueSendOptions): Promise<void> {
+          return startPublishSpan({ bindingName, bodySize: getBodySize(message) }, () =>
+            Reflect.apply(original, target, [message, options]),
+          );
+        };
+      }
+
+      if (prop === 'sendBatch') {
+        const original = Reflect.get(target, prop, receiver) as Queue['sendBatch'];
+        return function (
+          this: unknown,
+          messages: Iterable<MessageSendRequest>,
+          options?: QueueSendBatchOptions,
+        ): Promise<void> {
+          const messageArray = Array.from(messages);
+          const totalBodySize = messageArray.reduce<number>((acc, m) => {
+            const size = getBodySize(m.body);
+            return size === undefined ? acc : acc + size;
+          }, 0);
+
+          return startPublishSpan({ bindingName, bodySize: totalBodySize, messageCount: messageArray.length }, () =>
+            Reflect.apply(original, target, [messageArray, options]),
+          );
+        };
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}

--- a/packages/cloudflare/src/utils/isBinding.ts
+++ b/packages/cloudflare/src/utils/isBinding.ts
@@ -31,7 +31,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import type { DurableObjectNamespace } from '@cloudflare/workers-types';
+import type { DurableObjectNamespace, Queue } from '@cloudflare/workers-types';
 
 /**
  * Checks if a value is a JSRPC proxy (service binding).
@@ -58,4 +58,12 @@ const isNotJSRPC = (item: unknown): item is Record<string, unknown> => !isJSRPC(
  */
 export function isDurableObjectNamespace(item: unknown): item is DurableObjectNamespace {
   return item != null && isNotJSRPC(item) && typeof item.idFromName === 'function';
+}
+
+/**
+ * Duck-type check for Queue producer bindings.
+ * Queue has `send` and `sendBatch` async methods.
+ */
+export function isQueue(item: unknown): item is Queue {
+  return item != null && isNotJSRPC(item) && typeof item.send === 'function' && typeof item.sendBatch === 'function';
 }

--- a/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
+++ b/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
@@ -34,7 +34,7 @@ describe('instrumentEnv', () => {
     expect(instrumented.UNKNOWN).toBe(unknownBinding);
   });
 
-  it('returns env as-is when enableRpcTracePropagation is disabled', () => {
+  it('does not instrument DurableObjectNamespace when enableRpcTracePropagation is disabled', () => {
     const doNamespace = {
       idFromName: vi.fn(),
       idFromString: vi.fn(),
@@ -44,8 +44,7 @@ describe('instrumentEnv', () => {
     const env = { COUNTER: doNamespace };
     const instrumented = instrumentEnv(env);
 
-    // When trace propagation is disabled, env is returned as-is
-    expect(instrumented).toBe(env);
+    // DO bindings pass through untouched when RPC propagation is disabled
     expect(instrumented.COUNTER).toBe(doNamespace);
     expect(instrumentDurableObjectNamespace).not.toHaveBeenCalled();
   });
@@ -174,6 +173,47 @@ describe('instrumentEnv', () => {
 
     expect(instrumented.NULL_VAL).toBeNull();
     expect(instrumented.UNDEF_VAL).toBeUndefined();
+  });
+
+  it('wraps Queue bindings in a proxy', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const sendBatch = vi.fn().mockResolvedValue(undefined);
+    const queue = { send, sendBatch };
+    const env = { MY_QUEUE: queue };
+    const instrumented = instrumentEnv(env);
+
+    const wrapped = instrumented.MY_QUEUE as typeof queue;
+    // Wrapped binding is a Proxy, not the original reference
+    expect(wrapped).not.toBe(queue);
+    // Calls are forwarded to the underlying queue
+    await wrapped.send('hello');
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toBe('hello');
+  });
+
+  it('caches the wrapped Queue binding across repeated access', () => {
+    const queue = { send: vi.fn(), sendBatch: vi.fn() };
+    const env = { MY_QUEUE: queue };
+    const instrumented = instrumentEnv(env);
+
+    expect(instrumented.MY_QUEUE).toBe(instrumented.MY_QUEUE);
+  });
+
+  it('wraps Queue bindings independently from DO bindings', () => {
+    const queue = { send: vi.fn(), sendBatch: vi.fn() };
+    const doNamespace = {
+      idFromName: vi.fn(),
+      idFromString: vi.fn(),
+      get: vi.fn(),
+      newUniqueId: vi.fn(),
+    };
+    const env = { MY_QUEUE: queue, COUNTER: doNamespace };
+    const instrumented = instrumentEnv(env, { enableRpcTracePropagation: true });
+
+    // Access both — DO instrumentation only fires on property access
+    expect(instrumented.MY_QUEUE).not.toBe(queue);
+    instrumented.COUNTER;
+    expect(instrumentDurableObjectNamespace).toHaveBeenCalledWith(doNamespace);
   });
 
   describe('JSRPC RPC method instrumentation', () => {

--- a/packages/cloudflare/test/instrumentations/instrumentWorkerEntrypoint.test.ts
+++ b/packages/cloudflare/test/instrumentations/instrumentWorkerEntrypoint.test.ts
@@ -338,7 +338,7 @@ describe('instrumentWorkerEntrypoint', () => {
       );
       Reflect.construct(instrumented, [mockContext, mockEnv]);
 
-      expect(constructorEnv).toBe(mockEnv);
+      expect(constructorEnv).toStrictEqual(mockEnv);
     });
 
     it('exposes instrumented DurableObjectNamespace via this.env when enableRpcTracePropagation is enabled', async () => {

--- a/packages/cloudflare/test/instrumentations/instrumentWorkerEntrypoint.test.ts
+++ b/packages/cloudflare/test/instrumentations/instrumentWorkerEntrypoint.test.ts
@@ -317,30 +317,6 @@ describe('instrumentWorkerEntrypoint', () => {
       expect(constructorEnv).not.toBe(mockEnv);
     });
 
-    it('passes original env to the constructor when enableRpcTracePropagation is disabled', () => {
-      const mockContext = createMockExecutionContext();
-      const mockEnv = { SENTRY_DSN: 'dsn' };
-
-      let constructorEnv: unknown;
-      const TestClass = class extends WorkerEntrypoint {
-        constructor(ctx: ExecutionContext, env: typeof mockEnv) {
-          super();
-          constructorEnv = env;
-        }
-        fetch() {
-          return new Response('ok');
-        }
-      };
-
-      const instrumented = instrumentWorkerEntrypoint(
-        () => ({ enableRpcTracePropagation: false }),
-        TestClass as unknown as WorkerEntrypointConstructor,
-      );
-      Reflect.construct(instrumented, [mockContext, mockEnv]);
-
-      expect(constructorEnv).toStrictEqual(mockEnv);
-    });
-
     it('exposes instrumented DurableObjectNamespace via this.env when enableRpcTracePropagation is enabled', async () => {
       vi.spyOn(SentryCore, 'getTraceData').mockReturnValue({
         'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',

--- a/packages/cloudflare/test/instrumentations/worker/instrumentQueue.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentQueue.test.ts
@@ -278,6 +278,8 @@ describe('instrumentQueue', () => {
           'faas.trigger': 'pubsub',
           'messaging.destination.name': batch.queue,
           'messaging.system': 'cloudflare',
+          'messaging.operation.type': 'process',
+          'messaging.operation.name': 'process',
           'messaging.batch.message_count': batch.messages.length,
           'messaging.message.retry.count': batch.messages.reduce((acc, message) => acc + message.attempts - 1, 0),
           'sentry.sample_rate': 1,

--- a/packages/cloudflare/test/instrumentations/worker/instrumentQueueProducer.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentQueueProducer.test.ts
@@ -139,6 +139,36 @@ describe('instrumentQueueProducer', () => {
       expect(Array.isArray(passed)).toBe(true);
       expect(passed).toHaveLength(2);
     });
+
+    test('omits body size when all payloads cannot be serialized', async () => {
+      const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      const circular1: Record<string, unknown> = {};
+      circular1.self = circular1;
+      const circular2: Record<string, unknown> = {};
+      circular2.self = circular2;
+
+      await wrapped.sendBatch([{ body: circular1 }, { body: circular2 }]);
+
+      const attrs = startSpanSpy.mock.calls[0]![0].attributes!;
+      expect(attrs['messaging.message.body.size']).toBeUndefined();
+    });
+
+    test('sums only sizable bodies when batch contains mixed payloads', async () => {
+      const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+
+      await wrapped.sendBatch([{ body: 'aa' }, { body: circular }, { body: 'bbb' }]);
+
+      const attrs = startSpanSpy.mock.calls[0]![0].attributes!;
+      expect(attrs['messaging.message.body.size']).toBe(5);
+    });
   });
 
   test('forwards unknown property accesses transparently', () => {

--- a/packages/cloudflare/test/instrumentations/worker/instrumentQueueProducer.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentQueueProducer.test.ts
@@ -1,0 +1,153 @@
+import type { Queue } from '@cloudflare/workers-types';
+import * as SentryCore from '@sentry/core';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { instrumentQueueProducer } from '../../../src/instrumentations/worker/instrumentQueueProducer';
+
+function createMockQueue(): Queue {
+  return {
+    send: vi.fn().mockResolvedValue(undefined),
+    sendBatch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Queue;
+}
+
+describe('instrumentQueueProducer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('send', () => {
+    test('forwards the call to the underlying queue', async () => {
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      await wrapped.send({ hello: 'world' }, { contentType: 'json' });
+
+      expect(queue.send).toHaveBeenCalledTimes(1);
+      expect(queue.send).toHaveBeenLastCalledWith({ hello: 'world' }, { contentType: 'json' });
+    });
+
+    test('starts a queue.publish span with messaging attributes', async () => {
+      const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      await wrapped.send('hello');
+
+      expect(startSpanSpy).toHaveBeenCalledTimes(1);
+      const [spanCtx] = startSpanSpy.mock.calls[0]!;
+      expect(spanCtx).toMatchObject({
+        op: 'queue.publish',
+        name: 'send MY_QUEUE',
+        attributes: {
+          'messaging.system': 'cloudflare',
+          'messaging.destination.name': 'MY_QUEUE',
+          'messaging.operation.type': 'send',
+          'messaging.operation.name': 'send',
+          'messaging.message.body.size': 5,
+          'sentry.op': 'queue.publish',
+          'sentry.origin': 'auto.faas.cloudflare.queue',
+        },
+      });
+    });
+
+    test('computes body size for object payloads via JSON.stringify', async () => {
+      const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      await wrapped.send({ a: 1 });
+
+      const attrs = startSpanSpy.mock.calls[0]![0].attributes!;
+      expect(attrs['messaging.message.body.size']).toBe(JSON.stringify({ a: 1 }).length);
+    });
+
+    test('computes body size for ArrayBuffer payloads', async () => {
+      const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      const buf = new ArrayBuffer(42);
+      await wrapped.send(buf);
+
+      const attrs = startSpanSpy.mock.calls[0]![0].attributes!;
+      expect(attrs['messaging.message.body.size']).toBe(42);
+    });
+
+    test('omits body size when payload cannot be serialized', async () => {
+      const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      // Circular reference - JSON.stringify throws
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      await wrapped.send(circular);
+
+      const attrs = startSpanSpy.mock.calls[0]![0].attributes!;
+      expect(attrs['messaging.message.body.size']).toBeUndefined();
+    });
+  });
+
+  describe('sendBatch', () => {
+    test('forwards the call to the underlying queue', async () => {
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      await wrapped.sendBatch([{ body: 'a' }, { body: 'b' }]);
+
+      expect(queue.sendBatch).toHaveBeenCalledTimes(1);
+    });
+
+    test('starts a queue.publish span with batch attributes', async () => {
+      const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      await wrapped.sendBatch([{ body: 'aa' }, { body: 'bbb' }]);
+
+      expect(startSpanSpy).toHaveBeenCalledTimes(1);
+      const [spanCtx] = startSpanSpy.mock.calls[0]!;
+      expect(spanCtx).toMatchObject({
+        op: 'queue.publish',
+        name: 'send MY_QUEUE',
+        attributes: {
+          'messaging.system': 'cloudflare',
+          'messaging.destination.name': 'MY_QUEUE',
+          'messaging.operation.type': 'send',
+          'messaging.operation.name': 'send',
+          'messaging.batch.message_count': 2,
+          'messaging.message.body.size': 5,
+          'sentry.op': 'queue.publish',
+          'sentry.origin': 'auto.faas.cloudflare.queue',
+        },
+      });
+    });
+
+    test('handles iterables (not just arrays)', async () => {
+      const queue = createMockQueue();
+      const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE');
+
+      function* gen() {
+        yield { body: 'a' };
+        yield { body: 'b' };
+      }
+
+      await wrapped.sendBatch(gen());
+
+      expect(queue.sendBatch).toHaveBeenCalledTimes(1);
+      const passed = (queue.sendBatch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+      expect(Array.isArray(passed)).toBe(true);
+      expect(passed).toHaveLength(2);
+    });
+  });
+
+  test('forwards unknown property accesses transparently', () => {
+    const queue = Object.assign(createMockQueue(), {
+      customMethod: vi.fn().mockReturnValue('hi'),
+    }) as unknown as Queue & {
+      customMethod: () => string;
+    };
+    const wrapped = instrumentQueueProducer(queue, 'MY_QUEUE') as Queue & { customMethod: () => string };
+    expect(wrapped.customMethod()).toBe('hi');
+  });
+});

--- a/packages/cloudflare/test/utils/isBinding.test.ts
+++ b/packages/cloudflare/test/utils/isBinding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isDurableObjectNamespace, isJSRPC } from '../../src/utils/isBinding';
+import { isDurableObjectNamespace, isJSRPC, isQueue } from '../../src/utils/isBinding';
 
 describe('isJSRPC', () => {
   it('returns false for a plain object', () => {
@@ -118,5 +118,54 @@ describe('isDurableObjectNamespace', () => {
 
   it('returns false when idFromName is not a function', () => {
     expect(isDurableObjectNamespace({ idFromName: 'not-a-function' })).toBe(false);
+  });
+});
+
+describe('isQueue', () => {
+  it('returns true for an object with send and sendBatch methods', () => {
+    const queue = {
+      send: async () => {},
+      sendBatch: async () => {},
+    };
+    expect(isQueue(queue)).toBe(true);
+  });
+
+  it('returns false when send is missing', () => {
+    expect(isQueue({ sendBatch: async () => {} })).toBe(false);
+  });
+
+  it('returns false when sendBatch is missing', () => {
+    expect(isQueue({ send: async () => {} })).toBe(false);
+  });
+
+  it('returns false when send is not a function', () => {
+    expect(isQueue({ send: 'nope', sendBatch: async () => {} })).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isQueue(null)).toBe(false);
+    expect(isQueue(undefined)).toBe(false);
+  });
+
+  it('returns false for a JSRPC proxy even though it returns functions for send/sendBatch', () => {
+    const jsrpcProxy = new Proxy(
+      {},
+      {
+        get(_target, _prop) {
+          return () => {};
+        },
+      },
+    );
+    expect(isQueue(jsrpcProxy)).toBe(false);
+  });
+
+  it('returns false for a DurableObjectNamespace-like object', () => {
+    const doNamespace = {
+      idFromName: () => ({}),
+      idFromString: () => ({}),
+      get: () => ({}),
+      newUniqueId: () => ({}),
+    };
+    expect(isQueue(doNamespace)).toBe(false);
   });
 });


### PR DESCRIPTION
closes getsentry/sentry-javascript#14387 <br>closes getsentry/sentry-javascript#14387

We already had support for the consumer, but the producer was never instrumented. Which means we only knew when a queue was consumed, but never when it was produced.

Example trace (producer **new**): [https://sentry-sdks.sentry.io/explore/traces/trace/7ee71fd6dc8b4ce1a22b1bb9f9610b26/](<https://sentry-sdks.sentry.io/explore/traces/trace/7ee71fd6dc8b4ce1a22b1bb9f9610b26/>)<br>Example trace (consumer): [https://sentry-sdks.sentry.io/explore/traces/trace/486eb86cd02146279c4d547efb4cabab/](<https://sentry-sdks.sentry.io/explore/traces/trace/486eb86cd02146279c4d547efb4cabab/>)

In `wrangler.jsonc` a producer needs to be configured via `queues.producers`:

```jsonc
{
  "queues": {
    "producers": [
      {
        "queue": "test-queue",
        "binding": "MY_QUEUE",
      },
    ],
  },
}
```

Once this happens the `MY_QUEUE` is available in the `env` variable, which we already instrument. With that we only add `isQueue` inside `instrumentEnv.ts` and get instrument the producer:

```js
// this is the producer
this.env.MY_QUEUE.send({ somePayload: 'ʕっ•ᴥ•ʔっ' })
```

## Additional info

We are using `messaging.batch.message_count`, which is not yet in our semantic conventions: [https://getsentry.github.io/sentry-conventions/attributes/messaging/](<https://getsentry.github.io/sentry-conventions/attributes/messaging/>)

But it was already used before in our queue consumer logic. So the only thing is that it needs to be added first: [https://github.com/getsentry/sentry-conventions/issues/338](<https://github.com/getsentry/sentry-conventions/issues/338>) to make it official