### PR TITLE
test(cloudflare): Use Node v24 for Cloudflare e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/package.json
@@ -21,6 +21,7 @@
     "wrangler": "^4.63.0"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
@@ -22,7 +22,7 @@
     "wrangler": "^4.72.0"
   },
   "volta": {
-    "node": "22.22.0",
+    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
@@ -19,9 +19,10 @@
     "@cloudflare/workers-types": "^4.20250521.0",
     "typescript": "^5.9.3",
     "vitest": "3.1.0",
-    "wrangler": "4.61.0"
+    "wrangler": "^4.61.0"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "sentryTest": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/package.json
@@ -28,6 +28,7 @@
     "ws": "^8.18.3"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
@@ -27,6 +27,7 @@
     "wrangler": "^4.86.0"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
@@ -31,6 +31,7 @@
     "ws": "^8.18.3"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers/package.json
@@ -28,6 +28,7 @@
     "ws": "^8.18.3"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/package.json
@@ -28,6 +28,7 @@
     "ws": "^8.18.3"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -28,6 +28,7 @@
     "wrangler": "^4.61.0"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "sentryTest": {

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -36,6 +36,7 @@
     "wrangler": "^4.61.0"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "sentryTest": {

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
@@ -26,9 +26,10 @@
     "svelte-check": "^4.1.4",
     "typescript": "^5.0.0",
     "vite": "^6.1.1",
-    "wrangler": "4.61.0"
+    "wrangler": "^4.61.0"
   },
   "volta": {
+    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
Wrangler `4.87.0` requires Node v22, which is fine, as Cloudflare has its own runtime and specifies `compatibility_date`s for versioning their code.