### PR TITLE
chore: Add compatibility function for `sendDefaultPii`

### DIFF
--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -65,6 +65,7 @@ export {
   _INTERNAL_shouldSkipAiProviderWrapping,
   _INTERNAL_clearAiProviderSkips,
 } from './utils/ai/providerSkip';
+export { defaultPiiToCollectionOptions } from './utils/data-collection/defaultPiiToCollectionOptions';
 export { envToBool } from './utils/envToBool';
 export { applyScopeDataToEvent, mergeScopeData, getCombinedScopeData } from './utils/scopeData';
 export { prepareEvent } from './utils/prepareEvent';

--- a/packages/core/src/utils/data-collection/defaultPiiToCollectionOptions.ts
+++ b/packages/core/src/utils/data-collection/defaultPiiToCollectionOptions.ts
@@ -1,0 +1,24 @@
+// oxlint-disable-next-line typescript/no-explicit-any -> will be replaced with the new dataCollection type
+export function defaultPiiToCollectionOptions(sendDefaultPii?: boolean): any {
+  return sendDefaultPii === true
+    ? {
+        userInfo: true,
+        cookies: true,
+        httpHeaders: { request: true, response: true },
+        httpBodies: ['incomingRequest', 'outgoingRequest', 'incomingResponse', 'outgoingResponse'],
+        queryParams: true,
+        genAI: { inputs: true, outputs: true },
+        stackFrameVariables: true,
+        frameContextLines: 5,
+      }
+    : {
+        userInfo: false,
+        cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+        httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+        httpBodies: [],
+        queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+        genAI: { inputs: false, outputs: false },
+        stackFrameVariables: true,
+        frameContextLines: 5,
+      };
+}

