### PR TITLE
fix(replay): Capture aborted/errored fetch requests in replay network tab

### DIFF
--- a/packages/replay-internal/src/coreHandlers/handleNetworkBreadcrumbs.ts
+++ b/packages/replay-internal/src/coreHandlers/handleNetworkBreadcrumbs.ts
@@ -95,6 +95,6 @@ function _isXhrHint(hint?: BreadcrumbHint): hint is XhrHint {
   return hint?.xhr;
 }
 
-function _isFetchHint(hint?: BreadcrumbHint): hint is FetchHint {
-  return hint?.response;
+function _isFetchHint(hint?: BreadcrumbHint): hint is Partial<FetchHint> {
+  return hint?.input !== undefined;
 }

--- a/packages/replay-internal/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
@@ -359,6 +359,56 @@ other-header: test`;
       ]);
     });
 
+    it('handles fetch breadcrumb for aborted request (no response)', async () => {
+      const breadcrumb: Breadcrumb = {
+        category: 'fetch',
+        level: 'error',
+        data: {
+          method: 'GET',
+          url: 'https://example.com',
+        },
+      };
+
+      const hint: FetchBreadcrumbHint = {
+        data: new Error('The operation was aborted'),
+        input: ['GET', {}],
+        startTimestamp: BASE_TIMESTAMP + 1000,
+        endTimestamp: BASE_TIMESTAMP + 2000,
+      };
+      beforeAddNetworkBreadcrumb(options, breadcrumb, hint);
+
+      expect(breadcrumb).toEqual({
+        category: 'fetch',
+        level: 'error',
+        data: {
+          method: 'GET',
+          url: 'https://example.com',
+        },
+      });
+
+      await waitForReplayEventBuffer();
+
+      expect((options.replay.eventBuffer as EventBufferArray).events).toEqual([
+        {
+          type: 5,
+          timestamp: (BASE_TIMESTAMP + 1000) / 1000,
+          data: {
+            tag: 'performanceSpan',
+            payload: {
+              data: {
+                method: 'GET',
+                statusCode: 0,
+              },
+              description: 'https://example.com',
+              endTimestamp: (BASE_TIMESTAMP + 2000) / 1000,
+              op: 'resource.fetch',
+              startTimestamp: (BASE_TIMESTAMP + 1000) / 1000,
+            },
+          },
+        },
+      ]);
+    });
+
     it('parses fetch response body if necessary', async () => {
       const breadcrumb: Breadcrumb = {
         category: 'fetch',


### PR DESCRIPTION
Fetch requests that are aborted or fail before receiving response headers never appear in the replay network tab. Reproducible by calling `fetch()` with an `AbortController` that fires before headers arrive. With this setup the request shows up in Sentry breadcrumbs (on the error objects) but is missing from the replay network tab.

`_isFetchHint()` gates on `hint.response` existing, but when a fetch errors or is aborted the breadcrumb handler in the breadcrumb integration creates a hint with the error as `data` and no `response` (since none was received). Changed the guard to check `hint.input` instead, which is always present.

Not sure if there was a specific reason to guard on the response here, in that case we can look into alternative solutions. With the current setup at least I get the request to show up in the replay network tab:
<img width="547" height="134" alt="Screenshot 2026-05-08 at 13 04 16" src="https://github.com/user-attachments/assets/ad9e146f-4f49-4a73-a58e-9a5b7faa2274" />

Fixes https://github.com/getsentry/sentry-javascript/issues/20714