### PR TITLE
fix(node): Vendor `InstrumentationNodeModuleFile` to fix Bun `--bytecode` crash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -984,7 +984,7 @@ jobs:
           node-version-file: 'dev-packages/e2e-tests/test-applications/${{ matrix.test-application }}/package.json'
       - name: Set up Bun
         if:
-          contains(fromJSON('["node-exports-test-app","nextjs-16-bun", "elysia-bun", "hono-4"]'),
+          contains(fromJSON('["node-exports-test-app","nextjs-16-bun", "elysia-bun", "hono-4", "bun-bytecode"]'),
           matrix.test-application)
         uses: oven-sh/setup-bun@v2
         with:

--- a/dev-packages/e2e-tests/test-applications/bun-bytecode/package.json
+++ b/dev-packages/e2e-tests/test-applications/bun-bytecode/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bun-bytecode-test",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "clean": "npx rimraf node_modules pnpm-lock.yaml dist",
+    "test:build": "pnpm install && bun build src/main.ts --compile --bytecode --format=esm --outfile dist/main",
+    "test:assert": "dist/main"
+  },
+  "dependencies": {
+    "@sentry/bun": "file:../../packed/sentry-bun-packed.tgz"
+  },
+  "devDependencies": {
+    "bun-types": "^1.2.9"
+  },
+  "sentryTest": {
+    "optional": true
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/bun-bytecode/package.json
+++ b/dev-packages/e2e-tests/test-applications/bun-bytecode/package.json
@@ -13,9 +13,6 @@
   "devDependencies": {
     "bun-types": "^1.2.9"
   },
-  "sentryTest": {
-    "optional": true
-  },
   "volta": {
     "extends": "../../package.json"
   }

--- a/dev-packages/e2e-tests/test-applications/bun-bytecode/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/bun-bytecode/src/main.ts
@@ -1,0 +1,11 @@
+/**
+ * Verifies that @sentry/bun can be compiled with `bun build --compile --bytecode` without crashing at runtime.
+ */
+import * as Sentry from '@sentry/bun';
+
+Sentry.init({
+  dsn: 'https://username@domain/123',
+  tracesSampleRate: 0,
+});
+
+console.log('Bun bytecode compilation: OK');

--- a/dev-packages/e2e-tests/test-applications/bun-bytecode/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/bun-bytecode/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "types": ["bun-types"],
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext"
+  },
+  "include": ["src"]
+}

--- a/packages/node/src/integrations/tracing/InstrumentationNodeModuleFile.ts
+++ b/packages/node/src/integrations/tracing/InstrumentationNodeModuleFile.ts
@@ -20,6 +20,7 @@
  *   re-export chain, which Bun's bytecode bundler renames and loses scope for.
  * - This copy imports `normalize` directly from 'path' to break that chain.
  */
+/* oxlint-disable */
 
 import { normalize } from 'path';
 import type { InstrumentationModuleFile } from '@opentelemetry/instrumentation';

