### PR TITLE
test(node-integration): Raise kafkajs test timeout to 90s

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/test.ts
@@ -8,7 +8,7 @@ describe('kafkajs', () => {
   });
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
-    test('traces producers and consumers', { timeout: 60_000 }, async () => {
+    test('traces producers and consumers', { timeout: 90_000 }, async () => {
       // The producer and consumer transactions can arrive in any order,
       // so we collect them and assert after both have been received.
       const receivedTransactions: TransactionEvent[] = [];


### PR DESCRIPTION
## Summary

- Bumps the per-test Vitest timeout in `suites/tracing/kafkajs/test.ts` from `60_000` to `90_000`, matching the existing `postgres` / `postgresjs` heavier-weight docker-compose tests.

## Root cause

[Failing run](https://github.com/getsentry/sentry-javascript/actions/runs/25739611807/job/75586923038):

```
FAIL suites/tracing/kafkajs/test.ts > kafkajs > esm/cjs > esm > traces producers and consumers
Error: Test timed out in 60000ms.
```

The Vitest `{ timeout: 60_000 }` covers everything: `docker-compose up` + kafka broker healthcheck + scenario (connect admin, connect producer, create topic, connect consumer, subscribe, 4 s wait, produce, consume, both spans flushed). The compose healthcheck alone can take up to ~75 s on a busy runner (15 s `start_period` + 30 retries × 2 s interval), leaving the actual scenario little to no headroom.

Raising to `90_000` adds 50% of margin while staying within the precedent set by sibling heavy-broker tests (`postgres`, `postgresjs` line 419/508 both use `{ timeout: 90_000 }`).

Fixes #20840

🤖 Generated with [Claude Code](https://claude.com/claude-code)