### PR TITLE
fix(tests): pin wrangler to 4.86.0 in E2E test apps

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/package.json
@@ -18,7 +18,7 @@
     "astro": "^5.17.1"
   },
   "devDependencies": {
-    "wrangler": "^4.63.0"
+    "wrangler": "4.86.0"
   },
   "volta": {
     "node": "24.15.0",

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
@@ -19,7 +19,7 @@
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",
     "astro": "^6.0.0",
-    "wrangler": "4.86.0"
+    "wrangler": "4.91.0"
   },
   "volta": {
     "node": "24.15.0",

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
@@ -19,7 +19,7 @@
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",
     "astro": "^6.0.0",
-    "wrangler": "^4.72.0"
+    "wrangler": "4.86.0"
   },
   "volta": {
     "node": "24.15.0",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-hono/package.json
@@ -19,7 +19,7 @@
     "@cloudflare/workers-types": "^4.20250521.0",
     "typescript": "^5.9.3",
     "vitest": "3.1.0",
-    "wrangler": "^4.61.0"
+    "wrangler": "4.86.0"
   },
   "volta": {
     "node": "24.15.0",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/package.json
@@ -24,7 +24,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",
     "vitest": "~3.2.0",
-    "wrangler": "^4.61.0",
+    "wrangler": "4.86.0",
     "ws": "^8.18.3"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
@@ -24,7 +24,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^6.0.3",
-    "wrangler": "^4.86.0"
+    "wrangler": "4.86.0"
   },
   "volta": {
     "node": "24.15.0",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
@@ -27,7 +27,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",
     "vitest": "~3.2.0",
-    "wrangler": "^4.61.0",
+    "wrangler": "4.86.0",
     "ws": "^8.18.3"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-streaming/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-streaming/package.json
@@ -24,7 +24,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",
     "vitest": "~3.2.0",
-    "wrangler": "^4.61.0",
+    "wrangler": "4.86.0",
     "ws": "^8.18.3"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers/package.json
@@ -24,7 +24,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",
     "vitest": "~3.2.0",
-    "wrangler": "^4.61.0",
+    "wrangler": "4.86.0",
     "ws": "^8.18.3"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/package.json
@@ -24,7 +24,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",
     "vitest": "~3.2.0",
-    "wrangler": "^4.61.0",
+    "wrangler": "4.86.0",
     "ws": "^8.18.3"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -25,7 +25,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "tsx": "^4.20.3",
     "typescript": "^5.5.2",
-    "wrangler": "^4.61.0"
+    "wrangler": "4.86.0"
   },
   "volta": {
     "node": "24.15.0",

--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -23,7 +23,7 @@
     "@playwright/test": "~1.56.0",
     "@cloudflare/workers-types": "^4.20240725.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
-    "tsx": "^4.20.3",
+    "tsx": "4.21.0",
     "typescript": "^5.5.2",
     "wrangler": "4.86.0"
   },

--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -35,7 +35,6 @@
     "variants": [
       {
         "assert-command": "RUNTIME=node pnpm test:assert",
-        "build-command": "pnpm install",
         "label": "hono-4 (node)"
       },
       {

--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -35,6 +35,7 @@
     "variants": [
       {
         "assert-command": "RUNTIME=node pnpm test:assert",
+        "build-command": "pnpm install",
         "label": "hono-4 (node)"
       },
       {

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -33,7 +33,7 @@
     "eslint": "^9",
     "eslint-config-next": "^16",
     "typescript": "^5",
-    "wrangler": "^4.61.0"
+    "wrangler": "4.86.0"
   },
   "volta": {
     "node": "24.15.0",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
@@ -26,7 +26,7 @@
     "svelte-check": "^4.1.4",
     "typescript": "^5.0.0",
     "vite": "^6.4.2",
-    "wrangler": "^4.61.0"
+    "wrangler": "4.86.0"
   },
   "volta": {
     "node": "24.15.0",

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
@@ -32,7 +32,7 @@
     "typescript": "^5.9.0",
     "vite": "7.3.1",
     "vite-tsconfig-paths": "^5.1.4",
-    "wrangler": "^4.68.1"
+    "wrangler": "4.86.0"
   },
   "volta": {
     "node": "24.15.0",


### PR DESCRIPTION
This PR pins wrangler to `4.86.0` across all 13 E2E test apps that use it, looks like versions before 4.86.0 have a bug that corrupts `package.json` files in `node_modules` by overwriting them with ESM bundle output during builds.

This was causing the `hono-4` E2E test (and potentially others) to fail with `SyntaxError: Unexpected token 'v', "var name=""... is not valid JSON` on `@fastify/otel`'s `package.json`

Ref: https://github.com/cloudflare/workers-sdk/issues/13762