### PR TITLE
test(nextjs): Remove assertion on conditional span

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/tests/server-components.test.ts
@@ -68,7 +68,6 @@ test('Will create a transaction with spans for every server component and metada
   expect(spanDescriptions).toContainEqual('resolve page server component "/nested-layout"');
   expect(spanDescriptions).toContainEqual('generateMetadata /(nested-layout)/nested-layout/page');
   expect(spanDescriptions).toContainEqual('start response');
-  expect(spanDescriptions).toContainEqual('NextNodeServer.clientComponentLoading');
 });
 
 test('Will create a transaction with spans for every server component and metadata generation functions when visiting a dynamic page', async ({
@@ -94,5 +93,4 @@ test('Will create a transaction with spans for every server component and metada
   expect(spanDescriptions).toContainEqual('resolve page server component "/nested-layout/[dynamic]"');
   expect(spanDescriptions).toContainEqual('generateMetadata /(nested-layout)/nested-layout/[dynamic]/page');
   expect(spanDescriptions).toContainEqual('start response');
-  expect(spanDescriptions).toContainEqual('NextNodeServer.clientComponentLoading');
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/server-components.test.ts
@@ -70,7 +70,6 @@ test.skip('Will create a transaction with spans for every server component and m
   expect(spanDescriptions).toContainEqual('resolve page server component "/nested-layout"');
   expect(spanDescriptions).toContainEqual('generateMetadata /(nested-layout)/nested-layout/page');
   expect(spanDescriptions).toContainEqual('start response');
-  expect(spanDescriptions).toContainEqual('NextNodeServer.clientComponentLoading');
 });
 
 // TODO: Server component span tests need SDK adjustments for Cloudflare Workers
@@ -97,5 +96,4 @@ test.skip('Will create a transaction with spans for every server component and m
   expect(spanDescriptions).toContainEqual('resolve page server component "/nested-layout/[dynamic]"');
   expect(spanDescriptions).toContainEqual('generateMetadata /(nested-layout)/nested-layout/[dynamic]/page');
   expect(spanDescriptions).toContainEqual('start response');
-  expect(spanDescriptions).toContainEqual('NextNodeServer.clientComponentLoading');
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/server-components.test.ts
@@ -39,7 +39,6 @@ test('Will create streamed spans for every server component and metadata generat
   expect(spanNames).toContainEqual('resolve page server component "/nested-layout"');
   expect(spanNames).toContainEqual('generateMetadata /(nested-layout)/nested-layout/page');
   expect(spanNames).toContainEqual('start response');
-  expect(spanNames).toContainEqual('NextNodeServer.clientComponentLoading');
 });
 
 test('Will create streamed spans for every server component and metadata generation functions when visiting a dynamic page', async ({
@@ -66,5 +65,4 @@ test('Will create streamed spans for every server component and metadata generat
   expect(spanNames).toContainEqual('resolve page server component "/nested-layout/[dynamic]"');
   expect(spanNames).toContainEqual('generateMetadata /(nested-layout)/nested-layout/[dynamic]/page');
   expect(spanNames).toContainEqual('start response');
-  expect(spanNames).toContainEqual('NextNodeServer.clientComponentLoading');
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/tests/server-components.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/tests/server-components.test.ts
@@ -71,7 +71,6 @@ test('Will create a transaction with spans for every server component and metada
   expect(spanDescriptions).toContainEqual('resolve page server component "/nested-layout"');
   expect(spanDescriptions).toContainEqual('generateMetadata /(nested-layout)/nested-layout/page');
   expect(spanDescriptions).toContainEqual('start response');
-  expect(spanDescriptions).toContainEqual('NextNodeServer.clientComponentLoading');
 });
 
 test('Will create a transaction with spans for every server component and metadata generation functions when visiting a dynamic page', async ({
@@ -99,5 +98,4 @@ test('Will create a transaction with spans for every server component and metada
   expect(spanDescriptions).toContainEqual('resolve page server component "/nested-layout/[dynamic]"');
   expect(spanDescriptions).toContainEqual('generateMetadata /(nested-layout)/nested-layout/[dynamic]/page');
   expect(spanDescriptions).toContainEqual('start response');
-  expect(spanDescriptions).toContainEqual('NextNodeServer.clientComponentLoading');
 });


### PR DESCRIPTION
Next.js changed its internal timing so the `clientComponentLoading` span is no longer emitted. We just remove this brittle assertion as this was flaky already in the past.

closes https://github.com/getsentry/sentry-javascript/issues/21314
closes https://github.com/getsentry/sentry-javascript/issues/21315