### PR TITLE
chore(remix): Add quansync 0.2.11 resolution

### DIFF
--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -39,7 +39,8 @@
     "@vanilla-extract/css": "1.13.0",
     "@vanilla-extract/integration": "6.2.4",
     "@types/mime": "^3.0.0",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "quansync": "0.2.11"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
`local-pkg@1.2.0` bumped its `quansync` dependency from `^0.2.11` to `^1.0.0` yesterday. This is problematic because quansync dropped CJS exports in 1.0.0, breaking us on node 18 since it cannot require ESM modules.