### PR TITLE
ci(auto-fix-issue): Add show_full_output workflow input for debugging

### DIFF
--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -10,6 +10,11 @@ on:
         description: 'Issue number (e.g., 1234)'
         required: true
         type: number
+      show_full_output:
+        description: 'Show full Claude SDK output in logs (may expose secrets — use for debugging only)'
+        required: false
+        type: boolean
+        default: false
 
 # Per-issue concurrency to prevent duplicate analysis
 concurrency:
@@ -74,6 +79,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: '*'
+          show_full_output: ${{ github.event.inputs.show_full_output || 'false' }}
           prompt: |
             Fix the issue in getsentry/sentry-javascript with number #${{ steps.parse-issue.outputs.issue_number }}.
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `show_full_output` boolean input on the Auto Fix Issue `workflow_dispatch` form
- Wires it through to the `claude-code-action` step, which otherwise hides the SDK output for security
- Default is `false`, so normal runs are unchanged — flip it on per-run when debugging

## Why

The action's default-hidden output makes it hard to tell why a run finishes "successfully" without producing a PR or comment (e.g., when permission denials silently block the agent). With this opt-in, we can re-dispatch a problem run with full logging instead of editing the workflow each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)