### PR TITLE
test(supabase): Stop supabase before initializing

### DIFF
--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/package.json
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "clean": "npx rimraf node_modules pnpm-lock.yaml .next",
-    "start-local-supabase": "supabase init --force --workdir . && supabase start -o env && supabase db reset",
+    "start-local-supabase": "supabase stop --no-backup 2>/dev/null || true && supabase init --force --workdir . && supabase start -o env && supabase db reset",
     "test:prod": "TEST_ENV=production playwright test",
     "test:build": "pnpm install && pnpm start-local-supabase && pnpm build",
     "test:assert": "pnpm test:prod"


### PR DESCRIPTION
closes #20214 

The test failed with:

```
failed to start docker container: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint supabase_db_test-application (a2890079e9476a7ded9e9fbba9a9a60e82b00e74ea23f746beef34d99cbfb830): failed to bind host port for 0.0.0.0:54322:172.18.0.2:5432/tcp: address already in use
```

So for some reason the runner was reusing something from before, where the container ran. With that we stop Docker via the `supabase` CLI and then init it. 