### PR TITLE
ci: Ensure PR reminder workflow considers new sub teams

### DIFF
--- a/scripts/pr-review-reminder.mjs
+++ b/scripts/pr-review-reminder.mjs
@@ -8,7 +8,7 @@
  * @mentions are narrowed as follows:
  * - Individual users: not [outside collaborators](https://docs.github.com/en/organizations/managing-outside-collaborators)
  *   on this repo (via `repos.listCollaborators` with `affiliation: outside` — repo-scoped, no extra token).
- * - Team reviewers: only the org team `team-javascript-sdks` (by slug).
+ * - Team reviewers: only org teams in `SDK_TEAM_SLUGS` (by slug).
  *
  * Business days exclude weekends and a small set of recurring public holidays
  * (same calendar date each year) for US, CA, and AT.
@@ -21,8 +21,13 @@
  *   await run({ github, context, core });
  */
 
-// Team @mentions only for this slug. Individuals are filtered using outside-collaborator list (see below).
-const SDK_TEAM_SLUG = 'team-javascript-sdks';
+// Team @mentions only for these slugs. Individuals are filtered using outside-collaborator list (see below).
+const SDK_TEAM_SLUGS = new Set([
+  'team-javascript-sdks',
+  'team-javascript-sdks-framework',
+  'team-javascript-sdks-browser',
+  'team-javascript-sdks-server',
+]);
 
 // ---------------------------------------------------------------------------
 // Outside collaborators (repo API — works with default GITHUB_TOKEN).
@@ -254,7 +259,7 @@ export default async function run({ github, context, core }) {
 
     // Collect overdue team reviewers
     for (const team of pendingTeams) {
-      if (team.slug !== SDK_TEAM_SLUG) {
+      if (!SDK_TEAM_SLUGS.has(team.slug)) {
         continue;
       }
 


### PR DESCRIPTION
I noticed that we forgot to adjust this so it also reminds the new sub teams.