### PR TITLE
test(node): Fix flaky unhandled rejection and uncaught exception tests

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/additional-listener-test-script.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/additional-listener-test-script.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../../utils/setupOtel.js');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -11,9 +12,6 @@ process.on('uncaughtException', () => {
   // do nothing - this will prevent the Error below from closing this process before the timeout resolves
 });
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 throw new Error();

--- a/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../../utils/setupOtel.js');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -16,9 +17,6 @@ process.on('uncaughtException', () => {
   // do nothing - this will prevent the Error below from closing this process before the timeout resolves
 });
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 throw new Error();

--- a/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../../utils/setupOtel.js');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -12,11 +13,6 @@ const client = Sentry.init({
 
 setupOtel(client);
 
-setTimeout(() => {
-  // This should not be called because the script throws before this resolves.
-  // Using 3000ms to account for the SDK's 2000ms shutdown timeout + buffer.
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 3000);
+expectProcessToExit();
 
 throw new Error();

--- a/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../../utils/setupOtel.js');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -7,11 +8,6 @@ const client = Sentry.init({
 
 setupOtel(client);
 
-setTimeout(() => {
-  // This should not be called because the script throws before this resolves.
-  // Using 3000ms to account for the SDK's 2000ms shutdown timeout + buffer.
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 3000);
+expectProcessToExit();
 
 throw new Error();

--- a/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../../utils/setupOtel.js');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -8,9 +9,6 @@ const client = Sentry.init({
 
 setupOtel(client);
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 Promise.reject('test rejection');

--- a/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../../utils/setupOtel.js');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -8,10 +9,6 @@ const client = Sentry.init({
 
 setupOtel(client);
 
-setTimeout(() => {
-  // should not be called
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 Promise.reject('test rejection');

--- a/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../../utils/setupOtel.js');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -7,9 +8,6 @@ const client = Sentry.init({
 
 setupOtel(client);
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 Promise.reject(new Error('test rejection'));

--- a/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
+++ b/dev-packages/node-core-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../../utils/setupOtel.js');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 const client = Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -7,9 +8,6 @@ const client = Sentry.init({
 
 setupOtel(client);
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 Promise.reject('test rejection');

--- a/dev-packages/node-core-integration-tests/utils/expect-process-to-exit.js
+++ b/dev-packages/node-core-integration-tests/utils/expect-process-to-exit.js
@@ -1,0 +1,13 @@
+/**
+ * Sets a watchdog timer that prints "I'm alive!" and exits if the process
+ * doesn't terminate before the timeout. Uses 3000ms to account for the
+ * SDK's 2000ms shutdown timeout + buffer.
+ */
+function expectProcessToExit() {
+  setTimeout(() => {
+    process.stdout.write("I'm alive!");
+    process.exit(0);
+  }, 3000);
+}
+
+module.exports = { expectProcessToExit };

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/additional-listener-test-script.js
@@ -1,4 +1,5 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -8,9 +9,6 @@ process.on('uncaughtException', () => {
   // do nothing - this will prevent the Error below from closing this process before the timeout resolves
 });
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 throw new Error();

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
@@ -1,4 +1,5 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -13,9 +14,6 @@ process.on('uncaughtException', () => {
   // do nothing - this will prevent the Error below from closing this process before the timeout resolves
 });
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 throw new Error();

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
@@ -1,4 +1,5 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -9,11 +10,6 @@ Sentry.init({
   ],
 });
 
-setTimeout(() => {
-  // This should not be called because the script throws before this resolves.
-  // Using 3000ms to account for the SDK's 2000ms shutdown timeout + buffer.
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 3000);
+expectProcessToExit();
 
 throw new Error();

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
@@ -1,14 +1,10 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 
-setTimeout(() => {
-  // This should not be called because the script throws before this resolves.
-  // Using 3000ms to account for the SDK's 2000ms shutdown timeout + buffer.
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 3000);
+expectProcessToExit();
 
 throw new Error();

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-custom-name.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-custom-name.js
@@ -1,4 +1,5 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -18,10 +19,7 @@ class CustomIgnoredError extends Error {
   }
 }
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 // This should be ignored by the custom ignore matcher and not produce a warning
 Promise.reject(new CustomIgnoredError('This error should be ignored'));

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-default.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-default.js
@@ -1,4 +1,5 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -20,10 +21,7 @@ class AbortError extends Error {
   }
 }
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 // These should be ignored by default and not produce a warning
 Promise.reject(new AI_NoOutputGeneratedError('Stream aborted'));

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
@@ -1,13 +1,11 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'none' })],
 });
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 Promise.reject('test rejection');

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
@@ -1,14 +1,11 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'strict' })],
 });
 
-setTimeout(() => {
-  // should not be called
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 Promise.reject('test rejection');

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
@@ -1,12 +1,10 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 Promise.reject(new Error('test rejection'));

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
@@ -1,12 +1,10 @@
 const Sentry = require('@sentry/node');
+const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 
-setTimeout(() => {
-  process.stdout.write("I'm alive!");
-  process.exit(0);
-}, 500);
+expectProcessToExit();
 
 Promise.reject('test rejection');

--- a/dev-packages/node-integration-tests/utils/expect-process-to-exit.js
+++ b/dev-packages/node-integration-tests/utils/expect-process-to-exit.js
@@ -1,0 +1,13 @@
+/**
+ * Sets a watchdog timer that prints "I'm alive!" and exits if the process
+ * doesn't terminate before the timeout. Uses 3000ms to account for the
+ * SDK's 2000ms shutdown timeout + buffer.
+ */
+function expectProcessToExit() {
+  setTimeout(() => {
+    process.stdout.write("I'm alive!");
+    process.exit(0);
+  }, 3000);
+}
+
+module.exports = { expectProcessToExit };


### PR DESCRIPTION
closes #20697
closes [JS-2367](https://linear.app/getsentry/issue/JS-2367/flaky-ci-node-22-integration-tests-suitespublic)

closes #20791
closes [JS-2429](https://linear.app/getsentry/issue/JS-2429)

closes #20804
closes [JS-2435](https://linear.app/getsentry/issue/JS-2435)

Follow up to: https://github.com/getsentry/sentry-javascript/pull/21002

This one basically does the same, but changes it for all tests with that and outsources this into its own test util helper.

---

Claude text:

Extract `expectProcessToExit()` helper to consolidate watchdog timeout logic. Uses 3000ms to account for SDK's 2000ms shutdown timeout + buffer, fixing race conditions that caused flaky CI failures.
