### PR TITLE
docs(agents): No 'Test plan' checklist in PR bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Uses **Git Flow** (see `docs/gitflow.md`).
 
 ## Pull Requests
 
-- **Do NOT add a "Test plan" / "Testing" checklist to PR bodies.** CI runs the full test suite on every PR — a hand-rolled checklist duplicates that signal and rots fast. Use the PR body for *Summary* and *Root cause* (if relevant) only.
+- **Do NOT add a "Test plan" / "Testing" checklist to PR bodies.** CI runs the full test suite on every PR — a hand-rolled checklist duplicates that signal and rots fast. Use the PR body for _Summary_ and _Root cause_ (if relevant) only.
 - Include `Fixes #<issue-number>` somewhere in the PR body so the merge auto-closes the linked issue.
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,11 @@ Uses **Git Flow** (see `docs/gitflow.md`).
 4. `yarn build:dev`
 5. NEVER push on `develop`
 
+## Pull Requests
+
+- **Do NOT add a "Test plan" / "Testing" checklist to PR bodies.** CI runs the full test suite on every PR — a hand-rolled checklist duplicates that signal and rots fast. Use the PR body for *Summary* and *Root cause* (if relevant) only.
+- Include `Fixes #<issue-number>` somewhere in the PR body so the merge auto-closes the linked issue.
+
 ## Architecture
 
 ### Core


### PR DESCRIPTION
## Summary

Adds a "Pull Requests" section to `AGENTS.md` codifying two existing-but-undocumented conventions:

1. **No "Test plan" / "Testing" checklist** in PR bodies. CI runs the full test suite on every PR — a hand-rolled checklist duplicates that signal and rots fast. Use the PR body for *Summary* and *Root cause* (if relevant) only.
2. **Include `Fixes #<issue-number>`** in the PR body so merge auto-closes the linked issue.

