### PR TITLE
ref(node): Vendor `@opentelemetry/sql-common`

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -68,7 +68,6 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@opentelemetry/sql-common": "^0.41.2",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@sentry/core": "10.53.1",

--- a/packages/node/src/integrations/tracing/mysql2/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/mysql2/vendored/instrumentation.ts
@@ -33,7 +33,7 @@ import {
   semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
 import { DB_SYSTEM_VALUE_MYSQL, ATTR_DB_STATEMENT, ATTR_DB_SYSTEM } from './semconv';
-import { addSqlCommenterComment } from '@opentelemetry/sql-common';
+import { addSqlCommenterComment } from '../../utils/sql-common';
 import type { Connection, Query, QueryOptions, QueryError, FieldPacket, FormatFunction } from './mysql2-types';
 import { MySQL2InstrumentationConfig } from './types';
 import { getConnectionAttributes, getConnectionPrototypeToInstrument, getQueryText, getSpanName, once } from './utils';

--- a/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
@@ -53,7 +53,7 @@ import {
 } from './internal-types';
 import { PgInstrumentationConfig } from './types';
 import * as utils from './utils';
-import { addSqlCommenterComment } from '@opentelemetry/sql-common';
+import { addSqlCommenterComment } from '../../utils/sql-common';
 import { SDK_VERSION } from '@sentry/core';
 const PACKAGE_NAME = '@sentry/instrumentation-pg';
 import { SpanNames } from './enums/SpanNames';

--- a/packages/node/src/integrations/tracing/utils/sql-common.ts
+++ b/packages/node/src/integrations/tracing/utils/sql-common.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/5a5918fd4f9f16b14c9ef4d3de08ab98c20e5b46/packages/sql-common
+ * - Upstream version: @opentelemetry/sql-common@0.41.2
+ */
+
+/* eslint-disable */
+
+import { trace, Span, ROOT_CONTEXT, defaultTextMapSetter } from '@opentelemetry/api';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+
+// NOTE: This function currently is returning false-positives
+// in cases where comment characters appear in string literals
+// ("SELECT '-- not a comment';" would return true, although has no comment)
+function hasValidSqlComment(query: string): boolean {
+  const indexOpeningDashDashComment = query.indexOf('--');
+  if (indexOpeningDashDashComment >= 0) {
+    return true;
+  }
+
+  const indexOpeningSlashComment = query.indexOf('/*');
+  if (indexOpeningSlashComment < 0) {
+    return false;
+  }
+
+  const indexClosingSlashComment = query.indexOf('*/');
+  return indexOpeningDashDashComment < indexClosingSlashComment;
+}
+
+// sqlcommenter specification (https://google.github.io/sqlcommenter/spec/#value-serialization)
+// expects us to URL encode based on the RFC 3986 spec (https://en.wikipedia.org/wiki/Percent-encoding),
+// but encodeURIComponent does not handle some characters correctly (! ' ( ) *),
+// which means we need special handling for this
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+function fixedEncodeURIComponent(str: string) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, c => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+export function addSqlCommenterComment(span: Span, query: string): string {
+  if (typeof query !== 'string' || query.length === 0) {
+    return query;
+  }
+
+  // As per sqlcommenter spec we shall not add a comment if there already is a comment
+  // in the query
+  if (hasValidSqlComment(query)) {
+    return query;
+  }
+
+  const propagator = new W3CTraceContextPropagator();
+  const headers: { [key: string]: string } = {};
+  propagator.inject(trace.setSpan(ROOT_CONTEXT, span), headers, defaultTextMapSetter);
+
+  // sqlcommenter spec requires keys in the comment to be sorted lexicographically
+  const sortedKeys = Object.keys(headers).sort();
+
+  if (sortedKeys.length === 0) {
+    return query;
+  }
+
+  const commentString = sortedKeys
+    .map(key => {
+      const encodedValue = fixedEncodeURIComponent(headers[key]!);
+      return `${key}='${encodedValue}'`;
+    })
+    .join(',');
+
+  return `${query} /*${commentString}*/`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6016,7 +6016,7 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
   integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
 
-"@opentelemetry/core@2.6.1", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.1":
+"@opentelemetry/core@2.6.1", "@opentelemetry/core@^2.6.1":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.6.1.tgz#a59d22a9ae3be80bb41b280bbbe1fe9fbdb6c2a5"
   integrity sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6114,13 +6114,6 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz#10b2944ca559386590683392022a897eefd011d3"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
 
-"@opentelemetry/sql-common@^0.41.2":
-  version "0.41.2"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz#7f4a14166cfd6c9ffe89096db1cc75eaf6443b19"
-  integrity sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==
-  dependencies:
-    "@opentelemetry/core" "^2.0.0"
-
 "@oxc-parser/binding-android-arm64@0.76.0":
   version "0.76.0"
   resolved "https://registry.yarnpkg.com/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.76.0.tgz#2bf8524add42f7a399ea0da9ae8e764bb9aeb61b"


### PR DESCRIPTION
Vendors `@opentelemetry/sql-common@0.41.2` into `packages/node/src/integrations/tracing/utils/sql-common.ts` as a shared utility used by the `mysql2` and `postgres` vendored instrumentations. Removes the npm dependency.

Closes https://github.com/getsentry/sentry-javascript/issues/21130