### PR TITLE
feat(core): Migrate span streaming envelope to `dataCollection`

### DIFF
--- a/packages/core/src/tracing/spans/envelope.ts
+++ b/packages/core/src/tracing/spans/envelope.ts
@@ -25,7 +25,7 @@ export function createStreamedSpanEnvelope(
     ...(!!tunnel && dsn && { dsn: dsnToString(dsn) }),
   };
 
-  const inferSetting = options.sendDefaultPii ? 'auto' : 'never';
+  const inferSetting = client.getDataCollectionOptions().userInfo ? 'auto' : 'never';
 
   const spanContainer: SpanContainerItem = [
     { type: 'span', item_count: serializedSpans.length, content_type: 'application/vnd.sentry.items.span.v2+json' },

--- a/packages/core/test/lib/tracing/spans/envelope.test.ts
+++ b/packages/core/test/lib/tracing/spans/envelope.test.ts
@@ -240,11 +240,11 @@ describe('createStreamedSpanEnvelope', () => {
       ]);
     });
 
-    it("includes ingest_settings with 'auto' values when in browser and sendDefaultPii is true", () => {
+    it("includes ingest_settings with 'auto' values when in browser and dataCollection.userInfo is true", () => {
       vi.mocked(isBrowser).mockReturnValue(true);
 
       const mockSpan = createMockSerializedSpan();
-      const mockClient = new TestClient(getDefaultTestClientOptions({ sendDefaultPii: true }));
+      const mockClient = new TestClient(getDefaultTestClientOptions({ dataCollection: { userInfo: true } }));
       const dsc: Partial<DynamicSamplingContext> = {};
 
       const envelopeItems = createStreamedSpanEnvelope([mockSpan], dsc, mockClient)[1];
@@ -261,11 +261,11 @@ describe('createStreamedSpanEnvelope', () => {
       ]);
     });
 
-    it("includes ingest_settings with 'never' values when in browser and sendDefaultPii is false", () => {
+    it("includes ingest_settings with 'never' values when in browser and dataCollection.userInfo is false", () => {
       vi.mocked(isBrowser).mockReturnValue(true);
 
       const mockSpan = createMockSerializedSpan();
-      const mockClient = new TestClient(getDefaultTestClientOptions({ sendDefaultPii: false }));
+      const mockClient = new TestClient(getDefaultTestClientOptions({ dataCollection: { userInfo: false } }));
       const dsc: Partial<DynamicSamplingContext> = {};
 
       const envelopeItems = createStreamedSpanEnvelope([mockSpan], dsc, mockClient)[1];
@@ -284,6 +284,26 @@ describe('createStreamedSpanEnvelope', () => {
 
     it('omits ingest_settings when not in browser', () => {
       const mockSpan = createMockSerializedSpan();
+      const mockClient = new TestClient(getDefaultTestClientOptions({ dataCollection: { userInfo: true } }));
+      const dsc: Partial<DynamicSamplingContext> = {};
+
+      const envelopeItems = createStreamedSpanEnvelope([mockSpan], dsc, mockClient)[1];
+
+      expect(envelopeItems).toEqual([
+        [
+          { type: 'span', item_count: 1, content_type: 'application/vnd.sentry.items.span.v2+json' },
+          {
+            version: 2,
+            items: [mockSpan],
+          },
+        ],
+      ]);
+    });
+
+    it('respects sendDefaultPii bridged to dataCollection.userInfo', () => {
+      vi.mocked(isBrowser).mockReturnValue(true);
+
+      const mockSpan = createMockSerializedSpan();
       const mockClient = new TestClient(getDefaultTestClientOptions({ sendDefaultPii: true }));
       const dsc: Partial<DynamicSamplingContext> = {};
 
@@ -294,6 +314,7 @@ describe('createStreamedSpanEnvelope', () => {
           { type: 'span', item_count: 1, content_type: 'application/vnd.sentry.items.span.v2+json' },
           {
             version: 2,
+            ingest_settings: { infer_ip: 'auto', infer_user_agent: 'auto' },
             items: [mockSpan],
           },
         ],

--- a/packages/core/test/lib/tracing/spans/envelope.test.ts
+++ b/packages/core/test/lib/tracing/spans/envelope.test.ts
@@ -300,7 +300,7 @@ describe('createStreamedSpanEnvelope', () => {
       ]);
     });
 
-    it('respects sendDefaultPii bridged to dataCollection.userInfo', () => {
+    it("respects sendDefaultPii: true bridged to dataCollection.userInfo", () => {
       vi.mocked(isBrowser).mockReturnValue(true);
 
       const mockSpan = createMockSerializedSpan();
@@ -315,6 +315,27 @@ describe('createStreamedSpanEnvelope', () => {
           {
             version: 2,
             ingest_settings: { infer_ip: 'auto', infer_user_agent: 'auto' },
+            items: [mockSpan],
+          },
+        ],
+      ]);
+    });
+
+    it("respects sendDefaultPii: false bridged to dataCollection.userInfo", () => {
+      vi.mocked(isBrowser).mockReturnValue(true);
+
+      const mockSpan = createMockSerializedSpan();
+      const mockClient = new TestClient(getDefaultTestClientOptions({ sendDefaultPii: false }));
+      const dsc: Partial<DynamicSamplingContext> = {};
+
+      const envelopeItems = createStreamedSpanEnvelope([mockSpan], dsc, mockClient)[1];
+
+      expect(envelopeItems).toEqual([
+        [
+          { type: 'span', item_count: 1, content_type: 'application/vnd.sentry.items.span.v2+json' },
+          {
+            version: 2,
+            ingest_settings: { infer_ip: 'never', infer_user_agent: 'never' },
             items: [mockSpan],
           },
         ],

--- a/packages/core/test/lib/tracing/spans/envelope.test.ts
+++ b/packages/core/test/lib/tracing/spans/envelope.test.ts
@@ -300,7 +300,7 @@ describe('createStreamedSpanEnvelope', () => {
       ]);
     });
 
-    it("respects sendDefaultPii: true bridged to dataCollection.userInfo", () => {
+    it('respects sendDefaultPii: true bridged to dataCollection.userInfo', () => {
       vi.mocked(isBrowser).mockReturnValue(true);
 
       const mockSpan = createMockSerializedSpan();
@@ -321,7 +321,7 @@ describe('createStreamedSpanEnvelope', () => {
       ]);
     });
 
-    it("respects sendDefaultPii: false bridged to dataCollection.userInfo", () => {
+    it('respects sendDefaultPii: false bridged to dataCollection.userInfo', () => {
       vi.mocked(isBrowser).mockReturnValue(true);
 
       const mockSpan = createMockSerializedSpan();


### PR DESCRIPTION
Switch to reading from `dataCollection.userInfo` instead of `sendDefaultPii`

closes https://github.com/getsentry/sentry-javascript/issues/21079