### PR TITLE
fix(browser): Fix internal frame detection in minified bundles

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -106,6 +106,9 @@ export function wrap<T extends WrappableFunction, NonFunction>(
   // Wrap the function itself
   // It is important that `sentryWrapped` is not an arrow function to preserve the context of `this`
   const sentryWrapped = function (this: unknown, ...args: unknown[]): unknown {
+    // Track depth on GLOBAL_OBJ so the thirdPartyErrorFilterIntegration (in @sentry/core) can detect
+    // that processEvent is running inside a sentryWrapped call, even with minified/bundled code.
+    GLOBAL_OBJ._sentryWrappedDepth = (GLOBAL_OBJ._sentryWrappedDepth || 0) + 1;
     try {
       // Also wrap arguments that are themselves functions
       const wrappedArguments = args.map(arg => wrap(arg, options));
@@ -138,6 +141,8 @@ export function wrap<T extends WrappableFunction, NonFunction>(
       });
 
       throw ex;
+    } finally {
+      GLOBAL_OBJ._sentryWrappedDepth = (GLOBAL_OBJ._sentryWrappedDepth || 0) - 1;
     }
   } as unknown as WrappedFunction<T>;
 

--- a/packages/core/src/integrations/third-party-errors-filter.ts
+++ b/packages/core/src/integrations/third-party-errors-filter.ts
@@ -5,6 +5,7 @@ import type { Event } from '../types-hoist/event';
 import type { StackFrame } from '../types-hoist/stackframe';
 import { forEachEnvelopeItem } from '../utils/envelope';
 import { getFramesFromEvent } from '../utils/stacktrace';
