### PR TITLE
feat(core): Migrate trpc to `dataCollection`

### DIFF
--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -60,7 +60,11 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
         (clientOptions?.normalizeDepth ?? 5), // 5 is a sane depth
     );
 
-    if (options.attachRpcInput !== undefined ? options.attachRpcInput : dataCollection?.httpBodies.includes('incomingRequest')) {
+    if (
+      options.attachRpcInput !== undefined
+        ? options.attachRpcInput
+        : dataCollection?.httpBodies.includes('incomingRequest')
+    ) {
       if (rawInput !== undefined) {
         trpcContext.input = normalize(rawInput);
       }

--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -47,6 +47,7 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
 
     const client = getClient();
     const clientOptions = client?.getOptions();
+    const dataCollection = client?.getDataCollectionOptions();
 
     const trpcContext: Record<string, unknown> = {
       procedure_path: path,
@@ -59,7 +60,7 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
         (clientOptions?.normalizeDepth ?? 5), // 5 is a sane depth
     );
 
-    if (options.attachRpcInput !== undefined ? options.attachRpcInput : clientOptions?.sendDefaultPii) {
+    if (options.attachRpcInput !== undefined ? options.attachRpcInput : dataCollection?.httpBodies.includes('incomingRequest')) {
       if (rawInput !== undefined) {
         trpcContext.input = normalize(rawInput);
       }

--- a/packages/core/test/lib/trpc.test.ts
+++ b/packages/core/test/lib/trpc.test.ts
@@ -3,6 +3,7 @@ import { type Client, setCurrentClient, type Span, trpcMiddleware } from '../../
 import * as currentScopes from '../../src/currentScopes';
 import * as exports from '../../src/exports';
 import * as tracing from '../../src/tracing';
+import { resolveDataCollectionOptions } from '../../src/utils/data-collection/resolveDataCollectionOptions';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 
 describe('trpcMiddleware', () => {
@@ -13,6 +14,7 @@ describe('trpcMiddleware', () => {
       normalizeDepth: 3,
       sendDefaultPii: false,
     }),
+    getDataCollectionOptions: vi.fn().mockReturnValue(resolveDataCollectionOptions({ sendDefaultPii: false })),
     captureException: vi.fn(),
   } as unknown as Client;
 


### PR DESCRIPTION
We now attach the rpc input depending on https://develop.sentry.dev/sdk/foundations/client/data-collection/#body-type-collection.

closes https://github.com/getsentry/sentry-javascript/issues/21049