### PR TITLE
test(tanstack): Prefix test labels

### DIFF
--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
@@ -48,22 +48,22 @@
   "sentryTest": {
     "variants": [
       {
-        "label": "tunnel-generated",
+        "label": "tanstackstart-react (tunnel-generated)",
         "build-command": "pnpm test:build:tunnel-generated",
         "assert-command": "pnpm test:assert:tunnel-generated"
       },
       {
-        "label": "tunnel-static",
+        "label": "tanstackstart-react (tunnel-static)",
         "build-command": "pnpm test:build:tunnel-static",
         "assert-command": "pnpm test:assert:tunnel-static"
       },
       {
-        "label": "tunnel-custom",
+        "label": "tanstackstart-react (tunnel-custom)",
         "build-command": "pnpm test:build:tunnel-custom",
         "assert-command": "pnpm test:assert:tunnel-custom"
       },
       {
-        "label": "tunnel-object",
+        "label": "tanstackstart-react (tunnel-object)",
         "build-command": "pnpm test:build:tunnel-object",
         "assert-command": "pnpm test:assert:tunnel-object"
       }


### PR DESCRIPTION
To make the test names in CI (and therefore the generated issue names in case of flakiness) look better, I adjusted the label