### PR TITLE
feat(core): Migrate Supabase integration to `dataCollection`

### DIFF
--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -151,7 +151,7 @@ function isInstrumented<T>(fn: T): boolean | undefined {
 
 /**
  * Plain-object bodies are copied into `plainBody`; array inserts (and other non-plain shapes) stay only on `rawBody`.
- * Returns a payload suitable for span attributes / breadcrumbs when the client has `sendDefaultPii` enabled.
+ * Returns a payload suitable for span attributes / breadcrumbs when operation data collection is enabled.
  */
 function getMutationBodyPayloadForTelemetry(rawBody: unknown, plainBody: Record<string, unknown>): unknown | undefined {
   if (Object.keys(plainBody).length > 0) {
@@ -322,7 +322,7 @@ function instrumentSupabaseAuthClient(supabaseClientInstance: SupabaseClientInst
   markAsInstrumented(supabaseClientInstance.auth);
 }
 
-function instrumentSupabaseClientConstructor(SupabaseClient: unknown): void {
+function instrumentSupabaseClientConstructor(SupabaseClient: unknown, _options: { sendOperationData?: boolean }): void {
   if (isInstrumented((SupabaseClient as SupabaseClientConstructor).prototype.from)) {
     return;
   }
@@ -334,7 +334,7 @@ function instrumentSupabaseClientConstructor(SupabaseClient: unknown): void {
         const rv = Reflect.apply(target, thisArg, argumentsList);
         const PostgRESTQueryBuilder = (rv as PostgRESTQueryBuilder).constructor;
 
-        instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder as unknown as new () => PostgRESTQueryBuilder);
+        instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder as unknown as new () => PostgRESTQueryBuilder, _options);
 
         return rv;
       },
@@ -344,7 +344,10 @@ function instrumentSupabaseClientConstructor(SupabaseClient: unknown): void {
   markAsInstrumented((SupabaseClient as SupabaseClientConstructor).prototype.from);
 }
 
-function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilterBuilder['constructor']): void {
+function instrumentPostgRESTFilterBuilder(
+  PostgRESTFilterBuilder: PostgRESTFilterBuilder['constructor'],
+  _options: { sendOperationData?: boolean },
+): void {
   if (isInstrumented((PostgRESTFilterBuilder.prototype as unknown as PostgRESTProtoThenable).then)) {
     return;
   }
@@ -381,7 +384,8 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
           }
         }
 
-        const sendDefaultPii = Boolean(getClient()?.getOptions().sendDefaultPii);
+        const client = getClient();
+        const shouldSendData = _options.sendOperationData ?? client?.getDataCollectionOptions().userInfo === true;
         const bodyPayload = getMutationBodyPayloadForTelemetry(typedThis.body, body);
 
         // Adding operation to the beginning of the description if it's not a `select` operation
@@ -391,7 +395,7 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
           operation === 'select'
             ? ''
             : `${operation}${hasMutationBodyForDescription(typedThis.body, body) ? '(...) ' : ''}`;
-        const queryPart = sendDefaultPii ? queryItems.join(' ') : queryItems.length > 0 ? '[redacted]' : '';
+        const queryPart = shouldSendData ? queryItems.join(' ') : queryItems.length > 0 ? '[redacted]' : '';
         const descriptionMiddle = [mutationPart.trimEnd(), queryPart].filter(Boolean).join(' ');
         const description = descriptionMiddle ? `${descriptionMiddle} from(${table})` : `from(${table})`;
 
@@ -406,11 +410,11 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
         };
 
-        if (queryItems.length && sendDefaultPii) {
+        if (queryItems.length && shouldSendData) {
           attributes['db.query'] = queryItems;
         }
 
-        if (bodyPayload !== undefined && sendDefaultPii) {
+        if (bodyPayload !== undefined && shouldSendData) {
           attributes['db.body'] = bodyPayload;
         }
 
@@ -440,10 +444,10 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
                     }
 
                     const supabaseContext: Record<string, any> = {};
-                    if (queryItems.length && sendDefaultPii) {
+                    if (queryItems.length && shouldSendData) {
                       supabaseContext.query = queryItems;
                     }
-                    if (bodyPayload !== undefined && sendDefaultPii) {
+                    if (bodyPayload !== undefined && shouldSendData) {
                       supabaseContext.body = bodyPayload;
                     }
 
@@ -471,11 +475,11 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
 
                   const data: Record<string, unknown> = {};
 
-                  if (queryItems.length && sendDefaultPii) {
+                  if (queryItems.length && shouldSendData) {
                     data.query = queryItems;
                   }
 
-                  if (bodyPayload !== undefined && sendDefaultPii) {
+                  if (bodyPayload !== undefined && shouldSendData) {
                     data.body = bodyPayload;
                   }
 
@@ -506,7 +510,10 @@ function instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder: PostgRESTFilte
   markAsInstrumented((PostgRESTFilterBuilder.prototype as unknown as PostgRESTProtoThenable).then);
 }
 
-function instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder: new () => PostgRESTQueryBuilder): void {
+function instrumentPostgRESTQueryBuilder(
+  PostgRESTQueryBuilder: new () => PostgRESTQueryBuilder,
+  _options: { sendOperationData?: boolean },
+): void {
   // We need to wrap _all_ operations despite them sharing the same `PostgRESTFilterBuilder`
   // constructor, as we don't know which method will be called first, and we don't want to miss any calls.
   for (const operation of DB_OPERATIONS_TO_INSTRUMENT) {
@@ -524,7 +531,7 @@ function instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder: new () => PostgR
 
           DEBUG_BUILD && debug.log(`Instrumenting ${operation} operation's PostgRESTFilterBuilder`);
 
-          instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder);
+          instrumentPostgRESTFilterBuilder(PostgRESTFilterBuilder, _options);
 
           return rv;
         },
@@ -535,7 +542,10 @@ function instrumentPostgRESTQueryBuilder(PostgRESTQueryBuilder: new () => PostgR
   }
 }
 
-export const instrumentSupabaseClient = (supabaseClient: unknown): void => {
+export const instrumentSupabaseClient = (
+  supabaseClient: unknown,
+  options: { sendOperationData?: boolean } = {},
+): void => {
   if (!supabaseClient) {
     DEBUG_BUILD && debug.warn('Supabase integration was not installed because no Supabase client was provided.');
     return;
@@ -543,21 +553,33 @@ export const instrumentSupabaseClient = (supabaseClient: unknown): void => {
   const SupabaseClientConstructor =
     supabaseClient.constructor === Function ? supabaseClient : supabaseClient.constructor;
 
-  instrumentSupabaseClientConstructor(SupabaseClientConstructor);
+  instrumentSupabaseClientConstructor(SupabaseClientConstructor, options);
   instrumentSupabaseAuthClient(supabaseClient as SupabaseClientInstance);
 };
 
+interface SupabaseIntegrationOptions {
+  supabaseClient: any;
+  /**
+   * Whether to attach PostgREST query filters and mutation body payloads
+   * to Sentry telemetry.
+   *
+   * Falls back to `dataCollection.userInfo` when not set.
+   * @default undefined
+   */
+  sendOperationData?: boolean;
+}
+
 const INTEGRATION_NAME = 'Supabase';
 
-const _supabaseIntegration = ((supabaseClient: unknown) => {
+const _supabaseIntegration = ((supabaseClient: unknown, options: { sendOperationData?: boolean }) => {
   return {
     setupOnce() {
-      instrumentSupabaseClient(supabaseClient);
+      instrumentSupabaseClient(supabaseClient, options);
     },
     name: INTEGRATION_NAME,
   };
 }) satisfies IntegrationFn;
 
-export const supabaseIntegration = defineIntegration((options: { supabaseClient: any }) => {
-  return _supabaseIntegration(options.supabaseClient);
+export const supabaseIntegration = defineIntegration((options: SupabaseIntegrationOptions) => {
+  return _supabaseIntegration(options.supabaseClient, { sendOperationData: options.sendOperationData });
 }) satisfies IntegrationFn;

--- a/packages/core/test/lib/integrations/supabase.test.ts
+++ b/packages/core/test/lib/integrations/supabase.test.ts
@@ -7,6 +7,7 @@ import {
   translateFiltersIntoMethods,
 } from '../../../src/integrations/supabase';
 import type { PostgRESTQueryBuilder, SupabaseClientInstance } from '../../../src/integrations/supabase';
+import { resolveDataCollectionOptions } from '../../../src/utils/data-collection/resolveDataCollectionOptions';
 
 const tracingMocks = vi.hoisted(() => ({
   startSpan: vi.fn((_opts: unknown, cb: (span: unknown) => unknown) => {
@@ -38,13 +39,13 @@ type CreateMockSupabaseClientOptions = {
   method?: string;
   url?: URL | string;
   body?: unknown;
-  /** When set, configures the mocked Sentry client `sendDefaultPii`. Omit to leave `getClient` to the test file `beforeEach`. */
-  sendDefaultPii?: boolean;
+  /** When set, configures the mocked Sentry client's `dataCollection.userInfo`. Omit to leave `getClient` to the test file `beforeEach`. */
+  dataCollectionUserInfo?: boolean;
 };
 
 const DEFAULT_MOCK_SUPABASE_REST_URL = 'https://example.supabase.co/rest/v1/todos';
 
-/** Shared PATCH + query string + body shape for `sendDefaultPii` tests. */
+/** Shared PATCH + query string + body shape for operation data tests. */
 const MOCK_SUPABASE_PII_SCENARIO: Pick<CreateMockSupabaseClientOptions, 'method' | 'url' | 'body'> = {
   method: 'PATCH',
   url: 'https://example.supabase.co/rest/v1/users?email=eq.secret%40example.com&select=id',
@@ -52,9 +53,9 @@ const MOCK_SUPABASE_PII_SCENARIO: Pick<CreateMockSupabaseClientOptions, 'method'
 };
 
 function createMockSupabaseClient(resolveWith: unknown, options?: CreateMockSupabaseClientOptions): unknown {
-  if (options?.sendDefaultPii !== undefined) {
+  if (options?.dataCollectionUserInfo !== undefined) {
     currentScopesMocks.getClient.mockReturnValue({
-      getOptions: () => ({ sendDefaultPii: options.sendDefaultPii }),
+      getDataCollectionOptions: () => ({ userInfo: options.dataCollectionUserInfo }),
     } as any);
   }
 
@@ -223,7 +224,7 @@ describe('Supabase Integration', () => {
     });
   });
 
-  describe('sendDefaultPii', () => {
+  describe('operation data collection', () => {
     let captureExceptionSpy: ReturnType<typeof vi.spyOn>;
     let addBreadcrumbSpy: ReturnType<typeof vi.spyOn>;
 
@@ -236,10 +237,10 @@ describe('Supabase Integration', () => {
       vi.restoreAllMocks();
     });
 
-    it('omits db.query, db.body, and breadcrumb query/body when sendDefaultPii is false', async () => {
+    it('omits db.query, db.body, and breadcrumb query/body when dataCollection.userInfo is false', async () => {
       const client = createMockSupabaseClient(
         { status: 200 },
-        { ...MOCK_SUPABASE_PII_SCENARIO, sendDefaultPii: false },
+        { ...MOCK_SUPABASE_PII_SCENARIO, dataCollectionUserInfo: false },
       );
       instrumentSupabaseClient(client);
 
@@ -258,8 +259,11 @@ describe('Supabase Integration', () => {
       expect(breadcrumb).not.toHaveProperty('data');
     });
 
-    it('includes db.query, db.body, and breadcrumb query/body when sendDefaultPii is true', async () => {
-      const client = createMockSupabaseClient({ status: 200 }, { ...MOCK_SUPABASE_PII_SCENARIO, sendDefaultPii: true });
+    it('includes db.query, db.body, and breadcrumb query/body when dataCollection.userInfo is true', async () => {
+      const client = createMockSupabaseClient(
+        { status: 200 },
+        { ...MOCK_SUPABASE_PII_SCENARIO, dataCollectionUserInfo: true },
+      );
       instrumentSupabaseClient(client);
 
       await (client as any).from('users').update({}).then();
@@ -286,10 +290,95 @@ describe('Supabase Integration', () => {
       );
     });
 
-    it('omits supabase error context query/body when sendDefaultPii is false', async () => {
+    it('includes data when sendOperationData option is set, regardless of dataCollection.userInfo', async () => {
+      const client = createMockSupabaseClient(
+        { status: 200 },
+        { ...MOCK_SUPABASE_PII_SCENARIO, dataCollectionUserInfo: false },
+      );
+      instrumentSupabaseClient(client, { sendOperationData: true });
+
+      await (client as any).from('users').update({}).then();
+
+      const spanOptions = tracingMocks.startSpan.mock.calls[0]![0] as {
+        name: string;
+        attributes: Record<string, unknown>;
+      };
+      expect(spanOptions.name).toContain('eq(email, secret@example.com)');
+      expect(spanOptions.attributes['db.query']).toEqual(
+        expect.arrayContaining([expect.stringContaining('secret@example.com')]),
+      );
+      expect(spanOptions.attributes['db.body']).toEqual(
+        expect.objectContaining({ full_name: 'Jane Doe', phone: '555-0100' }),
+      );
+    });
+
+    it('sendOperationData: false takes precedence over dataCollection.userInfo: true', async () => {
+      const client = createMockSupabaseClient(
+        { status: 200 },
+        { ...MOCK_SUPABASE_PII_SCENARIO, dataCollectionUserInfo: true },
+      );
+      instrumentSupabaseClient(client, { sendOperationData: false });
+
+      await (client as any).from('users').update({}).then();
+
+      const spanOptions = tracingMocks.startSpan.mock.calls[0]![0] as {
+        name: string;
+        attributes: Record<string, unknown>;
+      };
+      expect(spanOptions.name).toContain('[redacted]');
+      expect(spanOptions.attributes['db.query']).toBeUndefined();
+      expect(spanOptions.attributes['db.body']).toBeUndefined();
+    });
+
+    it('includes data when legacy sendDefaultPii: true is bridged to dataCollection.userInfo', async () => {
+      const resolved = resolveDataCollectionOptions({ sendDefaultPii: true });
+      currentScopesMocks.getClient.mockReturnValue({
+        getDataCollectionOptions: () => resolved,
+      } as any);
+
+      const client = createMockSupabaseClient({ status: 200 }, { ...MOCK_SUPABASE_PII_SCENARIO });
+      instrumentSupabaseClient(client);
+
+      await (client as any).from('users').update({}).then();
+
+      const spanOptions = tracingMocks.startSpan.mock.calls[0]![0] as {
+        name: string;
+        attributes: Record<string, unknown>;
+      };
+      expect(spanOptions.name).toContain('eq(email, secret@example.com)');
+      expect(spanOptions.attributes['db.query']).toEqual(
+        expect.arrayContaining([expect.stringContaining('secret@example.com')]),
+      );
+      expect(spanOptions.attributes['db.body']).toEqual(
+        expect.objectContaining({ full_name: 'Jane Doe', phone: '555-0100' }),
+      );
+    });
+
+    it('redacts data when legacy sendDefaultPii is not set (bridged defaults)', async () => {
+      const resolved = resolveDataCollectionOptions({ sendDefaultPii: false });
+      currentScopesMocks.getClient.mockReturnValue({
+        getDataCollectionOptions: () => resolved,
+      } as any);
+
+      const client = createMockSupabaseClient({ status: 200 }, { ...MOCK_SUPABASE_PII_SCENARIO });
+      instrumentSupabaseClient(client);
+
+      await (client as any).from('users').update({}).then();
+
+      const spanOptions = tracingMocks.startSpan.mock.calls[0]![0] as {
+        name: string;
+        attributes: Record<string, unknown>;
+      };
+      expect(spanOptions.name).toContain('[redacted]');
+      expect(spanOptions.name).not.toContain('secret');
+      expect(spanOptions.attributes['db.query']).toBeUndefined();
+      expect(spanOptions.attributes['db.body']).toBeUndefined();
+    });
+
+    it('omits supabase error context query/body when data collection is off', async () => {
       const client = createMockSupabaseClient(
         { status: 400, error: { message: 'Bad request', code: '400' } },
-        { ...MOCK_SUPABASE_PII_SCENARIO, sendDefaultPii: false },
+        { ...MOCK_SUPABASE_PII_SCENARIO, dataCollectionUserInfo: false },
       );
       instrumentSupabaseClient(client);
 
@@ -328,7 +417,7 @@ describe('Supabase Integration', () => {
           method: 'POST',
           url: 'https://example.supabase.co/rest/v1/todos?columns=',
           body: [{ title: 'Test Todo' }],
-          sendDefaultPii: true,
+          dataCollectionUserInfo: true,
         },
       );
       instrumentSupabaseClient(client);


### PR DESCRIPTION
Replaces `sendDefaultPii` usage in the Supabase integration with the new `dataCollection` API

- Adds a new `sendOperationData` integration option to explicitly control whether PostgREST query filters and mutation body payloads are attached
- Falls back to dataCollection.userInfo when sendOperationData is not set, preserving backwards compatibility with legacy `sendDefaultPii: true` via the bridge function

  | Configuration | Data attached? |
  |---|---|
  | `sendOperationData: true` | Yes (explicit opt-in) |
  | `sendOperationData: false` | No (explicit opt-out) |
  | `sendOperationData` unset + `dataCollection.userInfo: true` | Yes |
  | `sendOperationData` unset + `sendDefaultPii: true` (bridged) | Yes |
  | `sendOperationData` unset + defaults | No |
  
closes https://github.com/getsentry/sentry-javascript/issues/21050