### PR TITLE
fix(hono): Capture transaction name on request for correct culprit

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hono-4/src/route-groups/test-middleware.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/route-groups/test-middleware.ts
@@ -7,6 +7,7 @@ middlewareRoutes.get('/named', c => c.json({ middleware: 'named' }));
 middlewareRoutes.get('/anonymous', c => c.json({ middleware: 'anonymous' }));
 middlewareRoutes.get('/multi', c => c.json({ middleware: 'multi' }));
 middlewareRoutes.get('/error', c => c.text('should not reach'));
+middlewareRoutes.get('/param/:id', c => c.json({ paramId: c.req.param('id') }));
 
 // Self-contained sub-app registering its own middleware via .use()
 const subAppWithMiddleware = new Hono();
@@ -18,6 +19,7 @@ subAppWithMiddleware.use('/anonymous/*', async (c, next) => {
 });
 subAppWithMiddleware.use('/multi/*', middlewareA, middlewareB);
 subAppWithMiddleware.use('/error/*', failingMiddleware);
+subAppWithMiddleware.use('/param/*', middlewareA);
 
 // .all() handler (1 parameter) — should NOT be wrapped as middleware by patchRoute.
 subAppWithMiddleware.all('/all-handler', async function allCatchAll(c) {

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/routes.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/routes.ts
@@ -34,6 +34,7 @@ export function addRoutes(app: Hono<{ Bindings?: { E2E_TEST_DSN: string } }>): v
   });
   app.use('/test-middleware/multi/*', middlewareA, middlewareB);
   app.use('/test-middleware/error/*', failingMiddleware);
