### PR TITLE
test(node): Fix flaky MongoDB integration test

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/mongodb/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb/scenario.mjs
@@ -5,6 +5,8 @@ const { MongoClient } = mongodb;
 
 const client = new MongoClient(process.env.MONGO_URL || '', {
   useUnifiedTopology: true,
+  heartbeatFrequencyMS: 60000,
+  minHeartbeatFrequencyMS: 60000,
 });
 
 async function run() {


### PR DESCRIPTION
closes #20781
closes [JS-2424](https://linear.app/getsentry/issue/JS-2424)

closes #20958
closes [JS-2523](https://linear.app/getsentry/issue/JS-2523)

Set high heartbeatFrequencyMS (60s) to prevent extra MongoDB driver heartbeats from firing during the test. The 2 isMaster spans come from the initial connection handshake and are deterministic. Extra heartbeats were causing 9 spans instead of 8 on slower CI machines.
