### PR TITLE
feat(remix): Migrate `sendDefaultPii` to `dataCollection`

### DIFF
--- a/packages/remix/src/server/errors.ts
+++ b/packages/remix/src/server/errors.ts
@@ -93,9 +93,13 @@ export async function errorHandleDataFunction(
   return handleCallbackErrors(
     async () => {
       if (name === 'action' && span) {
-        const options = getClient()?.getOptions() as RemixOptions | undefined;
+        const client = getClient();
+        const options = client?.getOptions() as RemixOptions | undefined;
 
-        if (options?.sendDefaultPii && options.captureActionFormDataKeys) {
+        if (
+          client?.getDataCollectionOptions().httpBodies.includes('incomingRequest') &&
+          options?.captureActionFormDataKeys
+        ) {
           await storeFormDataKeys(args, span, options.captureActionFormDataKeys);
         }
       }

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -378,7 +378,7 @@ function wrapRequestHandler<T extends ServerBuild | (() => ServerBuild | Promise
                   method: request.method,
                   ...httpHeadersToSpanAttributes(
                     winterCGHeadersToDict(request.headers),
-                    clientOptions.sendDefaultPii ?? false,
+                    getClient()?.getDataCollectionOptions(),
                   ),
                 },
               },

--- a/packages/remix/src/server/integrations/opentelemetry.ts
+++ b/packages/remix/src/server/integrations/opentelemetry.ts
@@ -22,7 +22,9 @@ const _remixIntegration = (() => {
       const options = client?.getOptions() as RemixOptions | undefined;
 
       instrumentRemix({
-        actionFormDataAttributes: options?.sendDefaultPii ? options?.captureActionFormDataKeys : undefined,
+        actionFormDataAttributes: client?.getDataCollectionOptions().httpBodies.includes('incomingRequest')
+          ? options?.captureActionFormDataKeys
+          : undefined,
       });
     },
 

--- a/packages/remix/test/server/errors.test.ts
+++ b/packages/remix/test/server/errors.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Client } from '@sentry/core';
+import * as core from '@sentry/core';
+
+vi.mock('../../src/utils/utils', () => ({
+  storeFormDataKeys: vi.fn(),
+}));
+
+import { storeFormDataKeys } from '../../src/utils/utils';
+import { errorHandleDataFunction } from '../../src/server/errors';
+
+function createMockClient(httpBodies: string[] = []): Client {
+  return {
+    getDataCollectionOptions: () => ({
+      userInfo: false,
+      cookies: true,
+      httpHeaders: { request: true, response: true },
+      httpBodies,
+      queryParams: true,
+      genAI: { inputs: true, outputs: true },
+      stackFrameVariables: true,
+      frameContextLines: 5,
+    }),
+    getOptions: () => ({
+      captureActionFormDataKeys: { username: true },
+    }),
+  } as unknown as Client;
+}
+
+describe('errorHandleDataFunction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('captures form data when httpBodies includes incomingRequest', async () => {
+    vi.spyOn(core, 'getClient').mockReturnValue(createMockClient(['incomingRequest']));
+    vi.spyOn(core, 'handleCallbackErrors').mockImplementation(async fn => fn());
+
+    const mockSpan = { setAttribute: vi.fn() } as any;
+    const mockArgs = { request: new Request('http://localhost', { method: 'POST' }) } as any;
+    const origFn = vi.fn().mockResolvedValue(new Response());
+
+    await errorHandleDataFunction.call(null, origFn, 'action', mockArgs, mockSpan);
+
+    expect(storeFormDataKeys).toHaveBeenCalledWith(mockArgs, mockSpan, { username: true });
+  });
+
+  it('does NOT capture form data when httpBodies is empty', async () => {
+    vi.spyOn(core, 'getClient').mockReturnValue(createMockClient([]));
+    vi.spyOn(core, 'handleCallbackErrors').mockImplementation(async fn => fn());
+
+    const mockSpan = { setAttribute: vi.fn() } as any;
+    const mockArgs = { request: new Request('http://localhost', { method: 'POST' }) } as any;
+    const origFn = vi.fn().mockResolvedValue(new Response());
+
+    await errorHandleDataFunction.call(null, origFn, 'action', mockArgs, mockSpan);
+
+    expect(storeFormDataKeys).not.toHaveBeenCalled();
+  });
+
+  it('does NOT capture form data for loader functions', async () => {
+    vi.spyOn(core, 'getClient').mockReturnValue(createMockClient(['incomingRequest']));
+    vi.spyOn(core, 'handleCallbackErrors').mockImplementation(async fn => fn());
+
+    const mockSpan = { setAttribute: vi.fn() } as any;
+    const mockArgs = { request: new Request('http://localhost') } as any;
+    const origFn = vi.fn().mockResolvedValue(new Response());
+
+    await errorHandleDataFunction.call(null, origFn, 'loader', mockArgs, mockSpan);
+
+    expect(storeFormDataKeys).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
 Replaces all `sendDefaultPii` usage in the Remix package with the new `dataCollection` option:

  - **`instrumentServer.ts`**: Passes `client.getDataCollectionOptions()` to `httpHeadersToSpanAttributes`
  - **`errors.ts`**: Gates action form data capture on `dataCollection.httpBodies.includes('incomingRequest')` 
  - **`opentelemetry.ts`**: Gates OTel form data attributes on `dataCollection.httpBodies.includes('incomingRequest')`

The Remix-specific `captureActionFormDataKeys` option is preserved — only the gating mechanism changes.
   
 closes #20933