### PR TITLE
feat(tanstackstart-react): Filter noisy dev transactions

### DIFF
--- a/packages/tanstackstart-react/src/client/sdk.ts
+++ b/packages/tanstackstart-react/src/client/sdk.ts
@@ -25,6 +25,8 @@ export function init(options: ReactBrowserOptions): Client | undefined {
     /\/@id\//,
     /\/@react-refresh/,
     /\/@tanstack-start\//,
+    /\/@fs\//,
+    /\/@vite\//,
   ];
 
   return initReactSDK(sentryOptions);

--- a/packages/tanstackstart-react/src/client/sdk.ts
+++ b/packages/tanstackstart-react/src/client/sdk.ts
@@ -18,5 +18,14 @@ export function init(options: ReactBrowserOptions): Client | undefined {
   applyTunnelRouteOption(sentryOptions);
   applySdkMetadata(sentryOptions, 'tanstackstart-react', ['tanstackstart-react', 'react']);
 
+  sentryOptions.ignoreSpans = [
+    ...(sentryOptions.ignoreSpans || []),
+    /\/node_modules\//,
+    /\/favicon\.ico/,
+    /\/@id\//,
+    /\/@react-refresh/,
+    /\/@tanstack-start\//,
+  ];
+
   return initReactSDK(sentryOptions);
 }

--- a/packages/tanstackstart-react/src/server/sdk.ts
+++ b/packages/tanstackstart-react/src/server/sdk.ts
@@ -16,11 +16,8 @@ export function init(options: NodeOptions): NodeClient | undefined {
   sentryOptions.ignoreSpans = [
     ...(sentryOptions.ignoreSpans || []),
     /\/node_modules\//,
-    /\/favicon\.ico/,
     /\/@id\//,
     /\/@react-refresh/,
-    /\/@tanstack-start\//,
-    /\/@fs\//,
     /\/@vite\//,
   ];
 

--- a/packages/tanstackstart-react/src/server/sdk.ts
+++ b/packages/tanstackstart-react/src/server/sdk.ts
@@ -13,5 +13,14 @@ export function init(options: NodeOptions): NodeClient | undefined {
 
   applySdkMetadata(sentryOptions, 'tanstackstart-react', ['tanstackstart-react', 'node']);
 
+  sentryOptions.ignoreSpans = [
+    ...(sentryOptions.ignoreSpans || []),
+    /GET \/node_modules\//,
+    /GET \/favicon\.ico/,
+    /GET \/@id\//,
+    /GET \/@react-refresh/,
+    /GET \/@tanstack-start\//,
+  ];
+
   return initNodeSdk(sentryOptions);
 }

--- a/packages/tanstackstart-react/src/server/sdk.ts
+++ b/packages/tanstackstart-react/src/server/sdk.ts
@@ -15,11 +15,11 @@ export function init(options: NodeOptions): NodeClient | undefined {
 
   sentryOptions.ignoreSpans = [
     ...(sentryOptions.ignoreSpans || []),
-    /GET \/node_modules\//,
-    /GET \/favicon\.ico/,
-    /GET \/@id\//,
-    /GET \/@react-refresh/,
-    /GET \/@tanstack-start\//,
+    /\/node_modules\//,
+    /\/favicon\.ico/,
+    /\/@id\//,
+    /\/@react-refresh/,
+    /\/@tanstack-start\//,
   ];
 
   return initNodeSdk(sentryOptions);

--- a/packages/tanstackstart-react/src/server/sdk.ts
+++ b/packages/tanstackstart-react/src/server/sdk.ts
@@ -20,6 +20,8 @@ export function init(options: NodeOptions): NodeClient | undefined {
     /\/@id\//,
     /\/@react-refresh/,
     /\/@tanstack-start\//,
+    /\/@fs\//,
+    /\/@vite\//,
   ];
 
   return initNodeSdk(sentryOptions);

--- a/packages/tanstackstart-react/test/client/sdk.test.ts
+++ b/packages/tanstackstart-react/test/client/sdk.test.ts
@@ -43,6 +43,35 @@ describe('TanStack Start React Client SDK', () => {
       expect(init({})).not.toBeUndefined();
     });
 
+    it('sets ignoreSpans to filter low-quality spans', () => {
+      init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      expect(reactInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ignoreSpans: expect.arrayContaining([
+            /\/node_modules\//,
+            /\/favicon\.ico/,
+            /\/@id\//,
+            /\/@react-refresh/,
+            /\/@tanstack-start\//,
+          ]),
+        }),
+      );
+    });
+
+    it('preserves user-defined ignoreSpans', () => {
+      init({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        ignoreSpans: [/custom-pattern/],
+      });
+
+      expect(reactInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ignoreSpans: expect.arrayContaining([/custom-pattern/, /\/favicon\.ico/]),
+        }),
+      );
+    });
+
     it('applies the managed tunnel route when no runtime tunnel is provided', () => {
       vi.stubGlobal('__SENTRY_TANSTACKSTART_TUNNEL_ROUTE__', '/managed-tunnel');
 

--- a/packages/tanstackstart-react/test/client/sdk.test.ts
+++ b/packages/tanstackstart-react/test/client/sdk.test.ts
@@ -54,6 +54,8 @@ describe('TanStack Start React Client SDK', () => {
             /\/@id\//,
             /\/@react-refresh/,
             /\/@tanstack-start\//,
+            /\/@fs\//,
+            /\/@vite\//,
           ]),
         }),
       );

