### PR TITLE
fix: Bump vite versions to fix vulnerability

### DIFF
--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/package.json
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/package.json
@@ -15,7 +15,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.3.2"
   },
   "dependencies": {
     "@sentry/browser": "file:../../packed/sentry-browser-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa-node-20-18/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa-node-20-18/package.json
@@ -35,7 +35,7 @@
     "@types/react-dom": "^19.1.2",
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3",
-    "vite": "^6.3.3",
+    "vite": "^6.4.2",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "browserslist": {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/package.json
@@ -35,7 +35,7 @@
     "@types/react-dom": "^19.1.2",
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3",
-    "vite": "^6.3.3",
+    "vite": "^6.4.2",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "browserslist": {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
-    "vite": "^6.0.1",
+    "vite": "^6.4.2",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "~5.0.0"
   },

--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/package.json
@@ -25,7 +25,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.7.2",
-    "vite": "^7.1.7",
+    "vite": "^7.3.2",
     "vite-plugin-solid": "^2.11.2"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/package.json
@@ -28,7 +28,7 @@
     "svelte-check": "^4.3.1",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",
-    "vite": "^7.1.3"
+    "vite": "^7.3.2"
   },
   "type": "module",
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
@@ -25,7 +25,7 @@
     "svelte": "^5.20.2",
     "svelte-check": "^4.1.4",
     "typescript": "^5.0.0",
-    "vite": "^6.1.1",
+    "vite": "^6.4.2",
     "wrangler": "^4.61.0"
   },
   "volta": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -62,7 +62,7 @@
     "@react-router/node": "^7.13.1",
     "react": "^18.3.1",
     "react-router": "^7.13.0",
-    "vite": "^6.1.0"
+    "vite": "^6.4.2"
   },
   "peerDependencies": {
     "@react-router/node": "7.x",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -81,7 +81,7 @@
     "@types/express": "^4.17.14",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "vite": "^6.0.0"
+    "vite": "^6.4.2"
   },
   "peerDependencies": {
     "@remix-run/node": "2.x",

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -22,7 +22,7 @@
     "@types/react-dom": "^18",
     "nock": "^13.5.5",
     "typescript": "~5.8.0",
-    "vite": "^6.0.0"
+    "vite": "^6.4.2"
   },
   "resolutions": {
     "@sentry/browser": "file:../../../browser",
@@ -39,7 +39,7 @@
     "@vanilla-extract/css": "1.13.0",
     "@vanilla-extract/integration": "6.2.4",
     "@types/mime": "^3.0.0",
-    "vite": "^6.0.0"
+    "vite": "^6.4.2"
   },
   "engines": {
     "node": ">=18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28553,6 +28553,7 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
+  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28553,7 +28553,6 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
-  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"
@@ -30468,10 +30467,10 @@ vite@^5.0.0, vite@^5.4.11, vite@^5.4.21:
   optionalDependencies:
     fsevents "~2.3.3"
 
-"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^6.0.0, vite@^6.1.0, vite@^6.3.5, vite@^6.4.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.4.1.tgz#afbe14518cdd6887e240a4b0221ab6d0ce733f96"
-  integrity sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==
+"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^6.3.5, vite@^6.4.1, vite@^6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.4.2.tgz#a4e548ca3a90ca9f3724582cab35e1ba15efc6f2"
+  integrity sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==
   dependencies:
     esbuild "^0.25.0"
     fdir "^6.4.4"


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/20309
closes https://github.com/getsentry/sentry-javascript/issues/20236
closes https://github.com/getsentry/sentry-javascript/issues/20235

Related CVE: 
- https://github.com/advisories/GHSA-p9ff-h696-f583