### PR TITLE
test(node): Increase timeout in OnUncaughtException test scripts to fix flaky CI

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
@@ -13,9 +13,10 @@ const client = Sentry.init({
 setupOtel(client);
 
 setTimeout(() => {
-  // This should not be called because the script throws before this resolves
+  // This should not be called because the script throws before this resolves.
+  // Using 3000ms to account for the SDK's 2000ms shutdown timeout + buffer.
   process.stdout.write("I'm alive!");
   process.exit(0);
-}, 500);
+}, 3000);
 
 throw new Error();

--- a/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
@@ -8,9 +8,10 @@ const client = Sentry.init({
 setupOtel(client);
 
 setTimeout(() => {
-  // This should not be called because the script throws before this resolves
+  // This should not be called because the script throws before this resolves.
+  // Using 3000ms to account for the SDK's 2000ms shutdown timeout + buffer.
   process.stdout.write("I'm alive!");
   process.exit(0);
-}, 500);
+}, 3000);
 
 throw new Error();

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
@@ -10,9 +10,10 @@ Sentry.init({
 });
 
 setTimeout(() => {
-  // This should not be called because the script throws before this resolves
+  // This should not be called because the script throws before this resolves.
+  // Using 3000ms to account for the SDK's 2000ms shutdown timeout + buffer.
   process.stdout.write("I'm alive!");
   process.exit(0);
-}, 500);
+}, 3000);
 
 throw new Error();

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
@@ -5,9 +5,10 @@ Sentry.init({
 });
 
 setTimeout(() => {
-  // This should not be called because the script throws before this resolves
+  // This should not be called because the script throws before this resolves.
+  // Using 3000ms to account for the SDK's 2000ms shutdown timeout + buffer.
   process.stdout.write("I'm alive!");
   process.exit(0);
-}, 500);
+}, 3000);
 
 throw new Error();


### PR DESCRIPTION
closes #20796
closes [JS-2432](https://linear.app/getsentry/issue/JS-2432)

closes #20698
closes [JS-2368](https://linear.app/getsentry/issue/JS-2368/flaky-ci-node-22-integration-tests-unhandled-error)

closes #20689
closes [JS-2363](https://linear.app/getsentry/issue/JS-2363/flaky-ci-node-24-integration-tests-unhandled-error)

closes #20974
closes [JS-2531](https://linear.app/getsentry/issue/JS-2531)

closes #20798
closes [JS-2434](https://linear.app/getsentry/issue/JS-2434)

closes #20792
closes [JS-2430](https://linear.app/getsentry/issue/JS-2430)

closes #20788
closes [JS-2428](https://linear.app/getsentry/issue/JS-2428)

The 500ms timeout was too short - when network conditions cause the SDK's client.close() to take longer than 500ms (it has a 2000ms timeout), the watchdog fires first and the test fails with "I'm alive!" in stdout.

This can be reproduced with the following script:

```js
const Sentry = require('@sentry/node');

Sentry.init({
  dsn: 'https://public@10.255.255.1/1337',  // Unreachable IP - simulates slow network
});

setTimeout(() => {
  process.stdout.write("I'm alive!");
  process.exit(0);
}, 3000);  // Was 500ms before the fix

throw new Error('Test');
```