+import { GLOBAL_OBJ } from '../utils/worldwide';
 
 interface Options {
   /**
@@ -75,7 +76,14 @@ export const thirdPartyErrorFilterIntegration = defineIntegration((options: Opti
     },
 
     processEvent(event) {
-      const frameKeys = getBundleKeysForAllFramesWithFilenames(event, options.ignoreSentryInternalFrames);
+      const insideSentryWrapped = options.ignoreSentryInternalFrames
+        ? (GLOBAL_OBJ._sentryWrappedDepth ?? 0) > 0
+        : false;
+      const frameKeys = getBundleKeysForAllFramesWithFilenames(
+        event,
+        options.ignoreSentryInternalFrames,
+        insideSentryWrapped,
+      );
 
       if (frameKeys) {
         const arrayMethod =
@@ -106,20 +114,30 @@ export const thirdPartyErrorFilterIntegration = defineIntegration((options: Opti
   };
 });
 
-/**
- * Checks if a stack frame is a Sentry internal frame by strictly matching:
- * 1. The frame must be the last frame in the stack
- * 2. The filename must indicate the internal helpers file
- * 3. The context_line must contain the exact pattern "fn.apply(this, wrappedArguments)"
- * 4. The comment pattern "Attempt to invoke user-land function" must be present in pre_context
- *
- */
-function isSentryInternalFrame(frame: StackFrame, frameIndex: number): boolean {
+/** Checks if a frame is Sentry-internal via runtime depth, function name, or source patterns. */
+function isSentryInternalFrame(frame: StackFrame, frameIndex: number, insideSentryWrapped: boolean): boolean {
   // Only match the last frame (index 0 in reversed stack)
-  if (frameIndex !== 0 || !frame.context_line || !frame.filename) {
+  if (frameIndex !== 0) {
     return false;
   }
 
+  // When processEvent runs inside a sentryWrapped call, the outermost frame is always
+  // the sentryWrapped function. This works regardless of minification/bundling because
+  // it's a runtime check, not a source pattern match.
+  if (insideSentryWrapped) {
+    return true;
+  }
+
+  // Match by function name (works when function names survive bundling but source patterns don't)
+  if (frame.function === 'sentryWrapped') {
+    return true;
+  }
+
+  if (!frame.context_line || !frame.filename) {
+    return false;
+  }
+
+  // Match by source code patterns (works in development / unbundled builds)
   if (
     !frame.filename.includes('sentry') ||
     !frame.filename.includes('helpers') || // Filename would look something like this: 'node_modules/@sentry/browser/build/npm/esm/helpers.js'
@@ -144,6 +162,7 @@ function isSentryInternalFrame(frame: StackFrame, frameIndex: number): boolean {
 function getBundleKeysForAllFramesWithFilenames(
   event: Event,
   ignoreSentryInternalFrames?: boolean,
+  insideSentryWrapped?: boolean,
 ): string[][] | undefined {
   const frames = getFramesFromEvent(event);
 
@@ -163,7 +182,7 @@ function getBundleKeysForAllFramesWithFilenames(
         return false;
       }
       // Optionally ignore Sentry internal frames
-      return !ignoreSentryInternalFrames || !isSentryInternalFrame(frame, index);
+      return !ignoreSentryInternalFrames || !isSentryInternalFrame(frame, index, !!insideSentryWrapped);
     })
     .map(frame => {
       if (!frame.module_metadata) {

--- a/packages/core/src/integrations/third-party-errors-filter.ts
+++ b/packages/core/src/integrations/third-party-errors-filter.ts
@@ -75,9 +75,21 @@ export const thirdPartyErrorFilterIntegration = defineIntegration((options: Opti
       });
     },
 
+    preprocessEvent(event) {
+      // Snapshot the depth counter onto the event before any event processors run.
+      // This is necessary because async event processors could cause the finally block
+      // in sentryWrapped to decrement the counter before processEvent reads it.
+      if (options.ignoreSentryInternalFrames && (GLOBAL_OBJ._sentryWrappedDepth ?? 0) > 0) {
+        event.sdkProcessingMetadata = {
+          ...event.sdkProcessingMetadata,
+          insideSentryWrapped: true,
+        };
+      }
+    },
+
     processEvent(event) {
       const insideSentryWrapped = options.ignoreSentryInternalFrames
-        ? (GLOBAL_OBJ._sentryWrappedDepth ?? 0) > 0
+        ? event.sdkProcessingMetadata?.insideSentryWrapped === true
         : false;
       const frameKeys = getBundleKeysForAllFramesWithFilenames(
         event,

--- a/packages/core/src/integrations/third-party-errors-filter.ts
+++ b/packages/core/src/integrations/third-party-errors-filter.ts
@@ -89,7 +89,7 @@ export const thirdPartyErrorFilterIntegration = defineIntegration((options: Opti
 
     processEvent(event) {
       const insideSentryWrapped = options.ignoreSentryInternalFrames
-        ? event.sdkProcessingMetadata?.insideSentryWrapped === true
+        ? event.sdkProcessingMetadata?.insideSentryWrapped === true && event.exception?.values?.length === 1
         : false;
       const frameKeys = getBundleKeysForAllFramesWithFilenames(
         event,
@@ -133,10 +133,11 @@ function isSentryInternalFrame(frame: StackFrame, frameIndex: number, insideSent
     return false;
   }
 
-  // When processEvent runs inside a sentryWrapped call, the outermost frame is always
-  // the sentryWrapped function. This works regardless of minification/bundling because
-  // it's a runtime check, not a source pattern match.
-  if (insideSentryWrapped) {
+  // When processEvent runs inside a sentryWrapped call and the frame looks minified,
+  // the outermost frame is the sentryWrapped function with a mangled name.
+  // We gate on minified shape to avoid false positives in non-minified builds
+  // where stripSentryFramesAndReverse already removed the sentryWrapped frame.
+  if (insideSentryWrapped && isLikelyMinifiedSentryWrappedFrame(frame)) {
     return true;
   }
 
@@ -204,6 +205,10 @@ function getBundleKeysForAllFramesWithFilenames(
         .filter(key => key.startsWith(BUNDLER_PLUGIN_APP_KEY_PREFIX))
         .map(key => key.slice(BUNDLER_PLUGIN_APP_KEY_PREFIX.length));
     });
+}
+
+function isLikelyMinifiedSentryWrappedFrame(frame: StackFrame): boolean {
+  return !frame.context_line && !frame.pre_context && !!frame.function && frame.function.length <= 2;
 }
 
 const BUNDLER_PLUGIN_APP_KEY_PREFIX = '_sentryBundlerPluginAppKey:';

--- a/packages/core/src/utils/worldwide.ts
+++ b/packages/core/src/utils/worldwide.ts
@@ -54,6 +54,7 @@ export type InternalGlobal = {
    */
   _sentryModuleMetadata?: Record<string, any>;
   _sentryEsmLoaderHookRegistered?: boolean;
+  _sentryWrappedDepth?: number;
 } & Carrier;
 
 /** Get's the global object for the current JavaScript runtime */

--- a/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
+++ b/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Client } from '../../../src/client';
 import { thirdPartyErrorFilterIntegration } from '../../../src/integrations/third-party-errors-filter';
 import { addMetadataToStackFrames } from '../../../src/metadata';
@@ -626,7 +626,7 @@ describe('ThirdPartyErrorFilter', () => {
         expect(result).toBeDefined();
       });
 
-      it('does not match when filename does not contain both helpers and sentry', async () => {
+      it('does not match when filename does not contain both helpers and sentry and function name is not sentryWrapped', async () => {
         const eventWithWrongFilename: Event = {
           exception: {
             values: [
@@ -636,7 +636,7 @@ describe('ThirdPartyErrorFilter', () => {
                     {
                       colno: 2,
                       filename: 'some-helpers.js',
-                      function: 'sentryWrapped',
+                      function: 'someFunction',
                       lineno: 117,
                       context_line: '      return fn.apply(this, wrappedArguments);',
                       pre_context: [
@@ -667,8 +667,182 @@ describe('ThirdPartyErrorFilter', () => {
 
         const event = clone(eventWithWrongFilename);
         const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
-        // Should not drop because filename doesn't contain "sentry"
+        // Should not drop because filename doesn't contain "sentry" and function name is not "sentryWrapped"
         expect(result).toBeDefined();
+      });
+    });
+
+    describe('minified/bundled code detection', () => {
+      afterEach(() => {
+        GLOBAL_OBJ._sentryWrappedDepth = 0;
+      });
+
+      it('detects Sentry internal frame when processEvent runs inside a sentryWrapped call', async () => {
+        const eventWithMinifiedSentryFrame: Event = {
+          exception: {
+            values: [
+              {
+                stacktrace: {
+                  frames: [
+                    {
+                      colno: 12345,
+                      filename: 'https://example.com/assets/app-abc123.js',
+                      function: 'a',
+                      lineno: 1,
+                    },
+                    {
+                      colno: 1,
+                      filename: 'other-file.js',
+                      function: 'function',
+                      lineno: 1,
+                    },
+                  ],
+                },
+                type: 'Error',
+                value: 'Third party error',
+              },
+            ],
+          },
+        };
+
+        const integration = thirdPartyErrorFilterIntegration({
+          behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
+          filterKeys: ['some-key'],
+          ignoreSentryInternalFrames: true,
+        });
+
+        // Simulate being inside a sentryWrapped call
+        GLOBAL_OBJ._sentryWrappedDepth = 1;
+        try {
+          const event = clone(eventWithMinifiedSentryFrame);
+          const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
+          expect(result).toBe(null);
+        } finally {
+          GLOBAL_OBJ._sentryWrappedDepth = 0;
+        }
+      });
+
+      it('detects Sentry internal frame by function name sentryWrapped even without source patterns', async () => {
+        const eventWithFunctionName: Event = {
+          exception: {
+            values: [
+              {
+                stacktrace: {
+                  frames: [
+                    {
+                      colno: 12345,
+                      filename: 'https://example.com/assets/app-abc123.js',
+                      function: 'sentryWrapped',
+                      lineno: 1,
+                    },
+                    {
+                      colno: 1,
+                      filename: 'other-file.js',
+                      function: 'function',
+                      lineno: 1,
+                    },
+                  ],
+                },
+                type: 'Error',
+                value: 'Third party error',
+              },
+            ],
+          },
+        };
+
+        const integration = thirdPartyErrorFilterIntegration({
+          behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
+          filterKeys: ['some-key'],
+          ignoreSentryInternalFrames: true,
+        });
+
+        const event = clone(eventWithFunctionName);
+        const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
+        expect(result).toBe(null);
+      });
+
+      it('does not detect minified frame as Sentry internal when not inside sentryWrapped and function name is mangled', async () => {
+        const eventWithMinifiedFrame: Event = {
+          exception: {
+            values: [
+              {
+                stacktrace: {
+                  frames: [
+                    {
+                      colno: 12345,
+                      filename: 'https://example.com/assets/app-abc123.js',
+                      function: 'a',
+                      lineno: 1,
+                    },
+                    {
+                      colno: 1,
+                      filename: 'other-file.js',
+                      function: 'function',
+                      lineno: 1,
+                    },
+                  ],
+                },
+                type: 'Error',
+                value: 'Third party error',
+              },
+            ],
+          },
+        };
+
+        const integration = thirdPartyErrorFilterIntegration({
+          behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
+          filterKeys: ['some-key'],
+          ignoreSentryInternalFrames: true,
+        });
+
+        GLOBAL_OBJ._sentryWrappedDepth = 0;
+        const event = clone(eventWithMinifiedFrame);
+        const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
+        expect(result).toBeDefined();
+      });
+
+      it('does not use sentryWrappedDepth when ignoreSentryInternalFrames is false', async () => {
+        const eventWithMinifiedSentryFrame: Event = {
+          exception: {
+            values: [
+              {
+                stacktrace: {
+                  frames: [
+                    {
+                      colno: 12345,
+                      filename: 'https://example.com/assets/app-abc123.js',
+                      function: 'a',
+                      lineno: 1,
+                    },
+                    {
+                      colno: 1,
+                      filename: 'other-file.js',
+                      function: 'function',
+                      lineno: 1,
+                    },
+                  ],
+                },
+                type: 'Error',
+                value: 'Third party error',
+              },
+            ],
+          },
+        };
+
+        const integration = thirdPartyErrorFilterIntegration({
+          behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
+          filterKeys: ['some-key'],
+          ignoreSentryInternalFrames: false,
+        });
+
+        GLOBAL_OBJ._sentryWrappedDepth = 1;
+        try {
+          const event = clone(eventWithMinifiedSentryFrame);
+          const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
+          expect(result).toBeDefined();
+        } finally {
+          GLOBAL_OBJ._sentryWrappedDepth = 0;
+        }
       });
     });
   });

--- a/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
+++ b/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
@@ -677,7 +677,7 @@ describe('ThirdPartyErrorFilter', () => {
         GLOBAL_OBJ._sentryWrappedDepth = 0;
       });
 
-      it('detects Sentry internal frame when processEvent runs inside a sentryWrapped call', async () => {
+      it('detects Sentry internal frame when preprocessEvent snapshots depth inside a sentryWrapped call', async () => {
         const eventWithMinifiedSentryFrame: Event = {
           exception: {
             values: [
@@ -713,13 +713,13 @@ describe('ThirdPartyErrorFilter', () => {
 
         // Simulate being inside a sentryWrapped call
         GLOBAL_OBJ._sentryWrappedDepth = 1;
-        try {
-          const event = clone(eventWithMinifiedSentryFrame);
-          const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
-          expect(result).toBe(null);
-        } finally {
-          GLOBAL_OBJ._sentryWrappedDepth = 0;
-        }
+        const event = clone(eventWithMinifiedSentryFrame);
+        // preprocessEvent snapshots the depth onto the event
+        integration.preprocessEvent?.(event, {}, MOCK_CLIENT);
+        // Even if depth resets before processEvent (async processor scenario), the snapshot survives
+        GLOBAL_OBJ._sentryWrappedDepth = 0;
+        const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
+        expect(result).toBe(null);
       });
 
       it('detects Sentry internal frame by function name sentryWrapped even without source patterns', async () => {
@@ -797,6 +797,7 @@ describe('ThirdPartyErrorFilter', () => {
 
         GLOBAL_OBJ._sentryWrappedDepth = 0;
         const event = clone(eventWithMinifiedFrame);
+        integration.preprocessEvent?.(event, {}, MOCK_CLIENT);
         const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
         expect(result).toBeDefined();
       });
@@ -836,13 +837,11 @@ describe('ThirdPartyErrorFilter', () => {
         });
 
         GLOBAL_OBJ._sentryWrappedDepth = 1;
-        try {
-          const event = clone(eventWithMinifiedSentryFrame);
-          const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
-          expect(result).toBeDefined();
-        } finally {
-          GLOBAL_OBJ._sentryWrappedDepth = 0;
-        }
+        const event = clone(eventWithMinifiedSentryFrame);
+        integration.preprocessEvent?.(event, {}, MOCK_CLIENT);
+        GLOBAL_OBJ._sentryWrappedDepth = 0;
+        const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
+        expect(result).toBeDefined();
       });
     });
   });

--- a/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
+++ b/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
@@ -802,6 +802,45 @@ describe('ThirdPartyErrorFilter', () => {
         expect(result).toBeDefined();
       });
 
+      it('does not exclude non-minified frame even when inside sentryWrapped (parser already stripped it)', async () => {
+        const eventWithNonMinifiedFrame: Event = {
+          exception: {
+            values: [
+              {
+                stacktrace: {
+                  frames: [
+                    {
+                      colno: 10,
+                      filename: 'app.js',
+                      function: 'handleClick',
+                      lineno: 42,
+                      context_line: '    throw new Error("oops");',
+                    },
+                  ],
+                },
+                type: 'Error',
+                value: 'oops',
+              },
+            ],
+          },
+        };
+
+        const integration = thirdPartyErrorFilterIntegration({
+          behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
+          filterKeys: ['some-key'],
+          ignoreSentryInternalFrames: true,
+        });
+
+        GLOBAL_OBJ._sentryWrappedDepth = 1;
+        const event = clone(eventWithNonMinifiedFrame);
+        integration.preprocessEvent?.(event, {}, MOCK_CLIENT);
+        GLOBAL_OBJ._sentryWrappedDepth = 0;
+        const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
+        // Should NOT be dropped — the frame has context_line, so it's not a minified sentryWrapped frame.
+        // The real sentryWrapped frame was already stripped by the parser.
+        expect(result).toBeDefined();
+      });
+
       it('does not use sentryWrappedDepth when ignoreSentryInternalFrames is false', async () => {
         const eventWithMinifiedSentryFrame: Event = {
           exception: {


### PR DESCRIPTION
The `ignoreSentryInternalFrames` option in `thirdPartyErrorFilterIntegration` relied on source-code-level signals (filename, context_line, comment patterns) that are all lost after minification.

This PR adds a runtime depth counter (`GLOBAL_OBJ._sentryWrappedDepth`) that tracks whether processEvent is running inside a sentryWrapped call. This works regardless of minification and also covers framework-caught errors (e.g. Vue swallowing the error before sentryWrapped's `catch` fires).

closes https://github.com/getsentry/sentry-javascript/issues/20687