### PR TITLE
fix(tests): Use stable instrumentations api in rr tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.client.tsx
@@ -26,8 +26,7 @@ startTransition(() => {
   hydrateRoot(
     document,
     <StrictMode>
-      {/* unstable_instrumentations is React Router 7.x's prop name (will become `instrumentations` in v8) */}
-      <HydratedRouter unstable_instrumentations={sentryClientInstrumentation} onError={Sentry.sentryOnError} />
+      <HydratedRouter instrumentations={sentryClientInstrumentation} onError={Sentry.sentryOnError} />
     </StrictMode>,
   );
 });

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.server.tsx
@@ -17,6 +17,4 @@ export default handleRequest;
 
 export const handleError: HandleErrorFunction = Sentry.createSentryHandleError({ logErrors: true });
 
-// Use Sentry's instrumentation API for server-side tracing
-// `unstable_instrumentations` is React Router 7.x's export name (will become `instrumentations` in v8)
-export const unstable_instrumentations = [Sentry.createSentryServerInstrumentation()];
+export const instrumentations = [Sentry.createSentryServerInstrumentation()];

--- a/packages/react-router/src/client/index.ts
+++ b/packages/react-router/src/client/index.ts
@@ -24,7 +24,7 @@ export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
  */
 export type { ErrorBoundaryProps, FallbackRender } from '@sentry/react';
 
-// React Router instrumentation API for use with unstable_instrumentations (React Router 7.x)
+// React Router instrumentation API for use with HydratedRouter's `instrumentations` prop
 export {
   createSentryClientInstrumentation,
   isClientInstrumentationApiUsed,

--- a/packages/react-router/src/client/tracingIntegration.ts
+++ b/packages/react-router/src/client/tracingIntegration.ts
@@ -19,7 +19,7 @@ export interface ReactRouterTracingIntegrationOptions {
 
   /**
    * Enable React Router's instrumentation API.
-   * When true, prepares for use with HydratedRouter's `unstable_instrumentations` prop.
+   * When true, prepares for use with HydratedRouter's `instrumentations` prop.
    * @experimental
    * @default false
    */

--- a/packages/react-router/src/common/types.ts
+++ b/packages/react-router/src/common/types.ts
@@ -1,8 +1,7 @@
 /**
  * Types for React Router's instrumentation API.
  *
- * Derived from React Router v7.x `unstable_instrumentations` API.
- * The stable `instrumentations` API is planned for React Router v8.
+ * Derived from React Router's `instrumentations` API.
  * If React Router changes these types, this file must be updated.
  *
  * @see https://reactrouter.com/how-to/instrumentation

--- a/packages/react-router/src/server/index.ts
+++ b/packages/react-router/src/server/index.ts
@@ -12,7 +12,7 @@ export { wrapServerLoader } from './wrapServerLoader';
 export { createSentryHandleError, type SentryHandleErrorOptions } from './createSentryHandleError';
 export { getMetaTagTransformer } from './getMetaTagTransformer';
 
-// React Router instrumentation API support (works with both unstable_instrumentations and instrumentations)
+// React Router instrumentation API support
 export {
   createSentryServerInstrumentation,
   isInstrumentationApiUsed,

--- a/packages/react-router/test/client/hydratedRouter.test.ts
+++ b/packages/react-router/test/client/hydratedRouter.test.ts
@@ -163,7 +163,7 @@ describe('instrumentHydratedRouter', () => {
   it('creates navigation span in Framework Mode (flag not set means router() was never called)', () => {
     // This is a regression test for Framework Mode (e.g., Remix) where:
     // 1. createSentryClientInstrumentation() may be called during SDK init
-    // 2. But the framework doesn't support unstable_instrumentations, so router() is never called
+    // 2. But the framework doesn't invoke the instrumentations API, so router() is never called
     // 3. In this case, the legacy navigation instrumentation should still create spans
     //
     // We simulate this by ensuring the flag is NOT set (since router() was never called)

--- a/packages/react-router/test/client/tracingIntegration.test.ts
+++ b/packages/react-router/test/client/tracingIntegration.test.ts
@@ -156,7 +156,7 @@ describe('reactRouterTracingIntegration', () => {
       // Scenario:
       // 1. User sets useInstrumentationAPI: true in reactRouterTracingIntegration options
       // 2. createSentryClientInstrumentation() is called eagerly during SDK init
-      // 3. BUT in Framework Mode, React Router doesn't support unstable_instrumentations,
+      // 3. BUT in Framework Mode, React Router doesn't invoke the instrumentations API,
       //    so router() method is NEVER called by the framework
       // 4. The SENTRY_CLIENT_INSTRUMENTATION_FLAG must NOT be set in this case
       // 5. isClientInstrumentationApiUsed() must return false


### PR DESCRIPTION
`unstable_instrumentations` [became stable](https://reactrouter.com/changelog#v7150) in the latest minor version.