### PR TITLE
ci: Only run Check lockfile when package.json or yarn.lock changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,6 +340,10 @@ jobs:
     needs: [job_get_metadata]
     timeout-minutes: 10
     runs-on: ubuntu-24.04
+    if: |
+      needs.job_get_metadata.outputs.changed_deps == 'true' ||
+      needs.job_get_metadata.outputs.is_base_branch == 'true' ||
+      needs.job_get_metadata.outputs.is_release == 'true'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v6

--- a/.github/workflows/ci-metadata.yml
+++ b/.github/workflows/ci-metadata.yml
@@ -22,6 +22,9 @@ on:
       changed_any_code:
         description: 'Whether any non-markdown files changed'
         value: ${{ jobs.get_metadata.outputs.changed_any_code }}
+      changed_deps:
+        description: 'Whether any package.json or yarn.lock changed'
+        value: ${{ jobs.get_metadata.outputs.changed_deps }}
       is_gitflow_sync:
         description: 'Whether this is a gitflow sync (master merge)'
         value: ${{ jobs.get_metadata.outputs.is_gitflow_sync }}
@@ -69,6 +72,9 @@ jobs:
               - '.github/**'
             any_code:
               - '!**/*.md'
+            deps:
+              - '**/package.json'
+              - 'yarn.lock'
 
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
@@ -78,6 +84,7 @@ jobs:
       is_release: ${{ startsWith(github.ref, 'refs/heads/release/') }}
       changed_ci: ${{ steps.changed.outputs.workflow == 'true' }}
       changed_any_code: ${{ steps.changed.outputs.any_code == 'true' }}
+      changed_deps: ${{ steps.changed.outputs.deps == 'true' }}
 
       # When merging into master, or from master
       is_gitflow_sync: ${{ github.head_ref == 'master' || github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
## Summary

Gates the `job_check_lockfile` job in `build.yml` on whether `package.json` (any of them) or `yarn.lock` actually changed. PRs that don't touch dependencies skip it.

## How

Adds a `deps` filter to the existing `dorny/paths-filter` step in `ci-metadata.yml` (matching `**/package.json` + `yarn.lock`), exposes it as a new `changed_deps` output, and adds an `if:` condition to `job_check_lockfile`:

```yaml
if: |
  needs.job_get_metadata.outputs.changed_deps == 'true' ||
  needs.job_get_metadata.outputs.is_base_branch == 'true' ||
  needs.job_get_metadata.outputs.is_release == 'true'
```

Pushes to base branches (`develop` / `v9` / `v8`) and release branches still run the check unconditionally — same safety pattern as `job_build`, so the lockfile is always verified end-to-end on those.
