### PR TITLE
test(node): Fix flaky node cron test

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/cron/cron/scenario.ts
+++ b/dev-packages/node-core-integration-tests/suites/cron/cron/scenario.ts
@@ -1,12 +1,10 @@
 import * as Sentry from '@sentry/node-core';
-import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import { CronJob } from 'cron';
 import { setupOtel } from '../../../utils/setupOtel';
 
 const client = Sentry.init({
-  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  dsn: process.env.SENTRY_DSN,
   release: '1.0',
-  transport: loggingTransport,
 });
 
 setupOtel(client);

--- a/dev-packages/node-core-integration-tests/suites/cron/cron/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/cron/cron/test.ts
@@ -7,6 +7,7 @@ afterAll(() => {
 
 test('cron instrumentation', async () => {
   await createRunner(__dirname, 'scenario.ts')
+    .withMockSentryServer()
     .expect({
       check_in: {
         check_in_id: expect.any(String),

--- a/dev-packages/node-integration-tests/suites/cron/cron/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/cron/scenario.ts
@@ -1,11 +1,9 @@
 import * as Sentry from '@sentry/node';
-import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import { CronJob } from 'cron';
 
 Sentry.init({
-  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  dsn: process.env.SENTRY_DSN,
   release: '1.0',
-  transport: loggingTransport,
 });
 
 const CronJobWithCheckIn = Sentry.cron.instrumentCron(CronJob, 'my-cron-job');

--- a/dev-packages/node-integration-tests/suites/cron/cron/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/cron/test.ts
@@ -7,6 +7,7 @@ afterAll(() => {
 
 test('cron instrumentation', { timeout: 30_000 }, async () => {
   await createRunner(__dirname, 'scenario.ts')
+    .withMockSentryServer()
     .expect({
       check_in: {
         check_in_id: expect.any(String),


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/20652

cron instrumentation used loggingTransport, which console.logs each envelope as JSON. The scenario also console.logs (You will see this message every second). The runner parses envelopes by splitting child stdout on newlines. Under CI load that mix can produce ordering / buffering issues or fragile parsing compared with sending envelopes over HTTP.

## Fix
Align with the pattern used elsewhere (including the ANR fix):

* scenario.ts — Drop loggingTransport and initialize with dsn: process.env.SENTRY_DSN so the runner-injected URL from the mock ingest server is used. 
* test.ts — Call .withMockSentryServer() so check-ins and the error event are received via the mock HTTP server instead of stdout.