### PR TITLE
chore(browser): Remove debug config from tests

### DIFF
--- a/packages/browser/test/profiling/UIProfiler.test.ts
+++ b/packages/browser/test/profiling/UIProfiler.test.ts
@@ -590,7 +590,6 @@ describe('Browser Profiling v2 trace lifecycle', () => {
 
     Sentry.init({
       ...getBaseOptionsForTraceLifecycle(send),
-      debug: true,
     });
 
     Sentry.uiProfiler.startProfiler();
@@ -691,7 +690,6 @@ describe('Browser Profiling v2 manual lifecycle', () => {
 
     Sentry.init({
       ...getBaseOptionsForManualLifecycle(send),
-      debug: true,
     });
 
     Sentry.uiProfiler.startProfiler();

--- a/packages/browser/test/profiling/integration.test.ts
+++ b/packages/browser/test/profiling/integration.test.ts
@@ -69,7 +69,6 @@ describe('BrowserProfilingIntegration', () => {
   });
 
   it("warns when profileLifecycle is 'trace' but tracing is disabled", async () => {
-    debug.enable();
     const warnSpy = vi.spyOn(debug, 'warn').mockImplementation(() => {});
 
     // @ts-expect-error mock constructor


### PR DESCRIPTION
This lead to hard to read logs, as this enables the debugger which leaks into other tests as well etc.