### PR TITLE
test(node): Fix ANR test for flakiness

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/forked.js
@@ -9,7 +9,7 @@ setTimeout(() => {
 }, 10000);
 
 const client = Sentry.init({
-  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  dsn: process.env.SENTRY_DSN,
   release: '1.0',
   debug: true,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-core-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/anr/test.ts
@@ -221,7 +221,11 @@ describe('should report ANR when event loop blocked', { timeout: 90_000 }, () =>
   });
 
   test('from forked process', async () => {
-    await createRunner(__dirname, 'forker.js').expect({ event: ANR_EVENT_WITH_SCOPE }).start().completed();
+    await createRunner(__dirname, 'forker.js')
+      .withMockSentryServer()
+      .expect({ event: ANR_EVENT_WITH_SCOPE })
+      .start()
+      .completed();
   });
 
   test('worker can be stopped and restarted', async () => {

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -8,7 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
-  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  dsn: process.env.SENTRY_DSN,
   release: '1.0',
   debug: true,
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -210,7 +210,11 @@ describe('should report ANR when event loop blocked', { timeout: 90_000 }, () =>
   });
 
   test('from forked process', async () => {
-    await createRunner(__dirname, 'forker.js').expect({ event: ANR_EVENT_WITH_SCOPE }).start().completed();
+    await createRunner(__dirname, 'forker.js')
+      .withMockSentryServer()
+      .expect({ event: ANR_EVENT_WITH_SCOPE })
+      .start()
+      .completed();
   });
 
   test('worker can be stopped and restarted', async () => {


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/20643

Reasoning by Cursor:

### Cause
The from forked process case was different from the stable ANR scenarios (basic.mjs, etc.):

forked.js used a hard-coded ingest DSN instead of process.env.SENTRY_DSN.
The test did not call .withMockSentryServer(), so the runner never started the local mock ingest server or injected SENTRY_DSN.
So the runner depended on the ANR worker’s debug stdout ([ANR Worker] … + JSON envelope) being forwarded through fork() + stdio: 'inherit'. That path is sensitive to timing, buffering, and CI load—the kind of setup that shows up as intermittent failures ([issue #20643](https://github.com/getsentry/sentry-javascript/issues/20643)).

### Fix
forked.js — initialize with dsn: process.env.SENTRY_DSN, matching basic.mjs so the forked child uses the same DSN the runner configures when the mock server is enabled.
test.ts — chain .withMockSentryServer() on the forker.js runner so events are delivered over HTTP to the mock server (same mechanism as the other ANR tests), instead of relying on debug lines on stdout.

Not 100% sure if this will fix the flakiness but it def. seems like an overall good change to me anyhow!