### PR TITLE
fix(nextjs): Shim `pinoIntegration` on edge runtime

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/instrumentation.ts
@@ -1,4 +1,8 @@
 import * as Sentry from '@sentry/nextjs';
+// Regression guard for https://github.com/getsentry/sentry-javascript/issues/21317:
+import { pinoIntegration } from '@sentry/nextjs';
+
+void pinoIntegration;
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {

--- a/packages/nextjs/src/common/pinoIntegrationShim.ts
+++ b/packages/nextjs/src/common/pinoIntegrationShim.ts
@@ -1,0 +1,22 @@
+import { defineIntegration } from '@sentry/core';
+
+/**
+ * Shim for the edge build so named imports from `@sentry/nextjs` stay resolvable in
+ * edge-compiled instrumentation modules. The real, Node-only implementation ships in the server build.
+ *
+ * See: https://github.com/getsentry/sentry-javascript/issues/21317
+ */
+const _pinoIntegration = defineIntegration(() => {
+  return {
+    name: 'Pino',
+  };
+});
+
+export const pinoIntegration = Object.assign(_pinoIntegration, {
+  trackLogger(_logger: unknown): void {
+    // no-op outside of Node
+  },
+  untrackLogger(_logger: unknown): void {
+    // no-op outside of Node
+  },
+});

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -35,6 +35,8 @@ export * from '@sentry/vercel-edge';
 export * from '../common';
 export { captureUnderscoreErrorException } from '../common/pages-router-instrumentation/_error';
 
+export { pinoIntegration } from '../common/pinoIntegrationShim';
+
 // Override core span methods with Next.js-specific implementations that support Cache Components
 export { startSpan, startSpanManual, startInactiveSpan } from '../common/utils/nextSpan';
 export { wrapApiHandlerWithSentry } from './wrapApiHandlerWithSentry';

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -24,6 +24,8 @@ export declare function init(
 export declare const linkedErrorsIntegration: typeof clientSdk.linkedErrorsIntegration;
 export declare const contextLinesIntegration: typeof clientSdk.contextLinesIntegration;
 export declare const consoleIntegration: typeof serverSdk.consoleIntegration;
+// Node-only at runtime; the edge build exports an inert shim so named imports resolve in edge-compiled modules.
+export declare const pinoIntegration: typeof serverSdk.pinoIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
 export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
 

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -29,6 +29,9 @@ import { maybeCleanupQueueSpan } from './vercelQueuesMonitoring';
 
 export * from '@sentry/node';
 
+// Explicitly re-export so it is statically detectable by turbopack
+export { pinoIntegration } from '@sentry/node';
+
 export { captureUnderscoreErrorException } from '../common/pages-router-instrumentation/_error';
 
 // Override core span methods with Next.js-specific implementations that support Cache Components

--- a/packages/nextjs/test/serverExports.test.ts
+++ b/packages/nextjs/test/serverExports.test.ts
@@ -3,24 +3,30 @@ import { resolve } from 'node:path';
 import { init, parse } from 'cjs-module-lexer';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-const cjsBuildPath = resolve(__dirname, '../build/cjs/index.server.js');
-
 /**
- * These exports flow through the wildcard `export * from '@sentry/node'` in the server entry.
- * Turbopack's static import analyzer seems to not be able to detect these.
+ * Node-only exports must be statically resolvable from the server AND edge builds, since Next.js compiles
+ * instrumentation modules for the edge runtime too. Otherwise named imports from `@sentry/nextjs` fail to compile
+ * under Turbopack/webpack.
+ *
  *
  * Regression test for https://github.com/getsentry/sentry-javascript/issues/21317
  */
-describe('server entry static named exports', () => {
-  let staticExports: string[];
+describe('`pinoIntegration` is a statically detectable export from every runtime build', () => {
+  const builds = {
+    server: resolve(__dirname, '../build/cjs/index.server.js'),
+    edge: resolve(__dirname, '../build/cjs/edge/index.js'),
+  };
+
+  const staticExports: Record<string, string[]> = {};
 
   beforeAll(async () => {
     await init();
-    const source = readFileSync(cjsBuildPath, 'utf8');
-    staticExports = parse(source).exports;
+    for (const [runtime, path] of Object.entries(builds)) {
+      staticExports[runtime] = parse(readFileSync(path, 'utf8')).exports;
+    }
   });
 
-  it.each(['pinoIntegration'])('statically exports `%s` from the CJS build', name => {
-    expect(staticExports).toContain(name);
+  it.each(Object.keys(builds))('statically exports `pinoIntegration` from the %s build', runtime => {
+    expect(staticExports[runtime]).toContain('pinoIntegration');
   });
 });

--- a/packages/nextjs/test/serverExports.test.ts
+++ b/packages/nextjs/test/serverExports.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { init, parse } from 'cjs-module-lexer';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const cjsBuildPath = resolve(__dirname, '../build/cjs/index.server.js');
+
+/**
+ * These exports flow through the wildcard `export * from '@sentry/node'` in the server entry.
+ * Turbopack's static import analyzer seems to not be able to detect these.
+ *
+ * Regression test for https://github.com/getsentry/sentry-javascript/issues/21317
+ */
+describe('server entry static named exports', () => {
+  let staticExports: string[];
+
+  beforeAll(async () => {
+    await init();
+    const source = readFileSync(cjsBuildPath, 'utf8');
+    staticExports = parse(source).exports;
+  });
+
+  it.each(['pinoIntegration'])('statically exports `%s` from the CJS build', name => {
+    expect(staticExports).toContain(name);
+  });
+});


### PR DESCRIPTION
Next.js compiles instrumentation modules for the edge runtime too, so we shim this integration on edge.

closes https://github.com/getsentry/sentry-javascript/issues/21317