### PR TITLE
chore(skills): Use `yarn-update-dependency`

### DIFF
--- a/.agents/skills/fix-security-vulnerability/SKILL.md
+++ b/.agents/skills/fix-security-vulnerability/SKILL.md
@@ -92,7 +92,7 @@ git pull origin develop
 git checkout -b fix/dependabot-alert-<alert-number>
 ```
 
-Then apply the fix commands from Step 5 of the single-alert workflow (edit `package.json`, `yarn install`, `yarn dedupe-deps:fix`, verify) — but **skip the "Do NOT commit" instruction**, since user approval was already obtained in Step 2b. After applying:
+Then apply the fix commands from Step 5 of the single-alert workflow (`npx yarn-update-dependency@latest <package>`, `yarn dedupe-deps:fix`, verify) — but **skip the "Do NOT commit" instruction**, since user approval was already obtained in Step 2b. After applying:
 
 ```bash
 # 3. Stage and commit the changes
@@ -263,8 +263,8 @@ Present findings and **wait for user approval** before making changes:
 <One of: Safe to bump / Version-specific test - do not bump / Bump parent package>
 
 ### Proposed Fix
-1. Update <file>: "<package>": "<new-version>"
-2. yarn install && yarn dedupe-deps:fix
+1. npx yarn-update-dependency@latest <package>
+2. yarn dedupe-deps:fix
 3. Verify with: yarn why <package>
 
 Proceed?
@@ -273,15 +273,14 @@ Proceed?
 ### Step 5: Apply Fix (After Approval)
 
 ```bash
-# 1. Edit package.json
-# 2. Update lockfile
-yarn install
-# 3. Deduplicate
+# 1. Upgrade the package (updates package.json + lockfile)
+npx yarn-update-dependency@latest <package>
+# 2. Deduplicate
 yarn dedupe-deps:fix
-# 4. Verify
+# 3. Verify
 yarn dedupe-deps:check
 yarn why <package>
-# 5. Show changes
+# 4. Show changes
 git diff
 ```
 
@@ -325,6 +324,7 @@ gh api --method PATCH repos/getsentry/sentry-javascript/dependabot/alerts/<numbe
 
 | Command                                                                                                      | Purpose                      |
 | ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `npx yarn-update-dependency@latest <pkg>`                                                                    | Upgrade package across repo  |
 | `yarn why <pkg>`                                                                                             | Show dependency tree         |
 | `yarn dedupe-deps:fix`                                                                                       | Fix duplicates in yarn.lock  |
 | `yarn dedupe-deps:check`                                                                                     | Verify no duplicate issues   |


### PR DESCRIPTION
Updates the `fix-security-vulnerability` skill to make use of our internal util.