### PR TITLE
feat(core): Add `dataCollection` client option

### DIFF
--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -402,6 +402,7 @@ export type { Extra, Extras } from './types-hoist/extra';
 export type { Integration, IntegrationFn } from './types-hoist/integration';
 export type { Mechanism } from './types-hoist/mechanism';
 export type { ExtractedNodeRequestData, HttpHeaderValue, Primitive, WorkerLocation } from './types-hoist/misc';
+export type { CollectBehavior, DataCollection, HttpBodyCollectionTarget } from './types-hoist/datacollection';
 export type { ClientOptions, CoreOptions as Options } from './types-hoist/options';
 export type { Package } from './types-hoist/package';
 export type { PolymorphicEvent, PolymorphicRequest } from './types-hoist/polymorphics';

--- a/packages/core/src/types-hoist/datacollection.ts
+++ b/packages/core/src/types-hoist/datacollection.ts
@@ -1,10 +1,5 @@
 /**
  * Controls how key-value data (headers, cookies, query params) is collected and filtered.
- *
- * - `true`          → `{ mode: 'denyList' }`
- * - `false`         → `{ mode: 'off' }`
- * - `{ deny: [] }`  → `{ mode: 'denyList', terms: [] }`
- * - `{ allow: [] }` → `{ mode: 'allowList', terms: [] }`
  */
 export type CollectBehavior = boolean | { allow: string[] } | { deny: string[] };
 

--- a/packages/core/src/types-hoist/datacollection.ts
+++ b/packages/core/src/types-hoist/datacollection.ts
@@ -1,5 +1,9 @@
 /**
  * Controls how key-value data (headers, cookies, query params) is collected and filtered.
+ * - `true`: Collect all data without filtering (empty denylist). Senstive values like keys and tokens are always filtered out.
+ * - `false`: Do not collect any data.
+ * - `{ allow: string[] }`: Collect only the specified keys.
+ * - `{ deny: string[] }`: Collect all keys except the specified ones.
  */
 export type CollectBehavior = boolean | { allow: string[] } | { deny: string[] };
 

--- a/packages/core/src/types-hoist/datacollection.ts
+++ b/packages/core/src/types-hoist/datacollection.ts
@@ -1,5 +1,6 @@
 /**
  * Controls how key-value data (headers, cookies, query params) is collected and filtered.
+ *
  * - `true`: Collect all data without filtering (empty denylist). Senstive values like keys and tokens are always filtered out.
  * - `false`: Do not collect any data.
  * - `{ allow: string[] }`: Collect only the specified keys.

--- a/packages/core/src/types-hoist/datacollection.ts
+++ b/packages/core/src/types-hoist/datacollection.ts
@@ -1,0 +1,72 @@
+/**
+ * Controls how key-value data (headers, cookies, query params) is collected and filtered.
+ *
+ * - `true`          → `{ mode: 'denyList' }`
+ * - `false`         → `{ mode: 'off' }`
+ * - `{ deny: [] }`  → `{ mode: 'denyList', terms: [] }`
+ * - `{ allow: [] }` → `{ mode: 'allowList', terms: [] }`
+ */
+export type CollectBehavior = boolean | { allow: string[] } | { deny: string[] };
+
+export type HttpBodyCollectionTarget = 'incomingRequest' | 'outgoingRequest' | 'incomingResponse' | 'outgoingResponse';
+
+/**
+ * Controls what data the SDK collects and sends to Sentry.
+ *
+ * All fields are optional. Omitted fields use the documented defaults.
+ */
+export interface DataCollection {
+  /**
+   * Automatically populate `user.*` fields from instrumentation sources.
+   * @default false
+   */
+  userInfo?: boolean;
+
+  /**
+   * Controls cookie collection and sensitive value filtering.
+   * @default true
+   */
+  cookies?: CollectBehavior;
+
+  /**
+   * Controls HTTP header collection for requests and responses.
+   * @default { request: true, response: true }
+   */
+  httpHeaders?: {
+    request?: CollectBehavior;
+    response?: CollectBehavior;
+  };
+
+  /**
+   * Which HTTP body types to collect. An empty array disables body collection.
+   * @default []
+   */
+  httpBodies?: HttpBodyCollectionTarget[];
+
+  /**
+   * Controls query parameter collection and sensitive value filtering.
+   * @default true
+   */
+  queryParams?: CollectBehavior;
+
+  /**
+   * Controls generative AI input/output recording.
+   * @default { inputs: true, outputs: true }
+   */
+  genAI?: {
+    inputs?: boolean;
+    outputs?: boolean;
+  };
+
+  /**
+   * Capture local variable values in stack frames.
+   * @default true
+   */
+  stackFrameVariables?: boolean;
+
+  /**
+   * Number of source code context lines to capture around stack frames.
+   * @default 5
+   */
+  frameContextLines?: number;
+}

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -1,5 +1,6 @@
 import type { CaptureContext } from '../scope';
 import type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
+import type { DataCollection } from './datacollection';
 import type { ErrorEvent, EventHint, TransactionEvent } from './event';
 import type { Integration } from './integration';
 import type { Log } from './log';
@@ -392,6 +393,14 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    * added in versions above `7.9.0`.
    */
   sendDefaultPii?: boolean;
+
+  /**
+   * Controls what data the SDK collects and sends to Sentry.
+   * All fields are optional — omitted fields use the documented defaults.
+   *
+   * @see https://develop.sentry.dev/sdk/foundations/client/data-collection/
+   */
+  dataCollection?: DataCollection;
 
   /**
    * Controls whether and how to enhance fetch error messages by appending the request hostname.

--- a/packages/core/src/types-hoist/options.ts
+++ b/packages/core/src/types-hoist/options.ts
@@ -397,8 +397,6 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   /**
    * Controls what data the SDK collects and sends to Sentry.
    * All fields are optional — omitted fields use the documented defaults.
-   *
-   * @see https://develop.sentry.dev/sdk/foundations/client/data-collection/
    */
   dataCollection?: DataCollection;
 


### PR DESCRIPTION
Adds the new `dataCollection` option according to https://develop.sentry.dev/sdk/foundations/client/data-collection/#datacollection-options.

This PR only defines the type and sets it on the base options, no-op atm.

closes https://github.com/getsentry/sentry-javascript/issues/20924