### PR TITLE
ref(node): Stop custom-handling normalization of Domain/DomainEmitter

### DIFF
--- a/packages/core/src/utils/normalize.ts
+++ b/packages/core/src/utils/normalize.ts
@@ -187,14 +187,6 @@ function stringifyValue(
   value: Exclude<unknown, string | number | boolean | null>,
 ): string {
   try {
-    if (key === 'domain' && value && typeof value === 'object' && (value as { _events: unknown })._events) {
-      return '[Domain]';
-    }
-
-    if (key === 'domainEmitter') {
-      return '[DomainEmitter]';
-    }
-
     // It's safe to use `global`, `window`, and `document` here in this manner, as we are asserting using `typeof` first
     // which won't throw if they are not present.
 


### PR DESCRIPTION
We have custom code normalizing Domain and DomainEmitter, which are node-only but deprecated and not widely used anymore. This would have affected this being serialized in a nested object, e.g. extra, where it would be something like:


```js
// The rule is shape-based, not identity-based: any EventEmitter under `domain` matches.
const emitter = new EventEmitter();
emitter.on('error', () => undefined);
expect(normalize({ domain: emitter })).toEqual({ domain: '[Domain]' });
```

or

```js
// The Node `domain` module stamps the originating EventEmitter onto caught errors
// under `domainEmitter`. The rule is unconditional on the key match — no shape check —
// so even non-emitter values under `domainEmitter` get replaced.
const realEmitter = new EventEmitter();
realEmitter.on('data', () => undefined);

expect(normalize({ domainEmitter: realEmitter })).toEqual({ domainEmitter: '[DomainEmitter]' });
```

(We don't really have tests for this, I added these to verify how this looks today, they are not in the PR since they would be removed again basically)

With this PR, they will be normalized "normally", meaning they'd look something like this:


```diff
{
-   "domain": "[Domain]",
+   "domain": {
+     "_events": {
+       "newListener": "[Function: updateExceptionCapture]",
+       "removeListener": "[Function: updateExceptionCapture]",
+     },
+     "_eventsCount": 2,
+     "_maxListeners": undefined,
+     "members": [],
+   },
  }
```

or

```diff
{
-   "domainEmitter": "[DomainEmitter]",
+   "domainEmitter": {
+     "_events": {
+       "data": "[Function: <anonymous>]",
+     },
+     "_eventsCount": 1,
+     "_maxListeners": undefined,
+   },
  }
```

which is of course "worse" but IMHO this deprecated, not widely used feature does not necessarily warranty special handling in core - this code is also shipped to browsers.