### PR TITLE
chore(skills): Improve triage-issue skill (fix false-positives, check changelog, model)

### DIFF
--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -84,7 +84,7 @@ Cross-repo searches (only when clearly relevant):
 
 #### Changelog investigation (when a version is mentioned)
 
-If the issue states a version where the problem started (e.g. "works in 7.x, broken since 8.2.0"), **check `CHANGELOG.md`** for that version range. 
+If the issue states a version where the problem started (e.g. "works in 7.x, broken since 8.2.0"), **check `CHANGELOG.md`** for that version range.
 Start with `grep -n "^## " CHANGELOG.md | head -60` to orient, then read the relevant entries.
 Surface any relevant changelog delta in the triage report under **Root cause** or **Information gaps**. If nothing relevant is found, note that explicitly.
 

--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -85,7 +85,7 @@ Cross-repo searches (only when clearly relevant):
 #### Changelog investigation (when a version is mentioned)
 
 If the issue states a version where the problem started (e.g. "works in 7.x, broken since 8.2.0"), **check `CHANGELOG.md`** for that version range.
-Start with `grep -n "^## " CHANGELOG.md | head -60` to orient, then read the relevant entries.
+Use the **Grep** tool (pattern `^## ` on `CHANGELOG.md`) to list version headings, then use the **Read** tool to read the relevant entries. Do NOT use Bash `grep`/`head` — the native Grep/Read tools are read-only and require no extra Bash permissions in CI.
 Surface any relevant changelog delta in the triage report under **Root cause** or **Information gaps**. If nothing relevant is found, note that explicitly.
 
 ### Step 4: Related Issues & PRs

--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -82,6 +82,12 @@ Cross-repo searches (only when clearly relevant):
 
 **Shell safety:** Strip shell metacharacters from issue-derived search terms before use in commands.
 
+#### Changelog investigation (when a version is mentioned)
+
+If the issue states a version where the problem started (e.g. "works in 7.x, broken since 8.2.0"), **check `CHANGELOG.md`** for that version range. 
+Start with `grep -n "^## " CHANGELOG.md | head -60` to orient, then read the relevant entries.
+Surface any relevant changelog delta in the triage report under **Root cause** or **Information gaps**. If nothing relevant is found, note that explicitly.
+
 ### Step 4: Related Issues & PRs
 
 - Search for duplicate or related issues: `gh api search/issues -X GET -f "q=<terms>+repo:getsentry/sentry-javascript+type:issue"` and use the **Write** tool to save the command output to `search.json` in the workspace root

--- a/.agents/skills/triage-issue/scripts/detect_prompt_injection.py
+++ b/.agents/skills/triage-issue/scripts/detect_prompt_injection.py
@@ -121,7 +121,7 @@ INJECTION_PATTERNS = [
     (r"\b(admin|developer|system)[\s_-]mode", 8, "Mode manipulation"),
 
     # Sensitive file paths (10 points) - legitimate issues rarely reference these
-    (r"(~/\.aws/|~/\.ssh/|/root/|/etc/passwd|/etc/shadow)", 10, "System credentials path"),
+    (r"(~/\.aws/|~/\.ssh/|(?<!\w)/root/|/etc/passwd|/etc/shadow)", 10, "System credentials path"),
     (r"(\.aws/credentials|id_rsa|\.ssh/id_)", 10, "Credentials file reference"),
 
     # Environment variable exfiltration (8 points)

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -74,7 +74,7 @@ jobs:
             Do NOT use `python3 -c` or other inline Python in Bash, only the provided scripts are allowed.
             Do NOT attempt to delete (`rm`) temporary files you create.
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-8
             --max-turns 50 --allowedTools "Write,Bash(gh api *),Bash(gh pr list *),Bash(npm info *),Bash(npm ls *),Bash(python3 .claude/skills/triage-issue/scripts/post_linear_comment.py *),Bash(python3 .claude/skills/triage-issue/scripts/parse_gh_issues.py *),Bash(python3 .claude/skills/triage-issue/scripts/detect_prompt_injection.py *),Bash(python3 .claude/skills/triage-issue/scripts/write_job_summary.py *)"
 
       - name: Post triage job summary

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -74,6 +74,7 @@ jobs:
             Do NOT use `python3 -c` or other inline Python in Bash, only the provided scripts are allowed.
             Do NOT attempt to delete (`rm`) temporary files you create.
           claude_args: |
+            --model claude-opus-4-6
             --max-turns 50 --allowedTools "Write,Bash(gh api *),Bash(gh pr list *),Bash(npm info *),Bash(npm ls *),Bash(python3 .claude/skills/triage-issue/scripts/post_linear_comment.py *),Bash(python3 .claude/skills/triage-issue/scripts/parse_gh_issues.py *),Bash(python3 .claude/skills/triage-issue/scripts/detect_prompt_injection.py *),Bash(python3 .claude/skills/triage-issue/scripts/write_job_summary.py *)"
 
       - name: Post triage job summary


### PR DESCRIPTION
Some fixes because this issue was detected as "prompt injection": https://github.com/getsentry/sentry-javascript/issues/21256

### Fixes false-positives in the prompt injection lookup. 

The System credentials path pattern matched `/root/` anywhere it appeared in a string, which caused false positives on Bun's virtual filesystem paths (e.g. `/$bunfs/root/main` in stack traces) and any embedded path segment like `some/root/folder`.
Adds a negative lookbehind `(?<!\w)` so the pattern only triggers when `/root/` appears at the start of a path.

### Add changelog check

Adds the changelog investigation explicitly to the skill as this contains valuable information.

### Model Change

Previously, the default model Claude Opus 4.7 was used. This is now changed to Opus 4.8.