### PR TITLE
ref(node): Vendor `@fastify/otel`

### DIFF
--- a/.oxlintrc.base.json
+++ b/.oxlintrc.base.json
@@ -159,7 +159,8 @@
         "**/integrations/tracing/amqplib/vendored/**/*.ts",
         "**/integrations/tracing/prisma/vendored/**/*.ts",
         "**/integrations/tracing/graphql/vendored/**/*.ts",
-        "**/integrations/tracing/postgres/vendored/**/*.ts"
+        "**/integrations/tracing/postgres/vendored/**/*.ts",
+        "**/integrations/tracing/fastify/vendored/**/*.ts"
       ],
       "rules": {
         "typescript/no-explicit-any": "off"

--- a/dev-packages/e2e-tests/test-applications/nestjs-fastify/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-fastify/tests/transactions.test.ts
@@ -62,7 +62,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
           data: {
             'sentry.origin': 'auto.http.otel.fastify',
             'sentry.op': 'hook.fastify',
-            'hook.name': 'fastify -> @fastify/otel -> @fastify/middie - onRequest',
+            'hook.name': 'fastify -> @sentry/instrumentation-fastify -> @fastify/middie - onRequest',
             'fastify.type': 'hook',
             'hook.callback.name': 'runMiddie',
           },
@@ -80,7 +80,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
           data: {
             'sentry.origin': 'auto.http.otel.fastify',
             'sentry.op': 'request_handler.fastify',
-            'hook.name': 'fastify -> @fastify/otel -> @fastify/middie - route-handler',
+            'hook.name': 'fastify -> @sentry/instrumentation-fastify -> @fastify/middie - route-handler',
             'fastify.type': 'request-handler',
             'http.route': '/test-transaction',
             'hook.callback.name': 'anonymous',

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/tests/transactions.test.ts
@@ -69,11 +69,11 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     data: {
       'fastify.type': 'hook',
       'hook.callback.name': 'anonymous',
-      'hook.name': 'fastify -> @fastify/otel - onRequest',
+      'hook.name': 'fastify -> @sentry/instrumentation-fastify - onRequest',
       'sentry.op': 'hook.fastify',
       'sentry.origin': 'auto.http.otel.fastify',
     },
-    description: '@fastify/otel - onRequest',
+    description: '@sentry/instrumentation-fastify - onRequest',
     op: 'hook.fastify',
     parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
     span_id: expect.stringMatching(/[a-f0-9]{16}/),

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/tests/transactions.test.ts
@@ -69,11 +69,11 @@ test('Sends an API route transaction', async ({ baseURL }) => {
     data: {
       'fastify.type': 'hook',
       'hook.callback.name': 'anonymous',
-      'hook.name': 'fastify -> @fastify/otel - onRequest',
+      'hook.name': 'fastify -> @sentry/instrumentation-fastify - onRequest',
       'sentry.op': 'hook.fastify',
       'sentry.origin': 'auto.http.otel.fastify',
     },
-    description: '@fastify/otel - onRequest',
+    description: '@sentry/instrumentation-fastify - onRequest',
     op: 'hook.fastify',
     parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
     span_id: expect.stringMatching(/[a-f0-9]{16}/),

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -72,7 +72,6 @@
     "@opentelemetry/sql-common": "^0.41.2",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
-    "@fastify/otel": "0.18.0",
     "@sentry/core": "10.53.1",
     "@sentry/node-core": "10.53.1",
     "@sentry/opentelemetry": "10.53.1",

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -1,5 +1,5 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
-import { FastifyOtelInstrumentation } from '@fastify/otel';
+import { FastifyOtelInstrumentation } from './vendored/instrumentation';
 import type { Instrumentation, InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type { IntegrationFn, Span } from '@sentry/core';
 import {

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -294,7 +294,10 @@ function addFastifySpanAttributes(span: Span): void {
     // Try removing `fastify -> ` and `@fastify/otel -> ` prefixes
     // This is a bit of a hack, and not always working for all spans
     // But it's the best we can do without a proper API
-    const updatedName = attrName.replace(/^fastify -> /, '').replace(/^@fastify\/otel -> /, '');
+    const updatedName = attrName
+      .replace(/^fastify -> /, '')
+      .replace(/^@fastify\/otel -> /, '')
+      .replace(/^@sentry\/instrumentation-fastify -> /, '');
 
     span.updateName(updatedName);
   }

--- a/packages/node/src/integrations/tracing/fastify/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/fastify/vendored/instrumentation.ts
@@ -118,7 +118,7 @@ export class FastifyOtelInstrumentation extends InstrumentationBase<FastifyOtelI
           done();
         };
         emptyPlugin[Symbol.for('skip-override')] = true;
-        emptyPlugin[Symbol.for('fastify.display-name')] = '@fastify/otel';
+        emptyPlugin[Symbol.for('fastify.display-name')] = PACKAGE_NAME;
         message.fastify.register(emptyPlugin);
       };
       dc.subscribe('fastify.initialization', this._handleInitialization);
@@ -143,10 +143,10 @@ export class FastifyOtelInstrumentation extends InstrumentationBase<FastifyOtelI
 
     const pluginAny = FastifyInstrumentationPlugin as any;
     pluginAny[Symbol.for('skip-override')] = true;
-    pluginAny[Symbol.for('fastify.display-name')] = '@fastify/otel';
+    pluginAny[Symbol.for('fastify.display-name')] = PACKAGE_NAME;
     pluginAny[Symbol.for('plugin-meta')] = {
       fastify: SUPPORTED_VERSIONS,
-      name: '@fastify/otel',
+      name: PACKAGE_NAME,
     };
 
     return FastifyInstrumentationPlugin;
@@ -261,7 +261,7 @@ export class FastifyOtelInstrumentation extends InstrumentationBase<FastifyOtelI
           }
 
           const attributes: Record<string, string> = {
-            [ATTRIBUTE_NAMES.ROOT]: '@fastify/otel',
+            [ATTRIBUTE_NAMES.ROOT]: PACKAGE_NAME,
             [ATTR_HTTP_REQUEST_METHOD]: request.method,
             [ATTR_URL_PATH]: request.url,
           };

--- a/packages/node/src/integrations/tracing/fastify/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/fastify/vendored/instrumentation.ts
@@ -1,0 +1,506 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024-present The Fastify team <https://github.com/fastify/fastify#team>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/fastify/otel/tree/bae80d6caef4287e7f01ff3c8dc753243706ea86
+ * - Upstream version: @fastify/otel@0.18.1
+ * - Converted from JavaScript to TypeScript with minimal type annotations
+ * - Removed `ignorePaths` / `minimatch` support (not used by the Sentry integration)
+ */
+/* eslint-disable */
+
+import * as dc from 'node:diagnostics_channel';
+import { context, trace, SpanStatusCode, propagation, diag, type Span } from '@opentelemetry/api';
+import { getRPCMetadata, RPCType } from '@opentelemetry/core';
+import {
+  ATTR_HTTP_ROUTE,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_URL_PATH,
+} from '@opentelemetry/semantic-conventions';
+import { InstrumentationBase, type InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { SDK_VERSION } from '@sentry/core';
+
+const PACKAGE_VERSION = SDK_VERSION;
+const PACKAGE_NAME = '@sentry/instrumentation-fastify';
+
+const SUPPORTED_VERSIONS = '>=4.0.0 <6';
+const FASTIFY_HOOKS = [
+  'onRequest',
+  'preParsing',
+  'preValidation',
+  'preHandler',
+  'preSerialization',
+  'onSend',
+  'onResponse',
+  'onError',
+];
+const ATTRIBUTE_NAMES = {
+  HOOK_NAME: 'hook.name',
+  FASTIFY_TYPE: 'fastify.type',
+  HOOK_CALLBACK_NAME: 'hook.callback.name',
+  ROOT: 'fastify.root',
+};
+const HOOK_TYPES = {
+  ROUTE: 'route-hook',
+  INSTANCE: 'hook',
+  HANDLER: 'request-handler',
+};
+const ANONYMOUS_FUNCTION_NAME = 'anonymous';
+
+const kInstrumentation = Symbol('fastify otel instance');
+const kRequestSpan = Symbol('fastify otel request spans');
+const kRequestContext = Symbol('fastify otel request context');
+const kAddHookOriginal = Symbol('fastify otel addhook original');
+const kSetNotFoundOriginal = Symbol('fastify otel setnotfound original');
+const kRecordExceptions = Symbol('fastify otel record exceptions');
+
+export interface FastifyOtelInstrumentationOpts extends InstrumentationConfig {
+  registerOnInitialization?: boolean;
+  requestHook?: (span: Span, request: any) => void;
+  lifecycleHook?: (span: Span, info: { hookName: string; request: any; handler?: string }) => void;
+  recordExceptions?: boolean;
+}
+
+export class FastifyOtelInstrumentation extends InstrumentationBase<FastifyOtelInstrumentationOpts> {
+  _otelLogger: any = null;
+  _requestHook: ((span: Span, request: any) => void) | null = null;
+  _lifecycleHook: ((span: Span, info: any) => void) | null = null;
+  _handleInitialization: ((message: any) => void) | undefined = undefined;
+
+  [kRecordExceptions]: boolean = true;
+
+  constructor(config: FastifyOtelInstrumentationOpts = {}) {
+    super(PACKAGE_NAME, PACKAGE_VERSION, config);
+    this._otelLogger = diag.createComponentLogger({ namespace: PACKAGE_NAME });
+    this[kRecordExceptions] = true;
+
+    if (config?.recordExceptions != null) {
+      if (typeof config.recordExceptions !== 'boolean') {
+        throw new TypeError('recordExceptions must be a boolean');
+      }
+
+      this[kRecordExceptions] = config.recordExceptions;
+    }
+    if (typeof config?.requestHook === 'function') {
+      this._requestHook = config.requestHook;
+    }
+    if (typeof config?.lifecycleHook === 'function') {
+      this._lifecycleHook = config.lifecycleHook;
+    }
+  }
+
+  enable(): any {
+    if (this._handleInitialization === undefined && this.getConfig().registerOnInitialization) {
+      this._handleInitialization = (message: any) => {
+        this.plugin()(message.fastify, undefined, () => {});
+        const emptyPlugin: any = (_: any, __: any, done: () => void) => {
+          done();
+        };
+        emptyPlugin[Symbol.for('skip-override')] = true;
+        emptyPlugin[Symbol.for('fastify.display-name')] = '@fastify/otel';
+        message.fastify.register(emptyPlugin);
+      };
+      dc.subscribe('fastify.initialization', this._handleInitialization);
+    }
+    return super.enable();
+  }
+
+  disable(): any {
+    if (this._handleInitialization) {
+      dc.unsubscribe('fastify.initialization', this._handleInitialization);
+      this._handleInitialization = undefined;
+    }
+    return super.disable();
+  }
+
+  init() {
+    return [];
+  }
+
+  plugin(): any {
+    const instrumentation = this;
+
+    const pluginAny = FastifyInstrumentationPlugin as any;
+    pluginAny[Symbol.for('skip-override')] = true;
+    pluginAny[Symbol.for('fastify.display-name')] = '@fastify/otel';
+    pluginAny[Symbol.for('plugin-meta')] = {
+      fastify: SUPPORTED_VERSIONS,
+      name: '@fastify/otel',
+    };
+
+    return FastifyInstrumentationPlugin;
+
+    function FastifyInstrumentationPlugin(instance: any, _opts: any, done: () => void) {
+      instance.decorate(kInstrumentation, instrumentation);
+      instance.decorate(kAddHookOriginal, instance.addHook);
+      instance.decorate(kSetNotFoundOriginal, instance.setNotFoundHandler);
+      instance.decorateRequest('opentelemetry', function opentelemetry(this: any) {
+        const ctx = this[kRequestContext];
+        const span = this[kRequestSpan];
+
+        return {
+          enabled: this.routeOptions.config?.otel !== false,
+          span,
+          tracer: instrumentation.tracer,
+          context: ctx,
+          inject: (carrier: any, setter?: any) => {
+            return propagation.inject(ctx, carrier, setter);
+          },
+          extract: (carrier: any, getter?: any) => {
+            return propagation.extract(ctx, carrier, getter);
+          },
+        };
+      });
+      instance.decorateRequest(kRequestSpan, null);
+      instance.decorateRequest(kRequestContext, null);
+
+      instance.addHook('onRoute', function otelWireRoute(this: any, routeOptions: any) {
+        if (routeOptions.config?.otel === false) {
+          instrumentation._otelLogger.debug(
+            `Ignoring route instrumentation ${routeOptions.method} ${routeOptions.url} because it is disabled`,
+          );
+
+          return;
+        }
+
+        for (const hook of FASTIFY_HOOKS) {
+          if (routeOptions[hook] != null) {
+            const handlerLike = routeOptions[hook];
+
+            if (typeof handlerLike === 'function') {
+              routeOptions[hook] = handlerWrapper(handlerLike, hook, {
+                [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - route -> ${hook}`,
+                [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.ROUTE,
+                [ATTR_HTTP_ROUTE]: routeOptions.url,
+                [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]:
+                  handlerLike.name?.length > 0 ? handlerLike.name : ANONYMOUS_FUNCTION_NAME,
+              });
+            } else if (Array.isArray(handlerLike)) {
+              const wrappedHandlers: any[] = [];
+
+              for (const handler of handlerLike) {
+                wrappedHandlers.push(
+                  handlerWrapper(handler, hook, {
+                    [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - route -> ${hook}`,
+                    [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.ROUTE,
+                    [ATTR_HTTP_ROUTE]: routeOptions.url,
+                    [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]:
+                      handler.name?.length > 0 ? handler.name : ANONYMOUS_FUNCTION_NAME,
+                  }),
+                );
+              }
+
+              routeOptions[hook] = wrappedHandlers;
+            }
+          }
+        }
+
+        if (routeOptions.onSend != null) {
+          routeOptions.onSend = Array.isArray(routeOptions.onSend)
+            ? [...routeOptions.onSend, finalizeResponseSpanHook]
+            : [routeOptions.onSend, finalizeResponseSpanHook];
+        } else {
+          routeOptions.onSend = finalizeResponseSpanHook;
+        }
+
+        if (routeOptions.onError != null) {
+          routeOptions.onError = Array.isArray(routeOptions.onError)
+            ? [...routeOptions.onError, recordErrorInSpanHook]
+            : [routeOptions.onError, recordErrorInSpanHook];
+        } else {
+          routeOptions.onError = recordErrorInSpanHook;
+        }
+
+        routeOptions.handler = handlerWrapper(routeOptions.handler, 'handler', {
+          [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - route-handler`,
+          [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.HANDLER,
+          [ATTR_HTTP_ROUTE]: routeOptions.url,
+          [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]:
+            routeOptions.handler.name.length > 0 ? routeOptions.handler.name : ANONYMOUS_FUNCTION_NAME,
+        });
+      });
+
+      instance.addHook(
+        'onRequest',
+        function startRequestSpanHook(this: any, request: any, _reply: any, hookDone: () => void) {
+          if (this[kInstrumentation].isEnabled() === false || request.routeOptions.config?.otel === false) {
+            return hookDone();
+          }
+
+          let ctx = context.active();
+
+          if (trace.getSpan(ctx) == null) {
+            ctx = propagation.extract(ctx, request.headers);
+          }
+
+          const rpcMetadata = getRPCMetadata(ctx);
+
+          if (request.routeOptions.url != null && rpcMetadata?.type === RPCType.HTTP) {
+            rpcMetadata.route = request.routeOptions.url;
+          }
+
+          const attributes: Record<string, string> = {
+            [ATTRIBUTE_NAMES.ROOT]: '@fastify/otel',
+            [ATTR_HTTP_REQUEST_METHOD]: request.method,
+            [ATTR_URL_PATH]: request.url,
+          };
+
+          if (request.routeOptions.url != null) {
+            attributes[ATTR_HTTP_ROUTE] = request.routeOptions.url;
+          }
+
+          const span = this[kInstrumentation].tracer.startSpan('request', { attributes }, ctx);
+
+          try {
+            this[kInstrumentation]._requestHook?.(span, request);
+          } catch (err) {
+            this[kInstrumentation]._otelLogger.error({ err }, 'requestHook threw');
+          }
+
+          request[kRequestContext] = trace.setSpan(ctx, span);
+          request[kRequestSpan] = span;
+
+          context.with(request[kRequestContext], () => {
+            hookDone();
+          });
+        },
+      );
+
+      instance.addHook('onResponse', function finalizeNotFoundSpanHook(request: any, reply: any, hookDone: () => void) {
+        const span = request[kRequestSpan];
+
+        if (span != null) {
+          span.setAttributes({
+            [ATTR_HTTP_RESPONSE_STATUS_CODE]: reply.statusCode,
+          });
+          span.end();
+        }
+
+        request[kRequestSpan] = null;
+
+        hookDone();
+      });
+
+      instance.addHook = addHookPatched;
+      instance.setNotFoundHandler = setNotFoundHandlerPatched;
+
+      done();
+
+      function finalizeResponseSpanHook(
+        request: any,
+        reply: any,
+        payload: any,
+        hookDone: (err: null, payload: any) => void,
+      ) {
+        const span = request[kRequestSpan];
+
+        if (span != null) {
+          if (reply.statusCode >= 500) {
+            span.setStatus({ code: SpanStatusCode.ERROR });
+          }
+
+          span.setAttributes({
+            [ATTR_HTTP_RESPONSE_STATUS_CODE]: reply.statusCode,
+          });
+          span.end();
+        }
+
+        request[kRequestSpan] = null;
+
+        hookDone(null, payload);
+      }
+
+      function recordErrorInSpanHook(request: any, _reply: any, error: any, hookDone: () => void) {
+        const span = request[kRequestSpan];
+
+        if (span != null) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error.message,
+          });
+          if (instrumentation[kRecordExceptions] !== false) {
+            span.recordException(error);
+          }
+        }
+
+        hookDone();
+      }
+
+      function addHookPatched(this: any, name: string, hook: (...args: any[]) => any) {
+        const addHookOriginal = this[kAddHookOriginal];
+
+        if (FASTIFY_HOOKS.includes(name)) {
+          return addHookOriginal.call(
+            this,
+            name,
+            handlerWrapper(hook, name, {
+              [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - ${name}`,
+              [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.INSTANCE,
+              [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]: hook.name?.length > 0 ? hook.name : ANONYMOUS_FUNCTION_NAME,
+            }),
+          );
+        } else {
+          return addHookOriginal.call(this, name, hook);
+        }
+      }
+
+      function setNotFoundHandlerPatched(this: any, hooks: any, handler?: any) {
+        const setNotFoundHandlerOriginal = this[kSetNotFoundOriginal];
+        if (typeof hooks === 'function') {
+          handler = handlerWrapper(hooks, 'notFoundHandler', {
+            [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - not-found-handler`,
+            [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.INSTANCE,
+            [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]: hooks.name?.length > 0 ? hooks.name : ANONYMOUS_FUNCTION_NAME,
+          });
+          setNotFoundHandlerOriginal.call(this, handler);
+        } else {
+          if (hooks.preValidation != null) {
+            hooks.preValidation = handlerWrapper(hooks.preValidation, 'notFoundHandler - preValidation', {
+              [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - not-found-handler - preValidation`,
+              [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.INSTANCE,
+              [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]:
+                hooks.preValidation.name?.length > 0 ? hooks.preValidation.name : ANONYMOUS_FUNCTION_NAME,
+            });
+          }
+
+          if (hooks.preHandler != null) {
+            hooks.preHandler = handlerWrapper(hooks.preHandler, 'notFoundHandler - preHandler', {
+              [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - not-found-handler - preHandler`,
+              [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.INSTANCE,
+              [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]:
+                hooks.preHandler.name?.length > 0 ? hooks.preHandler.name : ANONYMOUS_FUNCTION_NAME,
+            });
+          }
+
+          handler = handlerWrapper(handler, 'notFoundHandler', {
+            [ATTRIBUTE_NAMES.HOOK_NAME]: `${this.pluginName} - not-found-handler`,
+            [ATTRIBUTE_NAMES.FASTIFY_TYPE]: HOOK_TYPES.INSTANCE,
+            [ATTRIBUTE_NAMES.HOOK_CALLBACK_NAME]: handler.name?.length > 0 ? handler.name : ANONYMOUS_FUNCTION_NAME,
+          });
+          setNotFoundHandlerOriginal.call(this, hooks, handler);
+        }
+      }
+
+      function getRequestFromArgs(args: any[]) {
+        for (const arg of args) {
+          if (arg?.routeOptions && arg.url && arg.method) {
+            return arg;
+          }
+        }
+        return null;
+      }
+
+      function handlerWrapper(
+        handler: (...args: any[]) => any,
+        hookName: string,
+        spanAttributes: Record<string, string> = {},
+      ) {
+        return function handlerWrapped(this: any, ...args: any[]) {
+          const instrumentation: FastifyOtelInstrumentation = this[kInstrumentation];
+
+          const request = getRequestFromArgs(args);
+          if (request === null) {
+            instrumentation._otelLogger.debug(
+              `Ignoring route instrumentation because ${hookName} was called without a Fastify request argument`,
+            );
+            return handler.call(this, ...args);
+          }
+
+          if (instrumentation.isEnabled() === false || request.routeOptions.config?.otel === false) {
+            instrumentation._otelLogger.debug(
+              `Ignoring route instrumentation ${request.routeOptions.method} ${request.routeOptions.url} because it is disabled`,
+            );
+            return handler.call(this, ...args);
+          }
+
+          const ctx = request[kRequestContext] ?? context.active();
+          const handlerName = handler.name?.length > 0 ? handler.name : (this.pluginName ?? ANONYMOUS_FUNCTION_NAME);
+
+          const span = instrumentation.tracer.startSpan(
+            `${hookName} - ${handlerName}`,
+            {
+              attributes: spanAttributes,
+            },
+            ctx,
+          );
+
+          if (instrumentation._lifecycleHook != null) {
+            try {
+              instrumentation._lifecycleHook(span, {
+                hookName,
+                request,
+                handler: handlerName,
+              });
+            } catch (err) {
+              instrumentation._otelLogger.error({ err }, 'Execution of lifecycleHook failed');
+            }
+          }
+
+          return context.with(
+            trace.setSpan(ctx, span),
+            function (this: any) {
+              try {
+                const res = handler.call(this, ...args);
+
+                if (typeof res?.then === 'function') {
+                  return res.then(
+                    (result: any) => {
+                      span.end();
+                      return result;
+                    },
+                    (error: any) => {
+                      span.setStatus({
+                        code: SpanStatusCode.ERROR,
+                        message: error.message,
+                      });
+                      if (instrumentation[kRecordExceptions] !== false) {
+                        span.recordException(error);
+                      }
+                      span.end();
+                      return Promise.reject(error);
+                    },
+                  );
+                }
+
+                span.end();
+                return res;
+              } catch (error: any) {
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: error.message,
+                });
+                if (instrumentation[kRecordExceptions] !== false) {
+                  span.recordException(error);
+                }
+                span.end();
+                throw error;
+              }
+            },
+            this,
+          );
+        };
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4309,16 +4309,6 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.0.0.tgz#f22824caff3ae506b18207bad4126dbc6ccdb6b8"
   integrity sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==
 
-"@fastify/otel@0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@fastify/otel/-/otel-0.18.0.tgz#d21814af7c97579856698e03aae0581beb3e734b"
-  integrity sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==
-  dependencies:
-    "@opentelemetry/core" "^2.0.0"
-    "@opentelemetry/instrumentation" "^0.212.0"
-    "@opentelemetry/semantic-conventions" "^1.28.0"
-    minimatch "^10.2.4"
-
 "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -6009,13 +5999,6 @@
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
 
-"@opentelemetry/api-logs@0.212.0":
-  version "0.212.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz#ec66a0951b84b1f082e13fd8a027b9f9d65a3f7a"
-  integrity sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==
-  dependencies:
-    "@opentelemetry/api" "^1.3.0"
-
 "@opentelemetry/api-logs@0.214.0":
   version "0.214.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz#74a54ad7b166c6fa30a0df811954c0f5a435deee"
@@ -6068,15 +6051,6 @@
   dependencies:
     "@opentelemetry/api-logs" "0.214.0"
     import-in-the-middle "^3.0.0"
-    require-in-the-middle "^8.0.0"
-
-"@opentelemetry/instrumentation@^0.212.0":
-  version "0.212.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz#238b6e3e2131217ff4acfe7e8e7b6ce1f0ac0ba0"
-  integrity sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==
-  dependencies:
-    "@opentelemetry/api-logs" "0.212.0"
-    import-in-the-middle "^2.0.6"
     require-in-the-middle "^8.0.0"
 
 "@opentelemetry/otlp-exporter-base@0.214.0":
@@ -6135,7 +6109,7 @@
     "@opentelemetry/resources" "2.6.1"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.40.0":
+"@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.40.0":
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz#10b2944ca559386590683392022a897eefd011d3"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
@@ -18817,16 +18791,6 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz#1972337bfe020d05f6b5e020c13334567436324f"
-  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
-  dependencies:
-    acorn "^8.15.0"
-    acorn-import-attributes "^1.9.5"
-    cjs-module-lexer "^2.2.0"
-    module-details-from-path "^1.0.4"
-
 import-in-the-middle@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz#720c12b4c07ea58b32a54667e70a022e18cc36a3"
@@ -21684,7 +21648,7 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@10.2.4, minimatch@10.2.5, minimatch@^10.2.2, minimatch@^10.2.4, minimatch@^10.2.5:
+minimatch@10.2.4, minimatch@10.2.5, minimatch@^10.2.2, minimatch@^10.2.5:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==


### PR DESCRIPTION
Vendors `@fastify/otel@0.18.1` into the SDK with minimal changes. The original source is in plain Javascript so this was adapted with minimal type annotations to make it compatible with the TS compiler of this repo.

The original instrumentation also had an `ignorePaths` code path, which relies on `minimatch` as a dependency but was never exposed by the Sentry integration. For this reason this was already cleaned out so we can avoid the `minimatch` dependency. Everything else is preserved as is.

Closes #20162