### PR TITLE
ci(auto-fix-issue): Skip git history as first step for flaky tests

### DIFF
--- a/.github/workflows/auto-fix-issue.yml
+++ b/.github/workflows/auto-fix-issue.yml
@@ -107,6 +107,11 @@ jobs:
             6. Checkout a new branch and commit the fix
             7. Create a pull request for the fix
 
+            Investigation scope:
+            - This workflow always runs on the latest `develop`. Treat the current checkout as the source of truth — diagnose and fix from the code as it is now.
+            - For flaky test issues specifically: do NOT start by inspecting git history, `git log`, `git blame`, or diffs. Reproduce/reason about the flake from the current code first.
+            - Reach for git history only as an escalated step, once you have a concrete reason to believe a recent change is responsible and reading the code alone is not enough.
+
             Be economic with your turns:
             - Your budget is measured in *agent turns* (assistant messages), not individual tool calls. A single turn can contain many parallel tool calls and counts as one turn — so batching is free.
             - Plan before acting. Prefer targeted commands over broad ones: read specific line ranges instead of whole files, grep for the exact symbol instead of listing directories.


### PR DESCRIPTION
## Summary

- Adds an "Investigation scope" section to the auto-fix-issue prompt
- Tells the agent to treat the current checkout as the source of truth (the workflow always runs on latest `develop`)
- For flaky test issues specifically: don't open with `git log`/`git blame`/diff exploration — diagnose from the current code first
- Reach for git history only as an escalated step, with a concrete reason

## Why

Recent runs burned turns on speculative history digging that rarely pays off for flaky tests. The flake almost always reproduces against the current code, so that's where investigation should start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)