### PR TITLE
ref(node): Vendor `@opentelemetry/instrumentation-pg`

### DIFF
--- a/.oxlintrc.base.json
+++ b/.oxlintrc.base.json
@@ -158,7 +158,8 @@
         "**/integrations/tracing/mongoose/vendored/**/*.ts",
         "**/integrations/tracing/amqplib/vendored/**/*.ts",
         "**/integrations/tracing/prisma/vendored/**/*.ts",
-        "**/integrations/tracing/graphql/vendored/**/*.ts"
+        "**/integrations/tracing/graphql/vendored/**/*.ts",
+        "**/integrations/tracing/postgres/vendored/**/*.ts"
       ],
       "rules": {
         "typescript/no-explicit-any": "off"

--- a/dev-packages/e2e-tests/test-applications/generic-ts3.8/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/generic-ts3.8/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["es2018", "DOM"],
     "skipLibCheck": false,
     "noEmit": true,
-    "types": [],
+    "types": ["node"],
     "target": "es2018",
     "moduleResolution": "node"
   }

--- a/dev-packages/e2e-tests/test-applications/generic-ts5.0/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/generic-ts5.0/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["es2018", "DOM"],
     "skipLibCheck": false,
     "noEmit": true,
-    "types": [],
+    "types": ["node"],
     "target": "es2018",
     "moduleResolution": "node"
   }

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/package.json
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/package.json
@@ -41,6 +41,7 @@
     "@tailwindcss/vite": "4.0.0-alpha.17",
     "@total-typescript/ts-reset": "^0.4.2",
     "@types/eslint": "^8.4.10",
+    "@types/node": "^18.19.1",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
     "esbuild": "0.25.0",

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "baseUrl": ".",
-    "types": ["@shopify/oxygen-workers-types"],
+    "types": ["@shopify/oxygen-workers-types", "node"],
     "paths": {
       "~/*": ["app/*"]
     },

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "baseUrl": ".",
-    "types": ["@shopify/oxygen-workers-types", "node"],
+    "types": ["@shopify/oxygen-workers-types"],
     "paths": {
       "~/*": ["app/*"]
     },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -70,7 +70,6 @@
     "@opentelemetry/instrumentation": "^0.214.0",
     "@opentelemetry/instrumentation-http": "0.214.0",
     "@opentelemetry/sql-common": "^0.41.2",
-    "@opentelemetry/instrumentation-pg": "0.66.0",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@fastify/otel": "0.18.0",

--- a/packages/node/src/integrations/tracing/postgres/index.ts
+++ b/packages/node/src/integrations/tracing/postgres/index.ts
@@ -1,4 +1,4 @@
-import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
+import { PgInstrumentation } from './vendored/instrumentation';
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { addOriginToSpan, generateInstrumentOnce } from '@sentry/node-core';

--- a/packages/node/src/integrations/tracing/postgres/vendored/enums/AttributeNames.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/enums/AttributeNames.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ */
+/* eslint-disable */
+
+// Postgresql specific attributes not covered by semantic conventions
+export enum AttributeNames {
+  PG_VALUES = 'db.postgresql.values',
+  PG_PLAN = 'db.postgresql.plan',
+  IDLE_TIMEOUT_MILLIS = 'db.postgresql.idle.timeout.millis',
+  MAX_CLIENT = 'db.postgresql.max.client',
+}

--- a/packages/node/src/integrations/tracing/postgres/vendored/enums/AttributeNames.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/enums/AttributeNames.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * NOTICE from the Sentry authors:
- * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
- * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.70.0
  */
 /* eslint-disable */
 

--- a/packages/node/src/integrations/tracing/postgres/vendored/enums/SpanNames.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/enums/SpanNames.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ */
+/* eslint-disable */
+
+// Contains span names produced by instrumentation
+export enum SpanNames {
+  QUERY_PREFIX = 'pg.query',
+  CONNECT = 'pg.connect',
+  POOL_CONNECT = 'pg-pool.connect',
+}

--- a/packages/node/src/integrations/tracing/postgres/vendored/enums/SpanNames.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/enums/SpanNames.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * NOTICE from the Sentry authors:
- * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
- * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.70.0
  */
 /* eslint-disable */
 

--- a/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * NOTICE from the Sentry authors:
- * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
- * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.70.0
  * - Types from `pg` and `pg-pool` packages inlined as simplified interfaces
  * - Minor TypeScript strictness adjustments
  */

--- a/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
@@ -43,7 +43,6 @@ import {
   UpDownCounter,
 } from '@opentelemetry/api';
 import type { PgClient } from './pg-types';
