### PR TITLE
ref(node): Remove unused `@opentelemetry/instrumentation-http` dependency

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -68,7 +68,6 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@opentelemetry/instrumentation-http": "0.214.0",
     "@opentelemetry/sql-common": "^0.41.2",
     "@opentelemetry/instrumentation-pg": "0.66.0",
     "@opentelemetry/sdk-trace-base": "^2.6.1",


### PR DESCRIPTION
Removes `@opentelemetry/instrumentation-http` from `@sentry/node` dependencies. The otel instrumentation was essentially already removed in https://github.com/getsentry/sentry-javascript/pull/20393 and the dependency seems to just be a leftover.