### PR TITLE
feat(nitro): Add unstorage tracing channel instrumentation

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nitro-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/package.json
@@ -19,7 +19,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "latest || *",
-    "nitro": "^3.0.260415-beta",
+    "nitro": "^3.0.260429-beta",
     "rolldown": "latest",
     "vite": "latest"
   },

--- a/dev-packages/e2e-tests/test-applications/nitro-3/server/api/test-cache.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/server/api/test-cache.ts
@@ -1,0 +1,82 @@
+import { defineCachedFunction, defineCachedHandler } from 'nitro/cache';
+import { defineHandler, getQuery } from 'nitro/h3';
+
+const getCachedUser = defineCachedFunction(
+  async (userId: string) => {
+    return {
+      id: userId,
+      name: `User ${userId}`,
+      email: `user${userId}@example.com`,
+      timestamp: Date.now(),
+    };
+  },
+  {
+    maxAge: 60,
+    name: 'getCachedUser',
+    getKey: (userId: string) => `user:${userId}`,
+  },
+);
+
+const getCachedData = defineCachedFunction(
+  async (key: string) => {
+    return {
+      key,
+      value: `cached-value-${key}`,
+      timestamp: Date.now(),
+    };
+  },
+  {
+    maxAge: 120,
+    name: 'getCachedData',
+    getKey: (key: string) => `data:${key}`,
+  },
+);
+
+const cachedHandler = defineCachedHandler(
+  async event => {
+    return {
+      message: 'This response is cached',
+      timestamp: Date.now(),
+      path: event.path,
+    };
+  },
+  {
+    maxAge: 60,
+    name: 'cachedHandler',
+  },
+);
+
+export default defineHandler(async event => {
+  const results: Record<string, unknown> = {};
+  const testKey = String(getQuery(event).user ?? '123');
+  const dataKey = String(getQuery(event).data ?? 'test-key');
+
+  // cachedFunction - first call (cache miss)
+  const user1 = await getCachedUser(testKey);
+  results.cachedUser1 = user1;
+
+  // cachedFunction - second call (cache hit)
+  const user2 = await getCachedUser(testKey);
+  results.cachedUser2 = user2;
+
+  // cachedFunction with different key (cache miss)
+  const user3 = await getCachedUser(`${testKey}456`);
+  results.cachedUser3 = user3;
+
+  // another cachedFunction
+  const data1 = await getCachedData(dataKey);
+  results.cachedData1 = data1;
+
+  // cachedFunction - cache hit
+  const data2 = await getCachedData(dataKey);
+  results.cachedData2 = data2;
+
+  // cachedEventHandler
+  const cachedResponse = await cachedHandler(event);
+  results.cachedResponse = cachedResponse;
+
+  return {
+    success: true,
+    results,
+  };
+});

--- a/dev-packages/e2e-tests/test-applications/nitro-3/server/api/test-storage-aliases.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/server/api/test-storage-aliases.ts
@@ -1,0 +1,45 @@
+import { defineHandler } from 'nitro/h3';
+import { useStorage } from 'nitro/storage';
+
+export default defineHandler(async () => {
+  const storage = useStorage('cache');
+
+  const results: Record<string, unknown> = {};
+
+  // Test set (alias for setItem)
+  await storage.set('alias:user', { name: 'Jane Doe', role: 'admin' });
+  results.set = 'success';
+
+  // Test get (alias for getItem)
+  const user = await storage.get('alias:user');
+  results.get = user;
+
+  // Test has (alias for hasItem)
+  const hasUser = await storage.has('alias:user');
+  results.has = hasUser;
+
+  // Setup for delete tests
+  await storage.set('alias:temp1', 'temp1');
+  await storage.set('alias:temp2', 'temp2');
+
+  // Test del (alias for removeItem)
+  await storage.del('alias:temp1');
+  results.del = 'success';
+
+  // Test remove (alias for removeItem)
+  await storage.remove('alias:temp2');
+  results.remove = 'success';
+
+  // Verify deletions worked
+  const hasTemp1 = await storage.has('alias:temp1');
+  const hasTemp2 = await storage.has('alias:temp2');
+  results.verifyDeletions = !hasTemp1 && !hasTemp2;
+
+  // Clean up
+  await storage.clear();
+
+  return {
+    success: true,
+    results,
+  };
+});

