### PR TITLE
chore(v8/craft): remove deno registry craft target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -83,14 +83,6 @@ targets:
   - name: npm
     id: '@sentry/deno'
     includeNames: /^sentry-deno-\d.*\.tgz$/
-  - name: commit-on-git-repository
-    # This will publish on the Deno registry
-    id: getsentry/deno
-    archive: /^sentry-deno-\d.*\.tgz$/
-    repositoryUrl: https://github.com/getsentry/sentry-deno.git
-    stripComponents: 1
-    branch: main
-    createTag: true
 
   ## 5. Node-based Packages
   - name: npm


### PR DESCRIPTION
This PR removes the deno registry craft target to avoid failing v8 releases midwy through.

The last two releases (8.55.1 and 8.55.2) failed to publish to the registry. We stopped publishing our SDK to the registry with v9.

Moreover, craft's github token doesn't have access to publish to the sentry-deno repo anymore.