### PR TITLE
fix(test): fix hanging nuxt-5 e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-5/.npmrc
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/.npmrc
@@ -1,0 +1,1 @@
+strict-peer-deps = false

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/package.json
@@ -13,8 +13,8 @@
     "test": "playwright test",
     "test:prod": "TEST_ENV=production playwright test",
     "test:dev": "bash ./nuxt-start-dev-server.bash && TEST_ENV=development playwright test environment",
-    "test:build": "pnpm install && pnpm build",
-    "test:build-canary": "pnpm add nuxt@npm:nuxt-nightly@latest && pnpm add nitro@npm:nitro-nightly@latest && pnpm install --force && pnpm build",
+    "test:build": "npm install && pnpm build",
+    "test:build-canary": "pnpm add nuxt@npm:nuxt-nightly@latest && pnpm add nitro@npm:nitro-nightly@latest && npm install --force && pnpm build",
     "test:assert": "pnpm test:prod && pnpm test:dev"
   },
   "//": [


### PR DESCRIPTION
1. `dev-packages/e2e-tests/test-applications/nuxt-5/package.json` pins `"nuxt": "npm:nuxt-nightly@5.x"`, an aliased dependency.
2. `nuxt-nightly@5.0.0-...` depends on `"@nuxt/nitro-server": "npm:@nuxt/nitro-server-nightly@<exact same version>"`.
3. `@nuxt/nitro-server-nightly` declares `"peerDependencies": { "nuxt": "npm:nuxt-nightly@<exact same version>" }`. This is a self-referencing aliased peer dep that loops back to the top-level dependency being installed.
4. pnpm's peer-dependency resolver deadlocks on this cycle: process goes to 0% CPU, no open sockets, threads parked in kevent/uv_cond_wait. Resolution shows `resolved 498, reused 0, downloaded 417, added 0`, then hangs forever.

The solution is to use npm to install the dependencies, since npm does not deadlock on this sort of peerDep alias cycle.
