### PR TITLE
feat(core): Add `applicationKey` to `BuildTimeOptionsBase`

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -35,6 +35,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           // todo(v11): Extract `release` build time option here - cannot be done currently, because it conflicts with the `DeprecatedRuntimeOptions` type
           // release,
           bundleSizeOptimizations,
+          applicationKey,
           unstable_sentryVitePluginOptions,
           debug,
           org,
@@ -109,6 +110,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
               },
               plugins: [
                 sentryVitePlugin({
+                  applicationKey,
                   // Priority: top-level options > deprecated options > env vars
                   // eslint-disable-next-line deprecation/deprecation
                   org: org ?? uploadOptions.org ?? env.SENTRY_ORG,

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -269,6 +269,21 @@ describe('sentryAstro integration', () => {
     );
   });
 
+  it('passes top-level applicationKey to the vite plugin', async () => {
+    const integration = sentryAstro({
+      applicationKey: 'my-app-key',
+      sourceMapsUploadOptions: { enabled: true, org: 'my-org', project: 'my-project' },
+    });
+    // @ts-expect-error - the hook exists and we only need to pass what we actually use
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
+
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationKey: 'my-app-key',
+      }),
+    );
+  });
+
   it("doesn't enable source maps if `sourceMapsUploadOptions.enabled` is `false`", async () => {
     const integration = sentryAstro({
       sourceMapsUploadOptions: { enabled: false },

--- a/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
+++ b/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
@@ -125,6 +125,15 @@ export interface BuildTimeOptionsBase {
    * Options for bundle size optimizations by excluding certain features of the Sentry SDK.
    */
   bundleSizeOptimizations?: BundleSizeOptimizationsOptions;
+
+  /**
+   * A key that is used to identify the application in the Sentry bundler plugins.
+   * This key is used by the `thirdPartyErrorFilterIntegration` to filter out errors
+   * originating from third-party scripts.
+   *
+   * @see https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration
+   */
+  applicationKey?: string;
 }
 
 /**

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -171,6 +171,7 @@ export function getPluginOptions(
   }
 
   return {
+    applicationKey: moduleOptions.applicationKey,
     // eslint-disable-next-line deprecation/deprecation
     org: moduleOptions.org ?? sourceMapsUploadOptions.org ?? process.env.SENTRY_ORG,
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/nuxt/test/vite/sourceMaps.test.ts
+++ b/packages/nuxt/test/vite/sourceMaps.test.ts
@@ -231,6 +231,18 @@ describe('getPluginOptions', () => {
     });
   });
 
+  it('passes applicationKey to plugin options', () => {
+    const options: SentryNuxtModuleOptions = {
+      applicationKey: 'my-app-key',
+    };
+
+    const result = getPluginOptions(options);
+
+    expect(result).toMatchObject({
+      applicationKey: 'my-app-key',
+    });
+  });
+
   it('supports bundleSizeOptimizations', () => {
     const options: SentryNuxtModuleOptions = {
       bundleSizeOptimizations: {

--- a/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
+++ b/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
@@ -10,6 +10,7 @@ export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuil
     debug,
     unstable_sentryVitePluginOptions,
     bundleSizeOptimizations,
+    applicationKey,
     authToken,
     org,
     project,
@@ -19,6 +20,7 @@ export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuil
   } = options;
 
   const sentryVitePlugins = sentryVitePlugin({
+    applicationKey,
     authToken: authToken ?? process.env.SENTRY_AUTH_TOKEN,
     bundleSizeOptimizations,
     debug: debug ?? false,

--- a/packages/react-router/test/vite/makeCustomSentryVitePlugins.test.ts
+++ b/packages/react-router/test/vite/makeCustomSentryVitePlugins.test.ts
@@ -48,6 +48,18 @@ describe('makeCustomSentryVitePlugins', () => {
     );
   });
 
+  it('should pass applicationKey to sentryVitePlugin', async () => {
+    await makeCustomSentryVitePlugins({
+      applicationKey: 'my-app-key',
+    });
+
+    expect(sentryVitePlugin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationKey: 'my-app-key',
+      }),
+    );
+  });
+
   it('should return all plugins from sentryVitePlugin', async () => {
     const plugins = await makeCustomSentryVitePlugins({});
     expect(plugins).toHaveLength(1);

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -207,6 +207,20 @@ describe('generateVitePluginOptions', () => {
     expect(result).toBeNull();
   });
 
+  it('passes applicationKey through to vite plugin options', () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    const options: SentrySvelteKitPluginOptions = {
+      autoUploadSourceMaps: true,
+      applicationKey: 'my-app-key',
+    };
+    const result = generateVitePluginOptions(options);
+    expect(result).toEqual(expect.objectContaining({ applicationKey: 'my-app-key' }));
+
+    process.env.NODE_ENV = originalEnv;
+  });
+
   it('uses default `debug` value if only default options are provided', () => {
     const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production'; // Ensure we're not in development mode

--- a/packages/tanstackstart-react/src/vite/sourceMaps.ts
+++ b/packages/tanstackstart-react/src/vite/sourceMaps.ts
@@ -9,6 +9,7 @@ type FilesToDeleteAfterUpload = string | string[] | undefined;
  */
 export function makeAddSentryVitePlugin(options: BuildTimeOptionsBase): Plugin[] {
   const {
+    applicationKey,
     authToken,
     bundleSizeOptimizations,
     debug,
@@ -52,6 +53,7 @@ export function makeAddSentryVitePlugin(options: BuildTimeOptionsBase): Plugin[]
   };
 
   const sentryPlugins = sentryVitePlugin({
+    applicationKey,
     authToken: authToken ?? process.env.SENTRY_AUTH_TOKEN,
     bundleSizeOptimizations: bundleSizeOptimizations ?? undefined,
     debug: debug ?? false,

--- a/packages/tanstackstart-react/test/vite/sourceMaps.test.ts
+++ b/packages/tanstackstart-react/test/vite/sourceMaps.test.ts
@@ -98,6 +98,18 @@ describe('makeAddSentryVitePlugin()', () => {
     );
   });
 
+  it('passes applicationKey to sentryVitePlugin', () => {
+    makeAddSentryVitePlugin({
+      applicationKey: 'my-app-key',
+    });
+
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationKey: 'my-app-key',
+      }),
+    );
+  });
+
   it('returns Sentry Vite plugins and config plugin', () => {
     const plugins = makeAddSentryVitePlugin({
       org: 'my-org',


### PR DESCRIPTION
 Adds a top-level `applicationKey` option to the shared `BuildTimeOptionsBase` interface, so users can configure `thirdPartyErrorFilterIntegration` without needing `unstable_*` escape hatches.

Wires up forwarding in:
  - React Router
  - SvelteKit
  - Astro 
  - Nuxt
  
 Will do Next.js in a follow up as this does not implement the interface

closes https://github.com/getsentry/sentry-javascript/issues/17384