### PR TITLE
feat(core): Add `addConsoleInstrumentationFilter` utility

### DIFF
--- a/dev-packages/node-integration-tests/suites/integrations/console/filter/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/integrations/console/filter/instrument.mjs
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+  defaultIntegrations: false,
+  integrations: [Sentry.consoleIntegration({ filter: ['foo'] })],
+});

--- a/dev-packages/node-integration-tests/suites/integrations/console/filter/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/integrations/console/filter/scenario.mjs
@@ -1,0 +1,9 @@
+/* eslint-disable no-console */
+import * as Sentry from '@sentry/node';
+
+console.log('hello');
+console.log('foo');
+console.log('foo2');
+console.log('baz');
+
+Sentry.captureException(new Error('Test Error'));

--- a/dev-packages/node-integration-tests/suites/integrations/console/filter/test.ts
+++ b/dev-packages/node-integration-tests/suites/integrations/console/filter/test.ts
@@ -1,0 +1,35 @@
+import { afterAll, describe, expect } from 'vitest';
+import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../../utils/runner';
+
+describe('Console Integration', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('filters console messages', async () => {
+      await createRunner()
+        .expect({
+          event: {
+            exception: {
+              values: [
+                {
+                  value: 'Test Error',
+                },
+              ],
+            },
+            breadcrumbs: [
+              expect.objectContaining({
+                message: 'hello',
+              }),
+              expect.objectContaining({
+                message: 'baz',
+              }),
+            ],
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
+});

--- a/packages/core/src/instrument/console.ts
+++ b/packages/core/src/instrument/console.ts
@@ -67,9 +67,8 @@ function instrumentConsole(): void {
       return function (...args: any[]): void {
         const firstArg = args[0];
         const log = originalConsoleMethods[level];
-        const filter = _options?.filter;
 
-        const isFiltered = filter && typeof firstArg === 'string' && stringMatchesSomePattern(firstArg, filter);
+        const isFiltered = _filter.size && typeof firstArg === 'string' && stringMatchesSomePattern(firstArg, Array.from(_filter));
 
         // Only trigger handlers for non-filtered messages
         if (!isFiltered) {

--- a/packages/core/src/instrument/console.ts
+++ b/packages/core/src/instrument/console.ts
@@ -1,10 +1,23 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
+import { DEBUG_BUILD } from '../debug-build';
 import type { ConsoleLevel, HandlerDataConsole } from '../types-hoist/instrument';
 import { CONSOLE_LEVELS, originalConsoleMethods } from '../utils/debug-logger';
 import { fill } from '../utils/object';
+import { stringMatchesSomePattern } from '../utils/string';
 import { GLOBAL_OBJ } from '../utils/worldwide';
 import { addHandler, maybeInstrument, triggerHandlers } from './handlers';
+import { debug } from '../utils/debug-logger';
+
+interface ConsoleInstrumentationOptions {
+  /**
+   * Filter out console messages that match the given strings or regular expressions.
+   * These will neither be passed to the handler, and they will also not be logged to the user, unless they have debug enabled.
+   */
+  filter?: (string | RegExp)[];
+}
+
+let _options: ConsoleInstrumentationOptions = {};
 
 /**
  * Add an instrumentation handler for when a console.xxx method is called.
@@ -18,6 +31,18 @@ export function addConsoleInstrumentationHandler(handler: (data: HandlerDataCons
   const removeHandler = addHandler(type, handler);
   maybeInstrument(type, instrumentConsole);
   return removeHandler;
+}
+
+export function addConsoleInstrumentationFilter(filter: (string | RegExp)[]): void {
+  _options = {
+    ..._options,
+    filter: [...(_options.filter || []), ...filter],
+  };
+}
+
+/** Only exported for tests. */
+export function _INTERNAL_resetConsoleInstrumentationOptions(): void {
+  _options = {};
 }
 
 function instrumentConsole(): void {
@@ -34,10 +59,22 @@ function instrumentConsole(): void {
       originalConsoleMethods[level] = originalConsoleMethod;
 
       return function (...args: any[]): void {
-        triggerHandlers('console', { args, level } as HandlerDataConsole);
-
+        const firstArg = args[0];
         const log = originalConsoleMethods[level];
-        log?.apply(GLOBAL_OBJ.console, args);
+        const filter = _options?.filter;
+
+        const isFiltered = filter && typeof firstArg === 'string' && stringMatchesSomePattern(firstArg, filter);
+
+        // Only trigger handlers for non-filtered messages
+        if (!isFiltered) {
+          triggerHandlers('console', { args, level } as HandlerDataConsole);
+        }
+
+        // Only log filtered messages in debug mode
+        if (!isFiltered || (DEBUG_BUILD && debug.isEnabled())) {
+          // Call original console method
+          log?.apply(GLOBAL_OBJ.console, args);
+        }
       };
     });
   });

--- a/packages/core/src/instrument/console.ts
+++ b/packages/core/src/instrument/console.ts
@@ -68,8 +68,7 @@ function instrumentConsole(): void {
         const firstArg = args[0];
         const log = originalConsoleMethods[level];
 
-        const isFiltered =
-          _filter.size && typeof firstArg === 'string' && stringMatchesSomePattern(firstArg, Array.from(_filter));
+        const isFiltered = _filter.size && typeof firstArg === 'string' && stringMatchesSomePattern(firstArg, _filter);
 
         // Only trigger handlers for non-filtered messages
         if (!isFiltered) {

--- a/packages/core/src/instrument/console.ts
+++ b/packages/core/src/instrument/console.ts
@@ -9,15 +9,12 @@ import { GLOBAL_OBJ } from '../utils/worldwide';
 import { addHandler, maybeInstrument, triggerHandlers } from './handlers';
 import { debug } from '../utils/debug-logger';
 
-interface ConsoleInstrumentationOptions {
-  /**
-   * Filter out console messages that match the given strings or regular expressions.
-   * These will neither be passed to the handler, and they will also not be logged to the user, unless they have debug enabled.
-   */
-  filter?: (string | RegExp)[];
-}
-
-let _options: ConsoleInstrumentationOptions = {};
+/**
+ * Filter out console messages that match the given strings or regular expressions.
+ * These will neither be passed to the handler, and they will also not be logged to the user, unless they have debug enabled.
+ * This is a set to avoid duplicate integration setups to add the same filter multiple times.
+*/
+const _filter = new Set<string | RegExp>([]);
 
 /**
  * Add an instrumentation handler for when a console.xxx method is called.
@@ -34,15 +31,14 @@ export function addConsoleInstrumentationHandler(handler: (data: HandlerDataCons
 }
 
 export function addConsoleInstrumentationFilter(filter: (string | RegExp)[]): void {
-  _options = {
-    ..._options,
-    filter: [...(_options.filter || []), ...filter],
-  };
+  for (const f of filter) {
+    _filter.add(f);
+  }
 }
 
 /** Only exported for tests. */
 export function _INTERNAL_resetConsoleInstrumentationOptions(): void {
-  _options = {};
+  _filter.clear();
 }
 
 function instrumentConsole(): void {

--- a/packages/core/src/instrument/console.ts
+++ b/packages/core/src/instrument/console.ts
@@ -13,7 +13,7 @@ import { debug } from '../utils/debug-logger';
  * Filter out console messages that match the given strings or regular expressions.
  * These will neither be passed to the handler, and they will also not be logged to the user, unless they have debug enabled.
  * This is a set to avoid duplicate integration setups to add the same filter multiple times.
-*/
+ */
 const _filter = new Set<string | RegExp>([]);
 
 /**
@@ -30,10 +30,20 @@ export function addConsoleInstrumentationHandler(handler: (data: HandlerDataCons
   return removeHandler;
 }
 
-export function addConsoleInstrumentationFilter(filter: (string | RegExp)[]): void {
+/**
+ * Add a filter to the console instrumentation to filter out console messages that match the given strings or regular expressions.
+ * Returns a function to remove the filter.
+ */
+export function addConsoleInstrumentationFilter(filter: (string | RegExp)[]): () => void {
   for (const f of filter) {
     _filter.add(f);
   }
+
+  return () => {
+    for (const f of filter) {
+      _filter.delete(f);
+    }
+  };
 }
 
 /** Only exported for tests. */

--- a/packages/core/src/instrument/console.ts
+++ b/packages/core/src/instrument/console.ts
@@ -68,7 +68,8 @@ function instrumentConsole(): void {
         const firstArg = args[0];
         const log = originalConsoleMethods[level];
 
-        const isFiltered = _filter.size && typeof firstArg === 'string' && stringMatchesSomePattern(firstArg, Array.from(_filter));
+        const isFiltered =
+          _filter.size && typeof firstArg === 'string' && stringMatchesSomePattern(firstArg, Array.from(_filter));
 
         // Only trigger handlers for non-filtered messages
         if (!isFiltered) {

--- a/packages/core/src/integrations/console.ts
+++ b/packages/core/src/integrations/console.ts
@@ -53,12 +53,12 @@ export const consoleIntegration = defineIntegration((options: Partial<ConsoleInt
 
         addConsoleBreadcrumb(level, args);
       });
+      client.registerCleanup(unsubscribe);
 
       if (options.filter) {
-        addConsoleInstrumentationFilter(options.filter);
+        const unsubscribe = addConsoleInstrumentationFilter(options.filter);
+        client.registerCleanup(unsubscribe);
       }
-
-      client.registerCleanup(unsubscribe);
     },
   };
 });

--- a/packages/core/src/integrations/console.ts
+++ b/packages/core/src/integrations/console.ts
@@ -10,6 +10,11 @@ import { GLOBAL_OBJ } from '../utils/worldwide';
 
 interface ConsoleIntegrationOptions {
   levels: ConsoleLevel[];
+  /**
+   * Filter out console messages that match the given strings or regular expressions.
+   * These will neither be passed to the handler, and they will also not be logged to the user, unless they have debug enabled.
+   */
+  filter?: (string | RegExp)[];
 }
 
 type GlobalObjectWithUtil = typeof GLOBAL_OBJ & {

--- a/packages/core/src/integrations/console.ts
+++ b/packages/core/src/integrations/console.ts
@@ -1,6 +1,6 @@
 import { addBreadcrumb } from '../breadcrumbs';
 import { getClient } from '../currentScopes';
-import { addConsoleInstrumentationHandler } from '../instrument/console';
+import { addConsoleInstrumentationFilter, addConsoleInstrumentationHandler } from '../instrument/console';
 import { defineIntegration } from '../integration';
 import type { ConsoleLevel } from '../types-hoist/instrument';
 import { CONSOLE_LEVELS } from '../utils/debug-logger';
@@ -53,6 +53,10 @@ export const consoleIntegration = defineIntegration((options: Partial<ConsoleInt
 
         addConsoleBreadcrumb(level, args);
       });
+
+      if (options.filter) {
+        addConsoleInstrumentationFilter(options.filter);
+      }
 
       client.registerCleanup(unsubscribe);
     },

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -208,7 +208,7 @@ export { dsnFromString, dsnToString, makeDsn } from './utils/dsn';
 export { SentryError } from './utils/error';
 export { GLOBAL_OBJ } from './utils/worldwide';
 export type { InternalGlobal } from './utils/worldwide';
-export { addConsoleInstrumentationHandler } from './instrument/console';
+export { addConsoleInstrumentationHandler, addConsoleInstrumentationFilter } from './instrument/console';
 export { addFetchEndInstrumentationHandler, addFetchInstrumentationHandler } from './instrument/fetch';
 export { addGlobalErrorInstrumentationHandler } from './instrument/globalError';
 export { addGlobalUnhandledRejectionInstrumentationHandler } from './instrument/globalUnhandledRejection';

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -136,8 +136,15 @@ export function isMatchingPattern(
  */
 export function stringMatchesSomePattern(
   testString: string,
-  patterns: Array<string | RegExp | ((value: string) => boolean)> = [],
+  patterns:
+    | Array<string | RegExp | ((value: string) => boolean)>
+    | Set<string | RegExp | ((value: string) => boolean)> = [],
   requireExactStringMatch: boolean = false,
 ): boolean {
-  return patterns.some(pattern => isMatchingPattern(testString, pattern, requireExactStringMatch));
+  for (const pattern of patterns) {
+    if (isMatchingPattern(testString, pattern, requireExactStringMatch)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/core/test/lib/instrument/console.test.ts
+++ b/packages/core/test/lib/instrument/console.test.ts
@@ -1,22 +1,110 @@
-import { describe, expect, it, vi } from 'vitest';
-import { addConsoleInstrumentationHandler } from '../../../src/instrument/console';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _INTERNAL_resetConsoleInstrumentationOptions,
+  addConsoleInstrumentationFilter,
+  addConsoleInstrumentationHandler,
+} from '../../../src/instrument/console';
 import { GLOBAL_OBJ } from '../../../src/utils/worldwide';
+import { debug, originalConsoleMethods } from '../../../src/utils/debug-logger';
+import { resetInstrumentationHandlers } from '../../../src/instrument/handlers';
 
 describe('addConsoleInstrumentationHandler', () => {
+  let _originalConsoleMethods: typeof originalConsoleMethods = {};
+
+  afterEach(() => {
+    Object.assign(originalConsoleMethods, _originalConsoleMethods);
+    resetInstrumentationHandlers();
+    vi.restoreAllMocks();
+  });
+
+  // This cannot be done in beforeEach, as the first invocation of `addConsoleInstrumentationHandler` will overwrite the original console methods.
+  // Due to `fill` being called
+  // So instead, we need to call this each time after calling `addConsoleInstrumentationHandler`
+  function mockConsoleMethods() {
+    // Re-store this with the current implementation
+    Object.assign(_originalConsoleMethods, originalConsoleMethods);
+
+    // Overwrite with mock console methods
+    Object.assign(originalConsoleMethods, {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+    });
+  }
+
   it.each(['log', 'warn', 'error', 'debug', 'info'] as const)(
     'calls registered handler when console.%s is called',
     level => {
       const handler = vi.fn();
       addConsoleInstrumentationHandler(handler);
+      mockConsoleMethods();
 
       GLOBAL_OBJ.console[level]('test message');
 
       expect(handler).toHaveBeenCalledWith(expect.objectContaining({ args: ['test message'], level }));
+      expect(originalConsoleMethods[level]).toHaveBeenCalledWith('test message');
     },
   );
 
   it('calls through to the underlying console method without throwing', () => {
     addConsoleInstrumentationHandler(vi.fn());
+    mockConsoleMethods();
     expect(() => GLOBAL_OBJ.console.log('hello')).not.toThrow();
+  });
+
+  describe('filter', () => {
+    afterEach(() => {
+      _INTERNAL_resetConsoleInstrumentationOptions();
+    });
+
+    describe('when debug is disabled', () => {
+      beforeEach(() => {
+        vi.spyOn(debug, 'isEnabled').mockImplementation(() => false);
+      });
+
+      it('filters out messages that match the filter', () => {
+        const handler = vi.fn();
+        addConsoleInstrumentationHandler(handler);
+        addConsoleInstrumentationFilter(['test message']);
+        mockConsoleMethods();
+
+        GLOBAL_OBJ.console.log('test message');
+
+        expect(originalConsoleMethods.log).not.toHaveBeenCalledWith('test message');
+        expect(handler).not.toHaveBeenCalled();
+      });
+
+      it('does not filter out messages that do not match the filter', () => {
+        const handler = vi.fn();
+        addConsoleInstrumentationHandler(handler);
+        addConsoleInstrumentationFilter(['test message']);
+        mockConsoleMethods();
+
+        GLOBAL_OBJ.console.log('other message');
+
+        expect(handler).toHaveBeenCalled();
+        expect(originalConsoleMethods.log).toHaveBeenCalledWith('other message');
+      });
+    });
+
+    describe('when debug is enabled', () => {
+      beforeEach(() => {
+        vi.spyOn(debug, 'isEnabled').mockImplementation(() => true);
+      });
+
+      it('logs filtered messages but does not call the handler for them', () => {
+        const handler = vi.fn();
+        addConsoleInstrumentationHandler(handler);
+        addConsoleInstrumentationFilter(['test message']);
+        mockConsoleMethods();
+
+        GLOBAL_OBJ.console.log('test message');
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(originalConsoleMethods.log).toHaveBeenCalledWith('test message');
+      });
+    });
   });
 });

--- a/packages/node-core/src/integrations/console.ts
+++ b/packages/node-core/src/integrations/console.ts
@@ -10,10 +10,16 @@ import {
   maybeInstrument,
   originalConsoleMethods,
   triggerHandlers,
+  addConsoleInstrumentationFilter,
 } from '@sentry/core';
 
 interface ConsoleIntegrationOptions {
   levels: ConsoleLevel[];
+  /**
+   * Filter out console messages that match the given strings or regular expressions.
+   * These will neither be passed to the handler, and they will also not be logged to the user, unless they have debug enabled.
+   */
+  filter?: (string | RegExp)[];
 }
 
 /**
@@ -35,6 +41,11 @@ export const consoleIntegration = defineIntegration((options: Partial<ConsoleInt
 
       // Delegate breadcrumb handling to the core console integration.
       const core = coreConsoleIntegration(options);
+
+      if (options.filter) {
+        addConsoleInstrumentationFilter(options.filter);
+      }
+
       core.setup?.(client);
     },
   };

--- a/packages/node-core/src/integrations/console.ts
+++ b/packages/node-core/src/integrations/console.ts
@@ -45,6 +45,10 @@ export const consoleIntegration = defineIntegration((options: Partial<ConsoleInt
   };
 });
 
+/**
+ * NOTE: This currently ignores the filter option.
+ * We can revisit this later.
+ */
 function instrumentConsoleLambda(): void {
   const consoleObj = GLOBAL_OBJ?.console;
   if (!consoleObj) {

--- a/packages/node-core/src/integrations/console.ts
+++ b/packages/node-core/src/integrations/console.ts
@@ -41,11 +41,6 @@ export const consoleIntegration = defineIntegration((options: Partial<ConsoleInt
 
       // Delegate breadcrumb handling to the core console integration.
       const core = coreConsoleIntegration(options);
-
-      if (options.filter) {
-        addConsoleInstrumentationFilter(options.filter);
-      }
-
       core.setup?.(client);
     },
   };

--- a/packages/node-core/src/integrations/console.ts
+++ b/packages/node-core/src/integrations/console.ts
@@ -10,7 +10,6 @@ import {
   maybeInstrument,
   originalConsoleMethods,
   triggerHandlers,
-  addConsoleInstrumentationFilter,
 } from '@sentry/core';
 
 interface ConsoleIntegrationOptions {


### PR DESCRIPTION
We want to leverage this for Node 26 to filter deprecation messages from IITM, but this could also be used by users if they want to silence certain things.

Required for https://github.com/getsentry/sentry-javascript/pull/20710