### PR TITLE
chore: Update claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,7 +29,13 @@
       "WebFetch(domain:docs.sentry.io)",
       "WebFetch(domain:develop.sentry.dev)",
       "Bash(grep:*)",
-      "Bash(mv:*)"
+      "Bash(mv:*)",
+      "Bash(npm view:*)",
+      "Bash(gh search:*)",
+      "Edit(/**)",
+      "Write(/**)",
+      "MultiEdit(/**)",
+      "NotebookEdit(/**)"
     ],
     "deny": []
   }


### PR DESCRIPTION
I find myself constantly allowing this - any reasons not to do this?

This allows the following for claude:

```
"Bash(mv:*)",
"Bash(npm view:*)",
"Bash(gh search:*)",
"Edit(/**)",
"Write(/**)",
"MultiEdit(/**)",
"NotebookEdit(/**)"
```

the `/**` allows edits in the repo itself only.