### PR TITLE
[PoC] feat(browser): Attach `session.id` to outgoing telemetry

### DIFF
--- a/packages/browser/src/integrations/browsersession.ts
+++ b/packages/browser/src/integrations/browsersession.ts
@@ -54,6 +54,7 @@ export const browserSessionIntegration = defineIntegration((options: BrowserSess
       // for errors and transactions (non-streamed spans)
       client.addEventProcessor(event => {
         if (event.type && event.type !== 'transaction') {
+          // ignore other events than errors and transactions for now
           return event;
         }
 
@@ -62,20 +63,20 @@ export const browserSessionIntegration = defineIntegration((options: BrowserSess
           return event;
         }
 
-        if (!event.tags?.[SEMANTIC_ATTRIBUTE_SESSION_ID]) {
-          event.tags = {
-            ...event.tags,
-            [SEMANTIC_ATTRIBUTE_SESSION_ID]: sessionId,
-          };
-        }
+        // set a session context on the event. Relay will extract the `session.id`
+        // tag from this context which will make it queryable in the UI.
+        event.contexts = {
+          session: {
+            id: sessionId,
+          },
+          ...event.contexts,
+        };
 
         event.spans?.forEach(span => {
-          if (!span.data?.[SEMANTIC_ATTRIBUTE_SESSION_ID]) {
-            span.data = {
-              ...span.data,
-              [SEMANTIC_ATTRIBUTE_SESSION_ID]: sessionId,
-            };
-          }
+          span.data = {
+            [SEMANTIC_ATTRIBUTE_SESSION_ID]: sessionId,
+            ...span.data,
+          };
         });
 
         return event;

--- a/packages/browser/src/integrations/browsersession.ts
+++ b/packages/browser/src/integrations/browsersession.ts
@@ -1,4 +1,11 @@
-import { captureSession, debug, defineIntegration, getIsolationScope, startSession } from '@sentry/core/browser';
+import {
+  captureSession,
+  debug,
+  defineIntegration,
+  getIsolationScope,
+  SEMANTIC_ATTRIBUTE_SESSION_ID,
+  startSession,
+} from '@sentry/core/browser';
 import { addHistoryInstrumentationHandler } from '@sentry-internal/browser-utils';
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../helpers';
@@ -29,6 +36,51 @@ export const browserSessionIntegration = defineIntegration((options: BrowserSess
 
   return {
     name: 'BrowserSession',
+    setup(client) {
+      function attachSessionId<T extends { attributes?: Record<string, unknown> | undefined }>(telemetryItem: T): T {
+        const session = getIsolationScope().getSession();
+        const attributes = telemetryItem.attributes ?? (telemetryItem.attributes = {});
+        if (session?.sid && !attributes?.[SEMANTIC_ATTRIBUTE_SESSION_ID]) {
+          attributes[SEMANTIC_ATTRIBUTE_SESSION_ID] = session.sid;
+        }
+        return telemetryItem;
+      }
+
+      client.on('processMetric', attachSessionId);
+      client.on('beforeCaptureLog', attachSessionId);
+      // only applies to streamed spans
+      client.on('processSpan', attachSessionId);
+
+      // for errors and transactions (non-streamed spans)
+      client.addEventProcessor(event => {
+        if (event.type && event.type !== 'transaction') {
+          return event;
+        }
+
+        const sessionId = getIsolationScope().getSession()?.sid;
+        if (!sessionId) {
+          return event;
+        }
+
+        if (!event.tags?.[SEMANTIC_ATTRIBUTE_SESSION_ID]) {
+          event.tags = {
+            ...event.tags,
+            [SEMANTIC_ATTRIBUTE_SESSION_ID]: sessionId,
+          };
+        }
+
+        event.spans?.forEach(span => {
+          if (!span.data?.[SEMANTIC_ATTRIBUTE_SESSION_ID]) {
+            span.data = {
+              ...span.data,
+              [SEMANTIC_ATTRIBUTE_SESSION_ID]: sessionId,
+            };
+          }
+        });
+
+        return event;
+      });
+    },
     setupOnce() {
       if (typeof WINDOW.document === 'undefined') {
         DEBUG_BUILD &&

--- a/packages/core/src/semanticAttributes.ts
+++ b/packages/core/src/semanticAttributes.ts
@@ -116,3 +116,5 @@ export const SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE = 'sentry.link.type';
  * For LangGraph: configurable.thread_id
  */
 export const GEN_AI_CONVERSATION_ID_ATTRIBUTE = 'gen_ai.conversation.id';
+
+export const SEMANTIC_ATTRIBUTE_SESSION_ID = 'session.id';

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -16,6 +16,7 @@ export interface Contexts extends Record<string, Context | undefined> {
   state?: StateContext;
   profile?: ProfileContext;
   flags?: FeatureFlagContext;
+  session?: SessionContext;
 }
 
 export interface StateContext extends Record<string, unknown> {
@@ -138,4 +139,8 @@ export interface MissingInstrumentationContext extends Record<string, unknown> {
  */
 export interface FeatureFlagContext extends Record<string, unknown> {
   values: FeatureFlag[];
+}
+
+export interface SessionContext extends Record<string, unknown> {
+  id?: string;
 }


### PR DESCRIPTION
PoC for now but wanted to code out what attaching a session id to various telemetry items would look like in browser. Depends on https://github.com/getsentry/sentry-conventions/pull/412 and likely some more conversations 