--- a/dev-packages/e2e-tests/test-applications/nitro-3/server/api/test-storage.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/server/api/test-storage.ts
@@ -1,0 +1,53 @@
+import { defineHandler } from 'nitro/h3';
+import { useStorage } from 'nitro/storage';
+
+export default defineHandler(async () => {
+  const storage = useStorage('cache');
+
+  const results: Record<string, unknown> = {};
+
+  // Test setItem
+  await storage.setItem('user:123', { name: 'John Doe', email: 'john@example.com' });
+  results.setItem = 'success';
+
+  // Test setItemRaw
+  await storage.setItemRaw('raw:data', Buffer.from('raw data'));
+  results.setItemRaw = 'success';
+
+  // Manually set batch items
+  await storage.setItem('batch:1', 'value1');
+  await storage.setItem('batch:2', 'value2');
+
+  // Test hasItem
+  const hasUser = await storage.hasItem('user:123');
+  results.hasItem = hasUser;
+
+  // Test getItem
+  const user = await storage.getItem('user:123');
+  results.getItem = user;
+
+  // Test getItemRaw
+  const rawData = await storage.getItemRaw('raw:data');
+  results.getItemRaw = rawData?.toString();
+
+  // Test getKeys
+  const keys = await storage.getKeys('batch:');
+  results.getKeys = keys;
+
+  // Test removeItem
+  await storage.removeItem('batch:1');
+  results.removeItem = 'success';
+
+  // Test clear
+  await storage.clear();
+  results.clear = 'success';
+
+  // Verify clear worked
+  const keysAfterClear = await storage.getKeys();
+  results.keysAfterClear = keysAfterClear;
+
+  return {
+    success: true,
+    results,
+  };
+});

