### PR TITLE
chore: Remove git:* allowed permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,6 @@
     "allow": [
       "Bash(find:*)",
       "Bash(ls:*)",
-      "Bash(git:*)",
       "Bash(git status:*)",
       "Bash(git log:*)",
       "Bash(git diff:*)",


### PR DESCRIPTION
Removed the allowed `git:*` permission. That allow lists all write operations as well. If someone wants this that should go to `settings.local.json` instead.