### PR TITLE
chore(changelog): clarify array attributes impact on `beforeSend*` callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@
 
   Arrays of primitive values (`string`, `number`, `boolean`) are now accepted as attribute values. Arrays containing non-primitive elements will be dropped and won't show up in Sentry. Array attributes on logs and metrics were previously stringified and will now be sent as actual arrays instead. **If you have custom rules that process attribute values in any `beforeSend*` callbacks (e.g., data scrubbing), you may need to update them to correctly handle array values.**
 
+  For instance, here's how you can update a `beforeSendLog` callback to handle arrays:
+
+  ```ts
+  beforeSendLog: log => {
+    const attributes = log.attributes;
+    Object.keys(attributes).forEach(key => {
+      const value = attributes[key];
+      if (typeof value === 'string') {
+        attributes[key] = scrubData(value);
+      }
+      if (Array.isArray(value)) {
+        attributes[key] = value.map(v => (typeof v === 'string' ? scrubData(v) : v));
+      }
+    });
+    return log;
+  };
+  ```
+
 - **feat(browser): Add `fetchStreamPerformanceIntegration` for streamed response tracking ([#20778](https://github.com/getsentry/sentry-javascript/pull/20778))**
 
   A new integration that tracks the performance of streamed fetch responses. Use this to measure time-to-first-byte and streaming duration for APIs that return chunked/streamed data. This replaces the now deprecated `trackFetchStreamPerformance` option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 - **feat(core): Support array attributes for spans, logs, and metrics ([#20427](https://github.com/getsentry/sentry-javascript/pull/20427))**
 
-  Arrays of primitive values (`string`, `number`, `boolean`) are now accepted as attribute values. Arrays containing non-primitive elements will be dropped. Array attributes on logs and metrics were previously stringified and will now be sent as actual arrays instead. **If you use `beforeSend*` callbacks that assume attribute values are always primitive (e.g., `typeof value === 'string'`), update them to handle array values as well.**
+  Arrays of primitive values (`string`, `number`, `boolean`) are now accepted as attribute values. Arrays containing non-primitive elements will be dropped and won't show up in Sentry. Array attributes on logs and metrics were previously stringified and will now be sent as actual arrays instead. **If you have custom rules that process attribute values in any `beforeSend*` callbacks (e.g., PII scrubbing), you may need to update them to correctly handle array values.**
 
 - **feat(browser): Add `fetchStreamPerformanceIntegration` for streamed response tracking ([#20778](https://github.com/getsentry/sentry-javascript/pull/20778))**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 ### Important Changes
 
+- **feat(core): Support array attributes for spans, logs, and metrics ([#20427](https://github.com/getsentry/sentry-javascript/pull/20427))**
+
+  Arrays of primitive values (`string`, `number`, `boolean`) are now accepted as attribute values. Arrays containing non-primitive elements will be dropped. Array attributes on logs and metrics were previously stringified and will now be sent as actual arrays instead. **If you use `beforeSend*` callbacks that assume attribute values are always primitive (e.g., `typeof value === 'string'`), update them to handle array values as well.**
+
 - **feat(browser): Add `fetchStreamPerformanceIntegration` for streamed response tracking ([#20778](https://github.com/getsentry/sentry-javascript/pull/20778))**
 
   A new integration that tracks the performance of streamed fetch responses. Use this to measure time-to-first-byte and streaming duration for APIs that return chunked/streamed data. This replaces the now deprecated `trackFetchStreamPerformance` option.
@@ -27,10 +31,6 @@
 - **feat(core): Add `dataCollection` client option ([#20965](https://github.com/getsentry/sentry-javascript/pull/20965))**
 
   Adds a new `dataCollection` client option for controlling what data the SDK collects and sends to Sentry. This provides a centralized way to configure data collection behavior across different SDK features. In the future, this option will be used for fine-granular data filtering, while the simple `sendDefaultPii` boolean option will be deprecated and removed in a future release.
-
-- **feat(core): Support array attributes for spans, logs, and metrics ([#20427](https://github.com/getsentry/sentry-javascript/pull/20427))**
-
-  Arrays of primitive values (`string`, `number`, `boolean`) are now accepted as attribute values. Arrays containing non-primitive elements will be dropped and won't show up in Sentry. Note that array attributes on logs and metrics were previously stringified in certain cases and will now be sent as arrays instead.
 
 - **feat(hono): Add `hono.request` spans for internal `.request()` calls ([#20843](https://github.com/getsentry/sentry-javascript/pull/20843))**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 - **feat(core): Support array attributes for spans, logs, and metrics ([#20427](https://github.com/getsentry/sentry-javascript/pull/20427))**
 
-  Arrays of primitive values (`string`, `number`, `boolean`) are now accepted as attribute values. Arrays containing non-primitive elements will be dropped and won't show up in Sentry. Array attributes on logs and metrics were previously stringified and will now be sent as actual arrays instead. **If you have custom rules that process attribute values in any `beforeSend*` callbacks (e.g., PII scrubbing), you may need to update them to correctly handle array values.**
+  Arrays of primitive values (`string`, `number`, `boolean`) are now accepted as attribute values. Arrays containing non-primitive elements will be dropped and won't show up in Sentry. Array attributes on logs and metrics were previously stringified and will now be sent as actual arrays instead. **If you have custom rules that process attribute values in any `beforeSend*` callbacks (e.g., data scrubbing), you may need to update them to correctly handle array values.**
 
 - **feat(browser): Add `fetchStreamPerformanceIntegration` for streamed response tracking ([#20778](https://github.com/getsentry/sentry-javascript/pull/20778))**
 


### PR DESCRIPTION
The last release shipped array attribute support, which can subtly break user hooks if users have special treatment for these. Update the changelog to be a bit more explicit about this behavioral change.