### PR TITLE
docs(tanstackstart-react): Promote SDK to beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- **docs(tanstackstart-react): Promote SDK status to beta ([#21175](https://github.com/getsentry/sentry-javascript/pull/21175))**
+
+  This release promotes the `@sentry/tanstackstart-react` SDK to beta. For details on how to use it, check out the
+  [Sentry TanStack Start SDK docs](https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/). Please reach out on
+  [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns.
+
 - **test(tanstackstart-react): Move initialization to client entry point ([#21161](https://github.com/getsentry/sentry-javascript/pull/21161))**
 
   Change the recommended setup for the SDK to do `Sentry.init()` in the client entry file to capture telemetry that is emitted ahead of page hydration.

--- a/packages/tanstackstart-react/README.md
+++ b/packages/tanstackstart-react/README.md
@@ -4,13 +4,14 @@
   </a>
 </p>
 
-# Official Sentry SDK for TanStack Start React (Alpha)
+# Official Sentry SDK for TanStack Start React (Beta)
 
 [![npm version](https://img.shields.io/npm/v/@sentry/tanstackstart-react.svg)](https://www.npmjs.com/package/@sentry/tanstackstart-react)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/tanstackstart-react.svg)](https://www.npmjs.com/package/@sentry/tanstackstart-react)
 [![npm dt](https://img.shields.io/npm/dt/@sentry/tanstackstart-react.svg)](https://www.npmjs.com/package/@sentry/tanstackstart-react)
 
-> NOTICE: This package is in alpha state and may be subject to breaking changes.
+> This SDK is currently in **BETA**. Beta features are still in progress and may have bugs. Please reach out on
+> [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback or concerns.
 
 > See the [Official Sentry TanStack Start SDK Docs](https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/) to get started.
 


### PR DESCRIPTION
Promotes the TanStack Start React SDK from alpha to beta.