### PR TITLE
fix(replays): Record `sentry._internal.replay_is_buffering` for spans

### DIFF
--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -363,6 +363,9 @@ export class Replay implements Integration {
     const replayId = this.getReplayId(true);
     if (replayId) {
       safeSetSpanJSONAttributes(span, { 'sentry.replay_id': replayId });
+      if (this.getRecordingMode() === 'buffer') {
+        safeSetSpanJSONAttributes(span, { 'sentry._internal.replay_is_buffering': true });
+      }
     }
   }
 

--- a/packages/replay-internal/test/unit/processSpan.test.ts
+++ b/packages/replay-internal/test/unit/processSpan.test.ts
@@ -25,11 +25,30 @@ const replay = new Replay();
 describe('Replay.processSpan', () => {
   it('sets sentry.replay_id when replay is active', () => {
     vi.spyOn(replay, 'getReplayId').mockReturnValue('abc123sessionid');
+    vi.spyOn(replay, 'getRecordingMode').mockReturnValue('session');
 
     const span = makeSpanJSON();
     replay.processSpan(span);
 
     expect(span.attributes).toEqual(expect.objectContaining({ 'sentry.replay_id': 'abc123sessionid' }));
+    expect(span.attributes).not.toHaveProperty('sentry._internal.replay_is_buffering');
+
+    vi.restoreAllMocks();
+  });
+
+  it('sets replay_is_buffering when recording mode is buffer', () => {
+    vi.spyOn(replay, 'getReplayId').mockReturnValue('abc123sessionid');
+    vi.spyOn(replay, 'getRecordingMode').mockReturnValue('buffer');
+
+    const span = makeSpanJSON();
+    replay.processSpan(span);
+
+    expect(span.attributes).toEqual(
+      expect.objectContaining({
+        'sentry.replay_id': 'abc123sessionid',
+        'sentry._internal.replay_is_buffering': true,
+      }),
+    );
 
     vi.restoreAllMocks();
   });
@@ -41,12 +60,14 @@ describe('Replay.processSpan', () => {
     replay.processSpan(span);
 
     expect(span.attributes).not.toHaveProperty('sentry.replay_id');
+    expect(span.attributes).not.toHaveProperty('sentry._internal.replay_is_buffering');
 
     vi.restoreAllMocks();
   });
 
   it('does not overwrite an existing sentry.replay_id attribute', () => {
     vi.spyOn(replay, 'getReplayId').mockReturnValue('new-id');
+    vi.spyOn(replay, 'getRecordingMode').mockReturnValue('session');
 
     const span = makeSpanJSON({ attributes: { 'sentry.replay_id': 'existing-id' } });
     replay.processSpan(span);


### PR DESCRIPTION
The currently replay ID is stored using the `sentry.replay_id` attribute. This attribute is set when the current replay's recording mode is either `sampled` (i.e. it will be sent to Sentry) or `buffer` (i.e. it _may_ be sent to Sentry, if an error occurs). Because a buffered replay might not actually be sent to Sentry, logs and metrics set an additional `sentry._internal.replay_is_buffering` attribute so that the product knows it can't assume the replay actually exists:

https://github.com/getsentry/sentry-javascript/blob/310789985a507a0f01cb9f8155c506a6eec5e36c/packages/core/src/logs/internal.ts#L122-L128

https://github.com/getsentry/sentry-javascript/blob/310789985a507a0f01cb9f8155c506a6eec5e36c/packages/core/src/metrics/internal.ts#L111-L116

Spans, however, don't currently set this attribute. For consistency, set it on spans too.

---

🤖: Used Claude Code (Opus 4.6) to generate the code, with human refactoring + careful review.