### PR TITLE
fix(cloudflare): avoid flush lock self-wait

### DIFF
--- a/packages/cloudflare/src/workflows.ts
+++ b/packages/cloudflare/src/workflows.ts
@@ -63,9 +63,9 @@ async function propagationContextFromInstanceId(instanceId: string): Promise<Pro
 class WrappedWorkflowStep implements WorkflowStep {
   public constructor(
     private _instanceId: string,
-    private _ctx: ExecutionContext,
     private _options: CloudflareOptions,
     private _step: WorkflowStep,
+    private _waitUntil: ExecutionContext['waitUntil'],
   ) {}
 
   public async do<T extends Rpc.Serializable<T>>(
@@ -112,7 +112,7 @@ class WrappedWorkflowStep implements WorkflowStep {
             captureException(error, { mechanism: { handled: true, type: 'auto.faas.cloudflare.workflow' } });
             throw error;
           } finally {
-            this._ctx.waitUntil(flush(2000));
+            this._waitUntil(flush(2000));
           }
         },
       );
@@ -175,7 +175,8 @@ export function instrumentWorkflowWithSentry<
               setAsyncLocalStorageAsyncContextStrategy();
 
               return withIsolationScope(async isolationScope => {
-                const client = init({ ...options, enableDedupe: false });
+                const waitUntil = context.waitUntil.bind(context);
+                const client = init({ ...options, ctx: context, enableDedupe: false });
                 isolationScope.setClient(client);
 
                 addCloudResourceContext(isolationScope);
@@ -188,10 +189,10 @@ export function instrumentWorkflowWithSentry<
                     return await obj.run.call(
                       obj,
                       event,
-                      new WrappedWorkflowStep(event.instanceId, context, options, step),
+                      new WrappedWorkflowStep(event.instanceId, options, step, waitUntil),
                     );
                   } finally {
-                    context.waitUntil(flushAndDispose(client));
+                    waitUntil(flushAndDispose(client));
                   }
                 });
               });

--- a/packages/cloudflare/test/workflow.test.ts
+++ b/packages/cloudflare/test/workflow.test.ts
@@ -74,6 +74,31 @@ const INSTANCE_ID = 'ae0ee067-61b3-4852-9219-5d62282270f0';
 const SAMPLE_RAND = '0.44116884107728693';
 const TRACE_ID = INSTANCE_ID.replace(/-/g, '');
 
+async function drainWaitUntilLikeCloudflareVitestPool(
+  waitUntilPromises: Promise<unknown>[],
+  timeoutMs = 100,
+): Promise<void> {
+  while (waitUntilPromises.length > 0) {
+    const batch = waitUntilPromises.splice(0);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const result = await Promise.race([
+      Promise.allSettled(batch).then(() => 'settled' as const),
+      new Promise<'timed-out'>(resolve => {
+        timeoutId = setTimeout(() => resolve('timed-out'), timeoutMs);
+      }),
+    ]);
+
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    if (result === 'timed-out') {
+      throw new Error('Cloudflare Vitest worker pool timed out while draining waitUntil promises');
+    }
+  }
+}
+
 describe.skipIf(NODE_MAJOR_VERSION < 20)('workflows', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -150,6 +175,35 @@ describe.skipIf(NODE_MAJOR_VERSION < 20)('workflows', () => {
         ],
       ],
     ]);
+  });
+
+  test('workflow step and final flush waitUntil promises can be drained by the Cloudflare Vitest worker pool', async () => {
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const context: ExecutionContext = {
+      waitUntil: vi.fn((promise: Promise<unknown>) => {
+        waitUntilPromises.push(promise);
+      }),
+      passThroughOnException: vi.fn(),
+      props: {},
+    };
+
+    class WaitUntilWorkflow {
+      public constructor(private _ctx: ExecutionContext) {}
+
+      public async run(_event: Readonly<WorkflowEvent<Params>>, step: WorkflowStep): Promise<void> {
+        await step.do('waitUntil step', async () => {
+          this._ctx.waitUntil(new Promise<void>(resolve => setTimeout(resolve, 0)));
+        });
+      }
+    }
+
+    const TestWorkflowInstrumented = instrumentWorkflowWithSentry(getSentryOptions, WaitUntilWorkflow as any);
+    const workflow = new TestWorkflowInstrumented(context, {}) as WaitUntilWorkflow;
+    const event = { payload: {}, timestamp: new Date(), instanceId: INSTANCE_ID };
+
+    await workflow.run(event, mockStep);
+
+    await expect(drainWaitUntilLikeCloudflareVitestPool(waitUntilPromises)).resolves.toBeUndefined();
   });
 
   test('Wraps env with instrumentEnv', async () => {


### PR DESCRIPTION
## Summary

- Fix workflow final flushing to use the original/bound `waitUntil`, matching the request wrapper pattern.
- Pass the workflow execution context into Cloudflare SDK initialization so workflow flushes wait for already-scheduled `waitUntil` work without scheduling the final `flushAndDispose(client)` through the same flush-locked `context.waitUntil`.
- Add a regression test that models the Cloudflare Vitest worker pool draining `waitUntil` promises with a timeout.

## Test plan

```bash
cd packages/cloudflare && yarn test:unit test/workflow.test.ts test/flush.test.ts
```

Result:

```text
Test Files  2 passed (2)
Tests       14 passed (14)
```

Note: this PR was written by Pi using GPT-5.5 on medium and directly guided/steered and reviewed by Dillon Mulroy <dillon@cloudflare.com>.
