### PR TITLE
test(browser): Unflake some more tests

### DIFF
--- a/dev-packages/browser-integration-tests/suites/profiling/traceLifecycleMode_overlapping-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/profiling/traceLifecycleMode_overlapping-spans/test.ts
@@ -39,16 +39,15 @@ sentryTest(
     }
 
     const url = await getLocalTestUrl({ testDir: __dirname, responseHeaders: { 'Document-Policy': 'js-profiling' } });
-    await page.goto(url);
 
-    const profileChunkEnvelopePromise = getMultipleSentryEnvelopeRequests<ProfileChunkEnvelope>(
+    const profileChunkEnvelopes = await getMultipleSentryEnvelopeRequests<ProfileChunkEnvelope>(
       page,
       1,
-      { envelopeType: 'profile_chunk' },
+      { url, envelopeType: 'profile_chunk', timeout: 5000 },
       properFullEnvelopeRequestParser,
     );
 
-    const profileChunkEnvelopeItem = (await profileChunkEnvelopePromise)[0][1][0];
+    const profileChunkEnvelopeItem = profileChunkEnvelopes[0][1][0];
     const envelopeItemHeader = profileChunkEnvelopeItem[0];
     const envelopeItemPayload = profileChunkEnvelopeItem[1];
 

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-sync/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-sync/test.ts
@@ -21,9 +21,9 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.goto(url);
-
     const errorEventsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
+
+    await page.goto(url);
 
     await runScriptInSandbox(page, {
       content: `

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/error/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/error/test.ts
@@ -21,9 +21,9 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    await page.goto(url);
-
     const errorEventsPromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
+
+    await page.goto(url);
 
     await runScriptInSandbox(page, {
       content: `


### PR DESCRIPTION
Found some other places in browser-integration-tests that could theoretically be flaky due to when we start listening for events vs. when we navigate.