### PR TITLE
feat(logs): Migrate log envelope user inference to `dataCollection`

### DIFF
--- a/packages/core/src/logs/internal.ts
+++ b/packages/core/src/logs/internal.ts
@@ -197,7 +197,7 @@ export function _INTERNAL_flushLogsBuffer(client: Client, maybeLogBuffer?: Array
     clientOptions._metadata,
     clientOptions.tunnel,
     client.getDsn(),
-    clientOptions.sendDefaultPii,
+    client.getDataCollectionOptions().userInfo,
   );
 
   // Clear the log buffer after envelopes have been constructed.


### PR DESCRIPTION
Replaces `clientOptions.sendDefaultPii` with `client.getDataCollectionOptions().userInfo`

closes https://github.com/getsentry/sentry-javascript/issues/21052