### PR TITLE
feat(tanstackstart-react): Add distributed tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   Change the recommended setup for the SDK to do `Sentry.init()` in the client entry file to capture telemetry that is emitted ahead of page hydration.
 
+- **feat(tanstackstart-react): Add distributed tracing ([#21144](https://github.com/getsentry/sentry-javascript/pull/21144))**
+
+  Server and client traces are now automatically connected, allowing you to see the full request lifecycle from server-side rendering through client-side hydration in a single trace.
+
 ## 10.54.0
 
 ### Important Changes

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/src/routes/__root.tsx
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/src/routes/__root.tsx
@@ -1,31 +1,21 @@
 import type { ReactNode } from 'react';
 import { Outlet, createRootRoute, HeadContent, Scripts } from '@tanstack/react-router';
-import { getTraceData } from '@sentry/tanstackstart-react';
 
 export const Route = createRootRoute({
-  head: () => {
-    const traceData = getTraceData();
-    const sentryMeta = Object.entries(traceData).map(([key, value]) => ({
-      name: key,
-      content: value,
-    }));
-
-    return {
-      meta: [
-        {
-          charSet: 'utf-8',
-        },
-        {
-          name: 'viewport',
-          content: 'width=device-width, initial-scale=1',
-        },
-        {
-          title: 'TanStack Start Cloudflare E2E Test',
-        },
-        ...sentryMeta,
-      ],
-    };
-  },
+  head: () => ({
+    meta: [
+      {
+        charSet: 'utf-8',
+      },
+      {
+        name: 'viewport',
+        content: 'width=device-width, initial-scale=1',
+      },
+      {
+        title: 'TanStack Start Cloudflare E2E Test',
+      },
+    ],
+  }),
   component: RootComponent,
 });
 

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/tests/trace-propagation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/tests/trace-propagation.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test.describe('Trace propagation', () => {
+  test('should inject metatags in ssr pageload', async ({ page }) => {
+    await page.goto('/');
+
+    const sentryTraceContent = await page.getAttribute('meta[name="sentry-trace"]', 'content');
+    expect(sentryTraceContent).toBeDefined();
+    expect(sentryTraceContent).toMatch(/^[a-f0-9]{32}-[a-f0-9]{16}-[01]$/);
+
+    const baggageContent = await page.getAttribute('meta[name="baggage"]', 'content');
+    expect(baggageContent).toBeDefined();
+    expect(baggageContent).toContain('sentry-environment=qa');
+    expect(baggageContent).toContain('sentry-public_key=');
+    expect(baggageContent).toContain('sentry-trace_id=');
+    expect(baggageContent).toContain('sentry-sampled=');
+  });
+
+  test('should have trace connection between server and client', async ({ page }) => {
+    const serverTxPromise = waitForTransaction('tanstackstart-react-cloudflare', transactionEvent => {
+      return transactionEvent?.contexts?.trace?.op === 'http.server' && transactionEvent?.transaction === 'GET /';
+    });
+
+    const clientTxPromise = waitForTransaction('tanstackstart-react-cloudflare', transactionEvent => {
+      return transactionEvent?.contexts?.trace?.op === 'pageload' && transactionEvent?.transaction === '/';
+    });
+
+    await page.goto('/');
+
+    const serverTx = await serverTxPromise;
+    const clientTx = await clientTxPromise;
+
+    expect(clientTx.contexts?.trace?.trace_id).toBe(serverTx.contexts?.trace?.trace_id);
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/tests/transaction.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/tests/transaction.test.ts
@@ -95,25 +95,3 @@ test('Sends server-side transaction for page request', async ({ baseURL }) => {
     status: 'ok',
   });
 });
-
-test('Propagates trace from server to client', async ({ page }) => {
-  const serverTransactionPromise = waitForTransaction('tanstackstart-react-cloudflare', transactionEvent => {
-    return transactionEvent?.contexts?.trace?.op === 'http.server' && transactionEvent?.transaction === 'GET /';
-  });
-
-  const clientTransactionPromise = waitForTransaction('tanstackstart-react-cloudflare', transactionEvent => {
-    return transactionEvent?.contexts?.trace?.op === 'pageload' && transactionEvent?.transaction === '/';
-  });
-
-  await page.goto('/');
-
-  const serverTransaction = await serverTransactionPromise;
-  const clientTransaction = await clientTransactionPromise;
-
-  const serverTraceId = serverTransaction.contexts?.trace?.trace_id;
-  const clientTraceId = clientTransaction.contexts?.trace?.trace_id;
-
-  expect(serverTraceId).toMatch(/[a-f0-9]{32}/);
-  expect(clientTraceId).toMatch(/[a-f0-9]{32}/);
-  expect(clientTraceId).toBe(serverTraceId);
-});

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/trace-propagation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/trace-propagation.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+const usesManagedTunnelRoute =
+  (process.env.E2E_TEST_TUNNEL_ROUTE_MODE ?? 'off') !== 'off' || process.env.E2E_TEST_CUSTOM_TUNNEL_ROUTE === '1';
+
+test.skip(usesManagedTunnelRoute, 'Default e2e suites run only in the proxy variant');
+
+test.describe('Trace propagation', () => {
+  test('should inject metatags in ssr pageload', async ({ page }) => {
+    await page.goto('/');
+
+    const sentryTraceContent = await page.getAttribute('meta[name="sentry-trace"]', 'content');
+    expect(sentryTraceContent).toBeDefined();
+    expect(sentryTraceContent).toMatch(/^[a-f0-9]{32}-[a-f0-9]{16}-[01]$/);
+
+    const baggageContent = await page.getAttribute('meta[name="baggage"]', 'content');
+    expect(baggageContent).toBeDefined();
+    expect(baggageContent).toContain('sentry-environment=qa');
+    expect(baggageContent).toContain('sentry-public_key=');
+    expect(baggageContent).toContain('sentry-trace_id=');
+    expect(baggageContent).toContain('sentry-sampled=');
+  });
+
+  test('should have trace connection between server and client', async ({ page }) => {
+    const serverTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
+      return transactionEvent?.contexts?.trace?.op === 'http.server' && transactionEvent?.transaction === 'GET /';
+    });
+
+    const clientTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
+      return transactionEvent?.contexts?.trace?.op === 'pageload' && transactionEvent?.transaction === '/';
+    });
+
+    await page.goto('/');
+
+    const serverTx = await serverTxPromise;
+    const clientTx = await clientTxPromise;
+
+    expect(clientTx.contexts?.trace?.trace_id).toBe(serverTx.contexts?.trace?.trace_id);
+  });
+});

