### PR TITLE
ref(core): Deprecate `sendDefaultPii` in favor or `dataCollection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-- **ref(core): Deprecate `sendDefaultPii` in favor of `dataCollection` (#21277](https://github.com/getsentry/sentry-javascript/pull/21277)**
+- **ref(core): Deprecate `sendDefaultPii` in favor of `dataCollection` [#21277](https://github.com/getsentry/sentry-javascript/pull/21277)**
 
   `sendDefaultPii` is deprecated and will be removed in v11. The new `dataCollection` option lets you control each category of collected data.
   `sendDefaultPii: true` still works and maps to enabling all `dataCollection` categories.
-  `dataColleciton.userInfo` defaults to `false` and only gates auto-populated `user.*` fields (e.g. IP address from a request).
+  `dataCollection.userInfo` defaults to `false` and only gates auto-populated `user.*` fields (e.g. IP address from a request).
   Data you set explicitly via `Sentry.setUser()` is always sent regardless.
 
   Note that an empty `dataCollection: {}` falls back to more permissive defaults than `sendDefaultPii: false`, so replicate the old behavior by opting out explicitly:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- **ref(core): Deprecate `sendDefaultPii` in favor of `dataCollection` (#21277](https://github.com/getsentry/sentry-javascript/pull/21277)**
+
+  `sendDefaultPii` is deprecated and will be removed in v11. The new `dataCollection` option lets you control each category of collected data.
+  `sendDefaultPii: true` still works and maps to enabling all `dataCollection` categories.
+  `dataColleciton.userInfo` defaults to `false` and only gates auto-populated `user.*` fields (e.g. IP address from a request).
+  Data you set explicitly via `Sentry.setUser()` is always sent regardless.
+
+  Note that an empty `dataCollection: {}` falls back to more permissive defaults than `sendDefaultPii: false`, so replicate the old behavior by opting out explicitly:
+
+  ```js
+  Sentry.init({
+    dataCollection: {
+      genAI: { inputs: false, outputs: false },
+      httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+    },
+  });
+  ```
+
 ## 10.55.0
 
 ### Important Changes

--- a/packages/aws-serverless/README.md
+++ b/packages/aws-serverless/README.md
@@ -41,9 +41,9 @@ import * as Sentry from '@sentry/aws-serverless';
 
 Sentry.init({
   dsn: '__DSN__',
-  // Adds request headers and IP for users, for more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  // Adds HTTP request headers and IP for users, for more info visit:
+  // https://docs.sentry.io/platforms/javascript/guides/aws-lambda/configuration/options/#dataCollection
+  dataCollection: { userInfo: true, httpHeaders: { request: true } },
   // Add Tracing by setting tracesSampleRate and adding integration
   // Set tracesSampleRate to 1.0 to capture 100% of transactions
   // We recommend adjusting this value in production

--- a/packages/browser/src/integrations/httpclient.ts
+++ b/packages/browser/src/integrations/httpclient.ts
@@ -433,6 +433,7 @@ function _getDataCollectionSettings() {
   // collect headers/cookies with deny-list filtering even without sendDefaultPii).
   const options = client.getOptions();
   if (options.dataCollection == null) {
+    // eslint-disable-next-line deprecation/deprecation
     const enabled = Boolean(options.sendDefaultPii);
     return { cookies: enabled, requestHeaders: enabled, responseHeaders: enabled };
   }

--- a/packages/cloudflare/src/sdk.ts
+++ b/packages/cloudflare/src/sdk.ts
@@ -27,6 +27,7 @@ export function getDefaultIntegrations(options: CloudflareOptions): Integration[
   // TODO(v11): Drop this transitional gating and let `requestDataIntegration` rely on the resolved
   // `dataCollection` defaults directly. Until then, preserve the historical Cloudflare behavior of not
   // attaching cookies unless the user explicitly opts in via `sendDefaultPii` or `dataCollection.cookies`.
+  // eslint-disable-next-line deprecation/deprecation
   const cookiesEnabled = options.sendDefaultPii || options.dataCollection?.cookies != null;
   return [
     // The Dedupe integration should not be used in workflows because we want to

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -390,7 +390,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    * each category of collected data individually. `sendDefaultPii` will be removed in the next major
    * version (v11). For backwards compatibility, setting `sendDefaultPii: true` currently behaves like
    * enabling all `dataCollection` categories. If both `sendDefaultPii` and `dataCollection` are set,
-   * `dataCollection` takes precedence.
+   * `sendDefaultPii` will be ignored.
    */
   sendDefaultPii?: boolean;
 

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -386,17 +386,21 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    *
    * @default false
    *
-   * NOTE: This option currently controls only a few data points in a selected
-   * set of SDKs. The goal for this option is to eventually control all sensitive
-   * data the SDK sets by default. However, this would be a breaking change so
-   * until the next major update this option only controls data points which were
-   * added in versions above `7.9.0`.
+   * @deprecated Use the {@link ClientOptions.dataCollection} option instead, which lets you control
+   * each category of collected data individually. `sendDefaultPii` will be removed in the next major
+   * version (v11). For backwards compatibility, setting `sendDefaultPii: true` currently behaves like
+   * enabling all `dataCollection` categories. If both `sendDefaultPii` and `dataCollection` are set,
+   * `dataCollection` takes precedence.
    */
   sendDefaultPii?: boolean;
 
   /**
    * Controls what data the SDK collects and sends to Sentry.
    * All fields are optional — omitted fields use the documented defaults.
+   *
+   * This replaces the deprecated {@link ClientOptions.sendDefaultPii} option and lets you control
+   * each category of collected data (user info, cookies, headers, query params, request/response
+   * bodies, gen AI inputs/outputs, etc.) individually.
    */
   dataCollection?: DataCollection;
 

--- a/packages/node/src/integrations/tracing/anthropic-ai/index.ts
+++ b/packages/node/src/integrations/tracing/anthropic-ai/index.ts
@@ -37,13 +37,14 @@ const _anthropicAIIntegration = ((options: AnthropicAiOptions = {}) => {
  *
  * ## Options
  *
- * - `recordInputs`: Whether to record prompt messages (default: follows `sendDefaultPii` or `dataCollection.genAI.inputs`)
- * - `recordOutputs`: Whether to record response text (default: follows `sendDefaultPii` or `dataCollection.genAI.outputs`)
+ * - `recordInputs`: Whether to record prompt messages (default: follows `dataCollection.genAI.inputs`, or the deprecated `sendDefaultPii` option)
+ * - `recordOutputs`: Whether to record response text (default: follows `dataCollection.genAI.outputs`, or the deprecated `sendDefaultPii` option)
  *
  * ### Default Behavior
  *
  * By default, the integration will:
- * - Record inputs and outputs based on `sendDefaultPii` or `dataCollection.genAI` in your Sentry client options
+ * - Record inputs and outputs based on `dataCollection.genAI` in your Sentry client options
+ *   (or the deprecated `sendDefaultPii` option, for backwards compatibility)
  * - Integration-level `recordInputs`/`recordOutputs` options take precedence over global config
  *
  * @example

--- a/packages/node/src/integrations/tracing/google-genai/index.ts
+++ b/packages/node/src/integrations/tracing/google-genai/index.ts
@@ -36,18 +36,19 @@ const _googleGenAIIntegration = ((options: GoogleGenAIOptions = {}) => {
  *
  * ## Options
  *
- * - `recordInputs`: Whether to record prompt messages (default: respects `sendDefaultPii` client option)
- * - `recordOutputs`: Whether to record response text (default: respects `sendDefaultPii` client option)
+ * - `recordInputs`: Whether to record prompt messages (default: follows `dataCollection.genAI.inputs`)
+ * - `recordOutputs`: Whether to record response text (default: follows `dataCollection.genAI.outputs`)
  *
  * ### Default Behavior
  *
  * By default, the integration will:
- * - Record inputs and outputs ONLY if `sendDefaultPii` is set to `true` in your Sentry client options
- * - Otherwise, inputs and outputs are NOT recorded unless explicitly enabled
+ * - Record inputs and outputs based on `dataCollection.genAI` in your Sentry client options
+ *   (or the deprecated `sendDefaultPii` option, for backwards compatibility)
+ * - Integration-level `recordInputs`/`recordOutputs` options take precedence over global config
  *
  * @example
  * ```javascript
