### PR TITLE
test(browser): Fix flaky loader test

### DIFF
--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/subject.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/subject.js
@@ -1,6 +1,8 @@
 setTimeout(() => {
   const cdnScript = document.createElement('script');
-  cdnScript.src = '/cdn.bundle.js';
+  // Distinct URL from the loader's `/cdn.bundle.js` so Chromium cannot satisfy this via memory-cache
+  // (would skip `page.route` and make CDN load counts flaky).
+  cdnScript.src = `/cdn.bundle.js?sentryInjected=1`;
 
   cdnScript.addEventListener('load', () => {
     Sentry.init({

--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
@@ -30,8 +30,11 @@ sentryTest('it does not download the SDK if the SDK was loaded in the meanwhile'
   const tmpDir = await getLocalTestUrl({ testDir: __dirname, skipRouteHandler: true, skipDsnRouteHandler: true });
 
   await page.route(`${TEST_HOST}/*.*`, route => {
-    const file = route.request().url().split('/').pop();
+    const pathname = new URL(route.request().url()).pathname;
+    const file = pathname.split('/').pop() || '';
 
+    // Loader + subject both fetch the CDN bundle. Chromium may not hit `page.route` twice for the same URL
+    // (memory cache); subject.js uses a cache-busted URL so we reliably observe two network loads.
     if (file === 'cdn.bundle.js') {
       cdnLoadedCount++;
     }
@@ -47,10 +50,8 @@ sentryTest('it does not download the SDK if the SDK was loaded in the meanwhile'
 
   const eventData = envelopeRequestParser(req);
 
-  await waitForFunction(() => cdnLoadedCount === 2);
-
   // Still loaded the CDN bundle twice
-  expect(cdnLoadedCount).toBe(2);
+  await expect.poll(() => cdnLoadedCount, { timeout: 15_000 }).toBe(2);
 
   // But only sent to Sentry once
   expect(sentryEventCount).toBe(1);
@@ -62,10 +63,3 @@ sentryTest('it does not download the SDK if the SDK was loaded in the meanwhile'
   expect(eventData.exception?.values?.length).toBe(1);
   expect(eventData.exception?.values?.[0]?.value).toBe('window.doSomethingWrong is not a function');
 });
-
-async function waitForFunction(cb: () => boolean, timeout = 2000, increment = 100) {
-  while (timeout > 0 && !cb()) {
-    await new Promise(resolve => setTimeout(resolve, increment));
-    await waitForFunction(cb, timeout - increment, increment);
-  }
-}


### PR DESCRIPTION
Ironically, this flaked in a PR fixing another flake.

Closes https://github.com/getsentry/sentry-javascript/issues/20564