-import type { PgPool } from './pg-pool-types';
 import {
   PgClientConnect,
   PgClientExtended,
@@ -233,10 +232,7 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
 
         const span = plugin.tracer.startSpan(SpanNames.CONNECT, {
           kind: SpanKind.CLIENT,
-          attributes: utils.getSemanticAttributesFromConnection(
-            (this as any).connectionParameters ?? this,
-            plugin._semconvStability,
-          ),
+          attributes: utils.getSemanticAttributesFromConnection(this, plugin._semconvStability),
         });
 
         if (callback) {

--- a/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
@@ -1,0 +1,604 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Types from `pg` and `pg-pool` packages inlined as simplified interfaces
+ * - Minor TypeScript strictness adjustments
+ */
+/* eslint-disable */
+
+import {
+  isWrapped,
+  InstrumentationBase,
+  InstrumentationNodeModuleDefinition,
+  safeExecuteInTheMiddle,
+  InstrumentationNodeModuleFile,
+  SemconvStability,
+  semconvStabilityFromStr,
+} from '@opentelemetry/instrumentation';
+import {
+  context,
+  trace,
+  Span,
+  SpanStatusCode,
+  SpanKind,
+  Histogram,
+  ValueType,
+  Attributes,
+  HrTime,
+  UpDownCounter,
+} from '@opentelemetry/api';
+import type { PgClient } from './pg-types';
+import type { PgPool } from './pg-pool-types';
+import {
+  PgClientConnect,
+  PgClientExtended,
+  PostgresCallback,
+  PgPoolExtended,
+  PgPoolCallback,
+  EVENT_LISTENERS_SET,
+} from './internal-types';
+import { PgInstrumentationConfig } from './types';
+import * as utils from './utils';
+import { addSqlCommenterComment } from '@opentelemetry/sql-common';
+import { SDK_VERSION } from '@sentry/core';
+const PACKAGE_NAME = '@sentry/instrumentation-pg';
+import { SpanNames } from './enums/SpanNames';
+import { hrTime, hrTimeDuration, hrTimeToMilliseconds } from '@opentelemetry/core';
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_SERVER_PORT,
+  ATTR_SERVER_ADDRESS,
+  ATTR_DB_NAMESPACE,
+  ATTR_DB_OPERATION_NAME,
+  ATTR_DB_SYSTEM_NAME,
+  METRIC_DB_CLIENT_OPERATION_DURATION,
+} from '@opentelemetry/semantic-conventions';
+import {
+  METRIC_DB_CLIENT_CONNECTION_COUNT,
+  METRIC_DB_CLIENT_CONNECTION_PENDING_REQUESTS,
+  ATTR_DB_SYSTEM,
+  DB_SYSTEM_VALUE_POSTGRESQL,
+} from './semconv';
+
+function extractModuleExports(module: any) {
+  return module[Symbol.toStringTag] === 'Module'
+    ? module.default // ESM
+    : module; // CommonJS
+}
+
+export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConfig> {
+  declare private _operationDuration: Histogram;
+  declare private _connectionsCount: UpDownCounter;
+  declare private _connectionPendingRequests: UpDownCounter;
+  // Pool events connect, acquire, release and remove can be called
+  // multiple times without changing the values of total, idle and waiting
+  // connections. The _connectionsCounter is used to keep track of latest
+  // values and only update the metrics _connectionsCount and _connectionPendingRequests
+  // when the value change.
+  private _connectionsCounter: utils.poolConnectionsCounter = {
+    used: 0,
+    idle: 0,
+    pending: 0,
+  };
+  private _semconvStability: SemconvStability;
+
+  constructor(config: PgInstrumentationConfig = {}) {
+    super(PACKAGE_NAME, SDK_VERSION, config);
+    this._semconvStability = semconvStabilityFromStr('database', process.env.OTEL_SEMCONV_STABILITY_OPT_IN);
+  }
+
+  override _updateMetricInstruments() {
+    this._operationDuration = this.meter.createHistogram(METRIC_DB_CLIENT_OPERATION_DURATION, {
+      description: 'Duration of database client operations.',
+      unit: 's',
+      valueType: ValueType.DOUBLE,
+      advice: {
+        explicitBucketBoundaries: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10],
+      },
+    });
+
+    this._connectionsCounter = {
+      idle: 0,
+      pending: 0,
+      used: 0,
+    };
+    this._connectionsCount = this.meter.createUpDownCounter(METRIC_DB_CLIENT_CONNECTION_COUNT, {
+      description: 'The number of connections that are currently in state described by the state attribute.',
+      unit: '{connection}',
+    });
+    this._connectionPendingRequests = this.meter.createUpDownCounter(METRIC_DB_CLIENT_CONNECTION_PENDING_REQUESTS, {
+      description: 'The number of current pending requests for an open connection.',
+      unit: '{connection}',
+    });
+  }
+
+  protected init() {
+    const SUPPORTED_PG_VERSIONS = ['>=8.0.3 <9'];
+    const SUPPORTED_PG_POOL_VERSIONS = ['>=2.0.0 <4'];
+
+    const modulePgNativeClient = new InstrumentationNodeModuleFile(
+      'pg/lib/native/client.js',
+      SUPPORTED_PG_VERSIONS,
+      this._patchPgClient.bind(this),
+      this._unpatchPgClient.bind(this),
+    );
+
+    const modulePgClient = new InstrumentationNodeModuleFile(
+      'pg/lib/client.js',
+      SUPPORTED_PG_VERSIONS,
+      this._patchPgClient.bind(this),
+      this._unpatchPgClient.bind(this),
+    );
+
+    const modulePG = new InstrumentationNodeModuleDefinition(
+      'pg',
+      SUPPORTED_PG_VERSIONS,
+      (module: any) => {
+        const moduleExports = extractModuleExports(module);
+
+        this._patchPgClient(moduleExports.Client);
+        return module;
+      },
+      (module: any) => {
+        const moduleExports = extractModuleExports(module);
+
+        this._unpatchPgClient(moduleExports.Client);
+        return module;
+      },
+      [modulePgClient, modulePgNativeClient],
+    );
+
+    const modulePGPool = new InstrumentationNodeModuleDefinition(
+      'pg-pool',
+      SUPPORTED_PG_POOL_VERSIONS,
+      (module: any) => {
+        const moduleExports = extractModuleExports(module);
+        if (isWrapped(moduleExports.prototype.connect)) {
+          this._unwrap(moduleExports.prototype, 'connect');
+        }
+        this._wrap(moduleExports.prototype, 'connect', this._getPoolConnectPatch() as any);
+        return moduleExports;
+      },
+      (module: any) => {
+        const moduleExports = extractModuleExports(module);
+        if (isWrapped(moduleExports.prototype.connect)) {
+          this._unwrap(moduleExports.prototype, 'connect');
+        }
+      },
+    );
+
+    return [modulePG, modulePGPool];
+  }
+
+  private _patchPgClient(module: any) {
+    if (!module) {
+      return;
+    }
+
+    const moduleExports = extractModuleExports(module);
+
+    if (isWrapped(moduleExports.prototype.query)) {
+      this._unwrap(moduleExports.prototype, 'query');
+    }
+
+    if (isWrapped(moduleExports.prototype.connect)) {
+      this._unwrap(moduleExports.prototype, 'connect');
+    }
+
+    this._wrap(moduleExports.prototype, 'query', this._getClientQueryPatch() as any);
+
+    this._wrap(moduleExports.prototype, 'connect', this._getClientConnectPatch() as any);
+
+    return module;
+  }
+
+  private _unpatchPgClient(module: any) {
+    const moduleExports = extractModuleExports(module);
+
+    if (isWrapped(moduleExports.prototype.query)) {
+      this._unwrap(moduleExports.prototype, 'query');
+    }
+
+    if (isWrapped(moduleExports.prototype.connect)) {
+      this._unwrap(moduleExports.prototype, 'connect');
+    }
+
+    return module;
+  }
+
+  private _getClientConnectPatch() {
+    const plugin = this;
+    return (original: PgClientConnect) => {
+      return function connect(this: PgClient, callback?: Function) {
+        const config = plugin.getConfig();
+
+        if (utils.shouldSkipInstrumentation(config) || config.ignoreConnectSpans) {
+          return original.call(this, callback);
+        }
+
+        const span = plugin.tracer.startSpan(SpanNames.CONNECT, {
+          kind: SpanKind.CLIENT,
+          attributes: utils.getSemanticAttributesFromConnection(
+            (this as any).connectionParameters ?? this,
+            plugin._semconvStability,
+          ),
+        });
+
+        if (callback) {
+          const parentSpan = trace.getSpan(context.active());
+          callback = utils.patchClientConnectCallback(span, callback);
+          if (parentSpan) {
+            callback = context.bind(context.active(), callback);
+          }
+        }
+
+        const connectResult: unknown = context.with(trace.setSpan(context.active(), span), () => {
+          return original.call(this, callback);
+        });
+
+        return handleConnectResult(span, connectResult);
+      };
+    };
+  }
+
+  private recordOperationDuration(attributes: Attributes, startTime: HrTime) {
+    const metricsAttributes: Attributes = {};
+    const keysToCopy: string[] = [
+      ATTR_DB_NAMESPACE,
+      ATTR_ERROR_TYPE,
+      ATTR_SERVER_PORT,
+      ATTR_SERVER_ADDRESS,
+      ATTR_DB_OPERATION_NAME,
+    ];
+    if (this._semconvStability & SemconvStability.OLD) {
+      keysToCopy.push(ATTR_DB_SYSTEM);
+    }
+    if (this._semconvStability & SemconvStability.STABLE) {
+      keysToCopy.push(ATTR_DB_SYSTEM_NAME);
+    }
+
+    keysToCopy.forEach(key => {
+      if (key in attributes) {
+        metricsAttributes[key] = attributes[key];
+      }
+    });
+
+    const durationSeconds = hrTimeToMilliseconds(hrTimeDuration(startTime, hrTime())) / 1000;
+    this._operationDuration.record(durationSeconds, metricsAttributes);
+  }
+
+  private _getClientQueryPatch() {
+    const plugin = this;
+    return (original: (...args: any[]) => any) => {
+      this._diag.debug('Patching pg.Client.prototype.query');
+      return function query(this: PgClientExtended, ...args: unknown[]) {
+        if (utils.shouldSkipInstrumentation(plugin.getConfig())) {
+          return original.apply(this, args as never);
+        }
+        const startTime = hrTime();
+
+        // client.query(text, cb?), client.query(text, values, cb?), and
+        // client.query(configObj, cb?) are all valid signatures. We construct
+        // a queryConfig obj from all (valid) signatures to build the span in a
+        // unified way. We verify that we at least have query text, and code
+        // defensively when dealing with `queryConfig` after that (to handle all
+        // the other invalid cases, like a non-array for values being provided).
+        // The type casts here reflect only what we've actually validated.
+        const arg0 = args[0];
+        const firstArgIsString = typeof arg0 === 'string';
+        const firstArgIsQueryObjectWithText = utils.isObjectWithTextString(arg0);
+
+        // TODO: remove the `as ...` casts below when the TS version is upgraded.
+        // Newer TS versions will use the result of firstArgIsQueryObjectWithText
+        // to properly narrow arg0, but TS 4.3.5 does not.
+        const queryConfig = firstArgIsString
+          ? {
+              text: arg0 as string,
+              values: Array.isArray(args[1]) ? args[1] : undefined,
+            }
+          : firstArgIsQueryObjectWithText
+            ? {
+                ...(arg0 as any),
+                name: arg0.name,
+                text: arg0.text,
+                values: (arg0 as any).values ?? (Array.isArray(args[1]) ? args[1] : undefined),
+              }
+            : undefined;
+
+        const attributes: Attributes = {
+          [ATTR_DB_SYSTEM]: DB_SYSTEM_VALUE_POSTGRESQL,
+          [ATTR_DB_NAMESPACE]: this.database,
+          [ATTR_SERVER_PORT]: this.connectionParameters.port,
+          [ATTR_SERVER_ADDRESS]: this.connectionParameters.host,
+        };
+
+        if (queryConfig?.text) {
+          attributes[ATTR_DB_OPERATION_NAME] = utils.parseNormalizedOperationName(queryConfig?.text);
+        }
+
+        const recordDuration = () => {
+          plugin.recordOperationDuration(attributes, startTime);
+        };
+
+        const instrumentationConfig = plugin.getConfig();
+
+        const span = utils.handleConfigQuery.call(
+          this,
+          plugin.tracer,
+          instrumentationConfig,
+          plugin._semconvStability,
+          queryConfig,
+        );
+
+        // Modify query text w/ a tracing comment before invoking original for
+        // tracing, but only if args[0] has one of our expected shapes.
+        if (instrumentationConfig.addSqlCommenterCommentToQueries) {
+          if (firstArgIsString) {
+            args[0] = addSqlCommenterComment(span, arg0);
+          } else if (firstArgIsQueryObjectWithText && !('name' in arg0)) {
+            // In the case of a query object, we need to ensure there's no name field
+            // as this indicates a prepared query, where the comment would remain the same
+            // for every invocation and contain an outdated trace context.
+            args[0] = {
+              ...arg0,
+              text: addSqlCommenterComment(span, arg0.text),
+            };
+          }
+        }
+
+        // Bind callback (if any) to parent span (if any)
+        if (args.length > 0) {
+          const parentSpan = trace.getSpan(context.active());
+          if (typeof args[args.length - 1] === 'function') {
+            // Patch ParameterQuery callback
+            args[args.length - 1] = utils.patchCallback(
+              instrumentationConfig,
+              span,
+              args[args.length - 1] as PostgresCallback, // nb: not type safe.
+              attributes,
+              recordDuration,
+            );
+
+            // If a parent span exists, bind the callback
+            if (parentSpan) {
+              args[args.length - 1] = context.bind(context.active(), args[args.length - 1]);
+            }
+          } else if (typeof queryConfig?.callback === 'function') {
+            // Patch ConfigQuery callback
+            let callback = utils.patchCallback(
+              plugin.getConfig(),
+              span,
+              queryConfig.callback as PostgresCallback, // nb: not type safe.
+              attributes,
+              recordDuration,
+            );
+
+            // If a parent span existed, bind the callback
+            if (parentSpan) {
+              callback = context.bind(context.active(), callback);
+            }
+
+            (args[0] as { callback?: PostgresCallback }).callback = callback;
+          }
+        }
+
+        const { requestHook } = instrumentationConfig;
+        if (typeof requestHook === 'function' && queryConfig) {
+          safeExecuteInTheMiddle(
+            () => {
+              // pick keys to expose explicitly, so we're not leaking pg package
+              // internals that are subject to change
+              const { database, host, port, user } = this.connectionParameters;
+              const connection = { database, host, port, user };
+
+              requestHook(span, {
+                connection,
+                query: {
+                  text: queryConfig.text,
+                  // nb: if `client.query` is called with illegal arguments
+                  // (e.g., if `queryConfig.values` is passed explicitly, but a
+                  // non-array is given), then the type casts will be wrong. But
+                  // we leave it up to the queryHook to handle that, and we
+                  // catch and swallow any errors it throws. The other options
+                  // are all worse. E.g., we could leave `queryConfig.values`
+                  // and `queryConfig.name` as `unknown`, but then the hook body
+                  // would be forced to validate (or cast) them before using
+                  // them, which seems incredibly cumbersome given that these
+                  // casts will be correct 99.9% of the time -- and pg.query
+                  // will immediately throw during development in the other .1%
+                  // of cases. Alternatively, we could simply skip calling the
+                  // hook when `values` or `name` don't have the expected type,
+                  // but that would add unnecessary validation overhead to every
+                  // hook invocation and possibly be even more confusing/unexpected.
+                  values: queryConfig.values as unknown[],
+                  name: queryConfig.name as string | undefined,
+                },
+              });
+            },
+            err => {
+              if (err) {
+                plugin._diag.error('Error running query hook', err);
+              }
+            },
+            true,
+          );
+        }
+
+        let result: unknown;
+        try {
+          result = original.apply(this, args as never);
+        } catch (e: unknown) {
+          if (e instanceof Error) {
+            span.recordException(utils.sanitizedErrorMessage(e));
+          }
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: utils.getErrorMessage(e),
+          });
+          span.end();
+          throw e;
+        }
+
+        // Bind promise to parent span and end the span
+        if (result instanceof Promise) {
+          return result
+            .then((result: unknown) => {
+              // Return a pass-along promise which ends the span and then goes to user's orig resolvers
+              return new Promise(resolve => {
+                utils.handleExecutionResult(plugin.getConfig(), span, result);
+                recordDuration();
+                span.end();
+                resolve(result);
+              });
+            })
+            .catch((error: Error) => {
+              return new Promise((_, reject) => {
+                if (error instanceof Error) {
+                  span.recordException(utils.sanitizedErrorMessage(error));
+                }
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: error.message,
+                });
+                recordDuration();
+                span.end();
+                reject(error);
+              });
+            });
+        }
+
+        // else returns void
+        return result; // void
+      };
+    };
+  }
+
+  private _setPoolConnectEventListeners(pgPool: PgPoolExtended) {
+    if (pgPool[EVENT_LISTENERS_SET]) return;
+    const poolName = utils.getPoolName(pgPool.options);
+
+    pgPool.on('connect', () => {
+      this._connectionsCounter = utils.updateCounter(
+        poolName,
+        pgPool,
+        this._connectionsCount,
+        this._connectionPendingRequests,
+        this._connectionsCounter,
+      );
+    });
+
+    pgPool.on('acquire', () => {
+      this._connectionsCounter = utils.updateCounter(
+        poolName,
+        pgPool,
+        this._connectionsCount,
+        this._connectionPendingRequests,
+        this._connectionsCounter,
+      );
+    });
+
+    pgPool.on('remove', () => {
+      this._connectionsCounter = utils.updateCounter(
+        poolName,
+        pgPool,
+        this._connectionsCount,
+        this._connectionPendingRequests,
+        this._connectionsCounter,
+      );
+    });
+
+    pgPool.on('release' as any, () => {
+      this._connectionsCounter = utils.updateCounter(
+        poolName,
+        pgPool,
+        this._connectionsCount,
+        this._connectionPendingRequests,
+        this._connectionsCounter,
+      );
+    });
+    pgPool[EVENT_LISTENERS_SET] = true;
+  }
+
+  private _getPoolConnectPatch() {
+    const plugin = this;
+    return (originalConnect: (...args: any[]) => any) => {
+      return function connect(this: PgPoolExtended, callback?: PgPoolCallback) {
+        const config = plugin.getConfig();
+
+        if (utils.shouldSkipInstrumentation(config)) {
+          return originalConnect.call(this, callback as any);
+        }
+
+        // Still set up event listeners for metrics even when skipping spans
+        plugin._setPoolConnectEventListeners(this);
+
+        if (config.ignoreConnectSpans) {
+          return originalConnect.call(this, callback as any);
+        }
+
+        // setup span
+        const span = plugin.tracer.startSpan(SpanNames.POOL_CONNECT, {
+          kind: SpanKind.CLIENT,
+          attributes: utils.getSemanticAttributesFromPoolConnection(this.options, plugin._semconvStability),
+        });
+
+        if (callback) {
+          const parentSpan = trace.getSpan(context.active());
+          callback = utils.patchCallbackPGPool(span, callback) as PgPoolCallback;
+          // If a parent span exists, bind the callback
+          if (parentSpan) {
+            callback = context.bind(context.active(), callback);
+          }
+        }
+
+        const connectResult: unknown = context.with(trace.setSpan(context.active(), span), () => {
+          return originalConnect.call(this, callback as any);
+        });
+
+        return handleConnectResult(span, connectResult);
+      };
+    };
+  }
+}
+
+function handleConnectResult(span: Span, connectResult: unknown) {
+  if (!(connectResult instanceof Promise)) {
+    return connectResult;
+  }
+
+  const connectResultPromise = connectResult as Promise<unknown>;
+  return context.bind(
+    context.active(),
+    connectResultPromise
+      .then(result => {
+        span.end();
+        return result;
+      })
+      .catch((error: unknown) => {
+        if (error instanceof Error) {
+          span.recordException(utils.sanitizedErrorMessage(error));
+        }
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: utils.getErrorMessage(error),
+        });
+        span.end();
+        return Promise.reject(error);
+      }),
+  );
+}

