### PR TITLE
fix(nextjs): Skip build modification when SRI is enabled

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16/app/sri-test/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/app/sri-test/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+export default function SriTestPage() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <h1 id="sri-test-heading">SRI Test Page</h1>
+      <button id="counter-button" onClick={() => setCount(c => c + 1)}>
+        Count: {count}
+      </button>
+      <Link href="/sri-test/target" id="navigate-link">
+        Go to target
+      </Link>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/app/sri-test/target/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/app/sri-test/target/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+export default function SriTestTargetPage() {
+  const [clicked, setClicked] = useState(false);
+
+  return (
+    <div>
+      <h1 id="sri-target-heading">SRI Target Page</h1>
+      <button id="target-button" onClick={() => setClicked(true)}>
+        {clicked ? 'Clicked!' : 'Click me'}
+      </button>
+      <Link href="/sri-test" id="back-link">
+        Go back
+      </Link>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/next.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/next.config.ts
@@ -4,7 +4,13 @@ import type { NextConfig } from 'next';
 // Simulate Vercel environment for cron monitoring tests
 process.env.VERCEL = '1';
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  experimental: {
+    sri: {
+      algorithm: 'sha256',
+    },
+  },
+};
 
 export default withSentryConfig(nextConfig, {
   silent: true,

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/tests/sri.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/tests/sri.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+const isDevMode = !!process.env.TEST_ENV && process.env.TEST_ENV.includes('development');
+
+test.describe('Subresource Integrity (SRI)', () => {
+  test('page with client components loads correctly with SRI enabled', async ({ page }) => {
+    // SRI is only relevant for production builds
+    test.skip(isDevMode, 'SRI only applies to production builds');
+
+    const consoleErrors: string[] = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/sri-test');
+
+    const heading = page.locator('#sri-test-heading');
+    await expect(heading).toBeVisible();
+
+    // Verify client-side interactivity works (scripts loaded correctly)
+    const button = page.locator('#counter-button');
+    await expect(button).toContainText('Count: 0');
+    await button.click();
+    await expect(button).toContainText('Count: 1');
+
+    expect(consoleErrors.filter(e => e.includes('integrity'))).toHaveLength(0);
+  });
+
+  test('client-side navigation works with SRI enabled', async ({ page }) => {
+    test.skip(isDevMode, 'SRI only applies to production builds');
+
+    const consoleErrors: string[] = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    await page.goto('/sri-test');
+    await expect(page.locator('#sri-test-heading')).toBeVisible();
+
+    // Navigate to target page via client-side link
+    await page.locator('#navigate-link').click();
+    await expect(page.locator('#sri-target-heading')).toBeVisible();
+
+    // Verify client-side interactivity on the target page
+    const targetButton = page.locator('#target-button');
+    await expect(targetButton).toContainText('Click me');
+    await targetButton.click();
+    await expect(targetButton).toContainText('Clicked!');
+
+    // Navigate back
+    await page.locator('#back-link').click();
+    await expect(page.locator('#sri-test-heading')).toBeVisible();
+
+    expect(consoleErrors.filter(e => e.includes('integrity'))).toHaveLength(0);
+  });
+});

--- a/packages/nextjs/src/config/handleRunAfterProductionCompile.ts
+++ b/packages/nextjs/src/config/handleRunAfterProductionCompile.ts
@@ -15,7 +15,14 @@ export async function handleRunAfterProductionCompile(
     distDir,
     buildTool,
     usesNativeDebugIds,
-  }: { releaseName?: string; distDir: string; buildTool: 'webpack' | 'turbopack'; usesNativeDebugIds?: boolean },
+    sriEnabled,
+  }: {
+    releaseName?: string;
+    distDir: string;
+    buildTool: 'webpack' | 'turbopack';
+    usesNativeDebugIds?: boolean;
+    sriEnabled?: boolean;
+  },
   sentryBuildOptions: SentryBuildOptions,
 ): Promise<void> {
   if (sentryBuildOptions.debug) {
@@ -68,9 +75,18 @@ export async function handleRunAfterProductionCompile(
   // the deleted .map files, and in Next.js 16 (turbopack) those requests fall through
   // to the app router instead of returning 404, which can break middleware-dependent
   // features like Clerk auth.
+  // When SRI is enabled, we must skip this step because Next.js computes integrity
+  // hashes during the build — modifying files afterward invalidates those hashes.
   const deleteSourcemapsAfterUpload = sentryBuildOptions.sourcemaps?.deleteSourcemapsAfterUpload ?? false;
-  if (deleteSourcemapsAfterUpload && buildTool === 'turbopack') {
+  if (deleteSourcemapsAfterUpload && buildTool === 'turbopack' && !sriEnabled) {
     await stripSourceMappingURLComments(path.join(distDir, 'static'), sentryBuildOptions.debug);
+  }
+
+  if (deleteSourcemapsAfterUpload && buildTool === 'turbopack' && sriEnabled && sentryBuildOptions.debug) {
+    // eslint-disable-next-line no-console
+    console.debug(
+      '[@sentry/nextjs] Skipping sourceMappingURL comment stripping because Subresource Integrity (SRI) is enabled.',
+    );
   }
 }
 

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -46,6 +46,7 @@ export type NextConfigObject = {
     instrumentationHook?: boolean;
     clientTraceMetadata?: string[];
     serverComponentsExternalPackages?: string[]; // next < v15.0.0
+    sri?: { algorithm?: string };
   };
   productionBrowserSourceMaps?: boolean;
   // https://nextjs.org/docs/pages/api-reference/next-config-js/env

--- a/packages/nextjs/src/config/withSentryConfig/getFinalConfigObjectBundlerUtils.ts
+++ b/packages/nextjs/src/config/withSentryConfig/getFinalConfigObjectBundlerUtils.ts
@@ -140,6 +140,7 @@ export function maybeSetUpRunAfterProductionCompileHook({
           distDir,
           buildTool: bundlerInfo.isTurbopack ? 'turbopack' : 'webpack',
           usesNativeDebugIds: bundlerInfo.isTurbopack ? turboPackConfig?.debugIds : undefined,
+          sriEnabled: !!incomingUserNextConfigObject.experimental?.sri,
         },
         userSentryOptions,
       );
@@ -160,6 +161,7 @@ export function maybeSetUpRunAfterProductionCompileHook({
               distDir,
               buildTool: bundlerInfo.isTurbopack ? 'turbopack' : 'webpack',
               usesNativeDebugIds: bundlerInfo.isTurbopack ? turboPackConfig?.debugIds : undefined,
+              sriEnabled: !!incomingUserNextConfigObject.experimental?.sri,
             },
             userSentryOptions,
           );

--- a/packages/nextjs/test/config/handleRunAfterProductionCompile.test.ts
+++ b/packages/nextjs/test/config/handleRunAfterProductionCompile.test.ts
@@ -388,6 +388,43 @@ describe('handleRunAfterProductionCompile', () => {
 
       expect(readdirSpy).not.toHaveBeenCalled();
     });
+
+    it('does NOT strip sourceMappingURL comments when SRI is enabled', async () => {
+      await handleRunAfterProductionCompile(
+        {
+          releaseName: 'test-release',
+          distDir: '/path/to/.next',
+          buildTool: 'turbopack',
+          sriEnabled: true,
+        },
+        {
+          ...mockSentryBuildOptions,
+          sourcemaps: { deleteSourcemapsAfterUpload: true },
+        },
+      );
+
+      expect(readdirSpy).not.toHaveBeenCalled();
+    });
+
+    it('strips sourceMappingURL comments when SRI is not enabled', async () => {
+      await handleRunAfterProductionCompile(
+        {
+          releaseName: 'test-release',
+          distDir: '/path/to/.next',
+          buildTool: 'turbopack',
+          sriEnabled: false,
+        },
+        {
+          ...mockSentryBuildOptions,
+          sourcemaps: { deleteSourcemapsAfterUpload: true },
+        },
+      );
+
+      expect(readdirSpy).toHaveBeenCalledWith(
+        path.join('/path/to/.next', 'static'),
+        expect.objectContaining({ recursive: true }),
+      );
+    });
   });
 
   describe('path handling', () => {


### PR DESCRIPTION
With this we detect ant [SRI](https://nextjs.org/docs/app/guides/content-security-policy#subresource-integrity-experimental) config and, if enabled, skip the logic for stripping sourcemap comments on finished builds.

closes https://github.com/getsentry/sentry-javascript/issues/20675