### PR TITLE
chore(ci): Unflake gen_ai tests

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/test.ts
@@ -29,52 +29,83 @@ it('traces Google GenAI chat creation and message sending', async ({ signal }) =
       const container = envelope[1]?.[1]?.[1] as any;
       expect(container).toBeDefined();
       expect(container.items).toHaveLength(3);
-      const [firstSpan, secondSpan, thirdSpan] = container.items;
+      expect(container.items.map(span => span.name).sort()).toEqual([
+        'chat gemini-1.5-pro',
+        'embeddings text-embedding-004',
+        'generate_content gemini-1.5-flash',
+      ]);
 
-      // [0] chat gemini-1.5-pro
-      expect(firstSpan!.name).toBe('chat gemini-1.5-pro');
-      expect(firstSpan!.status).toBe('ok');
-      expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-      expect(firstSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.chat' });
-      expect(firstSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.google_genai' });
-      expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'google_genai' });
-      expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+      const chatSpan = container.items.find(span => span.name === 'chat gemini-1.5-pro');
+      expect(chatSpan).toBeDefined();
+      expect(chatSpan!.status).toBe('ok');
+      expect(chatSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
+      expect(chatSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.chat' });
+      expect(chatSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.google_genai' });
+      expect(chatSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'google_genai' });
+      expect(chatSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'gemini-1.5-pro',
       });
-      expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
-      expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 12 });
-      expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 20 });
+      expect(chatSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
+      expect(chatSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 12 });
+      expect(chatSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 20 });
 
-      // [1] generate_content gemini-1.5-flash
-      expect(secondSpan!.name).toBe('generate_content gemini-1.5-flash');
-      expect(secondSpan!.status).toBe('ok');
-      expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+      const generateContentSpan = container.items.find(span => span.name === 'generate_content gemini-1.5-flash');
+      expect(generateContentSpan).toBeDefined();
+      expect(generateContentSpan!.status).toBe('ok');
+      expect(generateContentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'generate_content',
       });
-      expect(secondSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.generate_content' });
-      expect(secondSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.google_genai' });
-      expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'google_genai' });
-      expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+      expect(generateContentSpan!.attributes['sentry.op']).toEqual({
+        type: 'string',
+        value: 'gen_ai.generate_content',
+      });
+      expect(generateContentSpan!.attributes['sentry.origin']).toEqual({
+        type: 'string',
+        value: 'auto.ai.google_genai',
+      });
+      expect(generateContentSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+        type: 'string',
+        value: 'google_genai',
+      });
+      expect(generateContentSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'gemini-1.5-flash',
       });
-      expect(secondSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({ type: 'double', value: 0.7 });
-      expect(secondSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE]).toEqual({ type: 'double', value: 0.9 });
-      expect(secondSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 100 });
-      expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
-      expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 12 });
-      expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 20 });
+      expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+        type: 'double',
+        value: 0.7,
+      });
+      expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE]).toEqual({ type: 'double', value: 0.9 });
+      expect(generateContentSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE]).toEqual({
+        type: 'integer',
+        value: 100,
+      });
+      expect(generateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+        type: 'integer',
+        value: 8,
+      });
+      expect(generateContentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+        type: 'integer',
+        value: 12,
+      });
+      expect(generateContentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+        type: 'integer',
+        value: 20,
+      });
 
-      // [2] embeddings text-embedding-004
-      expect(thirdSpan!.name).toBe('embeddings text-embedding-004');
-      expect(thirdSpan!.status).toBe('ok');
-      expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'embeddings' });
-      expect(thirdSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.embeddings' });
-      expect(thirdSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.google_genai' });
-      expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'google_genai' });
-      expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+      const embeddingsSpan = container.items.find(span => span.name === 'embeddings text-embedding-004');
+      expect(embeddingsSpan).toBeDefined();
+      expect(embeddingsSpan!.status).toBe('ok');
+      expect(embeddingsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+        type: 'string',
+        value: 'embeddings',
+      });
+      expect(embeddingsSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.embeddings' });
+      expect(embeddingsSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.google_genai' });
+      expect(embeddingsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'google_genai' });
+      expect(embeddingsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'text-embedding-004',
       });

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langchain/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langchain/test.ts
@@ -29,38 +29,42 @@ it('traces langchain chat model, chain, and tool invocations', async ({ signal }
       const container = envelope[1]?.[1]?.[1] as any;
       expect(container).toBeDefined();
       expect(container.items).toHaveLength(3);
-      const [firstSpan, secondSpan, thirdSpan] = container.items;
+      expect(container.items.map(span => span.name).sort()).toEqual([
+        'chain my_test_chain',
+        'chat claude-3-5-sonnet-20241022',
+        'execute_tool search_tool',
+      ]);
 
-      // [0] chat claude-3-5-sonnet-20241022
-      expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-      expect(firstSpan!.status).toBe('ok');
-      expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-      expect(firstSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.chat' });
-      expect(firstSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langchain' });
-      expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'anthropic' });
-      expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+      const chatSpan = container.items.find(span => span.name === 'chat claude-3-5-sonnet-20241022');
+      expect(chatSpan).toBeDefined();
+      expect(chatSpan!.status).toBe('ok');
+      expect(chatSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
+      expect(chatSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.chat' });
+      expect(chatSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langchain' });
+      expect(chatSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'anthropic' });
+      expect(chatSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'claude-3-5-sonnet-20241022',
       });
-      expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({ type: 'double', value: 0.7 });
-      expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 100 });
-      expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-      expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 15 });
-      expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 25 });
+      expect(chatSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({ type: 'double', value: 0.7 });
+      expect(chatSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 100 });
+      expect(chatSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
+      expect(chatSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 15 });
+      expect(chatSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 25 });
 