--- a/packages/node/src/integrations/tracing/InstrumentationNodeModuleFile.ts
+++ b/packages/node/src/integrations/tracing/InstrumentationNodeModuleFile.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored locally from @opentelemetry/instrumentation to work around a Bun
+ *   --bytecode bug (https://github.com/getsentry/sentry-javascript/issues/21256).
+ * - The upstream class imports `normalize` via an indirect platform/index
+ *   re-export chain, which Bun's bytecode bundler renames and loses scope for.
+ * - This copy imports `normalize` directly from 'path' to break that chain.
+ */
+
+import { normalize } from 'path';
+import type { InstrumentationModuleFile } from '@opentelemetry/instrumentation';
+
+export class InstrumentationNodeModuleFile implements InstrumentationModuleFile {
+  public name: string;
+  public supportedVersions: string[];
+  public patch: (moduleExports: any, moduleVersion?: string) => any;
+  public unpatch: (moduleExports?: any, moduleVersion?: string) => void;
+
+  constructor(
+    name: string,
+    supportedVersions: string[],
+    patch: (moduleExports: any, moduleVersion?: string) => any,
+    unpatch: (moduleExports?: any, moduleVersion?: string) => void,
+  ) {
+    this.name = normalize(name);
+    this.supportedVersions = supportedVersions;
+    this.patch = patch;
+    this.unpatch = unpatch;
+  }
+}

--- a/packages/node/src/integrations/tracing/amqplib/vendored/amqplib.ts
+++ b/packages/node/src/integrations/tracing/amqplib/vendored/amqplib.ts
@@ -35,12 +35,12 @@ import { timestampInSeconds } from '@sentry/core';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
   isWrapped,
   safeExecuteInTheMiddle,
   SemconvStability,
   semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../InstrumentationNodeModuleFile';
 import { ATTR_MESSAGING_OPERATION } from './semconv';
 import {
   ATTR_MESSAGING_DESTINATION,

--- a/packages/node/src/integrations/tracing/firebase/otel/patches/firestore.ts
+++ b/packages/node/src/integrations/tracing/firebase/otel/patches/firestore.ts
@@ -1,12 +1,8 @@
 import * as net from 'node:net';
 import type { Span, Tracer } from '@opentelemetry/api';
 import { context, diag, SpanKind, trace } from '@opentelemetry/api';
-import {
-  InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
-  isWrapped,
-  safeExecuteInTheMiddle,
-} from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleDefinition, isWrapped, safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../../InstrumentationNodeModuleFile';
 import {
   ATTR_DB_COLLECTION_NAME,
   ATTR_DB_NAMESPACE,

--- a/packages/node/src/integrations/tracing/firebase/otel/patches/functions.ts
+++ b/packages/node/src/integrations/tracing/firebase/otel/patches/functions.ts
@@ -1,12 +1,8 @@
 import type { Span, Tracer } from '@opentelemetry/api';
 import { context, diag, SpanKind, trace } from '@opentelemetry/api';
 import type { InstrumentationBase } from '@opentelemetry/instrumentation';
-import {
-  InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
-  isWrapped,
-  safeExecuteInTheMiddle,
-} from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleDefinition, isWrapped, safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../../InstrumentationNodeModuleFile';
 import type { SpanAttributes } from '@sentry/core';
 import type { FirebaseInstrumentation } from '../firebaseInstrumentation';
 import type {

--- a/packages/node/src/integrations/tracing/google-genai/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/google-genai/instrumentation.ts
@@ -1,9 +1,6 @@
 import type { InstrumentationConfig, InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
-import {
-  InstrumentationBase,
-  InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
-} from '@opentelemetry/instrumentation';
+import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../InstrumentationNodeModuleFile';
 import type { GoogleGenAIClient, GoogleGenAIOptions } from '@sentry/core';
 import {
   _INTERNAL_shouldSkipAiProviderWrapping,

--- a/packages/node/src/integrations/tracing/graphql/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/graphql/vendored/instrumentation.ts
@@ -26,9 +26,9 @@ import {
   isWrapped,
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../InstrumentationNodeModuleFile';
 import type {
   DefinitionNode,
   DocumentNode,

--- a/packages/node/src/integrations/tracing/knex/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/knex/vendored/instrumentation.ts
@@ -26,11 +26,11 @@ import * as constants from './constants';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
   isWrapped,
   SemconvStability,
   semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../InstrumentationNodeModuleFile';
 import * as utils from './utils';
 import { KnexInstrumentationConfig } from './types';
 import {

--- a/packages/node/src/integrations/tracing/langchain/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/langchain/instrumentation.ts
@@ -3,8 +3,8 @@ import {
   type InstrumentationConfig,
   type InstrumentationModuleDefinition,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../InstrumentationNodeModuleFile';
 import type { LangChainOptions } from '@sentry/core';
 import {
   _INTERNAL_mergeLangChainCallbackHandler,

--- a/packages/node/src/integrations/tracing/langgraph/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/langgraph/instrumentation.ts
@@ -3,8 +3,8 @@ import {
   type InstrumentationConfig,
   type InstrumentationModuleDefinition,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../InstrumentationNodeModuleFile';
 import type { CompiledGraph, LangGraphOptions } from '@sentry/core';
 import { getClient, instrumentCreateReactAgent, instrumentLangGraph, SDK_VERSION } from '@sentry/core';
 

--- a/packages/node/src/integrations/tracing/mongo/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/mongo/vendored/instrumentation.ts
@@ -23,12 +23,12 @@ import { context, trace, Span, SpanKind, SpanStatusCode, UpDownCounter, type Att
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
   isWrapped,
   safeExecuteInTheMiddle,
   SemconvStability,
   semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../InstrumentationNodeModuleFile';
 import {
   ATTR_DB_COLLECTION_NAME,
   ATTR_DB_NAMESPACE,

--- a/packages/node/src/integrations/tracing/mysql2/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/mysql2/vendored/instrumentation.ts
@@ -26,12 +26,12 @@ import { SDK_VERSION } from '@sentry/core';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
   isWrapped,
   safeExecuteInTheMiddle,
   SemconvStability,
   semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../InstrumentationNodeModuleFile';
 import { DB_SYSTEM_VALUE_MYSQL, ATTR_DB_STATEMENT, ATTR_DB_SYSTEM } from './semconv';
 import { addSqlCommenterComment } from '../../utils/sql-common';
 import type { Connection, Query, QueryOptions, QueryError, FieldPacket, FormatFunction } from './mysql2-types';

--- a/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/postgres/vendored/instrumentation.ts
@@ -26,10 +26,10 @@ import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
   safeExecuteInTheMiddle,
-  InstrumentationNodeModuleFile,
   SemconvStability,
   semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../InstrumentationNodeModuleFile';
 import {
   context,
   trace,

--- a/packages/node/src/integrations/tracing/postgresjs.ts
+++ b/packages/node/src/integrations/tracing/postgresjs.ts
@@ -5,9 +5,9 @@ import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from './InstrumentationNodeModuleFile';
 import {
   ATTR_DB_OPERATION_NAME,
   ATTR_DB_QUERY_TEXT,

--- a/packages/node/src/integrations/tracing/redis/vendored/redis-instrumentation.ts
+++ b/packages/node/src/integrations/tracing/redis/vendored/redis-instrumentation.ts
@@ -26,12 +26,12 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  InstrumentationNodeModuleFile,
   isWrapped,
   safeExecuteInTheMiddle,
   SemconvStability,
   semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
+import { InstrumentationNodeModuleFile } from '../../InstrumentationNodeModuleFile';
 import {
   ATTR_DB_OPERATION_NAME,
   ATTR_DB_QUERY_TEXT,

--- a/packages/node/test/integrations/tracing/instrumentationNodeModuleFile.test.ts
+++ b/packages/node/test/integrations/tracing/instrumentationNodeModuleFile.test.ts
@@ -21,22 +21,12 @@ describe('InstrumentationNodeModuleFile import guard', () => {
           walkDir(fullPath);
         } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
           const content = fs.readFileSync(fullPath, 'utf-8');
-          if (
-            content.includes('InstrumentationNodeModuleFile') &&
-            content.includes("from '@opentelemetry/instrumentation'")
-          ) {
-            const lines = content.split('\n');
-            const hasDirectImport = lines.some(
-              line => line.includes('InstrumentationNodeModuleFile') && line.includes('@opentelemetry/instrumentation'),
-            );
-            const hasNamedImport = lines.some(line =>
-              /import\s*\{[^}]*InstrumentationNodeModuleFile[^}]*\}\s*from\s*'@opentelemetry\/instrumentation'/.test(
-                line,
-              ),
-            );
-            if (hasDirectImport || hasNamedImport) {
-              offendingFiles.push(path.relative(TRACING_DIR, fullPath));
-            }
+          // Match multi-line imports: look for an import block from @opentelemetry/instrumentation
+          // that includes InstrumentationNodeModuleFile as a named import
+          const importBlockRegex =
+            /import\s*\{[^}]*InstrumentationNodeModuleFile[^}]*\}\s*from\s*['"]@opentelemetry\/instrumentation['"]/s;
+          if (importBlockRegex.test(content)) {
+            offendingFiles.push(path.relative(TRACING_DIR, fullPath));
           }
         }
       }

--- a/packages/node/test/integrations/tracing/instrumentationNodeModuleFile.test.ts
+++ b/packages/node/test/integrations/tracing/instrumentationNodeModuleFile.test.ts
@@ -1,0 +1,49 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const TRACING_DIR = path.resolve(__dirname, '../../../src/integrations/tracing');
+
+/**
+ * Importing InstrumentationNodeModuleFile from @opentelemetry/instrumentation causes
+ * Bun's --bytecode compiler to inline a re-export chain that loses scope bindings.
+ * All instrumentations must use the local vendored copy instead.
+ */
+describe('InstrumentationNodeModuleFile import guard', () => {
+  it('no file should import InstrumentationNodeModuleFile from @opentelemetry/instrumentation', () => {
+    const offendingFiles: string[] = [];
+
+    function walkDir(dir: string): void {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walkDir(fullPath);
+        } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+          const content = fs.readFileSync(fullPath, 'utf-8');
+          if (
+            content.includes('InstrumentationNodeModuleFile') &&
+            content.includes("from '@opentelemetry/instrumentation'")
+          ) {
+            const lines = content.split('\n');
+            const hasDirectImport = lines.some(
+              line => line.includes('InstrumentationNodeModuleFile') && line.includes('@opentelemetry/instrumentation'),
+            );
+            const hasNamedImport = lines.some(line =>
+              /import\s*\{[^}]*InstrumentationNodeModuleFile[^}]*\}\s*from\s*'@opentelemetry\/instrumentation'/.test(
+                line,
+              ),
+            );
+            if (hasDirectImport || hasNamedImport) {
+              offendingFiles.push(path.relative(TRACING_DIR, fullPath));
+            }
+          }
+        }
+      }
+    }
+
+    walkDir(TRACING_DIR);
+
+    expect(offendingFiles).toEqual([]);
+  });
+});


### PR DESCRIPTION
`InstrumentationNodeModuleFile` from `@opentelemetry/instrumentation` resolves `path.normalize`. When Bun's `--bytecode` compiler inlines the module tree into a single flat bundle, it renames `normalize` to `normalize4` and then loses the scope binding in bytecode compilation, producing a `ReferenceError` at runtime.

Vendor a local `InstrumentationNodeModuleFile` class that calls `path.normalize()` directly, replacing the import from `@opentelemetry/instrumentation` in all vendored instrumentations within `@sentry/node`.

Closes https://github.com/getsentry/sentry-javascript/issues/21256
