### PR TITLE
feat(tanstackstart-react): Add server-side route parametrization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
   Server and client traces are now automatically connected, allowing you to see the full request lifecycle from server-side rendering through client-side hydration in a single trace.
 
+- **feat(tanstackstart-react): Add server-side route parametrization ([#21147](https://github.com/getsentry/sentry-javascript/pull/21147))**
+
+  Server transaction names are now parametrized automatically (e.g., `GET /users/123` becomes `GET /users/$userId`), improving transaction grouping in Sentry.
+
 ## 10.54.0
 
 ### Important Changes

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/routes/api.user.$id.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/routes/api.user.$id.ts
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/api/user/$id')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        return new Response(JSON.stringify({ id: params.id }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    },
+  },
+});

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/routes/param.$id.tsx
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/routes/param.$id.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/param/$id')({
+  component: ParamPage,
+});
+
+function ParamPage() {
+  const { id } = Route.useParams();
+  return (
+    <div>
+      <p id="param-value">Param: {id}</p>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/routes/users.$userId.tsx
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/routes/users.$userId.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/users/$userId')({
+  component: UserPage,
+});
+
+function UserPage() {
+  const { userId } = Route.useParams();
+  return (
+    <div>
+      <p id="user-id">User: {userId}</p>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/routes/users.tsx
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/routes/users.tsx
@@ -1,0 +1,13 @@
+import { Outlet, createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/users')({
+  component: UsersLayout,
+});
+
+function UsersLayout() {
+  return (
+    <div>
+      <Outlet />
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/route-parametrization.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/route-parametrization.test.ts
@@ -21,3 +21,19 @@ test('should parametrize server transaction names for dynamic routes', async ({ 
 
   expect(serverTx.transaction).toBe('GET /param/$id');
 });
+
+test('should parametrize server transaction names for nested dynamic routes', async ({ page }) => {
+  const serverTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      typeof transactionEvent?.transaction === 'string' &&
+      transactionEvent.transaction.includes('/users/')
+    );
+  });
+
+  await page.goto('/users/123');
+
+  const serverTx = await serverTxPromise;
+
+  expect(serverTx.transaction).toBe('GET /users/$userId');
+});

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/route-parametrization.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/route-parametrization.test.ts
@@ -6,7 +6,7 @@ const usesManagedTunnelRoute =
 
 test.skip(usesManagedTunnelRoute, 'Default e2e suites run only in the proxy variant');
 
-test('should parametrize server transaction names for dynamic routes', async ({ page }) => {
+test('should parametrize server and client transaction names for dynamic routes', async ({ page }) => {
   const serverTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
     return (
       transactionEvent?.contexts?.trace?.op === 'http.server' &&
@@ -15,14 +15,31 @@ test('should parametrize server transaction names for dynamic routes', async ({ 
     );
   });
 
+  const clientTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'pageload' &&
+      typeof transactionEvent?.transaction === 'string' &&
+      transactionEvent.transaction.includes('/param/')
+    );
+  });
+
   await page.goto('/param/42');
 
   const serverTx = await serverTxPromise;
+  const clientTx = await clientTxPromise;
 
-  expect(serverTx.transaction).toBe('GET /param/$id');
+  expect(serverTx).toMatchObject({
+    transaction: 'GET /param/$id',
+    transaction_info: { source: 'route' },
+  });
+
+  expect(clientTx).toMatchObject({
+    transaction: '/param/$id',
+    transaction_info: { source: 'route' },
+  });
 });
 
-test('should parametrize server transaction names for nested dynamic routes', async ({ page }) => {
+test('should parametrize server and client transaction names for nested dynamic routes', async ({ page }) => {
   const serverTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
     return (
       transactionEvent?.contexts?.trace?.op === 'http.server' &&
@@ -31,9 +48,45 @@ test('should parametrize server transaction names for nested dynamic routes', as
     );
   });
 
+  const clientTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'pageload' &&
+      typeof transactionEvent?.transaction === 'string' &&
+      transactionEvent.transaction.includes('/users/')
+    );
+  });
+
   await page.goto('/users/123');
 
   const serverTx = await serverTxPromise;
+  const clientTx = await clientTxPromise;
 
-  expect(serverTx.transaction).toBe('GET /users/$userId');
+  expect(serverTx).toMatchObject({
+    transaction: 'GET /users/$userId',
+    transaction_info: { source: 'route' },
+  });
+
+  expect(clientTx).toMatchObject({
+    transaction: '/users/$userId',
+    transaction_info: { source: 'route' },
+  });
+});
+
+test('should parametrize API route transaction names', async ({ baseURL }) => {
+  const serverTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      typeof transactionEvent?.transaction === 'string' &&
+      transactionEvent.transaction.includes('/api/user/')
+    );
+  });
+
+  await fetch(`${baseURL}/api/user/456`);
+
+  const serverTx = await serverTxPromise;
+
+  expect(serverTx).toMatchObject({
+    transaction: 'GET /api/user/$id',
+    transaction_info: { source: 'route' },
+  });
 });

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/route-parametrization.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/route-parametrization.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+const usesManagedTunnelRoute =
+  (process.env.E2E_TEST_TUNNEL_ROUTE_MODE ?? 'off') !== 'off' || process.env.E2E_TEST_CUSTOM_TUNNEL_ROUTE === '1';
+
+test.skip(usesManagedTunnelRoute, 'Default e2e suites run only in the proxy variant');
+
+test('should parametrize server transaction names for dynamic routes', async ({ page }) => {
+  const serverTxPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      typeof transactionEvent?.transaction === 'string' &&
+      transactionEvent.transaction.includes('/param/')
+    );
+  });
+
+  await page.goto('/param/42');
+
+  const serverTx = await serverTxPromise;
+
+  expect(serverTx.transaction).toBe('GET /param/$id');
+});

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/route-parametrization.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/route-parametrization.test.ts
@@ -28,15 +28,11 @@ test('should parametrize server and client transaction names for dynamic routes'
   const serverTx = await serverTxPromise;
   const clientTx = await clientTxPromise;
 
-  expect(serverTx).toMatchObject({
-    transaction: 'GET /param/$id',
-    transaction_info: { source: 'route' },
-  });
+  expect(serverTx.transaction).toBe('GET /param/$id');
+  expect(serverTx.transaction_info?.source).toBe('route');
 
-  expect(clientTx).toMatchObject({
-    transaction: '/param/$id',
-    transaction_info: { source: 'route' },
-  });
+  expect(clientTx.transaction).toBe('/param/$id');
+  expect(clientTx.transaction_info?.source).toBe('route');
 });
 
 test('should parametrize server and client transaction names for nested dynamic routes', async ({ page }) => {
@@ -61,15 +57,11 @@ test('should parametrize server and client transaction names for nested dynamic 
   const serverTx = await serverTxPromise;
   const clientTx = await clientTxPromise;
 
-  expect(serverTx).toMatchObject({
-    transaction: 'GET /users/$userId',
-    transaction_info: { source: 'route' },
-  });
+  expect(serverTx.transaction).toBe('GET /users/$userId');
+  expect(serverTx.transaction_info?.source).toBe('route');
 
-  expect(clientTx).toMatchObject({
-    transaction: '/users/$userId',
-    transaction_info: { source: 'route' },
-  });
+  expect(clientTx.transaction).toBe('/users/$userId');
+  expect(clientTx.transaction_info?.source).toBe('route');
 });
 
 test('should parametrize API route transaction names', async ({ baseURL }) => {
@@ -85,8 +77,6 @@ test('should parametrize API route transaction names', async ({ baseURL }) => {
 
   const serverTx = await serverTxPromise;
 
-  expect(serverTx).toMatchObject({
-    transaction: 'GET /api/user/$id',
-    transaction_info: { source: 'route' },
-  });
+  expect(serverTx.transaction).toBe('GET /api/user/$id');
+  expect(serverTx.transaction_info?.source).toBe('route');
 });

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -12,9 +12,6 @@ function patternToRegex(pattern: string): RegExp {
   const segments = pattern
     .split('/')
     .map(segment => {
-      if (segment === '$') {
-        return '.+';
-      }
       if (segment.startsWith('$')) {
         return '[^/]+';
       }
@@ -28,7 +25,7 @@ function patternToRegex(pattern: string): RegExp {
  * Matches a URL pathname against a list of TanStack Start route patterns.
  * Patterns use `$param` syntax for dynamic segments (e.g., `/users/$id`).
  *
- * Patterns are sorted by specificity: more segments first, static before dynamic, splat last.
+ * Patterns are sorted by specificity: more segments first, static before dynamic.
  */
 export function matchUrlToRoutePattern(pathname: string, patterns: string[]): string | undefined {
   const sorted = [...patterns].sort((a, b) => {
@@ -36,11 +33,6 @@ export function matchUrlToRoutePattern(pathname: string, patterns: string[]): st
     const bSegments = b.split('/');
     if (bSegments.length !== aSegments.length) {
       return bSegments.length - aSegments.length;
-    }
-    const aSplat = aSegments.filter(s => s === '$').length;
-    const bSplat = bSegments.filter(s => s === '$').length;
-    if (aSplat !== bSplat) {
-      return aSplat - bSplat;
     }
     const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
     const bDynamic = bSegments.filter(s => s.startsWith('$')).length;

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -9,6 +9,9 @@ function patternToRegex(pattern: string): RegExp {
   const segments = pattern
     .split('/')
     .map(segment => {
+      if (segment === '$') {
+        return '.+';
+      }
       if (segment.startsWith('$')) {
         return '[^/]+';
       }

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -21,26 +21,43 @@ function patternToRegex(pattern: string): RegExp {
   return new RegExp(`^${segments}$`);
 }
 
+type CompiledPattern = { pattern: string; regex: RegExp };
+
+let compiledPatterns: CompiledPattern[] | undefined;
+let compiledFromPatterns: string[] | undefined;
+
+function getCompiledPatterns(patterns: string[]): CompiledPattern[] {
+  if (compiledPatterns && compiledFromPatterns === patterns) {
+    return compiledPatterns;
+  }
+
+  compiledFromPatterns = patterns;
+  compiledPatterns = [...patterns]
+    .sort((a, b) => {
+      const aSegments = a.split('/');
+      const bSegments = b.split('/');
+      if (bSegments.length !== aSegments.length) {
+        return bSegments.length - aSegments.length;
+      }
+      const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
+      const bDynamic = bSegments.filter(s => s.startsWith('$')).length;
+      return aDynamic - bDynamic;
+    })
+    .map(pattern => ({ pattern, regex: patternToRegex(pattern) }));
+
+  return compiledPatterns;
+}
+
 /**
  * Matches a URL pathname against a list of TanStack Start route patterns.
  * Patterns use `$param` syntax for dynamic segments (e.g., `/users/$id`).
  *
  * Patterns are sorted by specificity: more segments first, static segments before dynamic.
+ * Compiled regexes are cached across calls since the pattern list is static at build time.
  */
 export function matchUrlToRoutePattern(pathname: string, patterns: string[]): string | undefined {
-  const sorted = [...patterns].sort((a, b) => {
-    const aSegments = a.split('/');
-    const bSegments = b.split('/');
-    if (bSegments.length !== aSegments.length) {
-      return bSegments.length - aSegments.length;
-    }
-    const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
-    const bDynamic = bSegments.filter(s => s.startsWith('$')).length;
-    return aDynamic - bDynamic;
-  });
-
-  for (const pattern of sorted) {
-    if (patternToRegex(pattern).test(pathname)) {
+  for (const { pattern, regex } of getCompiledPatterns(patterns)) {
+    if (regex.test(pathname)) {
       return pattern;
     }
   }

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -2,6 +2,7 @@ import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import {
   escapeStringForRegex,
   getActiveSpan,
+  getCurrentScope,
   getRootSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   spanToJSON,
@@ -25,21 +26,10 @@ function patternToRegex(pattern: string): RegExp {
  * Matches a URL pathname against a list of TanStack Start route patterns.
  * Patterns use `$param` syntax for dynamic segments (e.g., `/users/$id`).
  *
- * Patterns are sorted by specificity: more segments first, static before dynamic.
+ * Patterns are expected to be pre-sorted by specificity (more segments first, static before dynamic).
  */
 export function matchUrlToRoutePattern(pathname: string, patterns: string[]): string | undefined {
-  const sorted = [...patterns].sort((a, b) => {
-    const aSegments = a.split('/');
-    const bSegments = b.split('/');
-    if (bSegments.length !== aSegments.length) {
-      return bSegments.length - aSegments.length;
-    }
-    const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
-    const bDynamic = bSegments.filter(s => s.startsWith('$')).length;
-    return aDynamic - bDynamic;
-  });
-
-  for (const pattern of sorted) {
+  for (const pattern of patterns) {
     if (patternToRegex(pattern).test(pathname)) {
       return pattern;
     }
@@ -67,7 +57,9 @@ export function updateSpanWithRouteParametrization(method: string, pathname: str
     return;
   }
 
-  updateSpanName(rootSpan, `${method} ${matchedPattern}`);
+  const transactionName = `${method} ${matchedPattern}`;
+  updateSpanName(rootSpan, transactionName);
   rootSpan.setAttribute(ATTR_HTTP_ROUTE, matchedPattern);
   rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
+  getCurrentScope().setTransactionName(transactionName);
 }

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -1,9 +1,12 @@
 import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
-import { getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON, updateSpanName } from '@sentry/core';
-
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+import {
+  escapeStringForRegex,
+  getActiveSpan,
+  getRootSpan,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  spanToJSON,
+  updateSpanName,
+} from '@sentry/core';
 
 function patternToRegex(pattern: string): RegExp {
   const segments = pattern
@@ -15,7 +18,7 @@ function patternToRegex(pattern: string): RegExp {
       if (segment.startsWith('$')) {
         return '[^/]+';
       }
-      return escapeRegex(segment);
+      return escapeStringForRegex(segment);
     })
     .join('/');
   return new RegExp(`^${segments}$`);
@@ -25,7 +28,7 @@ function patternToRegex(pattern: string): RegExp {
  * Matches a URL pathname against a list of TanStack Start route patterns.
  * Patterns use `$param` syntax for dynamic segments (e.g., `/users/$id`).
  *
- * Patterns are sorted by specificity: more segments first, static segments before dynamic.
+ * Patterns are sorted by specificity: more segments first, static before dynamic, splat last.
  */
 export function matchUrlToRoutePattern(pathname: string, patterns: string[]): string | undefined {
   const sorted = [...patterns].sort((a, b) => {
@@ -33,6 +36,11 @@ export function matchUrlToRoutePattern(pathname: string, patterns: string[]): st
     const bSegments = b.split('/');
     if (bSegments.length !== aSegments.length) {
       return bSegments.length - aSegments.length;
+    }
+    const aSplat = aSegments.filter(s => s === '$').length;
+    const bSplat = bSegments.filter(s => s === '$').length;
+    if (aSplat !== bSplat) {
+      return aSplat - bSplat;
     }
     const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
     const bDynamic = bSegments.filter(s => s.startsWith('$')).length;

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -1,0 +1,70 @@
+import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
+import { getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON, updateSpanName } from '@sentry/core';
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function patternToRegex(pattern: string): RegExp {
+  const segments = pattern
+    .split('/')
+    .map(segment => {
+      if (segment.startsWith('$')) {
+        return '[^/]+';
+      }
+      return escapeRegex(segment);
+    })
+    .join('/');
+  return new RegExp(`^${segments}$`);
+}
+
+/**
+ * Matches a URL pathname against a list of TanStack Start route patterns.
+ * Patterns use `$param` syntax for dynamic segments (e.g., `/users/$id`).
+ *
+ * Patterns are sorted by specificity: more segments first, static segments before dynamic.
+ */
+export function matchUrlToRoutePattern(pathname: string, patterns: string[]): string | undefined {
+  const sorted = [...patterns].sort((a, b) => {
+    const aSegments = a.split('/');
+    const bSegments = b.split('/');
+    if (bSegments.length !== aSegments.length) {
+      return bSegments.length - aSegments.length;
+    }
+    const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
+    const bDynamic = bSegments.filter(s => s.startsWith('$')).length;
+    return aDynamic - bDynamic;
+  });
+
+  for (const pattern of sorted) {
+    if (patternToRegex(pattern).test(pathname)) {
+      return pattern;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Updates the active root span with a parametrized route name.
+ */
+export function updateSpanWithRouteParametrization(method: string, pathname: string, patterns: string[]): void {
+  const matchedPattern = matchUrlToRoutePattern(pathname, patterns);
+  if (!matchedPattern) {
+    return;
+  }
+
+  const activeSpan = getActiveSpan();
+  if (!activeSpan) {
+    return;
+  }
+
+  const rootSpan = getRootSpan(activeSpan);
+  const rootSpanData = spanToJSON(rootSpan).data;
+  if (rootSpanData?.[ATTR_HTTP_ROUTE]) {
+    return;
+  }
+
+  updateSpanName(rootSpan, `${method} ${matchedPattern}`);
+  rootSpan.setAttribute(ATTR_HTTP_ROUTE, matchedPattern);
+  rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
+}

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -29,8 +29,9 @@ function patternToRegex(pattern: string): RegExp {
  * Patterns are expected to be pre-sorted by specificity (more segments first, static before dynamic).
  */
 export function matchUrlToRoutePattern(pathname: string, patterns: string[]): string | undefined {
+  const normalizedPathname = pathname.length > 1 ? pathname.replace(/\/$/, '') : pathname;
   for (const pattern of patterns) {
-    if (patternToRegex(pattern).test(pathname)) {
+    if (patternToRegex(pattern).test(normalizedPathname)) {
       return pattern;
     }
   }

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -21,43 +21,26 @@ function patternToRegex(pattern: string): RegExp {
   return new RegExp(`^${segments}$`);
 }
 
-type CompiledPattern = { pattern: string; regex: RegExp };
-
-let compiledPatterns: CompiledPattern[] | undefined;
-let compiledFromPatterns: string[] | undefined;
-
-function getCompiledPatterns(patterns: string[]): CompiledPattern[] {
-  if (compiledPatterns && compiledFromPatterns === patterns) {
-    return compiledPatterns;
-  }
-
-  compiledFromPatterns = patterns;
-  compiledPatterns = [...patterns]
-    .sort((a, b) => {
-      const aSegments = a.split('/');
-      const bSegments = b.split('/');
-      if (bSegments.length !== aSegments.length) {
-        return bSegments.length - aSegments.length;
-      }
-      const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
-      const bDynamic = bSegments.filter(s => s.startsWith('$')).length;
-      return aDynamic - bDynamic;
-    })
-    .map(pattern => ({ pattern, regex: patternToRegex(pattern) }));
-
-  return compiledPatterns;
-}
-
 /**
  * Matches a URL pathname against a list of TanStack Start route patterns.
  * Patterns use `$param` syntax for dynamic segments (e.g., `/users/$id`).
  *
  * Patterns are sorted by specificity: more segments first, static segments before dynamic.
- * Compiled regexes are cached across calls since the pattern list is static at build time.
  */
 export function matchUrlToRoutePattern(pathname: string, patterns: string[]): string | undefined {
-  for (const { pattern, regex } of getCompiledPatterns(patterns)) {
-    if (regex.test(pathname)) {
+  const sorted = [...patterns].sort((a, b) => {
+    const aSegments = a.split('/');
+    const bSegments = b.split('/');
+    if (bSegments.length !== aSegments.length) {
+      return bSegments.length - aSegments.length;
+    }
+    const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
+    const bDynamic = bSegments.filter(s => s.startsWith('$')).length;
+    return aDynamic - bDynamic;
+  });
+
+  for (const pattern of sorted) {
+    if (patternToRegex(pattern).test(pathname)) {
       return pattern;
     }
   }

--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -5,7 +5,10 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startSpan,
 } from '@sentry/node';
+import { updateSpanWithRouteParametrization } from './routeParametrization';
 import { extractServerFunctionSha256 } from './utils';
+
+declare const __SENTRY_ROUTE_PATTERNS__: string[] | undefined;
 
 export type ServerEntry = {
   fetch: (request: Request, opts?: unknown) => Promise<Response> | Response;
@@ -159,6 +162,10 @@ export function wrapFetchWithSentry(serverEntry: ServerEntry): ServerEntry {
                 return target.apply(thisArg, args);
               },
             );
+          }
+
+          if (typeof __SENTRY_ROUTE_PATTERNS__ !== 'undefined') {
+            updateSpanWithRouteParametrization(method, url.pathname, __SENTRY_ROUTE_PATTERNS__);
           }
 
           return injectMetaTagsInResponse(await target.apply(thisArg, args));

--- a/packages/tanstackstart-react/src/vite/routePatterns.ts
+++ b/packages/tanstackstart-react/src/vite/routePatterns.ts
@@ -1,0 +1,64 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Plugin } from 'vite';
+
+/**
+ * Extracts route patterns from TanStack Start's generated routeTree.gen.ts
+ * and replaces `__SENTRY_ROUTE_PATTERNS__` references with the extracted patterns.
+ *
+ * Reads the route tree lazily during `transform` to ensure it exists after TanStack Start generates it.
+ */
+export function makeRoutePatternPlugin(): Plugin {
+  let resolvedRoot = '';
+
+  return {
+    name: 'sentry-tanstackstart-route-patterns',
+    enforce: 'post',
+
+    configResolved(config) {
+      resolvedRoot = config.root || process.cwd();
+    },
+
+    transform(code, id) {
+      if (!code.includes('__SENTRY_ROUTE_PATTERNS__')) {
+        return null;
+      }
+
+      const routeTreePath = path.resolve(resolvedRoot, 'src/routeTree.gen.ts');
+      let patterns: string[] = ['/'];
+      try {
+        if (fs.existsSync(routeTreePath)) {
+          patterns = extractRoutePatterns(fs.readFileSync(routeTreePath, 'utf-8'));
+        }
+      } catch {
+        // skip
+      }
+
+      return {
+        code: code.replace(/__SENTRY_ROUTE_PATTERNS__/g, JSON.stringify(patterns)),
+        map: null,
+      };
+    },
+  };
+}
+
+/**
+ * Extracts route path patterns from the content of routeTree.gen.ts.
+ *
+ * Matches patterns like: `path: '/page-b/$id'`
+ *
+ * Only exported for testing.
+ */
+export function extractRoutePatterns(content: string): string[] {
+  const patterns: string[] = [];
+  const regex = /path:\s*['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    const pattern = match[1];
+    if (pattern && pattern !== '/') {
+      patterns.push(pattern);
+    }
+  }
+  patterns.push('/');
+  return [...new Set(patterns)];
+}

--- a/packages/tanstackstart-react/src/vite/routePatterns.ts
+++ b/packages/tanstackstart-react/src/vite/routePatterns.ts
@@ -68,5 +68,14 @@ export function extractRoutePatterns(content: string): string[] {
     }
   }
 
-  return [...new Set(patterns)];
+  return [...new Set(patterns)].sort((a, b) => {
+    const aSegments = a.split('/');
+    const bSegments = b.split('/');
+    if (bSegments.length !== aSegments.length) {
+      return bSegments.length - aSegments.length;
+    }
+    const aDynamic = aSegments.filter(s => s.startsWith('$')).length;
+    const bDynamic = bSegments.filter(s => s.startsWith('$')).length;
+    return aDynamic - bDynamic;
+  });
 }

--- a/packages/tanstackstart-react/src/vite/routePatterns.ts
+++ b/packages/tanstackstart-react/src/vite/routePatterns.ts
@@ -21,12 +21,15 @@ export function makeRoutePatternPlugin(): Plugin {
     },
 
     transform(code, id) {
+      // this is set in the `wrapFetchWithSentry` where the paths are getting replaced by their parametrized counterparts
+      // so this extraction should only happen once during the build (for the `wrapFetchWithSentry` file)
       if (!code.includes('__SENTRY_ROUTE_PATTERNS__')) {
         return null;
       }
 
+      // extract the patterns from the route tree file
       const routeTreePath = path.resolve(resolvedRoot, 'src/routeTree.gen.ts');
-      let patterns: string[] = ['/'];
+      let patterns: string[] = [];
       try {
         if (fs.existsSync(routeTreePath)) {
           patterns = extractRoutePatterns(fs.readFileSync(routeTreePath, 'utf-8'));
@@ -49,13 +52,11 @@ export function makeRoutePatternPlugin(): Plugin {
  * Parses the `fullPaths` type union which contains the resolved full paths
  * (e.g., `fullPaths: '/' | '/page-a' | '/users/$userId'`).
  * This is more reliable than `path:` properties which can be relative for nested routes.
- *
- * Only exported for testing.
  */
 export function extractRoutePatterns(content: string): string[] {
   const fullPathsMatch = content.match(/fullPaths:\s*([\s\S]*?)(?:\n\s*\w|\n\})/);
   if (!fullPathsMatch) {
-    return ['/'];
+    return [];
   }
 
   const patterns: string[] = [];
@@ -65,10 +66,6 @@ export function extractRoutePatterns(content: string): string[] {
     if (match[1]) {
       patterns.push(match[1]);
     }
-  }
-
-  if (!patterns.includes('/')) {
-    patterns.push('/');
   }
 
   return [...new Set(patterns)];

--- a/packages/tanstackstart-react/src/vite/routePatterns.ts
+++ b/packages/tanstackstart-react/src/vite/routePatterns.ts
@@ -60,7 +60,7 @@ export function extractRoutePatterns(content: string): string[] {
   }
 
   const patterns: string[] = [];
-  const pathRegex = /'([^']+)'/g;
+  const pathRegex = /['"]([^'"]+)['"]/g;
   let match;
   while ((match = pathRegex.exec(fullPathsMatch[1] || '')) !== null) {
     if (match[1]) {

--- a/packages/tanstackstart-react/src/vite/routePatterns.ts
+++ b/packages/tanstackstart-react/src/vite/routePatterns.ts
@@ -6,7 +6,8 @@ import type { Plugin } from 'vite';
  * Extracts route patterns from TanStack Start's generated routeTree.gen.ts
  * and replaces `__SENTRY_ROUTE_PATTERNS__` references with the extracted patterns.
  *
- * Reads the route tree lazily during `transform` to ensure it exists after TanStack Start generates it.
+ * The route tree file is read during `transform` rather than `config` because
+ * TanStack Start generates it during the build.
  */
 export function makeRoutePatternPlugin(): Plugin {
   let resolvedRoot = '';

--- a/packages/tanstackstart-react/src/vite/routePatterns.ts
+++ b/packages/tanstackstart-react/src/vite/routePatterns.ts
@@ -43,22 +43,32 @@ export function makeRoutePatternPlugin(): Plugin {
 }
 
 /**
- * Extracts route path patterns from the content of routeTree.gen.ts.
+ * Extracts full route path patterns from the content of routeTree.gen.ts.
  *
- * Matches patterns like: `path: '/page-b/$id'`
+ * Parses the `fullPaths` type union which contains the resolved full paths
+ * (e.g., `fullPaths: '/' | '/page-a' | '/users/$userId'`).
+ * This is more reliable than `path:` properties which can be relative for nested routes.
  *
  * Only exported for testing.
  */
 export function extractRoutePatterns(content: string): string[] {
+  const fullPathsMatch = content.match(/fullPaths:\s*([\s\S]*?)(?:\n\s*\w|\n\})/);
+  if (!fullPathsMatch) {
+    return ['/'];
+  }
+
   const patterns: string[] = [];
-  const regex = /path:\s*['"]([^'"]+)['"]/g;
+  const pathRegex = /'([^']+)'/g;
   let match;
-  while ((match = regex.exec(content)) !== null) {
-    const pattern = match[1];
-    if (pattern && pattern !== '/') {
-      patterns.push(pattern);
+  while ((match = pathRegex.exec(fullPathsMatch[1] || '')) !== null) {
+    if (match[1]) {
+      patterns.push(match[1]);
     }
   }
-  patterns.push('/');
+
+  if (!patterns.includes('/')) {
+    patterns.push('/');
+  }
+
   return [...new Set(patterns)];
 }

--- a/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
+++ b/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
@@ -85,22 +85,18 @@ export interface SentryTanstackStartOptions extends BuildTimeOptionsBase {
  * @returns An array of Vite plugins
  */
 export function sentryTanstackStart(options: SentryTanstackStartOptions = {}): Plugin[] {
-  const tunnelRoutePlugin = options.tunnelRoute ? makeTunnelRoutePlugin(options.tunnelRoute, options.debug) : undefined;
+  const plugins: Plugin[] = [makeRoutePatternPlugin()];
 
-  // In development, only add route patterns plugin and tunnel route
+  if (options.tunnelRoute) {
+    plugins.push(makeTunnelRoutePlugin(options.tunnelRoute, options.debug));
+  }
+
+  // only add build-time plugins in production builds
   if (process.env.NODE_ENV === 'development') {
-    const devPlugins: Plugin[] = [makeRoutePatternPlugin()];
-    if (tunnelRoutePlugin) {
-      devPlugins.push(tunnelRoutePlugin);
-    }
-    return devPlugins;
+    return plugins;
   }
 
-  const plugins: Plugin[] = [makeRoutePatternPlugin(), ...makeAddSentryVitePlugin(options)];
-
-  if (tunnelRoutePlugin) {
-    plugins.push(tunnelRoutePlugin);
-  }
+  plugins.push(...makeAddSentryVitePlugin(options));
 
   // middleware auto-instrumentation
   if (options.autoInstrumentMiddleware !== false) {

--- a/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
+++ b/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
@@ -1,6 +1,7 @@
 import type { BuildTimeOptionsBase } from '@sentry/core';
 import type { Plugin } from 'vite';
 import { makeAutoInstrumentMiddlewarePlugin } from './autoInstrumentMiddleware';
+import { makeRoutePatternPlugin } from './routePatterns';
 import { makeAddSentryVitePlugin, makeEnableSourceMapsVitePlugin } from './sourceMaps';
 import type { TunnelRouteOptions } from './tunnelRoute';
 import { makeTunnelRoutePlugin } from './tunnelRoute';
@@ -86,12 +87,16 @@ export interface SentryTanstackStartOptions extends BuildTimeOptionsBase {
 export function sentryTanstackStart(options: SentryTanstackStartOptions = {}): Plugin[] {
   const tunnelRoutePlugin = options.tunnelRoute ? makeTunnelRoutePlugin(options.tunnelRoute, options.debug) : undefined;
 
-  // only add build-time plugins in production builds
+  // In development, only add route patterns plugin and tunnel route
   if (process.env.NODE_ENV === 'development') {
-    return tunnelRoutePlugin ? [tunnelRoutePlugin] : [];
+    const devPlugins: Plugin[] = [makeRoutePatternPlugin()];
+    if (tunnelRoutePlugin) {
+      devPlugins.push(tunnelRoutePlugin);
+    }
+    return devPlugins;
   }
 
-  const plugins: Plugin[] = [...makeAddSentryVitePlugin(options)];
+  const plugins: Plugin[] = [makeRoutePatternPlugin(), ...makeAddSentryVitePlugin(options)];
 
   if (tunnelRoutePlugin) {
     plugins.push(tunnelRoutePlugin);

--- a/packages/tanstackstart-react/test/server/routeParametrization.test.ts
+++ b/packages/tanstackstart-react/test/server/routeParametrization.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { matchUrlToRoutePattern } from '../../src/server/routeParametrization';
+
+describe('matchUrlToRoutePattern', () => {
+  const patterns = ['/', '/page-a', '/page-b/$id', '/users/$userId/posts/$postId', '/api/health'];
+
+  it('matches the root route', () => {
+    expect(matchUrlToRoutePattern('/', patterns)).toBe('/');
+  });
+
+  it('matches a static route', () => {
+    expect(matchUrlToRoutePattern('/page-a', patterns)).toBe('/page-a');
+  });
+
+  it('matches a single-param route', () => {
+    expect(matchUrlToRoutePattern('/page-b/42', patterns)).toBe('/page-b/$id');
+  });
+
+  it('matches a multi-param route', () => {
+    expect(matchUrlToRoutePattern('/users/123/posts/456', patterns)).toBe('/users/$userId/posts/$postId');
+  });
+
+  it('matches a static API route', () => {
+    expect(matchUrlToRoutePattern('/api/health', patterns)).toBe('/api/health');
+  });
+
+  it('returns undefined for unmatched paths', () => {
+    expect(matchUrlToRoutePattern('/unknown', patterns)).toBeUndefined();
+  });
+
+  it('returns undefined for partially matched paths', () => {
+    expect(matchUrlToRoutePattern('/page-b', patterns)).toBeUndefined();
+  });
+
+  it('prefers static over dynamic matches', () => {
+    const patternsWithOverlap = ['/page-b/$id', '/page-b/special'];
+    expect(matchUrlToRoutePattern('/page-b/special', patternsWithOverlap)).toBe('/page-b/special');
+  });
+
+  it('prefers more specific routes (more segments)', () => {
+    const patternsNested = ['/users/$id', '/users/$id/profile'];
+    expect(matchUrlToRoutePattern('/users/123/profile', patternsNested)).toBe('/users/$id/profile');
+  });
+});

--- a/packages/tanstackstart-react/test/server/routeParametrization.test.ts
+++ b/packages/tanstackstart-react/test/server/routeParametrization.test.ts
@@ -20,10 +20,6 @@ describe('matchUrlToRoutePattern', () => {
     expect(matchUrlToRoutePattern('/users/123/posts/456', patterns)).toBe('/users/$userId/posts/$postId');
   });
 
-  it('matches a static API route', () => {
-    expect(matchUrlToRoutePattern('/api/health', patterns)).toBe('/api/health');
-  });
-
   it('returns undefined for unmatched paths', () => {
     expect(matchUrlToRoutePattern('/unknown', patterns)).toBeUndefined();
   });

--- a/packages/tanstackstart-react/test/server/routeParametrization.test.ts
+++ b/packages/tanstackstart-react/test/server/routeParametrization.test.ts
@@ -37,21 +37,4 @@ describe('matchUrlToRoutePattern', () => {
     const patternsNested = ['/users/$id', '/users/$id/profile'];
     expect(matchUrlToRoutePattern('/users/123/profile', patternsNested)).toBe('/users/$id/profile');
   });
-
-  it('matches splat/catch-all routes across multiple segments', () => {
-    const patternsWithSplat = ['/', '/files/$'];
-    expect(matchUrlToRoutePattern('/files/a/b/c', patternsWithSplat)).toBe('/files/$');
-    expect(matchUrlToRoutePattern('/files/readme.txt', patternsWithSplat)).toBe('/files/$');
-  });
-
-  it('prefers specific routes over splat routes', () => {
-    const patternsWithSplat = ['/files/$', '/files/upload'];
-    expect(matchUrlToRoutePattern('/files/upload', patternsWithSplat)).toBe('/files/upload');
-    expect(matchUrlToRoutePattern('/files/a/b', patternsWithSplat)).toBe('/files/$');
-  });
-
-  it('prefers named param routes over splat routes with same segment count', () => {
-    const patternsWithBoth = ['/files/$', '/files/$name'];
-    expect(matchUrlToRoutePattern('/files/readme.txt', patternsWithBoth)).toBe('/files/$name');
-  });
 });

--- a/packages/tanstackstart-react/test/server/routeParametrization.test.ts
+++ b/packages/tanstackstart-react/test/server/routeParametrization.test.ts
@@ -38,4 +38,9 @@ describe('matchUrlToRoutePattern', () => {
     const patternsNested = ['/users/$id/profile', '/users/$id'];
     expect(matchUrlToRoutePattern('/users/123/profile', patternsNested)).toBe('/users/$id/profile');
   });
+
+  it('handles URLs with trailing slashes', () => {
+    expect(matchUrlToRoutePattern('/page-a/', patterns)).toBe('/page-a');
+    expect(matchUrlToRoutePattern('/page-b/42/', patterns)).toBe('/page-b/$id');
+  });
 });

--- a/packages/tanstackstart-react/test/server/routeParametrization.test.ts
+++ b/packages/tanstackstart-react/test/server/routeParametrization.test.ts
@@ -41,4 +41,16 @@ describe('matchUrlToRoutePattern', () => {
     const patternsNested = ['/users/$id', '/users/$id/profile'];
     expect(matchUrlToRoutePattern('/users/123/profile', patternsNested)).toBe('/users/$id/profile');
   });
+
+  it('matches splat/catch-all routes across multiple segments', () => {
+    const patternsWithSplat = ['/', '/files/$'];
+    expect(matchUrlToRoutePattern('/files/a/b/c', patternsWithSplat)).toBe('/files/$');
+    expect(matchUrlToRoutePattern('/files/readme.txt', patternsWithSplat)).toBe('/files/$');
+  });
+
+  it('prefers specific routes over splat routes', () => {
+    const patternsWithSplat = ['/files/$', '/files/upload'];
+    expect(matchUrlToRoutePattern('/files/upload', patternsWithSplat)).toBe('/files/upload');
+    expect(matchUrlToRoutePattern('/files/a/b', patternsWithSplat)).toBe('/files/$');
+  });
 });

--- a/packages/tanstackstart-react/test/server/routeParametrization.test.ts
+++ b/packages/tanstackstart-react/test/server/routeParametrization.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { matchUrlToRoutePattern } from '../../src/server/routeParametrization';
 
 describe('matchUrlToRoutePattern', () => {
-  const patterns = ['/', '/page-a', '/page-b/$id', '/users/$userId/posts/$postId', '/api/health'];
+  // Pre-sorted by specificity: more segments first, static before dynamic
+  const patterns = ['/users/$userId/posts/$postId', '/api/health', '/page-a', '/page-b/$id', '/'];
 
   it('matches the root route', () => {
     expect(matchUrlToRoutePattern('/', patterns)).toBe('/');
@@ -28,13 +29,13 @@ describe('matchUrlToRoutePattern', () => {
     expect(matchUrlToRoutePattern('/page-b', patterns)).toBeUndefined();
   });
 
-  it('prefers static over dynamic matches', () => {
-    const patternsWithOverlap = ['/page-b/$id', '/page-b/special'];
+  it('prefers static over dynamic matches when pre-sorted', () => {
+    const patternsWithOverlap = ['/page-b/special', '/page-b/$id'];
     expect(matchUrlToRoutePattern('/page-b/special', patternsWithOverlap)).toBe('/page-b/special');
   });
 
-  it('prefers more specific routes (more segments)', () => {
-    const patternsNested = ['/users/$id', '/users/$id/profile'];
+  it('prefers more specific routes when pre-sorted', () => {
+    const patternsNested = ['/users/$id/profile', '/users/$id'];
     expect(matchUrlToRoutePattern('/users/123/profile', patternsNested)).toBe('/users/$id/profile');
   });
 });

--- a/packages/tanstackstart-react/test/server/routeParametrization.test.ts
+++ b/packages/tanstackstart-react/test/server/routeParametrization.test.ts
@@ -53,4 +53,9 @@ describe('matchUrlToRoutePattern', () => {
     expect(matchUrlToRoutePattern('/files/upload', patternsWithSplat)).toBe('/files/upload');
     expect(matchUrlToRoutePattern('/files/a/b', patternsWithSplat)).toBe('/files/$');
   });
+
+  it('prefers named param routes over splat routes with same segment count', () => {
+    const patternsWithBoth = ['/files/$', '/files/$name'];
+    expect(matchUrlToRoutePattern('/files/readme.txt', patternsWithBoth)).toBe('/files/$name');
+  });
 });

--- a/packages/tanstackstart-react/test/vite/routePatterns.test.ts
+++ b/packages/tanstackstart-react/test/vite/routePatterns.test.ts
@@ -68,6 +68,19 @@ export interface FileRouteTypes {
     expect(patterns).toEqual(['/users/$id/profile', '/page-b/special', '/page-b/$id', '/users/$id', '/']);
   });
 
+  it('handles double-quoted paths (quoteStyle: "double")', () => {
+    const content = `
+export interface FileRouteTypes {
+  fullPaths: "/" | "/page-a" | "/page-b/$id"
+  fileRoutesByTo: FileRoutesByTo
+}
+`;
+    const patterns = extractRoutePatterns(content);
+    expect(patterns).toContain('/');
+    expect(patterns).toContain('/page-a');
+    expect(patterns).toContain('/page-b/$id');
+  });
+
   it('deduplicates patterns', () => {
     const content = `
 export interface FileRouteTypes {

--- a/packages/tanstackstart-react/test/vite/routePatterns.test.ts
+++ b/packages/tanstackstart-react/test/vite/routePatterns.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { extractRoutePatterns } from '../../src/vite/routePatterns';
+
+describe('extractRoutePatterns', () => {
+  it('extracts route patterns from routeTree.gen.ts content', () => {
+    const content = `
+const PageARoute = PageARouteImport.update({
+  id: '/page-a',
+  path: '/page-a',
+  getParentRoute: () => rootRouteImport,
+})
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+})
+const PageBIdRoute = PageBIdRouteImport.update({
+  id: '/page-b/$id',
+  path: '/page-b/$id',
+  getParentRoute: () => rootRouteImport,
+})
+`;
+    const patterns = extractRoutePatterns(content);
+    expect(patterns).toContain('/page-a');
+    expect(patterns).toContain('/page-b/$id');
+    expect(patterns).toContain('/');
+  });
+
+  it('always includes the root route', () => {
+    const patterns = extractRoutePatterns('');
+    expect(patterns).toEqual(['/']);
+  });
+
+  it('handles nested routes', () => {
+    const content = `
+const UsersIdRoute = UsersIdRouteImport.update({
+  id: '/users/$userId',
+  path: '/users/$userId',
+})
+const UsersIdPostsRoute = UsersIdPostsRouteImport.update({
+  id: '/users/$userId/posts/$postId',
+  path: '/users/$userId/posts/$postId',
+})
+`;
+    const patterns = extractRoutePatterns(content);
+    expect(patterns).toContain('/users/$userId');
+    expect(patterns).toContain('/users/$userId/posts/$postId');
+  });
+});

--- a/packages/tanstackstart-react/test/vite/routePatterns.test.ts
+++ b/packages/tanstackstart-react/test/vite/routePatterns.test.ts
@@ -2,28 +2,37 @@ import { describe, expect, it } from 'vitest';
 import { extractRoutePatterns } from '../../src/vite/routePatterns';
 
 describe('extractRoutePatterns', () => {
-  it('extracts route patterns from routeTree.gen.ts content', () => {
+  it('extracts full path patterns from single-line fullPaths union', () => {
     const content = `
-const PageARoute = PageARouteImport.update({
-  id: '/page-a',
-  path: '/page-a',
-  getParentRoute: () => rootRouteImport,
-})
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-})
-const PageBIdRoute = PageBIdRouteImport.update({
-  id: '/page-b/$id',
-  path: '/page-b/$id',
-  getParentRoute: () => rootRouteImport,
-})
+export interface FileRouteTypes {
+  fullPaths: '/' | '/page-a' | '/page-b/$id'
+  fileRoutesByTo: FileRoutesByTo
+}
 `;
     const patterns = extractRoutePatterns(content);
+    expect(patterns).toContain('/');
     expect(patterns).toContain('/page-a');
     expect(patterns).toContain('/page-b/$id');
+    expect(patterns).toHaveLength(3);
+  });
+
+  it('extracts full path patterns from multi-line fullPaths union', () => {
+    const content = `
+export interface FileRouteTypes {
+  fullPaths:
+    | '/'
+    | '/page-a'
+    | '/page-b/$id'
+    | '/api/error'
+  fileRoutesByTo: FileRoutesByTo
+}
+`;
+    const patterns = extractRoutePatterns(content);
     expect(patterns).toContain('/');
+    expect(patterns).toContain('/page-a');
+    expect(patterns).toContain('/page-b/$id');
+    expect(patterns).toContain('/api/error');
+    expect(patterns).toHaveLength(4);
   });
 
   it('always includes the root route', () => {
@@ -31,19 +40,31 @@ const PageBIdRoute = PageBIdRouteImport.update({
     expect(patterns).toEqual(['/']);
   });
 
-  it('handles nested routes', () => {
+  it('extracts nested route full paths correctly', () => {
     const content = `
-const UsersIdRoute = UsersIdRouteImport.update({
-  id: '/users/$userId',
-  path: '/users/$userId',
-})
-const UsersIdPostsRoute = UsersIdPostsRouteImport.update({
-  id: '/users/$userId/posts/$postId',
-  path: '/users/$userId/posts/$postId',
-})
+export interface FileRouteTypes {
+  fullPaths:
+    | '/'
+    | '/users'
+    | '/users/$userId'
+    | '/users/$userId/posts/$postId'
+  fileRoutesByTo: FileRoutesByTo
+}
 `;
     const patterns = extractRoutePatterns(content);
+    expect(patterns).toContain('/users');
     expect(patterns).toContain('/users/$userId');
     expect(patterns).toContain('/users/$userId/posts/$postId');
+  });
+
+  it('deduplicates patterns', () => {
+    const content = `
+export interface FileRouteTypes {
+  fullPaths: '/' | '/page-a' | '/page-a'
+  fileRoutesByTo: FileRoutesByTo
+}
+`;
+    const patterns = extractRoutePatterns(content);
+    expect(patterns.filter(p => p === '/page-a')).toHaveLength(1);
   });
 });

--- a/packages/tanstackstart-react/test/vite/routePatterns.test.ts
+++ b/packages/tanstackstart-react/test/vite/routePatterns.test.ts
@@ -57,6 +57,17 @@ export interface FileRouteTypes {
     expect(patterns).toContain('/users/$userId/posts/$postId');
   });
 
+  it('sorts patterns by specificity: more segments first, static before dynamic', () => {
+    const content = `
+export interface FileRouteTypes {
+  fullPaths: '/' | '/page-b/$id' | '/page-b/special' | '/users/$id/profile' | '/users/$id'
+  fileRoutesByTo: FileRoutesByTo
+}
+`;
+    const patterns = extractRoutePatterns(content);
+    expect(patterns).toEqual(['/users/$id/profile', '/page-b/special', '/page-b/$id', '/users/$id', '/']);
+  });
+
   it('deduplicates patterns', () => {
     const content = `
 export interface FileRouteTypes {

--- a/packages/tanstackstart-react/test/vite/routePatterns.test.ts
+++ b/packages/tanstackstart-react/test/vite/routePatterns.test.ts
@@ -35,9 +35,9 @@ export interface FileRouteTypes {
     expect(patterns).toHaveLength(4);
   });
 
-  it('always includes the root route', () => {
+  it('returns empty array when fullPaths is not found', () => {
     const patterns = extractRoutePatterns('');
-    expect(patterns).toEqual(['/']);
+    expect(patterns).toEqual([]);
   });
 
   it('extracts nested route full paths correctly', () => {

--- a/packages/tanstackstart-react/test/vite/sentryTanstackStart.test.ts
+++ b/packages/tanstackstart-react/test/vite/sentryTanstackStart.test.ts
@@ -192,9 +192,9 @@ describe('sentryTanstackStart()', () => {
 
       expect(plugins).toEqual([
         mockRoutePatternPlugin,
+        mockTunnelRoutePlugin,
         mockSourceMapsConfigPlugin,
         mockSentryVitePlugin,
-        mockTunnelRoutePlugin,
         mockMiddlewarePlugin,
       ]);
     });

--- a/packages/tanstackstart-react/test/vite/sentryTanstackStart.test.ts
+++ b/packages/tanstackstart-react/test/vite/sentryTanstackStart.test.ts
@@ -35,6 +35,16 @@ const mockTunnelRoutePlugin: Plugin = {
   transform: vi.fn(),
 };
 
+const mockRoutePatternPlugin: Plugin = {
+  name: 'sentry-tanstackstart-route-patterns',
+  enforce: 'pre',
+  config: vi.fn(),
+};
+
+vi.mock('../../src/vite/routePatterns', () => ({
+  makeRoutePatternPlugin: vi.fn(() => mockRoutePatternPlugin),
+}));
+
 vi.mock('../../src/vite/sourceMaps', () => ({
   makeAddSentryVitePlugin: vi.fn(() => [mockSourceMapsConfigPlugin, mockSentryVitePlugin]),
   makeEnableSourceMapsVitePlugin: vi.fn(() => [mockEnableSourceMapsPlugin]),
@@ -62,7 +72,12 @@ describe('sentryTanstackStart()', () => {
     it('returns source maps plugins in production mode', () => {
       const plugins = sentryTanstackStart({ autoInstrumentMiddleware: false });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockEnableSourceMapsPlugin]);
+      expect(plugins).toEqual([
+        mockRoutePatternPlugin,
+        mockSourceMapsConfigPlugin,
+        mockSentryVitePlugin,
+        mockEnableSourceMapsPlugin,
+      ]);
     });
 
     it('returns no plugins in development mode when tunnelRoute is not configured', () => {
@@ -70,7 +85,7 @@ describe('sentryTanstackStart()', () => {
 
       const plugins = sentryTanstackStart({ autoInstrumentMiddleware: false });
 
-      expect(plugins).toEqual([]);
+      expect(plugins).toEqual([mockRoutePatternPlugin]);
     });
 
     it('returns only the tunnel route plugin in development mode when tunnelRoute is configured', () => {
@@ -81,7 +96,7 @@ describe('sentryTanstackStart()', () => {
         tunnelRoute: { allowedDsns: ['https://public@o0.ingest.sentry.io/0'] },
       });
 
-      expect(plugins).toEqual([mockTunnelRoutePlugin]);
+      expect(plugins).toEqual([mockRoutePatternPlugin, mockTunnelRoutePlugin]);
     });
 
     it('returns Sentry Vite plugins but not enable source maps plugin when sourcemaps.disable is true', () => {
@@ -90,7 +105,7 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: true },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
+      expect(plugins).toEqual([mockRoutePatternPlugin, mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
     });
 
     it('returns Sentry Vite plugins but not enable source maps plugin when sourcemaps.disable is "disable-upload"', () => {
@@ -99,7 +114,7 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: 'disable-upload' },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
+      expect(plugins).toEqual([mockRoutePatternPlugin, mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
     });
 
     it('returns Sentry Vite plugins and enable source maps plugin when sourcemaps.disable is false', () => {
@@ -108,7 +123,12 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: false },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockEnableSourceMapsPlugin]);
+      expect(plugins).toEqual([
+        mockRoutePatternPlugin,
+        mockSourceMapsConfigPlugin,
+        mockSentryVitePlugin,
+        mockEnableSourceMapsPlugin,
+      ]);
     });
   });
 
@@ -116,7 +136,12 @@ describe('sentryTanstackStart()', () => {
     it('includes middleware plugin by default', () => {
       const plugins = sentryTanstackStart({ sourcemaps: { disable: true } });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockMiddlewarePlugin]);
+      expect(plugins).toEqual([
+        mockRoutePatternPlugin,
+        mockSourceMapsConfigPlugin,
+        mockSentryVitePlugin,
+        mockMiddlewarePlugin,
+      ]);
     });
 
     it('includes middleware plugin when autoInstrumentMiddleware is true', () => {
@@ -125,7 +150,12 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: true },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin, mockMiddlewarePlugin]);
+      expect(plugins).toEqual([
+        mockRoutePatternPlugin,
+        mockSourceMapsConfigPlugin,
+        mockSentryVitePlugin,
+        mockMiddlewarePlugin,
+      ]);
     });
 
     it('does not include middleware plugin when autoInstrumentMiddleware is false', () => {
@@ -134,7 +164,7 @@ describe('sentryTanstackStart()', () => {
         sourcemaps: { disable: true },
       });
 
-      expect(plugins).toEqual([mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
+      expect(plugins).toEqual([mockRoutePatternPlugin, mockSourceMapsConfigPlugin, mockSentryVitePlugin]);
     });
 
     it('passes correct options to makeAutoInstrumentMiddlewarePlugin', () => {
@@ -161,6 +191,7 @@ describe('sentryTanstackStart()', () => {
       });
 
       expect(plugins).toEqual([
+        mockRoutePatternPlugin,
         mockSourceMapsConfigPlugin,
         mockSentryVitePlugin,
         mockTunnelRoutePlugin,


### PR DESCRIPTION
Server transactions now use parametrized route names instead of raw URLs. `GET /users/123` becomes `GET /users/$id`, fixing high-cardinality transaction grouping. 

The framework provides no way to do this natively, so this is implemented using a build manifest approach that should hopefully work in most cases. Route patterns are extracted from `routeTree.gen.ts` at build time and presorted by number of static/dynamic segments, then matched against request URLs at runtime in `wrapFetchWithSentry`.

Closes https://github.com/getsentry/sentry-javascript/issues/18284