### PR TITLE
test(opentelemetry): Avoid wallclock race in remaining startSpan timestamp tests

### DIFF
--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -2120,10 +2120,7 @@ describe('span.end() timestamp conversion', () => {
   });
 
   it('converts seconds to milliseconds for startInactiveSpan', () => {
-    // +10s buffer: if the wallclock rolls past the next-second boundary between computing
-    // nowSec and creating the span, `endTime = [nowSec, 0]` is < startTime, OTel clamps
-    // endTime to startTime, and `endTime[1]` ends up at the startTime's nanos rather than 0.
-    // See #20962 / #21045 for the same fix on the sibling child-span test.
+    // +10s buffer (see startInactiveSpan test above): avoids OTel's endTime-before-startTime clamp.
     const nowSec = Math.floor(Date.now() / 1000) + 10;
     const span = startInactiveSpan({ name: 'test' });
     span.end(nowSec);

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -2120,9 +2120,11 @@ describe('span.end() timestamp conversion', () => {
   });
 
   it('converts seconds to milliseconds for startInactiveSpan', () => {
-    // Use a timestamp in seconds that is after the span start (i.e. in the future)
-    // OTel resets endTime to startTime if endTime < startTime
-    const nowSec = Math.floor(Date.now() / 1000) + 1;
+    // +10s buffer: if the wallclock rolls past the next-second boundary between computing
+    // nowSec and creating the span, `endTime = [nowSec, 0]` is < startTime, OTel clamps
+    // endTime to startTime, and `endTime[1]` ends up at the startTime's nanos rather than 0.
+    // See #20962 / #21045 for the same fix on the sibling child-span test.
+    const nowSec = Math.floor(Date.now() / 1000) + 10;
     const span = startInactiveSpan({ name: 'test' });
     span.end(nowSec);
 
@@ -2164,7 +2166,8 @@ describe('span.end() timestamp conversion', () => {
   });
 
   it('handles HrTime input for startInactiveSpan', () => {
-    const nowSec = Math.floor(Date.now() / 1000) + 1;
+    // +10s buffer (see startInactiveSpan test above): avoids OTel's endTime-before-startTime clamp.
+    const nowSec = Math.floor(Date.now() / 1000) + 10;
     const span = startInactiveSpan({ name: 'test' });
     span.end([nowSec, 500000000] as [number, number]);
 
@@ -2174,7 +2177,8 @@ describe('span.end() timestamp conversion', () => {
   });
 
   it('converts seconds to milliseconds for startSpanManual callback span', () => {
-    const nowSec = Math.floor(Date.now() / 1000) + 1;
+    // +10s buffer (see startInactiveSpan test above): avoids OTel's endTime-before-startTime clamp.
+    const nowSec = Math.floor(Date.now() / 1000) + 10;
     startSpanManual({ name: 'test' }, span => {
       span.end(nowSec);
 

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -2162,43 +2162,43 @@ describe('span.end() timestamp conversion', () => {
     expect(endTime![0]).not.toBe(0);
   });
 
-  it('handles HrTime input for startInactiveSpan', () => {
-    // +10s buffer (see startInactiveSpan test above): avoids OTel's endTime-before-startTime clamp.
-    const nowSec = Math.floor(Date.now() / 1000) + 10;
-    const span = startInactiveSpan({ name: 'test' });
-    span.end([nowSec, 500000000] as [number, number]);
-
-    const endTime = getSpanEndTime(span);
-    expect(endTime![0]).toBe(nowSec);
-    expect(endTime![1]).toBe(500000000);
-  });
-
-  it('converts seconds to milliseconds for startSpanManual callback span', () => {
-    // +10s buffer (see startInactiveSpan test above): avoids OTel's endTime-before-startTime clamp.
-    const nowSec = Math.floor(Date.now() / 1000) + 10;
-    startSpanManual({ name: 'test' }, span => {
-      span.end(nowSec);
+  // +10s buffer: if the wallclock rolls past the next-second boundary between computing
+  // nowSec and creating the span, `endTime = [nowSec, 0]` is < startTime, OTel clamps
+  // endTime to startTime, and `endTime[1]` ends up at the startTime's nanos rather than 0.
+  describe('span.end() timestamp conversion', () => {
+    it('handles HrTime input for startInactiveSpan', () => {
+      const nowSec = Math.floor(Date.now() / 1000) + 10;
+      const span = startInactiveSpan({ name: 'test' });
+      span.end([nowSec, 500000000] as [number, number]);
 
       const endTime = getSpanEndTime(span);
       expect(endTime![0]).toBe(nowSec);
-      expect(endTime![1]).toBe(0);
-    });
-  });
-
-  it('converts seconds to milliseconds for startSpan child span', () => {
-    // +10s buffer (not +1 like sibling tests): the outer startSpan + inner startInactiveSpan
-    // adds enough wallclock overhead that nowSec*1000 can slip behind innerSpan's startTime,
-    // tripping OTel's `endTime < startTime` clamp and copying startTime's nanos onto endTime.
-    const nowSec = Math.floor(Date.now() / 1000) + 10;
-    let capturedEndTime: [number, number] | undefined;
-    startSpan({ name: 'outer' }, () => {
-      const innerSpan = startInactiveSpan({ name: 'inner' });
-      innerSpan.end(nowSec);
-      capturedEndTime = getSpanEndTime(innerSpan);
+      expect(endTime![1]).toBe(500000000);
     });
 
-    expect(capturedEndTime![0]).toBe(nowSec);
-    expect(capturedEndTime![1]).toBe(0);
+    it('converts seconds to milliseconds for startSpanManual callback span', () => {
+      const nowSec = Math.floor(Date.now() / 1000) + 10;
+      startSpanManual({ name: 'test' }, span => {
+        span.end(nowSec);
+
+        const endTime = getSpanEndTime(span);
+        expect(endTime![0]).toBe(nowSec);
+        expect(endTime![1]).toBe(0);
+      });
+    });
+
+    it('converts seconds to milliseconds for startSpan child span', () => {
+      const nowSec = Math.floor(Date.now() / 1000) + 10;
+      let capturedEndTime: [number, number] | undefined;
+      startSpan({ name: 'outer' }, () => {
+        const innerSpan = startInactiveSpan({ name: 'inner' });
+        innerSpan.end(nowSec);
+        capturedEndTime = getSpanEndTime(innerSpan);
+      });
+
+      expect(capturedEndTime![0]).toBe(nowSec);
+      expect(capturedEndTime![1]).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #20901. Closes #20851.

PR #21045 fixed `converts seconds to milliseconds for startSpan child span` by bumping its `+1`s buffer to `+10`s. The same wallclock-boundary race affects the three sibling tests in the same describe block:

- `converts seconds to milliseconds for startInactiveSpan` ← flake #20901
- `converts seconds to milliseconds for startSpanManual callback span` ← flake #20851
- `handles HrTime input for startInactiveSpan` — no flake report yet, but vulnerable to the same clamp; if the wallclock rolls past `nowSec * 1000` ms before span creation, OTel clamps `endTime` to `startTime` and `endTime[1]` is no longer `500_000_000`. Bumped for consistency.

If `Date.now()` is in the last few microseconds of a second when `nowSec = Math.floor(Date.now() / 1000) + 1` is computed, span creation can cross the boundary so the span's `startTime` lands at `[nowSec, ~N ns]` — *after* the requested `endTime = [nowSec, 0]`. OTel's `Span.end` then triggers:

```js
if (this._duration[0] < 0) {
  this.endTime = this.startTime.slice();
  this._duration = [0, 0];
}
```

…copying the startTime nanos onto `endTime[1]`, breaking the `toBe(0)` (or `toBe(500_000_000)`) assertion.

Bumping the buffer to `+10`s puts the requested `endTime` safely past the span's start time so the clamp can't fire under normal test execution.