### PR TITLE
feat(tanstackstart-react): Enable component tracking

### DIFF
--- a/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
+++ b/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
@@ -23,6 +23,18 @@ export interface SentryTanstackStartOptions extends BuildTimeOptionsBase {
   autoInstrumentMiddleware?: boolean;
 
   /**
+   * Options for automatic React component name annotation.
+   *
+   * When enabled, the Sentry Vite plugin adds `data-sentry-component`, `data-sentry-element`,
+   * and `data-sentry-source-file` attributes to JSX elements during build. This improves
+   * readability of component names in Session Replay, breadcrumbs, and performance monitoring.
+   */
+  reactComponentAnnotation?: {
+    enabled?: boolean;
+    ignoredComponents?: string[];
+  };
+
+  /**
    * Configures a framework-managed same-origin tunnel route for Sentry envelopes.
    *
    * This creates a TanStack Start server route backed by `createSentryTunnelRoute()` and applies the resulting path

--- a/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
+++ b/packages/tanstackstart-react/src/vite/sentryTanstackStart.ts
@@ -23,14 +23,21 @@ export interface SentryTanstackStartOptions extends BuildTimeOptionsBase {
   autoInstrumentMiddleware?: boolean;
 
   /**
-   * Options for automatic React component name annotation.
-   *
-   * When enabled, the Sentry Vite plugin adds `data-sentry-component`, `data-sentry-element`,
-   * and `data-sentry-source-file` attributes to JSX elements during build. This improves
-   * readability of component names in Session Replay, breadcrumbs, and performance monitoring.
+   * Options related to react component name annotations.
+   * Disabled by default, unless a value is set for this option.
+   * When enabled, your app's DOM will automatically be annotated during build-time with their respective component names.
+   * This will unlock the capability to search for Replays in Sentry by component name, as well as see component names in breadcrumbs and performance monitoring.
+   * Please note that this feature is not currently supported by the esbuild bundler plugins, and will only annotate React components
    */
   reactComponentAnnotation?: {
+    /**
+     * Whether the component name annotate plugin should be enabled or not.
+     */
     enabled?: boolean;
+
+    /**
+     * A list of strings representing the names of components to ignore. The plugin will not apply `data-sentry` annotations on the DOM element for these components.
+     */
     ignoredComponents?: string[];
   };
 

--- a/packages/tanstackstart-react/src/vite/sourceMaps.ts
+++ b/packages/tanstackstart-react/src/vite/sourceMaps.ts
@@ -7,7 +7,9 @@ type FilesToDeleteAfterUpload = string | string[] | undefined;
 /**
  * A Sentry plugin for adding the @sentry/vite-plugin to automatically upload source maps to Sentry.
  */
-export function makeAddSentryVitePlugin(options: BuildTimeOptionsBase): Plugin[] {
+export function makeAddSentryVitePlugin(
+  options: BuildTimeOptionsBase & { reactComponentAnnotation?: { enabled?: boolean; ignoredComponents?: string[] } },
+): Plugin[] {
   const {
     applicationKey,
     authToken,
@@ -22,6 +24,7 @@ export function makeAddSentryVitePlugin(options: BuildTimeOptionsBase): Plugin[]
     silent,
     sourcemaps,
     telemetry,
+    reactComponentAnnotation,
   } = options;
 
   // defer resolving the filesToDeleteAfterUpload until we got access to the Vite config
@@ -71,6 +74,10 @@ export function makeAddSentryVitePlugin(options: BuildTimeOptionsBase): Plugin[]
       // Keep runtime support while staying resilient to type version skew.
       rewriteSources: (sourcemaps as unknown as { rewriteSources?: unknown } | undefined)?.rewriteSources as never,
       filesToDeleteAfterUpload: filesToDeleteAfterUploadPromise,
+    },
+    reactComponentAnnotation: {
+      enabled: reactComponentAnnotation?.enabled ?? undefined,
+      ignoredComponents: reactComponentAnnotation?.ignoredComponents ?? undefined,
     },
     telemetry: telemetry ?? true,
     url: sentryUrl,

--- a/packages/tanstackstart-react/src/vite/sourceMaps.ts
+++ b/packages/tanstackstart-react/src/vite/sourceMaps.ts
@@ -1,4 +1,3 @@
-import type { BuildTimeOptionsBase } from '@sentry/core';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import type { Plugin, UserConfig } from 'vite';
 import type { SentryTanstackStartOptions } from './sentryTanstackStart';
@@ -93,7 +92,7 @@ export function makeAddSentryVitePlugin(options: SentryTanstackStartOptions): Pl
 /**
  * A Sentry plugin for TanStack Start React to enable "hidden" source maps if they are unset.
  */
-export function makeEnableSourceMapsVitePlugin(options: BuildTimeOptionsBase): Plugin[] {
+export function makeEnableSourceMapsVitePlugin(options: SentryTanstackStartOptions): Plugin[] {
   return [
     {
       name: 'sentry-tanstackstart-react-source-maps',
@@ -129,7 +128,7 @@ export function makeEnableSourceMapsVitePlugin(options: BuildTimeOptionsBase): P
  */
 export function getUpdatedSourceMapSettings(
   viteConfig: UserConfig,
-  sentryPluginOptions?: BuildTimeOptionsBase,
+  sentryPluginOptions?: SentryTanstackStartOptions,
 ): boolean | 'inline' | 'hidden' {
   viteConfig.build = viteConfig.build || {};
 

--- a/packages/tanstackstart-react/src/vite/sourceMaps.ts
+++ b/packages/tanstackstart-react/src/vite/sourceMaps.ts
@@ -1,15 +1,14 @@
 import type { BuildTimeOptionsBase } from '@sentry/core';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import type { Plugin, UserConfig } from 'vite';
+import type { SentryTanstackStartOptions } from './sentryTanstackStart';
 
 type FilesToDeleteAfterUpload = string | string[] | undefined;
 
 /**
  * A Sentry plugin for adding the @sentry/vite-plugin to automatically upload source maps to Sentry.
  */
-export function makeAddSentryVitePlugin(
-  options: BuildTimeOptionsBase & { reactComponentAnnotation?: { enabled?: boolean; ignoredComponents?: string[] } },
-): Plugin[] {
+export function makeAddSentryVitePlugin(options: SentryTanstackStartOptions): Plugin[] {
   const {
     applicationKey,
     authToken,

--- a/packages/tanstackstart-react/test/vite/sourceMaps.test.ts
+++ b/packages/tanstackstart-react/test/vite/sourceMaps.test.ts
@@ -242,6 +242,37 @@ describe('makeAddSentryVitePlugin()', () => {
       }),
     );
   });
+
+  it('passes reactComponentAnnotation options to the vite plugin', () => {
+    makeAddSentryVitePlugin({
+      reactComponentAnnotation: {
+        enabled: true,
+        ignoredComponents: ['MyIgnoredComponent'],
+      },
+    });
+
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reactComponentAnnotation: {
+          enabled: true,
+          ignoredComponents: ['MyIgnoredComponent'],
+        },
+      }),
+    );
+  });
+
+  it('passes undefined reactComponentAnnotation values when not configured', () => {
+    makeAddSentryVitePlugin({});
+
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reactComponentAnnotation: {
+          enabled: undefined,
+          ignoredComponents: undefined,
+        },
+      }),
+    );
+  });
 });
 
 describe('getUpdatedSourceMapSettings', () => {


### PR DESCRIPTION
Passes the `reactComponentAnnotation` option through to `sentryVitePlugin`, adding `data-sentry-component` and `data-sentry-source-file` attributes to React components at build time for better component names in Session Replay and breadcrumbs.

Had a look at a replay in Sentry with this enabled and disabled and seems to do it's job.

Not annotated
<img width="273" height="156" alt="Screenshot 2026-05-24 at 11 16 41" src="https://github.com/user-attachments/assets/9f9aef75-481e-45d6-9a63-241cb7d10858" />

Annotated
<img width="273" height="156" alt="Screenshot 2026-05-24 at 11 16 23" src="https://github.com/user-attachments/assets/9019d0bd-c026-4a1e-8535-8ea0e81b647b" />

Fixes #18288