### PR TITLE
feat(deno): Add `processSegmentSpan` to Deno context integration

### DIFF
--- a/dev-packages/e2e-tests/test-applications/deno-streamed/package.json
+++ b/dev-packages/e2e-tests/test-applications/deno-streamed/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "deno run --allow-net --allow-env --allow-read src/app.ts",
+    "start": "deno run --allow-net --allow-env --allow-read --allow-sys src/app.ts",
     "test": "playwright test",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "test:build": "pnpm install",

--- a/dev-packages/e2e-tests/test-applications/deno-streamed/tests/spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-streamed/tests/spans.test.ts
@@ -3,11 +3,20 @@ import { waitForStreamedSpans, getSpanOp } from '@sentry-internal/test-utils';
 
 const SEGMENT_SPAN = {
   attributes: {
+    'app.start_time': {
+      type: 'string',
+      value: expect.any(String),
+    },
     'client.address': {
       type: 'string',
       value: expect.any(String),
     },
     'client.port': {
+      type: 'integer',
+      value: expect.any(Number),
+    },
+    // TODO: 'device.archs' is set but arrays are not yet serialized in span attributes
+    'device.processor_count': {
       type: 'integer',
       value: expect.any(Number),
     },
@@ -50,6 +59,14 @@ const SEGMENT_SPAN = {
     'http.response.status_code': {
       type: 'integer',
       value: expect.any(Number),
+    },
+    'os.name': {
+      type: 'string',
+      value: expect.any(String),
+    },
+    'os.version': {
+      type: 'string',
+      value: expect.any(String),
     },
     'sentry.environment': {
       type: 'string',
@@ -114,6 +131,14 @@ const SEGMENT_SPAN = {
     'user_agent.original': {
       type: 'string',
       value: 'node',
+    },
+    'process.runtime.engine.name': {
+      type: 'string',
+      value: 'v8',
+    },
+    'process.runtime.engine.version': {
+      type: 'string',
+      value: expect.any(String),
     },
   },
   end_timestamp: expect.any(Number),

--- a/packages/deno/src/integrations/context.ts
+++ b/packages/deno/src/integrations/context.ts
@@ -1,5 +1,5 @@
 import type { Event, IntegrationFn } from '@sentry/core';
-import { defineIntegration } from '@sentry/core';
+import { defineIntegration, safeSetSpanJSONAttributes } from '@sentry/core';
 
 const INTEGRATION_NAME = 'DenoContext';
 
@@ -53,10 +53,32 @@ async function addDenoRuntimeContext(event: Event): Promise<Event> {
 }
 
 const _denoContextIntegration = (() => {
+  // Eagerly resolve the async OS release so it's available synchronously in processSegmentSpan
+  let cachedOsRelease: string | undefined;
+  getOSRelease()
+    .then(release => {
+      cachedOsRelease = release;
+    })
+    .catch(() => {
+      // Ignore - os.version will be undefined
+    });
+
   return {
     name: INTEGRATION_NAME,
     processEvent(event) {
       return addDenoRuntimeContext(event);
+    },
+    processSegmentSpan(span) {
+      safeSetSpanJSONAttributes(span, {
+        'app.start_time': new Date(Date.now() - performance.now()).toISOString(),
+        'device.archs': [Deno.build.arch],
+        // eslint-disable-next-line no-restricted-globals
+        'device.processor_count': navigator.hardwareConcurrency,
+        'os.name': getOSName(),
+        'os.version': cachedOsRelease,
+        'process.runtime.engine.name': 'v8',
+        'process.runtime.engine.version': Deno.version.v8,
+      });
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/deno/src/integrations/context.ts
+++ b/packages/deno/src/integrations/context.ts
@@ -1,4 +1,4 @@
-import type { Event, IntegrationFn } from '@sentry/core';
+import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration, safeSetSpanJSONAttributes } from '@sentry/core';
 
 const INTEGRATION_NAME = 'DenoContext';
@@ -22,42 +22,38 @@ async function getOSRelease(): Promise<string | undefined> {
     : undefined;
 }
 
-async function addDenoRuntimeContext(event: Event): Promise<Event> {
-  event.contexts = {
-    ...{
-      app: {
-        app_start_time: new Date(Date.now() - performance.now()).toISOString(),
-      },
-      device: {
-        arch: Deno.build.arch,
-        // eslint-disable-next-line no-restricted-globals
-        processor_count: navigator.hardwareConcurrency,
-      },
-      os: {
-        name: getOSName(),
-        version: await getOSRelease(),
-      },
-      v8: {
-        name: 'v8',
-        version: Deno.version.v8,
-      },
-      typescript: {
-        name: 'TypeScript',
-        version: Deno.version.typescript,
-      },
-    },
-    ...event.contexts,
+const _denoContextIntegration = (() => {
+  const appStartTime = new Date(Date.now() - performance.now()).toISOString();
+  const osName = getOSName();
+  const arch = Deno.build.arch;
+  // eslint-disable-next-line no-restricted-globals
+  const processorCount = navigator.hardwareConcurrency;
+  const v8Version = Deno.version.v8;
+  const tsVersion = Deno.version.typescript;
+
+  const cachedContext = {
+    app: { app_start_time: appStartTime },
+    device: { arch, processor_count: processorCount },
+    os: { name: osName } as { name: string; version?: string },
+    v8: { name: 'v8', version: v8Version },
+    typescript: { name: 'TypeScript', version: tsVersion },
   };
 
-  return event;
-}
+  const cachedSpanAttributes: Record<string, unknown> = {
+    'app.start_time': appStartTime,
+    // Convention uses 'device.archs' (string[]), but array attributes are not yet serialized.
+    // Once array serialization lands, this will start appearing on spans automatically.
+    'device.archs': [arch],
+    'device.processor_count': processorCount,
+    'os.name': osName,
+    'process.runtime.engine.name': 'v8',
+    'process.runtime.engine.version': v8Version,
+  };
 
-const _denoContextIntegration = (() => {
-  // Eagerly resolve the async OS release so it's available synchronously in processSegmentSpan
-  let cachedOsRelease: string | undefined;
   getOSRelease()
     .then(release => {
-      cachedOsRelease = release;
+      cachedContext.os.version = release;
+      cachedSpanAttributes['os.version'] = release;
     })
     .catch(() => {
       // Ignore - os.version will be undefined
@@ -66,19 +62,14 @@ const _denoContextIntegration = (() => {
   return {
     name: INTEGRATION_NAME,
     processEvent(event) {
-      return addDenoRuntimeContext(event);
+      event.contexts = {
+        ...cachedContext,
+        ...event.contexts,
+      };
+      return event;
     },
     processSegmentSpan(span) {
-      safeSetSpanJSONAttributes(span, {
-        'app.start_time': new Date(Date.now() - performance.now()).toISOString(),
-        'device.archs': [Deno.build.arch],
-        // eslint-disable-next-line no-restricted-globals
-        'device.processor_count': navigator.hardwareConcurrency,
-        'os.name': getOSName(),
-        'os.version': cachedOsRelease,
-        'process.runtime.engine.name': 'v8',
-        'process.runtime.engine.version': Deno.version.v8,
-      });
+      safeSetSpanJSONAttributes(span, cachedSpanAttributes);
     },
   };
 }) satisfies IntegrationFn;


### PR DESCRIPTION
Adds `processSegmentSpan` to the `denoContextIntegration` for span streaming support.

Attributes added in  https://github.com/getsentry/sentry-conventions/pull/347

closes https://github.com/getsentry/sentry-javascript/issues/20381