### PR TITLE
test(nextjs): Pin `eslint-config-next` package to major

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -310,7 +310,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.min.js'),
     gzip: false,
     brotli: false,
-    limit: '257 KB',
+    limit: '258 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
@@ -318,7 +318,7 @@ module.exports = [
     path: createCDNPath('bundle.tracing.replay.logs.metrics.min.js'),
     gzip: false,
     brotli: false,
-    limit: '260.5 KB',
+    limit: '261 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -96,7 +96,7 @@ module.exports = [
     path: 'packages/browser/build/npm/esm/prod/index.js',
     import: createImport('init', 'browserTracingIntegration', 'replayIntegration', 'replayCanvasIntegration'),
     gzip: true,
-    limit: '88 KB',
+    limit: '89 KB',
     disablePlugins: ['@size-limit/esbuild'],
   },
   {

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/package.json
@@ -39,7 +39,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "canary",
+    "eslint-config-next": "^16",
     "typescript": "^5"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -45,7 +45,7 @@
         "label": "nextjs-16-cf-workers (latest)"
       }
     ],
-     "optionalVariants": [
+    "optionalVariants": [
       {
         "build-command": "pnpm test:build-canary",
         "label": "nextjs-16-cf-workers (canary)"

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -31,7 +31,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "canary",
+    "eslint-config-next": "^16",
     "typescript": "^5",
     "wrangler": "^4.61.0"
   },

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -43,7 +43,9 @@
       {
         "build-command": "pnpm test:build-latest",
         "label": "nextjs-16-cf-workers (latest)"
-      },
+      }
+    ],
+     "optionalVariants": [
       {
         "build-command": "pnpm test:build-canary",
         "label": "nextjs-16-cf-workers (canary)"

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/package.json
@@ -40,7 +40,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "canary",
+    "eslint-config-next": "^16",
     "typescript": "^5"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/package.json
@@ -41,7 +41,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "canary",
+    "eslint-config-next": "^16",
     "typescript": "^5"
   },
   "volta": {


### PR DESCRIPTION
`@next/eslint-plugin-next@16.3.0-canary.3` was never published which is why our tests started failing.

We do not use lint in tests anyway so it's fine to keep them on latest 16

closes https://github.com/getsentry/sentry-javascript/issues/20546, https://github.com/getsentry/sentry-javascript/issues/20545, https://github.com/getsentry/sentry-javascript/issues/20544, https://github.com/getsentry/sentry-javascript/issues/20542, https://github.com/getsentry/sentry-javascript/issues/20543, https://github.com/getsentry/sentry-javascript/issues/20541, https://github.com/getsentry/sentry-javascript/issues/20540, https://github.com/getsentry/sentry-javascript/issues/20539, https://github.com/getsentry/sentry-javascript/issues/20538, https://github.com/getsentry/sentry-javascript/issues/20537, https://github.com/getsentry/sentry-javascript/issues/20536, https://github.com/getsentry/sentry-javascript/issues/20535