-      // [1] chain my_test_chain
-      expect(secondSpan!.name).toBe('chain my_test_chain');
-      expect(secondSpan!.status).toBe('ok');
-      expect(secondSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langchain' });
-      expect(secondSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.invoke_agent' });
-      expect(secondSpan!.attributes['langchain.chain.name']).toEqual({ type: 'string', value: 'my_test_chain' });
+      const chainSpan = container.items.find(span => span.name === 'chain my_test_chain');
+      expect(chainSpan).toBeDefined();
+      expect(chainSpan!.status).toBe('ok');
+      expect(chainSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langchain' });
+      expect(chainSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.invoke_agent' });
+      expect(chainSpan!.attributes['langchain.chain.name']).toEqual({ type: 'string', value: 'my_test_chain' });
 
-      // [2] execute_tool search_tool
-      expect(thirdSpan!.name).toBe('execute_tool search_tool');
-      expect(thirdSpan!.status).toBe('ok');
-      expect(thirdSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langchain' });
-      expect(thirdSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.execute_tool' });
-      expect(thirdSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'search_tool' });
+      const toolSpan = container.items.find(span => span.name === 'execute_tool search_tool');
+      expect(toolSpan).toBeDefined();
+      expect(toolSpan!.status).toBe('ok');
+      expect(toolSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langchain' });
+      expect(toolSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.execute_tool' });
+      expect(toolSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'search_tool' });
     })
     .start(signal);
   await runner.makeRequest('get', '/');

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/test.ts
@@ -29,47 +29,62 @@ it('traces langgraph compile and invoke operations', async ({ signal }) => {
       expect(container).toBeDefined();
 
       expect(container.items).toHaveLength(2);
-      const [firstSpan, secondSpan] = container.items;
+      expect(container.items.map(span => span.name).sort()).toEqual([
+        'create_agent weather_assistant',
+        'invoke_agent weather_assistant',
+      ]);
 
-      // [0] create_agent weather_assistant
-      expect(firstSpan!.name).toBe('create_agent weather_assistant');
-      expect(firstSpan!.status).toBe('ok');
-      expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+      const createAgentSpan = container.items.find(span => span.name === 'create_agent weather_assistant');
+      expect(createAgentSpan).toBeDefined();
+      expect(createAgentSpan!.status).toBe('ok');
+      expect(createAgentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'create_agent',
       });
-      expect(firstSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.create_agent' });
-      expect(firstSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langgraph' });
-      expect(firstSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE]).toEqual({
+      expect(createAgentSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.create_agent' });
+      expect(createAgentSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langgraph' });
+      expect(createAgentSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'weather_assistant',
       });
 
-      // [1] invoke_agent weather_assistant
-      expect(secondSpan!.name).toBe('invoke_agent weather_assistant');
-      expect(secondSpan!.status).toBe('ok');
-      expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+      const invokeAgentSpan = container.items.find(span => span.name === 'invoke_agent weather_assistant');
+      expect(invokeAgentSpan).toBeDefined();
+      expect(invokeAgentSpan!.status).toBe('ok');
+      expect(invokeAgentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'invoke_agent',
       });
-      expect(secondSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.invoke_agent' });
-      expect(secondSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langgraph' });
-      expect(secondSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE]).toEqual({
+      expect(invokeAgentSpan!.attributes['sentry.op']).toEqual({ type: 'string', value: 'gen_ai.invoke_agent' });
+      expect(invokeAgentSpan!.attributes['sentry.origin']).toEqual({ type: 'string', value: 'auto.ai.langgraph' });
+      expect(invokeAgentSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'weather_assistant',
       });
-      expect(secondSpan!.attributes[GEN_AI_PIPELINE_NAME_ATTRIBUTE]).toEqual({
+      expect(invokeAgentSpan!.attributes[GEN_AI_PIPELINE_NAME_ATTRIBUTE]).toEqual({
         type: 'string',
         value: 'weather_assistant',
       });
-      expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+      expect(invokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
         type: 'string',
         value: '[{"role":"user","content":"What is the weather in SF?"}]',
       });
-      expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'mock-model' });
-      expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 20 });
-      expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-      expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 30 });
+      expect(invokeAgentSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+        type: 'string',
+        value: 'mock-model',
+      });
+      expect(invokeAgentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+        type: 'integer',
+        value: 20,
+      });
+      expect(invokeAgentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+        type: 'integer',
+        value: 10,
+      });
+      expect(invokeAgentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+        type: 'integer',
+        value: 30,
+      });
     })
     .start(signal);
   await runner.makeRequest('get', '/');

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
@@ -62,49 +62,53 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
+            const completionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'msg_mock123',
+            );
+            expect(completionSpan).toBeDefined();
+            expect(completionSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(completionSpan!.status).toBe('ok');
+            expect(completionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(completionSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(completionSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
+            expect(completionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(completionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(completionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(completionSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+            expect(completionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(completionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(completionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(completionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
 
-            // [0] messages.create — basic message completion without PII
-            expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_mock123');
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+            const errorSpan = container.items.find(span => span.name === 'chat error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(errorSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
+            expect(errorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
 
-            // [1] messages.create with error-model — error handling
-            expect(secondSpan!.name).toBe('chat error-model');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
+            const tokenCountingSpan = container.items.find(
+              span =>
+                span.name === 'chat claude-3-haiku-20240307' &&
+                span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE] === undefined,
+            );
+            expect(tokenCountingSpan).toBeDefined();
+            expect(tokenCountingSpan!.status).toBe('ok');
+            expect(tokenCountingSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(tokenCountingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
 
-            // [2] messages.countTokens — token counting
-            expect(thirdSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-
-            // [3] models.retrieve
-            expect(fourthSpan!.name).toBe('models claude-3-haiku-20240307');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('models');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
-            expect(fourthSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
-            expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            const modelsSpan = container.items.find(span => span.name === 'models claude-3-haiku-20240307');
+            expect(modelsSpan).toBeDefined();
+            expect(modelsSpan!.status).toBe('ok');
+            expect(modelsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('models');
+            expect(modelsSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
+            expect(modelsSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
+            expect(modelsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(modelsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(modelsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(modelsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
           },
         })
         .start()
@@ -124,27 +128,24 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            const nonStreamingSpans = container.items.filter(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'msg_withresponse',
+            );
+            expect(nonStreamingSpans).toHaveLength(2);
+            for (const span of nonStreamingSpans) {
+              expect(span.name).toBe('chat claude-3-haiku-20240307');
+              expect(span.status).toBe('ok');
+              expect(span.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+              expect(span.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            }
 
-            // [0] .withResponse() — non-streaming
-            expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_withresponse');
-
-            // [1] .asResponse() — non-streaming
-            expect(secondSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_withresponse');
-
-            // [2] streaming .withResponse()
-            expect(thirdSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream_withresponse');
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            const streamingSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'msg_stream_withresponse',
+            );
+            expect(streamingSpan).toBeDefined();
+            expect(streamingSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(streamingSpan!.status).toBe('ok');
+            expect(streamingSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
           },
         })
         .start()
@@ -160,32 +161,38 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(5);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan] = container.items;
+            const completionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'msg_mock123',
+            );
+            expect(completionSpan).toBeDefined();
+            expect(completionSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(completionSpan!.status).toBe('ok');
 
-            // [0] messages.create — basic message completion
-            expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_mock123');
+            const errorSpan = container.items.find(span => span.name === 'chat error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
 
-            // [1] messages.create with error-model — error handling
-            expect(secondSpan!.name).toBe('chat error-model');
-            expect(secondSpan!.status).toBe('error');
+            const tokenCountingSpan = container.items.find(
+              span =>
+                span.name === 'chat claude-3-haiku-20240307' &&
+                span.status === 'ok' &&
+                span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE] === undefined,
+            );
+            expect(tokenCountingSpan).toBeDefined();
+            expect(tokenCountingSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
 
-            // [2] messages.countTokens — token counting
-            expect(thirdSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            const modelsSpan = container.items.find(span => span.name === 'models claude-3-haiku-20240307');
+            expect(modelsSpan).toBeDefined();
+            expect(modelsSpan!.status).toBe('ok');
+            expect(modelsSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
 
-            // [3] models.retrieve
-            expect(fourthSpan!.name).toBe('models claude-3-haiku-20240307');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
-
-            // [4] messages.create stream: true + messages.stream (both share this span due to pre-existing bug)
-            expect(fifthSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(fifthSpan!.status).toBe('ok');
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream123');
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            const streamingSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'msg_stream123',
+            );
+            expect(streamingSpan).toBeDefined();
+            expect(streamingSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(streamingSpan!.status).toBe('ok');
+            expect(streamingSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
           },
         })
         .expect({ event: EXPECTED_STREAM_EVENT_HANDLER_MESSAGE })
@@ -202,61 +209,67 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(5);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan] = container.items;
-
-            // [0] messages.create — basic message completion with PII
-            expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
-              '[{"role":"user","content":"What is the capital of France?"}]',
+            const completionSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                '[{"role":"user","content":"What is the capital of France?"}]',
             );
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_mock123');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from Anthropic mock!');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
+            expect(completionSpan).toBeDefined();
+            expect(completionSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(completionSpan!.status).toBe('ok');
+            expect(completionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(completionSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+            expect(completionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(completionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(completionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(completionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_mock123');
+            expect(completionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from Anthropic mock!');
+            expect(completionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(completionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(completionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(completionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+            expect(completionSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(completionSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
 
-            // [1] messages.create with error-model — error handling with PII
-            expect(secondSpan!.name).toBe('chat error-model');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
-              '[{"role":"user","content":"This will fail"}]',
+            const errorSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                '[{"role":"user","content":"This will fail"}]',
             );
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.name).toBe('chat error-model');
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
 
-            // [2] messages.countTokens — token counting with PII (response text records input_tokens as "15")
-            expect(thirdSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('15');
+            const tokenCountingSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]?.value === '15',
+            );
+            expect(tokenCountingSpan).toBeDefined();
+            expect(tokenCountingSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(tokenCountingSpan!.status).toBe('ok');
+            expect(tokenCountingSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
 
-            // [3] models.retrieve with PII
-            expect(fourthSpan!.name).toBe('models claude-3-haiku-20240307');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
+            const modelsSpan = container.items.find(span => span.name === 'models claude-3-haiku-20240307');
+            expect(modelsSpan).toBeDefined();
+            expect(modelsSpan!.status).toBe('ok');
+            expect(modelsSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
 
-            // [4] messages.create stream: true + messages.stream (both share this span due to pre-existing bug)
             // TODO: messages.stream() should produce its own distinct gen_ai span, but it
             // currently does not (pre-existing bug). Once fixed, add an additional indexed span assertion.
-            expect(fifthSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(fifthSpan!.status).toBe('ok');
-            expect(fifthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(fifthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(fifthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream123');
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from stream!');
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+            const streamingSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'msg_stream123',
+            );
+            expect(streamingSpan).toBeDefined();
+            expect(streamingSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(streamingSpan!.status).toBe('ok');
+            expect(streamingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(streamingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(streamingSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
+            expect(streamingSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(streamingSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from stream!');
+            expect(streamingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(streamingSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(streamingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
           },
         })
         .expect({ event: EXPECTED_STREAM_EVENT_HANDLER_MESSAGE })
@@ -273,43 +286,47 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(5);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan] = container.items;
+            const completionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'msg_mock123',
+            );
+            expect(completionSpan).toBeDefined();
+            expect(completionSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(completionSpan!.status).toBe('ok');
+            expect(completionSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(completionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(completionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
 
-            // [0] messages.create — chat span with custom PII options (input messages + response text recorded)
-            expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_mock123');
+            const errorSpan = container.items.find(span => span.name === 'chat error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
 
-            // [1] messages.create with error-model — error handling
-            expect(secondSpan!.name).toBe('chat error-model');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            const tokenCountingSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]?.value === '15',
+            );
+            expect(tokenCountingSpan).toBeDefined();
+            expect(tokenCountingSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(tokenCountingSpan!.status).toBe('ok');
+            expect(tokenCountingSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(tokenCountingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
 
-            // [2] messages.countTokens — token counting with options (response text = "15")
-            expect(thirdSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('15');
+            const modelsSpan = container.items.find(span => span.name === 'models claude-3-haiku-20240307');
+            expect(modelsSpan).toBeDefined();
+            expect(modelsSpan!.status).toBe('ok');
+            expect(modelsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('models');
+            expect(modelsSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
+            expect(modelsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(modelsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(modelsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+            expect(modelsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
 
-            // [3] models.retrieve with options
-            expect(fourthSpan!.name).toBe('models claude-3-haiku-20240307');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('models');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
-            expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-
-            // [4] messages.create stream: true + messages.stream (share this span due to pre-existing bug)
-            expect(fifthSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(fifthSpan!.status).toBe('ok');
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream123');
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            const streamingSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'msg_stream123',
+            );
+            expect(streamingSpan).toBeDefined();
+            expect(streamingSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(streamingSpan!.status).toBe('ok');
+            expect(streamingSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
           },
         })
         .expect({ event: EXPECTED_STREAM_EVENT_HANDLER_MESSAGE })
@@ -334,43 +351,53 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            const requestStreamSpans = container.items.filter(
+              span => span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]?.value === true,
+            );
+            expect(requestStreamSpans).toHaveLength(2);
+            for (const span of requestStreamSpans) {
+              expect(span.name).toBe('chat claude-3-haiku-20240307');
+              expect(span.status).toBe('ok');
+              expect(span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
+              expect(span.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+              expect(span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream_1');
+            }
 
-            // [0] messages.create with stream: true
-            expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream_1');
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["end_turn"]');
+            const detailedStreamSpan = requestStreamSpans.find(
+              span => span.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]?.value === '["end_turn"]',
+            );
+            expect(detailedStreamSpan).toBeDefined();
+            expect(detailedStreamSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(detailedStreamSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(detailedStreamSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe(
+              'claude-3-haiku-20240307',
+            );
+            expect(detailedStreamSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe(
+              'claude-3-haiku-20240307',
+            );
+            expect(detailedStreamSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(detailedStreamSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(detailedStreamSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
 
-            // [1] messages.stream (no request.stream attribute — distinguishes from the other two)
-            expect(secondSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream_1');
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
-
-            // [2] messages.stream with redundant stream: true param
-            expect(thirdSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream_1');
+            const messagesStreamSpan = container.items.find(
+              span => span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE] === undefined,
+            );
+            expect(messagesStreamSpan).toBeDefined();
+            expect(messagesStreamSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(messagesStreamSpan!.status).toBe('ok');
+            expect(messagesStreamSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(messagesStreamSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(messagesStreamSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe(
+              'claude-3-haiku-20240307',
+            );
+            expect(messagesStreamSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(messagesStreamSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe(
+              'claude-3-haiku-20240307',
+            );
+            expect(messagesStreamSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('msg_stream_1');
+            expect(messagesStreamSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(messagesStreamSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(messagesStreamSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
           },
         })
         .start()
@@ -386,28 +413,26 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            const requestStreamSpans = container.items.filter(
+              span => span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]?.value === true,
+            );
+            expect(requestStreamSpans).toHaveLength(2);
+            for (const span of requestStreamSpans) {
+              expect(span.name).toBe('chat claude-3-haiku-20240307');
+              expect(span.status).toBe('ok');
+              expect(span.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+              expect(span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
+              expect(span.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from stream!');
+            }
 
-            // [0] messages.create with stream: true — response text captured with PII
-            expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from stream!');
-
-            // [1] messages.stream — response text captured with PII, no request.stream param
-            expect(secondSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from stream!');
-
-            // [2] messages.stream with redundant stream: true — response text captured with PII
-            expect(thirdSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from stream!');
+            const messagesStreamSpan = container.items.find(
+              span => span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE] === undefined,
+            );
+            expect(messagesStreamSpan).toBeDefined();
+            expect(messagesStreamSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(messagesStreamSpan!.status).toBe('ok');
+            expect(messagesStreamSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(messagesStreamSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('Hello from stream!');
           },
         })
         .start()
@@ -460,22 +485,23 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
+            const streamingToolSpan = container.items.find(span => span.status === 'ok');
+            expect(streamingToolSpan).toBeDefined();
+            expect(streamingToolSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(streamingToolSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(streamingToolSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
+            expect(streamingToolSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(streamingToolSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toBe(
+              EXPECTED_TOOLS_JSON,
+            );
+            expect(streamingToolSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE].value).toBe(
+              EXPECTED_TOOL_CALLS_JSON,
+            );
 
-            // [0] messages.create(stream: true) with tools — available tools + tool calls recorded with PII
-            expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toBe(EXPECTED_TOOLS_JSON);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE].value).toBe(EXPECTED_TOOL_CALLS_JSON);
-
-            // [1] messages.stream — currently records as error since messages.stream doesn't get
-            //     iterable semantics through the mock; this preserves observed behavior.
-            expect(secondSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            const errorSpan = container.items.find(span => span.status === 'error');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.name).toBe('chat claude-3-haiku-20240307');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
           },
         })
         .start()
@@ -496,33 +522,43 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
+            const createInitErrorSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]?.value === 'error-stream-init' &&
+                span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]?.value === true,
+            );
+            expect(createInitErrorSpan).toBeDefined();
+            expect(createInitErrorSpan!.name).toBe('chat error-stream-init');
+            expect(createInitErrorSpan!.status).toBe('error');
 
-            // [0] messages.create(stream: true) error on stream init
-            expect(firstSpan!.name).toBe('chat error-stream-init');
-            expect(firstSpan!.status).toBe('error');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-stream-init');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
+            const streamInitErrorSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]?.value === 'error-stream-init' &&
+                span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE] === undefined,
+            );
+            expect(streamInitErrorSpan).toBeDefined();
+            expect(streamInitErrorSpan!.name).toBe('chat error-stream-init');
+            expect(streamInitErrorSpan!.status).toBe('error');
 
-            // [1] messages.stream error on stream init (no request.stream param)
-            expect(secondSpan!.name).toBe('chat error-stream-init');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-stream-init');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+            const createMidwayErrorSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]?.value === 'error-stream-midway' &&
+                span.status === 'ok',
+            );
+            expect(createMidwayErrorSpan).toBeDefined();
+            expect(createMidwayErrorSpan!.name).toBe('chat error-stream-midway');
+            expect(createMidwayErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
+            expect(createMidwayErrorSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(createMidwayErrorSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('This stream will ');
 
-            // [2] messages.create(stream: true) midway error — finishes 'ok' with partial text
-            expect(thirdSpan!.name).toBe('chat error-stream-midway');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-stream-midway');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE].value).toBe(true);
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toBe('This stream will ');
-
-            // [3] messages.stream midway error — errors out
-            expect(fourthSpan!.name).toBe('chat error-stream-midway');
-            expect(fourthSpan!.status).toBe('error');
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-stream-midway');
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+            const streamMidwayErrorSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]?.value === 'error-stream-midway' &&
+                span.status === 'error',
+            );
+            expect(streamMidwayErrorSpan).toBeDefined();
+            expect(streamMidwayErrorSpan!.name).toBe('chat error-stream-midway');
+            expect(streamMidwayErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
           },
         })
         .start()
@@ -543,24 +579,22 @@ describe('Anthropic integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            const invalidFormatSpan = container.items.find(span => span.name === 'chat invalid-format');
+            expect(invalidFormatSpan).toBeDefined();
+            expect(invalidFormatSpan!.status).toBe('error');
+            expect(invalidFormatSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('invalid-format');
+            expect(invalidFormatSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
 
-            // [0] messages.create with invalid-format — tool format error
-            expect(firstSpan!.name).toBe('chat invalid-format');
-            expect(firstSpan!.status).toBe('error');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('invalid-format');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            const modelErrorSpan = container.items.find(span => span.name === 'models nonexistent-model');
+            expect(modelErrorSpan).toBeDefined();
+            expect(modelErrorSpan!.status).toBe('error');
+            expect(modelErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('nonexistent-model');
+            expect(modelErrorSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
 
-            // [1] models.retrieve('nonexistent-model') — model retrieval error
-            expect(secondSpan!.name).toBe('models nonexistent-model');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('nonexistent-model');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.models');
-
-            // [2] Successful tool usage (for comparison)
-            expect(thirdSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE].value).toContain('tool_ok_1');
+            const toolSuccessSpan = container.items.find(span => span.name === 'chat claude-3-haiku-20240307');
+            expect(toolSuccessSpan).toBeDefined();
+            expect(toolSuccessSpan!.status).toBe('ok');
+            expect(toolSuccessSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE].value).toContain('tool_ok_1');
           },
         })
         .start()
@@ -584,34 +618,38 @@ describe('Anthropic integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
-
-              // [0] First call: last message is large and truncated (only C's remain, D's cropped)
-              expect(firstSpan!.name).toBe('chat claude-3-haiku-20240307');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
-                /^\[\{"role":"user","content":"C+"\}\]$/,
-              );
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
-
-              // [1] Second call: last message is small and kept without truncation
               const smallMsgValue = JSON.stringify([
                 { role: 'user', content: 'This is a small message that fits within the limit' },
               ]);
-              expect(secondSpan!.name).toBe('chat claude-3-haiku-20240307');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(smallMsgValue);
-              expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
+              const truncatedSpan = container.items.find(span =>
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.match(
+                  /^\[\{"role":"user","content":"C+"\}\]$/,
+                ),
+              );
+              expect(truncatedSpan).toBeDefined();
+              expect(truncatedSpan!.name).toBe('chat claude-3-haiku-20240307');
+              expect(truncatedSpan!.status).toBe('ok');
+              expect(truncatedSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+              expect(truncatedSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(truncatedSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
+              expect(truncatedSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+              expect(truncatedSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-haiku-20240307');
+              expect(truncatedSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
+
+              const smallMessageSpan = container.items.find(
+                span => span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value === smallMsgValue,
+              );
+              expect(smallMessageSpan).toBeDefined();
+              expect(smallMessageSpan!.name).toBe('chat claude-3-haiku-20240307');
+              expect(smallMessageSpan!.status).toBe('ok');
+              expect(smallMessageSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+              expect(smallMessageSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(smallMessageSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
+              expect(smallMessageSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+              expect(smallMessageSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe(
+                'claude-3-haiku-20240307',
+              );
+              expect(smallMessageSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
             },
           })
           .start()
@@ -720,15 +758,17 @@ describe('Anthropic integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
+              const conversationSpan = container.items.find(
+                span => span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value === expectedAllMessages,
+              );
+              expect(conversationSpan).toBeDefined();
+              expect(conversationSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
 
-              // [0] messages.create with multi-message conversation — all messages preserved
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(expectedAllMessages);
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
-
-              // [1] messages.create with long string input — not truncated
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(expectedLongString);
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(1);
+              const longStringSpan = container.items.find(
+                span => span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value === expectedLongString,
+              );
+              expect(longStringSpan).toBeDefined();
+              expect(longStringSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(1);
             },
           })
           .start()

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/test.ts
@@ -36,41 +36,45 @@ describe('Google GenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'chat gemini-1.5-pro',
+              'generate_content error-model',
+              'generate_content gemini-1.5-flash',
+            ]);
 
-            // [0] chat.sendMessage (should get model from context)
-            expect(firstSpan!.name).toBe('chat gemini-1.5-pro');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.google_genai');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-pro');
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
+            const chatSpan = container.items.find(span => span.name === 'chat gemini-1.5-pro');
+            expect(chatSpan).toBeDefined();
+            expect(chatSpan!.status).toBe('ok');
+            expect(chatSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(chatSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(chatSpan!.attributes['sentry.origin'].value).toBe('auto.ai.google_genai');
+            expect(chatSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
+            expect(chatSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-pro');
+            expect(chatSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
+            expect(chatSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
+            expect(chatSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
 
-            // [1] models.generateContent
-            expect(secondSpan!.name).toBe('generate_content gemini-1.5-flash');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-flash');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.9);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
+            const generateContentSpan = container.items.find(span => span.name === 'generate_content gemini-1.5-flash');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.status).toBe('ok');
+            expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(generateContentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(generateContentSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-flash');
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.9);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+            expect(generateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
+            expect(generateContentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
+            expect(generateContentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
 
-            // [2] error handling
-            expect(thirdSpan!.name).toBe('generate_content error-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
+            const errorSpan = container.items.find(span => span.name === 'generate_content error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(errorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(errorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
+            expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
           },
         })
         .start()
@@ -86,38 +90,42 @@ describe('Google GenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'chat gemini-1.5-pro',
+              'generate_content error-model',
+              'generate_content gemini-1.5-flash',
+            ]);
 
-            // [0] chat.sendMessage with PII
-            expect(firstSpan!.name).toBe('chat gemini-1.5-pro');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-pro');
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
+            const chatSpan = container.items.find(span => span.name === 'chat gemini-1.5-pro');
+            expect(chatSpan).toBeDefined();
+            expect(chatSpan!.status).toBe('ok');
+            expect(chatSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(chatSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(chatSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
+            expect(chatSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-pro');
+            expect(chatSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(chatSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+            expect(chatSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
+            expect(chatSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
+            expect(chatSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
 
-            // [1] models.generateContent with PII
-            expect(secondSpan!.name).toBe('generate_content gemini-1.5-flash');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.9);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+            const generateContentSpan = container.items.find(span => span.name === 'generate_content gemini-1.5-flash');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.status).toBe('ok');
+            expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(generateContentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(generateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(generateContentSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.9);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
 
-            // [2] error handling with PII
-            expect(thirdSpan!.name).toBe('generate_content error-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            const errorSpan = container.items.find(span => span.name === 'generate_content error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(errorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(errorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
           },
         })
         .start()
@@ -133,21 +141,25 @@ describe('Google GenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'chat gemini-1.5-pro',
+              'generate_content error-model',
+              'generate_content gemini-1.5-flash',
+            ]);
 
-            // [0] chat.sendMessage with custom options (PII enabled via recordInputs/recordOutputs)
-            expect(firstSpan!.name).toBe('chat gemini-1.5-pro');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+            const chatSpan = container.items.find(span => span.name === 'chat gemini-1.5-pro');
+            expect(chatSpan).toBeDefined();
+            expect(chatSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(chatSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(chatSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
 
-            // [1] models.generateContent with custom options
-            expect(secondSpan!.name).toBe('generate_content gemini-1.5-flash');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            const generateContentSpan = container.items.find(span => span.name === 'generate_content gemini-1.5-flash');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
 
-            // [2] error handling with custom options
-            expect(thirdSpan!.name).toBe('generate_content error-model');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            const errorSpan = container.items.find(span => span.name === 'generate_content error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
           },
         })
         .start()
@@ -166,50 +178,52 @@ describe('Google GenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-            // [0] Non-streaming with tools
-            expect(firstSpan!.name).toBe('generate_content gemini-2.0-flash-001');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toBe(
-              EXPECTED_AVAILABLE_TOOLS_JSON,
+            const nonStreamingToolsSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]?.value === EXPECTED_AVAILABLE_TOOLS_JSON &&
+                span.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE] === undefined,
             );
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toBeUndefined();
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(8);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(23);
+            expect(nonStreamingToolsSpan).toBeDefined();
+            expect(nonStreamingToolsSpan!.name).toBe('generate_content gemini-2.0-flash-001');
+            expect(nonStreamingToolsSpan!.status).toBe('ok');
+            expect(nonStreamingToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(nonStreamingToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(nonStreamingToolsSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+            expect(nonStreamingToolsSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toBeDefined();
+            expect(nonStreamingToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(nonStreamingToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(8);
+            expect(nonStreamingToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(23);
 
-            // [1] Streaming with tools
-            expect(secondSpan!.name).toBe('generate_content gemini-2.0-flash-001');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toBe(
-              EXPECTED_AVAILABLE_TOOLS_JSON,
+            const streamingToolsSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]?.value === EXPECTED_AVAILABLE_TOOLS_JSON &&
+                span.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]?.value === true,
             );
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('mock-response-tools-id');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gemini-2.0-flash-001');
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(12);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(22);
+            expect(streamingToolsSpan).toBeDefined();
+            expect(streamingToolsSpan!.name).toBe('generate_content gemini-2.0-flash-001');
+            expect(streamingToolsSpan!.status).toBe('ok');
+            expect(streamingToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(streamingToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(streamingToolsSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+            expect(streamingToolsSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toBeDefined();
+            expect(streamingToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('mock-response-tools-id');
+            expect(streamingToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gemini-2.0-flash-001');
+            expect(streamingToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(12);
+            expect(streamingToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(streamingToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(22);
 
-            // [2] Without tools for comparison
-            expect(thirdSpan!.name).toBe('generate_content gemini-2.0-flash-001');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toBeUndefined();
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
+            const noToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE] === undefined,
+            );
+            expect(noToolsSpan).toBeDefined();
+            expect(noToolsSpan!.name).toBe('generate_content gemini-2.0-flash-001');
+            expect(noToolsSpan!.status).toBe('ok');
+            expect(noToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(noToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(noToolsSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+            expect(noToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
+            expect(noToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
+            expect(noToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
           },
         })
         .start()
@@ -225,42 +239,49 @@ describe('Google GenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'chat gemini-1.5-pro',
+              'generate_content blocked-model',
+              'generate_content error-model',
+              'generate_content gemini-1.5-flash',
+            ]);
 
-            // [0] models.generateContentStream (streaming)
-            expect(firstSpan!.name).toBe('generate_content gemini-1.5-flash');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.9);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('mock-response-streaming-id');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-pro');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["STOP"]');
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(22);
+            const generateContentSpan = container.items.find(span => span.name === 'generate_content gemini-1.5-flash');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.status).toBe('ok');
+            expect(generateContentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(generateContentSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.9);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+            expect(generateContentSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe(
+              'mock-response-streaming-id',
+            );
+            expect(generateContentSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-pro');
+            expect(generateContentSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["STOP"]');
+            expect(generateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(generateContentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
+            expect(generateContentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(22);
 
-            // [1] chat.sendMessageStream (streaming)
-            expect(secondSpan!.name).toBe('chat gemini-1.5-pro');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('mock-response-streaming-id');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-pro');
+            const chatSpan = container.items.find(span => span.name === 'chat gemini-1.5-pro');
+            expect(chatSpan).toBeDefined();
+            expect(chatSpan!.status).toBe('ok');
+            expect(chatSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(chatSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(chatSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE].value).toBe('mock-response-streaming-id');
+            expect(chatSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gemini-1.5-pro');
 
-            // [2] blocked content streaming
-            expect(thirdSpan!.name).toBe('generate_content blocked-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            const blockedSpan = container.items.find(span => span.name === 'generate_content blocked-model');
+            expect(blockedSpan).toBeDefined();
+            expect(blockedSpan!.status).toBe('error');
+            expect(blockedSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(blockedSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
 
-            // [3] error handling for streaming
-            expect(fourthSpan!.name).toBe('generate_content error-model');
-            expect(fourthSpan!.status).toBe('error');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            const errorSpan = container.items.find(span => span.name === 'generate_content error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(errorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
           },
         })
         .start()
@@ -276,41 +297,46 @@ describe('Google GenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'chat gemini-1.5-pro',
+              'generate_content blocked-model',
+              'generate_content error-model',
+              'generate_content gemini-1.5-flash',
+            ]);
 
-            // [0] models.generateContentStream (streaming) with PII
-            expect(firstSpan!.name).toBe('generate_content gemini-1.5-flash');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.9);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["STOP"]');
+            const generateContentSpan = container.items.find(span => span.name === 'generate_content gemini-1.5-flash');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.status).toBe('ok');
+            expect(generateContentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(generateContentSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(generateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.9);
+            expect(generateContentSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+            expect(generateContentSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["STOP"]');
 
-            // [1] chat.sendMessageStream (streaming) with PII
-            expect(secondSpan!.name).toBe('chat gemini-1.5-pro');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["STOP"]');
+            const chatSpan = container.items.find(span => span.name === 'chat gemini-1.5-pro');
+            expect(chatSpan).toBeDefined();
+            expect(chatSpan!.status).toBe('ok');
+            expect(chatSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(chatSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(chatSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(chatSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["STOP"]');
 
-            // [2] blocked content stream with PII
-            expect(thirdSpan!.name).toBe('generate_content blocked-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            const blockedSpan = container.items.find(span => span.name === 'generate_content blocked-model');
+            expect(blockedSpan).toBeDefined();
+            expect(blockedSpan!.status).toBe('error');
+            expect(blockedSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(blockedSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE].value).toBe(true);
+            expect(blockedSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(blockedSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
 
-            // [3] error handling for streaming with PII
-            expect(fourthSpan!.name).toBe('generate_content error-model');
-            expect(fourthSpan!.status).toBe('error');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            const errorSpan = container.items.find(span => span.name === 'generate_content error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            expect(errorSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(errorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
           },
         })
         .start()
@@ -330,30 +356,32 @@ describe('Google GenAI integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
-
-              // [0] First call: Last message is large and gets truncated (only C's remain, D's are cropped)
-              expect(firstSpan!.name).toBe('generate_content gemini-1.5-flash');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
-                /^\[\{"role":"user","parts":\[\{"text":"C+"\}\]\}\]$/,
+              const truncatedSpan = container.items.find(span =>
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.match(
+                  /^\[\{"role":"user","parts":\[\{"text":"C+"\}\]\}\]$/,
+                ),
               );
+              expect(truncatedSpan).toBeDefined();
+              expect(truncatedSpan!.name).toBe('generate_content gemini-1.5-flash');
+              expect(truncatedSpan!.status).toBe('ok');
+              expect(truncatedSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+              expect(truncatedSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
 
-              // [1] Second call: Last message is small and kept without truncation
-              expect(secondSpan!.name).toBe('generate_content gemini-1.5-flash');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
-                JSON.stringify([
-                  {
-                    role: 'user',
-                    parts: [{ text: 'This is a small message that fits within the limit' }],
-                  },
-                ]),
+              const smallMessageSpan = container.items.find(
+                span =>
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                  JSON.stringify([
+                    {
+                      role: 'user',
+                      parts: [{ text: 'This is a small message that fits within the limit' }],
+                    },
+                  ]),
               );
+              expect(smallMessageSpan).toBeDefined();
+              expect(smallMessageSpan!.name).toBe('generate_content gemini-1.5-flash');
+              expect(smallMessageSpan!.status).toBe('ok');
+              expect(smallMessageSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+              expect(smallMessageSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
             },
           })
           .start()
@@ -398,29 +426,30 @@ describe('Google GenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'embeddings error-model',
+              'embeddings text-embedding-004',
+              'embeddings text-embedding-004',
+            ]);
 
-            // [0] embedContent with string contents (no PII)
-            expect(firstSpan!.name).toBe('embeddings text-embedding-004');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.google_genai');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('text-embedding-004');
-            expect(firstSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toBeUndefined();
+            const successfulSpans = container.items.filter(
+              span => span.name === 'embeddings text-embedding-004' && span.status === 'ok',
+            );
+            expect(successfulSpans).toHaveLength(2);
+            for (const span of successfulSpans) {
+              expect(span.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
+              expect(span.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
+              expect(span.attributes['sentry.origin'].value).toBe('auto.ai.google_genai');
+              expect(span.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
+              expect(span.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('text-embedding-004');
+              expect(span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toBeUndefined();
+            }
 
-            // [1] embedContent error model
-            expect(secondSpan!.name).toBe('embeddings error-model');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
-
-            // [2] embedContent with array contents (no PII)
-            expect(thirdSpan!.name).toBe('embeddings text-embedding-004');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
+            const errorSpan = container.items.find(span => span.name === 'embeddings error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
+            expect(errorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
           },
         })
         .start()
@@ -436,30 +465,38 @@ describe('Google GenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'embeddings error-model',
+              'embeddings text-embedding-004',
+              'embeddings text-embedding-004',
+            ]);
 
-            // [0] embedContent with string contents and PII
-            expect(firstSpan!.name).toBe('embeddings text-embedding-004');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
-            expect(firstSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe(
-              'What is the capital of France?',
+            const stringInputSpan = container.items.find(
+              span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === 'What is the capital of France?',
             );
+            expect(stringInputSpan).toBeDefined();
+            expect(stringInputSpan!.name).toBe('embeddings text-embedding-004');
+            expect(stringInputSpan!.status).toBe('ok');
+            expect(stringInputSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
+            expect(stringInputSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('google_genai');
 
-            // [1] embedContent error model with PII
-            expect(secondSpan!.name).toBe('embeddings error-model');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
-            expect(secondSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe('This will fail');
-
-            // [2] embedContent with array contents and PII
-            expect(thirdSpan!.name).toBe('embeddings text-embedding-004');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
-            expect(thirdSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe(
-              '[{"role":"user","parts":[{"text":"First input text"}]},{"role":"user","parts":[{"text":"Second input text"}]}]',
+            const errorSpan = container.items.find(
+              span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === 'This will fail',
             );
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.name).toBe('embeddings error-model');
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
+
+            const arrayInputSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value ===
+                '[{"role":"user","parts":[{"text":"First input text"}]},{"role":"user","parts":[{"text":"Second input text"}]}]',
+            );
+            expect(arrayInputSpan).toBeDefined();
+            expect(arrayInputSpan!.name).toBe('embeddings text-embedding-004');
+            expect(arrayInputSpan!.status).toBe('ok');
+            expect(arrayInputSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
           },
         })
         .start()

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
@@ -36,46 +36,50 @@ describe('LangChain integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'chat claude-3-5-sonnet-20241022',
+              'chat claude-3-opus-20240229',
+              'chat error-model',
+            ]);
 
-            // [0] chat model with claude-3-5-sonnet
-            expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-5-sonnet-20241022');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE]).toBeDefined();
+            const sonnetSpan = container.items.find(span => span.name === 'chat claude-3-5-sonnet-20241022');
+            expect(sonnetSpan).toBeDefined();
+            expect(sonnetSpan!.status).toBe('ok');
+            expect(sonnetSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(sonnetSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+            expect(sonnetSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+            expect(sonnetSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(sonnetSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-5-sonnet-20241022');
+            expect(sonnetSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(sonnetSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+            expect(sonnetSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(sonnetSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(sonnetSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+            expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
+            expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toBeDefined();
+            expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE]).toBeDefined();
 
-            // [1] chat model with claude-3-opus
-            expect(secondSpan!.name).toBe('chat claude-3-opus-20240229');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-opus-20240229');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.9);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.95);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(200);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+            const opusSpan = container.items.find(span => span.name === 'chat claude-3-opus-20240229');
+            expect(opusSpan).toBeDefined();
+            expect(opusSpan!.status).toBe('ok');
+            expect(opusSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(opusSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+            expect(opusSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(opusSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-opus-20240229');
+            expect(opusSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.9);
+            expect(opusSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.95);
+            expect(opusSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(200);
+            expect(opusSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(opusSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(opusSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
 
-            // [2] error handling
-            expect(thirdSpan!.name).toBe('chat error-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(thirdSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
+            const errorSpan = container.items.find(span => span.name === 'chat error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(errorSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+            expect(errorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
           },
         })
         .start()
@@ -92,16 +96,9 @@ describe('LangChain integration', () => {
             // Without the dedup guard, the file-level and module-level hooks
             // both patch the same prototype, producing 6 spans instead of 3.
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-            // [0] chat claude-3-5-sonnet
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-
-            // [1] chat claude-3-opus
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-
-            // [2] chat error-model
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            for (const span of container.items) {
+              expect(span.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            }
           },
         })
         .start()
@@ -117,46 +114,50 @@ describe('LangChain integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'chat claude-3-5-sonnet-20241022',
+              'chat claude-3-opus-20240229',
+              'chat error-model',
+            ]);
 
-            // [0] chat model with PII
-            expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-5-sonnet-20241022');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE]).toBeDefined();
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+            const sonnetSpan = container.items.find(span => span.name === 'chat claude-3-5-sonnet-20241022');
+            expect(sonnetSpan).toBeDefined();
+            expect(sonnetSpan!.status).toBe('ok');
+            expect(sonnetSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(sonnetSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+            expect(sonnetSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(sonnetSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-5-sonnet-20241022');
+            expect(sonnetSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+            expect(sonnetSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+            expect(sonnetSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+            expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
+            expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toBeDefined();
+            expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE]).toBeDefined();
+            expect(sonnetSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(sonnetSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(sonnetSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
 
-            // [1] chat model with PII
-            expect(secondSpan!.name).toBe('chat claude-3-opus-20240229');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-opus-20240229');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.9);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.95);
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(200);
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+            const opusSpan = container.items.find(span => span.name === 'chat claude-3-opus-20240229');
+            expect(opusSpan).toBeDefined();
+            expect(opusSpan!.status).toBe('ok');
+            expect(opusSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(opusSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-opus-20240229');
+            expect(opusSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.9);
+            expect(opusSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.95);
+            expect(opusSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(200);
+            expect(opusSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(opusSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+            expect(opusSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(opusSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(opusSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
 
-            // [2] error handling with PII
-            expect(thirdSpan!.name).toBe('chat error-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            const errorSpan = container.items.find(span => span.name === 'chat error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+            expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
+            expect(errorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
           },
         })
         .start()
@@ -207,30 +208,35 @@ describe('LangChain integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-              // [0] String input truncated (only C's remain, D's are cropped)
-              expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(1);
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
+              const stringInputSpan = container.items.find(
+                span => span.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]?.value === 1,
+              );
+              expect(stringInputSpan).toBeDefined();
+              expect(stringInputSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
+              expect(stringInputSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
                 /^\[\{"role":"user","content":"C+"\}\]$/,
               );
 
-              // [1] Array input, last message truncated (only C's remain, D's are cropped)
-              expect(secondSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(2);
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
-                /^\[\{"role":"user","content":"C+"\}\]$/,
+              const arrayInputSpan = container.items.find(
+                span =>
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]?.value === 2 &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.match(
+                    /^\[\{"role":"user","content":"C+"\}\]$/,
+                  ),
               );
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toBeDefined();
+              expect(arrayInputSpan).toBeDefined();
+              expect(arrayInputSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
+              expect(arrayInputSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toBeDefined();
 
-              // [2] Last message is small and kept without truncation
-              expect(thirdSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(2);
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
-                JSON.stringify([{ role: 'user', content: 'This is a small message that fits within the limit' }]),
+              const smallMessageSpan = container.items.find(
+                span =>
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                  JSON.stringify([{ role: 'user', content: 'This is a small message that fits within the limit' }]),
               );
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toBeDefined();
+              expect(smallMessageSpan).toBeDefined();
+              expect(smallMessageSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
+              expect(smallMessageSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(2);
+              expect(smallMessageSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toBeDefined();
             },
           })
           .start()
@@ -251,17 +257,18 @@ describe('LangChain integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
+              const anthropicSpan = container.items.find(
+                span => span.attributes['sentry.origin'].value === 'auto.ai.anthropic',
+              );
+              expect(anthropicSpan).toBeDefined();
+              expect(anthropicSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
 
-              // Verify the edge case limitation:
-              // [0] Direct Anthropic call made BEFORE LangChain import — IS instrumented
-              //     by Anthropic (origin: 'auto.ai.anthropic').
-              expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
-
-              // [1] LangChain call — IS instrumented by LangChain (origin: 'auto.ai.langchain').
-              expect(secondSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              // LangChain call is instrumented by LangChain.
+              const langchainSpan = container.items.find(
+                span => span.attributes['sentry.origin'].value === 'auto.ai.langchain',
+              );
+              expect(langchainSpan).toBeDefined();
+              expect(langchainSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
 
               // Third call (not present): Direct Anthropic call made AFTER LangChain import
               // is NOT instrumented, which demonstrates the skip mechanism works for NEW
@@ -312,28 +319,33 @@ describe('LangChain integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'chain format_prompt',
+              'chain parse_output',
+              'chain unknown_chain',
+              'chat claude-3-5-sonnet-20241022',
+            ]);
 
-            // [0] format_prompt chain (invoke_agent)
-            expect(firstSpan!.name).toBe('chain format_prompt');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-            expect(firstSpan!.attributes['langchain.chain.name'].value).toBe('format_prompt');
+            const formatPromptSpan = container.items.find(span => span.name === 'chain format_prompt');
+            expect(formatPromptSpan).toBeDefined();
+            expect(formatPromptSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(formatPromptSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+            expect(formatPromptSpan!.attributes['langchain.chain.name'].value).toBe('format_prompt');
 
-            // [1] chat model invoked inside the chain
-            expect(secondSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+            const chatSpan = container.items.find(span => span.name === 'chat claude-3-5-sonnet-20241022');
+            expect(chatSpan).toBeDefined();
+            expect(chatSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+            expect(chatSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
 
-            // [2] parse_output chain (invoke_agent)
-            expect(thirdSpan!.name).toBe('chain parse_output');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(thirdSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-            expect(thirdSpan!.attributes['langchain.chain.name'].value).toBe('parse_output');
+            const parseOutputSpan = container.items.find(span => span.name === 'chain parse_output');
+            expect(parseOutputSpan).toBeDefined();
+            expect(parseOutputSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(parseOutputSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+            expect(parseOutputSpan!.attributes['langchain.chain.name'].value).toBe('parse_output');
 
-            // [3] unknown_chain (fallback name)
-            expect(fourthSpan!.name).toBe('chain unknown_chain');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            const unknownChainSpan = container.items.find(span => span.name === 'chain unknown_chain');
+            expect(unknownChainSpan).toBeDefined();
+            expect(unknownChainSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
           },
         })
         .start()
@@ -353,28 +365,30 @@ describe('LangChain integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'embeddings error-model',
+              'embeddings text-embedding-3-small',
+              'embeddings text-embedding-3-small',
+            ]);
 
-            // [0] embedQuery span
-            expect(firstSpan!.name).toBe('embeddings text-embedding-3-small');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('text-embedding-3-small');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE].value).toBe(1536);
+            const successfulSpans = container.items.filter(
+              span => span.name === 'embeddings text-embedding-3-small' && span.status === 'ok',
+            );
+            expect(successfulSpans).toHaveLength(2);
+            for (const span of successfulSpans) {
+              expect(span.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
+              expect(span.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              expect(span.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('embeddings');
+              expect(span.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
+              expect(span.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('text-embedding-3-small');
+              expect(span.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE].value).toBe(1536);
+            }
 
-            // [1] embedDocuments span
-            expect(secondSpan!.name).toBe('embeddings text-embedding-3-small');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
-
-            // [2] Error span
-            expect(thirdSpan!.name).toBe('embeddings error-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
+            const errorSpan = container.items.find(span => span.name === 'embeddings error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
+            expect(errorSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
+            expect(errorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
           },
         })
         .start()
@@ -389,16 +403,9 @@ describe('LangChain integration', () => {
           span: container => {
             // The scenario makes 3 embedding calls (2 successful + 1 error).
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-            // [0] embedQuery
-            expect(firstSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
-
-            // [1] embedDocuments
-            expect(secondSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
-
-            // [2] error embedding call
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
+            for (const span of container.items) {
+              expect(span.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
+            }
           },
         })
         .start()
@@ -414,24 +421,32 @@ describe('LangChain integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'embeddings error-model',
+              'embeddings text-embedding-3-small',
+              'embeddings text-embedding-3-small',
+            ]);
 
-            // [0] embedQuery span with input recorded
-            expect(firstSpan!.name).toBe('embeddings text-embedding-3-small');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe('Hello world');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE].value).toBe(1536);
-
-            // [1] embedDocuments span with input recorded
-            expect(secondSpan!.name).toBe('embeddings text-embedding-3-small');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe(
-              JSON.stringify(['First document', 'Second document']),
+            const querySpan = container.items.find(
+              span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === 'Hello world',
             );
+            expect(querySpan).toBeDefined();
+            expect(querySpan!.name).toBe('embeddings text-embedding-3-small');
+            expect(querySpan!.status).toBe('ok');
+            expect(querySpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE].value).toBe(1536);
 
-            // [2] error embedding span (input still recorded with PII)
-            expect(thirdSpan!.name).toBe('embeddings error-model');
-            expect(thirdSpan!.status).toBe('error');
+            const documentsSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value ===
+                JSON.stringify(['First document', 'Second document']),
+            );
+            expect(documentsSpan).toBeDefined();
+            expect(documentsSpan!.name).toBe('embeddings text-embedding-3-small');
+            expect(documentsSpan!.status).toBe('ok');
+
+            const errorSpan = container.items.find(span => span.name === 'embeddings error-model');
+            expect(errorSpan).toBeDefined();
+            expect(errorSpan!.status).toBe('error');
           },
         })
         .start()

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/test.ts
@@ -40,46 +40,50 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
+              expect(container.items.map(span => span.name).sort()).toEqual([
+                'chat claude-3-5-sonnet-20241022',
+                'chat claude-3-opus-20240229',
+                'chat error-model',
+              ]);
 
-              // [0] chat model with claude-3-5-sonnet
-              expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-5-sonnet-20241022');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toBeDefined();
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE]).toBeDefined();
+              const sonnetSpan = container.items.find(span => span.name === 'chat claude-3-5-sonnet-20241022');
+              expect(sonnetSpan).toBeDefined();
+              expect(sonnetSpan!.status).toBe('ok');
+              expect(sonnetSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(sonnetSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              expect(sonnetSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+              expect(sonnetSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+              expect(sonnetSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-5-sonnet-20241022');
+              expect(sonnetSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+              expect(sonnetSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+              expect(sonnetSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(sonnetSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+              expect(sonnetSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+              expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
+              expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toBeDefined();
+              expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE]).toBeDefined();
 
-              // [1] chat model with claude-3-opus
-              expect(secondSpan!.name).toBe('chat claude-3-opus-20240229');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-opus-20240229');
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.9);
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.95);
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(200);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+              const opusSpan = container.items.find(span => span.name === 'chat claude-3-opus-20240229');
+              expect(opusSpan).toBeDefined();
+              expect(opusSpan!.status).toBe('ok');
+              expect(opusSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(opusSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              expect(opusSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+              expect(opusSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-opus-20240229');
+              expect(opusSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.9);
+              expect(opusSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.95);
+              expect(opusSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(200);
+              expect(opusSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(opusSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+              expect(opusSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
 
-              // [2] error handling
-              expect(thirdSpan!.name).toBe('chat error-model');
-              expect(thirdSpan!.status).toBe('error');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(thirdSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
+              const errorSpan = container.items.find(span => span.name === 'chat error-model');
+              expect(errorSpan).toBeDefined();
+              expect(errorSpan!.status).toBe('error');
+              expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(errorSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              expect(errorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+              expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
             },
           })
           .start()
@@ -107,46 +111,50 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
+              expect(container.items.map(span => span.name).sort()).toEqual([
+                'chat claude-3-5-sonnet-20241022',
+                'chat claude-3-opus-20240229',
+                'chat error-model',
+              ]);
 
-              // [0] chat model with PII
-              expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-5-sonnet-20241022');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toBeDefined();
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE]).toBeDefined();
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+              const sonnetSpan = container.items.find(span => span.name === 'chat claude-3-5-sonnet-20241022');
+              expect(sonnetSpan).toBeDefined();
+              expect(sonnetSpan!.status).toBe('ok');
+              expect(sonnetSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(sonnetSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              expect(sonnetSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+              expect(sonnetSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-5-sonnet-20241022');
+              expect(sonnetSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+              expect(sonnetSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+              expect(sonnetSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+              expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+              expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
+              expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toBeDefined();
+              expect(sonnetSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE]).toBeDefined();
+              expect(sonnetSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(sonnetSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+              expect(sonnetSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
 
-              // [1] chat model with PII
-              expect(secondSpan!.name).toBe('chat claude-3-opus-20240229');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-opus-20240229');
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.9);
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.95);
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(200);
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
-              expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
+              const opusSpan = container.items.find(span => span.name === 'chat claude-3-opus-20240229');
+              expect(opusSpan).toBeDefined();
+              expect(opusSpan!.status).toBe('ok');
+              expect(opusSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+              expect(opusSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('claude-3-opus-20240229');
+              expect(opusSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.9);
+              expect(opusSpan!.attributes[GEN_AI_REQUEST_TOP_P_ATTRIBUTE].value).toBe(0.95);
+              expect(opusSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(200);
+              expect(opusSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+              expect(opusSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toBeDefined();
+              expect(opusSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(opusSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+              expect(opusSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(25);
 
-              // [2] error handling with PII
-              expect(thirdSpan!.name).toBe('chat error-model');
-              expect(thirdSpan!.status).toBe('error');
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+              const errorSpan = container.items.find(span => span.name === 'chat error-model');
+              expect(errorSpan).toBeDefined();
+              expect(errorSpan!.status).toBe('error');
+              expect(errorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('anthropic');
+              expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
+              expect(errorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
             },
           })
           .start()
@@ -217,32 +225,37 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-              // [0] String input truncated (only C's remain, D's are cropped)
-              expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(1);
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
+              const stringInputSpan = container.items.find(
+                span => span.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]?.value === 1,
+              );
+              expect(stringInputSpan).toBeDefined();
+              expect(stringInputSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
+              expect(stringInputSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
                 /^\[\{"role":"user","content":"C+"\}\]$/,
               );
 
-              // [1] Array input, last message truncated (only C's remain, D's are cropped)
-              expect(secondSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(2);
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
-                /^\[\{"role":"user","content":"C+"\}\]$/,
+              const arrayInputSpan = container.items.find(
+                span =>
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]?.value === 2 &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.match(
+                    /^\[\{"role":"user","content":"C+"\}\]$/,
+                  ),
               );
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toMatch(
+              expect(arrayInputSpan).toBeDefined();
+              expect(arrayInputSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
+              expect(arrayInputSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toMatch(
                 /^\[\{"type":"text","content":"A+"\}\]$/,
               );
 
-              // [2] Last message is small and kept without truncation
-              expect(thirdSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(2);
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
-                JSON.stringify([{ role: 'user', content: 'This is a small message that fits within the limit' }]),
+              const smallMessageSpan = container.items.find(
+                span =>
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                  JSON.stringify([{ role: 'user', content: 'This is a small message that fits within the limit' }]),
               );
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toMatch(
+              expect(smallMessageSpan).toBeDefined();
+              expect(smallMessageSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
+              expect(smallMessageSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(2);
+              expect(smallMessageSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toMatch(
                 /^\[\{"type":"text","content":"A+"\}\]$/,
               );
             },
@@ -272,16 +285,17 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
+              const anthropicSpan = container.items.find(
+                span => span.attributes['sentry.origin'].value === 'auto.ai.anthropic',
+              );
+              expect(anthropicSpan).toBeDefined();
+              expect(anthropicSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
 
-              // [0] Direct Anthropic call made BEFORE LangChain import — instrumented
-              //     by Anthropic (origin: 'auto.ai.anthropic').
-              expect(firstSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.anthropic');
-
-              // [1] LangChain call — instrumented by LangChain (origin: 'auto.ai.langchain').
-              expect(secondSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
-              expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              const langchainSpan = container.items.find(
+                span => span.attributes['sentry.origin'].value === 'auto.ai.langchain',
+              );
+              expect(langchainSpan).toBeDefined();
+              expect(langchainSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
 
               // Third call (not present): Direct Anthropic call made AFTER LangChain import
               // is NOT instrumented, demonstrating the skip mechanism works for NEW clients.
@@ -313,46 +327,50 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
+              expect(container.items.map(span => span.name).sort()).toEqual([
+                'chat error-model',
+                'chat gpt-3.5-turbo',
+                'chat gpt-4o',
+              ]);
 
-              // [0] initChatModel with gpt-4o
-              expect(firstSpan!.name).toBe('chat gpt-4o');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gpt-4o');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gpt-4o');
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE].value).toBe('stop');
+              const gpt4oSpan = container.items.find(span => span.name === 'chat gpt-4o');
+              expect(gpt4oSpan).toBeDefined();
+              expect(gpt4oSpan!.status).toBe('ok');
+              expect(gpt4oSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(gpt4oSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              expect(gpt4oSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('chat');
+              expect(gpt4oSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
+              expect(gpt4oSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gpt-4o');
+              expect(gpt4oSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.7);
+              expect(gpt4oSpan!.attributes[GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE].value).toBe(100);
+              expect(gpt4oSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
+              expect(gpt4oSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
+              expect(gpt4oSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
+              expect(gpt4oSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toBeDefined();
+              expect(gpt4oSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gpt-4o');
+              expect(gpt4oSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE].value).toBe('stop');
 
-              // [1] initChatModel with gpt-3.5-turbo
-              expect(secondSpan!.name).toBe('chat gpt-3.5-turbo');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gpt-3.5-turbo');
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.5);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gpt-3.5-turbo');
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE].value).toBe('stop');
+              const gpt35Span = container.items.find(span => span.name === 'chat gpt-3.5-turbo');
+              expect(gpt35Span).toBeDefined();
+              expect(gpt35Span!.status).toBe('ok');
+              expect(gpt35Span!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(gpt35Span!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              expect(gpt35Span!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
+              expect(gpt35Span!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('gpt-3.5-turbo');
+              expect(gpt35Span!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE].value).toBe(0.5);
+              expect(gpt35Span!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(8);
+              expect(gpt35Span!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(12);
+              expect(gpt35Span!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(20);
+              expect(gpt35Span!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gpt-3.5-turbo');
+              expect(gpt35Span!.attributes[GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE].value).toBe('stop');
 
-              // [2] error handling
-              expect(thirdSpan!.name).toBe('chat error-model');
-              expect(thirdSpan!.status).toBe('error');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-              expect(thirdSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
+              const errorSpan = container.items.find(span => span.name === 'chat error-model');
+              expect(errorSpan).toBeDefined();
+              expect(errorSpan!.status).toBe('error');
+              expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(errorSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
+              expect(errorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('openai');
+              expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('error-model');
             },
           })
           .start()

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
@@ -32,33 +32,30 @@ describe('LangGraph integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'create_agent weather_assistant',
+              'invoke_agent weather_assistant',
+              'invoke_agent weather_assistant',
+            ]);
 
-            // [0] create_agent
-            expect(firstSpan!.name).toBe('create_agent weather_assistant');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('create_agent');
-            expect(firstSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('weather_assistant');
+            const createAgentSpan = container.items.find(span => span.name === 'create_agent weather_assistant');
+            expect(createAgentSpan).toBeDefined();
+            expect(createAgentSpan!.status).toBe('ok');
+            expect(createAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
+            expect(createAgentSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
+            expect(createAgentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('create_agent');
+            expect(createAgentSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('weather_assistant');
 
-            // [1] first invoke_agent
-            expect(secondSpan!.name).toBe('invoke_agent weather_assistant');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('invoke_agent');
-            expect(secondSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('weather_assistant');
-            expect(secondSpan!.attributes[GEN_AI_PIPELINE_NAME_ATTRIBUTE].value).toBe('weather_assistant');
-
-            // [2] second invoke_agent
-            expect(thirdSpan!.name).toBe('invoke_agent weather_assistant');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(thirdSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('invoke_agent');
-            expect(thirdSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('weather_assistant');
-            expect(thirdSpan!.attributes[GEN_AI_PIPELINE_NAME_ATTRIBUTE].value).toBe('weather_assistant');
+            const invokeAgentSpans = container.items.filter(span => span.name === 'invoke_agent weather_assistant');
+            expect(invokeAgentSpans).toHaveLength(2);
+            for (const span of invokeAgentSpans) {
+              expect(span.status).toBe('ok');
+              expect(span.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(span.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
+              expect(span.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('invoke_agent');
+              expect(span.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('weather_assistant');
+              expect(span.attributes[GEN_AI_PIPELINE_NAME_ATTRIBUTE].value).toBe('weather_assistant');
+            }
           },
         })
         .start()
@@ -74,27 +71,27 @@ describe('LangGraph integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            const createAgentSpan = container.items.find(span => span.name === 'create_agent weather_assistant');
+            expect(createAgentSpan).toBeDefined();
+            expect(createAgentSpan!.status).toBe('ok');
+            expect(createAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
 
-            // [0] create_agent
-            expect(firstSpan!.name).toBe('create_agent weather_assistant');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
-
-            // [1] first invoke_agent with PII ("What is the weather today?")
-            expect(secondSpan!.name).toBe('invoke_agent weather_assistant');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain(
-              'What is the weather today?',
+            const weatherTodaySpan = container.items.find(span =>
+              span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes('What is the weather today?'),
             );
+            expect(weatherTodaySpan).toBeDefined();
+            expect(weatherTodaySpan!.name).toBe('invoke_agent weather_assistant');
+            expect(weatherTodaySpan!.status).toBe('ok');
+            expect(weatherTodaySpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(weatherTodaySpan!.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
 
-            // [2] second invoke_agent with PII ("Tell me about the weather")
-            expect(thirdSpan!.name).toBe('invoke_agent weather_assistant');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain('Tell me about the weather');
+            const weatherDetailsSpan = container.items.find(span =>
+              span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Tell me about the weather'),
+            );
+            expect(weatherDetailsSpan).toBeDefined();
+            expect(weatherDetailsSpan!.name).toBe('invoke_agent weather_assistant');
+            expect(weatherDetailsSpan!.status).toBe('ok');
+            expect(weatherDetailsSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
           },
         })
         .start()
@@ -110,45 +107,56 @@ describe('LangGraph integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
+            expect(container.items.map(span => span.name).sort()).toEqual([
+              'create_agent tool_agent',
+              'create_agent tool_calling_agent',
+              'invoke_agent tool_agent',
+              'invoke_agent tool_calling_agent',
+            ]);
 
-            // [0] create_agent tool_agent
-            expect(firstSpan!.name).toBe('create_agent tool_agent');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
-            expect(firstSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('tool_agent');
+            const toolAgentSpan = container.items.find(span => span.name === 'create_agent tool_agent');
+            expect(toolAgentSpan).toBeDefined();
+            expect(toolAgentSpan!.status).toBe('ok');
+            expect(toolAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
+            expect(toolAgentSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('tool_agent');
 
-            // [1] invoke_agent tool_agent (tools available, not called)
-            expect(secondSpan!.name).toBe('invoke_agent tool_agent');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toContain('get_weather');
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain('What is the weather?');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gpt-4-0613');
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toContain(
+            const toolAgentInvokeSpan = container.items.find(span => span.name === 'invoke_agent tool_agent');
+            expect(toolAgentInvokeSpan).toBeDefined();
+            expect(toolAgentInvokeSpan!.status).toBe('ok');
+            expect(toolAgentInvokeSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(toolAgentInvokeSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toContain(
+              'get_weather',
+            );
+            expect(toolAgentInvokeSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain(
+              'What is the weather?',
+            );
+            expect(toolAgentInvokeSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gpt-4-0613');
+            expect(toolAgentInvokeSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toContain(
               'Response without calling tools',
             );
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(25);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(40);
+            expect(toolAgentInvokeSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(25);
+            expect(toolAgentInvokeSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(toolAgentInvokeSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(40);
 
-            // [2] create_agent tool_calling_agent
-            expect(thirdSpan!.name).toBe('create_agent tool_calling_agent');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
-            expect(thirdSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('tool_calling_agent');
+            const toolCallingAgentSpan = container.items.find(span => span.name === 'create_agent tool_calling_agent');
+            expect(toolCallingAgentSpan).toBeDefined();
+            expect(toolCallingAgentSpan!.status).toBe('ok');
+            expect(toolCallingAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
+            expect(toolCallingAgentSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('tool_calling_agent');
 
-            // [3] invoke_agent tool_calling_agent (with tool calls)
-            expect(fourthSpan!.name).toBe('invoke_agent tool_calling_agent');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain('San Francisco');
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gpt-4-0613');
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toMatch(/"role":"tool"/);
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE].value).toContain('get_weather');
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(80);
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(40);
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(120);
+            const toolCallingInvokeSpan = container.items.find(span => span.name === 'invoke_agent tool_calling_agent');
+            expect(toolCallingInvokeSpan).toBeDefined();
+            expect(toolCallingInvokeSpan!.status).toBe('ok');
+            expect(toolCallingInvokeSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(toolCallingInvokeSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain('San Francisco');
+            expect(toolCallingInvokeSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('gpt-4-0613');
+            expect(toolCallingInvokeSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE].value).toMatch(/"role":"tool"/);
+            expect(toolCallingInvokeSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE].value).toContain(
+              'get_weather',
+            );
+            expect(toolCallingInvokeSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(80);
+            expect(toolCallingInvokeSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(40);
+            expect(toolCallingInvokeSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(120);
           },
         })
         .start()
@@ -165,28 +173,33 @@ describe('LangGraph integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
+            const createAgentSpan = container.items.find(span => span.name === 'create_agent thread_test_agent');
+            expect(createAgentSpan).toBeDefined();
+            expect(createAgentSpan!.status).toBe('ok');
+            expect(createAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
 
-            // [0] create_agent
-            expect(firstSpan!.name).toBe('create_agent thread_test_agent');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
+            const firstThreadSpan = container.items.find(
+              span => span.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]?.value === 'thread_abc123_session_1',
+            );
+            expect(firstThreadSpan).toBeDefined();
+            expect(firstThreadSpan!.name).toBe('invoke_agent thread_test_agent');
+            expect(firstThreadSpan!.status).toBe('ok');
+            expect(firstThreadSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
 
-            // [1] first invoke_agent with thread_abc123_session_1
-            expect(secondSpan!.name).toBe('invoke_agent thread_test_agent');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(secondSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE].value).toBe('thread_abc123_session_1');
+            const secondThreadSpan = container.items.find(
+              span => span.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]?.value === 'thread_xyz789_session_2',
+            );
+            expect(secondThreadSpan).toBeDefined();
+            expect(secondThreadSpan!.name).toBe('invoke_agent thread_test_agent');
+            expect(secondThreadSpan!.status).toBe('ok');
 
-            // [2] second invoke_agent with thread_xyz789_session_2
-            expect(thirdSpan!.name).toBe('invoke_agent thread_test_agent');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE].value).toBe('thread_xyz789_session_2');
-
-            // [3] third invoke_agent without thread_id
-            expect(fourthSpan!.name).toBe('invoke_agent thread_test_agent');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBeUndefined();
+            const noThreadSpan = container.items.find(
+              span =>
+                span.name === 'invoke_agent thread_test_agent' &&
+                span.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE] === undefined,
+            );
+            expect(noThreadSpan).toBeDefined();
+            expect(noThreadSpan!.status).toBe('ok');
           },
         })
         .start()
@@ -206,11 +219,10 @@ describe('LangGraph integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [, secondSpan] = container.items;
+              const invokeAgentSpan = container.items.find(span => span.name === 'invoke_agent test-agent');
 
-              // [1] invoke_agent with system instructions
-              expect(secondSpan!.name).toBe('invoke_agent test-agent');
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toBe(
+              expect(invokeAgentSpan).toBeDefined();
+              expect(invokeAgentSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toBe(
                 JSON.stringify([{ type: 'text', content: 'You are a helpful assistant' }]),
               );
             },
@@ -239,22 +251,22 @@ describe('LangGraph integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan] = container.items;
+            const createAgentSpan = container.items.find(span => span.name === 'create_agent resume_agent');
+            expect(createAgentSpan).toBeDefined();
+            expect(createAgentSpan!.status).toBe('ok');
+            expect(createAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
+            expect(createAgentSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('resume_agent');
 
-            // [0] create_agent resume_agent
-            expect(firstSpan!.name).toBe('create_agent resume_agent');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.create_agent');
-            expect(firstSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('resume_agent');
-
-            // [1] first invoke_agent with thread_id 'resume-thread-1'
-            expect(secondSpan!.name).toBe('invoke_agent resume_agent');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
-            expect(secondSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('resume_agent');
-            expect(secondSpan!.attributes[GEN_AI_PIPELINE_NAME_ATTRIBUTE].value).toBe('resume_agent');
-            expect(secondSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE].value).toBe('resume-thread-1');
+            const invokeAgentSpan = container.items.find(
+              span => span.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]?.value === 'resume-thread-1',
+            );
+            expect(invokeAgentSpan).toBeDefined();
+            expect(invokeAgentSpan!.name).toBe('invoke_agent resume_agent');
+            expect(invokeAgentSpan!.status).toBe('ok');
+            expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(invokeAgentSpan!.attributes['sentry.origin'].value).toBe('auto.ai.langgraph');
+            expect(invokeAgentSpan!.attributes[GEN_AI_AGENT_NAME_ATTRIBUTE].value).toBe('resume_agent');
+            expect(invokeAgentSpan!.attributes[GEN_AI_PIPELINE_NAME_ATTRIBUTE].value).toBe('resume_agent');
           },
         })
         .start()
@@ -282,12 +294,13 @@ describe('LangGraph integration', () => {
               ]);
 
               expect(container.items).toHaveLength(2);
-              const [, secondSpan] = container.items;
+              const invokeAgentSpan = container.items.find(
+                span => span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value === expectedMessages,
+              );
 
-              // [1] invoke_agent with untruncated input
-              expect(secondSpan!.name).toBe('invoke_agent weather_assistant');
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(expectedMessages);
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
+              expect(invokeAgentSpan).toBeDefined();
+              expect(invokeAgentSpan!.name).toBe('invoke_agent weather_assistant');
+              expect(invokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
             },
           })
           .start()

--- a/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/test.ts
@@ -84,148 +84,239 @@ describe('OpenAI Tool Calls integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
-
-            // [0] chat completion with tools (non-streaming)
-            expect(firstSpan!.name).toBe('chat gpt-4');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const chatToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-tools-123',
+            );
+            expect(chatToolsSpan).toBeDefined();
+            expect(chatToolsSpan!.name).toBe('chat gpt-4');
+            expect(chatToolsSpan!.status).toBe('ok');
+            expect(chatToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(chatToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(chatToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
+            expect(chatToolsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(chatToolsSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: WEATHER_TOOL_DEFINITION,
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(chatToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'chatcmpl-tools-123',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["tool_calls"]',
             });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 15 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 25 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 40 });
-
-            // [1] chat completion with tools and streaming
-            expect(secondSpan!.name).toBe('chat gpt-4');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-              type: 'string',
-              value: 'gen_ai.chat',
+            expect(chatToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 15,
             });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-              type: 'string',
-              value: 'auto.ai.openai',
-            });
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: WEATHER_TOOL_DEFINITION,
-            });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: 'chatcmpl-stream-tools-123',
-            });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: '["tool_calls"]',
-            });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
-              type: 'boolean',
-              value: true,
-            });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 15 });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 25,
             });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 40 });
+            expect(chatToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 40,
+            });
 
-            // [2] responses API with tools (non-streaming)
-            expect(thirdSpan!.name).toBe('chat gpt-4');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const streamingChatToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-stream-tools-123',
+            );
+            expect(streamingChatToolsSpan).toBeDefined();
+            expect(streamingChatToolsSpan!.name).toBe('chat gpt-4');
+            expect(streamingChatToolsSpan!.status).toBe('ok');
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingChatToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
               type: 'string',
-              value: WEATHER_TOOL_DEFINITION,
+              value: 'openai',
             });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
-              value: 'resp_tools_789',
+              value: 'gpt-4',
             });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: '["completed"]',
-            });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 12 });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 20 });
-
-            // [3] responses API with tools and streaming
-            expect(fourthSpan!.name).toBe('chat gpt-4');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-              type: 'string',
-              value: 'gen_ai.chat',
-            });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-              type: 'string',
-              value: 'auto.ai.openai',
-            });
-            expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: WEATHER_TOOL_DEFINITION,
-            });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: 'resp_stream_tools_789',
-            });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: '["in_progress","completed"]',
-            });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
               type: 'boolean',
               value: true,
             });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: WEATHER_TOOL_DEFINITION,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chatcmpl-stream-tools-123',
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '["tool_calls"]',
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 15,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 25,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 40,
+            });
+
+            const responsesToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_tools_789',
+            );
+            expect(responsesToolsSpan).toBeDefined();
+            expect(responsesToolsSpan!.name).toBe('chat gpt-4');
+            expect(responsesToolsSpan!.status).toBe('ok');
+            expect(responsesToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(responsesToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              type: 'string',
+              value: 'gen_ai.chat',
+            });
+            expect(responsesToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              type: 'string',
+              value: 'auto.ai.openai',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+            expect(responsesToolsSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: WEATHER_TOOL_DEFINITION,
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'resp_tools_789',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '["completed"]',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 8,
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 12,
             });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 20 });
+            expect(responsesToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 20,
+            });
+
+            const streamingResponsesToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_stream_tools_789',
+            );
+            expect(streamingResponsesToolsSpan).toBeDefined();
+            expect(streamingResponsesToolsSpan!.name).toBe('chat gpt-4');
+            expect(streamingResponsesToolsSpan!.status).toBe('ok');
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              type: 'string',
+              value: 'gen_ai.chat',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              type: 'string',
+              value: 'auto.ai.openai',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: WEATHER_TOOL_DEFINITION,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'resp_stream_tools_789',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '["in_progress","completed"]',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 8,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 12,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 20,
+            });
           },
         })
         .start()
@@ -241,197 +332,291 @@ describe('OpenAI Tool Calls integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
-
-            // [0] chat completion with tools (non-streaming) with PII
-            expect(firstSpan!.name).toBe('chat gpt-4');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const chatToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-tools-123',
+            );
+            expect(chatToolsSpan).toBeDefined();
+            expect(chatToolsSpan!.name).toBe('chat gpt-4');
+            expect(chatToolsSpan!.status).toBe('ok');
+            expect(chatToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(chatToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(chatToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
+            expect(chatToolsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(chatToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1,
             });
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '[{"role":"user","content":"What is the weather like in Paris today?"}]',
             });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: WEATHER_TOOL_DEFINITION,
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(chatToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'chatcmpl-tools-123',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["tool_calls"]',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({ type: 'string', value: '[""]' });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '[""]',
+            });
+            expect(chatToolsSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: CHAT_TOOL_CALLS,
             });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 15 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 25 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 40 });
-
-            // [1] chat completion with tools and streaming with PII
-            expect(secondSpan!.name).toBe('chat gpt-4');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-              type: 'string',
-              value: 'gen_ai.chat',
-            });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-              type: 'string',
-              value: 'auto.ai.openai',
-            });
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
               type: 'integer',
-              value: 1,
+              value: 15,
             });
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: '[{"role":"user","content":"What is the weather like in Paris today?"}]',
-            });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: WEATHER_TOOL_DEFINITION,
-            });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: 'chatcmpl-stream-tools-123',
-            });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: '["tool_calls"]',
-            });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
-              type: 'boolean',
-              value: true,
-            });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: CHAT_STREAM_TOOL_CALLS,
-            });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 15 });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+            expect(chatToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 25,
             });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 40 });
+            expect(chatToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 40,
+            });
 
-            // [2] responses API with tools (non-streaming) with PII
-            expect(thirdSpan!.name).toBe('chat gpt-4');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const streamingChatToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-stream-tools-123',
+            );
+            expect(streamingChatToolsSpan).toBeDefined();
+            expect(streamingChatToolsSpan!.name).toBe('chat gpt-4');
+            expect(streamingChatToolsSpan!.status).toBe('ok');
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingChatToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
-              type: 'integer',
-              value: 1,
-            });
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
               type: 'string',
-              value: '[{"role":"user","content":"What is the weather like in Paris today?"}]',
+              value: 'openai',
             });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
-              value: WEATHER_TOOL_DEFINITION,
+              value: 'gpt-4',
             });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: 'resp_tools_789',
-            });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: '["completed"]',
-            });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: RESPONSES_TOOL_CALLS,
-            });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 12 });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 20 });
-
-            // [3] responses API with tools and streaming with PII
-            expect(fourthSpan!.name).toBe('chat gpt-4');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-              type: 'string',
-              value: 'gen_ai.chat',
-            });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-              type: 'string',
-              value: 'auto.ai.openai',
-            });
-            expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
-              type: 'integer',
-              value: 1,
-            });
-            expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: '[{"role":"user","content":"What is the weather like in Paris today?"}]',
-            });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: WEATHER_TOOL_DEFINITION,
-            });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: 'resp_stream_tools_789',
-            });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-              type: 'string',
-              value: '["in_progress","completed"]',
-            });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
               type: 'boolean',
               value: true,
             });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toEqual({
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 1,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '[{"role":"user","content":"What is the weather like in Paris today?"}]',
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: WEATHER_TOOL_DEFINITION,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chatcmpl-stream-tools-123',
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '["tool_calls"]',
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: CHAT_STREAM_TOOL_CALLS,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 15,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 25,
+            });
+            expect(streamingChatToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 40,
+            });
+
+            const responsesToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_tools_789',
+            );
+            expect(responsesToolsSpan).toBeDefined();
+            expect(responsesToolsSpan!.name).toBe('chat gpt-4');
+            expect(responsesToolsSpan!.status).toBe('ok');
+            expect(responsesToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(responsesToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              type: 'string',
+              value: 'gen_ai.chat',
+            });
+            expect(responsesToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              type: 'string',
+              value: 'auto.ai.openai',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+            expect(responsesToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 1,
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '[{"role":"user","content":"What is the weather like in Paris today?"}]',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: WEATHER_TOOL_DEFINITION,
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'resp_tools_789',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '["completed"]',
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: RESPONSES_TOOL_CALLS,
             });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+            expect(responsesToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 8,
+            });
+            expect(responsesToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 12,
             });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 20 });
+            expect(responsesToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 20,
+            });
+
+            const streamingResponsesToolsSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_stream_tools_789',
+            );
+            expect(streamingResponsesToolsSpan).toBeDefined();
+            expect(streamingResponsesToolsSpan!.name).toBe('chat gpt-4');
+            expect(streamingResponsesToolsSpan!.status).toBe('ok');
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              type: 'string',
+              value: 'gen_ai.chat',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              type: 'string',
+              value: 'auto.ai.openai',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 1,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '[{"role":"user","content":"What is the weather like in Paris today?"}]',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: WEATHER_TOOL_DEFINITION,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'resp_stream_tools_789',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: '["in_progress","completed"]',
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: RESPONSES_TOOL_CALLS,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 8,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 12,
+            });
+            expect(streamingResponsesToolsSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 20,
+            });
           },
         })
         .start()

--- a/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
@@ -37,180 +37,288 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(6);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan] = container.items;
-
-            // [0] basic chat completion without PII
-            expect(firstSpan!.name).toBe('chat gpt-3.5-turbo');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const chatCompletionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-mock123',
+            );
+            expect(chatCompletionSpan).toBeDefined();
+            expect(chatCompletionSpan!.name).toBe('chat gpt-3.5-turbo');
+            expect(chatCompletionSpan!.status).toBe('ok');
+            expect(chatCompletionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(chatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(chatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'gpt-3.5-turbo',
             });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({ type: 'double', value: 0.7 });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+              type: 'double',
+              value: 0.7,
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'gpt-3.5-turbo',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'chatcmpl-mock123',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["stop"]',
             });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 15 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 25 });
+            expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 15,
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 25,
+            });
 
-            // [1] responses API
-            expect(secondSpan!.name).toBe('chat gpt-3.5-turbo');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const responsesSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_mock456',
+            );
+            expect(responsesSpan).toBeDefined();
+            expect(responsesSpan!.name).toBe('chat gpt-3.5-turbo');
+            expect(responsesSpan!.status).toBe('ok');
+            expect(responsesSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(responsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(responsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
+            expect(responsesSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'gpt-3.5-turbo',
             });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'gpt-3.5-turbo',
             });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'resp_mock456',
             });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["completed"]',
             });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 5 });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 13 });
+            expect(responsesSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 5,
+            });
+            expect(responsesSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 8,
+            });
+            expect(responsesSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 13,
+            });
 
-            // [2] error handling (non-streaming)
-            expect(thirdSpan!.name).toBe('chat error-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const nonStreamingErrorSpan = container.items.find(
+              span =>
+                span.name === 'chat error-model' && span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE] === undefined,
+            );
+            expect(nonStreamingErrorSpan).toBeDefined();
+            expect(nonStreamingErrorSpan!.name).toBe('chat error-model');
+            expect(nonStreamingErrorSpan!.status).toBe('error');
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(nonStreamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(nonStreamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'error-model',
             });
 
-            // [3] chat completions streaming
-            expect(fourthSpan!.name).toBe('chat gpt-4');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const streamingChatCompletionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-stream-123',
+            );
+            expect(streamingChatCompletionSpan).toBeDefined();
+            expect(streamingChatCompletionSpan!.name).toBe('chat gpt-4');
+            expect(streamingChatCompletionSpan!.status).toBe('ok');
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingChatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
               type: 'double',
               value: 0.8,
             });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'chatcmpl-stream-123',
             });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["stop"]',
             });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 12 });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 12,
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 18,
             });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 30 });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 30,
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
               type: 'boolean',
               value: true,
             });
 
-            // [4] responses API streaming
-            expect(fifthSpan!.name).toBe('chat gpt-4');
-            expect(fifthSpan!.status).toBe('ok');
-            expect(fifthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(fifthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const streamingResponsesSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_stream_456',
+            );
+            expect(streamingResponsesSpan).toBeDefined();
+            expect(streamingResponsesSpan!.name).toBe('chat gpt-4');
+            expect(streamingResponsesSpan!.status).toBe('ok');
+            expect(streamingResponsesSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingResponsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(fifthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(streamingResponsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(fifthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(fifthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fifthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'resp_stream_456',
             });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["in_progress","completed"]',
             });
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 6 });
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 16 });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 6,
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 16,
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
               type: 'boolean',
               value: true,
             });
 
-            // [5] error handling in streaming context
-            expect(sixthSpan!.name).toBe('chat error-model');
-            expect(sixthSpan!.status).toBe('error');
-            expect(sixthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(sixthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            const streamingErrorSpan = container.items.find(
+              span =>
+                span.name === 'chat error-model' && span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]?.value === true,
+            );
+            expect(streamingErrorSpan).toBeDefined();
+            expect(streamingErrorSpan!.name).toBe('chat error-model');
+            expect(streamingErrorSpan!.status).toBe('error');
+            expect(streamingErrorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'error-model',
             });
-            expect(sixthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(sixthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(sixthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            expect(streamingErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingErrorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(streamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(sixthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(streamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
@@ -229,252 +337,360 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(6);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan] = container.items;
-
-            // [0] basic chat completion with PII
-            expect(firstSpan!.name).toBe('chat gpt-3.5-turbo');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const chatCompletionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-mock123',
+            );
+            expect(chatCompletionSpan).toBeDefined();
+            expect(chatCompletionSpan!.name).toBe('chat gpt-3.5-turbo');
+            expect(chatCompletionSpan!.status).toBe('ok');
+            expect(chatCompletionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(chatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(chatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'gpt-3.5-turbo',
             });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({ type: 'double', value: 0.7 });
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+              type: 'double',
+              value: 0.7,
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1,
             });
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '[{"role":"user","content":"What is the capital of France?"}]',
             });
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: JSON.stringify([{ type: 'text', content: 'You are a helpful assistant.' }]),
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'gpt-3.5-turbo',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'chatcmpl-mock123',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["stop"]',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+            expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["Hello from OpenAI mock!"]',
             });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 15 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 25 });
+            expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 15,
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 25,
+            });
 
-            // [1] responses API with PII
-            expect(secondSpan!.name).toBe('chat gpt-3.5-turbo');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const responsesSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_mock456',
+            );
+            expect(responsesSpan).toBeDefined();
+            expect(responsesSpan!.name).toBe('chat gpt-3.5-turbo');
+            expect(responsesSpan!.status).toBe('ok');
+            expect(responsesSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(responsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(responsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
+            expect(responsesSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'gpt-3.5-turbo',
             });
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1,
             });
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'Translate this to French: Hello',
             });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'Response to: Translate this to French: Hello',
             });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["completed"]',
             });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'gpt-3.5-turbo',
             });
-            expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(responsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'resp_mock456',
             });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 5 });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 8 });
-            expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 13 });
+            expect(responsesSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 5,
+            });
+            expect(responsesSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 8,
+            });
+            expect(responsesSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 13,
+            });
 
-            // [2] error handling with PII (non-streaming)
-            expect(thirdSpan!.name).toBe('chat error-model');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const nonStreamingErrorSpan = container.items.find(
+              span =>
+                span.name === 'chat error-model' && span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE] === undefined,
+            );
+            expect(nonStreamingErrorSpan).toBeDefined();
+            expect(nonStreamingErrorSpan!.name).toBe('chat error-model');
+            expect(nonStreamingErrorSpan!.status).toBe('error');
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(nonStreamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(nonStreamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'error-model',
             });
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1,
             });
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+            expect(nonStreamingErrorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '[{"role":"user","content":"This will fail"}]',
             });
 
-            // [3] chat completions streaming with PII
-            expect(fourthSpan!.name).toBe('chat gpt-4');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const streamingChatCompletionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-stream-123',
+            );
+            expect(streamingChatCompletionSpan).toBeDefined();
+            expect(streamingChatCompletionSpan!.name).toBe('chat gpt-4');
+            expect(streamingChatCompletionSpan!.status).toBe('ok');
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingChatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
               type: 'double',
               value: 0.8,
             });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1,
             });
-            expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '[{"role":"user","content":"Tell me about streaming"}]',
             });
-            expect(fourthSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: JSON.stringify([{ type: 'text', content: 'You are a helpful assistant.' }]),
             });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'Hello from OpenAI streaming!',
             });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["stop"]',
             });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'chatcmpl-stream-123',
             });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 12 });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 12,
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 18,
             });
-            expect(fourthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 30 });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 30,
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
               type: 'boolean',
               value: true,
             });
 
-            // [4] responses API streaming with PII
-            expect(fifthSpan!.name).toBe('chat gpt-4');
-            expect(fifthSpan!.status).toBe('ok');
-            expect(fifthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(fifthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const streamingResponsesSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_stream_456',
+            );
+            expect(streamingResponsesSpan).toBeDefined();
+            expect(streamingResponsesSpan!.name).toBe('chat gpt-4');
+            expect(streamingResponsesSpan!.status).toBe('ok');
+            expect(streamingResponsesSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingResponsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(fifthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(streamingResponsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(fifthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(fifthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fifthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(fifthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1,
             });
-            expect(fifthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'Test streaming responses API',
             });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'Streaming response to: Test streaming responses APITest streaming responses API',
             });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["in_progress","completed"]',
             });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'resp_stream_456',
             });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 6 });
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 16 });
-            expect(fifthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 6,
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 16,
+            });
+            expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
               type: 'boolean',
               value: true,
             });
 
-            // [5] error handling in streaming context with PII
-            expect(sixthSpan!.name).toBe('chat error-model');
-            expect(sixthSpan!.status).toBe('error');
-            expect(sixthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(sixthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            const streamingErrorSpan = container.items.find(
+              span =>
+                span.name === 'chat error-model' && span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]?.value === true,
+            );
+            expect(streamingErrorSpan).toBeDefined();
+            expect(streamingErrorSpan!.name).toBe('chat error-model');
+            expect(streamingErrorSpan!.status).toBe('error');
+            expect(streamingErrorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(streamingErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'error-model',
             });
-            expect(sixthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(sixthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+            expect(streamingErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingErrorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1,
             });
-            expect(sixthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+            expect(streamingErrorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '[{"role":"user","content":"This will fail"}]',
             });
-            expect(sixthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(sixthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            expect(streamingErrorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(streamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(sixthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(streamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
@@ -493,26 +709,33 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(6);
-            const [firstSpan, , , fourthSpan] = container.items;
+            const chatCompletionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-mock123',
+            );
+            expect(chatCompletionSpan).toBeDefined();
+            expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+            expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
+              type: 'string',
+              value: expect.any(String),
+            });
+            expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toMatchObject({
+              type: 'string',
+              value: expect.any(String),
+            });
 
-            // [0] non-streaming with input messages recorded via custom options
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
+            const streamingChatCompletionSpan = container.items.find(
+              span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-stream-123',
+            );
+            expect(streamingChatCompletionSpan).toBeDefined();
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+              type: 'boolean',
+              value: true,
+            });
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
               type: 'string',
               value: expect.any(String),
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toMatchObject({
-              type: 'string',
-              value: expect.any(String),
-            });
-
-            // [3] streaming with input messages recorded via custom options
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-            expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
-              type: 'string',
-              value: expect.any(String),
-            });
-            expect(fourthSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toMatchObject({
+            expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toMatchObject({
               type: 'string',
               value: expect.any(String),
             });
@@ -541,14 +764,15 @@ describe('OpenAI integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
-
-              // [0] chat completions: multiple messages all preserved (no popping to last message only)
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              const chatCompletionSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-mock123',
+              );
+              expect(chatCompletionSpan).toBeDefined();
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'chatcmpl-mock123',
               });
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
+              expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
                 type: 'string',
                 value: JSON.stringify([
                   { role: 'user', content: longContent },
@@ -556,21 +780,24 @@ describe('OpenAI integration', () => {
                   { role: 'user', content: 'Follow-up question' },
                 ]),
               });
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toMatchObject({
+              expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toMatchObject({
                 type: 'integer',
                 value: 3,
               });
 
-              // [1] responses API long string input is not truncated or wrapped in quotes
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              const responsesSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_mock456',
+              );
+              expect(responsesSpan).toBeDefined();
+              expect(responsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'resp_mock456',
               });
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
+              expect(responsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
                 type: 'string',
                 value: 'B'.repeat(50_000),
               });
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toMatchObject({
+              expect(responsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toMatchObject({
                 type: 'integer',
                 value: 1,
               });
@@ -594,90 +821,120 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-            // [0] embeddings API (single input)
-            expect(firstSpan!.name).toBe('embeddings text-embedding-3-small');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+            const singleEmbeddingSpan = container.items.find(
+              span =>
+                span.name === 'embeddings text-embedding-3-small' &&
+                span.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE] !== undefined,
+            );
+            expect(singleEmbeddingSpan).toBeDefined();
+            expect(singleEmbeddingSpan!.name).toBe('embeddings text-embedding-3-small');
+            expect(singleEmbeddingSpan!.status).toBe('ok');
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'embeddings',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.embeddings',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'text-embedding-3-small',
             });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'float',
             });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1536,
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'text-embedding-3-small',
             });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
 
-            // [1] embeddings API error model
-            expect(secondSpan!.name).toBe('embeddings error-model');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+            const errorEmbeddingSpan = container.items.find(span => span.name === 'embeddings error-model');
+            expect(errorEmbeddingSpan).toBeDefined();
+            expect(errorEmbeddingSpan!.name).toBe('embeddings error-model');
+            expect(errorEmbeddingSpan!.status).toBe('error');
+            expect(errorEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'embeddings',
             });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            expect(errorEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.embeddings',
             });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(errorEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(errorEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(errorEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'error-model',
             });
 
-            // [2] embeddings API (multiple inputs)
-            expect(thirdSpan!.name).toBe('embeddings text-embedding-3-small');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+            const multiEmbeddingSpan = container.items.find(
+              span =>
+                span.name === 'embeddings text-embedding-3-small' &&
+                span.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE] === undefined,
+            );
+            expect(multiEmbeddingSpan).toBeDefined();
+            expect(multiEmbeddingSpan!.name).toBe('embeddings text-embedding-3-small');
+            expect(multiEmbeddingSpan!.status).toBe('ok');
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'embeddings',
             });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.embeddings',
             });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'text-embedding-3-small',
             });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'text-embedding-3-small',
             });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
           },
         })
         .start()
