### PR TITLE
fix(e2e): Fix `astro-6` e2e test build by relaxing astro version range

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6/package.json
@@ -16,7 +16,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
-    "astro": "~6.2.0"
+    "astro": "^6.2.0"
   },
   "volta": {
     "node": "22.22.0",


### PR DESCRIPTION
`@astrojs/node@10.1.2` requires `astro@^6.3.0` due to a renamed internal export, but the test app pinned astro to `~6.2.0`.

 Fix: `~6.2.0` to `^6.2.0` so pnpm can resolve to astro@6.3+.