### PR TITLE
fix(core): Guard against undefined chained in copyProps

### DIFF
--- a/packages/core/src/utils/chain-and-copy-promiselike.ts
+++ b/packages/core/src/utils/chain-and-copy-promiselike.ts
@@ -32,6 +32,7 @@ export const chainAndCopyPromiseLike = <V, T extends PromiseLike<V>>(
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const copyProps = <T extends Record<string, any>>(original: T, chained: T): T => {
+  if (!chained) return original;
   let mutated = false;
   //oxlint-disable-next-line guard-for-in
   for (const key in original) {

--- a/packages/core/test/lib/utils/chain-and-copy-promiselike.test.ts
+++ b/packages/core/test/lib/utils/chain-and-copy-promiselike.test.ts
@@ -53,4 +53,25 @@ describe('chain and copy promiselike objects', () => {
     expect(success).toBe(true);
     expect(error).toBe(false);
   });
+
+  it('returns original when .then() returns undefined', () => {
+    const original = {
+      value: 42,
+      then() {
+        return undefined;
+      },
+      customMethod() {
+        return 'hello';
+      },
+    } as unknown as PromiseLike<number> & { customMethod: () => string };
+
+    const q = chainAndCopyPromiseLike(
+      original,
+      () => {},
+      () => {},
+    );
+
+    expect(q).toBe(original);
+    expect((q as typeof original).customMethod()).toBe('hello');
+  });
 });


### PR DESCRIPTION
Non-standard thenables (e.g. Fastify reply objects) can return `undefined` from `.then()`, which crashes `copyProps` with `TypeError: Cannot use 'in' operator to search for 'raw' in undefined`. Added a guard to return the original object as fallback when `chained` is falsy.

Closes https://github.com/getsentry/sentry-javascript/issues/20623