### PR TITLE
test(node): Update timeout for cron integration tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/cron/cron/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/cron/scenario.ts
@@ -27,4 +27,4 @@ cron.start();
 
 setTimeout(() => {
   process.exit();
-}, 5000);
+}, 15_000);

--- a/dev-packages/node-integration-tests/suites/cron/cron/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/cron/test.ts
@@ -5,7 +5,7 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('cron instrumentation', async () => {
+test('cron instrumentation', { timeout: 30_000 }, async () => {
   await createRunner(__dirname, 'scenario.ts')
     .expect({
       check_in: {

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/base/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/base/scenario.ts
@@ -33,4 +33,4 @@ const task = cronWithCheckIn.schedule(
 
 setTimeout(() => {
   process.exit();
-}, 5000);
+}, 15_000);

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/base/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/base/test.ts
@@ -5,7 +5,7 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('node-cron instrumentation', async () => {
+test('node-cron instrumentation', { timeout: 30_000 }, async () => {
   await createRunner(__dirname, 'scenario.ts')
     .expect({
       check_in: {

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/isolateTrace/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/isolateTrace/scenario.ts
@@ -53,4 +53,4 @@ const task2 = cronWithCheckIn.schedule(
 
 setTimeout(() => {
   process.exit();
-}, 5000);
+}, 15_000);

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/isolateTrace/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/isolateTrace/test.ts
@@ -5,7 +5,7 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('node-cron instrumentation', async () => {
+test('node-cron instrumentation', { timeout: 30_000 }, async () => {
   let firstErrorTraceId: string | undefined;
 
   await createRunner(__dirname, 'scenario.ts')

--- a/dev-packages/node-integration-tests/suites/cron/node-schedule/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-schedule/scenario.ts
@@ -25,4 +25,4 @@ const job = scheduleWithCheckIn.scheduleJob('my-cron-job', '* * * * * *', () => 
 
 setTimeout(() => {
   process.exit();
-}, 5000);
+}, 15_000);

--- a/dev-packages/node-integration-tests/suites/cron/node-schedule/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-schedule/test.ts
@@ -5,7 +5,7 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('node-schedule instrumentation', async () => {
+test('node-schedule instrumentation', { timeout: 30_000 }, async () => {
   await createRunner(__dirname, 'scenario.ts')
     .expect({
       check_in: {


### PR DESCRIPTION
Saw this flake once or twice, just increasing timeout for cron tests to allow for slow runner startup etc.