### PR TITLE
fix(hono): Preserve middleware handler metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-Work in this release was contributed by @abcang. Thank you for your contribution!
+Work in this release was contributed by @abcang and @ahmadio. Thank you for your contributions!
 
 - **feat(core): Support array attributes for spans, logs, and metrics ([#20427](https://github.com/getsentry/sentry-javascript/pull/20427))**
 

--- a/packages/hono/src/shared/wrapMiddlewareSpan.ts
+++ b/packages/hono/src/shared/wrapMiddlewareSpan.ts
@@ -3,7 +3,6 @@ import {
   getActiveSpan,
   getOriginalFunction,
   getRootSpan,
-  markFunctionWrapped,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
@@ -26,36 +25,42 @@ export function wrapMiddlewareWithSpan(handler: MiddlewareHandler): MiddlewareHa
     return handler;
   }
 
-  const wrapped: MiddlewareHandler = async function sentryTracedMiddleware(context, next) {
-    const activeSpan = getActiveSpan();
-    const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
-    const span = startInactiveSpan({
-      name: handler.name || '<anonymous>',
-      op: 'middleware.hono',
-      onlyIfParent: true,
-      parentSpan: rootSpan,
-      attributes: {
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'middleware.hono',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: MIDDLEWARE_ORIGIN,
-      },
-    });
+  return new Proxy(handler, {
+    async apply(_target, _thisArg, args: Parameters<MiddlewareHandler>) {
+      const [context, next] = args;
+      const activeSpan = getActiveSpan();
+      const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
+      const span = startInactiveSpan({
+        name: handler.name || '<anonymous>',
+        op: 'middleware.hono',
+        onlyIfParent: true,
+        parentSpan: rootSpan,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'middleware.hono',
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: MIDDLEWARE_ORIGIN,
+        },
+      });
 
-    try {
-      return await handler(context, next);
-    } catch (error) {
-      if (!isExpectedError(error)) {
-        span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-        captureException(error, {
-          mechanism: { handled: false, type: MIDDLEWARE_ORIGIN },
-        });
+      try {
+        return await handler(context, next);
+      } catch (error) {
+        if (!isExpectedError(error)) {
+          span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+          captureException(error, {
+            mechanism: { handled: false, type: MIDDLEWARE_ORIGIN },
+          });
+        }
+
+        throw error;
+      } finally {
+        span.end();
       }
-
-      throw error;
-    } finally {
-      span.end();
-    }
-  };
-
-  markFunctionWrapped(wrapped as unknown as WrappedFunction, handler as unknown as WrappedFunction);
-  return wrapped;
+    },
+    get(target, prop, receiver) {
+      if (prop === '__sentry_original__') {
+        return handler;
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
 }

--- a/packages/hono/test/shared/patchAppUse.test.ts
+++ b/packages/hono/test/shared/patchAppUse.test.ts
@@ -135,6 +135,33 @@ describe('patchAppUse (middleware spans)', () => {
     expect(firstCall![0].name).not.toBe(secondCall![0].name);
   });
 
+  it('preserves symbol-keyed and string-keyed properties on wrapped handlers', async () => {
+    const app = new Hono();
+    patchAppUse(app);
+
+    const META = Symbol('test-meta');
+    const OPENAPI = Symbol('openapi');
+
+    const handler = async (_c: unknown, next: () => Promise<void>) => next();
+    (handler as any)[META] = { summary: 'Get items' };
+    (handler as any)[OPENAPI] = { responses: { 200: {} } };
+    (handler as any).customProp = 'hello';
+
+    app.use('/test', handler);
+
+    const route = (app.routes ?? []).find(r => r.path === '/test');
+    expect(route).toBeDefined();
+
+    expect((route!.handler as any).__sentry_original__).toBe(handler);
+
+    const symbols = Object.getOwnPropertySymbols(route!.handler);
+    expect(symbols).toContain(META);
+    expect(symbols).toContain(OPENAPI);
+    expect((route!.handler as any)[META]).toEqual({ summary: 'Get items' });
+    expect((route!.handler as any)[OPENAPI]).toEqual({ responses: { 200: {} } });
+    expect((route!.handler as any).customProp).toBe('hello');
+  });
+
   it('preserves this context when calling the original use (Proxy forwards thisArg)', () => {
     type FakeApp = {
       _capturedThis: unknown;


### PR DESCRIPTION
Replaces the previous approach of creating a new `sentryTracedMiddleware` function with a Proxy approach to preserve any extra data set on the handler.

Closes: #20952