### PR TITLE
feat(cloudflare): Auto instrument D1 based on env

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/d1/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/index.ts
@@ -15,6 +15,8 @@ export default Sentry.withSentry(
     async fetch(request, env, _ctx) {
       const url = new URL(request.url);
 
+      await env.DB.exec('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)');
+
       if (url.pathname === '/prepare') {
         await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(1).all();
         return new Response('ok');
@@ -29,6 +31,11 @@ export default Sentry.withSentry(
 
         const isSameRef = prepareBeforeManual === prepareAfterManual ? 'true' : 'false';
         return new Response(isSameRef);
+      }
+
+      if (url.pathname === '/error') {
+        await env.DB.prepare('SELECT * FROM non_existent_table').all();
+        return new Response('ok');
       }
 
       return new Response('not found', { status: 404 });

--- a/dev-packages/cloudflare-integration-tests/suites/d1/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/index.ts
@@ -1,0 +1,37 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+  DB: D1Database;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1,
+  }),
+  {
+    async fetch(request, env, _ctx) {
+      const url = new URL(request.url);
+
+      if (url.pathname === '/prepare') {
+        await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(1).all();
+        return new Response('ok');
+      }
+
+      if (url.pathname === '/double-instrument') {
+        const prepareBeforeManual = env.DB.prepare;
+        const db = Sentry.instrumentD1WithSentry(env.DB);
+        const prepareAfterManual = db.prepare;
+
+        await db.prepare('SELECT * FROM users WHERE id = ?').bind(1).all();
+
+        const isSameRef = prepareBeforeManual === prepareAfterManual ? 'true' : 'false';
+        return new Response(isSameRef);
+      }
+
+      return new Response('not found', { status: 404 });
+    },
+  } satisfies ExportedHandler<Env>,
+);

