### PR TITLE
fix(profiling-node): Ensure node version support warning includes latest 26

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -644,7 +644,7 @@ export const _nodeProfilingIntegration = ((): ProfilingIntegration<NodeClient> =
       // eslint-disable-next-line no-console
       console.warn(
         `[Sentry Profiling] You are using a Node.js version that does not have prebuilt binaries (${NODE_MAJOR}).`,
-        'The @sentry/profiling-node package only has prebuilt support for the following LTS versions of Node.js: 16, 18, 20, 22, 24.',
+        'The @sentry/profiling-node package only has prebuilt support for the following LTS versions of Node.js: 16, 18, 20, 22, 24, 26.',
         'To use the @sentry/profiling-node package with this version of Node.js, you will need to compile the native addon from source.',
         'See: https://github.com/getsentry/sentry-javascript/tree/develop/packages/profiling-node#building-the-package-from-source',
       );


### PR DESCRIPTION
This was overlooked when we added 26 support.