### PR TITLE
feat(nextjs): Migrate `sendDefaultPii` to `dataCollection`

### DIFF
--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -1,6 +1,5 @@
 import type { Client, TransactionSource } from '@sentry/core';
 import {
-  _INTERNAL_filterKeyValueData,
   browserPerformanceTimeOrigin,
   debug,
   parseBaggageHeader,
@@ -130,7 +129,7 @@ export function pagesRouterInstrumentPageLoad(client: Client): void {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.nextjs.pages_router_instrumentation',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: route ? 'route' : 'url',
-        ...(params && getFilteredRouteParams(params, client)),
+        ...(params && { ...params }),
       },
     },
     { sentryTrace, baggage },
@@ -184,17 +183,6 @@ function getNextRouteFromPathname(pathname: string): string | undefined {
     const routeRegExp = convertNextRouteToRegExp(route);
     return pathname.match(routeRegExp);
   });
-}
-
-function getFilteredRouteParams(params: ParsedUrlQuery, client: Client): Record<string, string> {
-  const { queryParams } = client.getDataCollectionOptions();
-  const stringParams: Record<string, string> = {};
-  for (const [key, value] of Object.entries(params)) {
-    if (typeof value === 'string') {
-      stringParams[key] = value;
-    }
-  }
-  return _INTERNAL_filterKeyValueData(stringParams, queryParams);
 }
 
 /**

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -1,5 +1,6 @@
 import type { Client, TransactionSource } from '@sentry/core';
 import {
+  _INTERNAL_filterKeyValueData,
   browserPerformanceTimeOrigin,
   debug,
   parseBaggageHeader,
@@ -129,7 +130,7 @@ export function pagesRouterInstrumentPageLoad(client: Client): void {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.nextjs.pages_router_instrumentation',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: route ? 'route' : 'url',
-        ...(params && client.getOptions().sendDefaultPii && { ...params }),
+        ...(params && getFilteredRouteParams(params, client)),
       },
     },
     { sentryTrace, baggage },
@@ -183,6 +184,17 @@ function getNextRouteFromPathname(pathname: string): string | undefined {
     const routeRegExp = convertNextRouteToRegExp(route);
     return pathname.match(routeRegExp);
   });
+}
+
+function getFilteredRouteParams(params: ParsedUrlQuery, client: Client): Record<string, string> {
+  const { queryParams } = client.getDataCollectionOptions();
+  const stringParams: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === 'string') {
+      stringParams[key] = value;
+    }
+  }
+  return _INTERNAL_filterKeyValueData(stringParams, queryParams);
 }
 
 /**

--- a/packages/nextjs/src/common/utils/addHeadersAsAttributes.ts
+++ b/packages/nextjs/src/common/utils/addHeadersAsAttributes.ts
@@ -12,12 +12,19 @@ export function addHeadersAsAttributes(
     return {};
   }
 
+  const client = getClient();
+  const { httpHeaders } = client?.getDataCollectionOptions() ?? { httpHeaders: { request: false, response: false } };
+
+  if (httpHeaders.request === false) {
+    return {};
+  }
+
   const headersDict: Record<string, string | string[] | undefined> =
     headers instanceof Headers || (typeof headers === 'object' && 'get' in headers)
       ? winterCGHeadersToDict(headers as Headers)
       : headers;
 
-  const headerAttributes = httpHeadersToSpanAttributes(headersDict, getClient()?.getOptions().sendDefaultPii ?? false);
+  const headerAttributes = httpHeadersToSpanAttributes(headersDict, httpHeaders.request === true);
 
   if (span) {
     span.setAttributes(headerAttributes);

--- a/packages/nextjs/src/common/utils/addHeadersAsAttributes.ts
+++ b/packages/nextjs/src/common/utils/addHeadersAsAttributes.ts
@@ -13,9 +13,9 @@ export function addHeadersAsAttributes(
   }
 
   const client = getClient();
-  const { httpHeaders } = client?.getDataCollectionOptions() ?? { httpHeaders: { request: false, response: false } };
+  const dataCollection = client?.getDataCollectionOptions();
 
-  if (httpHeaders.request === false) {
+  if (dataCollection?.httpHeaders.request === false) {
     return {};
   }
 
@@ -24,7 +24,7 @@ export function addHeadersAsAttributes(
       ? winterCGHeadersToDict(headers as Headers)
       : headers;
 
-  const headerAttributes = httpHeadersToSpanAttributes(headersDict, httpHeaders.request === true);
+  const headerAttributes = httpHeadersToSpanAttributes(headersDict, dataCollection ?? false);
 
   if (span) {
     span.setAttributes(headerAttributes);

--- a/packages/nextjs/src/common/utils/setUrlProcessingMetadata.ts
+++ b/packages/nextjs/src/common/utils/setUrlProcessingMetadata.ts
@@ -11,9 +11,13 @@ export function setUrlProcessingMetadata(event: Event): void {
     return;
   }
 
-  // Only add URL if sendDefaultPii is enabled, as URLs may contain PII
   const client = getClient();
-  if (!client?.getOptions().sendDefaultPii) {
+  if (!client) {
+    return;
+  }
+
+  // todo(v11): Replace with a dataCollection gate once URL collection is covered by the spec.
+  if (!client.getOptions().sendDefaultPii) {
     return;
   }
 

--- a/packages/nextjs/src/common/utils/setUrlProcessingMetadata.ts
+++ b/packages/nextjs/src/common/utils/setUrlProcessingMetadata.ts
@@ -16,11 +16,6 @@ export function setUrlProcessingMetadata(event: Event): void {
     return;
   }
 
-  // todo(v11): Replace with a dataCollection gate once URL collection is covered by the spec.
-  if (!client.getOptions().sendDefaultPii) {
-    return;
-  }
-
   const traceData = event.contexts.trace.data;
 
   // Get the route from trace data

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -70,7 +70,7 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
   callback: A,
 ): Promise<ReturnType<A>> {
   return withIsolationScope(async isolationScope => {
-    const sendDefaultPii = getClient()?.getOptions().sendDefaultPii;
+    const shouldRecordResponse = getClient()?.getDataCollectionOptions().httpBodies.includes('outgoingResponse');
 
     let sentryTraceHeader;
     let baggageHeader;
@@ -138,7 +138,7 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
                 }
               });
 
-              if (options.recordResponse !== undefined ? options.recordResponse : sendDefaultPii) {
+              if (options.recordResponse !== undefined ? options.recordResponse : shouldRecordResponse) {
                 getIsolationScope().setExtra('server_action_result', result);
               }
 

--- a/packages/nextjs/test/performance/pagesRouterInstrumentation.test.ts
+++ b/packages/nextjs/test/performance/pagesRouterInstrumentation.test.ts
@@ -128,6 +128,9 @@ describe('pagesRouterInstrumentPageLoad', () => {
           'sentry.op': 'pageload',
           'sentry.origin': 'auto.pageload.nextjs.pages_router_instrumentation',
           'sentry.source': 'route',
+          user: 'lforst',
+          id: '1337',
+          q: '42',
         },
       },
     ],
@@ -190,6 +193,9 @@ describe('pagesRouterInstrumentPageLoad', () => {
       const client = {
         emit,
         getOptions: () => ({}),
+        getDataCollectionOptions: () => ({
+          queryParams: { deny: [] },
+        }),
       } as unknown as Client;
 
       pagesRouterInstrumentPageLoad(client);

--- a/packages/nextjs/test/performance/pagesRouterInstrumentation.test.ts
+++ b/packages/nextjs/test/performance/pagesRouterInstrumentation.test.ts
@@ -112,9 +112,9 @@ describe('pagesRouterInstrumentPageLoad', () => {
 
   it.each([
     [
-      'https://example.com/lforst/posts/1337?q=42',
+      'https://example.com/chargome/posts/1337?q=42',
       '/[user]/posts/[id]',
-      { user: 'lforst', id: '1337', q: '42' },
+      { user: 'chargome', id: '1337', q: '42' },
       {
         pageProps: {
           _sentryTraceData: 'c82b8554881b4d28ad977de04a4fb40a-a755953cd3394d5f-1',
@@ -128,7 +128,7 @@ describe('pagesRouterInstrumentPageLoad', () => {
           'sentry.op': 'pageload',
           'sentry.origin': 'auto.pageload.nextjs.pages_router_instrumentation',
           'sentry.source': 'route',
-          user: 'lforst',
+          user: 'chargome',
           id: '1337',
           q: '42',
         },
@@ -193,9 +193,6 @@ describe('pagesRouterInstrumentPageLoad', () => {
       const client = {
         emit,
         getOptions: () => ({}),
-        getDataCollectionOptions: () => ({
-          queryParams: { deny: [] },
-        }),
       } as unknown as Client;
 
       pagesRouterInstrumentPageLoad(client);

--- a/packages/nextjs/test/utils/addHeadersAsAttributes.test.ts
+++ b/packages/nextjs/test/utils/addHeadersAsAttributes.test.ts
@@ -18,7 +18,7 @@ describe('addHeadersAsAttributes', () => {
     expect(result).toEqual({});
   });
 
-  it('includes all headers with sensitive filtering when httpHeaders.request is true', () => {
+  it('passes PII headers through when httpHeaders.request is true', () => {
     vi.spyOn(SentryCore, 'getClient').mockReturnValue({
       getDataCollectionOptions: () => ({
         httpHeaders: { request: true, response: true },
@@ -27,37 +27,28 @@ describe('addHeadersAsAttributes', () => {
 
     const result = addHeadersAsAttributes({
       'content-type': 'application/json',
-      accept: 'text/html',
+      'x-forwarded-for': '127.0.0.1',
     });
 
     expect(result).toMatchObject({
       'http.request.header.content_type': 'application/json',
-      'http.request.header.accept': 'text/html',
+      'http.request.header.x_forwarded_for': '127.0.0.1',
     });
   });
 
-  it('applies stricter PII filtering when httpHeaders.request is a deny list', () => {
+  it('filters denied headers when httpHeaders.request is a deny list', () => {
     vi.spyOn(SentryCore, 'getClient').mockReturnValue({
       getDataCollectionOptions: () => ({
-        httpHeaders: { request: { deny: [] }, response: true },
+        httpHeaders: { request: { deny: ['forwarded'] }, response: true },
       }),
     } as unknown as SentryCore.Client);
 
     const result = addHeadersAsAttributes({
       'content-type': 'application/json',
-      accept: 'text/html',
+      'x-forwarded-for': '127.0.0.1',
     });
 
-    expect(result).toMatchObject({
-      'http.request.header.content_type': 'application/json',
-      'http.request.header.accept': 'text/html',
-    });
-  });
-
-  it('returns empty object when no client is available', () => {
-    vi.spyOn(SentryCore, 'getClient').mockReturnValue(undefined);
-
-    const result = addHeadersAsAttributes({ 'content-type': 'application/json' });
-    expect(result).toEqual({});
+    expect(result['http.request.header.content_type']).toBe('application/json');
+    expect(result['http.request.header.x_forwarded_for']).toBe('[Filtered]');
   });
 });

--- a/packages/nextjs/test/utils/addHeadersAsAttributes.test.ts
+++ b/packages/nextjs/test/utils/addHeadersAsAttributes.test.ts
@@ -1,0 +1,63 @@
+import * as SentryCore from '@sentry/core';
+import { describe, expect, it, vi } from 'vitest';
+import { addHeadersAsAttributes } from '../../src/common/utils/addHeadersAsAttributes';
+
+describe('addHeadersAsAttributes', () => {
+  it('returns empty object when headers are undefined', () => {
+    expect(addHeadersAsAttributes(undefined)).toEqual({});
+  });
+
+  it('returns empty object when httpHeaders.request is false', () => {
+    vi.spyOn(SentryCore, 'getClient').mockReturnValue({
+      getDataCollectionOptions: () => ({
+        httpHeaders: { request: false, response: true },
+      }),
+    } as unknown as SentryCore.Client);
+
+    const result = addHeadersAsAttributes({ 'content-type': 'application/json' });
+    expect(result).toEqual({});
+  });
+
+  it('includes all headers with sensitive filtering when httpHeaders.request is true', () => {
+    vi.spyOn(SentryCore, 'getClient').mockReturnValue({
+      getDataCollectionOptions: () => ({
+        httpHeaders: { request: true, response: true },
+      }),
+    } as unknown as SentryCore.Client);
+
+    const result = addHeadersAsAttributes({
+      'content-type': 'application/json',
+      accept: 'text/html',
+    });
+
+    expect(result).toMatchObject({
+      'http.request.header.content_type': 'application/json',
+      'http.request.header.accept': 'text/html',
+    });
+  });
+
+  it('applies stricter PII filtering when httpHeaders.request is a deny list', () => {
+    vi.spyOn(SentryCore, 'getClient').mockReturnValue({
+      getDataCollectionOptions: () => ({
+        httpHeaders: { request: { deny: [] }, response: true },
+      }),
+    } as unknown as SentryCore.Client);
+
+    const result = addHeadersAsAttributes({
+      'content-type': 'application/json',
+      accept: 'text/html',
+    });
+
+    expect(result).toMatchObject({
+      'http.request.header.content_type': 'application/json',
+      'http.request.header.accept': 'text/html',
+    });
+  });
+
+  it('returns empty object when no client is available', () => {
+    vi.spyOn(SentryCore, 'getClient').mockReturnValue(undefined);
+
+    const result = addHeadersAsAttributes({ 'content-type': 'application/json' });
+    expect(result).toEqual({});
+  });
+});

--- a/packages/nextjs/test/utils/setUrlProcessingMetadata.test.ts
+++ b/packages/nextjs/test/utils/setUrlProcessingMetadata.test.ts
@@ -1,0 +1,101 @@
+import type { Event } from '@sentry/core';
+import * as SentryCore from '@sentry/core';
+import { describe, expect, it, vi } from 'vitest';
+import { setUrlProcessingMetadata } from '../../src/common/utils/setUrlProcessingMetadata';
+
+function makeTransactionEvent(overrides?: Partial<Event>): Event {
+  return {
+    type: 'transaction',
+    contexts: {
+      trace: {
+        op: 'http.server',
+        data: {
+          'next.route': '/api/users/[id]',
+          'http.target': '/api/users/123',
+        },
+      },
+    },
+    sdkProcessingMetadata: {
+      capturedSpanIsolationScope: {
+        getScopeData: () => ({
+          sdkProcessingMetadata: {
+            normalizedRequest: {
+              headers: {
+                'x-forwarded-proto': 'https',
+                host: 'example.com',
+              },
+            },
+          },
+        }),
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('setUrlProcessingMetadata', () => {
+  it('skips non-transaction events', () => {
+    const event = makeTransactionEvent({ type: undefined });
+    setUrlProcessingMetadata(event);
+    // No error thrown, nothing changed
+  });
+
+  it('skips when sendDefaultPii is false', () => {
+    vi.spyOn(SentryCore, 'getClient').mockReturnValue({
+      getOptions: () => ({ sendDefaultPii: false }),
+    } as unknown as SentryCore.Client);
+
+    const scopeData = {
+      sdkProcessingMetadata: {
+        normalizedRequest: {
+          headers: { host: 'example.com' },
+        },
+      },
+    };
+
+    const event = makeTransactionEvent({
+      sdkProcessingMetadata: {
+        capturedSpanIsolationScope: { getScopeData: () => scopeData },
+      },
+    });
+
+    setUrlProcessingMetadata(event);
+    expect(scopeData.sdkProcessingMetadata.normalizedRequest).not.toHaveProperty('url');
+  });
+
+  it('adds URL when sendDefaultPii is true', () => {
+    vi.spyOn(SentryCore, 'getClient').mockReturnValue({
+      getOptions: () => ({ sendDefaultPii: true }),
+    } as unknown as SentryCore.Client);
+
+    const scopeData = {
+      sdkProcessingMetadata: {
+        normalizedRequest: {
+          headers: {
+            'x-forwarded-proto': 'https',
+            host: 'example.com',
+          },
+        },
+      },
+    };
+
+    const event: Event = {
+      type: 'transaction',
+      contexts: {
+        trace: {
+          op: 'http.server',
+          data: {
+            'next.route': '/api/users/[id]',
+            'http.target': '/api/users/123',
+          },
+        },
+      },
+      sdkProcessingMetadata: {
+        capturedSpanIsolationScope: { getScopeData: () => scopeData },
+      },
+    };
+
+    setUrlProcessingMetadata(event);
+    expect(scopeData.sdkProcessingMetadata.normalizedRequest.url).toBe('https://example.com/api/users/123');
+  });
+});

--- a/packages/nextjs/test/utils/setUrlProcessingMetadata.test.ts
+++ b/packages/nextjs/test/utils/setUrlProcessingMetadata.test.ts
@@ -3,69 +3,15 @@ import * as SentryCore from '@sentry/core';
 import { describe, expect, it, vi } from 'vitest';
 import { setUrlProcessingMetadata } from '../../src/common/utils/setUrlProcessingMetadata';
 
-function makeTransactionEvent(overrides?: Partial<Event>): Event {
-  return {
-    type: 'transaction',
-    contexts: {
-      trace: {
-        op: 'http.server',
-        data: {
-          'next.route': '/api/users/[id]',
-          'http.target': '/api/users/123',
-        },
-      },
-    },
-    sdkProcessingMetadata: {
-      capturedSpanIsolationScope: {
-        getScopeData: () => ({
-          sdkProcessingMetadata: {
-            normalizedRequest: {
-              headers: {
-                'x-forwarded-proto': 'https',
-                host: 'example.com',
-              },
-            },
-          },
-        }),
-      },
-    },
-    ...overrides,
-  };
-}
-
 describe('setUrlProcessingMetadata', () => {
   it('skips non-transaction events', () => {
-    const event = makeTransactionEvent({ type: undefined });
+    const event: Event = { type: undefined };
     setUrlProcessingMetadata(event);
-    // No error thrown, nothing changed
   });
 
-  it('skips when sendDefaultPii is false', () => {
+  it('adds URL without sendDefaultPii', () => {
     vi.spyOn(SentryCore, 'getClient').mockReturnValue({
       getOptions: () => ({ sendDefaultPii: false }),
-    } as unknown as SentryCore.Client);
-
-    const scopeData = {
-      sdkProcessingMetadata: {
-        normalizedRequest: {
-          headers: { host: 'example.com' },
-        },
-      },
-    };
-
-    const event = makeTransactionEvent({
-      sdkProcessingMetadata: {
-        capturedSpanIsolationScope: { getScopeData: () => scopeData },
-      },
-    });
-
-    setUrlProcessingMetadata(event);
-    expect(scopeData.sdkProcessingMetadata.normalizedRequest).not.toHaveProperty('url');
-  });
-
-  it('adds URL when sendDefaultPii is true', () => {
-    vi.spyOn(SentryCore, 'getClient').mockReturnValue({
-      getOptions: () => ({ sendDefaultPii: true }),
     } as unknown as SentryCore.Client);
 
     const scopeData = {
@@ -97,5 +43,16 @@ describe('setUrlProcessingMetadata', () => {
 
     setUrlProcessingMetadata(event);
     expect(scopeData.sdkProcessingMetadata.normalizedRequest.url).toBe('https://example.com/api/users/123');
+  });
+
+  it('skips when no client is available', () => {
+    vi.spyOn(SentryCore, 'getClient').mockReturnValue(undefined);
+
+    const event: Event = {
+      type: 'transaction',
+      contexts: { trace: { op: 'http.server', data: { 'next.route': '/test' } } },
+    };
+
+    setUrlProcessingMetadata(event);
   });
 });


### PR DESCRIPTION
Migrate `sendDefaultPii` usage in the Next.js package to the `dataCollection` API:

- **`withServerActionInstrumentation`**: Use `getDataCollectionOptions().httpBodies.includes('outgoingResponse')` to gate server action response recording
- **`addHeadersAsAttributes`**: Use `httpHeaders.request` from `getDataCollectionOptions()` to control header span attributes and filtering level
- **`setUrlProcessingMetadata`**: Remove the `sendDefaultPii` gate — URLs are fundamental request metadata, not PII-gated data (see [spec update](https://github.com/getsentry/sentry-docs/pull/17911))
- **`pagesRouterRoutingInstrumentation`**: Remove the `sendDefaultPii` gate for route params — same reasoning as URLs

ref https://github.com/getsentry/sentry-docs/pull/17911



closes https://github.com/getsentry/sentry-javascript/issues/20932