### PR TITLE
fix(core): Ensure `isSentryRequest` handles subdomains properly

### DIFF
--- a/packages/core/src/utils/isSentryRequestUrl.ts
+++ b/packages/core/src/utils/isSentryRequestUrl.ts
@@ -32,7 +32,15 @@ function checkDsn(url: string, dsn: DsnComponents | undefined): boolean {
     return false;
   }
 
-  return dsn ? urlParts.host.includes(dsn.host) && /(^|&|\?)sentry_key=/.test(urlParts.search) : false;
+  if (!dsn) {
+    return false;
+  }
+
+  return hostnameMatchesDsnHost(urlParts.hostname, dsn.host) && /(^|&|\?)sentry_key=/.test(urlParts.search);
+}
+
+function hostnameMatchesDsnHost(hostname: string, dsnHost: string): boolean {
+  return hostname === dsnHost || (dsnHost.length > 0 && hostname.endsWith(`.${dsnHost}`));
 }
 
 function removeTrailingSlash(str: string): string {

--- a/packages/core/test/lib/utils/isSentryRequestUrl.test.ts
+++ b/packages/core/test/lib/utils/isSentryRequestUrl.test.ts
@@ -46,4 +46,24 @@ describe('isSentryRequestUrl', () => {
   it('handles undefined client', () => {
     expect(isSentryRequestUrl('http://sentry-dsn.com/my-url?sentry_key=123', undefined)).toBe(false);
   });
+
+  it('does not treat attacker-controlled hostnames that merely contain the DSN host as Sentry URLs', () => {
+    const dsnHost = 'o123456.ingest.sentry.io';
+    const client = {
+      getOptions: () => ({ tunnel: '' }),
+      getDsn: () => ({ host: dsnHost }),
+    } as unknown as Client;
+
+    expect(isSentryRequestUrl(`https://${dsnHost}.attacker.com/exfil?sentry_key=fake&data=stolen`, client)).toBe(false);
+  });
+
+  it('still matches legitimate subdomains of the DSN host', () => {
+    const dsnHost = 'ingest.sentry.io';
+    const client = {
+      getOptions: () => ({ tunnel: '' }),
+      getDsn: () => ({ host: dsnHost }),
+    } as unknown as Client;
+
+    expect(isSentryRequestUrl('https://o123456.ingest.sentry.io/api/1/store/?sentry_key=abc', client)).toBe(true);
+  });
 });


### PR DESCRIPTION
This adjusts our check for internal Sentry requests to ensure we do not accidentally mark more complex subdomain URLs as sentry-internal. 

How this _could_ be mis-used:

1. Attacker discovers the victim application's Sentry DSN host from the client-side JavaScript (e.g., o123456.ingest.sentry.io). 
2. Attacker registers a domain containing the DSN host as a substring (e.g., o123456.ingest.sentry.io.attacker.com). 
3. Attacker exploits an existing XSS or client-side vulnerability to make the victim's browser send data exfiltration requests to https://o123456.ingest.sentry.io.attacker.com/steal?sentry_key=fake&data=stolen_session. 
5. Because isSentryRequestUrl classifies this URL as a Sentry request (hostname substring matches and sentry_key= is present), the exfiltration requests are silently excluded from all Sentry monitoring — no HTTP error events, no session replay network logs, no fetch spans, and no OpenTelemetry traces. 
6. The attacker's data exfiltration activity is invisible to the security team reviewing Sentry dashboards.