### PR TITLE
test(node): Fix flaky thread-blocked-native worker thread test

### DIFF
--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/worker-block.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/worker-block.mjs
@@ -1,5 +1,26 @@
+import * as Sentry from '@sentry/node';
 import { longWork } from './long-work.js';
 
-setTimeout(() => {
+// Wait for Sentry to be fully initialized before blocking.
+// This prevents flaky tests on slow CI where the fixed 10s delay
+// might fire before the native polling has started.
+async function waitForSentryReady(timeoutMs = 30_000) {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const client = Sentry.getClient();
+    if (client?.getIntegrationByName('ThreadBlocked')) {
+      // Integration is installed, wait a bit for polling to start
+      // (polling starts via setImmediate in afterAllSetup)
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      return;
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  // Timeout - the test will fail anyway since no event will be sent
+}
+
+waitForSentryReady().then(() => {
   longWork();
-}, 10_000);
+});


### PR DESCRIPTION
closes #20703
closes [JS-2371](https://linear.app/getsentry/issue/JS-2371/flaky-ci-node-24-ts-38-integration-tests-suitesthread-blocked)

closes #20676
closes [JS-2358](https://linear.app/getsentry/issue/JS-2358/flaky-ci-node-20-integration-tests-suitesthread-blocked-nativetestts)

This was the best guess from Claude. I tried to reproduce this locally but failed. I used Docker to change the resources and lowered the CPU and memory on a reproduction. But I never reproduced the same failing state. However, this new approach is faster (Claude was very proud of that) as it is not waiting 10s, before it starts, but starts as soon as everything is set up - that also never failed locally - so it is a shot in the dark 🤞

--- 
Claude message: 

The worker thread test was flaky on CI because it used a fixed 10s delay before blocking the event loop. On slow CI machines, the Sentry SDK polling might not have fully started within that time window.

Replace the fixed delay with active polling that waits for the ThreadBlocked integration to be installed, then waits 1s for polling to start before blocking.

This makes the test:
- More reliable: actively verifies Sentry is ready instead of hoping
- Faster: ~3s vs ~12s locally
- Has a 30s timeout as a safety net