### PR TITLE
chore(skills): Update linear-project-status skill with more details & context

### DIFF
--- a/.agents/skills/linear-project-status/SKILL.md
+++ b/.agents/skills/linear-project-status/SKILL.md
@@ -6,7 +6,25 @@ argument-hint: <linear-project-url-or-id-or-slug>
 
 # Linear Project Status Audit
 
-You are producing a project-health audit for a Linear project. The audience is a project lead or engineering manager who wants both a fast "is this on track?" verdict and a concrete list of process gaps to fix. The skill is designed to be run roughly weekly.
+You are producing a project-health audit for a Linear project. The skill is designed to be run roughly weekly.
+
+## Audience and intent
+
+The audience is the **project lead reviewing a project they own** — not a manager reviewing a person, and not someone else evaluating the team. Frame everything accordingly.
+
+What this audit is:
+
+- A **process review of the project**: are the signals in Linear (target date, updates, milestones, scope) set up so the project can succeed and so stakeholders know where it stands?
+- A list of **pointers the lead can act on this week** to improve those signals.
+
+What this audit is **not**:
+
+- A judgment of any individual's performance or workload.
+- A claim that a green/yellow/red verdict reflects how well anyone is doing their job. Projects go yellow or red for legitimate reasons outside anyone's control (descopes, dependency slips, reprioritization, PTO, parallel work absorbing the team). That's fine — the verdict is a signal, not a grade.
+
+There is context the audit cannot see: PTO and absences, deprioritization in favor of higher-stakes work, decisions made in Slack/Notion/meetings that haven't been written into Linear, work happening in PRs that isn't yet linked to issues. When a dimension flags as `warn` or `bad`, the lead is the one who knows whether there's a benign explanation. The audit's job is to **surface the signal so they can decide**, not to assign blame.
+
+When you write recommendations, target **the project's process** ("add a target date", "split the milestone", "narrow scope before the ship date") — not the people ("X needs to update more often", "Y should be doing more"). If the data implies a people-shaped concern, name the project-shaped fix: "no updates in 3 weeks → consider setting a recurring weekly update reminder," not "the lead hasn't been updating."
 
 ## Input
 
@@ -54,36 +72,59 @@ For each dimension below, derive a verdict (`ok` / `warn` / `bad`) and a one-sen
 
 Goal: project should have weekly updates so stakeholders aren't in the dark.
 
-| Days since last update | Verdict |
-| ---------------------- | ------- |
-| ≤ 8 days               | ok      |
-| 9–14 days              | warn    |
-| > 14 days, or none     | bad     |
+The verdict has two parts: **what's the most recent gap**, and **is the cadence currently healthy** (looking at the last few weeks, not the distant past). What matters is the trajectory — if the recent rhythm is good, the lead is doing the right thing and we should reinforce that, not dwell on history.
+
+**Step 1 — most recent gap (days since last update):**
+
+| Days since last update | Verdict baseline |
+| ---------------------- | ---------------- |
+| ≤ 8 days               | ok               |
+| 9–14 days              | warn             |
+| > 14 days, or none     | bad              |
+
+**Step 2 — adjust for trajectory by looking at the last ~4 updates (or however many exist in the recent ~6 weeks):**
+
+- If the most recent update is fresh (≤ 8 days) but there's a long silence (>21 days) immediately before it in the recent window → downgrade to **`warn`**. Frame the note as a positive: the recent update is good, before that the cadence had slipped — recommend keeping up the weekly rhythm so it sticks. Don't make this a critique; the lead has already corrected course.
+- If the last few weeks (~4 updates / ~6 weeks) are in a reasonable rhythm — say, mostly weekly with the occasional 10–12 day gap — keep the verdict **`ok`** even if there was a long gap further back in the project's history. A multi-month dormant period followed by 6 weeks of steady updates is a project that's _in good shape now_; don't penalize it for ancient history.
+- If the last few weeks show repeated gaps (multiple >14d stretches), the project hasn't actually recovered — keep it at `warn` or escalate to `bad` depending on the pattern.
+
+Examples of how to read this:
+
+- Latest update 2 days ago, but the one before was 51 days earlier, and only 2 updates in the last 6 weeks → **warn**, with a note like "Updated 2 days ago — good. There was a 51-day gap before that; recommend keeping the weekly rhythm going."
+- Latest update 3 days ago, with 4 prior updates spaced 7–10 days apart, but a 60-day silence further back → **ok**, no special note needed. The recent rhythm is healthy.
+- Latest update 4 days ago, but with three >14-day gaps in the last 6 weeks → **warn**, the cadence isn't stable yet.
 
 Don't flag single-author updates. Projects are typically owned by one person and it's fine — even expected — for that person to write all updates. The cadence is what matters, not the authorship distribution.
 
 ### 2. Project lead
 
