### PR TITLE
chore(e2e): Remove vue/vue-router workaround from nuxt-4 canary build

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
@@ -14,7 +14,7 @@
     "test:prod": "TEST_ENV=production playwright test",
     "test:dev": "bash ./nuxt-start-dev-server.bash && TEST_ENV=development playwright test environment",
     "test:build": "pnpm install && pnpm build",
-    "test:build-canary": "pnpm add nuxt@npm:nuxt-nightly@latest && pnpm add nitropack@npm:nitropack-nightly@latest && pnpm add vue vue-router && pnpm install --force && pnpm build",
+    "test:build-canary": "pnpm add nuxt@npm:nuxt-nightly@latest && pnpm add nitropack@npm:nitropack-nightly@latest && pnpm install --force && pnpm build",
     "test:assert": "pnpm test:prod && pnpm test:dev"
   },
   "dependencies": {


### PR DESCRIPTION
The explicit `pnpm add vue vue-router` step was added in #20519 as a temporary workaround for nuxt/nuxt#34888. This has been fixed upstream in nuxt/nuxt#35126.