### PR TITLE
feat(hono): Emit warning if `@sentry/node` was imported instead of `@sentry/hono/node`

### DIFF
--- a/packages/hono/src/node/middleware.ts
+++ b/packages/hono/src/node/middleware.ts
@@ -17,9 +17,12 @@ export interface HonoNodeOptions extends Options<BaseTransportOptions> {}
 export const sentry = <E extends Env>(app: Hono<E>, options?: SentryHonoMiddlewareOptions): MiddlewareHandler => {
   const sentryClient = getClient();
   if (sentryClient === undefined) {
-    debug.warn(
-      'Sentry is not initialized. Call `init()` from @sentry/hono/node in an `instrument.ts` file loaded via `--import` to set up Sentry for your application.',
-    );
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[@sentry/hono] Sentry is not initialized. Call `init()` from `@sentry/hono/node` in an `instrument.ts` file loaded via `--import` to set up Sentry for your application.',
+      );
+    });
   } else {
     const isInitializedWithHonoSdk = sentryClient.getOptions()._metadata?.sdk?.name === 'sentry.javascript.hono';
 

--- a/packages/hono/src/node/middleware.ts
+++ b/packages/hono/src/node/middleware.ts
@@ -27,7 +27,7 @@ export const sentry = <E extends Env>(app: Hono<E>, options?: SentryHonoMiddlewa
       consoleSandbox(() => {
         // eslint-disable-next-line no-console
         console.warn(
-          '[Sentry] Detected `Sentry.init` call from `@sentry/node` instead of `@sentry/hono/node`. Import from `@sentry/hono/node` to ensure Hono-specific instrumentation is applied correctly.',
+          '[Sentry] Sentry was not initialized with `@sentry/hono/node`. Please import from `@sentry/hono/node` to ensure Hono-specific instrumentation is applied correctly.',
         );
       });
     } else {

--- a/packages/hono/src/node/middleware.ts
+++ b/packages/hono/src/node/middleware.ts
@@ -1,4 +1,4 @@
-import { type BaseTransportOptions, debug, type Options, getClient } from '@sentry/core';
+import { type BaseTransportOptions, consoleSandbox, debug, getClient, type Options } from '@sentry/core';
 import type { Env, Hono, MiddlewareHandler } from 'hono';
 import { requestHandler, responseHandler } from '../shared/middlewareHandlers';
 import { applyPatches } from '../shared/applyPatches';
@@ -21,8 +21,19 @@ export const sentry = <E extends Env>(app: Hono<E>, options?: SentryHonoMiddlewa
       'Sentry is not initialized. Call `init()` from @sentry/hono/node in an `instrument.ts` file loaded via `--import` to set up Sentry for your application.',
     );
   } else {
-    sentryClient.getOptions().debug &&
-      debug.log('Sentry is initialized, proceeding to set up Hono `sentry` middleware.');
+    const isInitializedWithHonoSdk = sentryClient.getOptions()._metadata?.sdk?.name === 'sentry.javascript.hono';
+
+    if (!isInitializedWithHonoSdk) {
+      consoleSandbox(() => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[Sentry] Detected `Sentry.init` call from `@sentry/node` instead of `@sentry/hono/node`. Import from `@sentry/hono/node` to ensure Hono-specific instrumentation is applied correctly.',
+        );
+      });
+    } else {
+      sentryClient.getOptions().debug &&
+        debug.log('Sentry is initialized, proceeding to set up Hono `sentry` middleware.');
+    }
   }
 
   applyPatches(app);

--- a/packages/hono/test/node/middleware.test.ts
+++ b/packages/hono/test/node/middleware.test.ts
@@ -72,15 +72,52 @@ describe('Hono Node Middleware', () => {
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Sentry is not initialized'));
     });
 
