### PR TITLE
test(browser): Allow profile frames without abs_path for clearTimeout

### DIFF
--- a/dev-packages/browser-integration-tests/suites/profiling/test-utils.ts
+++ b/dev-packages/browser-integration-tests/suites/profiling/test-utils.ts
@@ -99,8 +99,8 @@ export function validateProfile(
     expect(frame).toHaveProperty('function');
     expect(typeof frame.function).toBe('string');
 
-    // Some browser functions (fetch, setTimeout) may not have file locations
-    if (frame.function !== 'fetch' && frame.function !== 'setTimeout') {
+    // Some browser functions (fetch, setTimeout, clearTimeout) may not have file locations
+    if (frame.function !== 'fetch' && frame.function !== 'setTimeout' && frame.function !== 'clearTimeout') {
       expect(frame).toHaveProperty('abs_path');
       expect(frame).toHaveProperty('lineno');
       expect(frame).toHaveProperty('colno');


### PR DESCRIPTION
## Summary

- Adds `clearTimeout` to the list of built-in browser functions whose JSSelfProfiler-sampled frames may lack `abs_path`/`lineno`/`colno`, alongside `fetch` and `setTimeout`.

## Root cause

From the [failing run](https://github.com/getsentry/sentry-javascript/actions/runs/26017064860/job/76470759039):

```
Error: expect(received).toHaveProperty(path)
Received path: []
Received value: {"function": "clearTimeout"}
> 104 |       expect(frame).toHaveProperty('abs_path');
```

When the profiler stops, it clears its chunk timer; that `clearTimeout` call can land in a sample and produces a frame with only a function name, no source location — same shape as `setTimeout`/`fetch` frames the test already excludes. The fix is to add `clearTimeout` to the exclusion list.

Fixes #20957

🤖 Generated with [Claude Code](https://claude.com/claude-code)