--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -37,8 +37,9 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
       return originalResponse;
     }
 
-    // Type cast necessary b/c the body's ReadableStream type doesn't include
+    // Type case necessary b/c the body's ReadableStream type doesn't include
     // the async iterator that is actually available in Node
+    // We later on use the async iterator to read the body chunks
     // see https://github.com/microsoft/TypeScript/issues/39051
     const originalBody = originalResponse.body as NodeJS.ReadableStream | null;
     if (!originalBody) {

--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -67,7 +67,9 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
               yield chunk;
             }
           } catch (e) {
-            captureException(e);
+            captureException(e, {
+              mechanism: { type: 'auto.http.tanstackstart', handled: false },
+            });
             throw e;
           }
         }

--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -74,6 +74,7 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
           }
         }
 
+        let errored = false;
         try {
           for await (const chunk of bodyReporter()) {
             const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
@@ -81,9 +82,12 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
             controller.enqueue(new TextEncoder().encode(modifiedHtml));
           }
         } catch (e) {
+          errored = true;
           controller.error(e);
         } finally {
-          controller.close();
+          if (!errored) {
+            controller.close();
+          }
         }
       },
     });

--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -1,5 +1,10 @@
 import { flushIfServerless, getTraceMetaTags } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/node';
+import {
+  captureException,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  startSpan,
+} from '@sentry/node';
 import { extractServerFunctionSha256 } from './utils';
 
 export type ServerEntry = {
@@ -33,7 +38,9 @@ function addMetaTagToHead(htmlChunk: string, metaTagsStr: string): string {
 function injectMetaTagsInResponse(originalResponse: Response): Response {
   try {
     const contentType = originalResponse.headers.get('content-type');
-    if (!contentType?.startsWith('text/html')) {
+
+    const isPageloadRequest = contentType?.startsWith('text/html');
+    if (!isPageloadRequest) {
       return originalResponse;
     }
 
@@ -51,10 +58,25 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
 
     const newResponseStream = new ReadableStream({
       start: async controller => {
+        // Assign to a new variable to avoid TS losing the narrower type checked above.
+        const body = originalBody;
+
+        async function* bodyIterator(): AsyncGenerator<string | Buffer> {
+          try {
+            for await (const chunk of body) {
+              yield chunk;
+            }
+          } catch (e) {
+            captureException(e);
+            throw e;
+          }
+        }
+
         try {
-          for await (const chunk of originalBody) {
-            const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk as BufferSource, { stream: true });
-            controller.enqueue(new TextEncoder().encode(addMetaTagToHead(html, metaTagsStr)));
+          for await (const chunk of bodyIterator()) {
+            const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
+            const modifiedHtml = addMetaTagToHead(html, metaTagsStr);
+            controller.enqueue(new TextEncoder().encode(modifiedHtml));
           }
         } catch (e) {
           controller.error(e);
@@ -69,8 +91,9 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
       statusText: originalResponse.statusText,
       headers: new Headers(originalResponse.headers),
     });
-  } catch {
-    return originalResponse;
+  } catch (e) {
+    captureException(e);
+    throw e;
   }
 }
 

--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -1,10 +1,77 @@
-import { flushIfServerless } from '@sentry/core';
+import { flushIfServerless, getTraceMetaTags } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/node';
 import { extractServerFunctionSha256 } from './utils';
 
 export type ServerEntry = {
   fetch: (request: Request, opts?: unknown) => Promise<Response> | Response;
 };
+
+/**
+ * This function optimistically assumes that the HTML coming in chunks will not be split
+ * within the <head> tag. If this still happens, we simply won't replace anything.
+ */
+function addMetaTagToHead(htmlChunk: string, metaTagsStr: string): string {
+  if (typeof htmlChunk !== 'string' || !metaTagsStr) {
+    return htmlChunk;
+  }
+
+  if (htmlChunk.includes('"sentry-trace"')) {
+    return htmlChunk;
+  }
+
+  // Skip quoted attribute values so we don't match <head> inside e.g. data-code="...<head>..."
+  let replaced = false;
+  return htmlChunk.replace(/"[^"]*"|'[^']*'|(<head>)/g, (match, headTag) => {
+    if (headTag && !replaced) {
+      replaced = true;
+      return `<head>${metaTagsStr}`;
+    }
+    return match;
+  });
+}
+
+function injectMetaTagsInResponse(originalResponse: Response): Response {
+  try {
+    const contentType = originalResponse.headers.get('content-type');
+    if (!contentType?.startsWith('text/html')) {
+      return originalResponse;
+    }
+
+    // Type cast necessary b/c the body's ReadableStream type doesn't include
+    // the async iterator that is actually available in Node
+    // see https://github.com/microsoft/TypeScript/issues/39051
+    const originalBody = originalResponse.body as NodeJS.ReadableStream | null;
+    if (!originalBody) {
+      return originalResponse;
+    }
+
+    const metaTagsStr = getTraceMetaTags();
+    const decoder = new TextDecoder();
+
+    const newResponseStream = new ReadableStream({
+      start: async controller => {
+        try {
+          for await (const chunk of originalBody) {
+            const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk as BufferSource, { stream: true });
+            controller.enqueue(new TextEncoder().encode(addMetaTagToHead(html, metaTagsStr)));
+          }
+        } catch (e) {
+          controller.error(e);
+        } finally {
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(newResponseStream, {
+      status: originalResponse.status,
+      statusText: originalResponse.statusText,
+      headers: new Headers(originalResponse.headers),
+    });
+  } catch {
+    return originalResponse;
+  }
+}
 
 /**
  * This function can be used to wrap the server entry request handler to add tracing to server-side functionality.
@@ -62,7 +129,7 @@ export function wrapFetchWithSentry(serverEntry: ServerEntry): ServerEntry {
             );
           }
 
-          return await target.apply(thisArg, args);
+          return injectMetaTagsInResponse(await target.apply(thisArg, args));
         } finally {
           await flushIfServerless();
         }

--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -61,7 +61,7 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
         // Assign to a new variable to avoid TS losing the narrower type checked above.
         const body = originalBody;
 
-        async function* bodyIterator(): AsyncGenerator<string | Buffer> {
+        async function* bodyReporter(): AsyncGenerator<string | Buffer> {
           try {
             for await (const chunk of body) {
               yield chunk;
@@ -75,7 +75,7 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
         }
 
         try {
-          for await (const chunk of bodyIterator()) {
+          for await (const chunk of bodyReporter()) {
             const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
             const modifiedHtml = addMetaTagToHead(html, metaTagsStr);
             controller.enqueue(new TextEncoder().encode(modifiedHtml));
@@ -94,7 +94,9 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
       headers: new Headers(originalResponse.headers),
     });
   } catch (e) {
-    captureException(e);
+    captureException(e, {
+      mechanism: { type: 'auto.http.tanstackstart', handled: false },
+    });
     throw e;
   }
 }

--- a/packages/tanstackstart-react/test/server/wrapFetchWithSentry.test.ts
+++ b/packages/tanstackstart-react/test/server/wrapFetchWithSentry.test.ts
@@ -11,11 +11,18 @@ vi.mock('@sentry/node', async importOriginal => {
   };
 });
 
+const getTraceMetaTagsSpy = vi
+  .fn()
+  .mockReturnValue(
+    '<meta name="sentry-trace" content="abc123-def456-1"/>\n<meta name="baggage" content="sentry-trace_id=abc123"/>',
+  );
+
 vi.mock('@sentry/core', async importOriginal => {
   const original = await importOriginal();
   return {
     ...original,
     flushIfServerless: (...args: unknown[]) => flushIfServerlessSpy(...args),
+    getTraceMetaTags: () => getTraceMetaTagsSpy(),
   };
 });
 
@@ -51,6 +58,94 @@ describe('wrapFetchWithSentry', () => {
 
     expect(startSpanSpy).toHaveBeenCalled();
     expect(flushIfServerlessSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('injects meta tags into HTML responses', async () => {
+    const mockResponse = new Response('<head><meta charset="utf-8"/></head><body></body>', {
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+    });
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse);
+
+    const serverEntry = wrapFetchWithSentry({ fetch: fetchFn });
+    const request = new Request('http://localhost:3000/');
+
+    const response = await serverEntry.fetch(request);
+    const html = await response.text();
+
+    expect(html).toContain('<meta name="sentry-trace" content="abc123-def456-1"/>');
+    expect(html).toContain('<meta name="baggage" content="sentry-trace_id=abc123"/>');
+    expect(html).toContain('<meta charset="utf-8"/>');
+  });
+
+  it('does not inject meta tags into non-HTML responses', async () => {
+    const mockResponse = new Response('{"data": "value"}', {
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse);
+
+    const serverEntry = wrapFetchWithSentry({ fetch: fetchFn });
+    const request = new Request('http://localhost:3000/_serverFn/abc123');
+
+    const response = await serverEntry.fetch(request);
+    const body = await response.text();
+
+    expect(body).toBe('{"data": "value"}');
+    expect(body).not.toContain('sentry-trace');
+  });
+
+  it('does not inject duplicate meta tags if sentry-trace already exists', async () => {
+    const existingHtml =
+      '<head><meta name="sentry-trace" content="existing-trace"/><meta name="baggage" content="existing-baggage"/></head>';
+    const mockResponse = new Response(existingHtml, {
+      headers: new Headers({ 'content-type': 'text/html' }),
+    });
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse);
+
+    const serverEntry = wrapFetchWithSentry({ fetch: fetchFn });
+    const request = new Request('http://localhost:3000/');
+
+    const response = await serverEntry.fetch(request);
+    const html = await response.text();
+
+    expect(html).toBe(existingHtml);
+  });
+
+  it('preserves response status and headers when injecting meta tags', async () => {
+    const mockResponse = new Response('<head></head>', {
+      status: 201,
+      statusText: 'Created',
+      headers: new Headers({
+        'content-type': 'text/html',
+        'X-Custom-Header': 'custom-value',
+      }),
+    });
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse);
+
+    const serverEntry = wrapFetchWithSentry({ fetch: fetchFn });
+    const request = new Request('http://localhost:3000/');
+
+    const response = await serverEntry.fetch(request);
+
+    expect(response.status).toBe(201);
+    expect(response.statusText).toBe('Created');
+    expect(response.headers.get('content-type')).toBe('text/html');
+    expect(response.headers.get('X-Custom-Header')).toBe('custom-value');
+  });
+
+  it('does not inject meta tags into <head> inside quoted attribute values', async () => {
+    const mockResponse = new Response('<head></head><body><div data-content="<head>ignore"></div></body>', {
+      headers: new Headers({ 'content-type': 'text/html' }),
+    });
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse);
+
+    const serverEntry = wrapFetchWithSentry({ fetch: fetchFn });
+    const request = new Request('http://localhost:3000/');
+
+    const response = await serverEntry.fetch(request);
+    const html = await response.text();
+
+    expect(html).toContain('<head><meta name="sentry-trace"');
+    expect(html).toContain('data-content="<head>ignore"');
   });
 
   it('calls flushIfServerless even if the handler throws', async () => {

--- a/packages/tanstackstart-react/test/server/wrapFetchWithSentry.test.ts
+++ b/packages/tanstackstart-react/test/server/wrapFetchWithSentry.test.ts
@@ -3,11 +3,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const startSpanSpy = vi.fn((_, callback) => callback());
 const flushIfServerlessSpy = vi.fn().mockResolvedValue(undefined);
 
+const captureExceptionSpy = vi.fn();
+
 vi.mock('@sentry/node', async importOriginal => {
   const original = await importOriginal();
   return {
     ...original,
     startSpan: (...args: unknown[]) => startSpanSpy(...args),
+    captureException: (...args: unknown[]) => captureExceptionSpy(...args),
   };
 });
 
@@ -146,6 +149,34 @@ describe('wrapFetchWithSentry', () => {
 
     expect(html).toContain('<head><meta name="sentry-trace"');
     expect(html).toContain('data-content="<head>ignore"');
+  });
+
+  it('captures exception when HTML response body stream errors', async () => {
+    const streamError = new Error('stream read error');
+    const body = new ReadableStream({
+      start(controller) {
+        controller.error(streamError);
+      },
+    });
+    const mockResponse = new Response(body, {
+      headers: new Headers({ 'content-type': 'text/html' }),
+    });
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse);
+
+    const serverEntry = wrapFetchWithSentry({ fetch: fetchFn });
+    const request = new Request('http://localhost:3000/');
+
+    const response = await serverEntry.fetch(request);
+
+    try {
+      await response.text();
+    } catch {
+      // expected — the stream errors
+    }
+
+    expect(captureExceptionSpy).toHaveBeenCalledWith(streamError, {
+      mechanism: { type: 'auto.http.tanstackstart', handled: false },
+    });
   });
 
   it('calls flushIfServerless even if the handler throws', async () => {


### PR DESCRIPTION
Adds distributed tracing to the TanStack Start SDK by injecting `sentry-trace` and `baggage` meta tags into HTML responses in `wrapFetchWithSentry`. This connects server and client traces automatically without requiring any additional user setup.

The added functions that do the meta tag injections are essentially copies from the astro package ([addMetaTagToHead](https://github.com/getsentry/sentry-javascript/blob/develop/packages/astro/src/server/middleware.ts#L277-L291), [injectMetaTagsInResponse](https://github.com/getsentry/sentry-javascript/blob/develop/packages/astro/src/server/middleware.ts#L454-L514)).

Added a `trace-propagation` test to the main TSS e2e test application and adjusted the existing cloudflare TSS e2e test application to the new pattern (i.e. remove the manual injection of meta tags).

Example trace with my local sample app:
<img width="926" height="266" alt="Screenshot 2026-05-23 at 16 40 05" src="https://github.com/user-attachments/assets/56b7382d-25e1-451a-86b8-7cdd5e8c9c70" />

Closes https://github.com/getsentry/sentry-javascript/issues/18286