### PR TITLE
feat(browser): Add `fetchStreamPerformanceIntegration` for streamed response tracking

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/init.js
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    Sentry.browserTracingIntegration({ trackFetchStreamPerformance: true }),
+    Sentry.spanStreamingIntegration(),
+  ],
+  tracePropagationTargets: ['http://sentry-test-site.example'],
+  tracesSampleRate: 1,
+  autoSessionTracking: false,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/init.js
@@ -5,8 +5,9 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
-    Sentry.browserTracingIntegration({ trackFetchStreamPerformance: true }),
+    Sentry.browserTracingIntegration(),
     Sentry.spanStreamingIntegration(),
+    Sentry.fetchStreamPerformanceIntegration(),
   ],
   tracePropagationTargets: ['http://sentry-test-site.example'],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/subject.js
@@ -1,0 +1,1 @@
+fetch('http://sentry-test-site.example/delayed').then(res => res.text());

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../utils/fixtures';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
+import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
+
+sentryTest(
+  'span has correct attributes when trackFetchStreamPerformance is enabled',
+  async ({ getLocalTestUrl, page }) => {
+    sentryTest.skip(shouldSkipTracingTest());
+
+    await page.route('http://sentry-test-site.example/*', route =>
+      route.fulfill({ body: 'ok', status: 200 }),
+    );
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const spansPromise = waitForStreamedSpans(page, spans => spans.some(s => getSpanOp(s) === 'http.client'));
+
+    await page.goto(url);
+
+    const allSpans = await spansPromise;
+    const pageloadSpan = allSpans.find(s => getSpanOp(s) === 'pageload');
+    const requestSpan = allSpans.find(s => getSpanOp(s) === 'http.client');
+
+    expect(requestSpan).toBeDefined();
+    expect(requestSpan!.end_timestamp).toBeGreaterThan(requestSpan!.start_timestamp);
+    expect(requestSpan).toMatchObject({
+      name: 'GET http://sentry-test-site.example/delayed',
+      parent_span_id: pageloadSpan?.span_id,
+      span_id: expect.stringMatching(/[a-f\d]{16}/),
+      start_timestamp: expect.any(Number),
+      end_timestamp: expect.any(Number),
+      trace_id: pageloadSpan?.trace_id,
+      status: 'ok',
+      attributes: expect.objectContaining({
+        'http.method': { type: 'string', value: 'GET' },
+        'http.url': { type: 'string', value: 'http://sentry-test-site.example/delayed' },
+        url: { type: 'string', value: 'http://sentry-test-site.example/delayed' },
+        'server.address': { type: 'string', value: 'sentry-test-site.example' },
+        type: { type: 'string', value: 'fetch' },
+        'http.response.status_code': { type: 'integer', value: 200 },
+      }),
+    });
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
-import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
+import { getSpanOp, waitForStreamedSpan } from '../../../../utils/spanUtils';
 
 sentryTest(
   'creates an http.client.stream sibling span when fetchStreamPerformanceIntegration is used',
@@ -12,35 +12,21 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    const spansPromise = waitForStreamedSpans(
-      page,
-      spans =>
-        spans.some(s => getSpanOp(s) === 'http.client') && spans.some(s => getSpanOp(s) === 'http.client.stream'),
-    );
+    // Wait for each span type separately since they may arrive in different envelopes
+    const httpSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'http.client');
+    const streamSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'http.client.stream');
 
     await page.goto(url);
 
-    const allSpans = await spansPromise;
-    const pageloadSpan = allSpans.find(s => getSpanOp(s) === 'pageload');
-    const requestSpan = allSpans.find(s => getSpanOp(s) === 'http.client');
-    const streamSpan = allSpans.find(s => getSpanOp(s) === 'http.client.stream');
+    const [requestSpan, streamSpan] = await Promise.all([httpSpanPromise, streamSpanPromise]);
 
-    expect(requestSpan).toBeDefined();
-    expect(streamSpan).toBeDefined();
-
-    // The http.client span ends at header arrival
     expect(requestSpan).toMatchObject({
       name: 'GET http://sentry-test-site.example/delayed',
-      parent_span_id: pageloadSpan?.span_id,
-      trace_id: pageloadSpan?.trace_id,
       status: 'ok',
     });
 
-    // The stream span starts where the http.client span ends and shares the same parent
     expect(streamSpan).toMatchObject({
       name: 'GET http://sentry-test-site.example/delayed',
-      parent_span_id: pageloadSpan?.span_id,
-      trace_id: pageloadSpan?.trace_id,
       attributes: expect.objectContaining({
         'http.method': { type: 'string', value: 'GET' },
         url: { type: 'string', value: 'http://sentry-test-site.example/delayed' },
@@ -48,8 +34,6 @@ sentryTest(
       }),
     });
 
-    // Allow a small margin for timestamp resolution differences
-    expect(streamSpan!.start_timestamp).toBeGreaterThanOrEqual(requestSpan!.end_timestamp - 0.01);
-    expect(streamSpan!.end_timestamp).toBeGreaterThan(streamSpan!.start_timestamp);
+    expect(streamSpan.end_timestamp).toBeGreaterThan(streamSpan.start_timestamp);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
@@ -14,7 +14,8 @@ sentryTest(
 
     const spansPromise = waitForStreamedSpans(
       page,
-      spans => spans.some(s => getSpanOp(s) === 'http.client') && spans.some(s => getSpanOp(s) === 'http.client.stream'),
+      spans =>
+        spans.some(s => getSpanOp(s) === 'http.client') && spans.some(s => getSpanOp(s) === 'http.client.stream'),
     );
 
     await page.goto(url);

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
@@ -1,3 +1,5 @@
+import http from 'http';
+import type { AddressInfo } from 'net';
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
@@ -8,38 +10,57 @@ sentryTest(
   async ({ getLocalTestUrl, page }) => {
     sentryTest.skip(shouldSkipTracingTest());
 
-    await page.route('http://sentry-test-site.example/*', route =>
-      route.fulfill({
-        body: 'data: ok\n\n',
-        status: 200,
-        headers: { 'content-type': 'text/event-stream' },
-      }),
-    );
-
-    const url = await getLocalTestUrl({ testDir: __dirname });
-
-    // Wait for each span type separately since they may arrive in different envelopes
-    const httpSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'http.client');
-    const streamSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'http.client.stream');
-
-    await page.goto(url);
-
-    const [requestSpan, streamSpan] = await Promise.all([httpSpanPromise, streamSpanPromise]);
-
-    expect(requestSpan).toMatchObject({
-      name: 'GET http://sentry-test-site.example/delayed',
-      status: 'ok',
+    // Real server that responds with SSE headers and no content-length.
+    // Playwright's route.fulfill always adds content-length, so we proxy through
+    // a real server to get authentic streaming response headers.
+    const server = await new Promise<http.Server>(resolve => {
+      const s = http.createServer((req, res) => {
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+          'Access-Control-Allow-Origin': '*',
+        });
+        res.end('data: ok\n\n');
+      });
+      s.listen(0, () => resolve(s));
     });
 
-    expect(streamSpan).toMatchObject({
-      name: 'GET http://sentry-test-site.example/delayed',
-      attributes: expect.objectContaining({
-        'http.method': { type: 'string', value: 'GET' },
-        url: { type: 'string', value: 'http://sentry-test-site.example/delayed' },
-        type: { type: 'string', value: 'fetch' },
-      }),
-    });
+    const port = (server.address() as AddressInfo).port;
 
-    expect(streamSpan.end_timestamp).toBeGreaterThan(streamSpan.start_timestamp);
+    try {
+      await page.route('http://sentry-test-site.example/*', async route => {
+        const response = await route.fetch({ url: `http://localhost:${port}/sse` });
+        await route.fulfill({ response });
+      });
+
+      const url = await getLocalTestUrl({ testDir: __dirname });
+
+      // Wait for each span type separately since they may arrive in different envelopes
+      const httpSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'http.client');
+      const streamSpanPromise = waitForStreamedSpan(page, span => getSpanOp(span) === 'http.client.stream');
+
+      await page.goto(url);
+
+      const [requestSpan, streamSpan] = await Promise.all([httpSpanPromise, streamSpanPromise]);
+
+      expect(requestSpan).toMatchObject({
+        name: 'GET http://sentry-test-site.example/delayed',
+        status: 'ok',
+      });
+
+      expect(streamSpan).toMatchObject({
+        name: 'GET http://sentry-test-site.example/delayed',
+        attributes: expect.objectContaining({
+          'http.method': { type: 'string', value: 'GET' },
+          url: { type: 'string', value: 'http://sentry-test-site.example/delayed' },
+          type: { type: 'string', value: 'fetch' },
+        }),
+      });
+
+      expect(streamSpan.end_timestamp).toBeGreaterThan(streamSpan.start_timestamp);
+    } finally {
+      server.close();
+    }
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
@@ -8,7 +8,13 @@ sentryTest(
   async ({ getLocalTestUrl, page }) => {
     sentryTest.skip(shouldSkipTracingTest());
 
-    await page.route('http://sentry-test-site.example/*', route => route.fulfill({ body: 'ok', status: 200 }));
+    await page.route('http://sentry-test-site.example/*', route =>
+      route.fulfill({
+        body: 'data: ok\n\n',
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
@@ -4,7 +4,7 @@ import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpans } from '../../../../utils/spanUtils';
 
 sentryTest(
-  'span has correct attributes when trackFetchStreamPerformance is enabled',
+  'creates an http.client.stream sibling span when fetchStreamPerformanceIntegration is used',
   async ({ getLocalTestUrl, page }) => {
     sentryTest.skip(shouldSkipTracingTest());
 
@@ -12,32 +12,43 @@ sentryTest(
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 
-    const spansPromise = waitForStreamedSpans(page, spans => spans.some(s => getSpanOp(s) === 'http.client'));
+    const spansPromise = waitForStreamedSpans(
+      page,
+      spans => spans.some(s => getSpanOp(s) === 'http.client') && spans.some(s => getSpanOp(s) === 'http.client.stream'),
+    );
 
     await page.goto(url);
 
     const allSpans = await spansPromise;
     const pageloadSpan = allSpans.find(s => getSpanOp(s) === 'pageload');
     const requestSpan = allSpans.find(s => getSpanOp(s) === 'http.client');
+    const streamSpan = allSpans.find(s => getSpanOp(s) === 'http.client.stream');
 
     expect(requestSpan).toBeDefined();
-    expect(requestSpan!.end_timestamp).toBeGreaterThan(requestSpan!.start_timestamp);
+    expect(streamSpan).toBeDefined();
+
+    // The http.client span ends at header arrival
     expect(requestSpan).toMatchObject({
       name: 'GET http://sentry-test-site.example/delayed',
       parent_span_id: pageloadSpan?.span_id,
-      span_id: expect.stringMatching(/[a-f\d]{16}/),
-      start_timestamp: expect.any(Number),
-      end_timestamp: expect.any(Number),
       trace_id: pageloadSpan?.trace_id,
       status: 'ok',
+    });
+
+    // The stream span starts where the http.client span ends and shares the same parent
+    expect(streamSpan).toMatchObject({
+      name: 'GET http://sentry-test-site.example/delayed',
+      parent_span_id: pageloadSpan?.span_id,
+      trace_id: pageloadSpan?.trace_id,
       attributes: expect.objectContaining({
         'http.method': { type: 'string', value: 'GET' },
-        'http.url': { type: 'string', value: 'http://sentry-test-site.example/delayed' },
         url: { type: 'string', value: 'http://sentry-test-site.example/delayed' },
-        'server.address': { type: 'string', value: 'sentry-test-site.example' },
         type: { type: 'string', value: 'fetch' },
-        'http.response.status_code': { type: 'integer', value: 200 },
       }),
     });
+
+    // Allow a small margin for timestamp resolution differences
+    expect(streamSpan!.start_timestamp).toBeGreaterThanOrEqual(requestSpan!.end_timestamp - 0.01);
+    expect(streamSpan!.end_timestamp).toBeGreaterThan(streamSpan!.start_timestamp);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-streamed-track-stream-performance/test.ts
@@ -8,9 +8,7 @@ sentryTest(
   async ({ getLocalTestUrl, page }) => {
     sentryTest.skip(shouldSkipTracingTest());
 
-    await page.route('http://sentry-test-site.example/*', route =>
-      route.fulfill({ body: 'ok', status: 200 }),
-    );
+    await page.route('http://sentry-test-site.example/*', route => route.fulfill({ body: 'ok', status: 200 }));
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 

--- a/dev-packages/e2e-tests/test-applications/react-router-6/tests/sse.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/tests/sse.test.ts
@@ -14,23 +14,24 @@ test('Waits for sse streaming when creating spans', async ({ page }) => {
   const rootSpan = await transactionPromise;
   const sseFetchCall = rootSpan.spans?.filter(span => span.description === 'sse fetch call')[0]!;
   const httpGet = rootSpan.spans?.filter(span => span.description === 'GET http://localhost:8080/sse')[0]!;
+  const httpStream = rootSpan.spans?.filter(span => span.op === 'http.client.stream')[0]!;
 
   expect(sseFetchCall).toBeDefined();
   expect(httpGet).toBeDefined();
-
-  expect(sseFetchCall?.timestamp).toBeDefined();
-  expect(sseFetchCall?.start_timestamp).toBeDefined();
-  expect(httpGet?.timestamp).toBeDefined();
-  expect(httpGet?.start_timestamp).toBeDefined();
+  expect(httpStream).toBeDefined();
 
   // http headers get sent instantly from the server
   const resolveDuration = Math.round((sseFetchCall.timestamp as number) - sseFetchCall.start_timestamp);
 
-  // body streams after 2s
-  const resolveBodyDuration = Math.round((httpGet.timestamp as number) - httpGet.start_timestamp);
+  // http.client span ends at header arrival (~0s)
+  const httpGetDuration = Math.round((httpGet.timestamp as number) - httpGet.start_timestamp);
+
+  // body streaming duration is captured in the sibling http.client.stream span (~2s)
+  const streamDuration = Math.round((httpStream.timestamp as number) - httpStream.start_timestamp);
 
   expect(resolveDuration).toBe(0);
-  expect(resolveBodyDuration).toBe(2);
+  expect(httpGetDuration).toBe(0);
+  expect(streamDuration).toBe(2);
 });
 
 test('Waits for sse streaming when sse has been explicitly aborted', async ({ page }) => {

--- a/packages/browser/src/index.bundle.feedback.ts
+++ b/packages/browser/src/index.bundle.feedback.ts
@@ -5,6 +5,7 @@ import {
   loggerShim,
   replayIntegrationShim,
   spanStreamingIntegrationShim,
+  fetchStreamPerformanceIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { feedbackAsyncIntegration } from './feedbackAsync';
 
@@ -22,4 +23,5 @@ export {
   feedbackAsyncIntegration as feedbackIntegration,
   replayIntegrationShim as replayIntegration,
   spanStreamingIntegrationShim as spanStreamingIntegration,
+  fetchStreamPerformanceIntegrationShim as fetchStreamPerformanceIntegration,
 };

--- a/packages/browser/src/index.bundle.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.logs.metrics.ts
@@ -3,6 +3,7 @@ import {
   feedbackIntegrationShim,
   replayIntegrationShim,
   spanStreamingIntegrationShim,
+  fetchStreamPerformanceIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
@@ -18,4 +19,5 @@ export {
   feedbackIntegrationShim as feedbackIntegration,
   replayIntegrationShim as replayIntegration,
   spanStreamingIntegrationShim as spanStreamingIntegration,
+  fetchStreamPerformanceIntegrationShim as fetchStreamPerformanceIntegration,
 };

--- a/packages/browser/src/index.bundle.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.replay.feedback.ts
@@ -4,6 +4,7 @@ import {
   elementTimingIntegrationShim,
   loggerShim,
   spanStreamingIntegrationShim,
+  fetchStreamPerformanceIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { feedbackAsyncIntegration } from './feedbackAsync';
 
@@ -20,6 +21,7 @@ export {
   feedbackAsyncIntegration as feedbackAsyncIntegration,
   feedbackAsyncIntegration as feedbackIntegration,
   spanStreamingIntegrationShim as spanStreamingIntegration,
+  fetchStreamPerformanceIntegrationShim as fetchStreamPerformanceIntegration,
 };
 
 export { replayIntegration, getReplay } from '@sentry-internal/replay';

--- a/packages/browser/src/index.bundle.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.replay.logs.metrics.ts
@@ -2,6 +2,7 @@ import {
   browserTracingIntegrationShim,
   feedbackIntegrationShim,
   spanStreamingIntegrationShim,
+  fetchStreamPerformanceIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
@@ -18,4 +19,5 @@ export {
   feedbackIntegrationShim as feedbackAsyncIntegration,
   feedbackIntegrationShim as feedbackIntegration,
   spanStreamingIntegrationShim as spanStreamingIntegration,
+  fetchStreamPerformanceIntegrationShim as fetchStreamPerformanceIntegration,
 };

--- a/packages/browser/src/index.bundle.replay.ts
+++ b/packages/browser/src/index.bundle.replay.ts
@@ -5,6 +5,7 @@ import {
   feedbackIntegrationShim,
   loggerShim,
   spanStreamingIntegrationShim,
+  fetchStreamPerformanceIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
@@ -20,4 +21,5 @@ export {
   feedbackIntegrationShim as feedbackAsyncIntegration,
   feedbackIntegrationShim as feedbackIntegration,
   spanStreamingIntegrationShim as spanStreamingIntegration,
+  fetchStreamPerformanceIntegrationShim as fetchStreamPerformanceIntegration,
 };

--- a/packages/browser/src/index.bundle.tracing.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.logs.metrics.ts
@@ -31,6 +31,7 @@ export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
+export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
 
 export {
   feedbackIntegrationShim as feedbackAsyncIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
@@ -31,6 +31,7 @@ export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
+export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
 
 export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
 

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -37,6 +37,7 @@ export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
+export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
 
 export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
 

--- a/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
@@ -31,6 +31,7 @@ export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
+export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
 
 export { feedbackIntegrationShim as feedbackAsyncIntegration, feedbackIntegrationShim as feedbackIntegration };
 

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -36,6 +36,7 @@ export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
+export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
 
 export { feedbackIntegrationShim as feedbackAsyncIntegration, feedbackIntegrationShim as feedbackIntegration };
 

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -38,6 +38,7 @@ export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
+export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
 
 export {
   feedbackIntegrationShim as feedbackAsyncIntegration,

--- a/packages/browser/src/index.bundle.ts
+++ b/packages/browser/src/index.bundle.ts
@@ -6,6 +6,7 @@ import {
   loggerShim,
   replayIntegrationShim,
   spanStreamingIntegrationShim,
+  fetchStreamPerformanceIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
@@ -20,4 +21,5 @@ export {
   feedbackIntegrationShim as feedbackIntegration,
   replayIntegrationShim as replayIntegration,
   spanStreamingIntegrationShim as spanStreamingIntegration,
+  fetchStreamPerformanceIntegrationShim as fetchStreamPerformanceIntegration,
 };

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -45,6 +45,7 @@ export { elementTimingIntegration } from '@sentry-internal/browser-utils';
 export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 export { spanStreamingIntegration } from './integrations/spanstreaming';
+export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
 
 export type { RequestInstrumentationOptions } from './tracing/request';
 export {

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -58,7 +58,10 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
           // 1. No content-length header (streamed responses don't know the size upfront)
           // 2. Content-type is a known streaming type
           const contentType = handlerData.response.headers?.get('content-type') || '';
-          if (handlerData.response.headers?.get('content-length') || !STREAMING_CONTENT_TYPES.some(t => contentType.startsWith(t))) {
+          if (
+            handlerData.response.headers?.get('content-length') ||
+            !STREAMING_CONTENT_TYPES.some(t => contentType.startsWith(t))
+          ) {
             return;
           }
 

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -56,7 +56,8 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
         if (handlerData.endTimestamp && handlerData.response) {
           // Only create stream spans for responses that are likely streamed:
           // 1. No content-length header (streamed responses don't know the size upfront)
-          // 2. Content-type is a known streaming type
+          // 2. Content-type is a known streaming type (avoids false positives on HTTP/2
+          //    where content-length is often omitted even for regular responses)
           const contentType = handlerData.response.headers?.get('content-type') || '';
           if (
             handlerData.response.headers?.get('content-length') ||

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -1,0 +1,50 @@
+import type { IntegrationFn, Span } from '@sentry/core';
+import {
+  addFetchEndInstrumentationHandler,
+  addFetchInstrumentationHandler,
+  defineIntegration,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  startInactiveSpan,
+} from '@sentry/core';
+
+const responseToStreamSpan = new WeakMap<object, Span>();
+
+export const fetchStreamPerformanceIntegration = defineIntegration(() => {
+  return {
+    name: 'FetchStreamPerformance',
+
+    setup() {
+      addFetchEndInstrumentationHandler(handlerData => {
+        if (handlerData.response) {
+          const streamSpan = responseToStreamSpan.get(handlerData.response);
+          if (streamSpan && handlerData.endTimestamp) {
+            streamSpan.end(handlerData.endTimestamp);
+          }
+        }
+      });
+
+      addFetchInstrumentationHandler(handlerData => {
+        if (handlerData.endTimestamp && handlerData.response) {
+          const url = handlerData.fetchData?.url;
+          const method = handlerData.fetchData?.method;
+
+          const streamSpan = startInactiveSpan({
+            name: `${method} ${url}`,
+            op: 'http.client.stream',
+            startTime: handlerData.endTimestamp,
+            attributes: {
+              url,
+              'http.method': method,
+              type: 'fetch',
+              [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.client.stream',
+              [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser.stream',
+            },
+          });
+
+          responseToStreamSpan.set(handlerData.response, streamSpan);
+        }
+      });
+    },
+  };
+}) satisfies IntegrationFn;

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -3,9 +3,12 @@ import {
   addFetchEndInstrumentationHandler,
   addFetchInstrumentationHandler,
   defineIntegration,
+  getSanitizedUrlStringFromUrlObject,
+  parseStringToURLObject,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startInactiveSpan,
+  stripDataUrlContent,
 } from '@sentry/core';
 
 const responseToStreamSpan = new WeakMap<object, Span>();
@@ -26,15 +29,21 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
 
       addFetchInstrumentationHandler(handlerData => {
         if (handlerData.endTimestamp && handlerData.response) {
-          const url = handlerData.fetchData?.url;
-          const method = handlerData.fetchData?.method;
+          const url = handlerData.fetchData?.url || '';
+          const method = handlerData.fetchData?.method || 'GET';
+
+          const parsedUrl = parseStringToURLObject(url);
+          const sanitizedUrl = url.startsWith('data:')
+            ? stripDataUrlContent(url)
+            : parsedUrl
+              ? getSanitizedUrlStringFromUrlObject(parsedUrl)
+              : url;
 
           const streamSpan = startInactiveSpan({
-            name: `${method} ${url}`,
-            op: 'http.client.stream',
+            name: `${method} ${sanitizedUrl}`,
             startTime: handlerData.endTimestamp,
             attributes: {
-              url,
+              url: stripDataUrlContent(url),
               'http.method': method,
               type: 'fetch',
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.client.stream',

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -12,6 +12,10 @@ import {
 } from '@sentry/core';
 
 const responseToStreamSpan = new WeakMap<object, Span>();
+const responseToFallbackTimeout = new WeakMap<object, ReturnType<typeof setTimeout>>();
+
+// Matches the max timeout in `resolveResponse` in packages/core/src/instrument/fetch.ts
+const STREAM_RESOLVE_FALLBACK_MS = 90_000;
 
 export const fetchStreamPerformanceIntegration = defineIntegration(() => {
   return {
@@ -23,6 +27,11 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
           const streamSpan = responseToStreamSpan.get(handlerData.response);
           if (streamSpan && handlerData.endTimestamp) {
             streamSpan.end(handlerData.endTimestamp);
+
+            const fallbackTimeout = responseToFallbackTimeout.get(handlerData.response);
+            if (fallbackTimeout) {
+              clearTimeout(fallbackTimeout);
+            }
           }
         }
       });
@@ -52,6 +61,14 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
           });
 
           responseToStreamSpan.set(handlerData.response, streamSpan);
+
+          const fallbackTimeout = setTimeout(() => {
+            if (streamSpan.isRecording()) {
+              streamSpan.end();
+            }
+          }, STREAM_RESOLVE_FALLBACK_MS);
+
+          responseToFallbackTimeout.set(handlerData.response, fallbackTimeout);
         }
       });
     },

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -17,6 +17,8 @@ const responseToFallbackTimeout = new WeakMap<object, ReturnType<typeof setTimeo
 // Matches the max timeout in `resolveResponse` in packages/core/src/instrument/fetch.ts
 const STREAM_RESOLVE_FALLBACK_MS = 90_000;
 
+const STREAMING_CONTENT_TYPES = ['text/event-stream', 'application/x-ndjson', 'application/stream+json'];
+
 /**
  * Tracks streamed fetch response bodies by creating an `http.client.stream` sibling span.
  *
@@ -52,8 +54,11 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
       addFetchInstrumentationHandler(handlerData => {
         // Only create the stream span once headers have arrived
         if (handlerData.endTimestamp && handlerData.response) {
-          // Skip non-streamed responses (they don't have a content-length header)
-          if (handlerData.response.headers?.get('content-length')) {
+          // Only create stream spans for responses that are likely streamed:
+          // 1. No content-length header (streamed responses don't know the size upfront)
+          // 2. Content-type is a known streaming type
+          const contentType = handlerData.response.headers?.get('content-type') || '';
+          if (handlerData.response.headers?.get('content-length') || !STREAMING_CONTENT_TYPES.some(t => contentType.startsWith(t))) {
             return;
           }
 

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -17,11 +17,24 @@ const responseToFallbackTimeout = new WeakMap<object, ReturnType<typeof setTimeo
 // Matches the max timeout in `resolveResponse` in packages/core/src/instrument/fetch.ts
 const STREAM_RESOLVE_FALLBACK_MS = 90_000;
 
+/**
+ * Tracks streamed fetch response bodies by creating an `http.client.stream` sibling span.
+ *
+ * The regular `http.client` span ends when response headers arrive. This integration adds
+ * a span that starts at header arrival and ends when the body fully resolves:
+ *
+ * ```
+ * --------- pageload --------------------------------
+ *     -- http.client --
+ *                       -- http.client.stream -------
+ * ```
+ */
 export const fetchStreamPerformanceIntegration = defineIntegration(() => {
   return {
     name: 'FetchStreamPerformance',
 
     setup() {
+      // End the stream span when the response body finishes resolving
       addFetchEndInstrumentationHandler(handlerData => {
         if (handlerData.response) {
           const streamSpan = responseToStreamSpan.get(handlerData.response);
@@ -37,7 +50,13 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
       });
 
       addFetchInstrumentationHandler(handlerData => {
+        // Only create the stream span once headers have arrived
         if (handlerData.endTimestamp && handlerData.response) {
+          // Skip non-streamed responses (they don't have a content-length header)
+          if (handlerData.response.headers?.get('content-length')) {
+            return;
+          }
+
           const url = handlerData.fetchData?.url || '';
           const method = handlerData.fetchData?.method || 'GET';
 
@@ -62,6 +81,7 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
 
           responseToStreamSpan.set(handlerData.response, streamSpan);
 
+          // prevent the span from leaking indefinitely if the body never resolves
           const fallbackTimeout = setTimeout(() => {
             if (streamSpan.isRecording()) {
               streamSpan.end();

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -52,6 +52,7 @@ import {
 } from '@sentry-internal/browser-utils';
 import { DEBUG_BUILD } from '../debug-build';
 import { getHttpRequestData, WINDOW } from '../helpers';
+import { fetchStreamPerformanceIntegration } from '../integrations/fetchStreamPerformance';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
@@ -743,13 +744,16 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       instrumentOutgoingRequests(client, {
         traceFetch,
         traceXHR,
-        trackFetchStreamPerformance,
         tracePropagationTargets: client.getOptions().tracePropagationTargets,
         shouldCreateSpanForRequest,
         enableHTTPTimings,
         onRequestSpanStart,
         onRequestSpanEnd,
       });
+
+      if (trackFetchStreamPerformance) {
+        client.addIntegration(fetchStreamPerformanceIntegration());
+      }
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -175,6 +175,9 @@ export interface BrowserTracingOptions {
    * Do not enable this in case you have live streams or very long running streams.
    *
    * Default: false
+   *
+   * @deprecated Use `fetchStreamPerformanceIntegration()` instead. Add it to your `integrations` array
+   * to track the duration of streamed fetch response bodies.
    */
   trackFetchStreamPerformance: boolean;
 

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -124,7 +124,7 @@ export interface RequestInstrumentationOptions {
 }
 
 const responseToSpanId = new WeakMap<object, string>();
-const spanIdToEndTimestamp = new Map<string, number>();
+const spanIdToDeferredSpan = new Map<string, Span>();
 
 export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions = {
   traceFetch: true,
@@ -159,53 +159,41 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
   const propagateTraceparent = (client as BrowserClient).getOptions().propagateTraceparent;
 
   if (traceFetch) {
-    // Keeping track of http requests, whose body payloads resolved later than the initial resolved request
-    // e.g. streaming using server sent events (SSE)
-    client.addEventProcessor(event => {
-      if (event.type === 'transaction' && event.spans) {
-        event.spans.forEach(span => {
-          if (span.op === 'http.client') {
-            const updatedTimestamp = spanIdToEndTimestamp.get(span.span_id);
-            if (updatedTimestamp) {
-              span.timestamp = updatedTimestamp / 1000;
-              spanIdToEndTimestamp.delete(span.span_id);
-            }
-          }
-        });
-      }
-      return event;
-    });
-
-    client.on('processSpan', span => {
-      if (span.attributes?.['sentry.op'] === 'http.client') {
-        const updatedTimestamp = spanIdToEndTimestamp.get(span.span_id);
-        if (updatedTimestamp) {
-          span.end_timestamp = updatedTimestamp / 1000;
-          spanIdToEndTimestamp.delete(span.span_id);
-        }
-      }
-    });
-
     if (trackFetchStreamPerformance) {
       addFetchEndInstrumentationHandler(handlerData => {
         if (handlerData.response) {
-          const span = responseToSpanId.get(handlerData.response);
-          if (span && handlerData.endTimestamp) {
-            spanIdToEndTimestamp.set(span, handlerData.endTimestamp);
+          const spanId = responseToSpanId.get(handlerData.response);
+          if (spanId) {
+            const deferredSpan = spanIdToDeferredSpan.get(spanId);
+            if (deferredSpan && handlerData.endTimestamp) {
+              setHttpStatus(deferredSpan, handlerData.response.status);
+              deferredSpan.end(handlerData.endTimestamp);
+              spanIdToDeferredSpan.delete(spanId);
+            }
           }
         }
       });
     }
 
     addFetchInstrumentationHandler(handlerData => {
+      // When tracking streaming performance, defer span end until the response body resolves.
+      // We intercept the end call, save the span, and let the fetchEndInstrumentationHandler
+      // end it with the correct timestamp.
+      if (trackFetchStreamPerformance && handlerData.endTimestamp && handlerData.response) {
+        const spanId = handlerData.fetchData?.__span;
+        if (spanId && spans[spanId]) {
+          responseToSpanId.set(handlerData.response, spanId);
+          spanIdToDeferredSpan.set(spanId, spans[spanId]);
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete spans[spanId];
+          return;
+        }
+      }
+
       const createdSpan = instrumentFetchRequest(handlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
         propagateTraceparent,
         onRequestSpanEnd,
       });
-
-      if (handlerData.response && handlerData.fetchData.__span) {
-        responseToSpanId.set(handlerData.response, handlerData.fetchData.__span);
-      }
 
       // We cannot use `window.location` in the generic fetch instrumentation,
       // but we need it for reliable `server.address` attribute.

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -125,7 +125,7 @@ export interface RequestInstrumentationOptions {
 }
 
 const responseToSpanId = new WeakMap<object, string>();
-const spanIdToDeferredData = new Map<string, { span: Span; handlerData: HandlerDataFetch }>();
+const spanIdToDeferredHandlerData = new Map<string, HandlerDataFetch>();
 
 export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions = {
   traceFetch: true,
@@ -165,14 +165,14 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
         if (handlerData.response) {
           const spanId = responseToSpanId.get(handlerData.response);
           if (spanId) {
-            const deferred = spanIdToDeferredData.get(spanId);
-            if (deferred && handlerData.endTimestamp) {
-              deferred.handlerData.endTimestamp = handlerData.endTimestamp;
-              instrumentFetchRequest(deferred.handlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
+            const deferredHandlerData = spanIdToDeferredHandlerData.get(spanId);
+            if (deferredHandlerData && handlerData.endTimestamp) {
+              deferredHandlerData.endTimestamp = handlerData.endTimestamp;
+              instrumentFetchRequest(deferredHandlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
                 propagateTraceparent,
                 onRequestSpanEnd,
               });
-              spanIdToDeferredData.delete(spanId);
+              spanIdToDeferredHandlerData.delete(spanId);
             }
           }
         }
@@ -187,7 +187,7 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
         const spanId = handlerData.fetchData?.__span;
         if (spanId && spans[spanId]) {
           responseToSpanId.set(handlerData.response, spanId);
-          spanIdToDeferredData.set(spanId, { span: spans[spanId], handlerData });
+          spanIdToDeferredHandlerData.set(spanId, handlerData);
           return;
         }
       }

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -176,6 +176,16 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
       return event;
     });
 
+    client.on('processSpan', span => {
+      if (span.attributes?.['sentry.op'] === 'http.client') {
+        const updatedTimestamp = spanIdToEndTimestamp.get(span.span_id);
+        if (updatedTimestamp) {
+          span.end_timestamp = updatedTimestamp / 1000;
+          spanIdToEndTimestamp.delete(span.span_id);
+        }
+      }
+    });
+
     if (trackFetchStreamPerformance) {
       addFetchEndInstrumentationHandler(handlerData => {
         if (handlerData.response) {

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -167,7 +167,6 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
           if (spanId) {
             const deferred = spanIdToDeferredData.get(spanId);
             if (deferred && handlerData.endTimestamp) {
-              spans[spanId] = deferred.span;
               deferred.handlerData.endTimestamp = handlerData.endTimestamp;
               instrumentFetchRequest(deferred.handlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
                 propagateTraceparent,
@@ -189,8 +188,6 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
         if (spanId && spans[spanId]) {
           responseToSpanId.set(handlerData.response, spanId);
           spanIdToDeferredData.set(spanId, { span: spans[spanId], handlerData });
-          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-          delete spans[spanId];
           return;
         }
       }

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import type {
   Client,
+  HandlerDataFetch,
   HandlerDataXhr,
   RequestHookInfo,
   ResponseHookInfo,
@@ -124,7 +125,7 @@ export interface RequestInstrumentationOptions {
 }
 
 const responseToSpanId = new WeakMap<object, string>();
-const spanIdToDeferredSpan = new Map<string, Span>();
+const spanIdToDeferredData = new Map<string, { span: Span; handlerData: HandlerDataFetch }>();
 
 export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions = {
   traceFetch: true,
@@ -164,11 +165,15 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
         if (handlerData.response) {
           const spanId = responseToSpanId.get(handlerData.response);
           if (spanId) {
-            const deferredSpan = spanIdToDeferredSpan.get(spanId);
-            if (deferredSpan && handlerData.endTimestamp) {
-              setHttpStatus(deferredSpan, handlerData.response.status);
-              deferredSpan.end(handlerData.endTimestamp);
-              spanIdToDeferredSpan.delete(spanId);
+            const deferred = spanIdToDeferredData.get(spanId);
+            if (deferred && handlerData.endTimestamp) {
+              spans[spanId] = deferred.span;
+              deferred.handlerData.endTimestamp = handlerData.endTimestamp;
+              instrumentFetchRequest(deferred.handlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
+                propagateTraceparent,
+                onRequestSpanEnd,
+              });
+              spanIdToDeferredData.delete(spanId);
             }
           }
         }
@@ -183,7 +188,7 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
         const spanId = handlerData.fetchData?.__span;
         if (spanId && spans[spanId]) {
           responseToSpanId.set(handlerData.response, spanId);
-          spanIdToDeferredSpan.set(spanId, spans[spanId]);
+          spanIdToDeferredData.set(spanId, { span: spans[spanId], handlerData });
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
           delete spans[spanId];
           return;

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -126,6 +126,10 @@ export interface RequestInstrumentationOptions {
 
 const responseToSpanId = new WeakMap<object, string>();
 const spanIdToDeferredHandlerData = new Map<string, HandlerDataFetch>();
+const spanIdToFallbackTimeout = new Map<string, ReturnType<typeof setTimeout>>();
+
+// Matches the max fetch timeout defined in core/src/instrument/fetch.ts
+const STREAM_RESOLVE_FALLBACK_MS = 90_000;
 
 export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions = {
   traceFetch: true,
@@ -167,12 +171,20 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
           if (spanId) {
             const deferredHandlerData = spanIdToDeferredHandlerData.get(spanId);
             if (deferredHandlerData && handlerData.endTimestamp) {
+              // end span with the correct timestamp
               deferredHandlerData.endTimestamp = handlerData.endTimestamp;
               instrumentFetchRequest(deferredHandlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
                 propagateTraceparent,
                 onRequestSpanEnd,
               });
               spanIdToDeferredHandlerData.delete(spanId);
+
+              // clear fallback timeout since the body was successfully resolved and we ended the span
+              const fallbackTimeout = spanIdToFallbackTimeout.get(spanId);
+              if (fallbackTimeout) {
+                clearTimeout(fallbackTimeout);
+                spanIdToFallbackTimeout.delete(spanId);
+              }
             }
           }
         }
@@ -188,6 +200,21 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
         if (spanId && spans[spanId]) {
           responseToSpanId.set(handlerData.response, spanId);
           spanIdToDeferredHandlerData.set(spanId, handlerData);
+
+          // set fallback timeout to also end the span if the response body is not resolved
+          const fallbackTimeout = setTimeout(() => {
+            const deferredHandlerData = spanIdToDeferredHandlerData.get(spanId);
+            if (deferredHandlerData) {
+              instrumentFetchRequest(deferredHandlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
+                propagateTraceparent,
+                onRequestSpanEnd,
+              });
+              spanIdToDeferredHandlerData.delete(spanId);
+              spanIdToFallbackTimeout.delete(spanId);
+            }
+          }, STREAM_RESOLVE_FALLBACK_MS);
+
+          spanIdToFallbackTimeout.set(spanId, fallbackTimeout);
           return;
         }
       }

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines */
 import type {
   Client,
-  HandlerDataFetch,
   HandlerDataXhr,
   RequestHookInfo,
   ResponseHookInfo,
@@ -10,7 +9,6 @@ import type {
   SpanTimeInput,
 } from '@sentry/core';
 import {
-  addFetchEndInstrumentationHandler,
   addFetchInstrumentationHandler,
   getActiveSpan,
   getClient,
@@ -124,13 +122,6 @@ export interface RequestInstrumentationOptions {
   onRequestSpanEnd?(span: Span, responseInformation: ResponseHookInfo): void;
 }
 
-const responseToSpanId = new WeakMap<object, string>();
-const spanIdToDeferredHandlerData = new Map<string, HandlerDataFetch>();
-const spanIdToFallbackTimeout = new Map<string, ReturnType<typeof setTimeout>>();
-
-// Matches the max fetch timeout defined in core/src/instrument/fetch.ts
-const STREAM_RESOLVE_FALLBACK_MS = 90_000;
-
 export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions = {
   traceFetch: true,
   traceXHR: true,
@@ -143,7 +134,6 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
   const {
     traceFetch,
     traceXHR,
-    trackFetchStreamPerformance,
     shouldCreateSpanForRequest,
     enableHTTPTimings,
     tracePropagationTargets,
@@ -164,61 +154,7 @@ export function instrumentOutgoingRequests(client: Client, _options?: Partial<Re
   const propagateTraceparent = (client as BrowserClient).getOptions().propagateTraceparent;
 
   if (traceFetch) {
-    if (trackFetchStreamPerformance) {
-      addFetchEndInstrumentationHandler(handlerData => {
-        if (handlerData.response) {
-          const spanId = responseToSpanId.get(handlerData.response);
-          if (spanId) {
-            const deferredHandlerData = spanIdToDeferredHandlerData.get(spanId);
-            if (deferredHandlerData && handlerData.endTimestamp) {
-              // end span with the correct timestamp
-              deferredHandlerData.endTimestamp = handlerData.endTimestamp;
-              instrumentFetchRequest(deferredHandlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
-                propagateTraceparent,
-                onRequestSpanEnd,
-              });
-              spanIdToDeferredHandlerData.delete(spanId);
-
-              // clear fallback timeout since the body was successfully resolved and we ended the span
-              const fallbackTimeout = spanIdToFallbackTimeout.get(spanId);
-              if (fallbackTimeout) {
-                clearTimeout(fallbackTimeout);
-                spanIdToFallbackTimeout.delete(spanId);
-              }
-            }
-          }
-        }
-      });
-    }
-
     addFetchInstrumentationHandler(handlerData => {
-      // When tracking streaming performance, defer span end until the response body resolves.
-      // We intercept the end call, save the span, and let the fetchEndInstrumentationHandler
-      // end it with the correct timestamp.
-      if (trackFetchStreamPerformance && handlerData.endTimestamp && handlerData.response) {
-        const spanId = handlerData.fetchData?.__span;
-        if (spanId && spans[spanId]) {
-          responseToSpanId.set(handlerData.response, spanId);
-          spanIdToDeferredHandlerData.set(spanId, handlerData);
-
-          // set fallback timeout to also end the span if the response body is not resolved
-          const fallbackTimeout = setTimeout(() => {
-            const deferredHandlerData = spanIdToDeferredHandlerData.get(spanId);
-            if (deferredHandlerData) {
-              instrumentFetchRequest(deferredHandlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
-                propagateTraceparent,
-                onRequestSpanEnd,
-              });
-              spanIdToDeferredHandlerData.delete(spanId);
-              spanIdToFallbackTimeout.delete(spanId);
-            }
-          }, STREAM_RESOLVE_FALLBACK_MS);
-
-          spanIdToFallbackTimeout.set(spanId, fallbackTimeout);
-          return;
-        }
-      }
-
       const createdSpan = instrumentFetchRequest(handlerData, shouldCreateSpan, shouldAttachHeadersWithTargets, spans, {
         propagateTraceparent,
         onRequestSpanEnd,

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -93,6 +93,9 @@ export interface RequestInstrumentationOptions {
    * (https://github.com/getsentry/sentry-javascript/issues/13950)
    *
    * Default: false
+   *
+   * @deprecated Use `fetchStreamPerformanceIntegration()` instead. Add it to your `integrations` array
+   * to track the duration of streamed fetch response bodies.
    */
   trackFetchStreamPerformance: boolean;
 

--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -52,13 +52,6 @@ describe('instrumentOutgoingRequests', () => {
     expect(addXhrSpy).not.toHaveBeenCalled();
   });
 
-  it('does instrument streaming requests if trackFetchStreamPerformance is true', () => {
-    const addFetchEndSpy = vi.spyOn(utils, 'addFetchEndInstrumentationHandler');
-
-    instrumentOutgoingRequests(client, { trackFetchStreamPerformance: true });
-
-    expect(addFetchEndSpy).toHaveBeenCalledWith(expect.any(Function));
-  });
 });
 
 describe('shouldAttachHeaders', () => {

--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -12,12 +12,6 @@ beforeAll(() => {
 });
 
 class MockClient implements Partial<Client> {
-  public addEventProcessor: () => void;
-  public on: () => () => void;
-  constructor() {
-    this.addEventProcessor = vi.fn();
-    this.on = vi.fn(() => () => {});
-  }
   // @ts-expect-error not returning options for the test
   public getOptions() {
     return {};

--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -13,9 +13,10 @@ beforeAll(() => {
 
 class MockClient implements Partial<Client> {
   public addEventProcessor: () => void;
+  public on: () => () => void;
   constructor() {
-    // Mock addEventProcessor function
     this.addEventProcessor = vi.fn();
+    this.on = vi.fn(() => () => {});
   }
   // @ts-expect-error not returning options for the test
   public getOptions() {

--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -51,7 +51,6 @@ describe('instrumentOutgoingRequests', () => {
 
     expect(addXhrSpy).not.toHaveBeenCalled();
   });
-
 });
 
 describe('shouldAttachHeaders', () => {

--- a/packages/integration-shims/src/FetchStreamPerformance.ts
+++ b/packages/integration-shims/src/FetchStreamPerformance.ts
@@ -8,9 +8,7 @@ import { consoleSandbox, defineIntegration } from '@sentry/core';
 export const fetchStreamPerformanceIntegrationShim = defineIntegration(() => {
   consoleSandbox(() => {
     // eslint-disable-next-line no-console
-    console.warn(
-      'You are using fetchStreamPerformanceIntegration() even though this bundle does not include tracing.',
-    );
+    console.warn('You are using fetchStreamPerformanceIntegration() even though this bundle does not include tracing.');
   });
 
   return {

--- a/packages/integration-shims/src/FetchStreamPerformance.ts
+++ b/packages/integration-shims/src/FetchStreamPerformance.ts
@@ -1,0 +1,19 @@
+import { consoleSandbox, defineIntegration } from '@sentry/core';
+
+/**
+ * This is a shim for the FetchStreamPerformance integration.
+ * It is needed in order for the CDN bundles to continue working when users add/remove this integration
+ * from it, without changing their config. This is necessary for the loader mechanism.
+ */
+export const fetchStreamPerformanceIntegrationShim = defineIntegration(() => {
+  consoleSandbox(() => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'You are using fetchStreamPerformanceIntegration() even though this bundle does not include tracing.',
+    );
+  });
+
+  return {
+    name: 'FetchStreamPerformance',
+  };
+});

--- a/packages/integration-shims/src/index.ts
+++ b/packages/integration-shims/src/index.ts
@@ -5,3 +5,4 @@ export { launchDarklyIntegrationShim, buildLaunchDarklyFlagUsedHandlerShim } fro
 export { elementTimingIntegrationShim } from './ElementTiming';
 export { loggerShim, consoleLoggingIntegrationShim } from './logs';
 export { spanStreamingIntegrationShim } from './SpanStreaming';
+export { fetchStreamPerformanceIntegrationShim } from './FetchStreamPerformance';


### PR DESCRIPTION
Replaces the event processor approach for trackFetchStreamPerformance with a new `fetchStreamPerformanceIntegration()`.

Instead of retroactively patching `http.client` span timestamps, the integration creates a sibling `http.client.stream` span that starts when response headers arrive and ends when the response body fully resolves. The existing `trackFetchStreamPerformance` flag on the `browserTracingIntegration` still works by auto-adding the integration under the hood (deprecated in favor of adding the integration directly). Currently this will extend the pageload span until the full body of the streamed request has resolved. An added benefit of this approach is that we now get data about how much this is actually used.

Screenshots from a local sample app

Feature disabled:
<img width="836" height="66" alt="Screenshot 2026-05-13 at 13 12 58" src="https://github.com/user-attachments/assets/46b6159d-2366-4186-846b-6ba5939ff98e" />

Feature enabled:
<img width="836" height="107" alt="Screenshot 2026-05-13 at 13 11 31" src="https://github.com/user-attachments/assets/bf379cc7-eed7-4d43-84bb-45d2451fd305" />

Closes #20376