### PR TITLE
fix(angular): Bump Node version for Angular 21 E2E tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/angular-21/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-21/package.json
@@ -47,7 +47,7 @@
     "typescript": "~6.0.0"
   },
   "volta": {
-    "node": "22.22.0",
+    "node": "22.22.3",
     "extends": "../../package.json"
   },
   "sentryTest": {


### PR DESCRIPTION
Bump Node from `22.22.0` to `22.22.3` to satisfy Angular CLI 22 RC's minimum requirement in the canary variant.

Fixes #21111