### PR TITLE
test(opentelemetry): Avoid wallclock race in startSpan child end-time test

### DIFF
--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -2185,7 +2185,10 @@ describe('span.end() timestamp conversion', () => {
   });
 
   it('converts seconds to milliseconds for startSpan child span', () => {
-    const nowSec = Math.floor(Date.now() / 1000) + 1;
+    // +10s buffer (not +1 like sibling tests): the outer startSpan + inner startInactiveSpan
+    // adds enough wallclock overhead that nowSec*1000 can slip behind innerSpan's startTime,
+    // tripping OTel's `endTime < startTime` clamp and copying startTime's nanos onto endTime.
+    const nowSec = Math.floor(Date.now() / 1000) + 10;
     let capturedEndTime: [number, number] | undefined;
     startSpan({ name: 'outer' }, () => {
       const innerSpan = startInactiveSpan({ name: 'inner' });


### PR DESCRIPTION
## Summary

- Bumps the `nowSec` offset from `+1` to `+10` seconds in the "converts seconds to milliseconds for startSpan child span" test.

## Root cause

From the [failing run](https://github.com/getsentry/sentry-javascript/actions/runs/26021937452/job/76486630115):

```
AssertionError: expected 1000000 to be +0 // Object.is equality
> 2197 |     expect(capturedEndTime![1]).toBe(0);
```

The test does:

```ts
const nowSec = Math.floor(Date.now() / 1000) + 1;
startSpan({ name: 'outer' }, () => {
  const innerSpan = startInactiveSpan({ name: 'inner' });
  innerSpan.end(nowSec);
  capturedEndTime = getSpanEndTime(innerSpan);
});
expect(capturedEndTime![1]).toBe(0);
```

If the wallclock crosses the next-second boundary between computing `nowSec` and creating `innerSpan` (more likely here than in sibling tests because of the extra `outer` + callback overhead), `innerSpan.startTime` lands at `[nowSec, ~N ms in nanos]` — *after* the requested `endTime = [nowSec, 0]`. OTel's `Span.end` then detects negative duration and clamps:

```js
// @opentelemetry/sdk-trace-base / Span.js
if (this._duration[0] < 0) {
  this.endTime = this.startTime.slice();
  this._duration = [0, 0];
}
```

After the clamp, `endTime[1]` equals `startTime[1]` — the wallclock nanos, not `0`. The reported `1000000` ns is exactly the case where setup ran ~1 ms into the next second.

Bumping the buffer to `+10` s makes the clamp branch unreachable during normal test execution. Sibling tests using `+1` only create a single span, so they finish well before the boundary.

Fixes #20962

🤖 Generated with [Claude Code](https://claude.com/claude-code)