### PR TITLE
ref(opentelemetry): Vendor minimal `TraceState` implementation

### DIFF
--- a/packages/opentelemetry/src/sampler.ts
+++ b/packages/opentelemetry/src/sampler.ts
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 import type { Context, Span, TraceState as TraceStateInterface } from '@opentelemetry/api';
 import { isSpanContextValid, SpanKind, trace } from '@opentelemetry/api';
-import { TraceState } from '@opentelemetry/core';
+import { TraceState } from './utils/TraceState';
 import type { Sampler, SamplingResult } from '@opentelemetry/sdk-trace-base';
 import { SamplingDecision } from '@opentelemetry/sdk-trace-base';
 import {

--- a/packages/opentelemetry/src/utils/TraceState.ts
+++ b/packages/opentelemetry/src/utils/TraceState.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Minimal vendored implementation of `TraceState` from `@opentelemetry/core`
+ *   to avoid pulling in that dependency for a single class.
+ * - Drops raw-string parsing and key/value validation, neither of which are
+ *   used by the SDK — the W3C `tracestate` header is parsed by OTel's own
+ *   propagators (which use their own `TraceState`), and every key we `set`
+ *   is a known constant.
+ */
+import type { TraceState as TraceStateInterface } from '@opentelemetry/api';
+
+/**
+ * Minimal implementation of the W3C `tracestate` field as a `@opentelemetry/api`
+ * `TraceState`. New entries are inserted at the front of the list, and updating
+ * an existing key moves it to the front.
+ *
+ * See https://www.w3.org/TR/trace-context/#tracestate-field for the field spec.
+ */
+export class TraceState implements TraceStateInterface {
+  private _internalState: Map<string, string> = new Map();
+
+  /** @inheritDoc */
+  public set(key: string, value: string): TraceState {
+    const next = this._clone();
+    if (next._internalState.has(key)) {
+      next._internalState.delete(key);
+    }
+    next._internalState.set(key, value);
+    return next;
+  }
+
+  /** @inheritDoc */
+  public unset(key: string): TraceState {
+    const next = this._clone();
+    next._internalState.delete(key);
+    return next;
+  }
+
+  /** @inheritDoc */
+  public get(key: string): string | undefined {
+    return this._internalState.get(key);
+  }
+
+  /** @inheritDoc */
+  public serialize(): string {
+    return Array.from(this._internalState.keys())
+      .reverse()
+      .map(key => `${key}=${this._internalState.get(key)}`)
+      .join(',');
+  }
+
+  private _clone(): TraceState {
+    const next = new TraceState();
+    next._internalState = new Map(this._internalState);
+    return next;
+  }
+}

--- a/packages/opentelemetry/src/utils/makeTraceState.ts
+++ b/packages/opentelemetry/src/utils/makeTraceState.ts
@@ -1,7 +1,7 @@
-import { TraceState } from '@opentelemetry/core';
 import type { DynamicSamplingContext } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/core';
 import { SENTRY_TRACE_STATE_DSC, SENTRY_TRACE_STATE_SAMPLED_NOT_RECORDING } from '../constants';
+import { TraceState } from './TraceState';
 
 /**
  * Generate a TraceState for the given data.

--- a/packages/opentelemetry/test/contextManager.test.ts
+++ b/packages/opentelemetry/test/contextManager.test.ts
@@ -1,5 +1,5 @@
 import { context, trace, TraceFlags } from '@opentelemetry/api';
-import { TraceState } from '@opentelemetry/core';
+import { TraceState } from '../src/utils/TraceState';
 import { afterEach, describe, expect, it } from 'vitest';
 import { SENTRY_TRACE_STATE_CHILD_IGNORED } from '../src/constants';
 import { cleanupOtel, mockSdkInit } from './helpers/mockSdkInit';

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -1,6 +1,6 @@
 import type { SpanContext } from '@opentelemetry/api';
 import { context, ROOT_CONTEXT, trace, TraceFlags } from '@opentelemetry/api';
-import { TraceState } from '@opentelemetry/core';
+import { TraceState } from '../../src/utils/TraceState';
 import type { Event, TransactionEvent } from '@sentry/core';
 import {
   addBreadcrumb,

--- a/packages/opentelemetry/test/sampler.test.ts
+++ b/packages/opentelemetry/test/sampler.test.ts
@@ -1,5 +1,5 @@
 import { context, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
-import { TraceState } from '@opentelemetry/core';
+import { TraceState } from '../src/utils/TraceState';
 import { SamplingDecision } from '@opentelemetry/sdk-trace-base';
 import { ATTR_HTTP_REQUEST_METHOD } from '@opentelemetry/semantic-conventions';
 import { generateSpanId, generateTraceId } from '@sentry/core';

--- a/packages/opentelemetry/test/utils/TraceState.test.ts
+++ b/packages/opentelemetry/test/utils/TraceState.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { TraceState } from '../../src/utils/TraceState';
+
+describe('TraceState', () => {
+  it('returns undefined for unknown keys', () => {
+    expect(new TraceState().get('missing')).toBeUndefined();
+  });
+
+  it('set returns a new instance and leaves the original unchanged', () => {
+    const original = new TraceState();
+    const next = original.set('a', '1');
+
+    expect(next).not.toBe(original);
+    expect(original.get('a')).toBeUndefined();
+    expect(next.get('a')).toBe('1');
+  });
+
+  it('moves an updated key to the front of the serialized list', () => {
+    const state = new TraceState().set('a', '1').set('b', '2').set('a', '3');
+
+    expect(state.get('a')).toBe('3');
+    expect(state.serialize()).toBe('a=3,b=2');
+  });
+
+  it('serializes newest entries first', () => {
+    const state = new TraceState().set('a', '1').set('b', '2').set('c', '3');
+
+    expect(state.serialize()).toBe('c=3,b=2,a=1');
+  });
+
+  it('unset removes the key and returns a new instance', () => {
+    const state = new TraceState().set('a', '1').set('b', '2');
+    const next = state.unset('a');
+
+    expect(next).not.toBe(state);
+    expect(state.get('a')).toBe('1');
+    expect(next.get('a')).toBeUndefined();
+    expect(next.serialize()).toBe('b=2');
+  });
+
+  it('serializes an empty state to an empty string', () => {
+    expect(new TraceState().serialize()).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a small in-tree `TraceState` class under `packages/opentelemetry/src/utils/TraceState.ts` implementing `api.TraceState` from `@opentelemetry/api`.
- Swaps the four `import { TraceState } from '@opentelemetry/core'` sites (`sampler.ts`, `makeTraceState.ts`, and three test files) to use the vendored version.

## Why

The SDK only ever calls `new TraceState()` and chains `.set()`, `.get()`, `.unset()`, and `.serialize()` on the result — none of the upstream class's heavier behavior (raw `tracestate` header parsing, key/value validation, W3C length/item caps) ever runs against our inputs. Inlining the ~40 lines we actually use lets us drop one consumer of `@opentelemetry/core` from a heavily-imported file without behavior change.

## Deliberately dropped from upstream

- Raw-string parsing in the constructor — the W3C `tracestate` header is parsed by OTel's own `W3CTraceContextPropagator`, which uses its own `TraceState`. Our class is never constructed from a raw header.
- Key/value validation — we only `set` known `SENTRY_TRACE_STATE_*` constants.
- `MAX_TRACE_STATE_ITEMS` / `MAX_TRACE_STATE_LEN` truncation — only relevant when parsing input.

`@opentelemetry/core` remains a dependency because `propagator.ts`, `resource.ts`, `trace.ts`, and `utils/suppressTracing.ts` still use `isTracingSuppressed`, `W3CBaggagePropagator`, `SDK_INFO`, and `suppressTracing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)