### PR TITLE
feat(core): Migrate AI utils, genAI spans, and MCP server to `dataCollection`

### DIFF
--- a/packages/core/src/integrations/mcp-server/index.ts
+++ b/packages/core/src/integrations/mcp-server/index.ts
@@ -61,11 +61,11 @@ export function wrapMcpServerWithSentry<S extends object>(mcpServerInstance: S, 
 
   const serverInstance = mcpServerInstance as MCPServerInstance;
   const client = getClient();
-  const sendDefaultPii = Boolean(client?.getOptions().sendDefaultPii);
+  const genAI = client?.getDataCollectionOptions().genAI;
 
   const resolvedOptions: ResolvedMcpOptions = {
-    recordInputs: options?.recordInputs ?? sendDefaultPii,
-    recordOutputs: options?.recordOutputs ?? sendDefaultPii,
+    recordInputs: options?.recordInputs ?? genAI?.inputs ?? false,
+    recordOutputs: options?.recordOutputs ?? genAI?.outputs ?? false,
   };
 
   fill(serverInstance, 'connect', originalConnect => {

--- a/packages/core/src/integrations/mcp-server/piiFiltering.ts
+++ b/packages/core/src/integrations/mcp-server/piiFiltering.ts
@@ -1,7 +1,7 @@
 /**
  * PII filtering for MCP server spans
  *
- * Removes network-level sensitive data when sendDefaultPii is false.
+ * Removes network-level sensitive data when dataCollection.userInfo is false.
  * Input/output data (request arguments, tool/prompt results) is controlled
  * separately via recordInputs/recordOutputs options.
  */
@@ -9,7 +9,7 @@ import type { SpanAttributeValue } from '../../types/span';
 import { CLIENT_ADDRESS_ATTRIBUTE, CLIENT_PORT_ATTRIBUTE, MCP_RESOURCE_URI_ATTRIBUTE } from './attributes';
 
 /**
- * Network PII attributes that should be removed when sendDefaultPii is false
+ * Network PII attributes that should be removed when dataCollection.userInfo is false
  * @internal
  */
 const NETWORK_PII_ATTRIBUTES = new Set([CLIENT_ADDRESS_ATTRIBUTE, CLIENT_PORT_ATTRIBUTE, MCP_RESOURCE_URI_ATTRIBUTE]);
@@ -31,16 +31,16 @@ function isNetworkPiiAttribute(key: string): boolean {
 }
 
 /**
- * Removes network PII attributes from span data when sendDefaultPii is false
+ * Removes network PII attributes from span data when dataCollection.userInfo is false
  * @param spanData - Raw span attributes
- * @param sendDefaultPii - Whether to include PII data
+ * @param userInfo - Whether to include user identity data (IP, port, resource URIs)
  * @returns Filtered span attributes
  */
 export function filterMcpPiiFromSpanData(
   spanData: Record<string, unknown>,
-  sendDefaultPii: boolean,
+  userInfo: boolean,
 ): Record<string, SpanAttributeValue> {
-  if (sendDefaultPii) {
+  if (userInfo) {
     return spanData as Record<string, SpanAttributeValue>;
   }
 

--- a/packages/core/src/integrations/mcp-server/spans.ts
+++ b/packages/core/src/integrations/mcp-server/spans.ts
@@ -105,8 +105,8 @@ function createMcpSpan(config: McpSpanConfig): unknown {
   };
 
   const client = getClient();
-  const sendDefaultPii = Boolean(client?.getOptions().sendDefaultPii);
-  const attributes = filterMcpPiiFromSpanData(rawAttributes, sendDefaultPii) as Record<string, string | number>;
+  const userInfo = Boolean(client?.getDataCollectionOptions().userInfo);
+  const attributes = filterMcpPiiFromSpanData(rawAttributes, userInfo) as Record<string, string | number>;
 
   return startSpan(
     {
@@ -200,8 +200,8 @@ export function buildMcpServerSpanConfig(
   };
 
   const client = getClient();
-  const sendDefaultPii = Boolean(client?.getOptions().sendDefaultPii);
-  const attributes = filterMcpPiiFromSpanData(rawAttributes, sendDefaultPii) as Record<string, string | number>;
+  const userInfo = Boolean(client?.getDataCollectionOptions().userInfo);
+  const attributes = filterMcpPiiFromSpanData(rawAttributes, userInfo) as Record<string, string | number>;
 
   return {
     name: spanName,

--- a/packages/core/src/integrations/mcp-server/types.ts
+++ b/packages/core/src/integrations/mcp-server/types.ts
@@ -225,9 +225,9 @@ export type SessionData = {
  * Options for configuring the MCP server wrapper.
  */
 export type McpServerWrapperOptions = {
-  /** Whether to capture tool/prompt input arguments in spans. Defaults to sendDefaultPii. */
+  /** Whether to capture tool/prompt input arguments in spans. Defaults to `dataCollection.genAI.inputs` (or `sendDefaultPii` when `dataCollection` is not configured). */
   recordInputs?: boolean;
-  /** Whether to capture tool/prompt output results in spans. Defaults to sendDefaultPii. */
+  /** Whether to capture tool/prompt output results in spans. Defaults to `dataCollection.genAI.outputs` (or `sendDefaultPii` when `dataCollection` is not configured). */
   recordOutputs?: boolean;
 };
 

--- a/packages/core/src/tracing/langchain/types.ts
+++ b/packages/core/src/tracing/langchain/types.ts
@@ -4,13 +4,13 @@
 export interface LangChainOptions {
   /**
    * Whether to record input messages/prompts
-   * @default false (respects sendDefaultPii option)
+   * @default false (respects `dataCollection.genAI.inputs`, or `sendDefaultPii` when `dataCollection` is not configured)
    */
   recordInputs?: boolean;
 
   /**
    * Whether to record output text and responses
-   * @default false (respects sendDefaultPii option)
+   * @default false (respects `dataCollection.genAI.outputs`, or `sendDefaultPii` when `dataCollection` is not configured)
    */
   recordOutputs?: boolean;
 

--- a/packages/core/src/tracing/spans/extractGenAiSpans.ts
+++ b/packages/core/src/tracing/spans/extractGenAiSpans.ts
@@ -43,7 +43,7 @@ export function extractGenAiSpansFromEvent(event: Event, client: Client): SpanCo
 
   event.spans = remainingSpans;
 
-  const inferSetting = client.getOptions().sendDefaultPii ? 'auto' : 'never';
+  const inferSetting = client.getDataCollectionOptions().userInfo ? 'auto' : 'never';
 
   return [
     { type: 'span', item_count: genAiSpans.length, content_type: 'application/vnd.sentry.items.span.v2+json' },

--- a/packages/core/test/lib/integrations/mcp-server/mcpServerErrorCapture.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/mcpServerErrorCapture.test.ts
@@ -3,7 +3,7 @@ import * as currentScopes from '../../../../src/currentScopes';
 import * as exports from '../../../../src/exports';
 import { wrapMcpServerWithSentry } from '../../../../src/integrations/mcp-server';
 import { captureError } from '../../../../src/integrations/mcp-server/errorCapture';
-import { createMockMcpServer } from './testUtils';
+import { createMockClient, createMockMcpServer } from './testUtils';
 
 describe('MCP Server Error Capture', () => {
   const captureExceptionSpy = vi.spyOn(exports, 'captureException');
@@ -11,9 +11,7 @@ describe('MCP Server Error Capture', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    getClientSpy.mockReturnValue({
-      getOptions: () => ({ sendDefaultPii: true }),
-    } as ReturnType<typeof currentScopes.getClient>);
+    getClientSpy.mockReturnValue(createMockClient(true));
   });
 
   describe('captureError', () => {

--- a/packages/core/test/lib/integrations/mcp-server/mcpServerWrapper.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/mcpServerWrapper.test.ts
@@ -3,6 +3,7 @@ import * as currentScopes from '../../../../src/currentScopes';
 import { wrapMcpServerWithSentry } from '../../../../src/integrations/mcp-server';
 import * as tracingModule from '../../../../src/tracing';
 import {
+  createMockClient,
   createMockMcpServer,
   createMockMcpServerWithPreregisteredHandlers,
   createMockMcpServerWithRegisterApi,
@@ -15,12 +16,7 @@ describe('wrapMcpServerWithSentry', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock client to return sendDefaultPii:
-    getClientSpy.mockReturnValue({
-      getOptions: () => ({ sendDefaultPii: true }),
-      getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
-      emit: vi.fn(),
-    } as any);
+    getClientSpy.mockReturnValue(createMockClient(true));
   });
 
   it('should return the same instance (modified) if it is a valid MCP server instance', () => {

--- a/packages/core/test/lib/integrations/mcp-server/piiFiltering.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/piiFiltering.test.ts
@@ -3,7 +3,12 @@ import * as currentScopes from '../../../../src/currentScopes';
 import { wrapMcpServerWithSentry } from '../../../../src/integrations/mcp-server';
 import { filterMcpPiiFromSpanData } from '../../../../src/integrations/mcp-server/piiFiltering';
 import * as tracingModule from '../../../../src/tracing';
-import { createMockMcpServer, createMockTransport } from './testUtils';
+import {
+  createMockClient,
+  createMockMcpServer,
+  createMockTransport,
+  createTestClientWithSendDefaultPii,
+} from './testUtils';
 
 describe('MCP Server PII Filtering', () => {
   const startInactiveSpanSpy = vi.spyOn(tracingModule, 'startInactiveSpan');
@@ -23,12 +28,8 @@ describe('MCP Server PII Filtering', () => {
       mockTransport.sessionId = 'test-session-123';
     });
 
-    it('should include network PII when sendDefaultPii is true', async () => {
-      getClientSpy.mockReturnValue({
-        getOptions: () => ({ sendDefaultPii: true }),
-        getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
-        emit: vi.fn(),
-      } as unknown as ReturnType<typeof currentScopes.getClient>);
+    it('should include network PII when dataCollection.userInfo is true', async () => {
+      getClientSpy.mockReturnValue(createMockClient(true));
 
       const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
       await wrappedMcpServer.connect(mockTransport);
@@ -59,12 +60,8 @@ describe('MCP Server PII Filtering', () => {
       );
     });
 
-    it('should exclude network PII when sendDefaultPii is false', async () => {
-      getClientSpy.mockReturnValue({
-        getOptions: () => ({ sendDefaultPii: false }),
-        getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
-        emit: vi.fn(),
-      } as unknown as ReturnType<typeof currentScopes.getClient>);
+    it('should exclude network PII when dataCollection.userInfo is false', async () => {
+      getClientSpy.mockReturnValue(createMockClient(false));
 
       const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
       await wrappedMcpServer.connect(mockTransport);
@@ -105,8 +102,69 @@ describe('MCP Server PII Filtering', () => {
     });
   });
 
+  describe('Integration Tests - Network PII (sendDefaultPii bridge)', () => {
+    let mockMcpServer: ReturnType<typeof createMockMcpServer>;
+    let mockTransport: ReturnType<typeof createMockTransport>;
+
+    beforeEach(() => {
+      mockMcpServer = createMockMcpServer();
+      mockTransport = createMockTransport();
+      mockTransport.sessionId = 'test-session-123';
+    });
+
+    it('should include network PII when sendDefaultPii is true', async () => {
+      getClientSpy.mockReturnValue(createTestClientWithSendDefaultPii(true));
+
+      const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
+      await wrappedMcpServer.connect(mockTransport);
+
+      const extraWithClientInfo = {
+        requestInfo: { remoteAddress: '192.168.1.100', remotePort: 54321 },
+      };
+
+      mockTransport.onmessage?.(
+        { jsonrpc: '2.0', method: 'tools/call', id: 'req-pii-true', params: { name: 'weather', arguments: {} } },
+        extraWithClientInfo,
+      );
+
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            'client.address': '192.168.1.100',
+            'client.port': 54321,
+          }),
+        }),
+      );
+    });
+
+    it('should exclude network PII when sendDefaultPii is false', async () => {
+      getClientSpy.mockReturnValue(createTestClientWithSendDefaultPii(false));
+
+      const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
+      await wrappedMcpServer.connect(mockTransport);
+
+      const extraWithClientInfo = {
+        requestInfo: { remoteAddress: '192.168.1.100', remotePort: 54321 },
+      };
+
+      mockTransport.onmessage?.(
+        { jsonrpc: '2.0', method: 'tools/call', id: 'req-pii-false', params: { name: 'weather', arguments: {} } },
+        extraWithClientInfo,
+      );
+
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.not.objectContaining({
+            'client.address': expect.anything(),
+            'client.port': expect.anything(),
+          }),
+        }),
+      );
+    });
+  });
+
   describe('filterMcpPiiFromSpanData Function', () => {
-    it('should preserve all data when sendDefaultPii is true', () => {
+    it('should preserve all data when userInfo is true', () => {
       const spanData = {
         'client.address': '192.168.1.100',
         'client.port': 54321,
@@ -120,7 +178,7 @@ describe('MCP Server PII Filtering', () => {
       expect(result).toEqual(spanData);
     });
 
-    it('should only remove network PII when sendDefaultPii is false', () => {
+    it('should only remove network PII when userInfo is false', () => {
       const spanData = {
         'client.address': '192.168.1.100',
         'client.port': 54321,

--- a/packages/core/test/lib/integrations/mcp-server/semanticConventions.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/semanticConventions.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as currentScopes from '../../../../src/currentScopes';
 import { wrapMcpServerWithSentry } from '../../../../src/integrations/mcp-server';
 import * as tracingModule from '../../../../src/tracing';
-import { createMockMcpServer, createMockTransport } from './testUtils';
+import { createMockClient, createMockMcpServer, createMockTransport } from './testUtils';
 
 describe('MCP Server Semantic Conventions', () => {
   const startSpanSpy = vi.spyOn(tracingModule, 'startSpan');
@@ -11,12 +11,7 @@ describe('MCP Server Semantic Conventions', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock client to return sendDefaultPii: true for instrumentation tests
-    getClientSpy.mockReturnValue({
-      getOptions: () => ({ sendDefaultPii: true }),
-      getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
-      emit: vi.fn(),
-    } as unknown as ReturnType<typeof currentScopes.getClient>);
+    getClientSpy.mockReturnValue(createMockClient(true));
   });
 
   describe('Span Creation & Semantic Conventions', () => {

--- a/packages/core/test/lib/integrations/mcp-server/testUtils.ts
+++ b/packages/core/test/lib/integrations/mcp-server/testUtils.ts
@@ -1,4 +1,38 @@
+import type { Client } from '../../../../src/client';
 import { vi } from 'vitest';
+import { getDefaultTestClientOptions, TestClient } from '../../../mocks/client';
+
+/**
+ * Creates a mock Sentry client with getDataCollectionOptions for use in MCP server tests.
+ * @param userInfo - Whether user identity data (IP, port) is collected. Default: true
+ * @param genAI - Whether AI inputs/outputs are recorded. Defaults to match userInfo.
+ */
+export function createMockClient(userInfo = true, genAI?: { inputs: boolean; outputs: boolean }): Client {
+  const genAIOptions = genAI ?? { inputs: userInfo, outputs: userInfo };
+  return {
+    getOptions: () => ({}),
+    getDataCollectionOptions: () => ({
+      userInfo,
+      cookies: true,
+      httpHeaders: { request: true, response: true },
+      httpBodies: [],
+      queryParams: true,
+      genAI: genAIOptions,
+      stackFrameVariables: true,
+      frameContextLines: 5,
+    }),
+    getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
+    emit: vi.fn(),
+  } as unknown as Client;
+}
+
+/**
+ * Creates a real TestClient configured with the legacy sendDefaultPii flag.
+ * Use this in tests that verify the sendDefaultPii → dataCollection bridge still works.
+ */
+export function createTestClientWithSendDefaultPii(sendDefaultPii: boolean): Client {
+  return new TestClient(getDefaultTestClientOptions({ dsn: 'https://key@sentry.io/1', sendDefaultPii }));
+}
 
 /**
  * Create a mock MCP server instance for testing (legacy API: tool/resource/prompt)

--- a/packages/core/test/lib/integrations/mcp-server/transportInstrumentation.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/transportInstrumentation.test.ts
@@ -24,11 +24,13 @@ import {
 } from '../../../../src/integrations/mcp-server/transport';
 import * as tracingModule from '../../../../src/tracing';
 import {
+  createMockClient,
   createMockMcpServer,
   createMockSseTransport,
   createMockStdioTransport,
   createMockTransport,
   createMockWrapperTransport,
+  createTestClientWithSendDefaultPii,
 } from './testUtils';
 
 describe('MCP Server Transport Instrumentation', () => {
@@ -38,12 +40,7 @@ describe('MCP Server Transport Instrumentation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock client to return sendDefaultPii: true for instrumentation tests
-    getClientSpy.mockReturnValue({
-      getOptions: () => ({ sendDefaultPii: true }),
-      getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
-      emit: vi.fn(),
-    } as any);
+    getClientSpy.mockReturnValue(createMockClient(true));
   });
 
   describe('Transport-level instrumentation', () => {
@@ -727,12 +724,8 @@ describe('MCP Server Transport Instrumentation', () => {
   });
 
   describe('Wrapper Options', () => {
-    it('should NOT capture inputs/outputs when sendDefaultPii is false', async () => {
-      getClientSpy.mockReturnValue({
-        getOptions: () => ({ sendDefaultPii: false }),
-        getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
-        emit: vi.fn(),
-      } as any);
+    it('should NOT capture inputs/outputs when dataCollection.genAI.inputs/outputs are false', async () => {
+      getClientSpy.mockReturnValue(createMockClient(false));
 
       const mockMcpServer = createMockMcpServer();
       const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
@@ -759,12 +752,8 @@ describe('MCP Server Transport Instrumentation', () => {
       );
     });
 
-    it('should capture inputs/outputs when sendDefaultPii is true', async () => {
-      getClientSpy.mockReturnValue({
-        getOptions: () => ({ sendDefaultPii: true }),
-        getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
-        emit: vi.fn(),
-      } as any);
+    it('should capture inputs/outputs when dataCollection.genAI.inputs/outputs are true', async () => {
+      getClientSpy.mockReturnValue(createMockClient(true));
 
       const mockMcpServer = createMockMcpServer();
       const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
@@ -792,11 +781,7 @@ describe('MCP Server Transport Instrumentation', () => {
     });
 
     it('should allow explicit override of defaults', async () => {
-      getClientSpy.mockReturnValue({
-        getOptions: () => ({ sendDefaultPii: true }),
-        getDsn: () => ({ publicKey: 'test-key', host: 'test-host' }),
-        emit: vi.fn(),
-      } as any);
+      getClientSpy.mockReturnValue(createMockClient(true));
 
       const mockMcpServer = createMockMcpServer();
       const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer, { recordInputs: false });
@@ -818,6 +803,62 @@ describe('MCP Server Transport Instrumentation', () => {
         expect.objectContaining({
           attributes: expect.not.objectContaining({
             'mcp.request.argument.location': expect.anything(),
+          }),
+        }),
+      );
+    });
+
+    it('should NOT capture inputs/outputs when sendDefaultPii is false (legacy bridge)', async () => {
+      getClientSpy.mockReturnValue(createTestClientWithSendDefaultPii(false));
+
+      const mockMcpServer = createMockMcpServer();
+      const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
+      const transport = createMockTransport();
+
+      await wrappedMcpServer.connect(transport);
+
+      transport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          id: 'tool-1',
+          params: { name: 'weather', arguments: { location: 'London' } },
+        },
+        {},
+      );
+
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.not.objectContaining({
+            'mcp.request.argument.location': expect.anything(),
+          }),
+        }),
+      );
+    });
+
+    it('should capture inputs/outputs when sendDefaultPii is true (legacy bridge)', async () => {
+      getClientSpy.mockReturnValue(createTestClientWithSendDefaultPii(true));
+
+      const mockMcpServer = createMockMcpServer();
+      const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
+      const transport = createMockTransport();
+
+      await wrappedMcpServer.connect(transport);
+
+      transport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          id: 'tool-1',
+          params: { name: 'weather', arguments: { location: 'London' } },
+        },
+        {},
+      );
+
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            'mcp.request.argument.location': '"London"',
           }),
         }),
       );


### PR DESCRIPTION



Closes https://github.com/getsentry/sentry-javascript/issues/20928