--- a/packages/node/src/integrations/tracing/postgres/vendored/internal-types.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/internal-types.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * NOTICE from the Sentry authors:
- * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
- * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.70.0
  * - Types from `pg` and `pg-pool` packages inlined as simplified interfaces
  */
 /* eslint-disable */

--- a/packages/node/src/integrations/tracing/postgres/vendored/internal-types.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/internal-types.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Types from `pg` and `pg-pool` packages inlined as simplified interfaces
+ */
+/* eslint-disable */
+
+import type { PgClient } from './pg-types';
+import type { PgPool } from './pg-pool-types';
+
+export type PostgresCallback = (err: Error, res: object) => unknown;
+
+// NB: this type describes the shape of a parsed, normalized form of the
+// connection information that's stored inside each pg.Client instance. It's
+// _not_ the same as the ConnectionConfig type exported from `@types/pg`. That
+// type defines how data must be _passed in_ when creating a new `pg.Client`,
+// which doesn't necessarily match the normalized internal form. E.g., a user
+// can call `new Client({ connectionString: '...' }), but `connectionString`
+// will never show up in the type below, because only the extracted host, port,
+// etc. are recorded in this normalized config. The keys listed below are also
+// incomplete, which is fine because the type is internal and these keys are the
+// only ones our code is reading. See https://github.com/brianc/node-postgres/blob/fde5ec586e49258dfc4a2fcd861fcdecb4794fc3/lib/client.js#L25
+export interface PgParsedConnectionParams {
+  database?: string;
+  host?: string;
+  namespace?: string;
+  port?: number;
+  user?: string;
+}
+
+export interface PgClientExtended extends PgClient {
+  connectionParameters: PgParsedConnectionParams;
+}
+
+export type PgPoolCallback = (err: Error, client: any, done: (release?: any) => void) => void;
+
+export interface PgPoolOptionsParams {
+  allowExitOnIdle: boolean;
+  connectionString?: string; // connection string if provided directly
+  database: string;
+  host: string;
+  idleTimeoutMillis: number; // the minimum amount of time that an object may sit idle in the pool before it is eligible for eviction due to idle time
+  max: number;
+  maxClient: number; // maximum size of the pool
+  maxLifetimeSeconds: number;
+  maxUses: number;
+  namespace: string;
+  port: number;
+  user: string;
+}
+
+export const EVENT_LISTENERS_SET = Symbol('opentelemetry.instrumentation.pg.eventListenersSet');
+
+export interface PgPoolExtended extends PgPool {
+  options: PgPoolOptionsParams;
+  [EVENT_LISTENERS_SET]?: boolean; // flag to identify if the event listeners for instrumentation have been set
+}
+
+export type PgClientConnect = (callback?: Function) => Promise<void> | void;