-This dimension is binary — either there's a lead on the project or there isn't:
+This dimension is binary — either there's a lead set on the project or there isn't:
 
 | Condition                    | Verdict |
 | ---------------------------- | ------- |
 | `lead` is set on the project | ok      |
 | No lead set                  | bad     |
 
-Every project must have a designated lead. Don't try to infer a "de facto lead" from update authorship — the field is either set or it isn't. A missing lead is one of the most common process gaps; flag it visibly.
+Every project should have a designated lead so stakeholders know who to ask. Don't try to infer a "de facto lead" from update authorship — the field is either set or it isn't. A missing lead is a common process gap; flag it.
 
 ### 2b. Lead engagement
 
-Separately from the binary "is there a lead" check, evaluate whether the lead is actually doing project work. Surface this as its own line item in the report (e.g., "Lead engagement: warn").
+Separately from "is there a lead set", check whether the lead appears to be **finding time to engage with the project**. The point of this dimension is to surface, for the lead's own awareness, whether their attention on this project is showing up in Linear — not to grade their output.
 
-| Condition                                                                | Verdict |
-| ------------------------------------------------------------------------ | ------- |
-| Lead is assigned to a meaningful share of the project's issues           | ok      |
-| Lead is assigned to none or only a tiny fraction of the project's issues | warn    |
-| No lead is set (covered by dimension 2; skip this dimension)             | n/a     |
+A lead can be engaged in two legitimate shapes, and either is fine:
 
-Why: leads should be doing the work, not just owning the project nominally. One person doing the majority of issues is fine — that's how single-owner projects naturally look. The thing to flag is the lead being absent from the work, not other contributors being light.
+- **Implementer:** assigned to a meaningful share of the project's issues and moving them.
+- **Orchestrator:** not assigned to many issues themselves, but visibly driving the project — writing the status updates, posting project comments, managing milestones, triaging incoming issues, unblocking contributors. The work shows up as project-level signal rather than issue assignments.
+
+Look at both shapes together before judging. A lead with zero assigned issues who writes weekly updates and comments on blockers is engaged; flag only if **neither** shape of engagement is present.
+
+| Condition                                                                                         | Verdict |
+| ------------------------------------------------------------------------------------------------- | ------- |
+| Lead shows up as implementer (assigned issues moving) **or** orchestrator (updates/comments/etc.) | ok      |
+| Lead is largely absent from both issue work **and** project-level activity in the last few weeks  | warn    |
+| No lead is set (covered by dimension 2; skip this dimension)                                      | n/a     |
+
+A `warn` here is **not** a critique of the lead. It usually means the lead hasn't had time for this project lately — PTO, a competing priority, or coordination happening in Slack/meetings that hasn't been written into Linear. The lead is the one who knows which. The point of surfacing it is so they can decide whether to reclaim time, hand off, or just note that this is a temporary lull.
 
 ### 3. Target date — presence and realism
 
@@ -95,24 +136,36 @@ First, check presence — a target date is required on every project:
 To judge realism, compare days remaining to the open scope. Rough heuristic:
 
 - `bad` if target date is within 14 days AND (there are open issues with no recent activity, OR open issues outnumber completed ones). Both sub-conditions are scoped to the 14-day window — a young project with mostly-open issues isn't `bad`, only one about to ship that isn't ready.
-- `warn` if target date is within 30 days AND >40% of issues are still open, OR the target date is already in the past while the project is not completed.
+- `warn` if target date is within 30 days AND >40% of issues are still open.
 - `ok` otherwise.
+
+**Special case — target date is today or in the past, project not Completed:** This is a specific and common situation worth flagging explicitly rather than burying in the rules above:
+
+- `bad` if the target date has been past for more than ~7 days and the project status is still not `completed` / `canceled`. Either the project is silently slipping or the date is no longer a real commitment — both need a decision.
+- `warn` if the target date is today or up to a week past, and the latest status update doesn't say the release is shipping imminently. ("Today is the target — are we shipping today, or do we need a new date?")
+- If the latest update clearly says "shipping this week / shipping today" and the data backs it (open issues all small or near-done), keep this dimension `ok` but call out the imminence in **Top concerns** so the lead doesn't accidentally let the date drift again.
 
 These are anchors, not rules — if status updates say "we're descoping X" or "ship date moved deliberately", weight that.
 
 ### 4. Target date stability
 