--- a/packages/tanstackstart-react/test/server/sdk.test.ts
+++ b/packages/tanstackstart-react/test/server/sdk.test.ts
@@ -38,5 +38,34 @@ describe('TanStack Start React Server SDK', () => {
     it('returns client from init', () => {
       expect(init({})).not.toBeUndefined();
     });
+
+    it('sets ignoreSpans to filter low-quality transactions', () => {
+      init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      expect(nodeInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ignoreSpans: expect.arrayContaining([
+            /GET \/node_modules\//,
+            /GET \/favicon\.ico/,
+            /GET \/@id\//,
+            /GET \/@react-refresh/,
+            /GET \/@tanstack-start\//,
+          ]),
+        }),
+      );
+    });
+
+    it('preserves user-defined ignoreSpans', () => {
+      init({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        ignoreSpans: [/custom-pattern/],
+      });
+
+      expect(nodeInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ignoreSpans: expect.arrayContaining([/custom-pattern/, /GET \/favicon\.ico/]),
+        }),
+      );
+    });
   });
 });

--- a/packages/tanstackstart-react/test/server/sdk.test.ts
+++ b/packages/tanstackstart-react/test/server/sdk.test.ts
@@ -57,7 +57,7 @@ describe('TanStack Start React Server SDK', () => {
 
       expect(nodeInit).toHaveBeenCalledWith(
         expect.objectContaining({
-          ignoreSpans: expect.arrayContaining([/custom-pattern/, /\/favicon\.ico/]),
+          ignoreSpans: expect.arrayContaining([/custom-pattern/, /\/@vite\//]),
         }),
       );
     });

--- a/packages/tanstackstart-react/test/server/sdk.test.ts
+++ b/packages/tanstackstart-react/test/server/sdk.test.ts
@@ -45,11 +45,11 @@ describe('TanStack Start React Server SDK', () => {
       expect(nodeInit).toHaveBeenCalledWith(
         expect.objectContaining({
           ignoreSpans: expect.arrayContaining([
-            /GET \/node_modules\//,
-            /GET \/favicon\.ico/,
-            /GET \/@id\//,
-            /GET \/@react-refresh/,
-            /GET \/@tanstack-start\//,
+            /\/node_modules\//,
+            /\/favicon\.ico/,
+            /\/@id\//,
+            /\/@react-refresh/,
+            /\/@tanstack-start\//,
           ]),
         }),
       );
@@ -63,7 +63,7 @@ describe('TanStack Start React Server SDK', () => {
 
       expect(nodeInit).toHaveBeenCalledWith(
         expect.objectContaining({
-          ignoreSpans: expect.arrayContaining([/custom-pattern/, /GET \/favicon\.ico/]),
+          ignoreSpans: expect.arrayContaining([/custom-pattern/, /\/favicon\.ico/]),
         }),
       );
     });

--- a/packages/tanstackstart-react/test/server/sdk.test.ts
+++ b/packages/tanstackstart-react/test/server/sdk.test.ts
@@ -50,6 +50,8 @@ describe('TanStack Start React Server SDK', () => {
             /\/@id\//,
             /\/@react-refresh/,
             /\/@tanstack-start\//,
+            /\/@fs\//,
+            /\/@vite\//,
           ]),
         }),
       );

--- a/packages/tanstackstart-react/test/server/sdk.test.ts
+++ b/packages/tanstackstart-react/test/server/sdk.test.ts
@@ -44,15 +44,7 @@ describe('TanStack Start React Server SDK', () => {
 
       expect(nodeInit).toHaveBeenCalledWith(
         expect.objectContaining({
-          ignoreSpans: expect.arrayContaining([
-            /\/node_modules\//,
-            /\/favicon\.ico/,
-            /\/@id\//,
-            /\/@react-refresh/,
-            /\/@tanstack-start\//,
-            /\/@fs\//,
-            /\/@vite\//,
-          ]),
+          ignoreSpans: expect.arrayContaining([/\/node_modules\//, /\/@id\//, /\/@react-refresh/, /\/@vite\//]),
         }),
       );
     });


### PR DESCRIPTION
Vite dev server requests (`/node_modules/`, `/@id/`, `/@react-refresh`, `/@tanstack-start/`) and `/favicon.ico` generate noise. Filters them via `ignoreSpans` in `init()` so this works for both transactions and streamed spans.