### PR TITLE
ci(flaky-tests): Apply bug label for auto-triage

### DIFF
--- a/.github/FLAKY_CI_FAILURE_TEMPLATE.md
+++ b/.github/FLAKY_CI_FAILURE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 title: '[Flaky CI]: {{ env.JOB_NAME }} - {{ env.TEST_NAME }}'
-labels: Tests
+labels: Tests, Bug
 ---
 
 ### Flakiness Type

--- a/scripts/report-ci-failures.mjs
+++ b/scripts/report-ci-failures.mjs
@@ -102,7 +102,7 @@ export default async function run({ github, context, core }) {
         repo,
         title,
         body: issueBody.trim(),
-        labels: ['Tests'],
+        labels: ['Tests', 'Bug'],
       });
       core.info(`Created issue #${newIssue.data.number} for "${testName}" in ${jobName}`);
     }


### PR DESCRIPTION
Applying `Bug` to the auto generated issues will trigger our triaging agent (until we got something better for auto-fix). 