### PR TITLE
feat(cloudflare): Capture request body via httpServerIntegration

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/index.ts
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    integrations: [Sentry.httpServerIntegration({ maxRequestBodySize: 'none' })],
+  }),
+  {
+    async fetch(_request, _env, _ctx) {
+      Sentry.captureMessage('POST with disabled body capture');
+      return new Response('ok');
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from 'vitest';
+import { createRunner } from '../../../runner';
+
+it('Does not capture request body when maxRequestBodySize is none', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(envelope => {
+      const event = envelope[1]?.[0]?.[1] as Record<string, unknown>;
+      expect(event.message).toBe('POST with disabled body capture');
+      expect(event.request).toEqual(
+        expect.objectContaining({
+          method: 'POST',
+          url: expect.any(String),
+        }),
+      );
+      // Body should NOT be captured
+      expect((event.request as Record<string, unknown>).data).toBeUndefined();
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/', {
+    headers: { 'content-type': 'application/json' },
+    data: JSON.stringify({ secret: 'should-not-be-captured' }),
+  });
+
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "worker-name",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+}

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/index.ts
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    integrations: integrations => integrations.filter(i => i.name !== 'HttpServer'),
+  }),
+  {
+    async fetch(_request, _env, _ctx) {
+      Sentry.captureMessage('POST with filtered integration');
+      return new Response('ok');
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from 'vitest';
+import { createRunner } from '../../../runner';
+
+it('Does not capture request body when httpServerIntegration is filtered out', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(envelope => {
+      const event = envelope[1]?.[0]?.[1] as Record<string, unknown>;
+      expect(event.message).toBe('POST with filtered integration');
+      expect(event.request).toEqual(
+        expect.objectContaining({
+          method: 'POST',
+          url: expect.any(String),
+        }),
+      );
+      // Body should NOT be captured when integration is filtered out
+      expect((event.request as Record<string, unknown>).data).toBeUndefined();
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/', {
+    headers: { 'content-type': 'application/json' },
+    data: JSON.stringify({ secret: 'should-not-be-captured' }),
+  });
+
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "worker-name",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+}

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/index.ts
@@ -1,0 +1,38 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    integrations: [
+      Sentry.httpServerIntegration({
+        ignoreRequestBody: url => url.includes('/health') || url.includes('/upload'),
+      }),
+    ],
+  }),
+  {
+    async fetch(request, _env, _ctx) {
+      const url = new URL(request.url);
+
+      if (url.pathname === '/health') {
+        Sentry.captureMessage('Health check');
+        return new Response('ok');
+      }
+
+      if (url.pathname === '/upload') {
+        Sentry.captureMessage('Upload request');
+        return new Response('ok');
+      }
+
+      if (url.pathname === '/api') {
+        Sentry.captureMessage('API request');
+        return new Response('ok');
+      }
+
+      return new Response('Not found', { status: 404 });
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/test.ts
@@ -1,0 +1,56 @@
+import { expect, it } from 'vitest';
+import { createRunner } from '../../../runner';
+
+it('Does not capture body for ignored URLs (health check)', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(envelope => {
+      const event = envelope[1]?.[0]?.[1] as Record<string, unknown>;
+      expect(event.message).toBe('Health check');
+      // Body should NOT be captured because URL contains /health
+      expect((event.request as Record<string, unknown>).data).toBeUndefined();
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/health', {
+    headers: { 'content-type': 'application/json' },
+    data: JSON.stringify({ status: 'checking' }),
+  });
+
+  await runner.completed();
+});
+
+it('Does not capture body for ignored URLs (upload)', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(envelope => {
+      const event = envelope[1]?.[0]?.[1] as Record<string, unknown>;
+      expect(event.message).toBe('Upload request');
+      // Body should NOT be captured because URL contains /upload
+      expect((event.request as Record<string, unknown>).data).toBeUndefined();
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/upload', {
+    headers: { 'content-type': 'application/json' },
+    data: JSON.stringify({ file: 'large-data' }),
+  });
+
+  await runner.completed();
+});
+
+it('Captures body for non-ignored URLs', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(envelope => {
+      const event = envelope[1]?.[0]?.[1] as Record<string, unknown>;
+      expect(event.message).toBe('API request');
+      // Body SHOULD be captured because URL does not match ignore pattern
+      expect((event.request as Record<string, unknown>).data).toBe('{"action":"submit"}');
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/api', {
+    headers: { 'content-type': 'application/json' },
+    data: JSON.stringify({ action: 'submit' }),
+  });
+
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "worker-name",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+}

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/index.ts
@@ -1,0 +1,29 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    integrations: [Sentry.httpServerIntegration({ maxRequestBodySize: 'small' })],
+  }),
+  {
+    async fetch(request, _env, _ctx) {
+      const url = new URL(request.url);
+
+      if (url.pathname === '/small-body') {
+        Sentry.captureMessage('Small body request');
+        return new Response('ok');
+      }
+
+      if (url.pathname === '/large-body') {
+        Sentry.captureMessage('Large body request');
+        return new Response('ok');
+      }
+
+      return new Response('Not found', { status: 404 });
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from 'vitest';
+import { createRunner } from '../../../runner';
+
+it('Captures request body under 1000 bytes with maxRequestBodySize: small', async ({ signal }) => {
+  const smallBody = JSON.stringify({ data: 'x'.repeat(100) });
+
+  const runner = createRunner(__dirname)
+    .expect(envelope => {
+      const event = envelope[1]?.[0]?.[1] as Record<string, unknown>;
+      expect(event.message).toBe('Small body request');
+      expect((event.request as Record<string, unknown>).data).toBe(smallBody);
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/small-body', {
+    headers: { 'content-type': 'application/json' },
+    data: smallBody,
+  });
+
+  await runner.completed();
+});
+
+it('Truncates request body over 1000 bytes with maxRequestBodySize: small', async ({ signal }) => {
+  const largeBody = JSON.stringify({ data: 'x'.repeat(2000) });
+
+  const runner = createRunner(__dirname)
+    .expect(envelope => {
+      const event = envelope[1]?.[0]?.[1] as Record<string, unknown>;
+      expect(event.message).toBe('Large body request');
+      const capturedBody = (event.request as Record<string, unknown>).data as string;
+      // Body should be truncated to ~1000 bytes + "..."
+      expect(capturedBody).toBeDefined();
+      expect(capturedBody.endsWith('...')).toBe(true);
+      expect(capturedBody.length).toBeLessThanOrEqual(1000);
+    })
+    .start(signal);
+
+  await runner.makeRequest('post', '/large-body', {
+    headers: { 'content-type': 'application/json' },
+    data: largeBody,
+  });
+
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "worker-name",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+}

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/index.ts
@@ -1,0 +1,38 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+  }),
+  {
+    async fetch(request, _env, _ctx) {
+      const url = new URL(request.url);
+
+      if (url.pathname === '/post-json') {
+        Sentry.captureMessage('POST JSON request');
+        return new Response('ok');
+      }
+
+      if (url.pathname === '/post-form') {
+        Sentry.captureMessage('POST form request');
+        return new Response('ok');
+      }
+
+      if (url.pathname === '/post-text') {
+        Sentry.captureMessage('POST text request');
+        return new Response('ok');
+      }
+
+      if (url.pathname === '/post-no-body') {
+        Sentry.captureMessage('POST no body request');
+        return new Response('ok');
+      }
+
+      return new Response('Not found', { status: 404 });
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/test.ts
@@ -1,0 +1,95 @@
+import { expect, it } from 'vitest';
+import { eventEnvelope } from '../../../expect';
+import { createRunner } from '../../../runner';
+
+it('Captures JSON request body', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(
+      eventEnvelope({
+        level: 'info',
+        message: 'POST JSON request',
+        request: {
+          headers: expect.any(Object),
+          method: 'POST',
+          url: expect.stringContaining('/post-json'),
+          data: '{"username":"test","action":"login"}',
+        },
+      }),
+    )
+    .start(signal);
+
+  await runner.makeRequest('post', '/post-json', {
+    headers: { 'content-type': 'application/json' },
+    data: JSON.stringify({ username: 'test', action: 'login' }),
+  });
+
+  await runner.completed();
+});
+
+it('Captures form-urlencoded request body', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(
+      eventEnvelope({
+        level: 'info',
+        message: 'POST form request',
+        request: {
+          headers: expect.any(Object),
+          method: 'POST',
+          url: expect.stringContaining('/post-form'),
+          data: 'username=test&password=secret',
+        },
+      }),
+    )
+    .start(signal);
+
+  await runner.makeRequest('post', '/post-form', {
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    data: 'username=test&password=secret',
+  });
+
+  await runner.completed();
+});
+
+it('Captures plain text request body', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(
+      eventEnvelope({
+        level: 'info',
+        message: 'POST text request',
+        request: {
+          headers: expect.any(Object),
+          method: 'POST',
+          url: expect.stringContaining('/post-text'),
+          data: 'This is plain text content',
+        },
+      }),
+    )
+    .start(signal);
+
+  await runner.makeRequest('post', '/post-text', {
+    headers: { 'content-type': 'text/plain' },
+    data: 'This is plain text content',
+  });
+
+  await runner.completed();
+});
+
+it('Does not capture body for POST without content', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expect(
+      eventEnvelope({
+        level: 'info',
+        message: 'POST no body request',
+        request: {
+          headers: expect.any(Object),
+          method: 'POST',
+          url: expect.stringContaining('/post-no-body'),
+        },
+      }),
+    )
+    .start(signal);
+
+  await runner.makeRequest('post', '/post-no-body', {});
+
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "worker-name",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+}

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -122,6 +122,7 @@ export { wrapRequestHandler } from './request';
 export { CloudflareClient } from './client';
 export { getDefaultIntegrations } from './sdk';
 
