### PR TITLE
test(cloudflare-hono): fix 'occured' -> 'occurred' typo in error log

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-hono/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-hono/src/index.ts
@@ -17,7 +17,7 @@ app.get('/error', () => {
 });
 
 app.onError((err, ctx) => {
-  console.error(`Error occured: ${err.message}`);
+  console.error(`Error occurred: ${err.message}`);
   return ctx.json({ error: err.message }, 500);
 });
 


### PR DESCRIPTION
Fixes a spelling typo (`occured` -> `occurred`) in the cloudflare-hono e2e test app's error log message.