@@ -697,102 +954,132 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-            // [0] embeddings API with PII (single input)
-            expect(firstSpan!.name).toBe('embeddings text-embedding-3-small');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+            const singleEmbeddingSpan = container.items.find(
+              span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === 'Embedding test!',
+            );
+            expect(singleEmbeddingSpan).toBeDefined();
+            expect(singleEmbeddingSpan!.name).toBe('embeddings text-embedding-3-small');
+            expect(singleEmbeddingSpan!.status).toBe('ok');
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'embeddings',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.embeddings',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'text-embedding-3-small',
             });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'float',
             });
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE]).toEqual({
               type: 'integer',
               value: 1536,
             });
-            expect(firstSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'Embedding test!',
             });
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'text-embedding-3-small',
             });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
+            expect(singleEmbeddingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
 
-            // [1] embeddings API error model with PII
-            expect(secondSpan!.name).toBe('embeddings error-model');
-            expect(secondSpan!.status).toBe('error');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+            const errorEmbeddingSpan = container.items.find(
+              span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === 'Error embedding test!',
+            );
+            expect(errorEmbeddingSpan).toBeDefined();
+            expect(errorEmbeddingSpan!.name).toBe('embeddings error-model');
+            expect(errorEmbeddingSpan!.status).toBe('error');
+            expect(errorEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'embeddings',
             });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            expect(errorEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.embeddings',
             });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(errorEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(errorEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(errorEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'error-model',
             });
-            expect(secondSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
+            expect(errorEmbeddingSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'Error embedding test!',
             });
 
-            // [2] embeddings API with multiple inputs (not truncated)
-            expect(thirdSpan!.name).toBe('embeddings text-embedding-3-small');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+            const multiEmbeddingSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value ===
+                '["First input text","Second input text","Third input text"]',
+            );
+            expect(multiEmbeddingSpan).toBeDefined();
+            expect(multiEmbeddingSpan!.name).toBe('embeddings text-embedding-3-small');
+            expect(multiEmbeddingSpan!.status).toBe('ok');
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'embeddings',
             });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.embeddings',
             });
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'text-embedding-3-small',
             });