+export { httpServerIntegration } from './integrations/httpServer';
 export { fetchIntegration } from './integrations/fetch';
 export { vercelAIIntegration } from './integrations/tracing/vercelai';
 export { honoIntegration } from './integrations/hono';

--- a/packages/cloudflare/src/integrations/httpServer.ts
+++ b/packages/cloudflare/src/integrations/httpServer.ts
@@ -92,7 +92,8 @@ export async function captureIncomingRequestBody(client: Client, request: Reques
   }
 
   // Skip GET and HEAD requests - they don't have bodies
-  if (request.method === 'GET' || request.method === 'HEAD') {
+  // Also skip OPTIONS, even if they may have a body, they might not give a lot of extra value
+  if (request.method === 'GET' || request.method === 'HEAD' || request.method === 'OPTIONS') {
     return;
   }
 

--- a/packages/cloudflare/src/integrations/httpServer.ts
+++ b/packages/cloudflare/src/integrations/httpServer.ts
@@ -1,0 +1,105 @@
+import type { Client, IntegrationFn, MaxRequestBodySize } from '@sentry/core';
+import { captureBodyFromWinterCGRequest, defineIntegration, getIsolationScope } from '@sentry/core';
+
+const INTEGRATION_NAME = 'HttpServer';
+
+export interface HttpServerIntegrationOptions {
+  /**
+   * Controls the maximum size of incoming request bodies attached to events.
+   *
+   * Only applies to requests with textual content types (text/*, application/json,
+   * application/x-www-form-urlencoded, application/xml, application/graphql).
+   * Binary data is not captured.
+   *
+   * Available options:
+   * - `'none'`: No request bodies will be attached
+   * - `'small'`: Request bodies up to 1,000 bytes will be attached
+   * - `'medium'`: Request bodies up to 10,000 bytes will be attached (default)
+   * - `'always'`: Request bodies will always be attached (up to 1MB limit)
+   *
+   * @default 'medium'
+   */
+  maxRequestBodySize?: MaxRequestBodySize;
+
+  /**
+   * Do not capture the request body for incoming HTTP requests to URLs where the given callback returns `true`.
+   * This can be useful for long running requests where the body is not needed, health check endpoints,
+   * or requests containing sensitive data that should not be captured.
+   *
+   * @param url The full URL of the incoming request, including query string, protocol, host, etc.
+   * @param request The incoming Request object.
+   * @returns `true` to skip body capture for this request, `false` to capture normally.
+   *
+   * @example
+   * ```ts
+   * Sentry.httpServerIntegration({
+   *   ignoreRequestBody: (url) => url.includes('/health') || url.includes('/upload'),
+   * })
+   * ```
+   */
+  ignoreRequestBody?: (url: string, request: Request) => boolean;
+}
+
+interface HttpServerIntegrationInstance {
+  name: string;
+  maxRequestBodySize: MaxRequestBodySize;
+  ignoreRequestBody?: (url: string, request: Request) => boolean;
+}
+
+const _httpServerIntegration = ((options: HttpServerIntegrationOptions = {}): HttpServerIntegrationInstance => {
+  return {
+    name: INTEGRATION_NAME,
+    maxRequestBodySize: options.maxRequestBodySize ?? 'medium',
+    ignoreRequestBody: options.ignoreRequestBody,
+  };
+}) satisfies IntegrationFn;
+
+/**
+ * Configures incoming HTTP request handling for Cloudflare Workers.
+ *
+ * This integration controls how incoming HTTP request data is captured,
+ * matching the API of `httpServerIntegration` in Node.js.
+ *
+ * @example
+ * ```ts
+ * Sentry.init({
+ *   integrations: [
+ *     Sentry.httpServerIntegration({
+ *       maxRequestBodySize: 'medium',
+ *       ignoreRequestBody: (url) => url.includes('/health'),
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export const httpServerIntegration = defineIntegration(_httpServerIntegration);
+
+/**
+ * Capture the request body based on the HttpServer integration config.
+ * Called internally by `wrapRequestHandler`.
+ */
+export async function captureIncomingRequestBody(client: Client, request: Request): Promise<void> {
+  const integration = client.getIntegrationByName<HttpServerIntegrationInstance>(INTEGRATION_NAME);
+
+  if (!integration) {
+    return;
+  }
+
+  const maxRequestBodySize = integration.maxRequestBodySize;
+
+  if (maxRequestBodySize === 'none') {
+    return;
+  }
+
+  // Skip GET and HEAD requests - they don't have bodies
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    return;
+  }
+
+  if (integration.ignoreRequestBody?.(request.url, request)) {
+    return;
+  }
+
+  const isolationScope = getIsolationScope();
+  await captureBodyFromWinterCGRequest(request, isolationScope, maxRequestBodySize);
+}

