### PR TITLE
feat(profiling-node): Bump `@sentry-internal/node-cpu-profiler` to 2.4.0

### DIFF
--- a/packages/profiling-node/package.json
+++ b/packages/profiling-node/package.json
@@ -61,7 +61,7 @@
     "test:watch": "vitest --watch"
   },
   "dependencies": {
-    "@sentry-internal/node-cpu-profiler": "^2.2.0",
+    "@sentry-internal/node-cpu-profiler": "^2.4.0",
     "@sentry/core": "10.52.0",
     "@sentry/node": "10.52.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7686,10 +7686,10 @@
   resolved "https://registry.yarnpkg.com/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz#60de891bb126abfdc5410fdc6166aca065f10a0c"
   integrity sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==
 
-"@sentry-internal/node-cpu-profiler@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/node-cpu-profiler/-/node-cpu-profiler-2.2.0.tgz#0640d4aebb4d36031658ccff83dc22b76f437ede"
-  integrity sha512-oLHVYurqZfADPh5hvmQYS5qx8t0UZzT2u6+/68VXsFruQEOnYJTODKgU3BVLmemRs3WE6kCJjPeFdHVYOQGSzQ==
+"@sentry-internal/node-cpu-profiler@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/node-cpu-profiler/-/node-cpu-profiler-2.4.0.tgz#3f14cb7c3637b48e87056c2a5787c5e0aa90b987"
+  integrity sha512-zMrbqkd05LS1Ibt+js4R1aMmjdAO0yi9xiywWeulYs/bxN8P5qq20QHYleI76MorsocvYJAFo9GkYfzyzMd6Og==
   dependencies:
     detect-libc "^2.0.3"
     node-abi "^3.73.0"
@@ -28527,7 +28527,6 @@ stylus@0.59.0, stylus@^0.59.0:
 
 sucrase@^3.27.0, sucrase@^3.35.0, sucrase@getsentry/sucrase#es2020-polyfills:
   version "3.36.0"
-  uid fd682f6129e507c00bb4e6319cc5d6b767e36061
   resolved "https://codeload.github.com/getsentry/sucrase/tar.gz/fd682f6129e507c00bb4e6319cc5d6b767e36061"
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.2"


### PR DESCRIPTION
Bumps this from 2.2.0 to 2.4.0, including the following changes:

## v2.4.0

* feat: Add Node 26 support (https://github.com/getsentry/sentry-javascript-profiling-node-binaries/pull/32)

## v2.3.0

* fix: Memory leaks, integer truncation, UB, and double-stop (https://github.com/getsentry/sentry-javascript-profiling-node-binaries/pull/26)
* fix: Integer arithmetic for timestamps, emit elapsed_since_start_ns as string (https://github.com/getsentry/sentry-javascript-profiling-node-binaries/pull/28)
* fix: Dead member, capacity checks, insert perf, napi_env by value (https://github.com/getsentry/sentry-javascript-profiling-node-binaries/pull/27)
* chore: Replace execSync with execFileSync to prevent command injection (https://github.com/getsentry/sentry-javascript-profiling-node-binaries/pull/23)
* chore: Pin GitHub Actions to full-length commit SHAs (https://github.com/getsentry/sentry-javascript-profiling-node-binaries/pull/24)
* ci: Build Linux in container for wider glibc support (https://github.com/getsentry/sentry-javascript-profiling-node-binaries/pull/16)