--- a/packages/node/src/integrations/tracing/postgres/vendored/pg-pool-types.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/pg-pool-types.ts
@@ -1,0 +1,15 @@
+/*
+ * Simplified type definitions inlined from the `pg-pool` package.
+ * Only the members actually used by the vendored instrumentation are included.
+ */
+/* eslint-disable */
+
+export interface PgPool {
+  connect(callback?: any): any;
+  totalCount: number;
+  idleCount: number;
+  waitingCount: number;
+  options: any;
+  on(event: string, listener: (...args: any[]) => void): this;
+  [key: string]: any;
+}

--- a/packages/node/src/integrations/tracing/postgres/vendored/pg-pool-types.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/pg-pool-types.ts
@@ -1,15 +1,35 @@
 /*
  * Simplified type definitions inlined from the `pg-pool` package.
- * Only the members actually used by the vendored instrumentation are included.
+ * PoolClient and PoolConfig are replaced with structural equivalents.
  */
 /* eslint-disable */
 
+import type { PgPoolClient } from './pg-types';
+
 export interface PgPool {
-  connect(callback?: any): any;
-  totalCount: number;
-  idleCount: number;
-  waitingCount: number;
+  readonly totalCount: number;
+  readonly idleCount: number;
+  readonly waitingCount: number;
+  readonly expiredCount: number;
+
+  readonly ending: boolean;
+  readonly ended: boolean;
+
   options: any;
+
+  connect(): Promise<PgPoolClient>;
+  connect(
+    callback: (err: Error | undefined, client: PgPoolClient | undefined, done: (release?: any) => void) => void,
+  ): void;
+
+  end(): Promise<void>;
+  end(callback: () => void): void;
+
+  query(...args: any[]): any;
+
+  on(event: 'release' | 'error', listener: (err: Error, client: PgPoolClient) => void): this;
+  on(event: 'connect' | 'acquire' | 'remove', listener: (client: PgPoolClient) => void): this;
   on(event: string, listener: (...args: any[]) => void): this;
+
   [key: string]: any;
 }

