### PR TITLE
feat: Migrate `sendDefaultPii` in nitro, nuxt, sveltekit, astro to `dataCollection`

### DIFF
--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -221,7 +221,7 @@ async function instrumentRequestStartHttpServerSpan(
             url: stripUrlQueryAndFragment(ctx.url.href),
             ...httpHeadersToSpanAttributes(
               winterCGHeadersToDict(request.headers),
-              getClient()?.getOptions().sendDefaultPii ?? false,
+              getClient()?.getDataCollectionOptions() ?? false,
             ),
           };
 

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -54,7 +54,22 @@ describe('sentryMiddleware', () => {
       } as any;
     });
     vi.spyOn(SentryNode, 'getActiveSpan').mockImplementation(getSpanMock);
-    vi.spyOn(SentryNode, 'getClient').mockImplementation(() => ({ getOptions: () => ({}) }) as Client);
+    vi.spyOn(SentryNode, 'getClient').mockImplementation(
+      () =>
+        ({
+          getOptions: () => ({}),
+          getDataCollectionOptions: () => ({
+            userInfo: false,
+            cookies: true,
+            httpHeaders: { request: true, response: true },
+            httpBodies: [],
+            queryParams: true,
+            genAI: { inputs: false, outputs: false },
+            stackFrameVariables: true,
+            frameContextLines: 5,
+          }),
+        }) as unknown as Client,
+    );
     vi.spyOn(SentryNode, 'getTraceMetaTags').mockImplementation(
       () => `
     <meta name="sentry-trace" content="123">

--- a/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
@@ -160,10 +160,9 @@ function setupSrvxTracingChannels(): void {
       method: data.request.method,
     });
 
-    const sendDefaultPii = getClient()?.getOptions().sendDefaultPii ?? false;
     const headerAttributes = httpHeadersToSpanAttributes(
       Object.fromEntries(data.request.headers.entries()),
-      sendDefaultPii,
+      getClient()?.getDataCollectionOptions() ?? false,
     );
 
     return startSpanManual(

--- a/packages/nuxt/src/runtime/hooks/wrapMiddlewareHandler.ts
+++ b/packages/nuxt/src/runtime/hooks/wrapMiddlewareHandler.ts
@@ -201,7 +201,7 @@ function getSpanAttributes(
     headers = Object.fromEntries(eventH3v2?.req.headers.entries());
   }
 
-  const headerAttributes = httpHeadersToSpanAttributes(headers, getClient()?.getOptions().sendDefaultPii ?? false);
+  const headerAttributes = httpHeadersToSpanAttributes(headers, getClient()?.getDataCollectionOptions() ?? false);
 
   // Merge header attributes with existing attributes
   Object.assign(attributes, headerAttributes);

--- a/packages/nuxt/test/runtime/hooks/wrapMiddlewareHandler.test.ts
+++ b/packages/nuxt/test/runtime/hooks/wrapMiddlewareHandler.test.ts
@@ -40,7 +40,18 @@ describe('wrapMiddlewareHandlerWithSentry', () => {
 
     // Setup minimal required mocks
     (SentryCore.startSpan as any).mockImplementation((_config: any, callback: any) => callback(mockSpan));
-    (SentryCore.getClient as any).mockReturnValue({ getOptions: () => ({ sendDefaultPii: false }) });
+    (SentryCore.getClient as any).mockReturnValue({
+      getDataCollectionOptions: () => ({
+        userInfo: false,
+        cookies: true,
+        httpHeaders: { request: true, response: true },
+        httpBodies: [],
+        queryParams: true,
+        genAI: { inputs: false, outputs: false },
+        stackFrameVariables: true,
+        frameContextLines: 5,
+      }),
+    });
     (SentryCore.httpHeadersToSpanAttributes as any).mockReturnValue({ 'http.request.header.user_agent': 'test-agent' });
     (SentryCore.flushIfServerless as any).mockResolvedValue(undefined);
   });

--- a/packages/sveltekit/src/server-common/handle.ts
+++ b/packages/sveltekit/src/server-common/handle.ts
@@ -180,7 +180,7 @@ async function instrumentHandle(
           'sveltekit.tracing.original_name': originalName,
           ...httpHeadersToSpanAttributes(
             winterCGHeadersToDict(event.request.headers),
-            getClient()?.getOptions().sendDefaultPii ?? false,
+            getClient()?.getDataCollectionOptions() ?? false,
           ),
         });
       }
@@ -209,7 +209,7 @@ async function instrumentHandle(
               'http.method': event.request.method,
               ...httpHeadersToSpanAttributes(
                 winterCGHeadersToDict(event.request.headers),
-                getClient()?.getOptions().sendDefaultPii ?? false,
+                getClient()?.getDataCollectionOptions() ?? false,
               ),
             },
             name: routeName,


### PR DESCRIPTION



Closes https://github.com/getsentry/sentry-javascript/issues/20936
