### PR TITLE
feat(core): Change default of `dataCollection.userInfo` to `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,16 @@ Work in this release was contributed by @zhongrenfei1-hub. Thank you for your co
 
   `sendDefaultPii` is deprecated and will be removed in v11. The new `dataCollection` option lets you control each category of collected data.
   `sendDefaultPii: true` still works and maps to enabling all `dataCollection` categories.
-  `dataCollection.userInfo` defaults to `false` and only gates auto-populated `user.*` fields (e.g. IP address from a request).
-  Data you set explicitly via `Sentry.setUser()` is always sent regardless.
+  `dataCollection.userInfo` defaults to `true` when `dataCollection` is provided, meaning auto-populated `user.*` fields (e.g. IP address from a request) are collected by default.
+  Data you set explicitly (like via `Sentry.setUser()`) is always sent regardless.
+  When `dataCollection` is not set at all, the legacy `sendDefaultPii` behavior applies (`userInfo: false` by default) to preserve backward compatibility.
 
   Note that an empty `dataCollection: {}` falls back to more permissive defaults than `sendDefaultPii: false`, so replicate the old behavior by opting out explicitly:
 
   ```js
   Sentry.init({
     dataCollection: {
+      userInfo: false,
       genAI: { inputs: false, outputs: false },
       httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
       cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },

--- a/packages/core/src/utils/data-collection/defaultPiiToCollectionOptions.ts
+++ b/packages/core/src/utils/data-collection/defaultPiiToCollectionOptions.ts
@@ -3,6 +3,10 @@ import type { ResolvedDataCollection } from '../../types/datacollection';
 
 /**
  * Helper function that maps the `sendDefaultPii` boolean flag to the corresponding `DataCollection` configuration.
+ * Used as a backward-compatibility bridge when `dataCollection` is not set by the user.
+ *
+ * TODO(v11): Remove this function along with `sendDefaultPii`. Once `dataCollection` is the only API,
+ * the DEFAULTS in `resolveDataCollectionOptions` (including `userInfo: true`) will always apply.
  */
 export function defaultPiiToCollectionOptions(sendDefaultPii?: boolean): ResolvedDataCollection {
   return sendDefaultPii === true

--- a/packages/core/src/utils/data-collection/resolveDataCollectionOptions.ts
+++ b/packages/core/src/utils/data-collection/resolveDataCollectionOptions.ts
@@ -2,7 +2,7 @@ import type { DataCollection, ResolvedDataCollection } from '../../types/datacol
 import { defaultPiiToCollectionOptions } from './defaultPiiToCollectionOptions';
 
 const DEFAULTS: ResolvedDataCollection = {
-  userInfo: false,
+  userInfo: true,
   cookies: true,
   httpHeaders: { request: true, response: true },
   httpBodies: [],
@@ -19,11 +19,17 @@ const DEFAULTS: ResolvedDataCollection = {
  * 1. Fields explicitly set in `dataCollection`
  * 2. If `sendDefaultPii` is set and `dataCollection` is absent, bridge via `defaultPiiToCollectionOptions`
  * 3. Spec defaults
+ *
+ * TODO(v11): Remove `sendDefaultPii` support and always fall through to DEFAULTS so that `userInfo: true`
+ * NOTE: In v10, DEFAULTS only apply when `dataCollection` is explicitly provided.
+ * When `dataCollection` is absent, the legacy `sendDefaultPii` bridge is used, which defaults to
+ * `userInfo: false` to preserve backward compatibility.
  */
 export function resolveDataCollectionOptions(options: {
   dataCollection?: DataCollection;
   sendDefaultPii?: boolean;
 }): ResolvedDataCollection {
+  // TODO(v11): Remove the sendDefaultPii bridge and always use DEFAULTS.
   const base = options.dataCollection != null ? DEFAULTS : defaultPiiToCollectionOptions(options.sendDefaultPii);
 
   const dc = options.dataCollection ?? {};

--- a/packages/core/test/lib/metrics/internal.test.ts
+++ b/packages/core/test/lib/metrics/internal.test.ts
@@ -256,7 +256,8 @@ describe('_INTERNAL_captureMetric', () => {
   it('includes ingest_settings with auto when dataCollection.userInfo is true', () => {
     vi.spyOn(isBrowserModule, 'isBrowser').mockReturnValue(true);
 
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, dataCollection: { userInfo: true } });
+    // TODO(v11) Remove `dataCollection` as the defaults should be applied without explicitly adding the option
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, dataCollection: {} });
     const client = new TestClient(options);
     const scope = new Scope();
     scope.setClient(client);
@@ -271,7 +272,7 @@ describe('_INTERNAL_captureMetric', () => {
     expect(envelopeItemPayload.ingest_settings).toEqual({ infer_ip: 'auto', infer_user_agent: 'auto' });
   });
 
-  it('includes ingest_settings with never when dataCollection.userInfo is not set', () => {
+  it('includes ingest_settings with never when dataCollection is not set (sendDefaultPii bridge defaults to userInfo: false)', () => {
     vi.spyOn(isBrowserModule, 'isBrowser').mockReturnValue(true);
 
     const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });

--- a/packages/core/test/lib/tracing/spans/envelope.test.ts
+++ b/packages/core/test/lib/tracing/spans/envelope.test.ts
@@ -244,7 +244,8 @@ describe('createStreamedSpanEnvelope', () => {
       vi.mocked(isBrowser).mockReturnValue(true);
 
       const mockSpan = createMockSerializedSpan();
-      const mockClient = new TestClient(getDefaultTestClientOptions({ dataCollection: { userInfo: true } }));
+      // TODO(v11) Remove `dataCollection` as the defaults should be applied without explicitly adding the option
+      const mockClient = new TestClient(getDefaultTestClientOptions({ dataCollection: {} }));
       const dsc: Partial<DynamicSamplingContext> = {};
 
       const envelopeItems = createStreamedSpanEnvelope([mockSpan], dsc, mockClient)[1];
@@ -284,7 +285,8 @@ describe('createStreamedSpanEnvelope', () => {
 
     it('omits ingest_settings when not in browser', () => {
       const mockSpan = createMockSerializedSpan();
-      const mockClient = new TestClient(getDefaultTestClientOptions({ dataCollection: { userInfo: true } }));
+      // TODO(v11) Remove `dataCollection` as the defaults should be applied without explicitly adding the option
+      const mockClient = new TestClient(getDefaultTestClientOptions({ dataCollection: {} }));
       const dsc: Partial<DynamicSamplingContext> = {};
 
       const envelopeItems = createStreamedSpanEnvelope([mockSpan], dsc, mockClient)[1];

--- a/packages/core/test/lib/utils/data-collection/resolveDataCollectionOptions.test.ts
+++ b/packages/core/test/lib/utils/data-collection/resolveDataCollectionOptions.test.ts
@@ -3,7 +3,7 @@ import { resolveDataCollectionOptions } from '../../../../src/utils/data-collect
 
 describe('resolveDataCollectionOptions', () => {
   const SPEC_DEFAULTS = {
-    userInfo: false,
+    userInfo: true,
     cookies: true,
     httpHeaders: { request: true, response: true },
     httpBodies: [],
@@ -17,7 +17,7 @@ describe('resolveDataCollectionOptions', () => {
     it('falls through to sendDefaultPii: undefined bridge when neither option is set', () => {
       const result = resolveDataCollectionOptions({});
 
-      // sendDefaultPii undefined → restrictive bridge (backward compat)
+      // sendDefaultPii undefined → restrictive bridge (backward compat; userInfo defaults to true only when dataCollection is set)
       expect(result.userInfo).toBe(false);
       expect(result.httpBodies).toEqual([]);
       expect(result.genAI).toEqual({ inputs: false, outputs: false });


### PR DESCRIPTION
Changes the default of `dataColelction.userInfo` to `true`.

Closes https://github.com/getsentry/sentry-javascript/issues/21345
