### PR TITLE
test(react-router): Fix flaky E2E tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa-node-20-18/tests/performance/pageload.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa-node-20-18/tests/performance/pageload.client.test.ts
@@ -9,6 +9,7 @@ test.describe('client - pageload performance', () => {
     });
 
     await page.goto(`/performance`);
+    await page.getByRole('heading', { name: 'Performance Page' }).waitFor();
 
     const transaction = await txPromise;
 
@@ -62,6 +63,7 @@ test.describe('client - pageload performance', () => {
     });
 
     await page.goto(`/performance/with/sentry`);
+    await page.getByRole('heading', { name: 'Dynamic Parameter Page' }).waitFor();
 
     const transaction = await txPromise;
 

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/tests/performance/pageload.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/tests/performance/pageload.client.test.ts
@@ -9,6 +9,7 @@ test.describe('client - pageload performance', () => {
     });
 
     await page.goto(`/performance`);
+    await page.getByRole('heading', { name: 'Performance Page' }).waitFor();
 
     const transaction = await txPromise;
 
@@ -62,6 +63,7 @@ test.describe('client - pageload performance', () => {
     });
 
     await page.goto(`/performance/with/sentry`);
+    await page.getByRole('heading', { name: 'Dynamic Parameter Page' }).waitFor();
 
     const transaction = await txPromise;
 

--- a/packages/react/test/reactrouter-cross-usage.test.tsx
+++ b/packages/react/test/reactrouter-cross-usage.test.tsx
@@ -627,8 +627,13 @@ describe('React Router cross usage of wrappers', () => {
 
       await act(async () => {
         router.navigate('/settings');
-        await waitFor(() => expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1));
       });
+
+      await waitFor(() => {
+        expect(router.state.navigation.state).toBe('idle');
+        expect(router.state.location.pathname).toBe('/settings');
+      });
+      await waitFor(() => expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1));
 
       expect(mockStartBrowserTracingNavigationSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
         name: '/settings',
@@ -641,8 +646,13 @@ describe('React Router cross usage of wrappers', () => {
 
       await act(async () => {
         router.navigate('/profile');
-        await waitFor(() => expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(2));
       });
+
+      await waitFor(() => {
+        expect(router.state.navigation.state).toBe('idle');
+        expect(router.state.location.pathname).toBe('/profile');
+      });
+      await waitFor(() => expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(2));
 
       expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(2);
 
@@ -734,8 +744,13 @@ describe('React Router cross usage of wrappers', () => {
 
       await act(async () => {
         router.navigate('/user/2');
-        await waitFor(() => expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1));
       });
+
+      await waitFor(() => {
+        expect(router.state.navigation.state).toBe('idle');
+        expect(router.state.location.pathname).toBe('/user/2');
+      });
+      await waitFor(() => expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1));
 
       expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1);
       expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledWith(expect.any(BrowserClient), {
@@ -749,8 +764,13 @@ describe('React Router cross usage of wrappers', () => {
 
       await act(async () => {
         router.navigate('/user/3');
-        await waitFor(() => expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(2));
       });
+
+      await waitFor(() => {
+        expect(router.state.navigation.state).toBe('idle');
+        expect(router.state.location.pathname).toBe('/user/3');
+      });
+      await waitFor(() => expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(2));
 
       // Should create 2 spans - different concrete paths are different user actions
       expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/20532

This hopefully makes react-router framework E2E tests a bit less flaky.

## AI Summary of the problem

That app uses client-only hydration (hydrateRoot + HydratedRouter). The pageload transaction and React Router’s instrumentHydratedRouter updates can land in a race with page.goto finishing: sometimes CI loses that race, so the test times out or assertions fail.

This matches how other E2E apps avoid the same class of bug—for example the SvelteKit helpers wait for hydration / UI together with the pageload transaction so routing and tracing line up.

### What we changed

After each page.goto for the performance routes, the tests now wait for the route’s \<h1> before awaiting waitForTransaction:

/performance → Performance Page
/performance/with/sentry → Dynamic Parameter Page
So the HydratedRouter has rendered the matched route before the test blocks on the envelope, which stabilizes timing relative to router instrumentation.

