### PR TITLE
chore(build): Improve `makeProductionReplacePlugin` usage

### DIFF
--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -154,8 +154,9 @@ export function makeNPMConfigVariants(baseConfig, options = {}) {
         output: {
           format: 'esm',
           dir: path.join(baseConfig.output.dir, 'esm/prod'),
-          plugins: [makeProductionReplacePlugin(), makePackageNodeEsm()],
+          plugins: [makePackageNodeEsm()],
         },
+        plugins: [makeProductionReplacePlugin()],
       });
     } else {
       variantSpecificConfigs.push({
@@ -168,7 +169,13 @@ export function makeNPMConfigVariants(baseConfig, options = {}) {
     }
   }
 
-  return variantSpecificConfigs.map(variant => deepMerge(baseConfig, variant));
+  return variantSpecificConfigs.map(variant =>
+    // Plugin arrays must be merged in the right order or the build silently misbehaves
+    // (e.g. esbuild strips dev-mode marker comments before the replace plugin can act).
+    deepMerge(baseConfig, variant, {
+      customMerge: key => (key === 'plugins' ? mergePlugins : undefined),
+    }),
+  );
 }
 
 /**

--- a/dev-packages/rollup-utils/plugins/npmPlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/npmPlugins.mjs
@@ -125,17 +125,13 @@ export function makeDebugBuildStatementReplacePlugin() {
 export function makeProductionReplacePlugin() {
   const pattern = /\/\* rollup-include-development-only \*\/[\s\S]*?\/\* rollup-include-development-only-end \*\/\s*/g;
 
-  function stripDevBlocks(code) {
-    if (!code) return null;
-    if (!code.includes('rollup-include-development-only')) return null;
-    const replaced = code.replace(pattern, '');
-    return { code: replaced, map: null };
-  }
-
+  // This must run before transpilation, as that will strip the marker comments.
+  // The plugin sort order in utils.mjs pins this to run first
   return {
     name: 'remove-dev-mode-blocks',
-    renderChunk(code) {
-      return stripDevBlocks(code);
+    transform(code) {
+      if (!code.includes('rollup-include-development-only')) return null;
+      return { code: code.replace(pattern, ''), map: null };
     },
   };
 }


### PR DESCRIPTION
Small ref. that claude prompted me to do and IMHO it makes sense.

This moves the production replace plugin (only used in browser SDK to strip spotlight for prod) to run via transform, so this runs on module level, not on output chunks. 