### PR TITLE
ci: Verify yarn.lock stability via git diff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,8 +353,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: 'package.json'
+      - name: Install dependencies
+        run: yarn install --ignore-engines
       - name: Check that yarn.lock is stable
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: |
+          if ! git diff --exit-code yarn.lock; then
+            echo "::error::yarn.lock has uncommitted changes after running 'yarn install'. Please run 'yarn install' locally and commit the updated yarn.lock."
+            exit 1
+          fi
       - name: Check for duplicate dependencies in lockfile
         run: yarn dedupe-deps:check
 


### PR DESCRIPTION
## Summary

- The `job_check_lockfile` step in `build.yml` previously ran `yarn install --frozen-lockfile`, which has repeatedly failed to detect lockfile drift in practice.
- Switched to a regular `yarn install` followed by `git diff --exit-code yarn.lock`, so any modification yarn actually makes to the lockfile fails the job with a clear annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)