--- a/dev-packages/e2e-tests/test-applications/nitro-3/tests/cache.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/tests/cache.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/nitro';
+
+test.describe('Cache Instrumentation', () => {
+  const SEMANTIC_ATTRIBUTE_CACHE_KEY = 'cache.key';
+  const SEMANTIC_ATTRIBUTE_CACHE_HIT = 'cache.hit';
+
+  test('instruments cachedFunction and cachedHandler calls and creates spans with correct attributes', async ({
+    request,
+  }) => {
+    const transactionPromise = waitForTransaction('nitro-3', transactionEvent => {
+      return transactionEvent.transaction?.includes('GET /api/test-cache') ?? false;
+    });
+
+    const response = await request.get('/api/test-cache');
+    expect(response.status()).toBe(200);
+
+    const transaction = await transactionPromise;
+
+    const findSpansByOp = (op: string) => {
+      return transaction.spans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === op) || [];
+    };
+
+    const allCacheSpans = transaction.spans?.filter(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] === 'auto.cache.nitro',
+    );
+    expect(allCacheSpans?.length).toBeGreaterThan(0);
+
+    // getItem spans for cachedFunction - should have both cache miss and cache hit
+    const getItemSpans = findSpansByOp('cache.get_item');
+    expect(getItemSpans.length).toBeGreaterThan(0);
+
+    // Find cache miss (first call to getCachedUser('123'))
+    const cacheMissSpan = getItemSpans.find(
+      span =>
+        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
+        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123') &&
+        !span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT],
+    );
+    if (cacheMissSpan) {
+      expect(cacheMissSpan.data).toMatchObject({
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+        [SEMANTIC_ATTRIBUTE_CACHE_HIT]: false,
+        'db.operation.name': 'getItem',
+      });
+    }
+
+    // Find cache hit (second call to getCachedUser('123'))
+    const cacheHitSpan = getItemSpans.find(
+      span =>
+        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
+        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123') &&
+        span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT],
+    );
+    if (cacheHitSpan) {
+      expect(cacheHitSpan.data).toMatchObject({
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+        [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
+        'db.operation.name': 'getItem',
+      });
+    }
+
+    // setItem spans for cachedFunction - when cache miss occurs, value is set
+    const setItemSpans = findSpansByOp('cache.set_item');
+    expect(setItemSpans.length).toBeGreaterThan(0);
+
+    const cacheSetSpan = setItemSpans.find(
+      span =>
+        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
+        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123'),
+    );
+    if (cacheSetSpan) {
+      expect(cacheSetSpan.data).toMatchObject({
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.set_item',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+        'db.operation.name': 'setItem',
+      });
+    }
+
+    // Spans for different cached functions
+    const dataKeySpans = getItemSpans.filter(
+      span =>
+        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
+        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('data:test-key'),
+    );
+    expect(dataKeySpans.length).toBeGreaterThan(0);
+
+    // Spans for cachedHandler
+    const cachedHandlerSpans = getItemSpans.filter(
+      span =>
+        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
+        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('cachedHandler'),
+    );
+    expect(cachedHandlerSpans.length).toBeGreaterThan(0);
+
+    // Verify all cache spans have OK status
+    allCacheSpans?.forEach(span => {
+      expect(span.status).toBe('ok');
+    });
+
+    // Verify cache spans are properly nested under the transaction
+    allCacheSpans?.forEach(span => {
+      expect(span.parent_span_id).toBeDefined();
+    });
+  });
+
+  test('correctly tracks cache hits and misses for cachedFunction', async ({ request }) => {
+    const uniqueUser = `test-${Date.now()}`;
+    const uniqueData = `data-${Date.now()}`;
+
+    const transactionPromise = waitForTransaction('nitro-3', transactionEvent => {
+      return transactionEvent.transaction?.includes('GET /api/test-cache') ?? false;
+    });
+
+    await request.get(`/api/test-cache?user=${uniqueUser}&data=${uniqueData}`);
+    const transaction = await transactionPromise;
+
+    const allCacheSpans = transaction.spans?.filter(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] === 'auto.cache.nitro',
+    );
+    expect(allCacheSpans?.length).toBeGreaterThan(0);
+
+    const allGetItemSpans = allCacheSpans?.filter(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'cache.get_item',
+    );
+    const allSetItemSpans = allCacheSpans?.filter(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'cache.set_item',
+    );
+
+    expect(allGetItemSpans?.length).toBeGreaterThan(0);
+    expect(allSetItemSpans?.length).toBeGreaterThan(0);
+
+    const cacheMissSpans = allGetItemSpans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT] === false);
+    const cacheHitSpans = allGetItemSpans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT] === true);
+
+    // At least one cache miss (first calls to getCachedUser and getCachedData)
+    expect(cacheMissSpans?.length).toBeGreaterThanOrEqual(1);
+
+    // At least one cache hit (second calls to getCachedUser and getCachedData)
+    expect(cacheHitSpans?.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/nitro-3/tests/cache.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/tests/cache.test.ts
@@ -38,14 +38,13 @@ test.describe('Cache Instrumentation', () => {
         span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123') &&
         !span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT],
     );
-    if (cacheMissSpan) {
-      expect(cacheMissSpan.data).toMatchObject({
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
-        [SEMANTIC_ATTRIBUTE_CACHE_HIT]: false,
-        'db.operation.name': 'getItem',
-      });
-    }
+    expect(cacheMissSpan).toBeDefined();
+    expect(cacheMissSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: false,
+      'db.operation.name': 'getItem',
+    });
 
     // Find cache hit (second call to getCachedUser('123'))
     const cacheHitSpan = getItemSpans.find(
@@ -54,14 +53,13 @@ test.describe('Cache Instrumentation', () => {
         span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123') &&
         span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT],
     );
-    if (cacheHitSpan) {
-      expect(cacheHitSpan.data).toMatchObject({
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
-        [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
-        'db.operation.name': 'getItem',
-      });
-    }
+    expect(cacheHitSpan).toBeDefined();
+    expect(cacheHitSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
+      'db.operation.name': 'getItem',
+    });
 
     // setItem spans for cachedFunction - when cache miss occurs, value is set
     const setItemSpans = findSpansByOp('cache.set_item');
@@ -72,13 +70,12 @@ test.describe('Cache Instrumentation', () => {
         typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
         span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123'),
     );
-    if (cacheSetSpan) {
-      expect(cacheSetSpan.data).toMatchObject({
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.set_item',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
-        'db.operation.name': 'setItem',
-      });
-    }
+    expect(cacheSetSpan).toBeDefined();
+    expect(cacheSetSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.set_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      'db.operation.name': 'setItem',
+    });
 
     // Spans for different cached functions
     const dataKeySpans = getItemSpans.filter(

--- a/dev-packages/e2e-tests/test-applications/nitro-3/tests/storage-aliases.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/tests/storage-aliases.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/nitro';
+
+test.describe('Storage Instrumentation - Aliases', () => {
+  const prefixKey = (key: string) => `cache:${key}`;
+  const SEMANTIC_ATTRIBUTE_CACHE_KEY = 'cache.key';
+  const SEMANTIC_ATTRIBUTE_CACHE_HIT = 'cache.hit';
+
+  test('instruments storage alias methods (get, set, has, del, remove) and creates spans', async ({ request }) => {
+    const transactionPromise = waitForTransaction('nitro-3', transactionEvent => {
+      return transactionEvent.transaction?.includes('GET /api/test-storage-aliases') ?? false;
+    });
+
+    const response = await request.get('/api/test-storage-aliases');
+    expect(response.status()).toBe(200);
+
+    const transaction = await transactionPromise;
+
+    // Helper to find spans by operation
+    const findSpansByOp = (op: string) => {
+      return transaction.spans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === op) || [];
+    };
+
+    // Test set (alias for setItem)
+    const setSpans = findSpansByOp('cache.set_item');
+    expect(setSpans.length).toBeGreaterThanOrEqual(1);
+    const setSpan = setSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:user'));
+    expect(setSpan).toBeDefined();
+    expect(setSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.set_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:user'),
+      'db.operation.name': 'setItem',
+      'db.system.name': expect.any(String),
+    });
+    expect(setSpan?.description).toBe(prefixKey('alias:user'));
+
+    // Test get (alias for getItem)
+    const getSpans = findSpansByOp('cache.get_item');
+    expect(getSpans.length).toBeGreaterThanOrEqual(1);
+    const getSpan = getSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:user'));
+    expect(getSpan).toBeDefined();
+    expect(getSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:user'),
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
+      'db.operation.name': 'getItem',
+      'db.system.name': expect.any(String),
+    });
+    expect(getSpan?.description).toBe(prefixKey('alias:user'));
+
+    // Test has (alias for hasItem)
+    const hasSpans = findSpansByOp('cache.has_item');
+    expect(hasSpans.length).toBeGreaterThanOrEqual(1);
+    const hasSpan = hasSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:user'));
+    expect(hasSpan).toBeDefined();
+    expect(hasSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.has_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:user'),
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
+      'db.operation.name': 'hasItem',
+      'db.system.name': expect.any(String),
+    });
+
+    // Test del and remove (both aliases for removeItem)
+    const removeSpans = findSpansByOp('cache.remove_item');
+    expect(removeSpans.length).toBeGreaterThanOrEqual(2);
+
+    const delSpan = removeSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:temp1'));
+    expect(delSpan).toBeDefined();
+    expect(delSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.remove_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:temp1'),
+      'db.operation.name': 'removeItem',
+      'db.system.name': expect.any(String),
+    });
+    expect(delSpan?.description).toBe(prefixKey('alias:temp1'));
+
+    const removeSpan = removeSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:temp2'));
+    expect(removeSpan).toBeDefined();
+    expect(removeSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.remove_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:temp2'),
+      'db.operation.name': 'removeItem',
+      'db.system.name': expect.any(String),
+    });
+    expect(removeSpan?.description).toBe(prefixKey('alias:temp2'));
+
+    // Verify all spans have OK status
+    const allStorageSpans = transaction.spans?.filter(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] === 'auto.cache.nitro',
+    );
+    expect(allStorageSpans?.length).toBeGreaterThan(0);
+    allStorageSpans?.forEach(span => {
+      expect(span.status).toBe('ok');
+    });
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/nitro-3/tests/storage.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/tests/storage.test.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/nitro';
+
+test.describe('Storage Instrumentation', () => {
+  const prefixKey = (key: string) => `cache:${key}`;
+  const SEMANTIC_ATTRIBUTE_CACHE_KEY = 'cache.key';
+  const SEMANTIC_ATTRIBUTE_CACHE_HIT = 'cache.hit';
+
+  test('instruments all storage operations and creates spans with correct attributes', async ({ request }) => {
+    const transactionPromise = waitForTransaction('nitro-3', transactionEvent => {
+      return transactionEvent.transaction?.includes('GET /api/test-storage') ?? false;
+    });
+
+    const response = await request.get('/api/test-storage');
+    expect(response.status()).toBe(200);
+
+    const transaction = await transactionPromise;
+
+    // Helper to find spans by operation
+    const findSpansByOp = (op: string) => {
+      return transaction.spans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === op) || [];
+    };
+
+    // Test setItem spans
+    const setItemSpans = findSpansByOp('cache.set_item');
+    expect(setItemSpans.length).toBeGreaterThanOrEqual(1);
+    const setItemSpan = setItemSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('user:123'));
+    expect(setItemSpan).toBeDefined();
+    expect(setItemSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.set_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('user:123'),
+      'db.operation.name': 'setItem',
+      'db.system.name': expect.any(String),
+    });
+    expect(setItemSpan?.description).toBe(prefixKey('user:123'));
+
+    // Test setItemRaw spans
+    const setItemRawSpans = findSpansByOp('cache.set_item_raw');
+    expect(setItemRawSpans.length).toBeGreaterThanOrEqual(1);
+    const setItemRawSpan = setItemRawSpans.find(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('raw:data'),
+    );
+    expect(setItemRawSpan).toBeDefined();
+    expect(setItemRawSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.set_item_raw',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('raw:data'),
+      'db.operation.name': 'setItemRaw',
+      'db.system.name': expect.any(String),
+    });
+
+    // Test hasItem spans - should have cache hit attribute
+    const hasItemSpans = findSpansByOp('cache.has_item');
+    expect(hasItemSpans.length).toBeGreaterThanOrEqual(1);
+    const hasItemSpan = hasItemSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('user:123'));
+    expect(hasItemSpan).toBeDefined();
+    expect(hasItemSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.has_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('user:123'),
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
+      'db.operation.name': 'hasItem',
+      'db.system.name': expect.any(String),
+    });
+
+    // Test getItem spans - should have cache hit attribute
+    const getItemSpans = findSpansByOp('cache.get_item');
+    expect(getItemSpans.length).toBeGreaterThanOrEqual(1);
+    const getItemSpan = getItemSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('user:123'));
+    expect(getItemSpan).toBeDefined();
+    expect(getItemSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('user:123'),
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
+      'db.operation.name': 'getItem',
+      'db.system.name': expect.any(String),
+    });
+    expect(getItemSpan?.description).toBe(prefixKey('user:123'));
+
+    // Test getItemRaw spans - should have cache hit attribute
+    const getItemRawSpans = findSpansByOp('cache.get_item_raw');
+    expect(getItemRawSpans.length).toBeGreaterThanOrEqual(1);
+    const getItemRawSpan = getItemRawSpans.find(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('raw:data'),
+    );
+    expect(getItemRawSpan).toBeDefined();
+    expect(getItemRawSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_item_raw',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('raw:data'),
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
+      'db.operation.name': 'getItemRaw',
+      'db.system.name': expect.any(String),
+    });
+
+    // Test getKeys spans
+    const getKeysSpans = findSpansByOp('cache.get_keys');
+    expect(getKeysSpans.length).toBeGreaterThanOrEqual(1);
+    expect(getKeysSpans[0]?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get_keys',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      'db.operation.name': 'getKeys',
+      'db.system.name': expect.any(String),
+    });
+
+    // Test removeItem spans
+    const removeItemSpans = findSpansByOp('cache.remove_item');
+    expect(removeItemSpans.length).toBeGreaterThanOrEqual(1);
+    const removeItemSpan = removeItemSpans.find(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('batch:1'),
+    );
+    expect(removeItemSpan).toBeDefined();
+    expect(removeItemSpan?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.remove_item',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('batch:1'),
+      'db.operation.name': 'removeItem',
+      'db.system.name': expect.any(String),
+    });
+
+    // Test clear spans
+    const clearSpans = findSpansByOp('cache.clear');
+    expect(clearSpans.length).toBeGreaterThanOrEqual(1);
+    expect(clearSpans[0]?.data).toMatchObject({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.clear',
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nitro',
+      'db.operation.name': 'clear',
+      'db.system.name': expect.any(String),
+    });
+
+    // Verify all spans have OK status
+    const allStorageSpans = transaction.spans?.filter(
+      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] === 'auto.cache.nitro',
+    );
+    expect(allStorageSpans?.length).toBeGreaterThan(0);
+    allStorageSpans?.forEach(span => {
+      expect(span.status).toBe('ok');
+    });
+  });
+});