--- a/dev-packages/cloudflare-integration-tests/suites/d1/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/test.ts
@@ -1,0 +1,72 @@
+import type { Envelope } from '@sentry/core';
+import { expect, it } from 'vitest';
+import { createRunner } from '../../runner';
+
+function envelopeItemType(envelope: Envelope): string | undefined {
+  return envelope[1][0]?.[0]?.type as string | undefined;
+}
+
+function envelopeItem(envelope: Envelope): Record<string, unknown> {
+  return envelope[1][0]![1] as Record<string, unknown>;
+}
+
+function findD1Spans(envelope: Envelope): Array<Record<string, unknown>> {
+  if (envelopeItemType(envelope) !== 'transaction') return [];
+  const tx = envelopeItem(envelope);
+  const spans = (tx.spans as Array<Record<string, unknown>>) || [];
+  return spans.filter(s => (s.op as string) === 'db.query');
+}
+
+it('instruments D1 prepare().all() automatically via env', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .ignore('event')
+    .expect((envelope: Envelope) => {
+      if (envelopeItemType(envelope) !== 'transaction') return;
+      const d1Spans = findD1Spans(envelope);
+      expect(d1Spans.length).toBeGreaterThanOrEqual(1);
+
+      const querySpan = d1Spans.find(s => s.description === 'SELECT * FROM users WHERE id = ?');
+      expect(querySpan).toBeDefined();
+      expect(querySpan).toEqual({
+        data: {
+          'cloudflare.d1.duration': expect.any(Number),
+          'cloudflare.d1.query_type': 'all',
+          'cloudflare.d1.rows_read': expect.any(Number),
+          'cloudflare.d1.rows_written': expect.any(Number),
+          'sentry.op': 'db.query',
+          'sentry.origin': 'auto.db.cloudflare.d1',
+        },
+        description: 'SELECT * FROM users WHERE id = ?',
+        op: 'db.query',
+        origin: 'auto.db.cloudflare.d1',
+        parent_span_id: expect.any(String),
+        span_id: expect.any(String),
+        start_timestamp: expect.any(Number),
+        timestamp: expect.any(Number),
+        trace_id: expect.any(String),
+      });
+    })
+    .start(signal);
+
+  await runner.makeRequest('get', '/prepare');
+  await runner.completed();
+});
+
+it('does not double-instrument when instrumentD1WithSentry is used on top of env instrumentation', async ({
+  signal,
+}) => {
+  const runner = createRunner(__dirname)
+    .ignore('event')
+    .expect((envelope: Envelope) => {
+      if (envelopeItemType(envelope) !== 'transaction') return;
+      const d1Spans = findD1Spans(envelope);
+
+      const querySpans = d1Spans.filter(s => s.description === 'SELECT * FROM users WHERE id = ?');
+      expect(querySpans).toHaveLength(1);
+    })
+    .start(signal);
+
+  const response = await runner.makeRequest('get', '/double-instrument');
+  expect(response).toBe('true');
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/d1/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/test.ts
@@ -52,6 +52,48 @@ it('instruments D1 prepare().all() automatically via env', async ({ signal }) =>
   await runner.completed();
 });
 
+it('captures error event when a D1 query references a non-existent table', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .ignore('transaction')
+    .expect((envelope: Envelope) => {
+      expect(envelopeItemType(envelope)).toBe('event');
+      const event = envelopeItem(envelope);
+      expect(event.level).toBe('error');
+
+      const values = (event.exception as { values: Array<Record<string, unknown>> })?.values;
+      expect(values).toHaveLength(2);
+
+      expect(values).toEqual([
+        {
+          type: 'Error',
+          value: 'no such table: non_existent_table: SQLITE_ERROR',
+          stacktrace: expect.any(Object),
+          mechanism: {
+            type: 'auto.http.cloudflare',
+            handled: false,
+            source: 'cause',
+            exception_id: 1,
+            parent_id: 0,
+          },
+        },
+        {
+          type: 'Error',
+          value: 'D1_ERROR: no such table: non_existent_table: SQLITE_ERROR',
+          stacktrace: expect.any(Object),
+          mechanism: {
+            type: 'generic',
+            handled: true,
+            exception_id: 0,
+          },
+        },
+      ]);
+    })
+    .start(signal);
+
+  await runner.makeRequest('get', '/error', { expectError: true });
+  await runner.completed();
+});
+
 it('does not double-instrument when instrumentD1WithSentry is used on top of env instrumentation', async ({
   signal,
 }) => {

--- a/dev-packages/cloudflare-integration-tests/suites/d1/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "name": "d1-test-worker",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "test-db",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+    },
+  ],
+}