-    it('does not emit a warning when Sentry is already initialized', () => {
+    it('does not emit a warning when Sentry is already initialized with @sentry/hono/node', () => {
       const warnSpy = vi.spyOn(SentryCore.debug, 'warn');
-      const fakeClient = { getOptions: () => ({ debug: false }) };
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const fakeClient = {
+        getOptions: () => ({
+          debug: false,
+          _metadata: { sdk: { name: 'sentry.javascript.hono' } },
+        }),
+      };
       vi.spyOn(SentryCore, 'getClient').mockReturnValue(fakeClient as unknown as SentryCore.Client);
 
       const app = new Hono();
       sentry(app);
 
       expect(warnSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('emits a console.warn when Sentry is initialized with @sentry/node instead of @sentry/hono/node', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const fakeClient = {
+        getOptions: () => ({
+          debug: false,
+          _metadata: { sdk: { name: 'sentry.javascript.node' } },
+        }),
+      };
+      vi.spyOn(SentryCore, 'getClient').mockReturnValue(fakeClient as unknown as SentryCore.Client);
+
+      const app = new Hono();
+      sentry(app);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('@sentry/hono/node'));
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('emits a console.warn when Sentry is initialized without any SDK metadata', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const fakeClient = { getOptions: () => ({ debug: false }) };
+      vi.spyOn(SentryCore, 'getClient').mockReturnValue(fakeClient as unknown as SentryCore.Client);
+
+      const app = new Hono();
+      sentry(app);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('@sentry/hono/node'));
+      consoleWarnSpy.mockRestore();
     });
   });
 
@@ -145,16 +182,24 @@ describe('Hono Node Middleware', () => {
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Sentry is not initialized'));
     });
 
-    it('does not emit a warning when Sentry is already initialized', () => {
+    it('does not emit a warning when Sentry is already initialized with @sentry/hono/node', () => {
       const warnSpy = vi.spyOn(SentryCore.debug, 'warn');
-      const fakeClient = { getOptions: () => ({ debug: false }) };
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const fakeClient = {
+        getOptions: () => ({
+          debug: false,
+          _metadata: { sdk: { name: 'sentry.javascript.hono' } },
+        }),
+      };
       vi.spyOn(SentryCore, 'getClient').mockReturnValue(fakeClient as unknown as SentryCore.Client);
 
       const app = new Hono();
       const middleware = sentry(app);
 
       expect(warnSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
       expect(middleware.constructor.name).toBe('AsyncFunction');
+      consoleWarnSpy.mockRestore();
     });
   });
 

--- a/packages/hono/test/node/middleware.test.ts
+++ b/packages/hono/test/node/middleware.test.ts
@@ -62,18 +62,18 @@ describe('Hono Node Middleware', () => {
       expect(middleware.constructor.name).toBe('AsyncFunction');
     });
 
-    it('emits a warning when Sentry is not initialized', () => {
-      const warnSpy = vi.spyOn(SentryCore.debug, 'warn');
+    it('emits a console.warn when Sentry is not initialized', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       vi.spyOn(SentryCore, 'getClient').mockReturnValue(undefined);
 
       const app = new Hono();
       sentry(app);
 
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Sentry is not initialized'));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Sentry is not initialized'));
+      consoleWarnSpy.mockRestore();
     });
 
     it('does not emit a warning when Sentry is already initialized with @sentry/hono/node', () => {
-      const warnSpy = vi.spyOn(SentryCore.debug, 'warn');
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       const fakeClient = {
         getOptions: () => ({
@@ -86,7 +86,6 @@ describe('Hono Node Middleware', () => {
       const app = new Hono();
       sentry(app);
 
-      expect(warnSpy).not.toHaveBeenCalled();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
       consoleWarnSpy.mockRestore();
     });
@@ -172,18 +171,18 @@ describe('Hono Node Middleware', () => {
       expect(middleware.constructor.name).toBe('AsyncFunction');
     });
 
-    it('emits a warning when Sentry is not initialized', () => {
-      const warnSpy = vi.spyOn(SentryCore.debug, 'warn');
+    it('emits a console.warn when Sentry is not initialized', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       vi.spyOn(SentryCore, 'getClient').mockReturnValue(undefined);
 
       const app = new Hono();
       sentry(app);
 
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Sentry is not initialized'));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Sentry is not initialized'));
+      consoleWarnSpy.mockRestore();
     });
 
     it('does not emit a warning when Sentry is already initialized with @sentry/hono/node', () => {
-      const warnSpy = vi.spyOn(SentryCore.debug, 'warn');
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       const fakeClient = {
         getOptions: () => ({
@@ -196,7 +195,6 @@ describe('Hono Node Middleware', () => {
       const app = new Hono();
       const middleware = sentry(app);
 
-      expect(warnSpy).not.toHaveBeenCalled();
       expect(consoleWarnSpy).not.toHaveBeenCalled();
       expect(middleware.constructor.name).toBe('AsyncFunction');
       consoleWarnSpy.mockRestore();

--- a/packages/hono/test/node/middleware.test.ts
+++ b/packages/hono/test/node/middleware.test.ts
@@ -104,7 +104,7 @@ describe('Hono Node Middleware', () => {
       const app = new Hono();
       sentry(app);
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('@sentry/hono/node'));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('not initialized with `@sentry/hono/node`'));
       consoleWarnSpy.mockRestore();
     });
 
@@ -116,7 +116,7 @@ describe('Hono Node Middleware', () => {
       const app = new Hono();
       sentry(app);
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('@sentry/hono/node'));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('not initialized with `@sentry/hono/node`'));
       consoleWarnSpy.mockRestore();
     });
   });


### PR DESCRIPTION
The Hono Node setup requires a separate instrumentation file with the `Sentry.init()` call. It's important that `init` is imported from the Hono SDK and not Node. As this could easily be overlooked, but is very important for the correct setup, this warning is added.
