### PR TITLE
test(cloudflare): Retry until ready

### DIFF
--- a/dev-packages/cloudflare-integration-tests/runner.ts
+++ b/dev-packages/cloudflare-integration-tests/runner.ts
@@ -18,6 +18,29 @@ export function cleanupChildProcesses(): void {
 
 process.on('exit', cleanupChildProcesses);
 
+// Wrangler can report "Ready" before it can actually handle requests.
+// This retries fetch on connection errors to handle this race condition.
+async function fetchWithRetry(url: string, init: RequestInit, maxRetries = 10, retryDelayMs = 200): Promise<Response> {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return await fetch(url, init);
+    } catch (e) {
+      const isConnectionError =
+        e instanceof Error && (e.message.includes('ECONNREFUSED') || e.message.includes('fetch failed'));
+
+      if (isConnectionError && attempt < maxRetries - 1) {
+        if (process.env.DEBUG) log(`Request failed, retrying (attempt ${attempt + 1}/${maxRetries})...`);
+        await new Promise(r => setTimeout(r, retryDelayMs));
+        continue;
+      }
+
+      throw e;
+    }
+  }
+
+  throw new Error('fetchWithRetry: unreachable');
+}
+
 function deferredPromise<T = void>(
   done?: () => void,
 ): { resolve: (val: T) => void; reject: (reason?: unknown) => void; promise: Promise<T> } {
@@ -316,7 +339,7 @@ export function createRunner(...paths: string[]) {
           if (process.env.DEBUG) log('making request', method, url, headers, body);
 
           try {
-            const res = await fetch(url, { headers, method, body });
+            const res = await fetchWithRetry(url, { headers, method, body });
 
             if (!res.ok) {
               if (!expectError) {


### PR DESCRIPTION
closes #20674
closes [JS-2356](https://linear.app/getsentry/issue/JS-2356/flaky-ci-cloudflare-integration-tests-suitestracingdurableobjecttestts)

closes #20700
closes [JS-2369](https://linear.app/getsentry/issue/JS-2369/flaky-ci-cloudflare-integration-tests-suitestracingpropagationworker)

closes #20701
closes [JS-2370](https://linear.app/getsentry/issue/JS-2370/flaky-ci-cloudflare-integration-tests-unhandled-error)

It happens that the worker shows that it is ready, but is actually not yet ready to accept requests. With that we retry when `ECONNREFUSED` or a `fetch failed` happened. So we are actually waiting for the worker to be ready.