### PR TITLE
ref(node): Vendor lru-memoizer instrumentation

### DIFF
--- a/.oxlintrc.base.json
+++ b/.oxlintrc.base.json
@@ -141,13 +141,6 @@
       }
     },
     {
-      "files": ["**/integrations/tracing/lrumemoizer/vendored/**/*.ts"],
-      "rules": {
-        "typescript/no-explicit-any": "off",
-        "max-lines": "off"
-      }
-    },
-    {
       "files": ["**/scenarios/**", "**/rollup-utils/**"],
       "rules": {
         "no-console": "off"

--- a/.oxlintrc.base.json
+++ b/.oxlintrc.base.json
@@ -141,6 +141,13 @@
       }
     },
     {
+      "files": ["**/integrations/tracing/lrumemoizer/vendored/**/*.ts"],
+      "rules": {
+        "typescript/no-explicit-any": "off",
+        "max-lines": "off"
+      }
+    },
+    {
       "files": ["**/scenarios/**", "**/rollup-utils/**"],
       "rules": {
         "no-console": "off"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -79,7 +79,6 @@
     "@opentelemetry/instrumentation-kafkajs": "0.23.0",
     "@opentelemetry/instrumentation-knex": "0.58.0",
     "@opentelemetry/instrumentation-koa": "0.62.0",
-    "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
     "@opentelemetry/instrumentation-mongodb": "0.67.0",
     "@opentelemetry/instrumentation-mongoose": "0.60.0",
     "@opentelemetry/instrumentation-mysql": "0.60.0",

--- a/packages/node/src/integrations/tracing/lrumemoizer/index.ts
+++ b/packages/node/src/integrations/tracing/lrumemoizer/index.ts
@@ -1,4 +1,4 @@
-import { LruMemoizerInstrumentation } from '@opentelemetry/instrumentation-lru-memoizer';
+import { LruMemoizerInstrumentation } from './vendored/instrumentation';
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';

--- a/packages/node/src/integrations/tracing/lrumemoizer/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/lrumemoizer/vendored/instrumentation.ts
@@ -17,6 +17,7 @@
  * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-lru-memoizer
  * - Upstream version: @opentelemetry/instrumentation-lru-memoizer@0.62.0
  */
+/* eslint-disable */
 
 import { context } from '@opentelemetry/api';
 import {

--- a/packages/node/src/integrations/tracing/lrumemoizer/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/lrumemoizer/vendored/instrumentation.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-lru-memoizer
+ * - Upstream version: @opentelemetry/instrumentation-lru-memoizer@0.58.0
+ */
+/* eslint-disable */
+
+import { context } from '@opentelemetry/api';
+import {
+  InstrumentationBase,
+  InstrumentationConfig,
+  InstrumentationNodeModuleDefinition,
+} from '@opentelemetry/instrumentation';
+import { SDK_VERSION } from '@sentry/core';
+
+const PACKAGE_NAME = '@sentry/instrumentation-lru-memoizer';
+
+export class LruMemoizerInstrumentation extends InstrumentationBase {
+  constructor(config: InstrumentationConfig = {}) {
+    super(PACKAGE_NAME, SDK_VERSION, config);
+  }
+
+  init(): InstrumentationNodeModuleDefinition[] {
+    return [
+      new InstrumentationNodeModuleDefinition(
+        'lru-memoizer',
+        ['>=1.3 <4'],
+        moduleExports => {
+          // moduleExports is a function which receives an options object,
+          // and returns a "memoizer" function upon invocation.
+          // We want to patch this "memoizer's" internal function
+          const asyncMemoizer = function (this: unknown) {
+            // This following function is invoked every time the user wants to get a (possible) memoized value
+            // We replace it with another function in which we bind the current context to the last argument (callback)
+            const origMemoizer = moduleExports.apply(this, arguments);
+            return function (this: unknown) {
+              const modifiedArguments = [...arguments];
+              // last argument is the callback
+              const origCallback = modifiedArguments.pop();
+              const callbackWithContext =
+                typeof origCallback === 'function' ? context.bind(context.active(), origCallback) : origCallback;
+              modifiedArguments.push(callbackWithContext);
+              return origMemoizer.apply(this, modifiedArguments);
+            };
+          };
+
+          // sync function preserves context, but we still need to export it
+          // as the lru-memoizer package does
+          asyncMemoizer.sync = moduleExports.sync;
+          return asyncMemoizer;
+        },
+        undefined, // no need to disable as this instrumentation does not create any spans
+      ),
+    ];
+  }
+}

--- a/packages/node/src/integrations/tracing/lrumemoizer/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/lrumemoizer/vendored/instrumentation.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * NOTICE from the Sentry authors:
- * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-lru-memoizer
- * - Upstream version: @opentelemetry/instrumentation-lru-memoizer@0.58.0
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-lru-memoizer
+ * - Upstream version: @opentelemetry/instrumentation-lru-memoizer@0.62.0
  */
 /* eslint-disable */
 

--- a/packages/node/src/integrations/tracing/lrumemoizer/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/lrumemoizer/vendored/instrumentation.ts
@@ -17,7 +17,6 @@
  * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-lru-memoizer
  * - Upstream version: @opentelemetry/instrumentation-lru-memoizer@0.62.0
  */
-/* eslint-disable */
 
 import { context } from '@opentelemetry/api';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6289,13 +6289,6 @@
     "@opentelemetry/instrumentation" "^0.214.0"
     "@opentelemetry/semantic-conventions" "^1.36.0"
 
-"@opentelemetry/instrumentation-lru-memoizer@0.58.0":
-  version "0.58.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz#7c730a0cb963e8ac5f3d11023518050e5f124a6a"
-  integrity sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==
-  dependencies:
-    "@opentelemetry/instrumentation" "^0.214.0"
-
 "@opentelemetry/instrumentation-mongodb@0.67.0":
   version "0.67.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz#ac45611586e363e2d96c735d50f97556dd33c37e"


### PR DESCRIPTION
Vendors `@opentelemetry/instrumentation-lru-memoizer` into the SDK with no logic changes.

Closes https://github.com/getsentry/sentry-javascript/issues/20156