+  app.use('/test-middleware/param/*', middlewareA);
   app.route('/test-middleware', middlewareRoutes);
 
   // Sub-app middleware: registered on the sub-app, wrapped at mount time by route() patching

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/errors.test.ts
@@ -147,6 +147,7 @@ test.describe('middleware errors', () => {
     expect(errorEvent.exception?.values?.[0]?.value).toBe('Service Unavailable from middleware');
     expect(errorEvent.exception?.values?.[0]?.mechanism?.type).toBe('auto.middleware.hono');
     expect(errorEvent.exception?.values?.[0]?.mechanism?.handled).toBe(false);
+    expect(errorEvent.transaction).toBe('GET /test-errors/middleware-http-exception');
 
     const transaction = await transactionPromise;
     const middlewareSpan = (transaction.spans || []).find(s => s.op === 'middleware.hono');
@@ -183,7 +184,7 @@ test.describe('middleware errors', () => {
     const transaction = await transactionPromise;
 
     if (RUNTIME === 'cloudflare') {
-      expect(transaction.transaction).toBe('GET /test-errors/middleware-http-exception-4xx/*');
+      expect(transaction.transaction).toBe('GET /test-errors/middleware-http-exception-4xx');
 
       const middlewareSpan = (transaction.spans || []).find(s => s.op === 'middleware.hono');
       expect(middlewareSpan?.status).not.toBe('internal_error');

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
@@ -116,6 +116,9 @@ for (const { name, prefix } of SCENARIOS) {
           type: 'auto.middleware.hono',
         }),
       );
+
+      // The transaction name on the error event determines the culprit shown in Sentry.
+      expect(errorEvent.transaction).toBe(`GET ${prefix}/error`);
     });
 
     test('sets error status on middleware span when middleware throws', async ({ baseURL }) => {
@@ -126,7 +129,7 @@ for (const { name, prefix } of SCENARIOS) {
       await fetch(`${baseURL}${prefix}/error`);
 
       const transaction = await transactionPromise;
-      expect(transaction.transaction).toBe(`GET ${prefix}/error/*`);
+      expect(transaction.transaction).toBe(`GET ${prefix}/error`);
 
       const spans = transaction.spans || [];
 
@@ -136,6 +139,25 @@ for (const { name, prefix } of SCENARIOS) {
 
       expect(failingSpan).toBeDefined();
       expect(failingSpan?.status).toBe('internal_error');
+    });
+
+    test('uses parameterized route in transaction name', async ({ baseURL }) => {
+      const transactionPromise = waitForTransaction(APP_NAME, event => {
+        return event.contexts?.trace?.op === 'http.server' && !!event.transaction?.includes(`${prefix}/param/`);
+      });
+
+      const response = await fetch(`${baseURL}${prefix}/param/42`);
+      expect(response.status).toBe(200);
+
+      const transaction = await transactionPromise;
+      expect(transaction.transaction).toBe(`GET ${prefix}/param/:id`);
+
+      const spans = transaction.spans || [];
+      const middlewareSpan = spans.find(
+        (span: { description?: string; op?: string }) =>
+          span.op === 'middleware.hono' && span.description === 'middlewareA',
+      );
+      expect(middlewareSpan).toBeDefined();
     });
 
     test('includes request data on error events from middleware', async ({ baseURL }) => {

--- a/packages/hono/src/shared/middlewareHandlers.ts
+++ b/packages/hono/src/shared/middlewareHandlers.ts
@@ -6,6 +6,7 @@ import {
   getRootSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   updateSpanName,
+  type Scope,
   winterCGRequestToRequestData,
 } from '@sentry/core';
 import type { Context } from 'hono';
@@ -22,6 +23,8 @@ export function requestHandler(context: Context): void {
 
   const isolationScope = defaultScope === currentIsolationScope ? defaultScope : currentIsolationScope;
 
+  updateSpanRouteName(isolationScope, context);
+
   isolationScope.setSDKProcessingMetadata({
     normalizedRequest: winterCGRequestToRequestData(hasFetchEvent(context) ? context.event.request : context.req.raw),
   });
@@ -31,21 +34,25 @@ export function requestHandler(context: Context): void {
  * Response handler for Hono framework
  */
 export function responseHandler(context: Context): void {
-  const activeSpan = getActiveSpan();
-  if (activeSpan) {
-    activeSpan.updateName(`${context.req.method} ${routePath(context)}`);
-    activeSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
-
-    const rootSpan = getRootSpan(activeSpan);
-    updateSpanName(rootSpan, `${context.req.method} ${routePath(context)}`);
-    rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
-  }
-
-  getIsolationScope().setTransactionName(`${context.req.method} ${routePath(context)}`);
-
   if (context.error && !isExpectedError(context.error)) {
     getClient()?.captureException(context.error, {
       mechanism: { handled: false, type: 'auto.http.hono.context_error' },
     });
   }
+}
+
+function updateSpanRouteName(isolationScope: Scope, context: Context): void {
+  const activeSpan = getActiveSpan();
+  const lastMatchedRoute = routePath(context, -1);
+
+  if (activeSpan) {
+    activeSpan.updateName(`${context.req.method} ${lastMatchedRoute}`);
+    activeSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
+
+    const rootSpan = getRootSpan(activeSpan);
+    updateSpanName(rootSpan, `${context.req.method} ${lastMatchedRoute}`);
+    rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
+  }
+
+  isolationScope.setTransactionName(`${context.req.method} ${lastMatchedRoute}`);
 }

--- a/packages/hono/test/shared/middlewareHandlers.test.ts
+++ b/packages/hono/test/shared/middlewareHandlers.test.ts
@@ -1,6 +1,6 @@
 import * as SentryCore from '@sentry/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { responseHandler } from '../../src/shared/middlewareHandlers';
+import { requestHandler, responseHandler } from '../../src/shared/middlewareHandlers';
 
 vi.mock('hono/route', () => ({
   routePath: () => '/test',
@@ -11,6 +11,7 @@ vi.mock('../../src/utils/hono-context', () => ({
 }));
 
 const mockSetTransactionName = vi.fn();
+const mockSetSDKProcessingMetadata = vi.fn();
 
 vi.mock('@sentry/core', async () => {
   const actual = await vi.importActual('@sentry/core');
@@ -19,6 +20,7 @@ vi.mock('@sentry/core', async () => {
     getActiveSpan: vi.fn(() => null),
     getIsolationScope: vi.fn(() => ({
       setTransactionName: mockSetTransactionName,
+      setSDKProcessingMetadata: mockSetSDKProcessingMetadata,
     })),
     getClient: vi.fn(() => undefined),
   };
@@ -110,7 +112,7 @@ describe('responseHandler', () => {
   describe('transaction name', () => {
     it('sets transaction name on isolation scope', () => {
       // oxlint-disable-next-line typescript/no-explicit-any
-      responseHandler(createMockContext(200) as any);
+      requestHandler(createMockContext(200) as any);
 
       expect(mockSetTransactionName).toHaveBeenCalledWith('GET /test');
     });


### PR DESCRIPTION
Hono error events were showing a wrong culprit (`?(index)`) because the transaction name was only being set in the response handler. When an error was thrown during middleware execution, `captureException` ran before `responseHandler` had a chance to update the span name and isolation scope transaction name.

This PR moves the span and transaction name update into `requestHandler` so the correct route name is set before any middleware or route handler executes. The `responseHandler` now only captures errors.

Also switches from `routePath(context)` (last matched route so far) to `routePath(context, -1)` ([final matched route](https://hono.dev/docs/helpers/route#using-with-index-parameter)) which avoids wildcard patterns like `/error/*` leaking into the transaction name.

Also adds another test for route parametrization when using middleware.

Closes https://github.com/getsentry/sentry-javascript/issues/20399
