### PR TITLE
fix(nextjs): widen `project` option type to `string | string[]`

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -186,7 +186,7 @@ export type SentryBuildOptions = {
    *
    * This value can also be specified via the `SENTRY_PROJECT` environment variable.
    */
-  project?: string;
+  project?: string | string[];
 
   /**
    * The authentication token to use for all communication with Sentry.


### PR DESCRIPTION
`@sentry/bundler-plugin-core` accepts `string | string[]` for `project` but `SentryBuildOptions` narrowed it to `string`, causing a TS error when users passed an array even though the value is forwarded verbatim.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [x] Link an issue if there is one related to your pull request. If no issue is linked, one will be auto-generated and linked.

Closes #21066
