### PR TITLE
ci(size-bump): Fix path in size-limit auto-bump workflow

### DIFF
--- a/.github/workflows/bump-size-limits.yml
+++ b/.github/workflows/bump-size-limits.yml
@@ -10,6 +10,13 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  CACHED_DEPENDENCY_PATHS: |
+    ${{ github.workspace }}/node_modules
+    ${{ github.workspace }}/packages/*/node_modules
+    ${{ github.workspace }}/dev-packages/*/node_modules
+    ~/.cache/mongodb-binaries/
+
 concurrency:
   group: bump-size-limits
   cancel-in-progress: false


### PR DESCRIPTION
The install-dependencies composite action references `env.CACHED_DEPENDENCY_PATHS` as the `actions/cache` path input. Without it, the cache step fails with `'Input required and not supplied: path'`. Mirror the env block from build.yml.

