### PR TITLE
test(nextjs-16-streaming): Skip server-component tests in dev mode

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/server-components.test.ts
@@ -20,6 +20,8 @@ test('Sends a streamed span for a request to app router with URL', async ({ page
 test('Will create streamed spans for every server component and metadata generation functions when visiting a page', async ({
   page,
 }) => {
+  test.skip(isDevMode, 'Turbopack intermittently returns 404 for nested dynamic routes in dev mode');
+
   const spansPromise = waitForStreamedSpans('nextjs-16-streaming', spans => {
     return spans.some(span => span.name === 'GET /nested-layout' && span.is_segment);
   });
@@ -43,6 +45,8 @@ test('Will create streamed spans for every server component and metadata generat
 test('Will create streamed spans for every server component and metadata generation functions when visiting a dynamic page', async ({
   page,
 }) => {
+  test.skip(isDevMode, 'Turbopack intermittently returns 404 for nested dynamic routes in dev mode');
+
   const spansPromise = waitForStreamedSpans('nextjs-16-streaming', spans => {
     return spans.some(span => span.name === 'GET /nested-layout/[dynamic]' && span.is_segment);
   });


### PR DESCRIPTION
## Summary

- Adds `test.skip(isDevMode, ...)` to the two server-component tests at lines 20 and 43 of `nextjs-16-streaming/tests/server-components.test.ts`, mirroring the existing guard already on the line-5 sibling test.

## Root cause

The dev-mode run of [job 76892959990](https://github.com/getsentry/sentry-javascript/actions/runs/26142938112/job/76892959990) shows the dev server returning 404 every time the tests navigate into the `(nested-layout)` route group:

```
[WebServer] GET /nested-layout 404 in 776ms
[WebServer] GET /nested-layout 404 in 57ms
[WebServer] GET /nested-layout 404 in 44ms
[WebServer] GET /nested-layout 404 in 47ms
[WebServer] GET /nested-layout/123 404 in 50ms
...
```

The page never loads, no `GET /nested-layout` segment span is emitted, `waitForStreamedSpans` never resolves, and Playwright times out after 30 s on all four attempts.

This is the same Turbopack-in-dev bug already called out in the existing line-5 skip:

```ts
test.skip(isDevMode, 'Turbopack intermittently returns 404 for nested dynamic routes in dev mode');
```

The fix reuses that exact line on both affected tests. `test:prod` continues to run them and is unaffected.

Fixes #21023
Fixes #21000

🤖 Generated with [Claude Code](https://claude.com/claude-code)