--- a/packages/node/src/integrations/tracing/postgres/vendored/pg-types.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/pg-types.ts
@@ -1,36 +1,73 @@
 /*
  * Simplified type definitions inlined from the `pg` package.
- * Only the members actually used by the vendored instrumentation are included.
+ * Deep type trees (Connection, Submittable, QueryConfig generics, FieldDef,
+ * NoticeMessage, ClientConfig) are replaced with structural equivalents.
  */
 /* eslint-disable */
 
-export interface PgClient {
-  database: string;
-  connectionParameters: {
-    database?: string;
-    host?: string;
-    namespace?: string;
-    port?: number;
-    user?: string;
-    [key: string]: any;
-  };
+export interface FieldDef {
+  name: string;
+  tableID: number;
+  columnID: number;
+  dataTypeID: number;
+  dataTypeSize: number;
+  dataTypeModifier: number;
+  format: string;
+}
+
+export interface QueryResultBase {
+  command: string;
+  rowCount: number | null;
+  oid: number;
+  fields: FieldDef[];
+}
+
+export interface QueryResult<R = any> extends QueryResultBase {
+  rows: R[];
+}
+
+export interface QueryArrayResult<R extends any[] = any[]> extends QueryResultBase {
+  rows: R[];
+}
+
+export interface PgClientBase {
+  connect(): Promise<void>;
+  connect(callback: (err: Error) => void): void;
+
   query(...args: any[]): any;
-  connect(callback?: Function): any;
+
+  copyFrom(queryText: string): any;
+  copyTo(queryText: string): any;
+
+  pauseDrain(): void;
+  resumeDrain(): void;
+
+  escapeIdentifier(str: string): string;
+  escapeLiteral(str: string): string;
+
+  on(event: 'drain', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'notice', listener: (notice: any) => void): this;
+  on(event: 'notification', listener: (message: any) => void): this;
+  on(event: 'end', listener: () => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
+
   [key: string]: any;
 }
 
-export interface QueryResult {
-  command: string;
-  rowCount: number | null;
-  rows: any[];
-  fields: any[];
-  [key: string]: any;
+export interface PgClient extends PgClientBase {
+  user?: string | undefined;
+  database?: string | undefined;
+  port: number;
+  host: string;
+  password?: string | undefined;
+  ssl: boolean;
+  readonly connection: any;
+
+  end(): Promise<void>;
+  end(callback: (err: Error) => void): void;
 }
 
-export interface QueryArrayResult {
-  command: string;
-  rowCount: number | null;
-  rows: any[][];
-  fields: any[];
-  [key: string]: any;
+export interface PgPoolClient extends PgClientBase {
+  release(err?: Error | boolean): void;
 }

--- a/packages/node/src/integrations/tracing/postgres/vendored/pg-types.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/pg-types.ts
@@ -1,0 +1,36 @@
+/*
+ * Simplified type definitions inlined from the `pg` package.
+ * Only the members actually used by the vendored instrumentation are included.
+ */
+/* eslint-disable */
+
+export interface PgClient {
+  database: string;
+  connectionParameters: {
+    database?: string;
+    host?: string;
+    namespace?: string;
+    port?: number;
+    user?: string;
+    [key: string]: any;
+  };
+  query(...args: any[]): any;
+  connect(callback?: Function): any;
+  [key: string]: any;
+}
+
+export interface QueryResult {
+  command: string;
+  rowCount: number | null;
+  rows: any[];
+  fields: any[];
+  [key: string]: any;
+}
+
+export interface QueryArrayResult {
+  command: string;
+  rowCount: number | null;
+  rows: any[][];
+  fields: any[];
+  [key: string]: any;
+}

--- a/packages/node/src/integrations/tracing/postgres/vendored/semconv.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/semconv.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * NOTICE from the Sentry authors:
- * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
- * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.70.0
  */
 /* eslint-disable */
 

--- a/packages/node/src/integrations/tracing/postgres/vendored/semconv.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/semconv.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ */
+/* eslint-disable */
+
+/*
+ * This file contains a copy of unstable semantic convention definitions
+ * used by this package.
+ * @see https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv
+ */
+
+/**
+ * The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation **SHOULD** use a combination of parameters that would make the name unique, for example, combining attributes `server.address`, `server.port`, and `db.namespace`, formatted as `server.address:server.port/db.namespace`. Instrumentations that generate connection pool name following different patterns **SHOULD** document it.
+ *
+ * @example myDataSource
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_DB_CLIENT_CONNECTION_POOL_NAME = 'db.client.connection.pool.name' as const;
+
+/**
+ * The state of a connection in the pool
+ *
+ * @example idle
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_DB_CLIENT_CONNECTION_STATE = 'db.client.connection.state' as const;
+
+/**
+ * Deprecated, use `server.address`, `server.port` attributes instead.
+ *
+ * @example "Server=(localdb)\\v11.0;Integrated Security=true;"
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `server.address` and `server.port`.
+ */
+export const ATTR_DB_CONNECTION_STRING = 'db.connection_string' as const;
+
+/**
+ * Deprecated, use `db.namespace` instead.
+ *
+ * @example customers
+ * @example main
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `db.namespace`.
+ */
+export const ATTR_DB_NAME = 'db.name' as const;
+
+/**
+ * The database statement being executed.
+ *
+ * @example SELECT * FROM wuser_table
+ * @example SET mykey "WuValue"
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `db.query.text`.
+ */
+export const ATTR_DB_STATEMENT = 'db.statement' as const;
+
+/**
+ * Deprecated, use `db.system.name` instead.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `db.system.name`.
+ */
+export const ATTR_DB_SYSTEM = 'db.system' as const;
+
+/**
+ * Deprecated, no replacement at this time.
+ *
+ * @example readonly_user
+ * @example reporting_user
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Removed, no replacement at this time.
+ */
+export const ATTR_DB_USER = 'db.user' as const;
+
+/**
+ * Deprecated, use `server.address` on client spans and `client.address` on server spans.
+ *
+ * @example example.com
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `server.address` on client spans and `client.address` on server spans.
+ */
+export const ATTR_NET_PEER_NAME = 'net.peer.name' as const;
+
+/**
+ * Deprecated, use `server.port` on client spans and `client.port` on server spans.
+ *
+ * @example 8080
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `server.port` on client spans and `client.port` on server spans.
+ */
+export const ATTR_NET_PEER_PORT = 'net.peer.port' as const;
+
+/**
+ * Enum value "idle" for attribute {@link ATTR_DB_CLIENT_CONNECTION_STATE}.
+ */
+export const DB_CLIENT_CONNECTION_STATE_VALUE_IDLE = 'idle' as const;
+
+/**
+ * Enum value "used" for attribute {@link ATTR_DB_CLIENT_CONNECTION_STATE}.
+ */
+export const DB_CLIENT_CONNECTION_STATE_VALUE_USED = 'used' as const;
+
+/**
+ * Enum value "postgresql" for attribute {@link ATTR_DB_SYSTEM}.
+ */
+export const DB_SYSTEM_VALUE_POSTGRESQL = 'postgresql' as const;
+
+/**
+ * The number of connections that are currently in state described by the `state` attribute
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_DB_CLIENT_CONNECTION_COUNT = 'db.client.connection.count' as const;
+
+/**
+ * The number of current pending requests for an open connection
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_DB_CLIENT_CONNECTION_PENDING_REQUESTS = 'db.client.connection.pending_requests' as const;

--- a/packages/node/src/integrations/tracing/postgres/vendored/types.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/types.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * NOTICE from the Sentry authors:
- * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
- * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.70.0
  * - Types from `pg` package inlined as simplified interfaces
  */
 /* eslint-disable */

--- a/packages/node/src/integrations/tracing/postgres/vendored/types.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/types.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Types from `pg` package inlined as simplified interfaces
+ */
+/* eslint-disable */
+
+import type { QueryResult, QueryArrayResult } from './pg-types';
+import type * as api from '@opentelemetry/api';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+export interface PgResponseHookInformation {
+  data: QueryResult | QueryArrayResult;
+}
+
+export interface PgInstrumentationExecutionResponseHook {
+  (span: api.Span, responseInfo: PgResponseHookInformation): void;
+}
+
+export interface PgRequestHookInformation {
+  query: {
+    text: string;
+    name?: string;
+    values?: unknown[];
+  };
+  connection: {
+    database?: string;
+    host?: string;
+    port?: number;
+    user?: string;
+  };
+}
+
+export interface PgInstrumentationExecutionRequestHook {
+  (span: api.Span, queryInfo: PgRequestHookInformation): void;
+}
+
+export interface PgInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * If true, an attribute containing the query's parameters will be attached
+   * the spans generated to represent the query.
+   */
+  enhancedDatabaseReporting?: boolean;
+
+  /**
+   * Hook that allows adding custom span attributes or updating the
+   * span's name based on the data about the query to execute.
+   *
+   * @default undefined
+   */
+  requestHook?: PgInstrumentationExecutionRequestHook;
+
+  /**
+   * Hook that allows adding custom span attributes based on the data
+   * returned from "query" Pg actions.
+   *
+   * @default undefined
+   */
+  responseHook?: PgInstrumentationExecutionResponseHook;
+
+  /**
+   * If true, requires a parent span to create new spans.
+   *
+   * @default false
+   */
+  requireParentSpan?: boolean;
+
+  /**
+   * If true, queries are modified to also include a comment with
+   * the tracing context, following the {@link https://github.com/open-telemetry/opentelemetry-sqlcommenter sqlcommenter} format
+   */
+  addSqlCommenterCommentToQueries?: boolean;
+
+  /**
+   * If true, `pg.connect` and `pg-pool.connect` spans will not be created.
+   * Query spans and pool metrics are still recorded.
+   *
+   * @default false
+   */
+  ignoreConnectSpans?: boolean;
+}

--- a/packages/node/src/integrations/tracing/postgres/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/utils.ts
@@ -1,0 +1,448 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Types from `pg` package inlined as simplified interfaces
+ * - Minor TypeScript strictness adjustments
+ */
+/* eslint-disable */
+
+import {
+  context,
+  trace,
+  Span,
+  SpanStatusCode,
+  Tracer,
+  SpanKind,
+  diag,
+  UpDownCounter,
+  Attributes,
+} from '@opentelemetry/api';
+import { AttributeNames } from './enums/AttributeNames';
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_DB_SYSTEM_NAME,
+  ATTR_DB_NAMESPACE,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+  ATTR_DB_QUERY_TEXT,
+  DB_SYSTEM_NAME_VALUE_POSTGRESQL,
+} from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_DB_CLIENT_CONNECTION_POOL_NAME,
+  ATTR_DB_CLIENT_CONNECTION_STATE,
+  DB_CLIENT_CONNECTION_STATE_VALUE_USED,
+  DB_CLIENT_CONNECTION_STATE_VALUE_IDLE,
+  ATTR_DB_SYSTEM,
+  ATTR_DB_NAME,
+  ATTR_DB_USER,
+  DB_SYSTEM_VALUE_POSTGRESQL,
+  ATTR_DB_CONNECTION_STRING,
+  ATTR_NET_PEER_PORT,
+  ATTR_NET_PEER_NAME,
+  ATTR_DB_STATEMENT,
+} from './semconv';
+import {
+  PgClientExtended,
+  PostgresCallback,
+  PgPoolCallback,
+  PgPoolExtended,
+  PgParsedConnectionParams,
+  PgPoolOptionsParams,
+} from './internal-types';
+import { PgInstrumentationConfig } from './types';
+import type { PgClient, QueryResult, QueryArrayResult } from './pg-types';
+import { safeExecuteInTheMiddle, SemconvStability } from '@opentelemetry/instrumentation';
+import { SpanNames } from './enums/SpanNames';
+
+/**
+ * Helper function to get a low cardinality span name from whatever info we have
+ * about the query.
+ *
+ * This is tricky, because we don't have most of the information (table name,
+ * operation name, etc) the spec recommends using to build a low-cardinality
+ * value w/o parsing. So, we use db.name and assume that, if the query's a named
+ * prepared statement, those `name` values will be low cardinality. If we don't
+ * have a named prepared statement, we try to parse an operation (despite the
+ * spec's warnings).
+ *
+ * @params dbName The name of the db against which this query is being issued,
+ *   which could be missing if no db name was given at the time that the
+ *   connection was established.
+ * @params queryConfig Information we have about the query being issued, typed
+ *   to reflect only the validation we've actually done on the args to
+ *   `client.query()`. This will be undefined if `client.query()` was called
+ *   with invalid arguments.
+ */
+export function getQuerySpanName(dbName: string | undefined, queryConfig?: { text: string; name?: unknown }) {
+  // NB: when the query config is invalid, we omit the dbName too, so that
+  // someone (or some tool) reading the span name doesn't misinterpret the
+  // dbName as being a prepared statement or sql commit name.
+  if (!queryConfig) return SpanNames.QUERY_PREFIX;
+
+  // Either the name of a prepared statement; or an attempted parse
+  // of the SQL command, normalized to uppercase; or unknown.
+  const command =
+    typeof queryConfig.name === 'string' && queryConfig.name
+      ? queryConfig.name
+      : parseNormalizedOperationName(queryConfig.text);
+
+  return `${SpanNames.QUERY_PREFIX}:${command}${dbName ? ` ${dbName}` : ''}`;
+}
+
+export function parseNormalizedOperationName(queryText: string) {
+  // Trim the query text to handle leading/trailing whitespace
+  const trimmedQuery = queryText.trim();
+  const indexOfFirstSpace = trimmedQuery.indexOf(' ');
+  let sqlCommand = indexOfFirstSpace === -1 ? trimmedQuery : trimmedQuery.slice(0, indexOfFirstSpace);
+  sqlCommand = sqlCommand.toUpperCase();
+
+  // Handle query text being "COMMIT;", which has an extra semicolon before the space.
+  return sqlCommand.endsWith(';') ? sqlCommand.slice(0, -1) : sqlCommand;
+}
+
+export function parseAndMaskConnectionString(connectionString: string): string {
+  try {
+    // Parse the connection string
+    const url = new URL(connectionString);
+
+    // Remove all auth information (username and password)
+    url.username = '';
+    url.password = '';
+
+    return url.toString();
+  } catch (e) {
+    // If parsing fails, return a generic connection string
+    return 'postgresql://localhost:5432/';
+  }
+}
+
+export function getConnectionString(params: PgParsedConnectionParams | PgPoolOptionsParams) {
+  if ('connectionString' in params && params.connectionString) {
+    return parseAndMaskConnectionString(params.connectionString);
+  }
+  const host = params.host || 'localhost';
+  const port = params.port || 5432;
+  const database = params.database || '';
+  return `postgresql://${host}:${port}/${database}`;
+}
+
+function getPort(port: number | undefined): number | undefined {
+  // Port may be NaN as parseInt() is used on the value, passing null will result in NaN being parsed.
+  // https://github.com/brianc/node-postgres/blob/2a8efbee09a284be12748ed3962bc9b816965e36/packages/pg/lib/connection-parameters.js#L66
+  if (Number.isInteger(port)) {
+    return port;
+  }
+
+  // Unable to find the default used in pg code, so falling back to 'undefined'.
+  return undefined;
+}
+
+export function getSemanticAttributesFromConnection(
+  params: PgParsedConnectionParams,
+  semconvStability: SemconvStability,
+) {
+  let attributes: Attributes = {};
+
+  if (semconvStability & SemconvStability.OLD) {
+    attributes = {
+      ...attributes,
+      [ATTR_DB_SYSTEM]: DB_SYSTEM_VALUE_POSTGRESQL,
+      [ATTR_DB_NAME]: params.database,
+      [ATTR_DB_CONNECTION_STRING]: getConnectionString(params),
+      [ATTR_DB_USER]: params.user,
+      [ATTR_NET_PEER_NAME]: params.host, // required
+      [ATTR_NET_PEER_PORT]: getPort(params.port),
+    };
+  }
+  if (semconvStability & SemconvStability.STABLE) {
+    attributes = {
+      ...attributes,
+      [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_POSTGRESQL,
+      [ATTR_DB_NAMESPACE]: params.namespace,
+      [ATTR_SERVER_ADDRESS]: params.host,
+      [ATTR_SERVER_PORT]: getPort(params.port),
+    };
+  }
+
+  return attributes;
+}
+
+export function getSemanticAttributesFromPoolConnection(
+  params: PgPoolOptionsParams,
+  semconvStability: SemconvStability,
+) {
+  let url: URL | undefined;
+  try {
+    url = params.connectionString ? new URL(params.connectionString) : undefined;
+  } catch (e) {
+    url = undefined;
+  }
+  let attributes: Attributes = {
+    [AttributeNames.IDLE_TIMEOUT_MILLIS]: params.idleTimeoutMillis,
+    [AttributeNames.MAX_CLIENT]: params.maxClient,
+  };
+
+  if (semconvStability & SemconvStability.OLD) {
+    attributes = {
+      ...attributes,
+      [ATTR_DB_SYSTEM]: DB_SYSTEM_VALUE_POSTGRESQL,
+      [ATTR_DB_NAME]: url?.pathname.slice(1) ?? params.database,
+      [ATTR_DB_CONNECTION_STRING]: getConnectionString(params),
+      [ATTR_NET_PEER_NAME]: url?.hostname ?? params.host,
+      [ATTR_NET_PEER_PORT]: Number(url?.port) || getPort(params.port),
+      [ATTR_DB_USER]: url?.username ?? params.user,
+    };
+  }
+  if (semconvStability & SemconvStability.STABLE) {
+    attributes = {
+      ...attributes,
+      [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_POSTGRESQL,
+      [ATTR_DB_NAMESPACE]: params.namespace,
+      [ATTR_SERVER_ADDRESS]: url?.hostname ?? params.host,
+      [ATTR_SERVER_PORT]: Number(url?.port) || getPort(params.port),
+    };
+  }
+
+  return attributes;
+}
+
+export function shouldSkipInstrumentation(instrumentationConfig: PgInstrumentationConfig) {
+  return instrumentationConfig.requireParentSpan === true && trace.getSpan(context.active()) === undefined;
+}
+
+// Create a span from our normalized queryConfig object,
+// or return a basic span if no queryConfig was given/could be created.
+export function handleConfigQuery(
+  this: PgClientExtended,
+  tracer: Tracer,
+  instrumentationConfig: PgInstrumentationConfig,
+  semconvStability: SemconvStability,
+  queryConfig?: { text: string; values?: unknown; name?: unknown },
+) {
+  // Create child span.
+  const { connectionParameters } = this;
+  const dbName = connectionParameters.database;
+
+  const spanName = getQuerySpanName(dbName, queryConfig);
+  const span = tracer.startSpan(spanName, {
+    kind: SpanKind.CLIENT,
+    attributes: getSemanticAttributesFromConnection(connectionParameters, semconvStability),
+  });
+
+  if (!queryConfig) {
+    return span;
+  }
+
+  // Set attributes
+  if (queryConfig.text) {
+    if (semconvStability & SemconvStability.OLD) {
+      span.setAttribute(ATTR_DB_STATEMENT, queryConfig.text);
+    }
+    if (semconvStability & SemconvStability.STABLE) {
+      span.setAttribute(ATTR_DB_QUERY_TEXT, queryConfig.text);
+    }
+  }
+
+  if (instrumentationConfig.enhancedDatabaseReporting && Array.isArray(queryConfig.values)) {
+    try {
+      const convertedValues = queryConfig.values.map(value => {
+        if (value == null) {
+          return 'null';
+        } else if (value instanceof Buffer) {
+          return value.toString();
+        } else if (typeof value === 'object') {
+          if (typeof value.toPostgres === 'function') {
+            return value.toPostgres();
+          }
+          return JSON.stringify(value);
+        } else {
+          //string, number
+          return value.toString();
+        }
+      });
+      span.setAttribute(AttributeNames.PG_VALUES, convertedValues);
+    } catch (e) {
+      diag.error('failed to stringify ', queryConfig.values, e);
+    }
+  }
+
+  // Set plan name attribute, if present
+  if (typeof queryConfig.name === 'string') {
+    span.setAttribute(AttributeNames.PG_PLAN, queryConfig.name);
+  }
+
+  return span;
+}
+
+export function handleExecutionResult(
+  config: PgInstrumentationConfig,
+  span: Span,
+  pgResult: QueryResult | QueryArrayResult | unknown,
+) {
+  if (typeof config.responseHook === 'function') {
+    safeExecuteInTheMiddle(
+      () => {
+        config.responseHook!(span, {
+          data: pgResult as QueryResult | QueryArrayResult,
+        });
+      },
+      err => {
+        if (err) {
+          diag.error('Error running response hook', err);
+        }
+      },
+      true,
+    );
+  }
+}
+
+export function patchCallback(
+  instrumentationConfig: PgInstrumentationConfig,
+  span: Span,
+  cb: PostgresCallback,
+  attributes: Attributes,
+  recordDuration: { (): void },
+): PostgresCallback {
+  return function patchedCallback(this: PgClientExtended, err: Error, res: object) {
+    if (err) {
+      if (Object.prototype.hasOwnProperty.call(err, 'code')) {
+        attributes[ATTR_ERROR_TYPE] = (err as any)['code'];
+      }
+      if (err instanceof Error) {
+        span.recordException(sanitizedErrorMessage(err));
+      }
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err.message,
+      });
+    } else {
+      handleExecutionResult(instrumentationConfig, span, res);
+    }
+
+    recordDuration();
+    span.end();
+    cb.call(this, err, res);
+  };
+}
+
+export function getPoolName(pool: PgPoolOptionsParams): string {
+  let poolName = '';
+  poolName += (pool?.host ? `${pool.host}` : 'unknown_host') + ':';
+  poolName += (pool?.port ? `${pool.port}` : 'unknown_port') + '/';
+  poolName += pool?.database ? `${pool.database}` : 'unknown_database';
+
+  return poolName.trim();
+}
+
+export interface poolConnectionsCounter {
+  used: number;
+  idle: number;
+  pending: number;
+}
+
+export function updateCounter(
+  poolName: string,
+  pool: PgPoolExtended,
+  connectionCount: UpDownCounter,
+  connectionPendingRequests: UpDownCounter,
+  latestCounter: poolConnectionsCounter,
+): poolConnectionsCounter {
+  const all = pool.totalCount;
+  const pending = pool.waitingCount;
+  const idle = pool.idleCount;
+  const used = all - idle;
+
+  connectionCount.add(used - latestCounter.used, {
+    [ATTR_DB_CLIENT_CONNECTION_STATE]: DB_CLIENT_CONNECTION_STATE_VALUE_USED,
+    [ATTR_DB_CLIENT_CONNECTION_POOL_NAME]: poolName,
+  });
+
+  connectionCount.add(idle - latestCounter.idle, {
+    [ATTR_DB_CLIENT_CONNECTION_STATE]: DB_CLIENT_CONNECTION_STATE_VALUE_IDLE,
+    [ATTR_DB_CLIENT_CONNECTION_POOL_NAME]: poolName,
+  });
+
+  connectionPendingRequests.add(pending - latestCounter.pending, {
+    [ATTR_DB_CLIENT_CONNECTION_POOL_NAME]: poolName,
+  });
+
+  return { used: used, idle: idle, pending: pending };
+}
+
+export function patchCallbackPGPool(span: Span, cb: PgPoolCallback): PgPoolCallback {
+  return function patchedCallback(this: PgPoolExtended, err: Error, res: object, done: any) {
+    if (err) {
+      if (err instanceof Error) {
+        span.recordException(sanitizedErrorMessage(err));
+      }
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err.message,
+      });
+    }
+    span.end();
+    cb.call(this, err, res, done);
+  };
+}
+
+export function patchClientConnectCallback(span: Span, cb: Function): Function {
+  return function patchedClientConnectCallback(this: PgClient, err: Error) {
+    if (err) {
+      if (err instanceof Error) {
+        span.recordException(sanitizedErrorMessage(err));
+      }
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err.message,
+      });
+    }
+    span.end();
+    cb.apply(this, arguments);
+  };
+}
+
+/**
+ * Attempt to get a message string from a thrown value, while being quite
+ * defensive, to recognize the fact that, in JS, any kind of value (even
+ * primitives) can be thrown.
+ */
+export function getErrorMessage(e: unknown) {
+  return typeof e === 'object' && e !== null && 'message' in e
+    ? String((e as { message?: unknown }).message)
+    : undefined;
+}
+
+export function isObjectWithTextString(it: unknown): it is ObjectWithText {
+  return typeof it === 'object' && typeof (it as null | { text?: unknown })?.text === 'string';
+}
+
+export type ObjectWithText = {
+  text: string;
+  [k: string]: unknown;
+};
+
+/**
+ * Generates a sanitized message for the error.
+ * Only includes the error type and PostgreSQL error code, omitting any sensitive details.
+ */
+export function sanitizedErrorMessage(error: unknown): string {
+  const name = (error as any)?.name ?? 'PostgreSQLError';
+  const code = (error as any)?.code ?? 'UNKNOWN';
+
+  return `PostgreSQL error of type '${name}' occurred (code: ${code})`;
+}

