### PR TITLE
chore(ci): Use pull-requests: write for PR review reminder workflow

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -7,14 +7,12 @@ on:
     # Saturday/Sunday are never counted as business days.
     - cron: '0 10 * * 1-5'
 
-# pulls.* list + listRequestedReviewers → pull-requests: read
-# issues timeline + comments + createComment → issues: write
+# pulls.* list + listRequestedReviewers + createComment on PRs → pull-requests: write
 # repos.listCollaborators (outside) → Metadata read on the token (see GitHub App permission map)
 # checkout → contents: read
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
The schedule-triggered workflow was failing with 403 when trying to create comments on PRs. GitHub requires `pull-requests: write` (not `issues: write`) to create comments on pull requests via the Issues API when the workflow runs on schedule.

ref: https://github.com/getsentry/sentry-javascript/actions/workflows/pr-review-reminder.yml