### PR TITLE
fix(tests): pin tsx to 4.21.0 in hono-4 E2E test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -23,7 +23,7 @@
     "@playwright/test": "~1.56.0",
     "@cloudflare/workers-types": "^4.20240725.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
-    "tsx": "^4.20.3",
+    "tsx": "4.21.0",
     "typescript": "^5.5.2",
     "wrangler": "^4.61.0"
   },


### PR DESCRIPTION
tsx 4.21.1, published today, introduced a regression where its ESM loader transforms `.json` files into ESM output. This breaks `@fastify/otel`, which does a CJS `require('./package.json')` and gets `var name="@fastify/otel"...` instead of valid JSON, crashing the hono-4 (node) E2E test.

Pinning tsx to 4.21.0 avoids the regression.