--- a/packages/cloudflare/src/request.ts
+++ b/packages/cloudflare/src/request.ts
@@ -12,6 +12,7 @@ import {
   winterCGHeadersToDict,
   withIsolationScope,
 } from '@sentry/core';
+import { captureIncomingRequestBody } from './integrations/httpServer';
 import type { CloudflareOptions } from './client';
 import { flushAndDispose } from './flush';
 import { addCloudResourceContext, addCultureContext, addRequest } from './scope-utils';
@@ -82,6 +83,10 @@ export function wrapRequestHandler(
       if (typeof request.cf.httpProtocol === 'string') {
         attributes['network.protocol.name'] = request.cf.httpProtocol;
       }
+    }
+
+    if (client) {
+      await captureIncomingRequestBody(client, request);
     }
 
     // Do not capture spans for OPTIONS and HEAD requests

--- a/packages/cloudflare/src/request.ts
+++ b/packages/cloudflare/src/request.ts
@@ -85,10 +85,6 @@ export function wrapRequestHandler(
       }
     }
 
-    if (client) {
-      await captureIncomingRequestBody(client, request);
-    }
-
     // Do not capture spans for OPTIONS and HEAD requests
     if (request.method === 'OPTIONS' || request.method === 'HEAD') {
       try {
@@ -101,6 +97,10 @@ export function wrapRequestHandler(
       } finally {
         waitUntil?.(flushAndDispose(client));
       }
+    }
+
+    if (client) {
+      await captureIncomingRequestBody(client, request);
     }
 
     return continueTrace(

--- a/packages/cloudflare/src/sdk.ts
+++ b/packages/cloudflare/src/sdk.ts
@@ -15,6 +15,7 @@ import {
 import type { CloudflareClientOptions, CloudflareOptions } from './client';
 import { CloudflareClient } from './client';
 import { makeFlushLock } from './flush';
+import { httpServerIntegration } from './integrations/httpServer';
 import { fetchIntegration } from './integrations/fetch';
 import { honoIntegration } from './integrations/hono';
 import { setupOpenTelemetryTracer } from './opentelemetry/tracer';
@@ -36,6 +37,7 @@ export function getDefaultIntegrations(options: CloudflareOptions): Integration[
     linkedErrorsIntegration(),
     fetchIntegration(),
     honoIntegration(),
+    httpServerIntegration(),
     // TODO(v11): the `include` object should be defined directly in the integration based on `sendDefaultPii`
     requestDataIntegration(sendDefaultPii ? undefined : { include: { cookies: false } }),
     consoleIntegration(),

--- a/packages/cloudflare/test/instrumentations/instrumentWorkerEntrypoint.test.ts
+++ b/packages/cloudflare/test/instrumentations/instrumentWorkerEntrypoint.test.ts
@@ -341,7 +341,7 @@ describe('instrumentWorkerEntrypoint', () => {
       expect(constructorEnv).toBe(mockEnv);
     });
 
-    it('exposes instrumented DurableObjectNamespace via this.env when enableRpcTracePropagation is enabled', () => {
+    it('exposes instrumented DurableObjectNamespace via this.env when enableRpcTracePropagation is enabled', async () => {
       vi.spyOn(SentryCore, 'getTraceData').mockReturnValue({
         'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
         baggage: 'sentry-environment=production',
@@ -376,7 +376,7 @@ describe('instrumentWorkerEntrypoint', () => {
         TestClass as unknown as WorkerEntrypointConstructor,
       );
       const obj = Reflect.construct(instrumented, [mockContext, mockEnv]);
-      obj.fetch(new Request('https://example.com'));
+      await obj.fetch(new Request('https://example.com'));
 
       expect(rpcMethod).toHaveBeenCalledWith('arg1', {
         __sentry_rpc_meta__: {
@@ -386,7 +386,7 @@ describe('instrumentWorkerEntrypoint', () => {
       });
     });
 
-    it('returns original DurableObjectNamespace via this.env when enableRpcTracePropagation is disabled', () => {
+    it('returns original DurableObjectNamespace via this.env when enableRpcTracePropagation is disabled', async () => {
       vi.spyOn(SentryCore, 'getTraceData').mockReturnValue({
         'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
         baggage: 'sentry-environment=production',
@@ -421,12 +421,12 @@ describe('instrumentWorkerEntrypoint', () => {
         TestClass as unknown as WorkerEntrypointConstructor,
       );
       const obj = Reflect.construct(instrumented, [mockContext, mockEnv]);
-      obj.fetch(new Request('https://example.com'));
+      await obj.fetch(new Request('https://example.com'));
 
       expect(rpcMethod).toHaveBeenCalledWith('arg1');
     });
 
-    it('injects Sentry RPC meta into JSRPC calls via this.env when enableRpcTracePropagation is enabled', () => {
+    it('injects Sentry RPC meta into JSRPC calls via this.env when enableRpcTracePropagation is enabled', async () => {
       vi.spyOn(SentryCore, 'getTraceData').mockReturnValue({
         'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
         baggage: 'sentry-environment=production',
@@ -460,7 +460,7 @@ describe('instrumentWorkerEntrypoint', () => {
         TestClass as unknown as WorkerEntrypointConstructor,
       );
       const obj = Reflect.construct(instrumented, [mockContext, mockEnv]);
-      obj.fetch(new Request('https://example.com'));
+      await obj.fetch(new Request('https://example.com'));
 
       expect(rpcMethod).toHaveBeenCalledWith('arg1', 42, {
         __sentry_rpc_meta__: {
@@ -470,7 +470,7 @@ describe('instrumentWorkerEntrypoint', () => {
       });
     });
 
-    it('does not inject Sentry RPC meta into JSRPC calls via this.env when enableRpcTracePropagation is disabled', () => {
+    it('does not inject Sentry RPC meta into JSRPC calls via this.env when enableRpcTracePropagation is disabled', async () => {
       vi.spyOn(SentryCore, 'getTraceData').mockReturnValue({
         'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
         baggage: 'sentry-environment=production',
@@ -504,12 +504,12 @@ describe('instrumentWorkerEntrypoint', () => {
         TestClass as unknown as WorkerEntrypointConstructor,
       );
       const obj = Reflect.construct(instrumented, [mockContext, mockEnv]);
-      obj.fetch(new Request('https://example.com'));
+      await obj.fetch(new Request('https://example.com'));
 
       expect(rpcMethod).toHaveBeenCalledWith('arg1', 42);
     });
 
-    it('caches instrumented bindings across multiple accesses via this.env', () => {
+    it('caches instrumented bindings across multiple accesses via this.env', async () => {
       const mockContext = createMockExecutionContext();
       const doNamespace = {
         idFromName: vi.fn(),
@@ -535,12 +535,12 @@ describe('instrumentWorkerEntrypoint', () => {
         TestClass as unknown as WorkerEntrypointConstructor,
       );
       const obj = Reflect.construct(instrumented, [mockContext, mockEnv]);
-      obj.fetch(new Request('https://example.com'));
+      await obj.fetch(new Request('https://example.com'));
 
       expect(firstAccess).toBe(secondAccess);
     });
 
-    it('primitive env values are returned unchanged', () => {
+    it('primitive env values are returned unchanged', async () => {
       const mockContext = createMockExecutionContext();
       const mockEnv = { SENTRY_DSN: 'https://key@sentry.io/123', PORT: 8080, DEBUG: true };
 
@@ -562,7 +562,7 @@ describe('instrumentWorkerEntrypoint', () => {
         TestClass as unknown as WorkerEntrypointConstructor,
       );
       const obj = Reflect.construct(instrumented, [mockContext, mockEnv]);
-      obj.fetch(new Request('https://example.com'));
+      await obj.fetch(new Request('https://example.com'));
 
       expect(capturedDsn).toBe('https://key@sentry.io/123');
       expect(capturedPort).toBe(8080);

--- a/packages/cloudflare/test/request.test.ts
+++ b/packages/cloudflare/test/request.test.ts
@@ -262,6 +262,56 @@ describe('withSentry', () => {
       expect(sentryEvent.sdkProcessingMetadata?.normalizedRequest?.data).toBeUndefined();
     });
 
+    test('does not capture request body for HEAD requests', async () => {
+      let sentryEvent: Event = {};
+      const context = createMockExecutionContext();
+
+      await wrapRequestHandler(
+        {
+          options: {
+            ...MOCK_OPTIONS,
+            beforeSend(event) {
+              sentryEvent = event;
+              return null;
+            },
+          },
+          request: new Request('https://example.com', { method: 'HEAD' }),
+          context,
+        },
+        () => {
+          SentryCore.captureMessage('head request');
+          return new Response('test');
+        },
+      );
+
+      expect(sentryEvent.sdkProcessingMetadata?.normalizedRequest?.data).toBeUndefined();
+    });
+
+    test('does not capture request body for OPTIONS requests', async () => {
+      let sentryEvent: Event = {};
+      const context = createMockExecutionContext();
+
+      await wrapRequestHandler(
+        {
+          options: {
+            ...MOCK_OPTIONS,
+            beforeSend(event) {
+              sentryEvent = event;
+              return null;
+            },
+          },
+          request: new Request('https://example.com', { method: 'OPTIONS' }),
+          context,
+        },
+        () => {
+          SentryCore.captureMessage('options request');
+          return new Response('test');
+        },
+      );
+
+      expect(sentryEvent.sdkProcessingMetadata?.normalizedRequest?.data).toBeUndefined();
+    });
+
     test('does not capture request body for binary content types', async () => {
       let sentryEvent: Event = {};
       const context = createMockExecutionContext();

--- a/packages/cloudflare/test/request.test.ts
+++ b/packages/cloudflare/test/request.test.ts
@@ -204,6 +204,92 @@ describe('withSentry', () => {
 
       expect(sentryEvent.contexts?.culture).toEqual({ timezone: 'UTC' });
     });
+
+    test('captures request body with default integration (medium size)', async () => {
+      let sentryEvent: Event = {};
+      const context = createMockExecutionContext();
+
+      await wrapRequestHandler(
+        {
+          options: {
+            ...MOCK_OPTIONS,
+            // Default integrations include httpServerIntegration with 'medium' default
+            beforeSend(event) {
+              sentryEvent = event;
+              return null;
+            },
+          },
+          request: new Request('https://example.com', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ username: 'test', data: 'value' }),
+          }),
+          context,
+        },
+        () => {
+          SentryCore.captureMessage('request body');
+          return new Response('test');
+        },
+      );
+
+      expect(sentryEvent.sdkProcessingMetadata?.normalizedRequest?.data).toEqual(
+        JSON.stringify({ username: 'test', data: 'value' }),
+      );
+    });
+
+    test('does not capture request body for GET requests', async () => {
+      let sentryEvent: Event = {};
+      const context = createMockExecutionContext();
+
+      await wrapRequestHandler(
+        {
+          options: {
+            ...MOCK_OPTIONS,
+            beforeSend(event) {
+              sentryEvent = event;
+              return null;
+            },
+          },
+          request: new Request('https://example.com'),
+          context,
+        },
+        () => {
+          SentryCore.captureMessage('get request');
+          return new Response('test');
+        },
+      );
+
+      expect(sentryEvent.sdkProcessingMetadata?.normalizedRequest?.data).toBeUndefined();
+    });
+
+    test('does not capture request body for binary content types', async () => {
+      let sentryEvent: Event = {};
+      const context = createMockExecutionContext();
+
+      await wrapRequestHandler(
+        {
+          options: {
+            ...MOCK_OPTIONS,
+            beforeSend(event) {
+              sentryEvent = event;
+              return null;
+            },
+          },
+          request: new Request('https://example.com', {
+            method: 'POST',
+            headers: { 'content-type': 'image/png' },
+            body: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+          }),
+          context,
+        },
+        () => {
+          SentryCore.captureMessage('binary');
+          return new Response('test');
+        },
+      );
+
+      expect(sentryEvent.sdkProcessingMetadata?.normalizedRequest?.data).toBeUndefined();
+    });
   });
 
   describe('error instrumentation', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,11 +112,15 @@ export { shouldIgnoreSpan } from './utils/should-ignore-span';
 export {
   winterCGHeadersToDict,
   winterCGRequestToRequestData,
+  captureBodyFromWinterCGRequest,
   httpRequestToRequestData,
   extractQueryParamsFromUrl,
   headersToDict,
   httpHeadersToSpanAttributes,
+  getMaxBodyByteLength,
+  MAX_BODY_BYTE_LENGTH,
 } from './utils/request';
+export type { MaxRequestBodySize } from './utils/request';
 export { DEFAULT_ENVIRONMENT, DEV_ENVIRONMENT } from './constants';
 export { addBreadcrumb } from './breadcrumbs';
 export { functionToStringIntegration } from './integrations/functiontostring';

--- a/packages/core/src/types-hoist/webfetchapi.ts
+++ b/packages/core/src/types-hoist/webfetchapi.ts
@@ -13,5 +13,7 @@ export interface WebFetchRequest {
   readonly headers: WebFetchHeaders;
   readonly method: string;
   readonly url: string;
+  readonly body?: unknown;
   clone(): WebFetchRequest;
+  text(): Promise<string>;
 }

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -5,6 +5,7 @@ import type { PolymorphicRequest } from '../types-hoist/polymorphics';
 import type { RequestEventData } from '../types-hoist/request';
 import type { WebFetchHeaders, WebFetchRequest } from '../types-hoist/webfetchapi';
 import { debug } from './debug-logger';
+import { safeUnref } from './timer';
 
 /**
  * Maximum size of incoming HTTP request bodies attached to events.
@@ -31,7 +32,7 @@ const TEXT_CONTENT_TYPES = [
 /**
  * Convert a `maxRequestBodySize` setting to a maximum byte length.
  */
-export function getMaxBodyByteLength(maxRequestBodySize: MaxRequestBodySize): number {
+export function getMaxBodyByteLength(maxRequestBodySize: Omit<MaxRequestBodySize, 'none'>): number {
   if (maxRequestBodySize === 'small') return 1_000;
   if (maxRequestBodySize === 'medium') return 10_000;
   return MAX_BODY_BYTE_LENGTH;
@@ -146,7 +147,7 @@ export async function captureBodyFromWinterCGRequest(
     const clonedRequest = request.clone();
     const bodyPromise = clonedRequest.text();
     const timeoutPromise = new Promise<null>(resolve => {
-      setTimeout(() => resolve(null), 2000);
+      safeUnref(setTimeout(() => resolve(null), 2000));
     });
 
     const body = await Promise.race([bodyPromise, timeoutPromise]);

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -1,6 +1,41 @@
+/* eslint-disable max-lines-per-function */
+import { DEBUG_BUILD } from '../debug-build';
+import type { Scope } from '../scope';
 import type { PolymorphicRequest } from '../types-hoist/polymorphics';
 import type { RequestEventData } from '../types-hoist/request';
 import type { WebFetchHeaders, WebFetchRequest } from '../types-hoist/webfetchapi';
+import { debug } from './debug-logger';
+
+/**
+ * Maximum size of incoming HTTP request bodies attached to events.
+ *
+ * - `'none'`: No request bodies will be attached
+ * - `'small'`: Request bodies up to 1,000 bytes will be attached
+ * - `'medium'`: Request bodies up to 10,000 bytes will be attached
+ * - `'always'`: Request bodies will always be attached (up to 1MB hard cap)
+ */
+export type MaxRequestBodySize = 'none' | 'small' | 'medium' | 'always';
+
+/** Hard cap on captured body size, even when `maxRequestBodySize` is `'always'`. */
+export const MAX_BODY_BYTE_LENGTH = 1_024 * 1_024;
+
+/** Content types that are safe to capture as text. */
+const TEXT_CONTENT_TYPES = [
+  'text/',
+  'application/json',
+  'application/x-www-form-urlencoded',
+  'application/xml',
+  'application/graphql',
+];
+
+/**
+ * Convert a `maxRequestBodySize` setting to a maximum byte length.
+ */
+export function getMaxBodyByteLength(maxRequestBodySize: MaxRequestBodySize): number {
+  if (maxRequestBodySize === 'small') return 1_000;
+  if (maxRequestBodySize === 'medium') return 10_000;
+  return MAX_BODY_BYTE_LENGTH;
+}
 
 /**
  * Transforms a `Headers` object that implements the `Web Fetch API` (https://developer.mozilla.org/en-US/docs/Web/API/Headers) into a simple key-value dict.
@@ -54,6 +89,96 @@ export function winterCGRequestToRequestData(req: WebFetchRequest): RequestEvent
     headers,
     // TODO: Can we extract body data from the request?
   };
+}
+
+/**
+ * Checks if the content type is textual and safe to capture.
+ */
+function isTextualContentType(contentType: string | null): boolean {
+  if (!contentType) {
+    return false;
+  }
+  const lowerContentType = contentType.toLowerCase();
+  return TEXT_CONTENT_TYPES.some(type => lowerContentType.includes(type));
+}
+
+/**
+ * Captures the body from a Web Fetch API Request and adds it to the isolation scope.
+ *
+ * This function clones the request to read the body without affecting the original.
+ * Only textual content types are captured - binary data is skipped.
+ *
+ * This is used by WinterCG-compatible runtimes (Cloudflare Workers, Deno, Bun, Vercel Edge, etc.)
+ * that use the Web Fetch API Request object.
+ *
+ * @param request - The incoming Web Fetch API Request
+ * @param isolationScope - The isolation scope to add the body to
+ * @param maxRequestBodySize - The maximum size of the request body to capture ('small' = 1KB, 'medium' = 10KB, 'always' = 1MB)
+ */
+export async function captureBodyFromWinterCGRequest(
+  request: WebFetchRequest,
+  isolationScope: Scope,
+  maxRequestBodySize: Exclude<MaxRequestBodySize, 'none'>,
+): Promise<void> {
+  try {
+    const contentType = request.headers.get('content-type');
+
+    if (!isTextualContentType(contentType)) {
+      DEBUG_BUILD && debug.log('Skipping body capture for non-textual content type:', contentType);
+      return;
+    }
+
+    if (!request.body) {
+      return;
+    }
+
+    const contentLength = request.headers.get('content-length');
+    const maxBodySize = getMaxBodyByteLength(maxRequestBodySize);
+
+    if (contentLength) {
+      const length = parseInt(contentLength, 10);
+      if (!isNaN(length) && length > MAX_BODY_BYTE_LENGTH) {
+        DEBUG_BUILD && debug.log('Skipping body capture: body too large', length);
+        return;
+      }
+    }
+
+    const clonedRequest = request.clone();
+    const bodyPromise = clonedRequest.text();
+    const timeoutPromise = new Promise<null>(resolve => {
+      setTimeout(() => resolve(null), 2000);
+    });
+
+    const body = await Promise.race([bodyPromise, timeoutPromise]);
+
+    if (body === null) {
+      DEBUG_BUILD && debug.log('Timeout reading request body');
+      return;
+    }
+
+    if (!body) {
+      return;
+    }
+
+    // Using TextEncoder to get byte length for UTF-8 strings
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(body);
+    const bodyByteLength = bytes.length;
+
+    let truncatedBody: string;
+    if (bodyByteLength > maxBodySize) {
+      const decoder = new TextDecoder();
+      truncatedBody = `${decoder.decode(bytes.slice(0, maxBodySize - 3))}...`;
+    } else {
+      truncatedBody = body;
+    }
+
+    isolationScope.setSDKProcessingMetadata({ normalizedRequest: { data: truncatedBody } });
+
+    DEBUG_BUILD && debug.log('Captured request body:', bodyByteLength, 'bytes');
+  } catch (error) {
+    DEBUG_BUILD && debug.error('Error capturing request body:', error);
+  }
 }
 
 /**

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -32,7 +32,7 @@ const TEXT_CONTENT_TYPES = [
 /**
  * Convert a `maxRequestBodySize` setting to a maximum byte length.
  */
-export function getMaxBodyByteLength(maxRequestBodySize: Omit<MaxRequestBodySize, 'none'>): number {
+export function getMaxBodyByteLength(maxRequestBodySize: Exclude<MaxRequestBodySize, 'none'>): number {
   if (maxRequestBodySize === 'small') return 1_000;
   if (maxRequestBodySize === 'medium') return 10_000;
   return MAX_BODY_BYTE_LENGTH;

--- a/packages/core/test/lib/utils/request.test.ts
+++ b/packages/core/test/lib/utils/request.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  captureBodyFromWinterCGRequest,
   extractQueryParamsFromUrl,
   headersToDict,
   httpHeadersToSpanAttributes,
@@ -7,6 +8,7 @@ import {
   winterCGHeadersToDict,
   winterCGRequestToRequestData,
 } from '../../../src/utils/request';
+import type { Scope } from '../../../src/scope';
 
 describe('request utils', () => {
   describe('winterCGHeadersToDict', () => {
@@ -849,6 +851,294 @@ describe('request utils', () => {
           'http.response.header.cookie.session': '[Filtered]',
         });
       });
+    });
+  });
+
+  describe('captureBodyFromWinterCGRequest', () => {
+    function createMockRequest(options: {
+      body?: string | null;
+      contentType?: string;
+      contentLength?: string;
+    }): Request {
+      const headers = new Headers();
+      if (options.contentType) {
+        headers.set('content-type', options.contentType);
+      }
+      if (options.contentLength) {
+        headers.set('content-length', options.contentLength);
+      }
+
+      return new Request('https://example.com/test', {
+        method: 'POST',
+        headers,
+        body: options.body ?? undefined,
+      });
+    }
+
+    function createMockScope(): Scope & { capturedData: unknown } {
+      const scope = {
+        capturedData: undefined as unknown,
+        setSDKProcessingMetadata(metadata: { normalizedRequest?: { data?: unknown } }) {
+          scope.capturedData = metadata.normalizedRequest?.data;
+        },
+      };
+      return scope as Scope & { capturedData: unknown };
+    }
+
+    it('captures JSON body', async () => {
+      const jsonBody = JSON.stringify({ userId: 42, email: 'user@example.com', action: 'update_profile' });
+      const request = createMockRequest({
+        body: jsonBody,
+        contentType: 'application/json',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBe(jsonBody);
+    });
+
+    it('captures form-urlencoded body', async () => {
+      const request = createMockRequest({
+        body: 'username=test&password=secret',
+        contentType: 'application/x-www-form-urlencoded',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBe('username=test&password=secret');
+    });
+
+    it('captures text/plain body', async () => {
+      const request = createMockRequest({
+        body: 'Hello, World!',
+        contentType: 'text/plain',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBe('Hello, World!');
+    });
+
+    it('captures text/html body', async () => {
+      const request = createMockRequest({
+        body: '<html><body>Test</body></html>',
+        contentType: 'text/html',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBe('<html><body>Test</body></html>');
+    });
+
+    it('captures application/xml body', async () => {
+      const request = createMockRequest({
+        body: '<root><item>value</item></root>',
+        contentType: 'application/xml',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBe('<root><item>value</item></root>');
+    });
+
+    it('captures application/graphql body', async () => {
+      const request = createMockRequest({
+        body: 'query { user { name } }',
+        contentType: 'application/graphql',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBe('query { user { name } }');
+    });
+
+    it('skips non-textual content types', async () => {
+      const request = createMockRequest({
+        body: 'binary data',
+        contentType: 'application/octet-stream',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBeUndefined();
+    });
+
+    it('skips image content types', async () => {
+      const request = createMockRequest({
+        body: 'image data',
+        contentType: 'image/png',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBeUndefined();
+    });
+
+    it('skips when content-type is explicitly non-textual', async () => {
+      const request = {
+        headers: {
+          get: (name: string) => (name === 'content-type' ? null : null),
+        },
+        body: {},
+        clone: () => ({
+          text: () => Promise.resolve('some data'),
+        }),
+      } as unknown as Request;
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBeUndefined();
+    });
+
+    it('skips when body is null', async () => {
+      const request = createMockRequest({
+        body: null,
+        contentType: 'application/json',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBeUndefined();
+    });
+
+    it('skips when body is empty', async () => {
+      const request = createMockRequest({
+        body: '',
+        contentType: 'application/json',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBeUndefined();
+    });
+
+    it('truncates body when it exceeds small size limit (1000 bytes)', async () => {
+      const largeBody = 'x'.repeat(2000);
+      const request = createMockRequest({
+        body: largeBody,
+        contentType: 'text/plain',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'small');
+
+      expect(scope.capturedData).toHaveLength(1000);
+      expect((scope.capturedData as string).endsWith('...')).toBe(true);
+    });
+
+    it('truncates body when it exceeds medium size limit (10000 bytes)', async () => {
+      const largeBody = 'x'.repeat(20000);
+      const request = createMockRequest({
+        body: largeBody,
+        contentType: 'text/plain',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toHaveLength(10000);
+      expect((scope.capturedData as string).endsWith('...')).toBe(true);
+    });
+
+    it('does not truncate body within small size limit', async () => {
+      const smallBody = 'x'.repeat(500);
+      const request = createMockRequest({
+        body: smallBody,
+        contentType: 'text/plain',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'small');
+
+      expect(scope.capturedData).toBe(smallBody);
+    });
+
+    it('skips when content-length exceeds 1MB limit', async () => {
+      const request = createMockRequest({
+        body: 'small body',
+        contentType: 'application/json',
+        contentLength: '2000000',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'always');
+
+      expect(scope.capturedData).toBeUndefined();
+    });
+
+    it('captures body with always size limit', async () => {
+      const largeBody = 'x'.repeat(50000);
+      const request = createMockRequest({
+        body: largeBody,
+        contentType: 'text/plain',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'always');
+
+      expect(scope.capturedData).toBe(largeBody);
+    });
+
+    it('handles content-type with charset', async () => {
+      const request = createMockRequest({
+        body: '{"test":"value"}',
+        contentType: 'application/json; charset=utf-8',
+      });
+      const scope = createMockScope();
+
+      await captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      expect(scope.capturedData).toBe('{"test":"value"}');
+    });
+
+    it('does not throw on errors', async () => {
+      const request = {
+        headers: {
+          get: () => {
+            throw new Error('Test error');
+          },
+        },
+        body: 'test',
+        clone: () => request,
+      } as unknown as Request;
+      const scope = createMockScope();
+
+      await expect(captureBodyFromWinterCGRequest(request, scope, 'medium')).resolves.not.toThrow();
+      expect(scope.capturedData).toBeUndefined();
+    });
+
+    it('handles timeout gracefully', async () => {
+      vi.useFakeTimers();
+
+      const neverResolve = new Promise<string>(() => {});
+      const request = {
+        headers: new Headers({ 'content-type': 'application/json' }),
+        body: {},
+        clone: () => ({
+          text: () => neverResolve,
+        }),
+      } as unknown as Request;
+      const scope = createMockScope();
+
+      const promise = captureBodyFromWinterCGRequest(request, scope, 'medium');
+
+      await vi.advanceTimersByTimeAsync(2500);
+      await promise;
+
+      expect(scope.capturedData).toBeUndefined();
+
+      vi.useRealTimers();
     });
   });
 });

--- a/packages/node-core/src/integrations/http/constants.ts
+++ b/packages/node-core/src/integrations/http/constants.ts
@@ -1,4 +1,1 @@
 export const INSTRUMENTATION_NAME = '@sentry/instrumentation-http';
-
-/** We only want to capture request bodies up to 1mb. */
-export const MAX_BODY_BYTE_LENGTH = 1024 * 1024;

--- a/packages/node-core/src/utils/captureRequestBody.ts
+++ b/packages/node-core/src/utils/captureRequestBody.ts
@@ -12,7 +12,7 @@ import { DEBUG_BUILD } from '../debug-build';
 export function patchRequestToCaptureBody(
   req: IncomingMessage,
   isolationScope: Scope,
-  maxIncomingRequestBodySize: MaxRequestBodySize,
+  maxIncomingRequestBodySize: Omit<MaxRequestBodySize, 'none'>,
   integrationName: string,
 ): void {
   let bodyByteLength = 0;

--- a/packages/node-core/src/utils/captureRequestBody.ts
+++ b/packages/node-core/src/utils/captureRequestBody.ts
@@ -1,8 +1,7 @@
 import type { IncomingMessage } from 'node:http';
 import type { Scope } from '@sentry/core';
-import { debug } from '@sentry/core';
+import { debug, getMaxBodyByteLength, type MaxRequestBodySize } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
-import { MAX_BODY_BYTE_LENGTH } from '../integrations/http/constants';
 
 /**
  * This method patches the request object to capture the body.
@@ -13,7 +12,7 @@ import { MAX_BODY_BYTE_LENGTH } from '../integrations/http/constants';
 export function patchRequestToCaptureBody(
   req: IncomingMessage,
   isolationScope: Scope,
-  maxIncomingRequestBodySize: 'small' | 'medium' | 'always',
+  maxIncomingRequestBodySize: MaxRequestBodySize,
   integrationName: string,
 ): void {
   let bodyByteLength = 0;
@@ -28,12 +27,7 @@ export function patchRequestToCaptureBody(
    */
   const callbackMap = new WeakMap();
 
-  const maxBodySize =
-    maxIncomingRequestBodySize === 'small'
-      ? 1_000
-      : maxIncomingRequestBodySize === 'medium'
-        ? 10_000
-        : MAX_BODY_BYTE_LENGTH;
+  const maxBodySize = getMaxBodyByteLength(maxIncomingRequestBodySize);
 
   try {
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/node-core/src/utils/captureRequestBody.ts
+++ b/packages/node-core/src/utils/captureRequestBody.ts
@@ -12,7 +12,7 @@ import { DEBUG_BUILD } from '../debug-build';
 export function patchRequestToCaptureBody(
   req: IncomingMessage,
   isolationScope: Scope,
-  maxIncomingRequestBodySize: Omit<MaxRequestBodySize, 'none'>,
+  maxIncomingRequestBodySize: Exclude<MaxRequestBodySize, 'none'>,
   integrationName: string,
 ): void {
   let bodyByteLength = 0;


### PR DESCRIPTION
closes #17079
closes [JS-751](https://linear.app/getsentry/issue/JS-751/capture-request-body-in-cloudflare-workers)

This PR is basically adding and exporting `captureBodyFromWinterCGRequest` from `@sentry/core` and re-implementing `httpServerIntegration` for Cloudflare. There was no way to reuse the existing `httpServerIntegration`, as it is using `patchRequestToCaptureBody`, which wouldn't work in Cloudflare, as there is too late to be patched, so `captureBodyFromWinterCGRequest` was born. 

The original `httpServerIntegration` is also taking care of other SDK processing metadata via `httpRequestToRequestData`, which happens already for every request in Cloudflare via the `addHandler` in the [`scope-utils.ts`](https://github.com/getsentry/sentry-javascript/blob/99564760ce7914898d85ab83762b1531aec3d53a/packages/cloudflare/src/scope-utils.ts#L27). I still tried to reuse as much code as possible (that's the reason for the new exposed functionality in `@sentry/core`).

Two options from the original integration are missing `sessions` and `sessionFlushingDelayMS`. I don't think this can be implemented 1:1, that is why I left it out, as the sessions seem to be aggregated, which wouldn't work in Cloudflare, as we generate a new client for each request. And I think it is better if we don't enable that by default, as otherwise every request would send a session by default.

In theory this would also be usable for other runtimes like Bun or Deno if I'm not mistaken