### PR TITLE
fix(tanstackstart-react): Add server-side replayIntegration no-op stub

### DIFF
--- a/packages/tanstackstart-react/src/index.types.ts
+++ b/packages/tanstackstart-react/src/index.types.ts
@@ -39,6 +39,7 @@ export declare const unleashIntegration: typeof clientSdk.unleashIntegration;
 
 export declare const wrapMiddlewaresWithSentry: typeof serverSdk.wrapMiddlewaresWithSentry;
 
+export declare const replayIntegration: typeof clientSdk.replayIntegration;
 export declare const tanstackRouterBrowserTracingIntegration: typeof clientSdk.tanstackRouterBrowserTracingIntegration;
 export declare const sentryGlobalRequestMiddleware: typeof serverSdk.sentryGlobalRequestMiddleware;
 export declare const sentryGlobalFunctionMiddleware: typeof serverSdk.sentryGlobalFunctionMiddleware;

--- a/packages/tanstackstart-react/src/server/index.ts
+++ b/packages/tanstackstart-react/src/server/index.ts
@@ -12,6 +12,17 @@ export { sentryGlobalRequestMiddleware, sentryGlobalFunctionMiddleware } from '.
 export { createSentryTunnelRoute } from './tunnelRoute';
 
 /**
+ * A no-op stub of the replay integration for the server. Router setup code is shared between client and server,
+ * so this stub is needed to prevent build errors during SSR bundling.
+ */
+export function replayIntegration(_options?: Record<string, unknown>): Integration {
+  return {
+    name: 'Replay',
+    setup() {},
+  };
+}
+
+/**
  * A no-op stub of the browser tracing integration for the server. Router setup code is shared between client and server,
  * so this stub is needed to prevent build errors during SSR bundling.
  */


### PR DESCRIPTION
Using `Sentry.replayIntegration()` in shared client/server code (e.g. `router.tsx`) causes a build error because `@sentry/node` doesn't export it (noticed this while testing https://github.com/getsentry/sentry-javascript/pull/21149). Adds a no-op stub on the server side to get rid of the build error, same pattern as the existing `tanstackRouterBrowserTracingIntegration` stub.