-            expect(thirdSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
               type: 'string',
               value: '["First input text","Second input text","Third input text"]',
             });
-            expect(thirdSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'text-embedding-3-small',
             });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
-            expect(thirdSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({ type: 'integer', value: 10 });
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
+            expect(multiEmbeddingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              type: 'integer',
+              value: 10,
+            });
           },
         })
         .start()
@@ -900,67 +1187,84 @@ describe('OpenAI integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
-
-              // [0] Last message is large and gets truncated (only C's remain, D's are cropped)
-              expect(firstSpan!.name).toBe('chat gpt-3.5-turbo');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-                type: 'string',
-                value: 'gen_ai.chat',
-              });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-                type: 'string',
-                value: 'auto.ai.openai',
-              });
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'gpt-3.5-turbo',
-              });
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 2,
-              });
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
-                /^\[\{"role":"user","content":"C+"\}\]$/,
+              const truncatedMessageSpan = container.items.find(span =>
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.match(
+                  /^\[\{"role":"user","content":"C+"\}\]$/,
+                ),
               );
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toMatch(
-                /^\[\{"type":"text","content":"A+"\}\]$/,
-              );
-
-              // [1] Last message is small and kept without truncation
-              expect(secondSpan!.name).toBe('chat gpt-3.5-turbo');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              expect(truncatedMessageSpan).toBeDefined();
+              expect(truncatedMessageSpan!.name).toBe('chat gpt-3.5-turbo');
+              expect(truncatedMessageSpan!.status).toBe('ok');
+              expect(truncatedMessageSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'chat',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(truncatedMessageSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(truncatedMessageSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(truncatedMessageSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(truncatedMessageSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+              expect(truncatedMessageSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 2,
+              });
+              expect(truncatedMessageSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
+                /^\[\{"role":"user","content":"C+"\}\]$/,
+              );
+              expect(truncatedMessageSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toMatch(
+                /^\[\{"type":"text","content":"A+"\}\]$/,
+              );
+
+              const smallMessageSpan = container.items.find(
+                span =>
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                  JSON.stringify([{ role: 'user', content: 'This is a small message that fits within the limit' }]),
+              );
+              expect(smallMessageSpan).toBeDefined();
+              expect(smallMessageSpan!.name).toBe('chat gpt-3.5-turbo');
+              expect(smallMessageSpan!.status).toBe('ok');
+              expect(smallMessageSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(smallMessageSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+                type: 'string',
+                value: 'gen_ai.chat',
+              });
+              expect(smallMessageSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+                type: 'string',
+                value: 'auto.ai.openai',
+              });
+              expect(smallMessageSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(smallMessageSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-3.5-turbo',
+              });
+              expect(smallMessageSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: JSON.stringify([
                   { role: 'user', content: 'This is a small message that fits within the limit' },
                 ]),
               });
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+              expect(smallMessageSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 2,
               });
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toMatch(
+              expect(smallMessageSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toMatch(
                 /^\[\{"type":"text","content":"A+"\}\]$/,
               );
             },
@@ -1032,66 +1336,103 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(4);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
-
-            // [0] conversations.create returns conversation object with id
-            expect(firstSpan!.name).toBe('chat unknown');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const conversationCreateSpan = container.items.find(span => span.name === 'chat unknown');
+            expect(conversationCreateSpan).toBeDefined();
+            expect(conversationCreateSpan!.name).toBe('chat unknown');
+            expect(conversationCreateSpan!.status).toBe('ok');
+            expect(conversationCreateSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(conversationCreateSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(conversationCreateSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(firstSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toEqual({
+            expect(conversationCreateSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(conversationCreateSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'conv_689667905b048191b4740501625afd940c7533ace33a2dab',
             });
 
-            // [1] responses.create with conversation parameter
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const conversationResponseSpan = container.items.find(
+              span =>
+                span.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]?.value ===
+                  'conv_689667905b048191b4740501625afd940c7533ace33a2dab' &&
+                span.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]?.value === 'gpt-4',
+            );
+            expect(conversationResponseSpan).toBeDefined();
+            expect(conversationResponseSpan!.status).toBe('ok');
+            expect(conversationResponseSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(conversationResponseSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(conversationResponseSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(secondSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toEqual({
+            expect(conversationResponseSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(conversationResponseSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(conversationResponseSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'conv_689667905b048191b4740501625afd940c7533ace33a2dab',
             });
 
-            // [2] responses.create without conversation (first in chain, should NOT have gen_ai.conversation.id)
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const unlinkedResponseSpan = container.items.find(
+              span =>
+                span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]?.value === 'gen_ai.chat' &&
+                span.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE] === undefined,
+            );
+            expect(unlinkedResponseSpan).toBeDefined();
+            expect(unlinkedResponseSpan!.status).toBe('ok');
+            expect(unlinkedResponseSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(thirdSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBeUndefined();
+            expect(unlinkedResponseSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBeUndefined();
 
-            // [3] responses.create with previous_response_id (chaining)
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+            const previousResponseSpan = container.items.find(
+              span => span.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]?.value === 'resp_mock_conv_123',
+            );
+            expect(previousResponseSpan).toBeDefined();
+            expect(previousResponseSpan!.status).toBe('ok');
+            expect(previousResponseSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'chat',
+            });
+            expect(previousResponseSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
               type: 'string',
               value: 'gen_ai.chat',
             });
-            expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+            expect(previousResponseSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
               type: 'string',
               value: 'auto.ai.openai',
             });
-            expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-            expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-            expect(fourthSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toEqual({
+            expect(previousResponseSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'openai',
+            });
+            expect(previousResponseSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              type: 'string',
+              value: 'gpt-4',
+            });
+            expect(previousResponseSpan!.attributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toEqual({
               type: 'string',
               value: 'resp_mock_conv_123',
             });
@@ -1115,10 +1456,9 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
 
             // All three chat completion spans should have the same manually-set conversation ID
-            for (const span of [firstSpan, secondSpan, thirdSpan]) {
+            for (const span of container.items) {
               expect(span!.name).toBe('chat gpt-4');
               expect(span!.status).toBe('ok');
               expect(span!.attributes['gen_ai.conversation.id']).toEqual({
@@ -1149,10 +1489,9 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
 
             // Both chat completion spans should have the expected conversation ID
-            for (const span of [firstSpan, secondSpan]) {
+            for (const span of container.items) {
               expect(span!.name).toBe('chat gpt-4');
               expect(span!.status).toBe('ok');
               expect(span!.attributes['gen_ai.conversation.id']).toEqual({
@@ -1182,10 +1521,9 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
 
             // Both chat completion spans should have the expected conversation ID
-            for (const span of [firstSpan, secondSpan]) {
+            for (const span of container.items) {
               expect(span!.name).toBe('chat gpt-4');
               expect(span!.status).toBe('ok');
               expect(span!.attributes['gen_ai.conversation.id']).toEqual({
@@ -1246,10 +1584,9 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
 
             // Both calls should produce spans with the same response ID
-            for (const span of [firstSpan, secondSpan]) {
+            for (const span of container.items) {
               expect(span!.name).toBe('chat gpt-4');
               expect(span!.status).toBe('ok');
               expect(span!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
@@ -1278,10 +1615,9 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
 
             // Both vision request spans should contain [Blob substitute]
-            for (const span of [firstSpan, secondSpan]) {
+            for (const span of container.items) {
               expect(span!.name).toBe('chat gpt-4o');
               expect(span!.status).toBe('ok');
               expect(span!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
@@ -1309,10 +1645,11 @@ describe('OpenAI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [, secondSpan] = container.items;
-
-            // [1] multiple images span contains the https URL
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain(
+            const multipleImagesSpan = container.items.find(span =>
+              span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes('https://example.com/image.png'),
+            );
+            expect(multipleImagesSpan).toBeDefined();
+            expect(multipleImagesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain(
               'https://example.com/image.png',
             );
           },

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/test.ts
@@ -40,231 +40,288 @@ describe('OpenAI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(6);
-              const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan] = container.items;
-
-              // [0] basic chat completion without PII
-              expect(firstSpan!.name).toBe('chat gpt-3.5-turbo');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              const chatCompletionSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-mock123',
+              );
+              expect(chatCompletionSpan).toBeDefined();
+              expect(chatCompletionSpan!.name).toBe('chat gpt-3.5-turbo');
+              expect(chatCompletionSpan!.status).toBe('ok');
+              expect(chatCompletionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(chatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(chatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
                 type: 'double',
                 value: 0.7,
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'chatcmpl-mock123',
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '["stop"]',
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 15,
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 25,
               });
 
-              // [1] responses API
-              expect(secondSpan!.name).toBe('chat gpt-3.5-turbo');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const responsesSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_mock456',
+              );
+              expect(responsesSpan).toBeDefined();
+              expect(responsesSpan!.name).toBe('chat gpt-3.5-turbo');
+              expect(responsesSpan!.status).toBe('ok');
+              expect(responsesSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'chat',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(responsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(responsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
+              expect(responsesSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'resp_mock456',
               });
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '["completed"]',
               });
-              expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 5,
               });
-              expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 8,
               });
-              expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 13,
               });
 
-              // [2] error handling (non-streaming)
-              expect(thirdSpan!.name).toBe('chat error-model');
-              expect(thirdSpan!.status).toBe('error');
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-              expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-                type: 'string',
-                value: 'gen_ai.chat',
-              });
-              expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-                type: 'string',
-                value: 'auto.ai.openai',
-              });
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'error-model',
-              });
-
-              // [3] chat completions streaming
-              expect(fourthSpan!.name).toBe('chat gpt-4');
-              expect(fourthSpan!.status).toBe('ok');
-              expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const nonStreamingErrorSpan = container.items.find(
+                span =>
+                  span.name === 'chat error-model' && span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE] === undefined,
+              );
+              expect(nonStreamingErrorSpan).toBeDefined();
+              expect(nonStreamingErrorSpan!.name).toBe('chat error-model');
+              expect(nonStreamingErrorSpan!.status).toBe('error');
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'chat',
               });
-              expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
                 type: 'string',
-                value: 'gpt-4',
+                value: 'openai',
               });
-              expect(fourthSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
-                type: 'double',
-                value: 0.8,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'gpt-4',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'chatcmpl-stream-123',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: '["stop"]',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 12,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 18,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 30,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
-                type: 'boolean',
-                value: true,
-              });
-
-              // [4] responses API streaming
-              expect(fifthSpan!.name).toBe('chat gpt-4');
-              expect(fifthSpan!.status).toBe('ok');
-              expect(fifthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(fifthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-                type: 'string',
-                value: 'gen_ai.chat',
-              });
-              expect(fifthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-                type: 'string',
-                value: 'auto.ai.openai',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(fifthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-              expect(fifthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'gpt-4',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'resp_stream_456',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: '["in_progress","completed"]',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 6,
-              });
-              expect(fifthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 10,
-              });
-              expect(fifthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 16,
-              });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
-                type: 'boolean',
-                value: true,
-              });
-
-              // [5] error handling in streaming context
-              expect(sixthSpan!.name).toBe('chat error-model');
-              expect(sixthSpan!.status).toBe('error');
-              expect(sixthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(sixthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'error-model',
               });
-              expect(sixthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-              expect(sixthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(sixthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+
+              const streamingChatCompletionSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-stream-123',
+              );
+              expect(streamingChatCompletionSpan).toBeDefined();
+              expect(streamingChatCompletionSpan!.name).toBe('chat gpt-4');
+              expect(streamingChatCompletionSpan!.status).toBe('ok');
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(streamingChatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(sixthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(streamingChatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+                type: 'string',
+                value: 'auto.ai.openai',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-4',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+                type: 'double',
+                value: 0.8,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-4',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chatcmpl-stream-123',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: '["stop"]',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 12,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 18,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 30,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+
+              const streamingResponsesSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_stream_456',
+              );
+              expect(streamingResponsesSpan).toBeDefined();
+              expect(streamingResponsesSpan!.name).toBe('chat gpt-4');
+              expect(streamingResponsesSpan!.status).toBe('ok');
+              expect(streamingResponsesSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(streamingResponsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+                type: 'string',
+                value: 'gen_ai.chat',
+              });
+              expect(streamingResponsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+                type: 'string',
+                value: 'auto.ai.openai',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-4',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-4',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'resp_stream_456',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: '["in_progress","completed"]',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 6,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 10,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 16,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+
+              const streamingErrorSpan = container.items.find(
+                span =>
+                  span.name === 'chat error-model' && span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]?.value === true,
+              );
+              expect(streamingErrorSpan).toBeDefined();
+              expect(streamingErrorSpan!.name).toBe('chat error-model');
+              expect(streamingErrorSpan!.status).toBe('error');
+              expect(streamingErrorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(streamingErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'error-model',
+              });
+              expect(streamingErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+              expect(streamingErrorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(streamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+                type: 'string',
+                value: 'gen_ai.chat',
+              });
+              expect(streamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
@@ -293,303 +350,360 @@ describe('OpenAI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(6);
-              const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan] = container.items;
-
-              // [0] basic chat completion with PII
-              expect(firstSpan!.name).toBe('chat gpt-3.5-turbo');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              const chatCompletionSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-mock123',
+              );
+              expect(chatCompletionSpan).toBeDefined();
+              expect(chatCompletionSpan!.name).toBe('chat gpt-3.5-turbo');
+              expect(chatCompletionSpan!.status).toBe('ok');
+              expect(chatCompletionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(chatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(chatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
                 type: 'double',
                 value: 0.7,
               });
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 1,
               });
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '[{"role":"user","content":"What is the capital of France?"}]',
               });
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '[{"type":"text","content":"You are a helpful assistant."}]',
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'chatcmpl-mock123',
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '["stop"]',
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '["Hello from OpenAI mock!"]',
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 15,
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              expect(chatCompletionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 25,
               });
 
-              // [1] responses API with PII
-              expect(secondSpan!.name).toBe('chat gpt-3.5-turbo');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const responsesSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_mock456',
+              );
+              expect(responsesSpan).toBeDefined();
+              expect(responsesSpan!.name).toBe('chat gpt-3.5-turbo');
+              expect(responsesSpan!.status).toBe('ok');
+              expect(responsesSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'chat',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(responsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(responsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
+              expect(responsesSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 1,
               });
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'Translate this to French: Hello',
               });
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'Response to: Translate this to French: Hello',
               });
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '["completed"]',
               });
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'gpt-3.5-turbo',
               });
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'resp_mock456',
               });
-              expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 5,
               });
-              expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 8,
               });
