### PR TITLE
test(node): Fix flaky ANR tests by waiting for debugger to be ready

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/anr/app-path.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/app-path.mjs
@@ -4,6 +4,7 @@ import * as crypto from 'crypto';
 import * as path from 'path';
 import * as url from 'url';
 import { setupOtel } from '../../utils/setupOtel.js';
+import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
 
@@ -32,6 +33,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-core-integration-tests/suites/anr/basic-multiple.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic-multiple.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node-core';
 import * as assert from 'assert';
 import * as crypto from 'crypto';
 import { setupOtel } from '../../utils/setupOtel.js';
+import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
 
@@ -28,10 +29,11 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
 
-setTimeout(() => {
-  longWork();
-}, 4000);
+  // Second blocking event for maxAnrEvents test
+  setTimeout(() => {
+    longWork();
+  }, 2000);
+});

--- a/dev-packages/node-core-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic-session.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../utils/setupOtel.js');
+const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
 setTimeout(() => {
   process.exit();
@@ -27,6 +28,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-core-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../utils/setupOtel.js');
+const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
 
@@ -29,6 +30,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-core-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node-core';
 import * as assert from 'assert';
 import * as crypto from 'crypto';
 import { setupOtel } from '../../utils/setupOtel.js';
+import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
 
@@ -28,11 +29,11 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
 
-// Ensure we only send one event even with multiple blocking events
-setTimeout(() => {
-  longWork();
-}, 4000);
+  // Ensure we only send one event even with multiple blocking events
+  setTimeout(() => {
+    longWork();
+  }, 2000);
+});

--- a/dev-packages/node-core-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/forked.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../utils/setupOtel.js');
+const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
 setTimeout(() => {
   process.exit();
@@ -28,6 +29,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-core-integration-tests/suites/anr/indefinite.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/indefinite.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node-core';
 import * as assert from 'assert';
 import * as crypto from 'crypto';
 import { setupOtel } from '../../utils/setupOtel.js';
+import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 setTimeout(() => {
   process.exit();
@@ -27,6 +28,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-integration-tests/suites/anr/app-path.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/app-path.mjs
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import * as crypto from 'crypto';
 import * as path from 'path';
 import * as url from 'url';
+import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
 
@@ -29,6 +30,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 import * as assert from 'assert';
 import * as crypto from 'crypto';
+import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
 
@@ -25,10 +26,11 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
 
-setTimeout(() => {
-  longWork();
-}, 4000);
+  // Second blocking event for maxAnrEvents test
+  setTimeout(() => {
+    longWork();
+  }, 2000);
+});

--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const assert = require('assert');
 
 const Sentry = require('@sentry/node');
+const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
 setTimeout(() => {
   process.exit();
@@ -24,6 +25,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const assert = require('assert');
 
 const Sentry = require('@sentry/node');
+const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
 
@@ -26,6 +27,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 import * as assert from 'assert';
 import * as crypto from 'crypto';
+import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
 
@@ -25,11 +26,11 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
 
-// Ensure we only send one event even with multiple blocking events
-setTimeout(() => {
-  longWork();
-}, 4000);
+  // Ensure we only send one event even with multiple blocking events
+  setTimeout(() => {
+    longWork();
+  }, 2000);
+});

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const assert = require('assert');
 
 const Sentry = require('@sentry/node');
+const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
 setTimeout(() => {
   process.exit();
@@ -25,6 +26,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 import * as assert from 'assert';
 import * as crypto from 'crypto';
+import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 setTimeout(() => {
   process.exit();
@@ -24,6 +25,6 @@ function longWork() {
   }
 }
 
-setTimeout(() => {
+waitForDebuggerReady(() => {
   longWork();
-}, 1000);
+});

--- a/dev-packages/test-utils/src/anr.ts
+++ b/dev-packages/test-utils/src/anr.ts
@@ -1,0 +1,19 @@
+import * as inspector from 'inspector';
+
+/**
+ * Waits for the ANR worker's debugger to be fully ready before executing callback.
+ *
+ * The ANR worker creates an InspectorSession and connects to the main thread's debugger.
+ * We poll inspector.url() to detect when the debugger is active, then wait 200ms for the
+ * async session setup to complete.
+ */
+export function waitForDebuggerReady(cb: () => void): void {
+  const check = (): void => {
+    if (inspector.url()) {
+      setTimeout(cb, 200);
+    } else {
+      setImmediate(check);
+    }
+  };
+  setImmediate(check);
+}

--- a/dev-packages/test-utils/src/index.ts
+++ b/dev-packages/test-utils/src/index.ts
@@ -26,3 +26,5 @@ export type { CDPClientOptions } from './cdp-client';
 
 export { MemoryProfiler } from './memory-profiler';
 export type { MemoryProfilerOptions, SnapshotStats, SnapshotComparisonResult } from './memory-profiler';
+
+export { waitForDebuggerReady } from './anr';


### PR DESCRIPTION
closes #20704
closes [JS-2372](https://linear.app/getsentry/issue/JS-2372/flaky-ci-node-24-node-core-integration-tests-suitesanrtestts-should)

closes #20959
closes [JS-2524](https://linear.app/getsentry/issue/JS-2524)

The ANR worker thread creates an InspectorSession and connects to the main thread's debugger. Previously, tests would start blocking work immediately, but the debugger session might not be fully initialized yet, causing stack traces to capture the wrong location (processTimers instead of longWork).

This adds a `waitForDebuggerReady` helper to the test utils that polls `inspector.url()` to detect when the debugger is active, then waits 200ms for the async session setup to complete before starting the blocking work.

First the LLM suggested to increase the timeout, but I didn't think that was a good solution, given that CI good have worse when it's busy. I tested that locally a lot of times and tried to slow down the process, seemed stable so far.