- * // Record inputs and outputs when sendDefaultPii is false
+ * // Always record inputs and outputs regardless of global dataCollection config
  * Sentry.init({
  *   integrations: [
  *     Sentry.googleGenAiIntegration({
@@ -57,9 +58,9 @@ const _googleGenAIIntegration = ((options: GoogleGenAIOptions = {}) => {
  *   ],
  * });
  *
- * // Never record inputs/outputs regardless of sendDefaultPii
+ * // Never record inputs/outputs regardless of global dataCollection config
  * Sentry.init({
- *   sendDefaultPii: true,
+ *   dataCollection: { genAI: { inputs: true, outputs: true } },
  *   integrations: [
  *     Sentry.googleGenAiIntegration({
  *       recordInputs: false,

--- a/packages/node/src/integrations/tracing/langchain/index.ts
+++ b/packages/node/src/integrations/tracing/langchain/index.ts
@@ -36,7 +36,7 @@ const _langChainIntegration = ((options: LangChainOptions = {}) => {
  *
  * Sentry.init({
  *   integrations: [Sentry.langChainIntegration()],
- *   sendDefaultPii: true, // Enable to record inputs/outputs
+ *   dataCollection: { genAI: { inputs: true, outputs: true } }, // Enable to record inputs/outputs
  * });
  *
  * // LangChain calls are automatically instrumented
@@ -67,18 +67,19 @@ const _langChainIntegration = ((options: LangChainOptions = {}) => {
  *
  * ## Options
  *
- * - `recordInputs`: Whether to record input messages/prompts (default: respects `sendDefaultPii` client option)
- * - `recordOutputs`: Whether to record response text (default: respects `sendDefaultPii` client option)
+ * - `recordInputs`: Whether to record input messages/prompts (default: follows `dataCollection.genAI.inputs`, or the deprecated `sendDefaultPii` option)
+ * - `recordOutputs`: Whether to record response text (default: follows `dataCollection.genAI.outputs`, or the deprecated `sendDefaultPii` option)
  *
  * ### Default Behavior
  *
  * By default, the integration will:
- * - Record inputs and outputs ONLY if `sendDefaultPii` is set to `true` in your Sentry client options
- * - Otherwise, inputs and outputs are NOT recorded unless explicitly enabled
+ * - Record inputs and outputs based on `dataCollection.genAI` in your Sentry client options
+ *   (or the deprecated `sendDefaultPii` option, for backwards compatibility)
+ * - Integration-level `recordInputs`/`recordOutputs` options take precedence over global config
  *
  * @example
  * ```javascript
- * // Record inputs and outputs when sendDefaultPii is false
+ * // Always record inputs and outputs regardless of global dataCollection config
  * Sentry.init({
  *   integrations: [
  *     Sentry.langChainIntegration({
@@ -88,9 +89,9 @@ const _langChainIntegration = ((options: LangChainOptions = {}) => {
  *   ],
  * });
  *
- * // Never record inputs/outputs regardless of sendDefaultPii
+ * // Never record inputs/outputs regardless of global dataCollection config
  * Sentry.init({
- *   sendDefaultPii: true,
+ *   dataCollection: { genAI: { inputs: true, outputs: true } },
  *   integrations: [
  *     Sentry.langChainIntegration({
  *       recordInputs: false,

--- a/packages/node/src/integrations/tracing/langgraph/index.ts
+++ b/packages/node/src/integrations/tracing/langgraph/index.ts
@@ -36,13 +36,14 @@ const _langGraphIntegration = ((options: LangGraphOptions = {}) => {
  *
  * ## Options
  *
- * - `recordInputs`: Whether to record prompt messages (default: follows `sendDefaultPii` or `dataCollection.genAI.inputs`)
- * - `recordOutputs`: Whether to record response text (default: follows `sendDefaultPii` or `dataCollection.genAI.outputs`)
+ * - `recordInputs`: Whether to record prompt messages (default: follows `dataCollection.genAI.inputs`, or the deprecated `sendDefaultPii` option)
+ * - `recordOutputs`: Whether to record response text (default: follows `dataCollection.genAI.outputs`, or the deprecated `sendDefaultPii` option)
  *
  * ### Default Behavior
  *
  * By default, the integration will:
- * - Record inputs and outputs based on `sendDefaultPii` or `dataCollection.genAI` in your Sentry client options
+ * - Record inputs and outputs based on `dataCollection.genAI` in your Sentry client options
+ *   (or the deprecated `sendDefaultPii` option, for backwards compatibility)
  * - Integration-level `recordInputs`/`recordOutputs` options take precedence over global config
  *
  * @example

--- a/packages/node/src/integrations/tracing/openai/index.ts
+++ b/packages/node/src/integrations/tracing/openai/index.ts
@@ -36,13 +36,14 @@ const _openAiIntegration = ((options: OpenAiOptions = {}) => {
  *
  * ## Options
  *
- * - `recordInputs`: Whether to record prompt messages (default: follows `sendDefaultPii` or `dataCollection.genAI.inputs`)
- * - `recordOutputs`: Whether to record response text (default: follows `sendDefaultPii` or `dataCollection.genAI.outputs`)
+ * - `recordInputs`: Whether to record input messages/prompts (default: follows `dataCollection.genAI.inputs`, or the deprecated `sendDefaultPii` option)
+ * - `recordOutputs`: Whether to record response text (default: follows `dataCollection.genAI.outputs`, or the deprecated `sendDefaultPii` option)
  *
  * ### Default Behavior
  *
  * By default, the integration will:
- * - Record inputs and outputs based on `sendDefaultPii` or `dataCollection.genAI` in your Sentry client options
+ * - Record inputs and outputs based on `dataCollection.genAI` in your Sentry client options
+ *   (or the deprecated `sendDefaultPii` option, for backwards compatibility)
  * - Integration-level `recordInputs`/`recordOutputs` options take precedence over global config
  *
  * @example

--- a/packages/node/src/integrations/tracing/vercelai/types.ts
+++ b/packages/node/src/integrations/tracing/vercelai/types.ts
@@ -47,13 +47,13 @@ export declare type AttributeValue =
 
 export interface VercelAiOptions {
   /**
-   * Enable or disable input recording. Enabled if `sendDefaultPii` or `dataCollection.genAI.inputs` is `true`
+   * Enable or disable input recording. Enabled if `dataCollection.genAI.inputs` (or the deprecated `sendDefaultPii` option) is `true`
    * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings.
    * Integration-level options take precedence over global `dataCollection` config.
    */
   recordInputs?: boolean;
   /**
-   * Enable or disable output recording. Enabled if `sendDefaultPii` or `dataCollection.genAI.outputs` is `true`
+   * Enable or disable output recording. Enabled if `dataCollection.genAI.outputs` (or the deprecated `sendDefaultPii` option) is `true`
    * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings.
    * Integration-level options take precedence over global `dataCollection` config.
    */

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -56,8 +56,11 @@ export function getDefaultIntegrations(options: Options): Integration[] {
     linkedErrorsIntegration(),
     winterCGFetchIntegration(),
     consoleIntegration(),
-    // TODO(v11): integration can be included - but integration should not add IP address etc
-    ...(options.sendDefaultPii ? [requestDataIntegration()] : []),
+    // TODO(v11): integration can be included - but integration should not add IP address etc.
+    // Until then, only attach request data when the user opts in via `sendDefaultPii` or by configuring
+    // `dataCollection` (the integration itself respects the granular `dataCollection` settings).
+    // eslint-disable-next-line deprecation/deprecation
+    ...(options.sendDefaultPii || options.dataCollection != null ? [requestDataIntegration()] : []),
   ];
 }
 

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -45,7 +45,8 @@ declare const process: {
 const nodeStackParser = createStackParser(nodeStackLineParser());
 
 /** Get the default integrations for the browser SDK. */
-export function getDefaultIntegrations(options: Options): Integration[] {
+export function getDefaultIntegrations(_options: Options): Integration[] {
+  // todo(v11): remove options parameter
   return [
     dedupeIntegration(),
     // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -56,11 +56,7 @@ export function getDefaultIntegrations(options: Options): Integration[] {
     linkedErrorsIntegration(),
     winterCGFetchIntegration(),
     consoleIntegration(),
-    // TODO(v11): integration can be included - but integration should not add IP address etc.
-    // Until then, only attach request data when the user opts in via `sendDefaultPii` or by configuring
-    // `dataCollection` (the integration itself respects the granular `dataCollection` settings).
-    // eslint-disable-next-line deprecation/deprecation
-    ...(options.sendDefaultPii || options.dataCollection != null ? [requestDataIntegration()] : []),
+    requestDataIntegration(),
   ];
 }
 

--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -16,7 +16,6 @@ export const attachErrorHandler = (app: Vue, options?: Partial<VueOptions>): voi
       trace,
     };
 
-    // TODO(v11): guard via dataCollection?
     if (options?.attachProps !== false && vm) {
       // Vue2 - $options.propsData
       // Vue3 - $props

--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -16,7 +16,7 @@ export const attachErrorHandler = (app: Vue, options?: Partial<VueOptions>): voi
       trace,
     };
 
-    // TODO(v11): guard via sendDefaultPii?
+    // TODO(v11): guard via dataCollection?
     if (options?.attachProps !== false && vm) {
       // Vue2 - $options.propsData
       // Vue3 - $props


### PR DESCRIPTION
Deprecates `sendDefaultPii`.

Some `sendDefaultPii` occurences are still there as we still test against the deprecated behavior. This will be removed in v11.

Closes https://github.com/getsentry/sentry-javascript/issues/20937
