### PR TITLE
ref(node): Stop mutating OTel RPC metadata to set `http.route`

### DIFF
--- a/packages/node/src/integrations/tracing/connect/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/connect/vendored/instrumentation.ts
@@ -21,11 +21,11 @@
 /* eslint-disable */
 
 import { context, Span, SpanOptions } from '@opentelemetry/api';
-import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import type { ServerResponse } from 'http';
 import { AttributeNames, ConnectNames, ConnectTypes } from './enums/AttributeNames';
 import { HandleFunction, NextFunction, Server, PatchedRequest, Use, UseArgs, UseArgs2 } from './internal-types';
 import { SDK_VERSION } from '@sentry/core';
+import { setHttpServerSpanRouteAttribute } from '../../../../utils/setHttpServerSpanRouteAttribute';
 import {
   InstrumentationBase,
   InstrumentationConfig,
@@ -119,9 +119,8 @@ export class ConnectInstrumentation extends InstrumentationBase {
 
       replaceCurrentStackRoute(req, routeName);
 
-      const rpcMetadata = getRPCMetadata(context.active());
-      if (routeName && rpcMetadata?.type === RPCType.HTTP) {
-        rpcMetadata.route = generateRoute(req);
+      if (routeName) {
+        setHttpServerSpanRouteAttribute(generateRoute(req));
       }
 
       let spanName = '';

--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -1,8 +1,6 @@
 // Automatic istrumentation for Express using OTel
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
-import { context } from '@opentelemetry/api';
-import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 
 import { ensureIsWrapped, generateInstrumentOnce } from '@sentry/node-core';
 import {
@@ -17,6 +15,7 @@ import {
 } from '@sentry/core';
 export { expressErrorHandler } from '@sentry/core';
 import { DEBUG_BUILD } from '../../debug-build';
+import { setHttpServerSpanRouteAttribute } from '../../utils/setHttpServerSpanRouteAttribute';
 
 const INTEGRATION_NAME = 'Express';
 const SUPPORTED_VERSIONS = ['>=4.0.0 <6'];
@@ -51,9 +50,8 @@ export class ExpressInstrumentation extends InstrumentationBase<ExpressInstrumen
           patchExpressModule(express, () => ({
             ...this.getConfig(),
             onRouteResolved(route) {
-              const rpcMetadata = getRPCMetadata(context.active());
-              if (route && rpcMetadata?.type === RPCType.HTTP) {
-                rpcMetadata.route = route;
+              if (route) {
+                setHttpServerSpanRouteAttribute(route);
               }
             },
           }));

--- a/packages/node/src/integrations/tracing/fastify/v3/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/fastify/v3/instrumentation.ts
@@ -22,7 +22,6 @@
  */
 
 import { type Attributes, context, SpanStatusCode, trace } from '@opentelemetry/api';
-import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
@@ -37,6 +36,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   spanToJSON,
 } from '@sentry/core';
+import { setHttpServerSpanRouteAttribute } from '../../../../utils/setHttpServerSpanRouteAttribute';
 import type {
   FastifyErrorCodes,
   FastifyInstance,
@@ -99,12 +99,11 @@ export class FastifyInstrumentationV3 extends InstrumentationBase<FastifyInstrum
 
       const anyRequest = request as any;
 
-      const rpcMetadata = getRPCMetadata(context.active());
       const routeName = anyRequest.routeOptions
         ? anyRequest.routeOptions.url // since fastify@4.10.0
         : request.routerPath;
-      if (routeName && rpcMetadata?.type === RPCType.HTTP) {
-        rpcMetadata.route = routeName;
+      if (routeName) {
+        setHttpServerSpanRouteAttribute(routeName);
       }
 
       const method = request.method || 'GET';

--- a/packages/node/src/integrations/tracing/fastify/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/fastify/vendored/instrumentation.ts
@@ -31,7 +31,6 @@
 
 import * as dc from 'node:diagnostics_channel';
 import { context, trace, SpanStatusCode, propagation, diag, type Span } from '@opentelemetry/api';
-import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import {
   ATTR_HTTP_ROUTE,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
@@ -40,6 +39,7 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import { InstrumentationBase, type InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { SDK_VERSION } from '@sentry/core';
+import { setHttpServerSpanRouteAttribute } from '../../../../utils/setHttpServerSpanRouteAttribute';
 
 const PACKAGE_VERSION = SDK_VERSION;
 const PACKAGE_NAME = '@sentry/instrumentation-fastify';
@@ -254,10 +254,8 @@ export class FastifyOtelInstrumentation extends InstrumentationBase<FastifyOtelI
             ctx = propagation.extract(ctx, request.headers);
           }
 
-          const rpcMetadata = getRPCMetadata(ctx);
-
-          if (request.routeOptions.url != null && rpcMetadata?.type === RPCType.HTTP) {
-            rpcMetadata.route = request.routeOptions.url;
+          if (request.routeOptions.url != null) {
+            setHttpServerSpanRouteAttribute(request.routeOptions.url);
           }
 
           const attributes: Record<string, string> = {

--- a/packages/node/src/integrations/tracing/hapi/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/hapi/vendored/instrumentation.ts
@@ -22,7 +22,7 @@
 /* eslint-disable */
 
 import * as api from '@opentelemetry/api';
-import { getRPCMetadata, RPCType } from '@opentelemetry/core';
+import { setHttpServerSpanRouteAttribute } from '../../../../utils/setHttpServerSpanRouteAttribute';
 import {
   InstrumentationBase,
   InstrumentationConfig,
@@ -309,10 +309,7 @@ export class HapiInstrumentation extends InstrumentationBase {
         if (api.trace.getSpan(api.context.active()) === undefined) {
           return await oldHandler.call(this, ...params);
         }
-        const rpcMetadata = getRPCMetadata(api.context.active());
-        if (rpcMetadata?.type === RPCType.HTTP) {
-          rpcMetadata.route = route.path;
-        }
+        setHttpServerSpanRouteAttribute(route.path);
         const metadata = getRouteMetadata(route, instrumentation._semconvStability, pluginName);
         const span = instrumentation.tracer.startSpan(metadata.name, {
           attributes: metadata.attributes,

--- a/packages/node/src/integrations/tracing/koa/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/koa/vendored/instrumentation.ts
@@ -31,7 +31,7 @@ import {
 import { KoaLayerType, KoaInstrumentationConfig } from './types';
 import { SDK_VERSION } from '@sentry/core';
 import { getMiddlewareMetadata, isLayerIgnored } from './utils';
-import { getRPCMetadata, RPCType } from '@opentelemetry/core';
+import { setHttpServerSpanRouteAttribute } from '../../../../utils/setHttpServerSpanRouteAttribute';
 import { Next, kLayerPatched, KoaContext, KoaMiddleware, KoaPatchedMiddleware } from './internal-types';
 
 const PACKAGE_NAME = '@sentry/instrumentation-koa';
@@ -156,10 +156,8 @@ export class KoaInstrumentation extends InstrumentationBase<KoaInstrumentationCo
         attributes: metadata.attributes,
       });
 
-      const rpcMetadata = getRPCMetadata(api.context.active());
-
-      if (rpcMetadata?.type === RPCType.HTTP && context._matchedRoute) {
-        rpcMetadata.route = context._matchedRoute.toString();
+      if (context._matchedRoute) {
+        setHttpServerSpanRouteAttribute(context._matchedRoute.toString());
       }
 
       const { requestHook } = this.getConfig();

--- a/packages/node/src/utils/setHttpServerSpanRouteAttribute.ts
+++ b/packages/node/src/utils/setHttpServerSpanRouteAttribute.ts
@@ -1,0 +1,23 @@
+import { getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_OP, spanToJSON } from '@sentry/core';
+
+/**
+ * Set the `http.route` attribute on the root HTTP server span for the current trace.
+ *
+ * No-op when there is no active span, no root span, or the root span is not an
+ * `http.server` span — so framework instrumentations can call this unconditionally
+ * without risking attribute pollution on non-HTTP root spans.
+ */
+export function setHttpServerSpanRouteAttribute(route: string): void {
+  const activeSpan = getActiveSpan();
+  if (!activeSpan) {
+    return;
+  }
+  const rootSpan = getRootSpan(activeSpan);
+  if (!rootSpan) {
+    return;
+  }
+  if (spanToJSON(rootSpan).data[SEMANTIC_ATTRIBUTE_SENTRY_OP] !== 'http.server') {
+    return;
+  }
+  rootSpan.setAttribute('http.route', route);
+}

--- a/packages/react-router/src/server/createServerInstrumentation.ts
+++ b/packages/react-router/src/server/createServerInstrumentation.ts
@@ -1,5 +1,4 @@
 import { context, createContextKey } from '@opentelemetry/api';
-import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import {
   debug,
@@ -253,11 +252,6 @@ function updateRootSpanWithRoute(method: string, pattern: string | undefined, ur
 
   const hasPattern = !!pattern;
   const routeName = hasPattern ? normalizeRoutePath(pattern) || urlPath : urlPath;
-
-  const rpcMetadata = getRPCMetadata(context.active());
-  if (rpcMetadata?.type === RPCType.HTTP) {
-    rpcMetadata.route = routeName;
-  }
 
   const transactionName = `${method} ${routeName}`;
   updateSpanName(rootSpan, transactionName);

--- a/packages/react-router/src/server/wrapSentryHandleRequest.ts
+++ b/packages/react-router/src/server/wrapSentryHandleRequest.ts
@@ -1,5 +1,3 @@
-import { context } from '@opentelemetry/api';
-import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import {
   flushIfServerless,
@@ -72,13 +70,6 @@ export function wrapSentryHandleRequest(
     if (parameterizedPath && rootSpan) {
       // Normalize route name - avoid "//" for root routes
       const routeName = parameterizedPath.startsWith('/') ? parameterizedPath : `/${parameterizedPath}`;
-
-      // The express instrumentation writes on the rpcMetadata and that ends up stomping on the `http.route` attribute.
-      const rpcMetadata = getRPCMetadata(context.active());
-
-      if (rpcMetadata?.type === RPCType.HTTP) {
-        rpcMetadata.route = routeName;
-      }
 
       const transactionName = `${request.method} ${routeName}`;
 

--- a/packages/react-router/test/server/getMetaTagTransformer.test.ts
+++ b/packages/react-router/test/server/getMetaTagTransformer.test.ts
@@ -3,11 +3,6 @@ import { PassThrough } from 'stream';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { getMetaTagTransformer } from '../../src/server/getMetaTagTransformer';
 
-vi.mock('@opentelemetry/core', () => ({
-  RPCType: { HTTP: 'http' },
-  getRPCMetadata: vi.fn(),
-}));
-
 vi.mock('@sentry/core', () => ({
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE: 'sentry.source',
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN: 'sentry.origin',

--- a/packages/react-router/test/server/wrapSentryHandleRequest.test.ts
+++ b/packages/react-router/test/server/wrapSentryHandleRequest.test.ts
@@ -1,5 +1,4 @@
 import { PassThrough } from 'node:stream';
-import { RPCType } from '@opentelemetry/core';
 import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import {
   flushIfServerless,
@@ -13,10 +12,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { getMetaTagTransformer } from '../../src/server/getMetaTagTransformer';
 import { wrapSentryHandleRequest } from '../../src/server/wrapSentryHandleRequest';
 
-vi.mock('@opentelemetry/core', () => ({
-  RPCType: { HTTP: 'http' },
-  getRPCMetadata: vi.fn(),
-}));
 vi.mock('@sentry/core', () => ({
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE: 'sentry.source',
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN: 'sentry.origin',
@@ -64,13 +59,9 @@ describe('wrapSentryHandleRequest', () => {
 
     const mockActiveSpan = {};
     const mockRootSpan = { setAttributes: vi.fn() };
-    const mockRpcMetadata = { type: RPCType.HTTP, route: '/some-path' };
 
     (getActiveSpan as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockActiveSpan);
     (getRootSpan as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockRootSpan);
-    const getRPCMetadata = vi.fn().mockReturnValue(mockRpcMetadata);
-    (vi.importActual('@opentelemetry/core') as unknown as { getRPCMetadata: typeof getRPCMetadata }).getRPCMetadata =
-      getRPCMetadata;
 
     const routerContext = {
       staticHandlerContext: {
@@ -85,7 +76,6 @@ describe('wrapSentryHandleRequest', () => {
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.react_router.request_handler',
     });
-    expect(mockRpcMetadata.route).toBe('/some-path');
   });
 
   test('should not set span attributes when parameterized path does not exist', async () => {
@@ -113,13 +103,10 @@ describe('wrapSentryHandleRequest', () => {
     const originalHandler = vi.fn().mockResolvedValue('test');
     const wrappedHandler = wrapSentryHandleRequest(originalHandler);
 
-    const mockRpcMetadata = { type: RPCType.HTTP, route: '/some-path' };
+    const mockRootSpan = { setAttributes: vi.fn() };
 
     (getActiveSpan as unknown as ReturnType<typeof vi.fn>).mockReturnValue(null);
-
-    const getRPCMetadata = vi.fn().mockReturnValue(mockRpcMetadata);
-    (vi.importActual('@opentelemetry/core') as unknown as { getRPCMetadata: typeof getRPCMetadata }).getRPCMetadata =
-      getRPCMetadata;
+    (getRootSpan as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockRootSpan);
 
     const routerContext = {
       staticHandlerContext: {
@@ -129,7 +116,7 @@ describe('wrapSentryHandleRequest', () => {
 
     await wrappedHandler(new Request('https://tio.pepe'), 200, new Headers(), routerContext, {} as any);
 
-    expect(getRPCMetadata).not.toHaveBeenCalled();
+    expect(mockRootSpan.setAttributes).not.toHaveBeenCalled();
   });
 
   test('should call flushIfServerless on successful execution', async () => {
@@ -190,13 +177,9 @@ describe('wrapSentryHandleRequest', () => {
 
     const mockActiveSpan = {};
     const mockRootSpan = { setAttributes: vi.fn() };
-    const mockRpcMetadata = { type: RPCType.HTTP, route: '/some-path' };
 
     (getActiveSpan as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockActiveSpan);
     (getRootSpan as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockRootSpan);
-    const getRPCMetadata = vi.fn().mockReturnValue(mockRpcMetadata);
-    (vi.importActual('@opentelemetry/core') as unknown as { getRPCMetadata: typeof getRPCMetadata }).getRPCMetadata =
-      getRPCMetadata;
 
     const routerContext = {
       staticHandlerContext: {
@@ -211,7 +194,6 @@ describe('wrapSentryHandleRequest', () => {
       [ATTR_HTTP_ROUTE]: '/some-path',
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
     });
-    expect(mockRpcMetadata.route).toBe('/some-path');
   });
 });
 


### PR DESCRIPTION
## Summary

Sentry's framework instrumentations used to write the matched route by mutating OpenTelemetry's RPC-metadata context object (`getRPCMetadata(ctx).route = ...`). The HTTP server-span integration then read that value at response time and copied it to `http.route` on the span.

This PR cuts out the middle step for our own write sites: instead of mutating RPC metadata, framework instrumentations now write `http.route` directly onto the root `http.server` span via a small new helper, `setHttpServerSpanRouteAttribute(route)` in `@sentry/node`.

`@sentry/node-core`'s HTTP server-span integration **still reads** RPC metadata at response time, so any third-party OTel instrumentation that follows the upstream pattern (e.g. `@opentelemetry/instrumentation-*`) keeps working unchanged.

## What changed

- Added `packages/node/src/utils/setHttpServerSpanRouteAttribute.ts`. Resolves the root span via `getActiveSpan` / `getRootSpan`, guards on `op === 'http.server'` so it can't accidentally mutate non-HTTP root spans, and sets the `http.route` attribute.
- Switched the following Sentry-owned and vendored framework instrumentations to use it instead of writing to RPC metadata:
  - `packages/node/src/integrations/tracing/express.ts`
  - `packages/node/src/integrations/tracing/fastify/v3/instrumentation.ts`
  - `packages/node/src/integrations/tracing/fastify/vendored/instrumentation.ts`
  - `packages/node/src/integrations/tracing/connect/vendored/instrumentation.ts`
  - `packages/node/src/integrations/tracing/hapi/vendored/instrumentation.ts`
  - `packages/node/src/integrations/tracing/koa/vendored/instrumentation.ts`
- `packages/react-router/src/server/createServerInstrumentation.ts` and `wrapSentryHandleRequest.ts` already set `http.route` on the span directly; dropped the redundant `rpcMetadata.route = ...` (and the no-longer-needed `@opentelemetry/api` + `@opentelemetry/core` imports there).

## Test updates

`packages/react-router/test/server/{wrapSentryHandleRequest,getMetaTagTransformer}.test.ts` were mocking `@opentelemetry/core`'s `getRPCMetadata`. Mocks and the `RPCType` import are removed; the assertions now just verify the span-attribute path that was already being asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)