### PR TITLE
test(deps): Bump Next.js in E2E test apps to fix Server Components DoS

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^18.19.1",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
-    "next": "15.5.14",
+    "next": "15.5.15",
     "next-intl": "^4.3.12",
     "react": "latest",
     "react-dom": "latest",

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
@@ -20,7 +20,7 @@
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",
     "ai": "^3.0.0",
-    "next": "15.5.14",
+    "next": "15.5.15",
     "react": "latest",
     "react-dom": "latest",
     "typescript": "~5.0.0",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/package.json
@@ -15,7 +15,7 @@
     "@sentry/nextjs": "file:../../packed/sentry-nextjs-packed.tgz",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "import-in-the-middle": "^2",
-    "next": "16.1.7",
+    "next": "16.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "require-in-the-middle": "^8"

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/package.json
@@ -26,7 +26,7 @@
     "@sentry/nextjs": "file:../../packed/sentry-nextjs-packed.tgz",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "import-in-the-middle": "^1",
-    "next": "16.1.7",
+    "next": "16.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "require-in-the-middle": "^7",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/package.json
@@ -16,7 +16,7 @@
     "@sentry/nextjs": "file:../../packed/sentry-nextjs-packed.tgz",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "import-in-the-middle": "^2",
-    "next": "16.1.7",
+    "next": "16.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "require-in-the-middle": "^8"

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/package.json
@@ -27,7 +27,7 @@
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "ai": "^3.0.0",
     "import-in-the-middle": "^1",
-    "next": "16.1.7",
+    "next": "16.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "require-in-the-middle": "^7",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/package.json
@@ -28,7 +28,7 @@
     "@vercel/queue": "^0.1.3",
     "ai": "^3.0.0",
     "import-in-the-middle": "^2",
-    "next": "16.1.7",
+    "next": "16.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "require-in-the-middle": "^8",

--- a/dev-packages/e2e-tests/test-applications/nextjs-sourcemaps/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-sourcemaps/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "file:../../packed/sentry-nextjs-packed.tgz",
-    "next": "16.1.7",
+    "next": "16.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "typescript": "~5.0.0"


### PR DESCRIPTION
## Summary
- Bumps `next` 15.5.14 → 15.5.15 in `nextjs-15`, `nextjs-15-intl`
- Bumps `next` 16.1.7 → 16.2.3 in `nextjs-16`, `nextjs-16-cacheComponents`, `nextjs-16-trailing-slash`, `nextjs-16-bun`, `nextjs-16-tunnel`, `nextjs-sourcemaps`
- Fixes high-severity DoS vulnerability in Next.js Server Components