### PR TITLE
fix(e2e): Pin astro version in astro-6 test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6/package.json
@@ -16,7 +16,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
-    "astro": "^6.0.6"
+    "astro": "6.0.6"
   },
   "volta": {
     "node": "22.22.0",

--- a/dev-packages/e2e-tests/test-applications/astro-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6/package.json
@@ -16,7 +16,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
-    "astro": "6.0.6"
+    "astro": "~6.2.0"
   },
   "volta": {
     "node": "22.22.0",


### PR DESCRIPTION
Seems like the latest astro release included a breaking change that breaks our E2E test apps and broke our backsync: https://github.com/getsentry/sentry-javascript/pull/20708

Pinning on master to unblock CI and the backsync.