### PR TITLE
chore(ci): Do not report flaky test issues if we cannot find a test name

### DIFF
--- a/scripts/report-ci-failures.mjs
+++ b/scripts/report-ci-failures.mjs
@@ -68,9 +68,10 @@ export default async function run({ github, context, core }) {
       core.info(`Could not fetch annotations for ${jobName}: ${e.message}`);
     }
 
-    // If no test names found, fall back to one issue per job
+    // If no test names found, abort - this could mean something else, e.g. cache restoration or similar fails
+    // and also the issue is not super helpful in this case
     if (testNames.length === 0) {
-      testNames = ['Unknown test'];
+      continue;
     }
 
     // Create one issue per failing test for proper deduplication


### PR DESCRIPTION
Today, we got a bunch of flaky CI issues for e.g. failing cache or playwright installation. While these are also kind of flakes, the issues are not super actionable and it gets a bit noisy. I'd opt to not create an issue if we cannot identify a concrete test that is flaking. We miss out on some things being auto-reported here but that's also OK I'd say.

Closes https://github.com/getsentry/sentry-javascript/issues/20319
Closes https://github.com/getsentry/sentry-javascript/issues/20557
Closes https://github.com/getsentry/sentry-javascript/issues/20493
Closes https://github.com/getsentry/sentry-javascript/issues/20492
Closes https://github.com/getsentry/sentry-javascript/issues/20469
Closes https://github.com/getsentry/sentry-javascript/issues/20470