-A project's target date should change rarely. Each push-out is a small admission that the plan wasn't trusted.
+A project's target date should change rarely. Each push-out has a cost — stakeholders calibrate to dates, and frequent slippage erodes that signal.
 
-You typically can't query the target-date history directly. Read the status updates and the project description for explicit mentions of date changes. Count distinct dates that have been referenced as "the target".
+You typically can't query the target-date history directly. Read the status updates and the project description for explicit mentions of date changes (Linear sometimes includes a `diffMarkdown` field on status updates that shows the prior date — use it). Count distinct dates that have been referenced as "the target".
 
-| Pushes mentioned in recent updates | Verdict |
-| ---------------------------------- | ------- |
-| 0–1                                | ok      |
-| 2                                  | warn    |
-| 3+                                 | bad     |
+The verdict depends on both **how many** pushes and **how well-documented** they are. A push that's transparently explained in a status update ("descoping X to ship Y on time", "blocked on upstream Z, moving to next sprint", "lead out sick, extending one week") is materially different from a push with no recorded reason or a vague one ("needs more time", or no update at all near the push).
 
-If you can't tell, say so — don't guess. State: "Could not determine target-date history from available data."
+| Pushes mentioned in recent updates | All pushes well-explained?              | Verdict |
+| ---------------------------------- | --------------------------------------- | ------- |
+| 0–1                                | n/a                                     | ok      |
+| 2                                  | Yes (clear reason in updates)           | ok      |
+| 2                                  | No / vague                              | warn    |
+| 3+                                 | Yes (every push has a real explanation) | warn    |
+| 3+                                 | No / mixed / mostly vague               | bad     |
+
+"Well-explained" means the update names a specific cause the reader can evaluate — illness, dependency slip, scope change, reprioritization, external blocker. "Need more time" or silence around the push date doesn't count. When in doubt, downgrade rather than upgrade — three pushes is three pushes, and even well-documented ones add up.
+
+If you can't tell at all, say so — don't guess. State: "Could not determine target-date history from available data."
 
 ### 5. Issue staleness
 
@@ -126,13 +179,16 @@ Backlog-state issues that are stale are less alarming than started-state ones �
 
 ### 6. Milestone health
 
-For each milestone, check the target date and the state of its associated issues. (You may need to look at each issue's milestone via the issue payload; otherwise infer from titles/labels.)
+For each milestone, check the target date, the milestone's progress field, and the state of its associated issues. (You may need to look at each issue's milestone via the issue payload; otherwise infer from titles/labels.)
 
-- `bad`: milestone target date in the past AND issues attached are not all completed.
+- `bad`: milestone target date in the past AND the work clearly hasn't shipped (open issues remain in scope, status updates don't mention delivery).
 - `warn`: milestone target date in the past AND it's unclear whether the work shipped; OR milestone has no issues attached at all (it's just a date on a calendar).
-- `ok`: milestones are in the future, or past ones are clearly done.
+- **`warn` (tracking-hygiene gap):** milestone target date in the past, progress is still 0% / not marked complete, BUT the work clearly did ship — the milestone description says "DONE", linked issues are completed, or status updates describe the milestone's outcome as delivered. Treat this as a distinct case from "unclear whether shipped" and say so explicitly in the notes, because the project-shaped fix is different: just update the milestone state to reflect reality. This is benign as a delivery signal but misleads anyone reading the project at a glance.
+- `ok`: milestones are in the future, or past ones are clearly marked done.
 
 A project with no milestones isn't automatically a problem on small projects — but on multi-month projects, the absence of milestones is itself a `warn`.
+
+When you surface a tracking-hygiene gap in **Top concerns**, frame the recommendation as a quick cleanup ("mark milestone X complete — its description and linked PRs already show it shipped") rather than a delivery concern.
 
 ### 7. Scope stability (issue additions)
 
@@ -143,6 +199,15 @@ Compare issues added in the last 30 days against total open issues, and look at 
 - `ok`: rate of new issues is decreasing, or matches expected discovery on a young project.
 
 The point of this check: a project should converge toward a defined end state. A project where issues keep getting added is really a workstream, not a project.
+
+**Always distinguish planned decomposition from scope drift — decomposition is healthy and should never be flagged.** When new issues share a common `parentId` (or are otherwise clearly the structural breakdown of a previously-larger ticket), that's not scope growing — it's the same scope being made legible. A lead taking a vague "build server-utils" ticket and exploding it into 6 concrete sub-issues is doing exactly the right thing.
+
+Before flagging, group the new issues by `parentId`:
+
+- If most of the new issues in the last 30 days share one or a few `parentId`s — i.e., they're children of an existing in-scope issue — treat that batch as a single planned breakdown. Do not let it push the verdict toward `warn` or `bad`. Note it positively in the dimension's notes ("12 new issues, but all sub-issues of JS-1234 — planned decomposition, healthy").
+- If the new issues are scattered with no shared parent (or are themselves top-level), that's the actual signal scope stability is designed to catch — keep the standard thresholds.
+
+When in doubt, look at the status updates: if the lead's update describes the new tickets as planning/breakdown work, that's confirmation. Genuine drift looks like ad-hoc "oh and also..." tickets without a structural reason; decomposition looks like a coherent set added together.
 
 ### 8. Recent activity (last 7 days)
 
