### PR TITLE
meta(agents): Update AI commit attribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,15 @@ Single package: `cd packages/<name> && yarn test`
 
 ## Commit Attribution
 
-AI commits MUST include:
+AI commits MUST include a `Co-Authored-By` line with the appropriate committer email when known:
 
 ```
-Co-Authored-By: <agent model name> <noreply@anthropic.com>
+Co-Authored-By: <Claude model name> <noreply@anthropic.com>
+Co-Authored-By: <OpenAI/ChatGPT model name> <codex@openai.com>
+Co-Authored-By: <Cursor agent name> <cursoragent@cursor.com>
 ```
+
+Use the Cursor email for Cursor, even when it runs a Claude or OpenAI model. Omit the line only when there is no known committer email address for the agent.
 
 ## Git Workflow
 


### PR DESCRIPTION
Clarify that AI commits should use the committer email associated with the agent instead of assuming Anthropic-only attribution. Document known OpenAI and Cursor committer emails, and allow omitting the attribution line only when no committer email is known.

This will prevent stuff like this from happening

<img width="814" height="127" alt="image" src="https://github.com/user-attachments/assets/286705c1-5810-46c1-8ef2-063605655e01" />