### PR TITLE
chore: Ignore scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ packages/**/*.junit.xml
 # Local Claude Code settings that should not be committed
 .claude/settings.local.json
 .claude/worktrees
+.claude/scheduled_tasks.lock
 
 # Triage report
 **/triage_report.md


### PR DESCRIPTION
Ignore the lock file for [scheduled tasks](https://code.claude.com/docs/en/desktop-scheduled-tasks). 