### PR TITLE
fix(replay): Set replay_id on DSC after buffer-to-session conversion

### DIFF
--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -618,13 +618,10 @@ export class ReplayContainer implements ReplayContainerInterface {
       this._updateUserActivity(activityTime);
       this._updateSessionActivity(activityTime);
       this._maybeSaveSession();
+      setReplayIdOnDynamicSamplingContext(this.session.id);
     }
 
     this.startRecording();
-
-    if (this.session) {
-      setReplayIdOnDynamicSamplingContext(this.session.id);
-    }
   }
 
   /**

--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -621,6 +621,10 @@ export class ReplayContainer implements ReplayContainerInterface {
     }
 
     this.startRecording();
+
+    if (this.session) {
+      setReplayIdOnDynamicSamplingContext(this.session.id);
+    }
   }
 
   /**

--- a/packages/replay-internal/src/util/resetReplayIdOnDynamicSamplingContext.ts
+++ b/packages/replay-internal/src/util/resetReplayIdOnDynamicSamplingContext.ts
@@ -1,5 +1,9 @@
-import type { DynamicSamplingContext } from '@sentry/core';
-import { getActiveSpan, getCurrentScope, getDynamicSamplingContextFromSpan } from '@sentry/core';
+import type { DynamicSamplingContext } from "@sentry/core";
+import {
+  getActiveSpan,
+  getCurrentScope,
+  getDynamicSamplingContextFromSpan,
+} from "@sentry/core";
 
 /**
  * Reset the `replay_id` field on the DSC.

--- a/packages/replay-internal/src/util/resetReplayIdOnDynamicSamplingContext.ts
+++ b/packages/replay-internal/src/util/resetReplayIdOnDynamicSamplingContext.ts
@@ -1,9 +1,5 @@
-import type { DynamicSamplingContext } from "@sentry/core";
-import {
-  getActiveSpan,
-  getCurrentScope,
-  getDynamicSamplingContextFromSpan,
-} from "@sentry/core";
+import type { DynamicSamplingContext } from '@sentry/core';
+import { getActiveSpan, getCurrentScope, getDynamicSamplingContextFromSpan } from '@sentry/core';
 
 /**
  * Reset the `replay_id` field on the DSC.

--- a/packages/replay-internal/test/integration/errorSampleRate.test.ts
+++ b/packages/replay-internal/test/integration/errorSampleRate.test.ts
@@ -3,7 +3,7 @@
  */
 
 import '../utils/mock-internal-setTimeout';
-import { captureException, getClient } from '@sentry/core';
+import { captureException, getClient, getCurrentScope } from '@sentry/core';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -381,6 +381,28 @@ describe('Integration | errorSampleRate', () => {
           },
         ]),
       });
+    });
+
+    it('sets replay_id on DSC after converting from buffer to session mode', async () => {
+      const TEST_EVENT = getTestEventIncremental({ timestamp: BASE_TIMESTAMP });
+      mockRecord._emitter(TEST_EVENT);
+
+      // Simulate a cached DSC on the scope (as browserTracingIntegration would set)
+      getCurrentScope().setPropagationContext({
+        traceId: '00000000000000000000000000000000',
+        sampleRand: 0,
+        dsc: { trace_id: '00000000000000000000000000000000', sampled: 'true' },
+      });
+
+      expect(replay.recordingMode).toBe('buffer');
+      const dsc = getCurrentScope().getPropagationContext().dsc!;
+      expect(dsc.replay_id).toBeUndefined();
+
+      await replay.sendBufferedReplayOrFlush({ continueRecording: true });
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(replay.recordingMode).toBe('session');
+      expect(dsc.replay_id).toBe(replay.getSessionId());
     });
 
     // This tests a regression where we were calling flush indiscriminantly in `stop()`


### PR DESCRIPTION
Follow-up to a code review comment on https://github.com/getsentry/sentry-javascript/pull/20129 -- this sets a replayId on the DSC when a buffer mode replay is saved and converted to a session-based replay.

Normally, we attach the replay_id to a DSC using the `createDsc` hook, but only when replay is enabled and recordingMode is `session` (and not for `buffer`). https://github.com/getsentry/sentry-javascript/blob/billy/fix-dsc-after-buffer-to-session/packages/replay-internal/src/util/addGlobalListeners.ts#L40-L46

What I'm unsure of is if this does anything since we're mutating the DSC after an unknown period of time (e.g. we're in buffer mode, and an error happens after 30 minutes).

## Slop

- When `sendBufferedReplayOrFlush` converts from buffer to session mode, it calls `startRecording()` directly but never updates the cached DSC with `replay_id`
- The `createDsc` hook only fires for new spans, not for an already-cached DSC on the scope (set by `browserTracingIntegration`), so `replay_id` was missing from outgoing requests until a new span happened to be created
- Adds `setReplayIdOnDynamicSamplingContext()` (symmetric to the existing `resetReplayIdOnDynamicSamplingContext()`) and calls it after the buffer-to-session conversion completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)