@@ -156,9 +221,9 @@ Count issues that were either **completed** or **updated while in a `started` st
 | 1–2 issues moved; below the project's normal pace                    | warn    |
 | Zero issues moved or completed                                       | bad     |
 
-Why this matters even when other dimensions are fine: a project where no work happens for a week — even one with weekly status updates and a present lead — usually means the lead is working on something else, or real work is happening in PRs/Notion/Slack that isn't reflected in Linear. Both are worth surfacing.
+Why this matters even when other dimensions are fine: a project where Linear shows no movement for a week is either genuinely paused (PTO, competing priorities, deliberate hold — the lead will know) or work is happening in PRs/Notion/Slack that isn't reflected back into Linear. Both are worth surfacing so the lead can decide whether to act. Do not speculate about why activity is low — just surface it.
 
-Calibrate to the project's normal cadence (read recent history): a research project might genuinely move slowly and that's fine; a delivery project with no movement in a week is a `bad` even if the target date is months away.
+Calibrate to the project's normal cadence (read recent history): a research project might genuinely move slowly and that's fine; a delivery project with no movement in a week is worth flagging as `bad` even if the target date is months away.
 
 ### Blockers
 
@@ -182,6 +247,8 @@ Roll the per-dimension verdicts into one of:
 
 Don't double-count: a missing target date inflates a few dimensions; weigh holistically.
 