--- a/packages/node/src/integrations/tracing/postgres/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/utils.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  * NOTICE from the Sentry authors:
- * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/ed97091c9890dd18e52759f2ea98e9d7593b3ae4/packages/instrumentation-pg
- * - Upstream version: @opentelemetry/instrumentation-pg@0.66.0
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/15ef7506553f631ea4181391e0c5725a56f0d082/packages/instrumentation-pg
+ * - Upstream version: @opentelemetry/instrumentation-pg@0.70.0
  * - Types from `pg` package inlined as simplified interfaces
  * - Minor TypeScript strictness adjustments
  */

--- a/packages/node/test/integrations/tracing/postgres.test.ts
+++ b/packages/node/test/integrations/tracing/postgres.test.ts
@@ -1,9 +1,9 @@
-import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
+import { PgInstrumentation } from '../../../src/integrations/tracing/postgres/vendored/instrumentation';
 import { INSTRUMENTED } from '@sentry/node-core';
 import { beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { instrumentPostgres, postgresIntegration } from '../../../src/integrations/tracing/postgres';
 
-vi.mock('@opentelemetry/instrumentation-pg');
+vi.mock('../../../src/integrations/tracing/postgres/vendored/instrumentation');
 
 describe('postgres integration', () => {
   beforeEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6061,18 +6061,6 @@
     "@opentelemetry/semantic-conventions" "^1.29.0"
     forwarded-parse "2.1.2"
 
-"@opentelemetry/instrumentation-pg@0.66.0":
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz#78d16b50dc4c5d851015823611a46243d63a88fb"
-  integrity sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==
-  dependencies:
-    "@opentelemetry/core" "^2.0.0"
-    "@opentelemetry/instrumentation" "^0.214.0"
-    "@opentelemetry/semantic-conventions" "^1.34.0"
-    "@opentelemetry/sql-common" "^0.41.2"
-    "@types/pg" "8.15.6"
-    "@types/pg-pool" "2.0.7"
-
 "@opentelemetry/instrumentation@0.214.0", "@opentelemetry/instrumentation@^0.214.0":
   version "0.214.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz#2649e8a29a8c4748bc583d35281c80632f046e25"
@@ -6147,7 +6135,7 @@
     "@opentelemetry/resources" "2.6.1"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.40.0":
+"@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.40.0":
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz#10b2944ca559386590683392022a897eefd011d3"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
@@ -9405,14 +9393,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
   integrity sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==
 
-"@types/pg-pool@2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@types/pg-pool/-/pg-pool-2.0.7.tgz#c17945a74472d9a3beaf8e66d5aa6fc938328734"
-  integrity sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==
-  dependencies:
-    "@types/pg" "*"
-
-"@types/pg@*", "@types/pg@8.15.6", "@types/pg@^8.6.5":
+"@types/pg@^8.6.5":
   version "8.15.6"
   resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.6.tgz#4df7590b9ac557cbe5479e0074ec1540cbddad9b"
   integrity sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==


### PR DESCRIPTION
Vendors `@opentelemetry/instrumentation-pg@0.70.0` into the SDK with no logic changes. Types from `pg` and `pg-pool` are inlined as simplified interfaces to avoid requiring these packages as dependencies.

Adds "node" to the types field in the `generic-ts3.8`, `generic-ts5.0` and `remix-hydrogen` E2E test tsconfigs and adds `@types/node` as a devDependency in `remix-hydrogen`. These tests previously relied on `@types/node` being loaded transitively via `@opentelemetry/instrumentation-pg` → `@types/pg` (which has `/// <reference types="node" />`). Now that this path no longer exists `types: []` in the tsconfig results in these types not being available during the app build, because they get explicitly filtered.

Closes https://github.com/getsentry/sentry-javascript/issues/20158