--- a/packages/core/src/utils/data-collection/defaultPiiToCollectionOptions.ts
+++ b/packages/core/src/utils/data-collection/defaultPiiToCollectionOptions.ts
@@ -1,3 +1,5 @@
+import { PII_HEADER_SNIPPETS } from './filtering-snippets';
+
 // oxlint-disable-next-line typescript/no-explicit-any -> will be replaced with the new dataCollection type
 export function defaultPiiToCollectionOptions(sendDefaultPii?: boolean): any {
   return sendDefaultPii === true
@@ -13,10 +15,10 @@ export function defaultPiiToCollectionOptions(sendDefaultPii?: boolean): any {
       }
     : {
         userInfo: false,
-        cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
-        httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+        cookies: { deny: PII_HEADER_SNIPPETS },
+        httpHeaders: { deny: PII_HEADER_SNIPPETS },
         httpBodies: [],
-        queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+        queryParams: { deny: PII_HEADER_SNIPPETS },
         genAI: { inputs: false, outputs: false },
         stackFrameVariables: true,
         frameContextLines: 5,

--- a/packages/core/src/utils/data-collection/defaultPiiToCollectionOptions.ts
+++ b/packages/core/src/utils/data-collection/defaultPiiToCollectionOptions.ts
@@ -1,7 +1,10 @@
 import { PII_HEADER_SNIPPETS } from './filtering-snippets';
+import type { DataCollection } from '../../types-hoist/datacollection';
 
-// oxlint-disable-next-line typescript/no-explicit-any -> will be replaced with the new dataCollection type
-export function defaultPiiToCollectionOptions(sendDefaultPii?: boolean): any {
+/**
+ * Helper function that maps the `sendDefaultPii` boolean flag to the corresponding `DataCollection` configuration.
+ */
+export function defaultPiiToCollectionOptions(sendDefaultPii?: boolean): DataCollection {
   return sendDefaultPii === true
     ? {
         userInfo: true,
@@ -16,7 +19,7 @@ export function defaultPiiToCollectionOptions(sendDefaultPii?: boolean): any {
     : {
         userInfo: false,
         cookies: { deny: PII_HEADER_SNIPPETS },
-        httpHeaders: { deny: PII_HEADER_SNIPPETS },
+        httpHeaders: { request: { deny: PII_HEADER_SNIPPETS }, response: { deny: PII_HEADER_SNIPPETS } },
         httpBodies: [],
         queryParams: { deny: PII_HEADER_SNIPPETS },
         genAI: { inputs: false, outputs: false },

--- a/packages/core/src/utils/data-collection/filtering-snippets.ts
+++ b/packages/core/src/utils/data-collection/filtering-snippets.ts
@@ -1,0 +1,1 @@
+export const PII_HEADER_SNIPPETS = ['forwarded', '-ip', 'remote-', 'via', '-user'];

--- a/packages/core/test/lib/utils/data-collection/defaultPiiToCollectionOptions.test.ts
+++ b/packages/core/test/lib/utils/data-collection/defaultPiiToCollectionOptions.test.ts
@@ -35,7 +35,10 @@ describe('defaultPiiToCollectionOptions', () => {
     expect(defaultPiiToCollectionOptions(undefined)).toEqual({
       userInfo: false,
       cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
-      httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpHeaders: {
+        request: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+        response: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      },
       httpBodies: [],
       queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
       genAI: { inputs: false, outputs: false },
@@ -48,7 +51,10 @@ describe('defaultPiiToCollectionOptions', () => {
     expect(defaultPiiToCollectionOptions()).toEqual({
       userInfo: false,
       cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
-      httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpHeaders: {
+        request: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+        response: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      },
       httpBodies: [],
       queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
       genAI: { inputs: false, outputs: false },

--- a/packages/core/test/lib/utils/data-collection/defaultPiiToCollectionOptions.test.ts
+++ b/packages/core/test/lib/utils/data-collection/defaultPiiToCollectionOptions.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { defaultPiiToCollectionOptions } from '../../../../src/utils/data-collection/defaultPiiToCollectionOptions';
+
+describe('defaultPiiToCollectionOptions', () => {
+  it('returns permissive options when sendDefaultPii is true', () => {
+    expect(defaultPiiToCollectionOptions(true)).toEqual({
+      userInfo: true,
+      cookies: true,
+      httpHeaders: { request: true, response: true },
+      httpBodies: ['incomingRequest', 'outgoingRequest', 'incomingResponse', 'outgoingResponse'],
+      queryParams: true,
+      genAI: { inputs: true, outputs: true },
+      stackFrameVariables: true,
+      frameContextLines: 5,
+    });
+  });
+
+  it('returns restrictive options when sendDefaultPii is false', () => {
+    expect(defaultPiiToCollectionOptions(false)).toEqual({
+      userInfo: false,
+      cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpBodies: [],
+      queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: true,
+      frameContextLines: 5,
+    });
+  });
+
+  it('returns restrictive options when sendDefaultPii is undefined', () => {
+    expect(defaultPiiToCollectionOptions(undefined)).toEqual({
+      userInfo: false,
+      cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpBodies: [],
+      queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: true,
+      frameContextLines: 5,
+    });
+  });
+
+  it('returns restrictive options when called with no arguments', () => {
+    expect(defaultPiiToCollectionOptions()).toEqual({
+      userInfo: false,
+      cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpBodies: [],
+      queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: true,
+      frameContextLines: 5,
+    });
+  });
+});

--- a/packages/core/test/lib/utils/data-collection/defaultPiiToCollectionOptions.test.ts
+++ b/packages/core/test/lib/utils/data-collection/defaultPiiToCollectionOptions.test.ts
@@ -19,7 +19,10 @@ describe('defaultPiiToCollectionOptions', () => {
     expect(defaultPiiToCollectionOptions(false)).toEqual({
       userInfo: false,
       cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
-      httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      httpHeaders: {
+        request: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+        response: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      },
       httpBodies: [],
       queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
       genAI: { inputs: false, outputs: false },


### PR DESCRIPTION
Adds a function to bridge from `sendDefaultPii` to `dataCollection`.

Related to https://github.com/getsentry/sentry-javascript/pull/20965

Closes https://github.com/getsentry/sentry-javascript/issues/20925