### PR TITLE
test(e2e): Remove remaining `npmrc` pointing to Verdaccio

### DIFF
--- a/dev-packages/e2e-tests/test-applications/effect-3-node/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/effect-3-node/.npmrc
@@ -1,2 +1,0 @@
-@sentry:registry=http://127.0.0.1:4873
-@sentry-internal:registry=http://127.0.0.1:4873

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/.npmrc
@@ -1,2 +1,0 @@
-@sentry:registry=http://127.0.0.1:4873
-@sentry-internal:registry=http://127.0.0.1:4873

--- a/dev-packages/e2e-tests/test-applications/hono-4/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/hono-4/.npmrc
@@ -1,2 +1,0 @@
-@sentry:registry=http://127.0.0.1:4873
-@sentry-internal:registry=http://127.0.0.1:4873


### PR DESCRIPTION
pnpm overrides handle local package installs via local `file:` paths. The `npmrc` is not needed anymore but 3 files were still there as the E2E tests were added after merging the PR linked below.


Builds on top of https://github.com/getsentry/sentry-javascript/pull/20386
