### PR TITLE
ci(auto-fix-issue): Raise turn limit to 80 and tighten prompt

### DIFF
--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -101,6 +101,15 @@ jobs:
             6. Checkout a new branch and commit the fix
             7. Create a pull request for the fix
 
+            Be economic with tool calls:
+            - Every tool call (Bash, Read, Grep, Edit, etc.) counts against your budget. Plan before acting.
+            - Prefer targeted commands over broad ones: read specific line ranges instead of whole files, grep for the exact symbol instead of listing directories.
+            - Batch independent operations into a single message with parallel tool calls.
+            - Do NOT re-read a file you just edited to "verify" — the edit either succeeded or errored.
+            - Do NOT run the full test suite to verify a small fix; run only the directly relevant test file.
+            - Do NOT re-run linters/formatters/builds repeatedly. Run each at most once unless the code changed since.
+            - If a search returned what you need, stop searching. Do not look for confirmation.
+
             Turn budget:
             - You have a hard limit of 80 tool calls for this entire task. Stay well under it.
             - If you have used roughly 50 tool calls and do not yet have a small, verified fix with a clear path to opening a PR, STOP. Do not keep exploring, re-reading files, or retrying tests.

--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -100,5 +100,11 @@ jobs:
             5. Test the fix
             6. Checkout a new branch and commit the fix
             7. Create a pull request for the fix
+
+            Turn budget:
+            - You have a hard limit of 80 tool calls for this entire task. Stay well under it.
+            - If you have used roughly 50 tool calls and do not yet have a small, verified fix with a clear path to opening a PR, STOP. Do not keep exploring, re-reading files, or retrying tests.
+            - On stop: post a comment on the issue summarizing the root cause (if known), what you tried, and why you aborted, then exit. Do not open a PR.
+            - Re-running the same failing command, re-reading the same files, or going in circles is a signal to stop early — do not wait for the budget to run out.
           claude_args: |
-            --max-turns 50
+            --max-turns 80

--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -101,18 +101,18 @@ jobs:
             6. Checkout a new branch and commit the fix
             7. Create a pull request for the fix
 
-            Be economic with tool calls:
-            - Every tool call (Bash, Read, Grep, Edit, etc.) counts against your budget. Plan before acting.
-            - Prefer targeted commands over broad ones: read specific line ranges instead of whole files, grep for the exact symbol instead of listing directories.
-            - Batch independent operations into a single message with parallel tool calls.
+            Be economic with your turns:
+            - Your budget is measured in *agent turns* (assistant messages), not individual tool calls. A single turn can contain many parallel tool calls and counts as one turn — so batching is free.
+            - Plan before acting. Prefer targeted commands over broad ones: read specific line ranges instead of whole files, grep for the exact symbol instead of listing directories.
+            - In each turn, issue all independent tool calls in parallel rather than spreading them across multiple turns.
             - Do NOT re-read a file you just edited to "verify" — the edit either succeeded or errored.
             - Do NOT run the full test suite to verify a small fix; run only the directly relevant test file.
             - Do NOT re-run linters/formatters/builds repeatedly. Run each at most once unless the code changed since.
             - If a search returned what you need, stop searching. Do not look for confirmation.
 
             Turn budget:
-            - You have a hard limit of 80 tool calls for this entire task. Stay well under it.
-            - If you have used roughly 50 tool calls and do not yet have a small, verified fix with a clear path to opening a PR, STOP. Do not keep exploring, re-reading files, or retrying tests.
+            - You have a hard limit of 80 agent turns for this entire task. One turn = one assistant message, regardless of how many tool calls it contains. Stay well under the limit.
+            - If you have used roughly 50 turns and do not yet have a small, verified fix with a clear path to opening a PR, STOP. Do not keep exploring, re-reading files, or retrying tests.
             - On stop: post a comment on the issue summarizing the root cause (if known), what you tried, and why you aborted, then exit. Do not open a PR.
             - Re-running the same failing command, re-reading the same files, or going in circles is a signal to stop early — do not wait for the budget to run out.
           claude_args: |


### PR DESCRIPTION
## Summary

The `auto-fix-issue` workflow was failing with `Reached maximum number of turns (50)` because Claude hit the hard cap before either landing a fix or aborting cleanly. Two changes:

- **Raise `--max-turns` from 50 to 80** so larger but still tractable fixes can complete.
- **Tighten the prompt** in two ways so we rarely hit the cap:
  - Add a *Be economic with tool calls* section — plan before acting, batch parallel calls, avoid redundant reads/test runs, stop searching once the answer is found.
  - Add a *Turn budget* section — if ~50 tool calls in there's no clear path to a small verified fix, stop, comment on the issue with what was tried, and exit instead of grinding into the hard cap.

The net effect: fewer wasted turns per run, and when the issue is genuinely too big the action reports a useful issue comment instead of failing with a stack trace.