### PR TITLE
ref(browser): split web vitals integration

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/init.js
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    Sentry.browserTracingIntegration({
+      idleTimeout: 1000,
+    }),
+  ],
+  tracesSampleRate: 1,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/template.html
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/template.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <div>Rendered</div>
+  </body>
+</html>

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/test.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/core';
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
+
+sentryTest.beforeEach(({ browserName }) => {
+  if (shouldSkipTracingTest() || browserName !== 'chromium') {
+    sentryTest.skip();
+  }
+});
+
+// `connection.rtt` is recorded as a measurement, which is only flushed on the pageload
+// transaction. It must not leak onto navigation transactions.
+sentryTest(
+  'records `connection.rtt` as a measurement on pageload but not on navigation transactions',
+  async ({ getLocalTestUrl, page }) => {
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const pageloadRequest = await getFirstSentryEnvelopeRequest<Event>(page, url);
+    const navigationRequest = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+
+    expect(pageloadRequest.contexts?.trace?.op).toBe('pageload');
+    expect(navigationRequest.contexts?.trace?.op).toBe('navigation');
+
+    expect(pageloadRequest.measurements?.['connection.rtt']?.value).toBeDefined();
+    expect(navigationRequest.measurements?.['connection.rtt']).toBeUndefined();
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
+import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../utils/helpers';
 
 sentryTest.beforeEach(({ browserName }) => {
   if (shouldSkipTracingTest() || browserName !== 'chromium') {
@@ -14,10 +14,19 @@ sentryTest.beforeEach(({ browserName }) => {
 sentryTest(
   'records `connection.rtt` as a measurement on pageload but not on navigation transactions',
   async ({ getLocalTestUrl, page }) => {
+    const pageloadRequestPromise = waitForTransactionRequest(page, event => event.contexts?.trace?.op === 'pageload');
     const url = await getLocalTestUrl({ testDir: __dirname });
+    await page.goto(url);
 
-    const pageloadRequest = await getFirstSentryEnvelopeRequest<Event>(page, url);
-    const navigationRequest = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
+    const pageloadRequest = envelopeRequestParser(await pageloadRequestPromise) as Event;
+
+    const navigationRequestPromise = waitForTransactionRequest(
+      page,
+      event => event.contexts?.trace?.op === 'navigation',
+    );
+    await page.goto(`${url}#foo`);
+
+    const navigationRequest = envelopeRequestParser(await navigationRequestPromise) as Event;
 
     expect(pageloadRequest.contexts?.trace?.op).toBe('pageload');
     expect(navigationRequest.contexts?.trace?.op).toBe('navigation');

--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -8,6 +8,7 @@ export {
 
 export {
   addPerformanceEntries,
+  addWebVitalsToSpan,
   startTrackingInteractions,
   startTrackingLongTasks,
   startTrackingLongAnimationFrames,

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -823,7 +823,9 @@ function _trackNavigator(span: Span, spanStreamingEnabled: boolean | undefined):
     if (isMeasurementValue(connection.rtt)) {
       if (spanStreamingEnabled) {
         span.setAttribute('network.connection.rtt', connection.rtt);
-      } else {
+      } else if (spanToJSON(span).op === 'pageload') {
+        // Measurements are only recorded on the pageload span, matching the historical
+        // behavior where `connection.rtt` was only flushed for pageload transactions.
         setMeasurement('connection.rtt', connection.rtt, 'millisecond');
       }
     }

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -445,6 +445,7 @@ export function addWebVitalsToSpan(span: Span, options: AddWebVitalsToSpanOption
   const origin = browserPerformanceTimeOrigin();
   if (!getBrowserPerformanceAPI()?.getEntries || !origin) {
     // Gatekeeper if performance API not available
+    resetWebVitalState();
     return;
   }
 
@@ -506,6 +507,10 @@ export function addWebVitalsToSpan(span: Span, options: AddWebVitalsToSpanOption
     );
   }
 
+  resetWebVitalState();
+}
+
+function resetWebVitalState(): void {
   _lcpEntry = undefined;
   _clsEntry = undefined;
   _measurements = {};

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -486,7 +486,7 @@ export function addWebVitalsToSpan(span: Span, options: AddWebVitalsToSpanOption
       }
 
       Object.entries(_measurements).forEach(([measurementName, measurement]) => {
-        setMeasurement(measurementName, measurement.value, measurement.unit);
+        setMeasurement(measurementName, measurement.value, measurement.unit, span);
       });
 
       _setWebVitalAttributes(span, options);

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -123,9 +123,11 @@ export function startTrackingWebVitals({
         : undefined;
 
     const ttfbCleanupCallback = _trackTtfb();
+    const fpFcpCleanupCallback = _trackFpFcp();
 
     return (): void => {
       ttfbCleanupCallback();
+      fpFcpCleanupCallback();
       lcpCleanupCallback?.();
       clsCleanupCallback?.();
     };
@@ -303,25 +305,24 @@ function _trackTtfb(): () => void {
   });
 }
 
+/** Starts tracking First Paint and First Contentful Paint on the current page. */
+function _trackFpFcp(): () => void {
+  return addPerformanceInstrumentationHandler('paint', ({ entries }) => {
+    const firstHidden = getVisibilityWatcher();
+    for (const entry of entries) {
+      // Only report if the page wasn't hidden prior to the web vital.
+      const shouldRecord = entry.startTime < firstHidden.firstHiddenTime;
+      if (entry.name === 'first-paint' && shouldRecord) {
+        _measurements['fp'] = { value: entry.startTime, unit: 'millisecond' };
+      }
+      if (entry.name === 'first-contentful-paint' && shouldRecord) {
+        _measurements['fcp'] = { value: entry.startTime, unit: 'millisecond' };
+      }
+    }
+  });
+}
+
 interface AddPerformanceEntriesOptions {
-  /**
-   * Flag to determine if CLS should be recorded as a measurement on the pageload span or
-   * sent as a standalone span instead.
-   * Sending it as a standalone span will yield more accurate LCP values.
-   *
-   * Default: `false` for backwards compatibility.
-   */
-  recordClsOnPageloadSpan: boolean;
-
-  /**
-   * Flag to determine if LCP should be recorded as a measurement on the pageload span or
-   * sent as a standalone span instead.
-   * Sending it as a standalone span will yield more accurate LCP values.
-   *
-   * Default: `false` for backwards compatibility.
-   */
-  recordLcpOnPageloadSpan: boolean;
-
   /**
    * Resource spans with `op`s matching strings in the array will not be emitted.
    *
@@ -344,6 +345,31 @@ interface AddPerformanceEntriesOptions {
   spanStreamingEnabled?: boolean;
 }
 
+interface AddWebVitalsToSpanOptions {
+  /**
+   * Flag to determine if CLS should be recorded as a measurement on the pageload span or
+   * sent as a standalone span instead.
+   * Sending it as a standalone span will yield more accurate LCP values.
+   *
+   * Default: `false` for backwards compatibility.
+   */
+  recordClsOnPageloadSpan: boolean;
+
+  /**
+   * Flag to determine if LCP should be recorded as a measurement on the pageload span or
+   * sent as a standalone span instead.
+   * Sending it as a standalone span will yield more accurate LCP values.
+   *
+   * Default: `false` for backwards compatibility.
+   */
+  recordLcpOnPageloadSpan: boolean;
+
+  /**
+   * Whether span streaming is enabled.
+   */
+  spanStreamingEnabled?: boolean;
+}
+
 /** Add performance related spans to a transaction */
 export function addPerformanceEntries(span: Span, options: AddPerformanceEntriesOptions): void {
   const performance = getBrowserPerformanceAPI();
@@ -353,13 +379,7 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
     return;
   }
 
-  const {
-    spanStreamingEnabled,
-    ignorePerformanceApiSpans,
-    ignoreResourceSpans,
-    recordClsOnPageloadSpan,
-    recordLcpOnPageloadSpan,
-  } = options;
+  const { spanStreamingEnabled, ignorePerformanceApiSpans, ignoreResourceSpans } = options;
 
   const timeOrigin = msToSec(origin);
 
@@ -390,18 +410,6 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
       case 'paint':
       case 'measure': {
         _addMeasureSpans(span, entry, startTime, duration, timeOrigin, ignorePerformanceApiSpans);
-
-        // capture web vitals
-        const firstHidden = getVisibilityWatcher();
-        // Only report if the page wasn't hidden prior to the web vital.
-        const shouldRecord = entry.startTime < firstHidden.firstHiddenTime;
-
-        if (entry.name === 'first-paint' && shouldRecord) {
-          _measurements['fp'] = { value: entry.startTime, unit: 'millisecond' };
-        }
-        if (entry.name === 'first-contentful-paint' && shouldRecord) {
-          _measurements['fcp'] = { value: entry.startTime, unit: 'millisecond' };
-        }
         break;
       }
       case 'resource': {
@@ -423,9 +431,28 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
   _performanceCursor = Math.max(performanceEntries.length - 1, 0);
 
   _trackNavigator(span, spanStreamingEnabled);
+}
+
+/**
+ * Writes the collected web vitals (LCP, CLS, INP, TTFB, FP, FCP) onto the pageload span,
+ * either as measurements/attributes (v1) or as web vital attributes (span streaming).
+ *
+ * This should be called when the pageload span ends, after the web vitals have been finalized.
+ * It is a no-op for non-pageload spans, but always resets the collected web vital state so it
+ * doesn't leak into a subsequent navigation.
+ */
+export function addWebVitalsToSpan(span: Span, options: AddWebVitalsToSpanOptions): void {
+  const origin = browserPerformanceTimeOrigin();
+  if (!getBrowserPerformanceAPI()?.getEntries || !origin) {
+    // Gatekeeper if performance API not available
+    return;
+  }
+
+  const { spanStreamingEnabled, recordClsOnPageloadSpan, recordLcpOnPageloadSpan } = options;
+  const timeOrigin = msToSec(origin);
 
   // Measurements are only available for pageload transactions
-  if (op === 'pageload') {
+  if (spanToJSON(span).op === 'pageload') {
     _addTtfbRequestTimeToMeasurements(_measurements);
 
     if (spanStreamingEnabled) {
@@ -794,9 +821,10 @@ function _trackNavigator(span: Span, spanStreamingEnabled: boolean | undefined):
     }
 
     if (isMeasurementValue(connection.rtt)) {
-      _measurements['connection.rtt'] = { value: connection.rtt, unit: 'millisecond' };
       if (spanStreamingEnabled) {
         span.setAttribute('network.connection.rtt', connection.rtt);
+      } else {
+        setMeasurement('connection.rtt', connection.rtt, 'millisecond');
       }
     }
   }
@@ -819,7 +847,7 @@ function _trackNavigator(span: Span, spanStreamingEnabled: boolean | undefined):
 }
 
 /** Add LCP / CLS data to span to allow debugging */
-function _setWebVitalAttributes(span: Span, options: AddPerformanceEntriesOptions): void {
+function _setWebVitalAttributes(span: Span, options: AddWebVitalsToSpanOptions): void {
   // Only add LCP attributes if LCP is being recorded on the pageload span
   if (_lcpEntry && options.recordLcpOnPageloadSpan) {
     // Capture Properties of the LCP element that contributes to the LCP.

--- a/packages/browser-utils/test/browser/browserMetrics.test.ts
+++ b/packages/browser-utils/test/browser/browserMetrics.test.ts
@@ -9,12 +9,14 @@ import {
   setCurrentClient,
   spanToJSON,
 } from '@sentry/core';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   _addMeasureSpans,
   _addNavigationSpans,
   _addResourceSpans,
   _setResourceRequestAttributes,
+  addWebVitalsToSpan,
+  startTrackingWebVitals,
 } from '../../src/metrics/browserMetrics';
 import { WINDOW } from '../../src/types';
 import { getDefaultClientOptions, TestClient } from '../utils/TestClient';
@@ -46,6 +48,102 @@ function mockPerformanceResourceTiming(
 ): PerformanceResourceTiming & AdditionalPerformanceResourceTiming {
   return data as PerformanceResourceTiming & AdditionalPerformanceResourceTiming;
 }
+
+describe('addWebVitalsToSpan', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+
+    const client = new TestClient(
+      getDefaultClientOptions({
+        tracesSampleRate: 1,
+      }),
+    );
+    setCurrentClient(client);
+    client.init();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('clears pending measurements when the performance API is unavailable', async () => {
+    let performanceObserverCallback: ((list: PerformanceObserverEntryList) => void) | undefined;
+    class MockPerformanceObserver {
+      public static supportedEntryTypes = ['paint'];
+
+      public constructor(callback: (list: PerformanceObserverEntryList) => void) {
+        performanceObserverCallback = callback;
+      }
+
+      public observe(): void {
+        // noop
+      }
+
+      public disconnect(): void {
+        // noop
+      }
+    }
+
+    vi.stubGlobal('PerformanceObserver', MockPerformanceObserver);
+    vi.stubGlobal('addEventListener', vi.fn());
+    vi.stubGlobal('removeEventListener', vi.fn());
+    vi.stubGlobal('document', {
+      prerendering: false,
+      readyState: 'complete',
+      visibilityState: 'visible',
+    });
+
+    const cleanupWebVitals = startTrackingWebVitals({
+      recordClsStandaloneSpans: undefined,
+      recordLcpStandaloneSpans: undefined,
+      client: getClient()!,
+    });
+
+    performanceObserverCallback?.({
+      getEntries: () => [
+        {
+          entryType: 'paint',
+          name: 'first-paint',
+          duration: 0,
+          startTime: 12,
+          toJSON: () => ({}),
+        },
+        {
+          entryType: 'paint',
+          name: 'first-contentful-paint',
+          duration: 0,
+          startTime: 18,
+          toJSON: () => ({}),
+        },
+      ],
+    } as PerformanceObserverEntryList);
+    await Promise.resolve();
+    cleanupWebVitals();
+
+    vi.stubGlobal('addEventListener', undefined);
+    const spanWithPendingMeasurements = new SentrySpan({ op: 'pageload', name: '/', sampled: true });
+    addWebVitalsToSpan(spanWithPendingMeasurements, {
+      recordClsOnPageloadSpan: true,
+      recordLcpOnPageloadSpan: true,
+      spanStreamingEnabled: true,
+    });
+
+    vi.stubGlobal('addEventListener', vi.fn());
+
+    const nextPageloadSpan = new SentrySpan({ op: 'pageload', name: '/', sampled: true });
+    addWebVitalsToSpan(nextPageloadSpan, {
+      recordClsOnPageloadSpan: true,
+      recordLcpOnPageloadSpan: true,
+      spanStreamingEnabled: true,
+    });
+
+    expect(spanToJSON(nextPageloadSpan).data['browser.web_vital.fp.value']).toBeUndefined();
+    expect(spanToJSON(nextPageloadSpan).data['browser.web_vital.fcp.value']).toBeUndefined();
+  });
+});
 
 describe('_addMeasureSpans', () => {
   const span = new SentrySpan({ op: 'pageload', name: '/', sampled: true });

--- a/packages/browser/src/index.bundle.tracing.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.logs.metrics.ts
@@ -32,6 +32,7 @@ export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
 export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
+export { webVitalsIntegration } from './integrations/webVitals';
 
 export {
   feedbackIntegrationShim as feedbackAsyncIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
@@ -32,6 +32,7 @@ export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
 export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
+export { webVitalsIntegration } from './integrations/webVitals';
 
 export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
 

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -38,6 +38,7 @@ export { reportPageLoaded } from './tracing/reportPageLoaded';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
 export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
+export { webVitalsIntegration } from './integrations/webVitals';
 
 export { getFeedback, sendFeedback } from '@sentry-internal/feedback';
 

--- a/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
@@ -32,6 +32,7 @@ export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
 export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
+export { webVitalsIntegration } from './integrations/webVitals';
 
 export { feedbackIntegrationShim as feedbackAsyncIntegration, feedbackIntegrationShim as feedbackIntegration };
 

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -37,6 +37,7 @@ export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
 export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
+export { webVitalsIntegration } from './integrations/webVitals';
 
 export { feedbackIntegrationShim as feedbackAsyncIntegration, feedbackIntegrationShim as feedbackIntegration };
 

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -39,6 +39,7 @@ export { reportPageLoaded } from './tracing/reportPageLoaded';
 
 export { spanStreamingIntegration } from './integrations/spanstreaming';
 export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
+export { webVitalsIntegration } from './integrations/webVitals';
 
 export {
   feedbackIntegrationShim as feedbackAsyncIntegration,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -47,6 +47,7 @@ export { reportPageLoaded } from './tracing/reportPageLoaded';
 export { setActiveSpanInBrowser } from './tracing/setActiveSpan';
 export { spanStreamingIntegration } from './integrations/spanstreaming';
 export { fetchStreamPerformanceIntegration } from './integrations/fetchStreamPerformance';
+export { webVitalsIntegration } from './integrations/webVitals';
 
 export type { RequestInstrumentationOptions } from './tracing/request';
 export {

--- a/packages/browser/src/integrations/webVitals.ts
+++ b/packages/browser/src/integrations/webVitals.ts
@@ -17,7 +17,7 @@ export interface WebVitalsOptions {
   /**
    * Web vitals to skip.
    */
-  disable?: WebVitalName[];
+  ignore?: WebVitalName[];
 
   /**
    * @experimental
@@ -42,7 +42,7 @@ export function collectWebVitalsForClient(client: Client): void {
  * needed to customize options or to use it without `browserTracingIntegration`.
  */
 export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions = {}) => {
-  const disabled = new Set(options.disable ?? []);
+  const ignored = new Set(options.ignore ?? []);
 
   return {
     name: WEB_VITALS_INTEGRATION_NAME,
@@ -54,29 +54,29 @@ export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions
         client,
         startTrackingWebVitals({
           recordClsStandaloneSpans:
-            spanStreamingEnabled || disabled.has('cls') ? undefined : enableStandaloneClsSpans || false,
+            spanStreamingEnabled || ignored.has('cls') ? undefined : enableStandaloneClsSpans || false,
           recordLcpStandaloneSpans:
-            spanStreamingEnabled || disabled.has('lcp') ? undefined : enableStandaloneLcpSpans || false,
+            spanStreamingEnabled || ignored.has('lcp') ? undefined : enableStandaloneLcpSpans || false,
           client,
         }),
       );
 
       if (spanStreamingEnabled) {
-        if (!disabled.has('lcp')) {
+        if (!ignored.has('lcp')) {
           trackLcpAsSpan(client);
         }
-        if (!disabled.has('cls')) {
+        if (!ignored.has('cls')) {
           trackClsAsSpan(client);
         }
-        if (!disabled.has('inp')) {
+        if (!ignored.has('inp')) {
           trackInpAsSpan();
         }
-      } else if (!disabled.has('inp')) {
+      } else if (!ignored.has('inp')) {
         startTrackingINP();
       }
     },
     afterAllSetup() {
-      if (!disabled.has('inp')) {
+      if (!ignored.has('inp')) {
         registerInpInteractionListener();
       }
     },

--- a/packages/browser/src/integrations/webVitals.ts
+++ b/packages/browser/src/integrations/webVitals.ts
@@ -1,4 +1,4 @@
-import type { Client, IntegrationFn, Span } from '@sentry/core/browser';
+import type { IntegrationFn, Span } from '@sentry/core/browser';
 import { defineIntegration, hasSpanStreamingEnabled } from '@sentry/core/browser';
 import {
   addWebVitalsToSpan,
@@ -29,16 +29,6 @@ export interface WebVitalsOptions {
   }>;
 }
 
-const collectWebVitalsCallbacks = new WeakMap<Client, (span: Span) => void>();
-
-/**
- * Finalizes the collected web vitals and writes them onto the given (pageload) span.
- * Called by `browserTracingIntegration` when the pageload/navigation span ends.
- */
-export function collectWebVitalsForClient(client: Client, span: Span): void {
-  collectWebVitalsCallbacks.get(client)?.(span);
-}
-
 /**
  * Captures Core Web Vitals (LCP, CLS, INP) and related pageload vitals.
  *
@@ -66,14 +56,16 @@ export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions
         client,
       });
 
-      collectWebVitalsCallbacks.set(client, span => {
-        finalizeWebVitals();
-        addWebVitalsToSpan(span, {
-          // CLS/LCP are recorded as pageload span measurements only when they're neither
-          // tracked as standalone spans nor handled by span streaming (and not ignored).
-          recordClsOnPageloadSpan: recordClsStandaloneSpans === false,
-          recordLcpOnPageloadSpan: recordLcpStandaloneSpans === false,
-          spanStreamingEnabled,
+      client.on('afterStartPageLoadSpan', span => {
+        wrapPageloadSpanEnd(span, () => {
+          finalizeWebVitals();
+          addWebVitalsToSpan(span, {
+            // CLS/LCP are recorded as pageload span measurements only when they're neither
+            // tracked as standalone spans nor handled by span streaming (and not ignored).
+            recordClsOnPageloadSpan: recordClsStandaloneSpans === false,
+            recordLcpOnPageloadSpan: recordLcpStandaloneSpans === false,
+            spanStreamingEnabled,
+          });
         });
       });
 
@@ -98,3 +90,17 @@ export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions
     },
   };
 }) satisfies IntegrationFn;
+
+function wrapPageloadSpanEnd(span: Span, beforeEnd: () => void): void {
+  let hasEnded = false;
+  const originalEnd = span.end.bind(span);
+
+  span.end = (...args: Parameters<Span['end']>): void => {
+    if (!hasEnded) {
+      hasEnded = true;
+      beforeEnd();
+    }
+
+    originalEnd(...args);
+  };
+}

--- a/packages/browser/src/integrations/webVitals.ts
+++ b/packages/browser/src/integrations/webVitals.ts
@@ -1,0 +1,84 @@
+import type { Client, IntegrationFn } from '@sentry/core/browser';
+import { defineIntegration, hasSpanStreamingEnabled } from '@sentry/core/browser';
+import {
+  registerInpInteractionListener,
+  startTrackingINP,
+  startTrackingWebVitals,
+  trackClsAsSpan,
+  trackInpAsSpan,
+  trackLcpAsSpan,
+} from '@sentry-internal/browser-utils';
+
+export const WEB_VITALS_INTEGRATION_NAME = 'WebVitals';
+
+export type WebVitalName = 'cls' | 'inp' | 'lcp';
+
+export interface WebVitalsOptions {
+  /**
+   * Web vitals to skip.
+   */
+  disable?: WebVitalName[];
+
+  /**
+   * @experimental
+   */
+  _experiments?: Partial<{
+    enableStandaloneClsSpans: boolean;
+    enableStandaloneLcpSpans: boolean;
+  }>;
+}
+
+const collectWebVitalsCallbacks = new WeakMap<Client, () => void>();
+
+export function collectWebVitalsForClient(client: Client): void {
+  collectWebVitalsCallbacks.get(client)?.();
+}
+
+/**
+ * Captures Core Web Vitals (LCP, CLS, INP) and related pageload vitals.
+ *
+ * `browserTracingIntegration` auto-registers this integration if no
+ * `webVitalsIntegration` is already present, so explicit registration is only
+ * needed to customize options or to use it without `browserTracingIntegration`.
+ */
+export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions = {}) => {
+  const disabled = new Set(options.disable ?? []);
+
+  return {
+    name: WEB_VITALS_INTEGRATION_NAME,
+    setup(client) {
+      const spanStreamingEnabled = hasSpanStreamingEnabled(client);
+      const { enableStandaloneClsSpans, enableStandaloneLcpSpans } = options._experiments ?? {};
+
+      collectWebVitalsCallbacks.set(
+        client,
+        startTrackingWebVitals({
+          recordClsStandaloneSpans:
+            spanStreamingEnabled || disabled.has('cls') ? undefined : enableStandaloneClsSpans || false,
+          recordLcpStandaloneSpans:
+            spanStreamingEnabled || disabled.has('lcp') ? undefined : enableStandaloneLcpSpans || false,
+          client,
+        }),
+      );
+
+      if (spanStreamingEnabled) {
+        if (!disabled.has('lcp')) {
+          trackLcpAsSpan(client);
+        }
+        if (!disabled.has('cls')) {
+          trackClsAsSpan(client);
+        }
+        if (!disabled.has('inp')) {
+          trackInpAsSpan();
+        }
+      } else if (!disabled.has('inp')) {
+        startTrackingINP();
+      }
+    },
+    afterAllSetup() {
+      if (!disabled.has('inp')) {
+        registerInpInteractionListener();
+      }
+    },
+  };
+}) satisfies IntegrationFn;

--- a/packages/browser/src/integrations/webVitals.ts
+++ b/packages/browser/src/integrations/webVitals.ts
@@ -1,6 +1,7 @@
-import type { Client, IntegrationFn } from '@sentry/core/browser';
+import type { Client, IntegrationFn, Span } from '@sentry/core/browser';
 import { defineIntegration, hasSpanStreamingEnabled } from '@sentry/core/browser';
 import {
+  addWebVitalsToSpan,
   registerInpInteractionListener,
   startTrackingINP,
   startTrackingWebVitals,
@@ -28,10 +29,14 @@ export interface WebVitalsOptions {
   }>;
 }
 
-const collectWebVitalsCallbacks = new WeakMap<Client, () => void>();
+const collectWebVitalsCallbacks = new WeakMap<Client, (span: Span) => void>();
 
-export function collectWebVitalsForClient(client: Client): void {
-  collectWebVitalsCallbacks.get(client)?.();
+/**
+ * Finalizes the collected web vitals and writes them onto the given (pageload) span.
+ * Called by `browserTracingIntegration` when the pageload/navigation span ends.
+ */
+export function collectWebVitalsForClient(client: Client, span: Span): void {
+  collectWebVitalsCallbacks.get(client)?.(span);
 }
 
 /**
@@ -50,16 +55,27 @@ export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions
       const spanStreamingEnabled = hasSpanStreamingEnabled(client);
       const { enableStandaloneClsSpans, enableStandaloneLcpSpans } = options._experiments ?? {};
 
-      collectWebVitalsCallbacks.set(
+      const recordClsStandaloneSpans =
+        spanStreamingEnabled || ignored.has('cls') ? undefined : enableStandaloneClsSpans || false;
+      const recordLcpStandaloneSpans =
+        spanStreamingEnabled || ignored.has('lcp') ? undefined : enableStandaloneLcpSpans || false;
+
+      const finalizeWebVitals = startTrackingWebVitals({
+        recordClsStandaloneSpans,
+        recordLcpStandaloneSpans,
         client,
-        startTrackingWebVitals({
-          recordClsStandaloneSpans:
-            spanStreamingEnabled || ignored.has('cls') ? undefined : enableStandaloneClsSpans || false,
-          recordLcpStandaloneSpans:
-            spanStreamingEnabled || ignored.has('lcp') ? undefined : enableStandaloneLcpSpans || false,
-          client,
-        }),
-      );
+      });
+
+      collectWebVitalsCallbacks.set(client, span => {
+        finalizeWebVitals();
+        addWebVitalsToSpan(span, {
+          // CLS/LCP are recorded as pageload span measurements only when they're neither
+          // tracked as standalone spans nor handled by span streaming (and not ignored).
+          recordClsOnPageloadSpan: recordClsStandaloneSpans === false,
+          recordLcpOnPageloadSpan: recordLcpStandaloneSpans === false,
+          spanStreamingEnabled,
+        });
+      });
 
       if (spanStreamingEnabled) {
         if (!ignored.has('lcp')) {

--- a/packages/browser/src/integrations/webVitals.ts
+++ b/packages/browser/src/integrations/webVitals.ts
@@ -56,16 +56,24 @@ export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions
         client,
       });
 
+      const pageloadSpans = new WeakSet<Span>();
+
       client.on('afterStartPageLoadSpan', span => {
-        wrapPageloadSpanEnd(span, () => {
-          finalizeWebVitals();
-          addWebVitalsToSpan(span, {
-            // CLS/LCP are recorded as pageload span measurements only when they're neither
-            // tracked as standalone spans nor handled by span streaming (and not ignored).
-            recordClsOnPageloadSpan: recordClsStandaloneSpans === false,
-            recordLcpOnPageloadSpan: recordLcpStandaloneSpans === false,
-            spanStreamingEnabled,
-          });
+        pageloadSpans.add(span);
+      });
+
+      client.on('spanEnd', span => {
+        if (!pageloadSpans.delete(span)) {
+          return;
+        }
+
+        finalizeWebVitals();
+        addWebVitalsToSpan(span, {
+          // CLS/LCP are recorded as pageload span measurements only when they're neither
+          // tracked as standalone spans nor handled by span streaming (and not ignored).
+          recordClsOnPageloadSpan: recordClsStandaloneSpans === false,
+          recordLcpOnPageloadSpan: recordLcpStandaloneSpans === false,
+          spanStreamingEnabled,
         });
       });
 
@@ -90,17 +98,3 @@ export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions
     },
   };
 }) satisfies IntegrationFn;
-
-function wrapPageloadSpanEnd(span: Span, beforeEnd: () => void): void {
-  let hasEnded = false;
-  const originalEnd = span.end.bind(span);
-
-  span.end = (...args: Parameters<Span['end']>): void => {
-    if (!hasEnded) {
-      hasEnded = true;
-      beforeEnd();
-    }
-
-    originalEnd(...args);
-  };
-}

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -456,14 +456,13 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       // should wait for finish signal if it's a pageload transaction
       disableAutoFinish: isPageloadSpan,
       beforeSpanEnd: span => {
-        collectWebVitalsForClient(client);
-        const spanStreamingEnabled = hasSpanStreamingEnabled(client);
+        // The webVitalsIntegration owns all web vital logic; it finalizes the collected
+        // web vitals and writes them onto the pageload span.
+        collectWebVitalsForClient(client, span);
         addPerformanceEntries(span, {
-          recordClsOnPageloadSpan: !spanStreamingEnabled && !enableStandaloneClsSpans,
-          recordLcpOnPageloadSpan: !spanStreamingEnabled && !enableStandaloneLcpSpans,
           ignoreResourceSpans,
           ignorePerformanceApiSpans,
-          spanStreamingEnabled,
+          spanStreamingEnabled: hasSpanStreamingEnabled(client),
         });
         setActiveIdleSpan(client, undefined);
 

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -659,7 +659,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       if (client.addIntegration && !client.getIntegrationByName?.(WEB_VITALS_INTEGRATION_NAME)) {
         client.addIntegration(
           webVitalsIntegration({
-            disable: enableInp ? [] : ['inp'],
+            ignore: enableInp ? [] : ['inp'],
             _experiments: {
               enableStandaloneClsSpans,
               enableStandaloneLcpSpans,

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -40,19 +40,18 @@ import {
 import {
   addHistoryInstrumentationHandler,
   addPerformanceEntries,
-  registerInpInteractionListener,
-  startTrackingINP,
   startTrackingInteractions,
   startTrackingLongAnimationFrames,
   startTrackingLongTasks,
-  startTrackingWebVitals,
-  trackClsAsSpan,
-  trackInpAsSpan,
-  trackLcpAsSpan,
 } from '@sentry-internal/browser-utils';
 import { DEBUG_BUILD } from '../debug-build';
 import { getHttpRequestData, WINDOW } from '../helpers';
 import { fetchStreamPerformanceIntegration } from '../integrations/fetchStreamPerformance';
+import {
+  collectWebVitalsForClient,
+  WEB_VITALS_INTEGRATION_NAME,
+  webVitalsIntegration,
+} from '../integrations/webVitals';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
@@ -415,7 +414,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
 
   const _isBot = isBotUserAgent();
 
-  let _collectWebVitals: undefined | (() => void);
   let lastInteractionTimestamp: number | undefined;
 
   let _pageloadSpan: Span | undefined;
@@ -458,9 +456,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       // should wait for finish signal if it's a pageload transaction
       disableAutoFinish: isPageloadSpan,
       beforeSpanEnd: span => {
-        // This will generally always be defined here, because it is set in `setup()` of the integration
-        // but technically, it is optional, so we guard here to be extra safe
-        _collectWebVitals?.();
+        collectWebVitalsForClient(client);
         const spanStreamingEnabled = hasSpanStreamingEnabled(client);
         addPerformanceEntries(span, {
           recordClsOnPageloadSpan: !spanStreamingEnabled && !enableStandaloneClsSpans,
@@ -523,24 +519,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       }
 
       registerSpanErrorInstrumentation();
-
-      const spanStreamingEnabled = hasSpanStreamingEnabled(client);
-
-      _collectWebVitals = startTrackingWebVitals({
-        recordClsStandaloneSpans: spanStreamingEnabled ? undefined : enableStandaloneClsSpans || false,
-        recordLcpStandaloneSpans: spanStreamingEnabled ? undefined : enableStandaloneLcpSpans || false,
-        client,
-      });
-
-      if (spanStreamingEnabled) {
-        trackLcpAsSpan(client);
-        trackClsAsSpan(client);
-        if (enableInp) {
-          trackInpAsSpan();
-        }
-      } else if (enableInp) {
-        startTrackingINP();
-      }
 
       if (
         enableLongAnimationFrame &&
@@ -675,6 +653,21 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
         return;
       }
 
+      // Auto-register webVitalsIntegration if the user hasn't added one. We do this in
+      // afterAllSetup so that a user-provided webVitalsIntegration - which may be ordered after
+      // browserTracingIntegration in the integrations array - has already been installed.
+      if (client.addIntegration && !client.getIntegrationByName?.(WEB_VITALS_INTEGRATION_NAME)) {
+        client.addIntegration(
+          webVitalsIntegration({
+            disable: enableInp ? [] : ['inp'],
+            _experiments: {
+              enableStandaloneClsSpans,
+              enableStandaloneLcpSpans,
+            },
+          }),
+        );
+      }
+
       let startingUrl: string | undefined = getLocationHref();
 
       if (linkPreviousTrace !== 'off') {
@@ -738,10 +731,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
 
       if (enableInteractions) {
         registerInteractionListener(client, idleTimeout, finalTimeout, childSpanTimeout, latestRoute);
-      }
-
-      if (enableInp) {
-        registerInpInteractionListener();
       }
 
       instrumentOutgoingRequests(client, {

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -47,11 +47,7 @@ import {
 import { DEBUG_BUILD } from '../debug-build';
 import { getHttpRequestData, WINDOW } from '../helpers';
 import { fetchStreamPerformanceIntegration } from '../integrations/fetchStreamPerformance';
-import {
-  collectWebVitalsForClient,
-  WEB_VITALS_INTEGRATION_NAME,
-  webVitalsIntegration,
-} from '../integrations/webVitals';
+import { WEB_VITALS_INTEGRATION_NAME, webVitalsIntegration } from '../integrations/webVitals';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
@@ -456,9 +452,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       // should wait for finish signal if it's a pageload transaction
       disableAutoFinish: isPageloadSpan,
       beforeSpanEnd: span => {
-        // The webVitalsIntegration owns all web vital logic; it finalizes the collected
-        // web vitals and writes them onto the pageload span.
-        collectWebVitalsForClient(client, span);
         addPerformanceEntries(span, {
           ignoreResourceSpans,
           ignorePerformanceApiSpans,

--- a/packages/browser/test/index.bundle.tracing.logs.metrics.test.ts
+++ b/packages/browser/test/index.bundle.tracing.logs.metrics.test.ts
@@ -1,7 +1,7 @@
 import { logger as coreLogger, metrics as coreMetrics } from '@sentry/core/browser';
 import { feedbackIntegrationShim, replayIntegrationShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, spanStreamingIntegration } from '../src';
+import { browserTracingIntegration, spanStreamingIntegration, webVitalsIntegration } from '../src';
 import * as TracingLogsMetricsBundle from '../src/index.bundle.tracing.logs.metrics';
 
 describe('index.bundle.tracing.logs.metrics', () => {
@@ -11,6 +11,7 @@ describe('index.bundle.tracing.logs.metrics', () => {
     expect(TracingLogsMetricsBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(TracingLogsMetricsBundle.replayIntegration).toBe(replayIntegrationShim);
     expect(TracingLogsMetricsBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
+    expect(TracingLogsMetricsBundle.webVitalsIntegration).toBe(webVitalsIntegration);
 
     expect(TracingLogsMetricsBundle.logger).toBe(coreLogger);
     expect(TracingLogsMetricsBundle.metrics).toBe(coreMetrics);

--- a/packages/browser/test/index.bundle.tracing.replay.feedback.logs.metrics.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.feedback.logs.metrics.test.ts
@@ -5,6 +5,7 @@ import {
   feedbackAsyncIntegration,
   replayIntegration,
   spanStreamingIntegration,
+  webVitalsIntegration,
 } from '../src';
 import * as TracingReplayFeedbackLogsMetricsBundle from '../src/index.bundle.tracing.replay.feedback.logs.metrics';
 
@@ -15,6 +16,7 @@ describe('index.bundle.tracing.replay.feedback.logs.metrics', () => {
     expect(TracingReplayFeedbackLogsMetricsBundle.feedbackIntegration).toBe(feedbackAsyncIntegration);
     expect(TracingReplayFeedbackLogsMetricsBundle.replayIntegration).toBe(replayIntegration);
     expect(TracingReplayFeedbackLogsMetricsBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
+    expect(TracingReplayFeedbackLogsMetricsBundle.webVitalsIntegration).toBe(webVitalsIntegration);
 
     expect(TracingReplayFeedbackLogsMetricsBundle.logger).toBe(coreLogger);
     expect(TracingReplayFeedbackLogsMetricsBundle.metrics).toBe(coreMetrics);

--- a/packages/browser/test/index.bundle.tracing.replay.feedback.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.feedback.test.ts
@@ -5,6 +5,7 @@ import {
   feedbackAsyncIntegration,
   replayIntegration,
   spanStreamingIntegration,
+  webVitalsIntegration,
 } from '../src';
 import * as TracingReplayFeedbackBundle from '../src/index.bundle.tracing.replay.feedback';
 
@@ -15,6 +16,7 @@ describe('index.bundle.tracing.replay.feedback', () => {
     expect(TracingReplayFeedbackBundle.feedbackIntegration).toBe(feedbackAsyncIntegration);
     expect(TracingReplayFeedbackBundle.replayIntegration).toBe(replayIntegration);
     expect(TracingReplayFeedbackBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
+    expect(TracingReplayFeedbackBundle.webVitalsIntegration).toBe(webVitalsIntegration);
 
     expect(TracingReplayFeedbackBundle.logger).toBe(loggerShim);
     expect(TracingReplayFeedbackBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/index.bundle.tracing.replay.logs.metrics.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.logs.metrics.test.ts
@@ -1,7 +1,7 @@
 import { logger as coreLogger, metrics as coreMetrics } from '@sentry/core/browser';
 import { feedbackIntegrationShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, replayIntegration, spanStreamingIntegration } from '../src';
+import { browserTracingIntegration, replayIntegration, spanStreamingIntegration, webVitalsIntegration } from '../src';
 import * as TracingReplayLogsMetricsBundle from '../src/index.bundle.tracing.replay.logs.metrics';
 
 describe('index.bundle.tracing.replay.logs.metrics', () => {
@@ -11,6 +11,7 @@ describe('index.bundle.tracing.replay.logs.metrics', () => {
     expect(TracingReplayLogsMetricsBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(TracingReplayLogsMetricsBundle.replayIntegration).toBe(replayIntegration);
     expect(TracingReplayLogsMetricsBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
+    expect(TracingReplayLogsMetricsBundle.webVitalsIntegration).toBe(webVitalsIntegration);
 
     expect(TracingReplayLogsMetricsBundle.logger).toBe(coreLogger);
     expect(TracingReplayLogsMetricsBundle.metrics).toBe(coreMetrics);

--- a/packages/browser/test/index.bundle.tracing.replay.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.test.ts
@@ -1,6 +1,6 @@
 import { consoleLoggingIntegrationShim, feedbackIntegrationShim, loggerShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, replayIntegration, spanStreamingIntegration } from '../src';
+import { browserTracingIntegration, replayIntegration, spanStreamingIntegration, webVitalsIntegration } from '../src';
 import * as TracingReplayBundle from '../src/index.bundle.tracing.replay';
 
 describe('index.bundle.tracing.replay', () => {
@@ -10,6 +10,7 @@ describe('index.bundle.tracing.replay', () => {
     expect(TracingReplayBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(TracingReplayBundle.replayIntegration).toBe(replayIntegration);
     expect(TracingReplayBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
+    expect(TracingReplayBundle.webVitalsIntegration).toBe(webVitalsIntegration);
 
     expect(TracingReplayBundle.logger).toBe(loggerShim);
     expect(TracingReplayBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/index.bundle.tracing.test.ts
+++ b/packages/browser/test/index.bundle.tracing.test.ts
@@ -5,7 +5,7 @@ import {
   replayIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
-import { browserTracingIntegration, spanStreamingIntegration } from '../src';
+import { browserTracingIntegration, spanStreamingIntegration, webVitalsIntegration } from '../src';
 import * as TracingBundle from '../src/index.bundle.tracing';
 
 describe('index.bundle.tracing', () => {
@@ -15,6 +15,7 @@ describe('index.bundle.tracing', () => {
     expect(TracingBundle.feedbackIntegration).toBe(feedbackIntegrationShim);
     expect(TracingBundle.replayIntegration).toBe(replayIntegrationShim);
     expect(TracingBundle.spanStreamingIntegration).toBe(spanStreamingIntegration);
+    expect(TracingBundle.webVitalsIntegration).toBe(webVitalsIntegration);
 
     expect(TracingBundle.logger).toBe(loggerShim);
     expect(TracingBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);

--- a/packages/browser/test/integrations/webVitals.test.ts
+++ b/packages/browser/test/integrations/webVitals.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { collectWebVitalsForClient, webVitalsIntegration } from '../../src/integrations/webVitals';
+
+const mockRegisterInpInteractionListener = vi.hoisted(() => vi.fn());
+const mockStartTrackingINP = vi.hoisted(() => vi.fn());
+const mockStartTrackingWebVitals = vi.hoisted(() => vi.fn());
+const mockTrackClsAsSpan = vi.hoisted(() => vi.fn());
+const mockTrackInpAsSpan = vi.hoisted(() => vi.fn());
+const mockTrackLcpAsSpan = vi.hoisted(() => vi.fn());
+
+vi.mock('@sentry-internal/browser-utils', () => ({
+  registerInpInteractionListener: mockRegisterInpInteractionListener,
+  startTrackingINP: mockStartTrackingINP,
+  startTrackingWebVitals: mockStartTrackingWebVitals,
+  trackClsAsSpan: mockTrackClsAsSpan,
+  trackInpAsSpan: mockTrackInpAsSpan,
+  trackLcpAsSpan: mockTrackLcpAsSpan,
+}));
+
+describe('webVitalsIntegration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartTrackingWebVitals.mockReturnValue(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('tracks web vitals with the existing non-streaming behavior by default', () => {
+    const client = { getOptions: () => ({}) };
+    const integration = webVitalsIntegration();
+
+    integration.setup?.(client as never);
+    integration.afterAllSetup?.(client as never);
+
+    expect(mockStartTrackingWebVitals).toHaveBeenCalledWith({
+      recordClsStandaloneSpans: false,
+      recordLcpStandaloneSpans: false,
+      client,
+    });
+    expect(mockStartTrackingINP).toHaveBeenCalledTimes(1);
+    expect(mockRegisterInpInteractionListener).toHaveBeenCalledTimes(1);
+    expect(mockTrackLcpAsSpan).not.toHaveBeenCalled();
+    expect(mockTrackClsAsSpan).not.toHaveBeenCalled();
+    expect(mockTrackInpAsSpan).not.toHaveBeenCalled();
+  });
+
+  it('keeps standalone LCP and CLS experiments working', () => {
+    const client = { getOptions: () => ({}) };
+    const integration = webVitalsIntegration({
+      _experiments: {
+        enableStandaloneClsSpans: true,
+        enableStandaloneLcpSpans: true,
+      },
+    });
+
+    integration.setup?.(client as never);
+
+    expect(mockStartTrackingWebVitals).toHaveBeenCalledWith({
+      recordClsStandaloneSpans: true,
+      recordLcpStandaloneSpans: true,
+      client,
+    });
+  });
+
+  it('tracks LCP, CLS and INP as streamed spans when span streaming is enabled', () => {
+    const client = { getOptions: () => ({ traceLifecycle: 'stream' }) };
+    const integration = webVitalsIntegration();
+
+    integration.setup?.(client as never);
+    integration.afterAllSetup?.(client as never);
+
+    expect(mockStartTrackingWebVitals).toHaveBeenCalledWith({
+      recordClsStandaloneSpans: undefined,
+      recordLcpStandaloneSpans: undefined,
+      client,
+    });
+    expect(mockTrackLcpAsSpan).toHaveBeenCalledWith(client);
+    expect(mockTrackClsAsSpan).toHaveBeenCalledWith(client);
+    expect(mockTrackInpAsSpan).toHaveBeenCalledTimes(1);
+    expect(mockStartTrackingINP).not.toHaveBeenCalled();
+    expect(mockRegisterInpInteractionListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports disabling selected web vitals for browserTracingIntegration compatibility', () => {
+    const client = { getOptions: () => ({}) };
+    const integration = webVitalsIntegration({ disable: ['cls', 'inp', 'lcp'] });
+
+    integration.setup?.(client as never);
+    integration.afterAllSetup?.(client as never);
+
+    expect(mockStartTrackingWebVitals).toHaveBeenCalledWith({
+      recordClsStandaloneSpans: undefined,
+      recordLcpStandaloneSpans: undefined,
+      client,
+    });
+    expect(mockStartTrackingINP).not.toHaveBeenCalled();
+    expect(mockTrackInpAsSpan).not.toHaveBeenCalled();
+    expect(mockRegisterInpInteractionListener).not.toHaveBeenCalled();
+  });
+
+  it('exposes the web vital collection callback for browserTracingIntegration finalization', () => {
+    const collectWebVitals = vi.fn();
+    const client = { getOptions: () => ({}) };
+    mockStartTrackingWebVitals.mockReturnValue(collectWebVitals);
+
+    webVitalsIntegration().setup?.(client as never);
+    collectWebVitalsForClient(client as never);
+
+    expect(collectWebVitals).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/browser/test/integrations/webVitals.test.ts
+++ b/packages/browser/test/integrations/webVitals.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { collectWebVitalsForClient, webVitalsIntegration } from '../../src/integrations/webVitals';
+import { webVitalsIntegration } from '../../src/integrations/webVitals';
 
 const mockAddWebVitalsToSpan = vi.hoisted(() => vi.fn());
 const mockRegisterInpInteractionListener = vi.hoisted(() => vi.fn());
@@ -19,6 +19,29 @@ vi.mock('@sentry-internal/browser-utils', () => ({
   trackLcpAsSpan: mockTrackLcpAsSpan,
 }));
 
+function getMockClient(options: Record<string, unknown> = {}) {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  return {
+    getOptions: () => options,
+    on: vi.fn((hook: string, callback: (...args: unknown[]) => void) => {
+      const callbacks = listeners.get(hook) ?? [];
+      callbacks.push(callback);
+      listeners.set(hook, callbacks);
+
+      return () => {
+        const updatedCallbacks = listeners.get(hook)?.filter(cb => cb !== callback) ?? [];
+        listeners.set(hook, updatedCallbacks);
+      };
+    }),
+    emit: (hook: string, ...args: unknown[]) => {
+      listeners.get(hook)?.forEach(callback => {
+        callback(...args);
+      });
+    },
+  };
+}
+
 describe('webVitalsIntegration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,7 +53,7 @@ describe('webVitalsIntegration', () => {
   });
 
   it('tracks web vitals with the existing non-streaming behavior by default', () => {
-    const client = { getOptions: () => ({}) };
+    const client = getMockClient();
     const integration = webVitalsIntegration();
 
     integration.setup?.(client as never);
@@ -49,7 +72,7 @@ describe('webVitalsIntegration', () => {
   });
 
   it('keeps standalone LCP and CLS experiments working', () => {
-    const client = { getOptions: () => ({}) };
+    const client = getMockClient();
     const integration = webVitalsIntegration({
       _experiments: {
         enableStandaloneClsSpans: true,
@@ -67,7 +90,7 @@ describe('webVitalsIntegration', () => {
   });
 
   it('tracks LCP, CLS and INP as streamed spans when span streaming is enabled', () => {
-    const client = { getOptions: () => ({ traceLifecycle: 'stream' }) };
+    const client = getMockClient({ traceLifecycle: 'stream' });
     const integration = webVitalsIntegration();
 
     integration.setup?.(client as never);
@@ -86,7 +109,7 @@ describe('webVitalsIntegration', () => {
   });
 
   it('supports ignoring selected web vitals for browserTracingIntegration compatibility', () => {
-    const client = { getOptions: () => ({}) };
+    const client = getMockClient();
     const integration = webVitalsIntegration({ ignore: ['cls', 'inp', 'lcp'] });
 
     integration.setup?.(client as never);
@@ -102,14 +125,15 @@ describe('webVitalsIntegration', () => {
     expect(mockRegisterInpInteractionListener).not.toHaveBeenCalled();
   });
 
-  it('finalizes web vitals and writes them onto the span when collected for the client', () => {
+  it('finalizes web vitals and writes them onto the pageload span before it ends', () => {
     const finalizeWebVitals = vi.fn();
-    const client = { getOptions: () => ({}) };
-    const span = {};
+    const client = getMockClient();
+    const span = { end: vi.fn() };
     mockStartTrackingWebVitals.mockReturnValue(finalizeWebVitals);
 
     webVitalsIntegration().setup?.(client as never);
-    collectWebVitalsForClient(client as never, span as never);
+    client.emit('afterStartPageLoadSpan', span);
+    span.end();
 
     expect(finalizeWebVitals).toHaveBeenCalledTimes(1);
     expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
@@ -120,11 +144,12 @@ describe('webVitalsIntegration', () => {
   });
 
   it('does not record CLS/LCP on the pageload span when span streaming is enabled', () => {
-    const client = { getOptions: () => ({ traceLifecycle: 'stream' }) };
-    const span = {};
+    const client = getMockClient({ traceLifecycle: 'stream' });
+    const span = { end: vi.fn() };
 
     webVitalsIntegration().setup?.(client as never);
-    collectWebVitalsForClient(client as never, span as never);
+    client.emit('afterStartPageLoadSpan', span);
+    span.end();
 
     expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
       recordClsOnPageloadSpan: false,
@@ -134,14 +159,15 @@ describe('webVitalsIntegration', () => {
   });
 
   it('does not record CLS/LCP on the pageload span when standalone spans are enabled', () => {
-    const client = { getOptions: () => ({}) };
-    const span = {};
+    const client = getMockClient();
+    const span = { end: vi.fn() };
     const integration = webVitalsIntegration({
       _experiments: { enableStandaloneClsSpans: true, enableStandaloneLcpSpans: true },
     });
 
     integration.setup?.(client as never);
-    collectWebVitalsForClient(client as never, span as never);
+    client.emit('afterStartPageLoadSpan', span);
+    span.end();
 
     expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
       recordClsOnPageloadSpan: false,

--- a/packages/browser/test/integrations/webVitals.test.ts
+++ b/packages/browser/test/integrations/webVitals.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { collectWebVitalsForClient, webVitalsIntegration } from '../../src/integrations/webVitals';
 
+const mockAddWebVitalsToSpan = vi.hoisted(() => vi.fn());
 const mockRegisterInpInteractionListener = vi.hoisted(() => vi.fn());
 const mockStartTrackingINP = vi.hoisted(() => vi.fn());
 const mockStartTrackingWebVitals = vi.hoisted(() => vi.fn());
@@ -9,6 +10,7 @@ const mockTrackInpAsSpan = vi.hoisted(() => vi.fn());
 const mockTrackLcpAsSpan = vi.hoisted(() => vi.fn());
 
 vi.mock('@sentry-internal/browser-utils', () => ({
+  addWebVitalsToSpan: mockAddWebVitalsToSpan,
   registerInpInteractionListener: mockRegisterInpInteractionListener,
   startTrackingINP: mockStartTrackingINP,
   startTrackingWebVitals: mockStartTrackingWebVitals,
@@ -100,14 +102,51 @@ describe('webVitalsIntegration', () => {
     expect(mockRegisterInpInteractionListener).not.toHaveBeenCalled();
   });
 
-  it('exposes the web vital collection callback for browserTracingIntegration finalization', () => {
-    const collectWebVitals = vi.fn();
+  it('finalizes web vitals and writes them onto the span when collected for the client', () => {
+    const finalizeWebVitals = vi.fn();
     const client = { getOptions: () => ({}) };
-    mockStartTrackingWebVitals.mockReturnValue(collectWebVitals);
+    const span = {};
+    mockStartTrackingWebVitals.mockReturnValue(finalizeWebVitals);
 
     webVitalsIntegration().setup?.(client as never);
-    collectWebVitalsForClient(client as never);
+    collectWebVitalsForClient(client as never, span as never);
 
-    expect(collectWebVitals).toHaveBeenCalledTimes(1);
+    expect(finalizeWebVitals).toHaveBeenCalledTimes(1);
+    expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
+      recordClsOnPageloadSpan: true,
+      recordLcpOnPageloadSpan: true,
+      spanStreamingEnabled: false,
+    });
+  });
+
+  it('does not record CLS/LCP on the pageload span when span streaming is enabled', () => {
+    const client = { getOptions: () => ({ traceLifecycle: 'stream' }) };
+    const span = {};
+
+    webVitalsIntegration().setup?.(client as never);
+    collectWebVitalsForClient(client as never, span as never);
+
+    expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
+      recordClsOnPageloadSpan: false,
+      recordLcpOnPageloadSpan: false,
+      spanStreamingEnabled: true,
+    });
+  });
+
+  it('does not record CLS/LCP on the pageload span when standalone spans are enabled', () => {
+    const client = { getOptions: () => ({}) };
+    const span = {};
+    const integration = webVitalsIntegration({
+      _experiments: { enableStandaloneClsSpans: true, enableStandaloneLcpSpans: true },
+    });
+
+    integration.setup?.(client as never);
+    collectWebVitalsForClient(client as never, span as never);
+
+    expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
+      recordClsOnPageloadSpan: false,
+      recordLcpOnPageloadSpan: false,
+      spanStreamingEnabled: false,
+    });
   });
 });

--- a/packages/browser/test/integrations/webVitals.test.ts
+++ b/packages/browser/test/integrations/webVitals.test.ts
@@ -83,9 +83,9 @@ describe('webVitalsIntegration', () => {
     expect(mockRegisterInpInteractionListener).toHaveBeenCalledTimes(1);
   });
 
-  it('supports disabling selected web vitals for browserTracingIntegration compatibility', () => {
+  it('supports ignoring selected web vitals for browserTracingIntegration compatibility', () => {
     const client = { getOptions: () => ({}) };
-    const integration = webVitalsIntegration({ disable: ['cls', 'inp', 'lcp'] });
+    const integration = webVitalsIntegration({ ignore: ['cls', 'inp', 'lcp'] });
 
     integration.setup?.(client as never);
     integration.afterAllSetup?.(client as never);

--- a/packages/browser/test/integrations/webVitals.test.ts
+++ b/packages/browser/test/integrations/webVitals.test.ts
@@ -125,15 +125,15 @@ describe('webVitalsIntegration', () => {
     expect(mockRegisterInpInteractionListener).not.toHaveBeenCalled();
   });
 
-  it('finalizes web vitals and writes them onto the pageload span before it ends', () => {
+  it('finalizes web vitals and writes them onto the pageload span when it ends', () => {
     const finalizeWebVitals = vi.fn();
     const client = getMockClient();
-    const span = { end: vi.fn() };
+    const span = {};
     mockStartTrackingWebVitals.mockReturnValue(finalizeWebVitals);
 
     webVitalsIntegration().setup?.(client as never);
     client.emit('afterStartPageLoadSpan', span);
-    span.end();
+    client.emit('spanEnd', span);
 
     expect(finalizeWebVitals).toHaveBeenCalledTimes(1);
     expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
@@ -143,13 +143,25 @@ describe('webVitalsIntegration', () => {
     });
   });
 
+  it('does not write web vitals onto non-pageload spans', () => {
+    const finalizeWebVitals = vi.fn();
+    const client = getMockClient();
+    mockStartTrackingWebVitals.mockReturnValue(finalizeWebVitals);
+
+    webVitalsIntegration().setup?.(client as never);
+    client.emit('spanEnd', {});
+
+    expect(finalizeWebVitals).not.toHaveBeenCalled();
+    expect(mockAddWebVitalsToSpan).not.toHaveBeenCalled();
+  });
+
   it('does not record CLS/LCP on the pageload span when span streaming is enabled', () => {
     const client = getMockClient({ traceLifecycle: 'stream' });
-    const span = { end: vi.fn() };
+    const span = {};
 
     webVitalsIntegration().setup?.(client as never);
     client.emit('afterStartPageLoadSpan', span);
-    span.end();
+    client.emit('spanEnd', span);
 
     expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
       recordClsOnPageloadSpan: false,
@@ -160,14 +172,14 @@ describe('webVitalsIntegration', () => {
 
   it('does not record CLS/LCP on the pageload span when standalone spans are enabled', () => {
     const client = getMockClient();
-    const span = { end: vi.fn() };
+    const span = {};
     const integration = webVitalsIntegration({
       _experiments: { enableStandaloneClsSpans: true, enableStandaloneLcpSpans: true },
     });
 
     integration.setup?.(client as never);
     client.emit('afterStartPageLoadSpan', span);
-    span.end();
+    client.emit('spanEnd', span);
 
     expect(mockAddWebVitalsToSpan).toHaveBeenCalledWith(span, {
       recordClsOnPageloadSpan: false,

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -181,6 +181,19 @@ describe('browserTracingIntegration', () => {
     });
   });
 
+  it('auto-registers webVitalsIntegration', () => {
+    const client = new BrowserClient(
+      getDefaultBrowserClientOptions({
+        tracesSampleRate: 1,
+        integrations: [browserTracingIntegration()],
+      }),
+    );
+    setCurrentClient(client);
+    client.init();
+
+    expect(client.getIntegrationByName('WebVitals')).toBeDefined();
+  });
+
   it('works with tracing disabled', () => {
     const client = new BrowserClient(
       getDefaultBrowserClientOptions({

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1075,7 +1075,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   public emit(hook: 'endPageloadSpan'): void;
 
   /**
-   * Emit a hook event for browser tracing integrations to trigger aafter the pageload span was started.
+   * Emit a hook event for browser tracing integrations to trigger after the pageload span was started.
    */
   public emit(hook: 'afterStartPageLoadSpan', span: Span): void;
 


### PR DESCRIPTION
Splits out the web vitals recording logic to its own integration that is added by the browser tracing integration by default.


Closes #21209