### PR TITLE
docs: Add deprecation notices to `bin` scripts

### DIFF
--- a/packages/profiling-node/README.md
+++ b/packages/profiling-node/README.md
@@ -238,8 +238,10 @@ Once you run `node esbuild.serverless.js` esbuild wil bundle and output the file
 the binaries will be copied. This is wasteful as you will likely only need one of these libraries to be available during
 runtime.
 
-To prune the other libraries, profiling-node ships with a small utility script that helps you prune unused binaries. The
-script can be invoked via `sentry-prune-profiler-binaries`:
+> **Deprecation notice:** This script will be removed in the next major version. If you depend on it, please comment on
+> [this issue](https://github.com/getsentry/sentry-javascript/issues/20567).
+
+To prune the other libraries, profiling-node ships with a small utility script that helps you prune unused binaries:
 
 ```bash
 npx --package=@sentry/profiling-node sentry-prune-profiler-binaries

--- a/packages/profiling-node/scripts/prune-profiler-binaries.js
+++ b/packages/profiling-node/scripts/prune-profiler-binaries.js
@@ -56,6 +56,10 @@ Arguments:\n
   process.exit(0);
 }
 
+console.warn(
+  '[Sentry] Warning: This script will be removed in the next major version. See: https://github.com/getsentry/sentry-javascript/issues/20567',
+);
+
 const ARGV_ERRORS = [];
 
 const NODE_TO_ABI = {

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -122,13 +122,13 @@ Sentry.captureEvent({
 The Remix SDK provides a script that automatically creates a release and uploads sourcemaps. To generate sourcemaps with
 Remix, you need to call `remix build` with the `--sourcemap` option.
 
-On release, call `sentry-upload-sourcemaps` to upload source maps and create a release:
+On release, call the upload sourcemaps command to upload source maps and create a release:
 
 ```bash
-npx --package=@sentry/remix sentry-upload-sourcemaps
+npx @sentry/remix --upload-sourcemaps
 ```
 
-To see more details on how to use the command, call `npx --package=@sentry/remix sentry-upload-sourcemaps --help`.
+To see more details on how to use the command, run `npx @sentry/remix --upload-sourcemaps --help`.
 
 For more advanced configuration,
 [directly use `sentry-cli` to upload source maps.](https://github.com/getsentry/sentry-cli).

--- a/packages/remix/scripts/sentry-upload-sourcemaps.js
+++ b/packages/remix/scripts/sentry-upload-sourcemaps.js
@@ -8,6 +8,10 @@ const DEFAULT_URL_PREFIX = '~/build/';
 const DEFAULT_BUILD_PATH = 'public/build';
 
 const argv = yargs(process.argv.slice(2))
+  .option('upload-sourcemaps', {
+    type: 'boolean',
+    describe: 'Specifies the upload sourcemaps command. Recommended for forward compatibility.',
+  })
   .option('release', {
     type: 'string',
     describe:
@@ -48,7 +52,7 @@ const argv = yargs(process.argv.slice(2))
     default: true,
   })
   .usage(
-    'Usage: $0\n' +
+    'Usage: npx @sentry/remix --upload-sourcemaps\n' +
       '  [--release RELEASE]\n' +
       '  [--org ORG]\n' +
       '  [--project PROJECT]\n' +
@@ -63,6 +67,12 @@ const argv = yargs(process.argv.slice(2))
       'https://github.com/getsentry/sentry-cli',
   )
   .wrap(120).argv;
+
+if (!argv.uploadSourcemaps) {
+  process.stderr.write(
+    '[Sentry] Warning: Calling this script without --upload-sourcemaps is deprecated. Use: `npx @sentry/remix --upload-sourcemaps`',
+  );
+}
 
 const buildPath = argv.buildPath || DEFAULT_BUILD_PATH;
 const urlPrefix = argv.urlPrefix || DEFAULT_URL_PREFIX;

--- a/packages/remix/scripts/sentry-upload-sourcemaps.js
+++ b/packages/remix/scripts/sentry-upload-sourcemaps.js
@@ -70,7 +70,7 @@ const argv = yargs(process.argv.slice(2))
 
 if (!argv.uploadSourcemaps) {
   process.stderr.write(
-    '[Sentry] Warning: Calling this script without --upload-sourcemaps is deprecated. Use: `npx @sentry/remix --upload-sourcemaps`',
+    '[Sentry] Warning: Calling this script without --upload-sourcemaps is deprecated. Use: `npx @sentry/remix --upload-sourcemaps`\n',
   );
 }
 


### PR DESCRIPTION
If there is only one `bin` script (which is the case for Remix and Profiling), it's possible to just run `npx @sentry/remix` and it will run this one script. But to make it more clear what's going to happen, we're introducing an argument `--upload-sourcemaps`.


**Remix:** The script usage changes so we can rename the `bin` script in the next major version.

**Profiling:** The script is going to be deleted and deprecation notices are added.

Related to: https://github.com/getsentry/sentry-javascript/issues/20422
