### PR TITLE
fix(core): Include subpath type shims in published package

### DIFF
--- a/packages/core/browser.d.ts
+++ b/packages/core/browser.d.ts
@@ -1,0 +1,4 @@
+// This file is a compatibility shim for TypeScript compilers that do not
+// support the package.json `exports` field for resolving subpath exports.
+// Note: `typesVersions` in package.json may redirect this to the downleveled variant.
+export * from './build/types/browser';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,9 @@
   "files": [
     "/build",
     "browser.js",
-    "server.js"
+    "browser.d.ts",
+    "server.js",
+    "server.d.ts"
   ],
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
@@ -54,6 +56,12 @@
     "<5.0": {
       "build/types/index.d.ts": [
         "build/types-ts3.8/index.d.ts"
+      ],
+      "browser": [
+        "build/types-ts3.8/browser.d.ts"
+      ],
+      "server": [
+        "build/types-ts3.8/server.d.ts"
       ]
     }
   },

--- a/packages/core/server.d.ts
+++ b/packages/core/server.d.ts
@@ -1,0 +1,4 @@
+// This file is a compatibility shim for TypeScript compilers that do not
+// support the package.json `exports` field for resolving subpath exports.
+// Note: `typesVersions` in package.json may redirect this to the downleveled variant.
+export * from './build/types/server';


### PR DESCRIPTION
## Summary

- Adds `browser.d.ts` and `server.d.ts` to the `files` list in `@sentry/core` `package.json` so they are included in the published npm tarball
- Adds `typesVersions` entries for `browser` and `server` subpaths to support TypeScript < 5.0

## Context

PR [#20435](https://github.com/getsentry/sentry-javascript/pull/20435) introduced `@sentry/core/browser` and `@sentry/core/server` subpath exports and added root-level `.d.ts` shim files for compatibility with TypeScript compilers that don't support the `exports` field (e.g. `moduleResolution: "node"`). However, the `.d.ts` shims were not added to the `files` list, so they were excluded from the published `10.53.0` tarball.

This breaks downstream consumers like `@sentry/react-native` ([getsentry/sentry-react-native#6139](https://github.com/getsentry/sentry-react-native/pull/6139)) — their TS compiler can't resolve `@sentry/core/browser`, causing `BaseTransportOptions` to become unresolvable and `ReactNativeTransportOptions` to fail the type constraint check:

```
error TS2344: Type 'ReactNativeTransportOptions' does not satisfy the constraint 'BaseTransportOptions'.
  Type 'ReactNativeTransportOptions' is missing the following properties from type 'BaseTransportOptions': url, recordDroppedEvent
```

## Test plan

- [ ] Verify `npm pack --dry-run` includes `browser.d.ts` and `server.d.ts` at the package root
- [ ] Verify `@sentry/react-native` builds successfully against a patched `@sentry/core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)