### PR TITLE
chore(deps): Remove redundant yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,19 +150,11 @@
     "yalc": "^1.0.0-pre.53",
     "yarn-deduplicate": "6.0.2"
   },
-  "//_resolutions_comment": [
-    "Because new versions of strip-ansi, string-width, and wrap-ansi are ESM only packages,",
-    "we need to resolve them to the CommonJS versions."
-  ],
   "resolutions": {
     "**/nx/minimatch": "10.2.5",
     "**/ng-packagr/postcss-url/minimatch": "3.1.5",
     "**/@angular-devkit/build-angular/minimatch": "5.1.9",
-    "gauge/strip-ansi": "6.0.1",
-    "wide-align/string-width": "4.2.3",
-    "cliui/wrap-ansi": "7.0.0",
     "sucrase": "getsentry/sucrase#es2020-polyfills",
-    "**/express/path-to-regexp": "0.1.12",
     "**/nitropack/rollup-plugin-visualizer": "^6.0.3"
   },
   "version": "0.0.0",


### PR DESCRIPTION
## Summary

Drops four `resolutions` overrides in the root `package.json` that no longer change anything. For each, the parent package's own dependency range already restricts the transitive dep to the same (CJS) version that yarn would naturally select. Also drops the now-orphaned `//_resolutions_comment` (its three target packages — strip-ansi, string-width, wrap-ansi — are all removed here).

Removed:
- `gauge/strip-ansi: 6.0.1` — gauge@4.0.4 already pins `strip-ansi: ^6.0.1`
- `wide-align/string-width: 4.2.3` — wide-align@1.1.5 already constrains to `^1.0.2 || 2 || 3 || 4`
- `cliui/wrap-ansi: 7.0.0` — cliui@7.0.4 already pins `wrap-ansi: ^7.0.0`
- `**/express/path-to-regexp: 0.1.12` — express@4.22.1 already pins `~0.1.12`

Kept:
- 3× minimatch overrides — each actively pins a patched version (security fix; the parent requests a vulnerable version)
- `sucrase` fork — intentional, used for ES2020 polyfill control
- `**/nitropack/rollup-plugin-visualizer` — kept for now

Verified: `yarn install` after the change reports `Already up-to-date` — lockfile is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)