+The verdict is a **signal for the lead to interpret, not a grade**. Yellow or red can be the right state for a project (a project waiting on an upstream dependency, or one that's been deliberately paused, may legitimately read as yellow/red). The point of the audit is to make the situation legible and offer pointers to improve the project's process — not to imply anyone is doing poorly.
+
 ## Output
 
 Produce a single markdown report in the chat, using the structure below. Keep prose tight — managers skim.
@@ -201,28 +268,28 @@ Produce a single markdown report in the chat, using the structure below. Keep pr
 
 ## Dimension breakdown
 
-| Dimension        | Verdict  | Notes                                                 |
-| ---------------- | -------- | ----------------------------------------------------- |
-| Status updates   | 🟢/🟡/🔴 | <e.g., "Last update 3 days ago by @alice">            |
-| Lead             | 🟢/🟡/🔴 | <e.g., "@alice"; binary — set or not>                 |
-| Lead engagement  | 🟢/🟡    | <e.g., "Assigned to 7/8 issues"; omit row if no lead> |
-| Target date      | 🟢/🟡/🔴 | <e.g., "2026-06-30, 33 days away — looks tight">      |
-| Target stability | 🟢/🟡/🔴 | <e.g., "Pushed twice in last 6 weeks per updates">    |
-| Issue staleness  | 🟢/🟡/🔴 | <e.g., "4 in-progress issues untouched > 14 days">    |
-| Recent activity  | 🟢/🟡/🔴 | <e.g., "3 issues moved in last 7d">                   |
-| Milestones       | 🟢/🟡/🔴 | <e.g., "Milestone 'Alpha' past due, 3 issues open">   |
-| Scope stability  | 🟢/🟡/🔴 | <e.g., "12 new issues in last 30d, target in 20d">    |
+| Dimension        | Verdict  | Notes                                                            |
+| ---------------- | -------- | ---------------------------------------------------------------- |
+| Status updates   | 🟢/🟡/🔴 | <e.g., "Last update 3 days ago">                                 |
+| Lead             | 🟢/🟡/🔴 | <e.g., "@alice"; binary — set or not>                            |
+| Lead engagement  | 🟢/🟡    | <e.g., "Drives project via updates + comments"; omit if no lead> |
+| Target date      | 🟢/🟡/🔴 | <e.g., "2026-06-30, 33 days away — looks tight">                 |
+| Target stability | 🟢/🟡/🔴 | <e.g., "Pushed twice in last 6 weeks per updates">               |
+| Issue staleness  | 🟢/🟡/🔴 | <e.g., "4 in-progress issues untouched > 14 days">               |
+| Recent activity  | 🟢/🟡/🔴 | <e.g., "3 issues moved in last 7d">                              |
+| Milestones       | 🟢/🟡/🔴 | <e.g., "Milestone 'Alpha' past due, 3 issues open">              |
+| Scope stability  | 🟢/🟡/🔴 | <e.g., "12 new issues in last 30d, target in 20d">               |
 
 ## Recommended next steps
 
-<3–5 concrete actions for the project lead. Each should be doable this week.>
+<3–5 concrete actions targeting the project's process — things the lead could do this week to improve the signals in Linear. Frame as project-shaped fixes, not people-shaped critiques.>
 
 1. ...
 2. ...
 
 ---
 
-_Data as of <ISO date>. Run weekly to track trend._
+_Data as of <ISO date>. The audit can't see PTO, competing priorities, or work happening outside Linear — weigh accordingly. Run weekly to track trend._
 ```
 
 Notes on the report:
@@ -236,8 +303,9 @@ Notes on the report:
 
 ## Common failure modes to avoid
 
+- **Reviewing people instead of the project.** This is the most important one. The audit is about the project's signals and process, not the lead's or team's individual performance. Frame findings as project-shaped fixes ("add a target date", "tighten scope before ship"), not people-shaped critiques ("the lead needs to update more"). When a dimension flags, assume there's a benign reason the data can't see (PTO, competing priorities, work happening outside Linear) and let the user decide how to weight it.
 - **Treating Linear's defaults as health signals.** A project that has no milestones is not automatically broken; it's a `warn` only if the project is large enough to warrant them. Calibrate to the project size.
 - **Confusing a slow-moving project with a stuck one.** Some projects have low velocity by design (e.g., research, long-running compliance). If the status updates clearly explain low velocity, downgrade staleness flags accordingly.
 - **Citing issue counts without context.** "10 open issues" is meaningless without total / target-date / age. Pair every count with a denominator or a date.
-- **Refusing to give a verdict.** The user wants a Green/Yellow/Red call. Even if you're uncertain, pick one and explain the uncertainty in the verdict line. Don't punt.
+- **Refusing to give a verdict.** The user wants a Green/Yellow/Red call. Even if you're uncertain, pick one and explain the uncertainty in the verdict line. Don't punt. (Remember the verdict is a signal, not a grade — it's fine for a project to be yellow or red for legitimate reasons.)
 - **Hallucinating data Linear didn't return.** If the data is missing, say "could not determine from available data" rather than inventing.


### PR DESCRIPTION
## Summary

Sharpens the `linear-project-status` skill so it's clearly a tool for **project leads auditing their own projects**, not a performance review of any individual. The verdict (Green/Yellow/Red) becomes a signal for the lead to interpret with context the audit can't see (PTO, competing priorities, work outside Linear) — not a grade.

## Key changes

- **New "Audience and intent" section** up front, making the framing explicit. Recommendations target the project's process ("add a target date", "split the milestone"), not people ("X needs to update more").
- **Lead engagement (dim 2b)** reframed around whether the lead is *finding time to engage* with the project. Recognizes two healthy shapes — *implementer* (assigned to issues) and *orchestrator* (drives via updates / comments / milestones). A `warn` is explicitly not a critique.
- **Target date stability (dim 4)** now weighs both push count and quality of explanation. Well-documented pushes (illness, dependency slip, scope change) → `warn`; vague or undocumented pushes → `bad`. Avoids over-penalising a lead who's transparent about slippage.
- **Target date presence/realism (dim 3)** adds an explicit special-case block for "target date is today or past, project not Completed" — common enough to deserve direct handling.
- **Milestone health (dim 6)** adds a distinct "tracking-hygiene gap" verdict for past-due milestones where the work clearly shipped but wasn't marked complete. The recommendation is cleanup, not a delivery concern.
- **Status update cadence (dim 1)** now reads trajectory across the last ~6 weeks. Long silence followed by a fresh update → `warn` framed positively (the lead has already corrected course). Steady recent rhythm → `ok` even if there was an old gap further back. Don't dwell on distant history.
- **Scope stability (dim 7)** carves out planned decomposition explicitly: when new issues share a common `parentId`, that's a structural breakdown of existing scope (healthy), not drift — never flag it.
- **"Reviewing people instead of the project"** added as the top entry in the common failure modes list.

## Validation

Iterated against two real Sentry projects ([Hono SDK](https://linear.app/getsentry/project/hono-sdk-javascript-4117ec2adb5f) and [Multi-Runtime Server Integrations](https://linear.app/getsentry/project/multi-runtime-server-integrations-javascript-94fdc006d64e)) — each pass surfaced specific phrasings or rules that needed adjustment, which are now folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)