### PR TITLE
test(node): Unflake postgres tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-requestHook.js
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-requestHook.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node');
 const postgres = require('postgres');
+const { waitForPostgres } = require('./wait-for-postgres.js');
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
@@ -14,6 +15,7 @@ async function run() {
     },
     async () => {
       try {
+        await waitForPostgres(sql);
         await sql`
           CREATE TABLE "User" ("id" SERIAL NOT NULL,"createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,"email" TEXT NOT NULL,"name" TEXT,CONSTRAINT "User_pkey" PRIMARY KEY ("id"));
         `;

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-requestHook.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-requestHook.mjs
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/node';
+import { createRequire } from 'node:module';
 import postgres from 'postgres';
+
+const require = createRequire(import.meta.url);
+const { waitForPostgres } = require('./wait-for-postgres.js');
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
@@ -14,6 +18,7 @@ async function run() {
     },
     async () => {
       try {
+        await waitForPostgres(sql);
         await sql`
           CREATE TABLE "User" ("id" SERIAL NOT NULL,"createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,"email" TEXT NOT NULL,"name" TEXT,CONSTRAINT "User_pkey" PRIMARY KEY ("id"));
         `;

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-unsafe.cjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-unsafe.cjs
@@ -10,6 +10,7 @@ Sentry.init({
 
 // Import postgres AFTER Sentry.init() so instrumentation is set up
 const postgres = require('postgres');
+const { waitForPostgres } = require('./wait-for-postgres.js');
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
@@ -25,6 +26,7 @@ async function run() {
     },
     async () => {
       try {
+        await waitForPostgres(sql);
         // Test sql.unsafe() - this was not being instrumented before the fix
         await sql.unsafe('CREATE TABLE "User" ("id" SERIAL NOT NULL, "email" TEXT NOT NULL, PRIMARY KEY ("id"))');
 

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-unsafe.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-unsafe.mjs
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/node';
+import { createRequire } from 'node:module';
 import postgres from 'postgres';
+
+const require = createRequire(import.meta.url);
+const { waitForPostgres } = require('./wait-for-postgres.js');
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
@@ -15,6 +19,7 @@ async function run() {
     },
     async () => {
       try {
+        await waitForPostgres(sql);
         // Test sql.unsafe() - this was not being instrumented before the fix
         await sql.unsafe('CREATE TABLE "User" ("id" SERIAL NOT NULL, "email" TEXT NOT NULL, PRIMARY KEY ("id"))');
 

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-url.cjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-url.cjs
@@ -10,6 +10,7 @@ Sentry.init({
 
 // Import postgres AFTER Sentry.init() so instrumentation is set up
 const postgres = require('postgres');
+const { waitForPostgres } = require('./wait-for-postgres.js');
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
@@ -25,6 +26,7 @@ async function run() {
     },
     async () => {
       try {
+        await waitForPostgres(sql);
         await sql`
           CREATE TABLE "User" ("id" SERIAL NOT NULL,"createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,"email" TEXT NOT NULL,"name" TEXT,CONSTRAINT "User_pkey" PRIMARY KEY ("id"));
         `;

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-url.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario-url.mjs
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/node';
+import { createRequire } from 'node:module';
 import postgres from 'postgres';
+
+const require = createRequire(import.meta.url);
+const { waitForPostgres } = require('./wait-for-postgres.js');
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
@@ -15,6 +19,7 @@ async function run() {
     },
     async () => {
       try {
+        await waitForPostgres(sql);
         await sql`
           CREATE TABLE "User" ("id" SERIAL NOT NULL,"createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,"email" TEXT NOT NULL,"name" TEXT,CONSTRAINT "User_pkey" PRIMARY KEY ("id"));
         `;

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario.js
@@ -1,5 +1,6 @@
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
+const { waitForPostgres } = require('./wait-for-postgres.js');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -23,6 +24,7 @@ async function run() {
     },
     async () => {
       try {
+        await waitForPostgres(sql);
         await sql`
           CREATE TABLE "User" ("id" SERIAL NOT NULL,"createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,"email" TEXT NOT NULL,"name" TEXT,CONSTRAINT "User_pkey" PRIMARY KEY ("id"));
         `;

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/scenario.mjs
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/node';
+import { createRequire } from 'node:module';
 import postgres from 'postgres';
+
+const require = createRequire(import.meta.url);
+const { waitForPostgres } = require('./wait-for-postgres.js');
 
 // Stop the process from exiting before the transaction is sent
 setInterval(() => {}, 1000);
@@ -14,6 +18,7 @@ async function run() {
     },
     async () => {
       try {
+        await waitForPostgres(sql);
         await sql`
           CREATE TABLE "User" ("id" SERIAL NOT NULL,"createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,"email" TEXT NOT NULL,"name" TEXT,CONSTRAINT "User_pkey" PRIMARY KEY ("id"));
         `;

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/wait-for-postgres.js
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/wait-for-postgres.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Retries until Postgres accepts connections. `docker compose up --wait` can report healthy
+ * before the port forward on the host is ready (flaky on busy CI).
+ */
+async function waitForPostgres(sql, maxWaitMs = 60_000) {
+  const deadline = Date.now() + maxWaitMs;
+  for (;;) {
+    try {
+      await sql`SELECT 1`;
+      return;
+    } catch {
+      if (Date.now() > deadline) {
+        throw new Error('Timed out waiting for Postgres to accept connections');
+      }
+      await new Promise(r => setTimeout(r, 250));
+    }
+  }
+}
+
+module.exports = { waitForPostgres };


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/20553

The clanker identified this as possible problem here:
> docker compose up --wait waits on the container healthcheck (pg_isready inside the DB). On busy CI, localhost:5444 can still refuse connections briefly afterward, so the scenario could hit Postgres before it was reachable from the host and fail or behave inconsistently → flaky CJS (and the same class of failure for the other scenarios).