-              expect(secondSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              expect(responsesSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 13,
               });
 
-              // [2] error handling with PII (non-streaming)
-              expect(thirdSpan!.name).toBe('chat error-model');
-              expect(thirdSpan!.status).toBe('error');
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-              expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-                type: 'string',
-                value: 'gen_ai.chat',
-              });
-              expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-                type: 'string',
-                value: 'auto.ai.openai',
-              });
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'error-model',
-              });
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 1,
-              });
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: '[{"role":"user","content":"This will fail"}]',
-              });
-
-              // [3] chat completions streaming with PII
-              expect(fourthSpan!.name).toBe('chat gpt-4');
-              expect(fourthSpan!.status).toBe('ok');
-              expect(fourthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const nonStreamingErrorSpan = container.items.find(
+                span =>
+                  span.name === 'chat error-model' && span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE] === undefined,
+              );
+              expect(nonStreamingErrorSpan).toBeDefined();
+              expect(nonStreamingErrorSpan!.name).toBe('chat error-model');
+              expect(nonStreamingErrorSpan!.status).toBe('error');
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'chat',
               });
-              expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(fourthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(fourthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(fourthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
                 type: 'string',
-                value: 'gpt-4',
+                value: 'openai',
               });
-              expect(fourthSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
-                type: 'double',
-                value: 0.8,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-              expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 1,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: '[{"role":"user","content":"Tell me about streaming"}]',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: '[{"type":"text","content":"You are a helpful assistant."}]',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'Hello from OpenAI streaming!',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: '["stop"]',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'chatcmpl-stream-123',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'gpt-4',
-              });
-              expect(fourthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 12,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 18,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 30,
-              });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
-                type: 'boolean',
-                value: true,
-              });
-
-              // [4] responses API streaming with PII
-              expect(fifthSpan!.name).toBe('chat gpt-4');
-              expect(fifthSpan!.status).toBe('ok');
-              expect(fifthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(fifthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
-                type: 'string',
-                value: 'gen_ai.chat',
-              });
-              expect(fifthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
-                type: 'string',
-                value: 'auto.ai.openai',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(fifthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({ type: 'string', value: 'gpt-4' });
-              expect(fifthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-              expect(fifthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 1,
-              });
-              expect(fifthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'Test streaming responses API',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'Streaming response to: Test streaming responses APITest streaming responses API',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: '["in_progress","completed"]',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'resp_stream_456',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
-                type: 'string',
-                value: 'gpt-4',
-              });
-              expect(fifthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 6,
-              });
-              expect(fifthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 10,
-              });
-              expect(fifthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
-                type: 'integer',
-                value: 16,
-              });
-              expect(fifthSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
-                type: 'boolean',
-                value: true,
-              });
-
-              // [5] error handling in streaming context with PII
-              expect(sixthSpan!.name).toBe('chat error-model');
-              expect(sixthSpan!.status).toBe('error');
-              expect(sixthSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({ type: 'string', value: 'chat' });
-              expect(sixthSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'error-model',
               });
