### PR TITLE
feat(deps): bump @sentry-internal/node-cpu-profiler to 2.3.0

### DIFF
--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -61,7 +61,7 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@sentry-internal/node-cpu-profiler": "^2.2.0",
+    "@sentry-internal/node-cpu-profiler": "^2.3.0",
     "@sentry/core": "10.51.0",
     "@sentry/node": "10.51.0"
   },


### PR DESCRIPTION
## Summary
- Bumps `@sentry-internal/node-cpu-profiler` from `^2.2.0` to `^2.3.0` in `packages/profiling-node`

## Test plan
- [ ] CI passes once 2.3.0 is published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)