--- a/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
@@ -1,0 +1,169 @@
+import {
+  captureException,
+  flushIfServerless,
+  GLOBAL_OBJ,
+  SEMANTIC_ATTRIBUTE_CACHE_HIT,
+  SEMANTIC_ATTRIBUTE_CACHE_KEY,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SPAN_STATUS_ERROR,
+  SPAN_STATUS_OK,
+  startSpanManual,
+} from '@sentry/core';
+import { tracingChannel, type TracingChannelContextWithSpan } from '@sentry/opentelemetry/tracing-channel';
+import type { TraceContext } from 'unstorage/tracing';
+
+const ORIGIN = 'auto.cache.nitro';
+
+const globalWithStorageChannels = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
+  __SENTRY_NITRO_STORAGE_CHANNELS_INSTRUMENTED__: boolean;
+};
+
+const TRACED_OPERATIONS = [
+  'hasItem',
+  'getItem',
+  'getItemRaw',
+  'getItems',
+  'setItem',
+  'setItemRaw',
+  'setItems',
+  'removeItem',
+  'getKeys',
+  'clear',
+] as const;
+
+type TracedOperation = (typeof TRACED_OPERATIONS)[number];
+
+const CACHE_HIT_OPERATIONS = new Set<TracedOperation>(['hasItem', 'getItem', 'getItemRaw']);
+
+const CACHED_FN_HANDLERS_RE = /^nitro:(functions|handlers):/i;
+
+/**
+ * Subscribes to unstorage tracing channels and creates Sentry spans for storage operations.
+ */
+export function captureStorageEvents(): void {
+  if (globalWithStorageChannels.__SENTRY_NITRO_STORAGE_CHANNELS_INSTRUMENTED__) {
+    return;
+  }
+
+  for (const operation of TRACED_OPERATIONS) {
+    setupStorageTracingChannel(operation);
+  }
+
+  globalWithStorageChannels.__SENTRY_NITRO_STORAGE_CHANNELS_INSTRUMENTED__ = true;
+}
+
+function setupStorageTracingChannel(operation: TracedOperation): void {
+  const keys = (data: TraceContext): string[] => data.keys ?? [];
+  const mountBase = (data: TraceContext): string => (data.base ?? '').replace(/:$/, '');
+
+  const channel = tracingChannel<TraceContext>(`unstorage.${operation}`, data => {
+    const cacheKeys = keys(data);
+
+    return startSpanManual(
+      {
+        name: cacheKeys.join(', ') || operation,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: `cache.${normalizeMethodName(operation)}`,
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+          [SEMANTIC_ATTRIBUTE_CACHE_KEY]: cacheKeys.length > 1 ? cacheKeys : cacheKeys[0],
+          'db.operation.name': operation,
+          'db.collection.name': mountBase(data),
+          'db.system.name': data.driver?.name ?? 'unknown',
+        },
+      },
+      span => span,
+    );
+  });
+
+  channel.subscribe({
+    start() {},
+    asyncStart() {},
+    end() {},
+    asyncEnd(data: TracingChannelContextWithSpan<TraceContext & { result?: unknown }>) {
+      if (data._sentrySpan && CACHE_HIT_OPERATIONS.has(operation)) {
+        data._sentrySpan.setAttribute(SEMANTIC_ATTRIBUTE_CACHE_HIT, isCacheHit(data.keys?.[0], data.result));
+      }
+
+      data._sentrySpan?.setStatus({ code: SPAN_STATUS_OK });
+      data._sentrySpan?.end();
+
+      void flushIfServerless();
+    },
+    error(data: TracingChannelContextWithSpan<TraceContext & { error?: unknown }>) {
+      captureException(data.error, {
+        mechanism: { handled: false, type: ORIGIN },
+      });
+
+      data._sentrySpan?.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+      data._sentrySpan?.end();
+
+      void flushIfServerless();
+    },
+  });
+}
+
+function normalizeMethodName(methodName: string): string {
+  return methodName.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+}
+
+function isEmptyValue(value: unknown): value is null | undefined {
+  return value === null || value === undefined;
+}
+
+interface CacheEntry<T = unknown> {
+  value?: T;
+  expires?: number;
+}
+
+interface ResponseCacheEntry {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string | undefined>;
+}
+
+function isCacheHit(key: unknown, value: unknown): boolean {
+  try {
+    const isEmpty = isEmptyValue(value);
+    if (isEmpty || typeof key !== 'string' || !CACHED_FN_HANDLERS_RE.test(key)) {
+      return !isEmpty;
+    }
+
+    return validateCacheEntry(key, JSON.parse(String(value)) as CacheEntry);
+  } catch {
+    return false;
+  }
+}
+
+function validateCacheEntry(
+  key: string,
+  entry: CacheEntry | CacheEntry<ResponseCacheEntry & { status: number }>,
+): boolean {
+  if (isEmptyValue(entry.value)) {
+    return false;
+  }
+
+  if (Date.now() > (entry.expires || 0)) {
+    return false;
+  }
+
+  if (isResponseCacheEntry(key, entry)) {
+    if ((entry.value.status ?? 0) >= 400) {
+      return false;
+    }
+
+    if (entry.value.body === undefined) {
+      return false;
+    }
+
+    if (entry.value.headers?.etag === 'undefined' || entry.value.headers?.['last-modified'] === 'undefined') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isResponseCacheEntry(key: string, _: CacheEntry): _ is CacheEntry<ResponseCacheEntry & { status: number }> {
+  return key.startsWith('nitro:handlers:');
+}

--- a/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
@@ -77,9 +77,6 @@ function setupStorageTracingChannel(operation: TracedOperation): void {
   });
 
   channel.subscribe({
-    start() {},
-    asyncStart() {},
-    end() {},
     asyncEnd(data: TracingChannelContextWithSpan<TraceContext & { result?: unknown }>) {
       if (data._sentrySpan && CACHE_HIT_OPERATIONS.has(operation)) {
         data._sentrySpan.setAttribute(SEMANTIC_ATTRIBUTE_CACHE_HIT, isCacheHit(data.keys?.[0], data.result));

--- a/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
@@ -79,7 +79,8 @@ function setupStorageTracingChannel(operation: TracedOperation): void {
   channel.subscribe({
     asyncEnd(data: TracingChannelContextWithSpan<TraceContext & { result?: unknown }>) {
       if (data._sentrySpan && CACHE_HIT_OPERATIONS.has(operation)) {
-        data._sentrySpan.setAttribute(SEMANTIC_ATTRIBUTE_CACHE_HIT, isCacheHit(data.keys?.[0], data.result));
+        const hit = operation === 'hasItem' ? Boolean(data.result) : isCacheHit(data.keys?.[0], data.result);
+        data._sentrySpan.setAttribute(SEMANTIC_ATTRIBUTE_CACHE_HIT, hit);
       }
 
       data._sentrySpan?.setStatus({ code: SPAN_STATUS_OK });
@@ -126,7 +127,9 @@ function isCacheHit(key: unknown, value: unknown): boolean {
       return !isEmpty;
     }
 
-    return validateCacheEntry(key, JSON.parse(String(value)) as CacheEntry);
+    const entry = typeof value === 'string' ? (JSON.parse(value) as CacheEntry) : (value as CacheEntry);
+
+    return validateCacheEntry(key, entry);
   } catch {
     return false;
   }

--- a/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
@@ -42,11 +42,6 @@ export function captureTracingEvents(): void {
 }
 
 /**
- * No-op function to satisfy the tracing channel subscribe callbacks
- */
-const NOOP = (): void => {};
-
-/**
  * Extracts the HTTP status code from a tracing channel result.
  * The result is the return value of the traced handler, which is a Response for srvx
  * and may or may not be a Response for h3.
@@ -126,8 +121,6 @@ function setupH3TracingChannels(): void {
     start: (data: H3TracingRequestEvent) => {
       setServerTimingHeaders(data.event);
     },
-    asyncStart: NOOP,
-    end: NOOP,
     asyncEnd: (data: TracingChannelContextWithSpan<H3TracingRequestEvent>) => {
       onTraceEnd(data);
 
@@ -192,9 +185,6 @@ function setupSrvxTracingChannels(): void {
 
   // Subscribe to events (span already created in bindStore)
   fetchChannel.subscribe({
-    start: () => {},
-    asyncStart: () => {},
-    end: () => {},
     asyncEnd: data => {
       onTraceEnd(data);
 
@@ -239,9 +229,6 @@ function setupSrvxTracingChannels(): void {
 
   // Subscribe to events (span already created in bindStore)
   middlewareChannel.subscribe({
-    start: () => {},
-    asyncStart: () => {},
-    end: () => {},
     asyncEnd: onTraceEnd,
     error: onTraceError,
   });

--- a/packages/nitro/src/runtime/plugins/server.ts
+++ b/packages/nitro/src/runtime/plugins/server.ts
@@ -1,9 +1,11 @@
 import { definePlugin } from 'nitro';
 import { captureErrorHook } from '../hooks/captureErrorHook';
+import { captureStorageEvents } from '../hooks/captureStorageEvents';
 import { captureTracingEvents } from '../hooks/captureTracingEvents';
 
 export default definePlugin(nitroApp => {
   nitroApp.hooks.hook('error', captureErrorHook);
 
   captureTracingEvents();
+  captureStorageEvents();
 });


### PR DESCRIPTION
Subscribes to `unstorage` tracing events to create storage and cache spans for all storage operations (`getItem`, `setItem`, `hasItem`, `removeItem`, `getKeys`, `clear`, etc.).

The storage instrumentation now has full feature parity with Nuxt's SDK.

Note: The instrumentation takes effect if the user uses `^3.0.260429-beta` since that's the version that shipped storage events, before that version the channel will be inert.

I also sneaked in a minor refactor, we don't need the `NOOP` subscribers anymore since we patched the type in the `tracingChannel` helper we expose from `@sentry/opentelemetry`.

closes #18022