-              expect(sixthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-              expect(sixthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 1,
               });
-              expect(sixthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+              expect(nonStreamingErrorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '[{"role":"user","content":"This will fail"}]',
               });
-              expect(sixthSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(sixthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+
+              const streamingChatCompletionSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-stream-123',
+              );
+              expect(streamingChatCompletionSpan).toBeDefined();
+              expect(streamingChatCompletionSpan!.name).toBe('chat gpt-4');
+              expect(streamingChatCompletionSpan!.status).toBe('ok');
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(streamingChatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.chat',
               });
-              expect(sixthSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(streamingChatCompletionSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+                type: 'string',
+                value: 'auto.ai.openai',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-4',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE]).toEqual({
+                type: 'double',
+                value: 0.8,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 1,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: '[{"role":"user","content":"Tell me about streaming"}]',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: '[{"type":"text","content":"You are a helpful assistant."}]',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'Hello from OpenAI streaming!',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: '["stop"]',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chatcmpl-stream-123',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-4',
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 12,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 18,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 30,
+              });
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+
+              const streamingResponsesSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'resp_stream_456',
+              );
+              expect(streamingResponsesSpan).toBeDefined();
+              expect(streamingResponsesSpan!.name).toBe('chat gpt-4');
+              expect(streamingResponsesSpan!.status).toBe('ok');
+              expect(streamingResponsesSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(streamingResponsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+                type: 'string',
+                value: 'gen_ai.chat',
+              });
+              expect(streamingResponsesSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+                type: 'string',
+                value: 'auto.ai.openai',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-4',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 1,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'Test streaming responses API',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'Streaming response to: Test streaming responses APITest streaming responses API',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: '["in_progress","completed"]',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'resp_stream_456',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'gpt-4',
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 6,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 10,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 16,
+              });
+              expect(streamingResponsesSpan!.attributes[GEN_AI_RESPONSE_STREAMING_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+
+              const streamingErrorSpan = container.items.find(
+                span =>
+                  span.name === 'chat error-model' && span.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]?.value === true,
+              );
+              expect(streamingErrorSpan).toBeDefined();
+              expect(streamingErrorSpan!.name).toBe('chat error-model');
+              expect(streamingErrorSpan!.status).toBe('error');
+              expect(streamingErrorSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'chat',
+              });
+              expect(streamingErrorSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'error-model',
+              });
+              expect(streamingErrorSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+              expect(streamingErrorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toEqual({
+                type: 'integer',
+                value: 1,
+              });
+              expect(streamingErrorSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: '[{"role":"user","content":"This will fail"}]',
+              });
+              expect(streamingErrorSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(streamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+                type: 'string',
+                value: 'gen_ai.chat',
+              });
+              expect(streamingErrorSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
@@ -618,42 +732,51 @@ describe('OpenAI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(6);
-              const [firstSpan, , , fourthSpan] = container.items;
-
-              // [0] non-streaming with input messages recorded via custom options
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toMatchObject({
+              const chatCompletionSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-mock123',
+              );
+              expect(chatCompletionSpan).toBeDefined();
+              expect(chatCompletionSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toBeUndefined();
+              expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toMatchObject({
                 type: 'integer',
                 value: 1,
               });
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
+              expect(chatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
                 type: 'string',
                 value: expect.any(String),
               });
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toMatchObject({
+              expect(chatCompletionSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toMatchObject({
                 type: 'string',
                 value: expect.any(String),
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toMatchObject({
+              expect(chatCompletionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toMatchObject({
                 type: 'string',
                 value: expect.any(String),
               });
 
-              // [3] streaming with input messages recorded via custom options
-              expect(fourthSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({ type: 'boolean', value: true });
-              expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toMatchObject({
+              const streamingChatCompletionSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_ID_ATTRIBUTE]?.value === 'chatcmpl-stream-123',
+              );
+              expect(streamingChatCompletionSpan).toBeDefined();
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_REQUEST_STREAM_ATTRIBUTE]).toEqual({
+                type: 'boolean',
+                value: true,
+              });
+              expect(
+                streamingChatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE],
+              ).toMatchObject({
                 type: 'integer',
                 value: 1,
               });
-              expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toMatchObject({
                 type: 'string',
                 value: expect.any(String),
               });
-              expect(fourthSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toMatchObject({
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toMatchObject({
                 type: 'string',
                 value: expect.any(String),
               });
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toMatchObject({
+              expect(streamingChatCompletionSpan!.attributes[GEN_AI_RESPONSE_TEXT_ATTRIBUTE]).toMatchObject({
                 type: 'string',
                 value: expect.any(String),
               });
@@ -686,99 +809,117 @@ describe('OpenAI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-              // [0] embeddings API (single input)
-              expect(firstSpan!.name).toBe('embeddings text-embedding-3-small');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const singleEmbeddingSpan = container.items.find(
+                span =>
+                  span.name === 'embeddings text-embedding-3-small' &&
+                  span.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE] !== undefined,
+              );
+              expect(singleEmbeddingSpan).toBeDefined();
+              expect(singleEmbeddingSpan!.name).toBe('embeddings text-embedding-3-small');
+              expect(singleEmbeddingSpan!.status).toBe('ok');
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'embeddings',
               });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.embeddings',
               });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'text-embedding-3-small',
               });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'float',
               });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 1536,
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'text-embedding-3-small',
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
 
-              // [1] embeddings API error model
-              expect(secondSpan!.name).toBe('embeddings error-model');
-              expect(secondSpan!.status).toBe('error');
-              expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const errorEmbeddingSpan = container.items.find(span => span.name === 'embeddings error-model');
+              expect(errorEmbeddingSpan).toBeDefined();
+              expect(errorEmbeddingSpan!.name).toBe('embeddings error-model');
+              expect(errorEmbeddingSpan!.status).toBe('error');
+              expect(errorEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'embeddings',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(errorEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.embeddings',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(errorEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(errorEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(errorEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'error-model',
               });
 
-              // [2] embeddings API (multiple inputs)
-              expect(thirdSpan!.name).toBe('embeddings text-embedding-3-small');
-              expect(thirdSpan!.status).toBe('ok');
-              expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const multiEmbeddingSpan = container.items.find(
+                span =>
+                  span.name === 'embeddings text-embedding-3-small' &&
+                  span.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE] === undefined,
+              );
+              expect(multiEmbeddingSpan).toBeDefined();
+              expect(multiEmbeddingSpan!.name).toBe('embeddings text-embedding-3-small');
+              expect(multiEmbeddingSpan!.status).toBe('ok');
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'embeddings',
               });
-              expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.embeddings',
               });
-              expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'text-embedding-3-small',
               });
-              expect(thirdSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'text-embedding-3-small',
               });
-              expect(thirdSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
-              expect(thirdSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
@@ -811,111 +952,129 @@ describe('OpenAI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
-
-              // [0] embeddings API with PII (single input)
-              expect(firstSpan!.name).toBe('embeddings text-embedding-3-small');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const singleEmbeddingSpan = container.items.find(
+                span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === 'Embedding test!',
+              );
+              expect(singleEmbeddingSpan).toBeDefined();
+              expect(singleEmbeddingSpan!.name).toBe('embeddings text-embedding-3-small');
+              expect(singleEmbeddingSpan!.status).toBe('ok');
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'embeddings',
               });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.embeddings',
               });
-              expect(firstSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'text-embedding-3-small',
               });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'float',
               });
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 1536,
               });
-              expect(firstSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'Embedding test!',
               });
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'text-embedding-3-small',
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              expect(singleEmbeddingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
 
-              // [1] embeddings API error model with PII
-              expect(secondSpan!.name).toBe('embeddings error-model');
-              expect(secondSpan!.status).toBe('error');
-              expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const errorEmbeddingSpan = container.items.find(
+                span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === 'Error embedding test!',
+              );
+              expect(errorEmbeddingSpan).toBeDefined();
+              expect(errorEmbeddingSpan!.name).toBe('embeddings error-model');
+              expect(errorEmbeddingSpan!.status).toBe('error');
+              expect(errorEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'embeddings',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(errorEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.embeddings',
               });
-              expect(secondSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(errorEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(secondSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(errorEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(errorEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'error-model',
               });
-              expect(secondSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
+              expect(errorEmbeddingSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'Error embedding test!',
               });
 
-              // [2] embeddings API with multiple inputs (not truncated)
-              expect(thirdSpan!.name).toBe('embeddings text-embedding-3-small');
-              expect(thirdSpan!.status).toBe('ok');
-              expect(thirdSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
+              const multiEmbeddingSpan = container.items.find(
+                span =>
+                  span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value ===
+                  '["First input text","Second input text","Third input text"]',
+              );
+              expect(multiEmbeddingSpan).toBeDefined();
+              expect(multiEmbeddingSpan!.name).toBe('embeddings text-embedding-3-small');
+              expect(multiEmbeddingSpan!.status).toBe('ok');
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'embeddings',
               });
-              expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual({
                 type: 'string',
                 value: 'gen_ai.embeddings',
               });
-              expect(thirdSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toEqual({
                 type: 'string',
                 value: 'auto.ai.openai',
               });
-              expect(thirdSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({ type: 'string', value: 'openai' });
-              expect(thirdSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE]).toEqual({
+                type: 'string',
+                value: 'openai',
+              });
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'text-embedding-3-small',
               });
-              expect(thirdSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: '["First input text","Second input text","Third input text"]',
               });
-              expect(thirdSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE]).toEqual({
                 type: 'string',
                 value: 'text-embedding-3-small',
               });
