### PR TITLE
test(node-integration): Assert mongodb span breakdown for diagnostic failures

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/mongodb/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb/test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect } from 'vitest';
 import { assertSentryTransaction } from '../../../utils/assertions';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
-describe('MongoDB experimental Test', () => {
+describe('MongoDB auto-instrumentation', () => {
   let mongoServer: MongoMemoryServer;
 
   beforeAll(async () => {
@@ -122,20 +122,43 @@ describe('MongoDB experimental Test', () => {
           transaction: (txn: TransactionEvent) => {
             assertSentryTransaction(txn, { transaction: 'Test Transaction' });
             const spans = txn.spans || [];
-            expect(spans).toHaveLength(8);
+
+            // Assert the per-operation breakdown rather than just a total span
+            // count. When the driver occasionally emits an extra command
+            // (e.g. a stray `isMaster` from a reconnect, a `ping`, or a
+            // heartbeat), `toEqual` shows a clear per-operation diff like
+            // "isMaster: 2 → 3" instead of an opaque "8 vs 9" length
+            // mismatch — making future flakes self-diagnosing.
+            //
+            // `db.operation` isn't set on every span — the `endSessions`
+            // command exposes its name only via `db.statement` — so derive
+            // the operation by parsing the leading command name out of
+            // `db.statement` as a fallback.
+            const operationCounts = spans.reduce<Record<string, number>>((acc, span) => {
+              const data = (span.data ?? {}) as Record<string, unknown>;
+              let op = typeof data['db.operation'] === 'string' ? (data['db.operation'] as string) : undefined;
+              if (!op) {
+                const stmt = data['db.statement'];
+                const match = typeof stmt === 'string' ? stmt.match(/^\{"(\w+)"/) : null;
+                op = match ? match[1] : 'unknown';
+              }
+              acc[op] = (acc[op] || 0) + 1;
+              return acc;
+            }, {});
+
+            expect(operationCounts).toEqual({
+              find: 3,
+              isMaster: 2,
+              insert: 1,
+              update: 1,
+              endSessions: 1,
+            });
 
             expect(spans).toContainEqual(SPAN_FIND_MATCHER);
             expect(spans).toContainEqual(SPAN_INSERT_MATCHER);
             expect(spans).toContainEqual(SPAN_ISMASTER_MATCHER);
             expect(spans).toContainEqual(SPAN_UPDATE_MATCHER);
             expect(spans).toContainEqual(SPAN_ENDSESSIONS_MATCHER);
-
-            // Ensure duplicate spans are correctly there
-            const findSpans = spans.filter(span => span.data['db.operation'] === 'find');
-            expect(findSpans).toHaveLength(3);
-
-            const isMasterSpans = spans.filter(span => span.data['db.operation'] === 'isMaster');
-            expect(isMasterSpans).toHaveLength(2);
           },
         })
         .start()


### PR DESCRIPTION
## Summary

- Replaces the bare `expect(spans).toHaveLength(8)` + `findSpans.length === 3` + `isMasterSpans.length === 2` triple in `suites/tracing/mongodb/test.ts` with a single `toEqual` on the per-`db.operation` breakdown.

## Why

From the [failing run](https://github.com/getsentry/sentry-javascript/actions/runs/25613039324/job/75186545075):

```
AssertionError: expected [ { …(10) }, { …(10) }, …(7) ] to have a length of 8 but got 9
> 124 |          expect(spans).toHaveLength(8);
```

The previous assertion told us "8 expected, 9 received" — but nothing about *which* operation drifted. With this change, when the test fails the same way again, the diff is:

```
- Expected
+ Received

  Object {
    "find": 3,
-   "isMaster": 2,
+   "isMaster": 3,
    "insert": 1,
    "update": 1,
    "endSessions": 1,
  }
```

— pointing the next investigator straight at the extra `isMaster` (or whichever command actually drifted). The flake itself isn't fixed here; the goal is that the *next* occurrence is self-diagnosing instead of opaque.

## Detail

The scenario at `mongodb/scenario.mjs` issues 8 commands: 2 isMaster (from `connect()`), 1 insert, 3 find (one each from the two `findOne` calls plus the `find().toArray()`), 1 update, 1 endSessions (from `client.close()`). The new assertion encodes that exact breakdown.

`db.operation` isn't set on `endSessions` spans — they only expose the command name via `db.statement`. The classifier falls back to parsing the leading `{"<command>"` token out of `db.statement` for that case.

The `toContainEqual` matchers for span shape (find/insert/isMaster/update/endSessions) are unchanged.

Fixes #20781

🤖 Generated with [Claude Code](https://claude.com/claude-code)
