### PR TITLE
fix(deno): support Deno.serve instrumentation on Deno 2.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -999,7 +999,7 @@ jobs:
         if: matrix.test-application == 'deno' || matrix.test-application == 'deno-streamed'
         uses: denoland/setup-deno@v2.0.4
         with:
-          deno-version: v2.1.5
+          deno-version: ${{ matrix.deno-version || 'v2.1.5' }}
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         with:
@@ -1118,6 +1118,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: 'dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}/package.json'
+      - name: Set up Deno
+        if: matrix.test-application == 'deno' || matrix.test-application == 'deno-streamed'
+        uses: denoland/setup-deno@v2.0.4
+        with:
+          deno-version: ${{ matrix.deno-version || 'v2.1.5' }}
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         with:

--- a/dev-packages/e2e-tests/test-applications/deno-streamed/package.json
+++ b/dev-packages/e2e-tests/test-applications/deno-streamed/package.json
@@ -21,5 +21,13 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "sentryTest": {
+    "optionalVariants": [
+      {
+        "deno-version": "latest",
+        "label": "deno-streamed (latest)"
+      }
+    ]
   }
 }

--- a/dev-packages/e2e-tests/test-applications/deno/package.json
+++ b/dev-packages/e2e-tests/test-applications/deno/package.json
@@ -21,5 +21,13 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "sentryTest": {
+    "optionalVariants": [
+      {
+        "deno-version": "latest",
+        "label": "deno (latest)"
+      }
+    ]
   }
 }

--- a/packages/deno/src/integrations/deno-serve.ts
+++ b/packages/deno/src/integrations/deno-serve.ts
@@ -1,5 +1,5 @@
 import type { IntegrationFn } from '@sentry/core';
-import { defineIntegration } from '@sentry/core';
+import { debug, defineIntegration } from '@sentry/core';
 import { setAsyncLocalStorageAsyncContextStrategy } from '../async';
 import type { RequestHandlerWrapperOptions } from '../wrap-deno-request-handler';
 import { wrapDenoRequestHandler } from '../wrap-deno-request-handler';
@@ -44,24 +44,44 @@ const applyHandlerWrap = <A extends Deno.Addr>(
       () => handler(request, info as Deno.ServeHandlerInfo<A>),
     )) as Deno.ServeHandler;
 
+const instrumentedDenoServe = (serve: typeof Deno.serve): typeof Deno.serve =>
+  new Proxy(serve, {
+    apply(target, thisArg, args: ServeParams) {
+      if (isSimpleHandler(args)) {
+        args[0] = applyHandlerWrap(args[0]);
+      } else if (isServeOptWithFunction(args)) {
+        args[1] = applyHandlerWrap(args[1], args[0]);
+      } else if (isServeInitOptions(args)) {
+        args[0].handler = applyHandlerWrap(args[0].handler, args[0]);
+      }
+      // if none of those matched, it'll crash, most likely.
+      return target.apply(thisArg, args);
+    },
+  });
+
 const _denoServeIntegration = (() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
       setAsyncLocalStorageAsyncContextStrategy();
-      Deno.serve = new Proxy(Deno.serve, {
-        apply(target, thisArg, args: ServeParams) {
-          if (isSimpleHandler(args)) {
-            args[0] = applyHandlerWrap(args[0]);
-          } else if (isServeOptWithFunction(args)) {
-            args[1] = applyHandlerWrap(args[1], args[0]);
-          } else if (isServeInitOptions(args)) {
-            args[0].handler = applyHandlerWrap(args[0].handler, args[0]);
-          }
-          // if none of those matched, it'll crash, most likely.
-          return target.apply(thisArg, args);
-        },
-      });
+
+      const originalServe = Deno.serve;
+      const wrappedServe = instrumentedDenoServe(originalServe);
+
+      try {
+        const descriptor = Object.getOwnPropertyDescriptor(Deno, 'serve');
+
+        Object.defineProperty(Deno, 'serve', {
+          configurable: descriptor?.configurable ?? true,
+          enumerable: descriptor?.enumerable ?? true,
+          // writable: true avoids other instrumentations on older Deno versions
+          // from crashing if they used to do assignment
+          writable: true,
+          value: wrappedServe,
+        });
+      } catch (error) {
+        debug.warn('Could not instrument Deno.serve.', error);
+      }
     },
   };
 }) satisfies IntegrationFn;


### PR DESCRIPTION
Deno 2.8 changed the `serve` to be a configurable property instead without a setter, so setting it directly crashes Deno apps.

I have changed our serve instrumentation approach to use `Object.defineProperty` to override it, while wrapping everything in `try/catch` to avoid crashing user apps in the future.

I also added a couple of optional deno latest variants that would help us catch this in the future.

Fixes #21142