-              expect(thirdSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });
-              expect(thirdSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
+              expect(multiEmbeddingSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]).toEqual({
                 type: 'integer',
                 value: 10,
               });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -35,68 +35,104 @@ describe('Vercel AI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(7);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan, seventhSpan] = container.items;
+            const firstInvokeAgentSpan = container.items.find(
+              span =>
+                span.name === 'invoke_agent' &&
+                span.attributes['vercel.ai.operationId'].value === 'ai.generateText' &&
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE] === undefined &&
+                span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value === 10,
+            );
+            expect(firstInvokeAgentSpan).toBeDefined();
+            expect(firstInvokeAgentSpan!.name).toBe('invoke_agent');
+            expect(firstInvokeAgentSpan!.status).toBe('ok');
+            expect(firstInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(firstInvokeAgentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
+            expect(firstInvokeAgentSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
+            expect(firstInvokeAgentSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
+            expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(20);
+            expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(30);
+            expect(firstInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
 
-            // [0] First generateText — invoke_agent (no explicit telemetry, no PII)
-            expect(firstSpan!.name).toBe('invoke_agent');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(firstSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
-            expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(20);
-            expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(30);
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
+            const firstGenerateContentSpan = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.attributes['vercel.ai.operationId'].value === 'ai.generateText.doGenerate' &&
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE] === undefined,
+            );
+            expect(firstGenerateContentSpan).toBeDefined();
+            expect(firstGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(firstGenerateContentSpan!.status).toBe('ok');
+            expect(firstGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(firstGenerateContentSpan!.attributes['vercel.ai.operationId'].value).toBe(
+              'ai.generateText.doGenerate',
+            );
+            expect(firstGenerateContentSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('mock-provider');
+            expect(firstGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+            expect(firstGenerateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
 
-            // [1] First generateText — generate_content (doGenerate, no PII)
-            expect(secondSpan!.name).toBe('generate_content mock-model-id');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(secondSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText.doGenerate');
-            expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('mock-provider');
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
-
-            // [2] Second generateText — invoke_agent (explicit telemetry enabled)
-            expect(thirdSpan!.name).toBe('invoke_agent');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+            const secondInvokeAgentSpan = container.items.find(
+              span =>
+                span.name === 'invoke_agent' &&
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                  '[{"role":"user","content":"Where is the second span?"}]',
+            );
+            expect(secondInvokeAgentSpan).toBeDefined();
+            expect(secondInvokeAgentSpan!.name).toBe('invoke_agent');
+            expect(secondInvokeAgentSpan!.status).toBe('ok');
+            expect(secondInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(secondInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
               '[{"role":"user","content":"Where is the second span?"}]',
             );
-            expect(thirdSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
+            expect(secondInvokeAgentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
               '[{"role":"assistant","parts":[{"type":"text","content":"Second span here!"}],"finish_reason":"stop"}]',
             );
 
-            // [3] Second generateText — generate_content (doGenerate with telemetry)
-            expect(fourthSpan!.name).toBe('generate_content mock-model-id');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(fourthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(fourthSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain('Second span here!');
+            const secondGenerateContentSpan = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Second span here!'),
+            );
+            expect(secondGenerateContentSpan).toBeDefined();
+            expect(secondGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(secondGenerateContentSpan!.status).toBe('ok');
+            expect(secondGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(secondGenerateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(secondGenerateContentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain(
+              'Second span here!',
+            );
 
-            // [4] Third generateText — invoke_agent (tool call)
-            expect(fifthSpan!.name).toBe('invoke_agent');
-            expect(fifthSpan!.status).toBe('ok');
-            expect(fifthSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(25);
-            expect(fifthSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(40);
+            const toolInvokeAgentSpan = container.items.find(
+              span =>
+                span.name === 'invoke_agent' && span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]?.value === 15,
+            );
+            expect(toolInvokeAgentSpan).toBeDefined();
+            expect(toolInvokeAgentSpan!.name).toBe('invoke_agent');
+            expect(toolInvokeAgentSpan!.status).toBe('ok');
+            expect(toolInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(toolInvokeAgentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            expect(toolInvokeAgentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(25);
+            expect(toolInvokeAgentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(40);
 
-            // [5] Third generateText — generate_content (doGenerate with tools)
-            expect(sixthSpan!.name).toBe('generate_content mock-model-id');
-            expect(sixthSpan!.status).toBe('ok');
-            expect(sixthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(sixthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            const toolGenerateContentSpan = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]?.value === 15,
+            );
+            expect(toolGenerateContentSpan).toBeDefined();
+            expect(toolGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(toolGenerateContentSpan!.status).toBe('ok');
+            expect(toolGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(toolGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
 
-            // [6] Tool execution
-            expect(seventhSpan!.name).toBe('execute_tool getWeather');
-            expect(seventhSpan!.status).toBe('ok');
-            expect(seventhSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-            expect(seventhSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
-            expect(seventhSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
-            expect(seventhSpan!.attributes[GEN_AI_TOOL_TYPE_ATTRIBUTE].value).toBe('function');
+            const toolExecutionSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+            expect(toolExecutionSpan).toBeDefined();
+            expect(toolExecutionSpan!.name).toBe('execute_tool getWeather');
+            expect(toolExecutionSpan!.status).toBe('ok');
+            expect(toolExecutionSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+            expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+            expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
+            expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_TYPE_ATTRIBUTE].value).toBe('function');
           },
         })
         .start()
@@ -111,67 +147,105 @@ describe('Vercel AI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(7);
-            const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan, seventhSpan] = container.items;
-
-            // [0] First generateText — invoke_agent (PII auto-enabled)
-            expect(firstSpan!.name).toBe('invoke_agent');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(firstSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
-            expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+            const firstInvokeAgentSpan = container.items.find(
+              span =>
+                span.name === 'invoke_agent' &&
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                  '[{"role":"user","content":"Where is the first span?"}]',
+            );
+            expect(firstInvokeAgentSpan).toBeDefined();
+            expect(firstInvokeAgentSpan!.name).toBe('invoke_agent');
+            expect(firstInvokeAgentSpan!.status).toBe('ok');
+            expect(firstInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(firstInvokeAgentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
+            expect(firstInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
               '[{"role":"user","content":"Where is the first span?"}]',
             );
-            expect(firstSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
+            expect(firstInvokeAgentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
               '[{"role":"assistant","parts":[{"type":"text","content":"First span here!"}],"finish_reason":"stop"}]',
             );
 
-            // [1] First doGenerate with PII
-            expect(secondSpan!.name).toBe('generate_content mock-model-id');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(secondSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText.doGenerate');
-            expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-            expect(secondSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain('First span here!');
+            const firstGenerateContentSpan = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('First span here!'),
+            );
+            expect(firstGenerateContentSpan).toBeDefined();
+            expect(firstGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(firstGenerateContentSpan!.status).toBe('ok');
+            expect(firstGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(firstGenerateContentSpan!.attributes['vercel.ai.operationId'].value).toBe(
+              'ai.generateText.doGenerate',
+            );
+            expect(firstGenerateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(firstGenerateContentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain(
+              'First span here!',
+            );
 
-            // [2] Second generateText — invoke_agent (explicit telemetry)
-            expect(thirdSpan!.name).toBe('invoke_agent');
-            expect(thirdSpan!.status).toBe('ok');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+            const secondInvokeAgentSpan = container.items.find(
+              span =>
+                span.name === 'invoke_agent' &&
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                  '[{"role":"user","content":"Where is the second span?"}]',
+            );
+            expect(secondInvokeAgentSpan).toBeDefined();
+            expect(secondInvokeAgentSpan!.name).toBe('invoke_agent');
+            expect(secondInvokeAgentSpan!.status).toBe('ok');
+            expect(secondInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(secondInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
               '[{"role":"user","content":"Where is the second span?"}]',
             );
 
-            // [3] Second doGenerate
-            expect(fourthSpan!.name).toBe('generate_content mock-model-id');
-            expect(fourthSpan!.status).toBe('ok');
-            expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            const secondGenerateContentSpan = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Second span here!'),
+            );
+            expect(secondGenerateContentSpan).toBeDefined();
+            expect(secondGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(secondGenerateContentSpan!.status).toBe('ok');
+            expect(secondGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
 
-            // [4] Third generateText — invoke_agent (tool call prompt)
-            expect(fifthSpan!.name).toBe('invoke_agent');
-            expect(fifthSpan!.status).toBe('ok');
-            expect(fifthSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(fifthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+            const toolInvokeAgentSpan = container.items.find(
+              span =>
+                span.name === 'invoke_agent' &&
+                span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                  '[{"role":"user","content":"What is the weather in San Francisco?"}]',
+            );
+            expect(toolInvokeAgentSpan).toBeDefined();
+            expect(toolInvokeAgentSpan!.name).toBe('invoke_agent');
+            expect(toolInvokeAgentSpan!.status).toBe('ok');
+            expect(toolInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(toolInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
               '[{"role":"user","content":"What is the weather in San Francisco?"}]',
             );
-            expect(fifthSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+            expect(toolInvokeAgentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
 
-            // [5] Third doGenerate with available tools
-            expect(sixthSpan!.name).toBe('generate_content mock-model-id');
-            expect(sixthSpan!.status).toBe('ok');
-            expect(sixthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(sixthSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toContain('getWeather');
-            expect(sixthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+            const toolGenerateContentSpan = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]?.value?.includes('getWeather'),
+            );
+            expect(toolGenerateContentSpan).toBeDefined();
+            expect(toolGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(toolGenerateContentSpan!.status).toBe('ok');
+            expect(toolGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(toolGenerateContentSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toContain(
+              'getWeather',
+            );
+            expect(toolGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
 
-            // [6] Tool execution with PII
-            expect(seventhSpan!.name).toBe('execute_tool getWeather');
-            expect(seventhSpan!.status).toBe('ok');
-            expect(seventhSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-            expect(seventhSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
-            expect(seventhSpan!.attributes[GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE].value).toBe(
+            const toolExecutionSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+            expect(toolExecutionSpan).toBeDefined();
+            expect(toolExecutionSpan!.name).toBe('execute_tool getWeather');
+            expect(toolExecutionSpan!.status).toBe('ok');
+            expect(toolExecutionSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+            expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+            expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE].value).toBe(
               'Get the current weather for a location',
             );
-            expect(seventhSpan!.attributes[GEN_AI_TOOL_INPUT_ATTRIBUTE]).toBeDefined();
-            expect(seventhSpan!.attributes[GEN_AI_TOOL_OUTPUT_ATTRIBUTE]).toBeDefined();
+            expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_INPUT_ATTRIBUTE]).toBeDefined();
+            expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_OUTPUT_ATTRIBUTE]).toBeDefined();
           },
         })
         .start()
@@ -197,25 +271,28 @@ describe('Vercel AI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            const invokeAgentSpan = container.items.find(
+              span => span.name === 'invoke_agent' && span.status === 'error',
+            );
+            expect(invokeAgentSpan).toBeDefined();
+            expect(invokeAgentSpan!.name).toBe('invoke_agent');
+            expect(invokeAgentSpan!.status).toBe('error');
+            expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(invokeAgentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
 
-            // [0] invoke_agent (errored due to tool error)
-            expect(firstSpan!.name).toBe('invoke_agent');
-            expect(firstSpan!.status).toBe('error');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(firstSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
+            const generateContentSpan = container.items.find(span => span.name === 'generate_content mock-model-id');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(generateContentSpan!.status).toBe('ok');
+            expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(generateContentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText.doGenerate');
 
-            // [1] generate_content (doGenerate, succeeded)
-            expect(secondSpan!.name).toBe('generate_content mock-model-id');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(secondSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText.doGenerate');
-
-            // [2] execute_tool (errored)
-            expect(thirdSpan!.name).toBe('execute_tool getWeather');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-            expect(thirdSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+            const toolSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+            expect(toolSpan).toBeDefined();
+            expect(toolSpan!.name).toBe('execute_tool getWeather');
+            expect(toolSpan!.status).toBe('error');
+            expect(toolSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+            expect(toolSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
           },
         })
         .expect({
@@ -252,24 +329,27 @@ describe('Vercel AI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
-            const [firstSpan, secondSpan, thirdSpan] = container.items;
+            const invokeAgentSpan = container.items.find(
+              span => span.name === 'invoke_agent' && span.status === 'error',
+            );
+            expect(invokeAgentSpan).toBeDefined();
+            expect(invokeAgentSpan!.name).toBe('invoke_agent');
+            expect(invokeAgentSpan!.status).toBe('error');
+            expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(invokeAgentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
 
-            // [0] invoke_agent (errored)
-            expect(firstSpan!.name).toBe('invoke_agent');
-            expect(firstSpan!.status).toBe('error');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(firstSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
+            const generateContentSpan = container.items.find(span => span.name === 'generate_content mock-model-id');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(generateContentSpan!.status).toBe('ok');
+            expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
 
-            // [1] generate_content (doGenerate, succeeded)
-            expect(secondSpan!.name).toBe('generate_content mock-model-id');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-
-            // [2] execute_tool (errored)
-            expect(thirdSpan!.name).toBe('execute_tool getWeather');
-            expect(thirdSpan!.status).toBe('error');
-            expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-            expect(thirdSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+            const toolSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+            expect(toolSpan).toBeDefined();
+            expect(toolSpan!.name).toBe('execute_tool getWeather');
+            expect(toolSpan!.status).toBe('error');
+            expect(toolSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+            expect(toolSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
           },
         })
         .expect({
@@ -308,21 +388,21 @@ describe('Vercel AI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
+            const invokeAgentSpan = container.items.find(span => span.name === 'invoke_agent');
+            expect(invokeAgentSpan).toBeDefined();
+            expect(invokeAgentSpan!.name).toBe('invoke_agent');
+            expect(invokeAgentSpan!.status).toBe('ok');
+            expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(invokeAgentSpan!.attributes['sentry.origin'].value).toBe('auto.vercelai.otel');
+            expect(invokeAgentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('invoke_agent');
 
-            // [0] invoke_agent
-            expect(firstSpan!.name).toBe('invoke_agent');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(firstSpan!.attributes['sentry.origin'].value).toBe('auto.vercelai.otel');
-            expect(firstSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('invoke_agent');
-
-            // [1] generate_content (doGenerate)
-            expect(secondSpan!.name).toBe('generateText.doGenerate');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(secondSpan!.attributes['sentry.origin'].value).toBe('auto.vercelai.otel');
-            expect(secondSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+            const generateContentSpan = container.items.find(span => span.name === 'generateText.doGenerate');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.name).toBe('generateText.doGenerate');
+            expect(generateContentSpan!.status).toBe('ok');
+            expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(generateContentSpan!.attributes['sentry.origin'].value).toBe('auto.vercelai.otel');
+            expect(generateContentSpan!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
           },
         })
         .start()
@@ -342,18 +422,18 @@ describe('Vercel AI integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
-
-              // [0] invoke_agent (carries system instructions)
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(firstSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toBe(
+              const invokeAgentSpan = container.items.find(span => span.name === 'invoke_agent');
+              expect(invokeAgentSpan).toBeDefined();
+              expect(invokeAgentSpan!.name).toBe('invoke_agent');
+              expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(invokeAgentSpan!.attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE].value).toBe(
                 JSON.stringify([{ type: 'text', content: 'You are a helpful assistant' }]),
               );
 
-              // [1] generate_content
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              const generateContentSpan = container.items.find(span => span.name === 'generate_content mock-model-id');
+              expect(generateContentSpan).toBeDefined();
+              expect(generateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
             },
           })
           .start()
@@ -374,21 +454,35 @@ describe('Vercel AI integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(4);
-              const [firstSpan, , thirdSpan] = container.items;
-
-              // [0] First call — invoke_agent: last message truncated (only C's remain, D's cropped)
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
+              const truncatedInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.match(/^\[.*"(?:text|content)":"C+".*\]$/),
+              );
+              expect(truncatedInvokeAgentSpan).toBeDefined();
+              expect(truncatedInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(truncatedInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(truncatedInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(
+                3,
+              );
+              expect(truncatedInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toMatch(
                 /^\[.*"(?:text|content)":"C+".*\]$/,
               );
 
-              // [2] Second call — invoke_agent: last message is small and kept intact
-              expect(thirdSpan!.name).toBe('invoke_agent');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain(
+              const smallMessageInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value?.includes(
+                    'This is a small message that fits within the limit',
+                  ),
+              );
+              expect(smallMessageInvokeAgentSpan).toBeDefined();
+              expect(smallMessageInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(smallMessageInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(
+                smallMessageInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value,
+              ).toBe(3);
+              expect(smallMessageInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain(
                 'This is a small message that fits within the limit',
               );
             },
@@ -406,20 +500,24 @@ describe('Vercel AI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
+            const embedSpan = container.items.find(
+              span => span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]?.value === 10,
+            );
+            expect(embedSpan).toBeDefined();
+            expect(embedSpan!.name).toBe('embeddings mock-model-id');
+            expect(embedSpan!.status).toBe('ok');
+            expect(embedSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
+            expect(embedSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
+            expect(embedSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
 
-            // [0] embed doEmbed
-            expect(firstSpan!.name).toBe('embeddings mock-model-id');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
-            expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
-            expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-
-            // [1] embedMany doEmbed
-            expect(secondSpan!.name).toBe('embeddings mock-model-id');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
-            expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(20);
+            const embedManySpan = container.items.find(
+              span => span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]?.value === 20,
+            );
+            expect(embedManySpan).toBeDefined();
+            expect(embedManySpan!.name).toBe('embeddings mock-model-id');
+            expect(embedManySpan!.status).toBe('ok');
+            expect(embedManySpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
+            expect(embedManySpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(20);
           },
         })
         .start()
@@ -434,19 +532,23 @@ describe('Vercel AI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
+            const embedSpan = container.items.find(
+              span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === 'Embedding test!',
+            );
+            expect(embedSpan).toBeDefined();
+            expect(embedSpan!.name).toBe('embeddings mock-model-id');
+            expect(embedSpan!.status).toBe('ok');
+            expect(embedSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
+            expect(embedSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe('Embedding test!');
 
-            // [0] embed doEmbed with input
-            expect(firstSpan!.name).toBe('embeddings mock-model-id');
-            expect(firstSpan!.status).toBe('ok');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
-            expect(firstSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe('Embedding test!');
-
-            // [1] embedMany doEmbed with input
-            expect(secondSpan!.name).toBe('embeddings mock-model-id');
-            expect(secondSpan!.status).toBe('ok');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
-            expect(secondSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe(
+            const embedManySpan = container.items.find(
+              span => span.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE]?.value === '["First input","Second input"]',
+            );
+            expect(embedManySpan).toBeDefined();
+            expect(embedManySpan!.name).toBe('embeddings mock-model-id');
+            expect(embedManySpan!.status).toBe('ok');
+            expect(embedManySpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
+            expect(embedManySpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe(
               '["First input","Second input"]',
             );
           },
@@ -463,17 +565,17 @@ describe('Vercel AI integration', () => {
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);
-            const [firstSpan, secondSpan] = container.items;
+            const invokeAgentSpan = container.items.find(span => span.name === 'invoke_agent');
+            expect(invokeAgentSpan).toBeDefined();
+            expect(invokeAgentSpan!.name).toBe('invoke_agent');
+            expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(invokeAgentSpan!.attributes['gen_ai.conversation.id'].value).toBe('conv-a');
 
-            // [0] invoke_agent with user-set conversation id
-            expect(firstSpan!.name).toBe('invoke_agent');
-            expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(firstSpan!.attributes['gen_ai.conversation.id'].value).toBe('conv-a');
-
-            // [1] generate_content also inherits the conversation id
-            expect(secondSpan!.name).toBe('generate_content mock-model-id');
-            expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-            expect(secondSpan!.attributes['gen_ai.conversation.id'].value).toBe('conv-a');
+            const generateContentSpan = container.items.find(span => span.name === 'generate_content mock-model-id');
+            expect(generateContentSpan).toBeDefined();
+            expect(generateContentSpan!.name).toBe('generate_content mock-model-id');
+            expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(generateContentSpan!.attributes['gen_ai.conversation.id'].value).toBe('conv-a');
           },
         })
         .start()
@@ -494,23 +596,32 @@ describe('Vercel AI integration', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(2);
-              const [firstSpan, secondSpan] = container.items;
-
-              // [0] invoke_agent — input messages preserved in full (no truncation)
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              const invokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    JSON.stringify([
+                      { role: 'user', content: longContent },
+                      { role: 'assistant', content: 'Some reply' },
+                      { role: 'user', content: 'Follow-up question' },
+                    ]),
+              );
+              expect(invokeAgentSpan).toBeDefined();
+              expect(invokeAgentSpan!.name).toBe('invoke_agent');
+              expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(invokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 JSON.stringify([
                   { role: 'user', content: longContent },
                   { role: 'assistant', content: 'Some reply' },
                   { role: 'user', content: 'Follow-up question' },
                 ]),
               );
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
+              expect(invokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE].value).toBe(3);
 
-              // [1] generate_content
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              const generateContentSpan = container.items.find(span => span.name === 'generate_content mock-model-id');
+              expect(generateContentSpan).toBeDefined();
+              expect(generateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
             },
           })
           .start()

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/test.ts
@@ -35,60 +35,94 @@ describe('Vercel AI integration (V5)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(7);
-              const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan, seventhSpan] = container.items;
+              const firstInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes['vercel.ai.operationId'].value === 'ai.generateText' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE] === undefined &&
+                  span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value === 10,
+              );
+              expect(firstInvokeAgentSpan).toBeDefined();
+              expect(firstInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(firstInvokeAgentSpan!.status).toBe('ok');
+              expect(firstInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(firstInvokeAgentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(20);
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(30);
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
 
-              // [0] First generateText — invoke_agent (no explicit telemetry, no PII)
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(firstSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(20);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(30);
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
+              const firstGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes['vercel.ai.operationId'].value === 'ai.generateText.doGenerate' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE] === undefined,
+              );
+              expect(firstGenerateContentSpan).toBeDefined();
+              expect(firstGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(firstGenerateContentSpan!.status).toBe('ok');
+              expect(firstGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              expect(firstGenerateContentSpan!.attributes['vercel.ai.operationId'].value).toBe(
+                'ai.generateText.doGenerate',
+              );
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('mock-provider');
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
 
-              // [1] First generateText — generate_content (doGenerate, no PII)
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(secondSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText.doGenerate');
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('mock-provider');
-              expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
-
-              // [2] Second generateText — invoke_agent (explicit telemetry enabled)
-              expect(thirdSpan!.name).toBe('invoke_agent');
-              expect(thirdSpan!.status).toBe('ok');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              const secondInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    '[{"role":"user","content":"Where is the second span?"}]',
+              );
+              expect(secondInvokeAgentSpan).toBeDefined();
+              expect(secondInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(secondInvokeAgentSpan!.status).toBe('ok');
+              expect(secondInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(secondInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"user","content":"Where is the second span?"}]',
               );
-              expect(thirdSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              expect(secondInvokeAgentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"assistant","parts":[{"type":"text","content":"Second span here!"}],"finish_reason":"stop"}]',
               );
 
-              // [3] Second generateText — generate_content (doGenerate with PII)
-              expect(fourthSpan!.name).toBe('generate_content mock-model-id');
-              expect(fourthSpan!.status).toBe('ok');
-              expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              const secondGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Second span here!'),
+              );
+              expect(secondGenerateContentSpan).toBeDefined();
+              expect(secondGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(secondGenerateContentSpan!.status).toBe('ok');
+              expect(secondGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
 
-              // [4] Third generateText — invoke_agent (with tool call, no PII)
-              expect(fifthSpan!.name).toBe('invoke_agent');
-              expect(fifthSpan!.status).toBe('ok');
+              const toolInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' && span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]?.value === 15,
+              );
+              expect(toolInvokeAgentSpan).toBeDefined();
+              expect(toolInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(toolInvokeAgentSpan!.status).toBe('ok');
 
-              // [5] Third generateText — generate_content (doGenerate)
-              expect(sixthSpan!.name).toBe('generate_content mock-model-id');
-              expect(sixthSpan!.status).toBe('ok');
+              const toolGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]?.value === 15,
+              );
+              expect(toolGenerateContentSpan).toBeDefined();
+              expect(toolGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(toolGenerateContentSpan!.status).toBe('ok');
 
-              // [6] Tool execution
-              expect(seventhSpan!.name).toBe('execute_tool getWeather');
-              expect(seventhSpan!.status).toBe('ok');
-              expect(seventhSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_TYPE_ATTRIBUTE].value).toBe('function');
+              const toolExecutionSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+              expect(toolExecutionSpan).toBeDefined();
+              expect(toolExecutionSpan!.name).toBe('execute_tool getWeather');
+              expect(toolExecutionSpan!.status).toBe('ok');
+              expect(toolExecutionSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_TYPE_ATTRIBUTE].value).toBe('function');
             },
           })
           .start()
@@ -113,65 +147,101 @@ describe('Vercel AI integration (V5)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(7);
-              const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan, seventhSpan] = container.items;
-
-              // [0] First generateText — invoke_agent (PII auto-enabled)
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(firstSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              const firstInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    '[{"role":"user","content":"Where is the first span?"}]',
+              );
+              expect(firstInvokeAgentSpan).toBeDefined();
+              expect(firstInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(firstInvokeAgentSpan!.status).toBe('ok');
+              expect(firstInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(firstInvokeAgentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"user","content":"Where is the first span?"}]',
               );
-              expect(firstSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"assistant","parts":[{"type":"text","content":"First span here!"}],"finish_reason":"stop"}]',
               );
 
-              // [1] First doGenerate with PII
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(secondSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText.doGenerate');
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-              expect(secondSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain('First span here!');
+              const firstGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('First span here!'),
+              );
+              expect(firstGenerateContentSpan).toBeDefined();
+              expect(firstGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(firstGenerateContentSpan!.status).toBe('ok');
+              expect(firstGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              expect(firstGenerateContentSpan!.attributes['vercel.ai.operationId'].value).toBe(
+                'ai.generateText.doGenerate',
+              );
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain(
+                'First span here!',
+              );
 
-              // [2] Second generateText — invoke_agent (explicit telemetry)
-              expect(thirdSpan!.name).toBe('invoke_agent');
-              expect(thirdSpan!.status).toBe('ok');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              const secondInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    '[{"role":"user","content":"Where is the second span?"}]',
+              );
+              expect(secondInvokeAgentSpan).toBeDefined();
+              expect(secondInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(secondInvokeAgentSpan!.status).toBe('ok');
+              expect(secondInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(secondInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"user","content":"Where is the second span?"}]',
               );
 
-              // [3] Second doGenerate
-              expect(fourthSpan!.name).toBe('generate_content mock-model-id');
-              expect(fourthSpan!.status).toBe('ok');
-              expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              const secondGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Second span here!'),
+              );
+              expect(secondGenerateContentSpan).toBeDefined();
+              expect(secondGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(secondGenerateContentSpan!.status).toBe('ok');
+              expect(secondGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
 
-              // [4] Third generateText — invoke_agent (tool call prompt)
-              expect(fifthSpan!.name).toBe('invoke_agent');
-              expect(fifthSpan!.status).toBe('ok');
-              expect(fifthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              const toolInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    '[{"role":"user","content":"What is the weather in San Francisco?"}]',
+              );
+              expect(toolInvokeAgentSpan).toBeDefined();
+              expect(toolInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(toolInvokeAgentSpan!.status).toBe('ok');
+              expect(toolInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"user","content":"What is the weather in San Francisco?"}]',
               );
 
-              // [5] Third doGenerate with available tools
-              expect(sixthSpan!.name).toBe('generate_content mock-model-id');
-              expect(sixthSpan!.status).toBe('ok');
-              expect(sixthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(sixthSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toBeDefined();
-              expect(sixthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+              const toolGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE] !== undefined,
+              );
+              expect(toolGenerateContentSpan).toBeDefined();
+              expect(toolGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(toolGenerateContentSpan!.status).toBe('ok');
+              expect(toolGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              expect(toolGenerateContentSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toBeDefined();
+              expect(toolGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
 
-              // [6] Tool execution with PII
-              expect(seventhSpan!.name).toBe('execute_tool getWeather');
-              expect(seventhSpan!.status).toBe('ok');
-              expect(seventhSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE].value).toBe(
+              const toolExecutionSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+              expect(toolExecutionSpan).toBeDefined();
+              expect(toolExecutionSpan!.name).toBe('execute_tool getWeather');
+              expect(toolExecutionSpan!.status).toBe('ok');
+              expect(toolExecutionSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE].value).toBe(
                 'Get the current weather for a location',
               );
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_INPUT_ATTRIBUTE]).toBeDefined();
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_OUTPUT_ATTRIBUTE]).toBeDefined();
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_INPUT_ATTRIBUTE]).toBeDefined();
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_OUTPUT_ATTRIBUTE]).toBeDefined();
             },
           })
           .start()
@@ -203,22 +273,23 @@ describe('Vercel AI integration (V5)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
+              const invokeAgentSpan = container.items.find(span => span.name === 'invoke_agent');
+              expect(invokeAgentSpan).toBeDefined();
+              expect(invokeAgentSpan!.name).toBe('invoke_agent');
+              expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
 
-              // [0] invoke_agent
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              const generateContentSpan = container.items.find(span => span.name === 'generate_content mock-model-id');
+              expect(generateContentSpan).toBeDefined();
+              expect(generateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(generateContentSpan!.status).toBe('ok');
+              expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
 
-              // [1] generate_content (doGenerate)
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-
-              // [2] execute_tool (errored)
-              expect(thirdSpan!.name).toBe('execute_tool getWeather');
-              expect(thirdSpan!.status).toBe('error');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-              expect(thirdSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+              const toolSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+              expect(toolSpan).toBeDefined();
+              expect(toolSpan!.name).toBe('execute_tool getWeather');
+              expect(toolSpan!.status).toBe('error');
+              expect(toolSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              expect(toolSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
             },
           })
           .expect({
@@ -263,18 +334,20 @@ describe('Vercel AI integration (V5)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(7);
-              const [firstSpan, secondSpan, , , fifthSpan, sixthSpan, seventhSpan] = container.items;
+              const invokeAgentSpans = container.items.filter(
+                span => span.attributes['sentry.op'].value === 'gen_ai.invoke_agent',
+              );
+              expect(invokeAgentSpans).toHaveLength(3);
 
-              // invoke_agent spans at [0], [2], [4]
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(fifthSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              const generateContentSpans = container.items.filter(
+                span => span.attributes['sentry.op'].value === 'gen_ai.generate_content',
+              );
+              expect(generateContentSpans).toHaveLength(3);
 
-              // generate_content spans at [1], [3], [5]
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(sixthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-
-              // execute_tool at [6]
-              expect(seventhSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              const toolSpan = container.items.find(
+                span => span.attributes['sentry.op'].value === 'gen_ai.execute_tool',
+              );
+              expect(toolSpan).toBeDefined();
             },
           })
           .start()

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v6/test.ts
@@ -36,60 +36,94 @@ describe('Vercel AI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(7);
-              const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan, seventhSpan] = container.items;
+              const firstInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes['vercel.ai.operationId'].value === 'ai.generateText' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE] === undefined &&
+                  span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value === 10,
+              );
+              expect(firstInvokeAgentSpan).toBeDefined();
+              expect(firstInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(firstInvokeAgentSpan!.status).toBe('ok');
+              expect(firstInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(firstInvokeAgentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(20);
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(30);
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
 
-              // [0] First generateText — invoke_agent (no explicit telemetry, no PII)
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(firstSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
-              expect(firstSpan!.attributes[GEN_AI_RESPONSE_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
-              expect(firstSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(20);
-              expect(firstSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(30);
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
+              const firstGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes['vercel.ai.operationId'].value === 'ai.generateText.doGenerate' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE] === undefined,
+              );
+              expect(firstGenerateContentSpan).toBeDefined();
+              expect(firstGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(firstGenerateContentSpan!.status).toBe('ok');
+              expect(firstGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              expect(firstGenerateContentSpan!.attributes['vercel.ai.operationId'].value).toBe(
+                'ai.generateText.doGenerate',
+              );
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('mock-provider');
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
 
-              // [1] First generateText — generate_content (doGenerate, no PII)
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(secondSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText.doGenerate');
-              expect(secondSpan!.attributes[GEN_AI_SYSTEM_ATTRIBUTE].value).toBe('mock-provider');
-              expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
-
-              // [2] Second generateText — invoke_agent (explicit telemetry enabled)
-              expect(thirdSpan!.name).toBe('invoke_agent');
-              expect(thirdSpan!.status).toBe('ok');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(thirdSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              const secondInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    '[{"role":"user","content":"Where is the second span?"}]',
+              );
+              expect(secondInvokeAgentSpan).toBeDefined();
+              expect(secondInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(secondInvokeAgentSpan!.status).toBe('ok');
+              expect(secondInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(secondInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"user","content":"Where is the second span?"}]',
               );
-              expect(thirdSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              expect(secondInvokeAgentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"assistant","parts":[{"type":"text","content":"Second span here!"}],"finish_reason":"stop"}]',
               );
 
-              // [3] Second generateText — generate_content (doGenerate with PII)
-              expect(fourthSpan!.name).toBe('generate_content mock-model-id');
-              expect(fourthSpan!.status).toBe('ok');
-              expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              const secondGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Second span here!'),
+              );
+              expect(secondGenerateContentSpan).toBeDefined();
+              expect(secondGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(secondGenerateContentSpan!.status).toBe('ok');
+              expect(secondGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
 
-              // [4] Third generateText — invoke_agent (with tool call, no PII)
-              expect(fifthSpan!.name).toBe('invoke_agent');
-              expect(fifthSpan!.status).toBe('ok');
+              const toolInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' && span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]?.value === 15,
+              );
+              expect(toolInvokeAgentSpan).toBeDefined();
+              expect(toolInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(toolInvokeAgentSpan!.status).toBe('ok');
 
-              // [5] Third generateText — generate_content (doGenerate)
-              expect(sixthSpan!.name).toBe('generate_content mock-model-id');
-              expect(sixthSpan!.status).toBe('ok');
+              const toolGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]?.value === 15,
+              );
+              expect(toolGenerateContentSpan).toBeDefined();
+              expect(toolGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(toolGenerateContentSpan!.status).toBe('ok');
 
-              // [6] Tool execution
-              expect(seventhSpan!.name).toBe('execute_tool getWeather');
-              expect(seventhSpan!.status).toBe('ok');
-              expect(seventhSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_TYPE_ATTRIBUTE].value).toBe('function');
+              const toolExecutionSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+              expect(toolExecutionSpan).toBeDefined();
+              expect(toolExecutionSpan!.name).toBe('execute_tool getWeather');
+              expect(toolExecutionSpan!.status).toBe('ok');
+              expect(toolExecutionSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_TYPE_ATTRIBUTE].value).toBe('function');
             },
           })
           .start()
@@ -114,62 +148,98 @@ describe('Vercel AI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(7);
-              const [firstSpan, secondSpan, thirdSpan, fourthSpan, fifthSpan, sixthSpan, seventhSpan] = container.items;
-
-              // [0] First generateText — invoke_agent (PII auto-enabled)
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(firstSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
-              expect(firstSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              const firstInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    '[{"role":"user","content":"Where is the first span?"}]',
+              );
+              expect(firstInvokeAgentSpan).toBeDefined();
+              expect(firstInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(firstInvokeAgentSpan!.status).toBe('ok');
+              expect(firstInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(firstInvokeAgentSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText');
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"user","content":"Where is the first span?"}]',
               );
-              expect(firstSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              expect(firstInvokeAgentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"assistant","parts":[{"type":"text","content":"First span here!"}],"finish_reason":"stop"}]',
               );
 
-              // [1] First doGenerate with PII
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(secondSpan!.attributes['vercel.ai.operationId'].value).toBe('ai.generateText.doGenerate');
-              expect(secondSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
-              expect(secondSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain('First span here!');
+              const firstGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('First span here!'),
+              );
+              expect(firstGenerateContentSpan).toBeDefined();
+              expect(firstGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(firstGenerateContentSpan!.status).toBe('ok');
+              expect(firstGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              expect(firstGenerateContentSpan!.attributes['vercel.ai.operationId'].value).toBe(
+                'ai.generateText.doGenerate',
+              );
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeDefined();
+              expect(firstGenerateContentSpan!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain(
+                'First span here!',
+              );
 
-              // [2] Second generateText — invoke_agent (explicit telemetry)
-              expect(thirdSpan!.name).toBe('invoke_agent');
-              expect(thirdSpan!.status).toBe('ok');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              const secondInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    '[{"role":"user","content":"Where is the second span?"}]',
+              );
+              expect(secondInvokeAgentSpan).toBeDefined();
+              expect(secondInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(secondInvokeAgentSpan!.status).toBe('ok');
+              expect(secondInvokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
 
-              // [3] Second doGenerate
-              expect(fourthSpan!.name).toBe('generate_content mock-model-id');
-              expect(fourthSpan!.status).toBe('ok');
-              expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              const secondGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes('Second span here!'),
+              );
+              expect(secondGenerateContentSpan).toBeDefined();
+              expect(secondGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(secondGenerateContentSpan!.status).toBe('ok');
+              expect(secondGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
 
-              // [4] Third generateText — invoke_agent (tool call prompt)
-              expect(fifthSpan!.name).toBe('invoke_agent');
-              expect(fifthSpan!.status).toBe('ok');
-              expect(fifthSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
+              const toolInvokeAgentSpan = container.items.find(
+                span =>
+                  span.name === 'invoke_agent' &&
+                  span.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]?.value ===
+                    '[{"role":"user","content":"What is the weather in San Francisco?"}]',
+              );
+              expect(toolInvokeAgentSpan).toBeDefined();
+              expect(toolInvokeAgentSpan!.name).toBe('invoke_agent');
+              expect(toolInvokeAgentSpan!.status).toBe('ok');
+              expect(toolInvokeAgentSpan!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toBe(
                 '[{"role":"user","content":"What is the weather in San Francisco?"}]',
               );
 
-              // [5] Third doGenerate with available tools
-              expect(sixthSpan!.name).toBe('generate_content mock-model-id');
-              expect(sixthSpan!.status).toBe('ok');
-              expect(sixthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(sixthSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toBeDefined();
-              expect(sixthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+              const toolGenerateContentSpan = container.items.find(
+                span =>
+                  span.name === 'generate_content mock-model-id' &&
+                  span.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE] !== undefined,
+              );
+              expect(toolGenerateContentSpan).toBeDefined();
+              expect(toolGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(toolGenerateContentSpan!.status).toBe('ok');
+              expect(toolGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              expect(toolGenerateContentSpan!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toBeDefined();
+              expect(toolGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
 
-              // [6] Tool execution with PII
-              expect(seventhSpan!.name).toBe('execute_tool getWeather');
-              expect(seventhSpan!.status).toBe('ok');
-              expect(seventhSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE].value).toBe(
+              const toolExecutionSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+              expect(toolExecutionSpan).toBeDefined();
+              expect(toolExecutionSpan!.name).toBe('execute_tool getWeather');
+              expect(toolExecutionSpan!.status).toBe('ok');
+              expect(toolExecutionSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE].value).toBe(
                 'Get the current weather for a location',
               );
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_INPUT_ATTRIBUTE]).toBeDefined();
-              expect(seventhSpan!.attributes[GEN_AI_TOOL_OUTPUT_ATTRIBUTE]).toBeDefined();
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_INPUT_ATTRIBUTE]).toBeDefined();
+              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_OUTPUT_ATTRIBUTE]).toBeDefined();
             },
           })
           .start()
@@ -201,22 +271,23 @@ describe('Vercel AI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(3);
-              const [firstSpan, secondSpan, thirdSpan] = container.items;
+              const invokeAgentSpan = container.items.find(span => span.name === 'invoke_agent');
+              expect(invokeAgentSpan).toBeDefined();
+              expect(invokeAgentSpan!.name).toBe('invoke_agent');
+              expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
 
-              // [0] invoke_agent
-              expect(firstSpan!.name).toBe('invoke_agent');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              const generateContentSpan = container.items.find(span => span.name === 'generate_content mock-model-id');
+              expect(generateContentSpan).toBeDefined();
+              expect(generateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(generateContentSpan!.status).toBe('ok');
+              expect(generateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
 
-              // [1] generate_content (doGenerate)
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-
-              // [2] execute_tool (errored)
-              expect(thirdSpan!.name).toBe('execute_tool getWeather');
-              expect(thirdSpan!.status).toBe('error');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-              expect(thirdSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+              const toolSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+              expect(toolSpan).toBeDefined();
+              expect(toolSpan!.name).toBe('execute_tool getWeather');
+              expect(toolSpan!.status).toBe('error');
+              expect(toolSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              expect(toolSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
             },
           })
           .expect({
@@ -261,18 +332,20 @@ describe('Vercel AI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(7);
-              const [firstSpan, secondSpan, , , fifthSpan, sixthSpan, seventhSpan] = container.items;
+              const invokeAgentSpans = container.items.filter(
+                span => span.attributes['sentry.op'].value === 'gen_ai.invoke_agent',
+              );
+              expect(invokeAgentSpans).toHaveLength(3);
 
-              // invoke_agent spans at [0], [2], [4]
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(fifthSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              const generateContentSpans = container.items.filter(
+                span => span.attributes['sentry.op'].value === 'gen_ai.generate_content',
+              );
+              expect(generateContentSpans).toHaveLength(3);
 
-              // generate_content spans at [1], [3], [5]
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(sixthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-
-              // execute_tool at [6]
-              expect(seventhSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              const toolSpan = container.items.find(
+                span => span.attributes['sentry.op'].value === 'gen_ai.execute_tool',
+              );
+              expect(toolSpan).toBeDefined();
             },
           })
           .start()
@@ -297,37 +370,41 @@ describe('Vercel AI integration (V6)', () => {
           .expect({
             span: container => {
               expect(container.items).toHaveLength(4);
-              const [firstSpan, secondSpan, thirdSpan, fourthSpan] = container.items;
+              const invokeAgentSpan = container.items.find(span => span.name === 'invoke_agent weather_agent');
+              expect(invokeAgentSpan).toBeDefined();
+              expect(invokeAgentSpan!.name).toBe('invoke_agent weather_agent');
+              expect(invokeAgentSpan!.status).toBe('ok');
+              expect(invokeAgentSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(invokeAgentSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
 
-              // [0] invoke_agent (ToolLoopAgent outer span)
-              expect(firstSpan!.name).toBe('invoke_agent weather_agent');
-              expect(firstSpan!.status).toBe('ok');
-              expect(firstSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-              expect(firstSpan!.attributes[GEN_AI_REQUEST_MODEL_ATTRIBUTE].value).toBe('mock-model-id');
+              const toolCallsGenerateContentSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]?.value === '["tool-calls"]',
+              );
+              expect(toolCallsGenerateContentSpan).toBeDefined();
+              expect(toolCallsGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(toolCallsGenerateContentSpan!.status).toBe('ok');
+              expect(toolCallsGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              expect(toolCallsGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
+              expect(toolCallsGenerateContentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(20);
 
-              // [1] First doGenerate (returns tool-calls)
-              expect(secondSpan!.name).toBe('generate_content mock-model-id');
-              expect(secondSpan!.status).toBe('ok');
-              expect(secondSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(secondSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["tool-calls"]');
-              expect(secondSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(10);
-              expect(secondSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(20);
+              const toolSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+              expect(toolSpan).toBeDefined();
+              expect(toolSpan!.name).toBe('execute_tool getWeather');
+              expect(toolSpan!.status).toBe('ok');
+              expect(toolSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              expect(toolSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+              expect(toolSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
+              expect(toolSpan!.attributes[GEN_AI_TOOL_TYPE_ATTRIBUTE].value).toBe('function');
 
-              // [2] Tool execution
-              expect(thirdSpan!.name).toBe('execute_tool getWeather');
-              expect(thirdSpan!.status).toBe('ok');
-              expect(thirdSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-              expect(thirdSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
-              expect(thirdSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
-              expect(thirdSpan!.attributes[GEN_AI_TOOL_TYPE_ATTRIBUTE].value).toBe('function');
-
-              // [3] Second doGenerate (returns final text)
-              expect(fourthSpan!.name).toBe('generate_content mock-model-id');
-              expect(fourthSpan!.status).toBe('ok');
-              expect(fourthSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
-              expect(fourthSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE].value).toBe('["stop"]');
-              expect(fourthSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
-              expect(fourthSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(25);
+              const finalGenerateContentSpan = container.items.find(
+                span => span.attributes[GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE]?.value === '["stop"]',
+              );
+              expect(finalGenerateContentSpan).toBeDefined();
+              expect(finalGenerateContentSpan!.name).toBe('generate_content mock-model-id');
+              expect(finalGenerateContentSpan!.status).toBe('ok');
+              expect(finalGenerateContentSpan!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+              expect(finalGenerateContentSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(15);
+              expect(finalGenerateContentSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(25);
             },
           })
           .start()


### PR DESCRIPTION
Instead of asserting gen_ai spans order, we follow the common streaming approach of finding the spans by name and asserting existence.

Closes: #20812