### PR TITLE
test(browser): Fix flaky browser integration test for profiles

### DIFF
--- a/dev-packages/browser-integration-tests/suites/profiling/test-utils.ts
+++ b/dev-packages/browser-integration-tests/suites/profiling/test-utils.ts
@@ -7,6 +7,9 @@ interface ValidateProfileOptions {
   isChunkFormat?: boolean;
 }
 
+/** Seconds — consecutive chunk timestamps can jitter slightly below float precision (see profiling flakes). */
+const CHUNK_SAMPLE_TIMESTAMP_EPSILON_SEC = 1e-5;
+
 /**
  * Validates the metadata of a profile chunk envelope.
  * https://develop.sentry.dev/sdk/telemetry/profiles/sample-format-v2/
@@ -66,9 +69,9 @@ export function validateProfile(
       const ts = chunkProfileSample.timestamp;
       expect(Number.isFinite(ts)).toBe(true);
       expect(ts).toBeGreaterThan(0);
-      // Monotonic non-decreasing timestamps
-      expect(ts).toBeGreaterThanOrEqual(previousTimestamp);
-      previousTimestamp = ts;
+      // Monotonic non-decreasing timestamps (epsilon: jitter / IEEE754 around ~1e9 epoch seconds)
+      expect(ts).toBeGreaterThanOrEqual(previousTimestamp - CHUNK_SAMPLE_TIMESTAMP_EPSILON_SEC);
+      previousTimestamp = Math.max(previousTimestamp, ts);
     } else {
       // Legacy format uses elapsed_since_start_ns as a string
       const legacyProfileSample = sample as ThreadCpuProfile['samples'][number];

--- a/dev-packages/browser-integration-tests/suites/profiling/traceLifecycleMode_overlapping-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/profiling/traceLifecycleMode_overlapping-spans/test.ts
@@ -39,16 +39,15 @@ sentryTest(
     }
 
     const url = await getLocalTestUrl({ testDir: __dirname, responseHeaders: { 'Document-Policy': 'js-profiling' } });
-    await page.goto(url);
 
-    const profileChunkEnvelopePromise = getMultipleSentryEnvelopeRequests<ProfileChunkEnvelope>(
+    const profileChunkEnvelopes = await getMultipleSentryEnvelopeRequests<ProfileChunkEnvelope>(
       page,
       1,
-      { envelopeType: 'profile_chunk' },
+      { url, envelopeType: 'profile_chunk', timeout: 5000 },
       properFullEnvelopeRequestParser,
     );
 
-    const profileChunkEnvelopeItem = (await profileChunkEnvelopePromise)[0][1][0];
+    const profileChunkEnvelopeItem = profileChunkEnvelopes[0][1][0];
     const envelopeItemHeader = profileChunkEnvelopeItem[0];
     const envelopeItemPayload = profileChunkEnvelopeItem[1];
 


### PR DESCRIPTION
This updates a browser integration test to make it less flaky. Instead of first calling `await page.goto(...)` we now combine this with `getMultipleSentryEnvelopeRequests` to avoid possible race conditions.

Fixes https://github.com/getsentry/sentry-javascript/issues/20585
Fixes https://github.com/getsentry/sentry-javascript/issues/20524
Fixes https://github.com/getsentry/sentry-javascript/issues/20612