--- a/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
@@ -149,7 +149,7 @@ export function instrumentD1(db: D1Database): D1Database {
  * Instruments Cloudflare D1 bindings with Sentry.
  *
  * @deprecated `withSentry()` automatically instruments all D1 bindings via `env`
- * so this function is not needed anymore.
+ * so this function is not needed anymore. It will be removed in the next major version of the SDK.
  *
  * @example
  *

--- a/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
@@ -144,10 +144,12 @@ export function instrumentD1(db: D1Database): D1Database {
   return ensureInstrumented(db, _instrumentD1);
 }
 
+// todo(v11): Remove this export
 /**
  * Instruments Cloudflare D1 bindings with Sentry.
  *
- * @deprecated Use `withSentry()` instead, which automatically instruments all D1 bindings via env.
+ * @deprecated `withSentry()` automatically instruments all D1 bindings via `env`
+ * so this function is not needed anymore.
  *
  * @example
  *

--- a/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import type { D1Database, D1PreparedStatement, D1Response } from '@cloudflare/workers-types';
 import type { Span, SpanAttributes, StartSpanOptions } from '@sentry/core';
 import { addBreadcrumb, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SPAN_STATUS_ERROR, startSpan } from '@sentry/core';
+import { ensureInstrumented } from '../../instrument';
 
 // Patching is based on internal Cloudflare D1 API
 // https://github.com/cloudflare/workerd/blob/cd5279e7b305003f1d9c851e73efa9d67e4b68b2/src/cloudflare/internal/d1-api.ts
@@ -127,10 +129,25 @@ function createStartSpanOptions(query: string, type: 'first' | 'run' | 'all' | '
   };
 }
 
+function _instrumentD1(db: D1Database): D1Database {
+  db.prepare = new Proxy(db.prepare, {
+    apply(target, thisArg, args: Parameters<typeof db.prepare>) {
+      const [query] = args;
+      return instrumentD1PreparedStatement(Reflect.apply(target, thisArg, args), query);
+    },
+  });
+
+  return db;
+}
+
+export function instrumentD1(db: D1Database): D1Database {
+  return ensureInstrumented(db, _instrumentD1);
+}
+
 /**
  * Instruments Cloudflare D1 bindings with Sentry.
  *
- * Currently, only prepared statements are instrumented. `db.exec` and `db.batch` are not instrumented.
+ * @deprecated Use `withSentry()` instead, which automatically instruments all D1 bindings via env.
  *
  * @example
  *
@@ -142,13 +159,5 @@ function createStartSpanOptions(query: string, type: 'first' | 'run' | 'all' | '
  * ```
  */
 export function instrumentD1WithSentry(db: D1Database): D1Database {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  db.prepare = new Proxy(db.prepare, {
-    apply(target, thisArg, args: Parameters<typeof db.prepare>) {
-      const [query] = args;
-      return instrumentD1PreparedStatement(Reflect.apply(target, thisArg, args), query);
-    },
-  });
-
-  return db;
+  return instrumentD1(db);
 }

--- a/packages/cloudflare/src/instrumentations/worker/instrumentEnv.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentEnv.ts
@@ -1,5 +1,6 @@
 import type { CloudflareOptions } from '../../client';
-import { isDurableObjectNamespace, isJSRPC, isQueue } from '../../utils/isBinding';
+import { isD1Database, isDurableObjectNamespace, isJSRPC, isQueue } from '../../utils/isBinding';
+import { instrumentD1 } from './instrumentD1';
 import { appendRpcMeta } from '../../utils/rpcMeta';
 import { getEffectiveRpcPropagation } from '../../utils/rpcOptions';
 import { instrumentDurableObjectNamespace, STUB_NON_RPC_METHODS } from '../instrumentDurableObjectNamespace';
@@ -45,6 +46,12 @@ export function instrumentEnv<Env extends Record<string, unknown>>(env: Env, opt
 
       if (cached) {
         return cached;
+      }
+
+      if (isD1Database(item)) {
+        const instrumented = instrumentD1(item);
+        instrumentedBindings.set(item, instrumented);
+        return instrumented;
       }
 
       if (isQueue(item)) {

--- a/packages/cloudflare/src/utils/isBinding.ts
+++ b/packages/cloudflare/src/utils/isBinding.ts
@@ -31,7 +31,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import type { DurableObjectNamespace, Queue } from '@cloudflare/workers-types';
+import type { D1Database, DurableObjectNamespace, Queue } from '@cloudflare/workers-types';
 
 /**
  * Checks if a value is a JSRPC proxy (service binding).
@@ -66,4 +66,18 @@ export function isDurableObjectNamespace(item: unknown): item is DurableObjectNa
  */
 export function isQueue(item: unknown): item is Queue {
   return item != null && isNotJSRPC(item) && typeof item.send === 'function' && typeof item.sendBatch === 'function';
+}
+
+/**
+ * Duck-type check for D1Database bindings.
+ * D1Database has `prepare`, `batch`, and `exec` methods.
+ */
+export function isD1Database(item: unknown): item is D1Database {
+  return (
+    item != null &&
+    isNotJSRPC(item) &&
+    typeof item.prepare === 'function' &&
+    typeof item.batch === 'function' &&
+    typeof item.exec === 'function'
+  );
 }

--- a/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
+++ b/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
@@ -36,7 +36,7 @@ describe('instrumentEnv', () => {
     const instrumented = instrumentEnv(env);
 
     const db = instrumented.DB as typeof d1Database;
-    await db.exec('SELECT 1');
+    await db.prepare('SELECT 1').first();
 
     expect(startSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({ op: 'db.query', name: 'SELECT 1' }),

--- a/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
+++ b/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
@@ -17,6 +17,46 @@ describe('instrumentEnv', () => {
     vi.clearAllMocks();
   });
 
+  it('detects and instruments D1Database bindings', async () => {
+    const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+    const mockStatement = {
+      bind: vi.fn(),
+      first: vi.fn().mockResolvedValue(null),
+      run: vi.fn().mockResolvedValue({ success: true, meta: { duration: 0, rows_read: 0, rows_written: 0 } }),
+      all: vi.fn().mockResolvedValue({ success: true, meta: { duration: 0, rows_read: 0, rows_written: 0 } }),
+      raw: vi.fn().mockResolvedValue([]),
+    };
+    const d1Database = {
+      prepare: vi.fn().mockReturnValue(mockStatement),
+      batch: vi.fn().mockResolvedValue([]),
+      exec: vi.fn().mockResolvedValue({ count: 0, duration: 0 }),
+      dump: vi.fn(),
+    };
+    const env = { DB: d1Database };
+    const instrumented = instrumentEnv(env);
+
+    const db = instrumented.DB as typeof d1Database;
+    await db.exec('SELECT 1');
+
+    expect(startSpanSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ op: 'db.query', name: 'SELECT 1' }),
+      expect.any(Function),
+    );
+  });
+
+  it('caches instrumented D1 bindings across repeated access', () => {
+    const d1Database = {
+      prepare: vi.fn(),
+      batch: vi.fn(),
+      exec: vi.fn(),
+      dump: vi.fn(),
+    };
+    const env = { DB: d1Database };
+    const instrumented = instrumentEnv(env);
+
+    expect(instrumented.DB).toBe(instrumented.DB);
+  });
+
   it('returns primitive values unchanged', () => {
     const env = { SENTRY_DSN: 'https://key@sentry.io/123', PORT: 8080, DEBUG: true };
     const instrumented = instrumentEnv(env);

--- a/packages/cloudflare/test/instrumentations/worker/instrumentD1.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentD1.test.ts
@@ -1,7 +1,7 @@
 import type { D1Database, D1PreparedStatement } from '@cloudflare/workers-types';
 import * as SentryCore from '@sentry/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { instrumentD1WithSentry } from '../../../src/instrumentations/worker/instrumentD1';
+import { instrumentD1, instrumentD1WithSentry } from '../../../src/instrumentations/worker/instrumentD1';
 
 const MOCK_FIRST_RETURN_VALUE = { id: 1, name: 'Foo' };
 
@@ -23,7 +23,40 @@ const MOCK_D1_RESPONSE = {
   },
 };
 
-describe('instrumentD1WithSentry', () => {
+function createMockD1Statement(): D1PreparedStatement {
+  return {
+    bind: vi.fn().mockImplementation(createMockD1Statement),
+    first: vi.fn().mockImplementation(() => Promise.resolve(MOCK_FIRST_RETURN_VALUE)),
+    run: vi.fn().mockImplementation(() => Promise.resolve(MOCK_D1_RESPONSE)),
+    all: vi.fn().mockImplementation(() => Promise.resolve(MOCK_D1_RESPONSE)),
+    raw: vi.fn().mockImplementation(() => Promise.resolve(MOCK_RAW_RETURN_VALUE)),
+  };
+}
+
+function createMockD1Database(): D1Database {
+  return {
+    prepare: vi.fn().mockImplementation(createMockD1Statement),
+    dump: vi.fn(),
+    batch: vi.fn(),
+    exec: vi.fn(),
+  };
+}
+
+describe('instrumentD1WithSentry (deprecated)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('still instruments the database', async () => {
+    const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+    const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+    await instrumentedDb.prepare('SELECT 1').first();
+
+    expect(startSpanSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('instrumentD1', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -31,34 +64,15 @@ describe('instrumentD1WithSentry', () => {
   const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
   const addBreadcrumbSpy = vi.spyOn(SentryCore, 'addBreadcrumb');
 
-  function createMockD1Statement(): D1PreparedStatement {
-    return {
-      bind: vi.fn().mockImplementation(createMockD1Statement),
-      first: vi.fn().mockImplementation(() => Promise.resolve(MOCK_FIRST_RETURN_VALUE)),
-      run: vi.fn().mockImplementation(() => Promise.resolve(MOCK_D1_RESPONSE)),
-      all: vi.fn().mockImplementation(() => Promise.resolve(MOCK_D1_RESPONSE)),
-      raw: vi.fn().mockImplementation(() => Promise.resolve(MOCK_RAW_RETURN_VALUE)),
-    };
-  }
-
-  function createMockD1Database(): D1Database {
-    return {
-      prepare: vi.fn().mockImplementation(createMockD1Statement),
-      dump: vi.fn(),
-      batch: vi.fn(),
-      exec: vi.fn(),
-    };
-  }
-
   describe('statement.first()', () => {
     test('does not change return value', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       const response = await instrumentedDb.prepare('SELECT * FROM users').first();
       expect(response).toEqual(MOCK_FIRST_RETURN_VALUE);
     });
 
     test('instruments with spans', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('SELECT * FROM users').first();
 
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
@@ -76,7 +90,7 @@ describe('instrumentD1WithSentry', () => {
     });
 
     test('instruments with breadcrumbs', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('SELECT * FROM users').first();
 
       expect(addBreadcrumbSpy).toHaveBeenCalledTimes(1);
@@ -90,7 +104,7 @@ describe('instrumentD1WithSentry', () => {
     });
 
     test('works with statement.bind()', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('SELECT * FROM users').bind().first();
 
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
@@ -100,13 +114,13 @@ describe('instrumentD1WithSentry', () => {
 
   describe('statement.run()', () => {
     test('does not change return value', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       const response = await instrumentedDb.prepare('INSERT INTO users (name) VALUES (?)').run();
       expect(response).toEqual(MOCK_D1_RESPONSE);
     });
 
     test('instruments with spans', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('INSERT INTO users (name) VALUES (?)').run();
 
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
@@ -124,7 +138,7 @@ describe('instrumentD1WithSentry', () => {
     });
 
     test('instruments with breadcrumbs', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('INSERT INTO users (name) VALUES (?)').run();
 
       expect(addBreadcrumbSpy).toHaveBeenCalledTimes(1);
@@ -141,7 +155,7 @@ describe('instrumentD1WithSentry', () => {
     });
 
     test('works with statement.bind()', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('SELECT * FROM users').bind().run();
 
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
@@ -151,13 +165,13 @@ describe('instrumentD1WithSentry', () => {
 
   describe('statement.all()', () => {
     test('does not change return value', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
-      const response = await instrumentedDb.prepare('INSERT INTO users (name) VALUES (?)').run();
+      const instrumentedDb = instrumentD1(createMockD1Database());
+      const response = await instrumentedDb.prepare('SELECT * FROM users').all();
       expect(response).toEqual(MOCK_D1_RESPONSE);
     });
 
     test('instruments with spans', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('INSERT INTO users (name) VALUES (?)').all();
 
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
@@ -175,7 +189,7 @@ describe('instrumentD1WithSentry', () => {
     });
 
     test('instruments with breadcrumbs', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('INSERT INTO users (name) VALUES (?)').all();
 
       expect(addBreadcrumbSpy).toHaveBeenCalledTimes(1);
@@ -192,7 +206,7 @@ describe('instrumentD1WithSentry', () => {
     });
 
     test('works with statement.bind()', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('SELECT * FROM users').bind().all();
 
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
@@ -202,13 +216,13 @@ describe('instrumentD1WithSentry', () => {
 
   describe('statement.raw()', () => {
     test('does not change return value', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       const response = await instrumentedDb.prepare('SELECT * FROM users').raw();
       expect(response).toEqual(MOCK_RAW_RETURN_VALUE);
     });
 
     test('instruments with spans', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('SELECT * FROM users').raw();
 
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
@@ -226,7 +240,7 @@ describe('instrumentD1WithSentry', () => {
     });
 
     test('instruments with breadcrumbs', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('SELECT * FROM users').raw();
 
       expect(addBreadcrumbSpy).toHaveBeenCalledTimes(1);
@@ -240,11 +254,37 @@ describe('instrumentD1WithSentry', () => {
     });
 
     test('works with statement.bind()', async () => {
-      const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
+      const instrumentedDb = instrumentD1(createMockD1Database());
       await instrumentedDb.prepare('SELECT * FROM users').bind().raw();
 
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
       expect(addBreadcrumbSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('double instrumentation prevention', () => {
+    test('does not double-instrument the same database', async () => {
+      const db = createMockD1Database();
+      const first = instrumentD1(db);
+      const prepareAfterFirst = first.prepare;
+
+      const second = instrumentD1(db);
+
+      expect(first).toBe(second);
+      expect(second.prepare).toBe(prepareAfterFirst);
+    });
+
+    test('does not double-instrument when instrumentD1WithSentry is also used', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const db = createMockD1Database();
+      const fromEnv = instrumentD1(db);
+      const prepareAfterFirst = fromEnv.prepare;
+
+      const fromManual = instrumentD1WithSentry(db);
+
+      expect(fromEnv).toBe(fromManual);
+      expect(fromManual.prepare).toBe(prepareAfterFirst);
     });
   });
 });

--- a/packages/cloudflare/test/utils/isBinding.test.ts
+++ b/packages/cloudflare/test/utils/isBinding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isDurableObjectNamespace, isJSRPC, isQueue } from '../../src/utils/isBinding';
+import { isD1Database, isDurableObjectNamespace, isJSRPC, isQueue } from '../../src/utils/isBinding';
 
 describe('isJSRPC', () => {
   it('returns false for a plain object', () => {
@@ -167,5 +167,46 @@ describe('isQueue', () => {
       newUniqueId: () => ({}),
     };
     expect(isQueue(doNamespace)).toBe(false);
+  });
+});
+
+describe('isD1Database', () => {
+  it('returns true for an object with prepare, batch, and exec methods', () => {
+    const d1 = {
+      prepare: () => ({}),
+      batch: async () => [],
+      exec: async () => ({}),
+      dump: async () => new ArrayBuffer(0),
+    };
+    expect(isD1Database(d1)).toBe(true);
+  });
+
+  it('returns false when prepare is missing', () => {
+    expect(isD1Database({ batch: async () => [], exec: async () => ({}) })).toBe(false);
+  });
+
+  it('returns false when batch is missing', () => {
+    expect(isD1Database({ prepare: () => ({}), exec: async () => ({}) })).toBe(false);
+  });
+
+  it('returns false when exec is missing', () => {
+    expect(isD1Database({ prepare: () => ({}), batch: async () => [] })).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isD1Database(null)).toBe(false);
+    expect(isD1Database(undefined)).toBe(false);
+  });
+
+  it('returns false for a JSRPC proxy', () => {
+    const jsrpcProxy = new Proxy(
+      {},
+      {
+        get(_target, _prop) {
+          return () => {};
+        },
+      },
+    );
+    expect(isD1Database(jsrpcProxy)).toBe(false);
   });
 });


### PR DESCRIPTION
closes #20862
closes [JS-2462](https://linear.app/getsentry/issue/JS-2462)

Deprecate `instrumentD1WithSentry` in favor of automatic D1 instrumentation via `instrumentEnv`. Add `isD1Database` duck-type check and `instrumentD1` with `ensureInstrumented` to prevent double instrumentation.

---

The original ticket also states the following, which is outsourced into [its own ticket](https://github.com/getsentry/sentry-javascript/issues/21275):

> batch, exec and withSession are not instrumented.