### PR TITLE
fix(core): Don't emit `spanStart` when child span is `SentryNonRecordingSpan`

### DIFF
--- a/packages/cloudflare/test/client.test.ts
+++ b/packages/cloudflare/test/client.test.ts
@@ -1,7 +1,10 @@
+import { getClient, startInactiveSpan, startSpan } from '@sentry/core';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setAsyncLocalStorageAsyncContextStrategy } from '../src/async';
 import { CloudflareClient, type CloudflareClientOptions } from '../src/client';
 import { makeFlushLock } from '../src/flush';
+import { init } from '../src/sdk';
+import { resetSdk } from './testUtils';
 
 const MOCK_CLIENT_OPTIONS: CloudflareClientOptions = {
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
@@ -307,6 +310,76 @@ describe('CloudflareClient', () => {
       // Emit spanStart after dispose - should not be tracked
       client.emit('spanStart', mockSpan as any);
       expect(privateClient._pendingSpans.has('test-span-id')).toBe(false);
+    });
+  });
+
+  describe('pending spans with tracesSampleRate: 0', () => {
+    beforeEach(() => {
+      resetSdk();
+    });
+
+    it('does not accumulate pending spans when tracesSampleRate is 0', () => {
+      init({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        tracesSampleRate: 0,
+        skipOpenTelemetrySetup: true,
+      });
+
+      const client = getClient() as CloudflareClient;
+      const privateClient = client as unknown as { _pendingSpans: Set<string> };
+
+      startSpan({ name: 'root' }, () => {
+        for (let i = 0; i < 100; i++) {
+          const child = startInactiveSpan({ name: `child-${i}` });
+          child.end();
+        }
+      });
+
+      expect(privateClient._pendingSpans.size).toBe(0);
+    });
+
+    it('flush resolves immediately when tracesSampleRate is 0', async () => {
+      init({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        tracesSampleRate: 0,
+        skipOpenTelemetrySetup: true,
+      });
+
+      const client = getClient() as CloudflareClient;
+
+      startSpan({ name: 'root' }, () => {
+        for (let i = 0; i < 50; i++) {
+          const child = startInactiveSpan({ name: `child-${i}` });
+          child.end();
+        }
+      });
+
+      const start = Date.now();
+      await client.flush(2000);
+      const elapsed = Date.now() - start;
+
+      // Should resolve near-instantly, not wait for the 2s timeout
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it('still tracks recording spans with tracesSampleRate: 1', () => {
+      init({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        tracesSampleRate: 1,
+        skipOpenTelemetrySetup: true,
+      });
+
+      const client = getClient() as CloudflareClient;
+      const privateClient = client as unknown as { _pendingSpans: Set<string> };
+
+      startSpan({ name: 'root' }, () => {
+        const child = startInactiveSpan({ name: 'child' });
+        // Child is started but not ended — should be pending
+        expect(privateClient._pendingSpans.size).toBeGreaterThan(0);
+        child.end();
+      });
+
+      expect(privateClient._pendingSpans.size).toBe(0);
     });
   });
 });

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -554,11 +554,13 @@ function _startChildSpan(parentSpan: Span, scope: Scope, spanArguments: SentrySp
     }
   }
 
-  client.emit('spanStart', childSpan);
-  // If it has an endTimestamp, it's already ended
-  if (spanArguments.endTimestamp) {
-    client.emit('spanEnd', childSpan);
-    client.emit('afterSpanEnd', childSpan);
+  if (childSpan.isRecording()) {
+    client.emit('spanStart', childSpan);
+    // If it has an endTimestamp, it's already ended
+    if (spanArguments.endTimestamp) {
+      client.emit('spanEnd', childSpan);
+      client.emit('afterSpanEnd', childSpan);
+    }
   }
 
   return childSpan;

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -554,13 +554,8 @@ function _startChildSpan(parentSpan: Span, scope: Scope, spanArguments: SentrySp
     }
   }
 
-  if (childSpan.isRecording()) {
+  if (childSpan instanceof SentrySpan) {
     client.emit('spanStart', childSpan);
-    // If it has an endTimestamp, it's already ended
-    if (spanArguments.endTimestamp) {
-      client.emit('spanEnd', childSpan);
-      client.emit('afterSpanEnd', childSpan);
-    }
   }
 
   return childSpan;

--- a/packages/core/test/lib/tracing/idleSpan.test.ts
+++ b/packages/core/test/lib/tracing/idleSpan.test.ts
@@ -10,7 +10,6 @@ import {
   SentryNonRecordingSpan,
   SentrySpan,
   setCurrentClient,
-  spanIsSampled,
   spanToJSON,
   startInactiveSpan,
   startSpan,

--- a/packages/core/test/lib/tracing/idleSpan.test.ts
+++ b/packages/core/test/lib/tracing/idleSpan.test.ts
@@ -10,6 +10,7 @@ import {
   SentryNonRecordingSpan,
   SentrySpan,
   setCurrentClient,
+  spanIsSampled,
   spanToJSON,
   startInactiveSpan,
   startSpan,

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -11,6 +11,7 @@ import {
   setAsyncContextStrategy,
   setCurrentClient,
   spanToJSON,
+  timestampInSeconds,
   withScope,
 } from '../../../src';
 import { getAsyncContextStrategy } from '../../../src/asyncContext';
@@ -2371,6 +2372,48 @@ describe('span hooks', () => {
     expect(startedSpans).toHaveLength(1);
     expect(endedSpans).toHaveLength(1);
     expect(startedSpans[0]).toBeInstanceOf(SentrySpan);
+  });
+
+  it('only emits spanStart and spanEnd once for spans that end immediately', () => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 1 });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    const startedSpans: string[] = [];
+    const endedSpans: string[] = [];
+
+    client.on('spanStart', span => {
+      startedSpans.push(spanToJSON(span).description || '');
+    });
+
+    client.on('spanEnd', span => {
+      endedSpans.push(spanToJSON(span).description || '');
+    });
+
+    startSpan({ name: 'root' }, () => {
+      // @ts-expect-error - intentionally setting endTimestamp here despite this prop not being
+      // part of the public API. It demonstratest that this currently works.
+      startSpan({ name: 'child1', endTimestamp: timestampInSeconds() + 1 }, () => {
+        // nested child
+      });
+
+      // @ts-expect-error - intentionally setting endTimestamp here despite this prop not being
+      // part of the public API. It demonstratest that this currently works.
+      const child2 = startInactiveSpan({ name: 'child2', endTimestamp: timestampInSeconds() + 1 });
+      // repeated .end() calls don't do anything
+      child2.end();
+      child2.end();
+    });
+
+    // Root span is always a SentrySpan (even unsampled), so it emits spanStart/spanEnd.
+    // Child spans with tracesSampleRate: 0 are SentryNonRecordingSpan and should NOT emit.
+    expect(startedSpans).toEqual(['root', 'child1', 'child2']);
+    expect(endedSpans).toEqual(['child1', 'child2', 'root']);
   });
 });
 

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -2336,6 +2336,42 @@ describe('span hooks', () => {
     expect(startedSpans).toEqual(['span1', 'span2', 'span3', 'span5', 'span4']);
     expect(endedSpans).toEqual(['span5', 'span3', 'span2', 'span1']);
   });
+
+  it('does not emit spanStart for non-recording child spans', () => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 0 });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    const startedSpans: Span[] = [];
+    const endedSpans: Span[] = [];
+
+    client.on('spanStart', span => {
+      startedSpans.push(span);
+    });
+
+    client.on('spanEnd', span => {
+      endedSpans.push(span);
+    });
+
+    startSpan({ name: 'root' }, () => {
+      startSpan({ name: 'child1' }, () => {
+        // nested child
+      });
+      const child2 = startInactiveSpan({ name: 'child2' });
+      child2.end();
+    });
+
+    // Root span is always a SentrySpan (even unsampled), so it emits spanStart/spanEnd.
+    // Child spans with tracesSampleRate: 0 are SentryNonRecordingSpan and should NOT emit.
+    expect(startedSpans).toHaveLength(1);
+    expect(endedSpans).toHaveLength(1);
+    expect(startedSpans[0]).toBeInstanceOf(SentrySpan);
+  });
 });
 
 describe('suppressTracing', () => {


### PR DESCRIPTION
follow up to #21197 

Apparently when setting `tracesSampleRate: 0` (or any value between 0 and 1), there are `SentryNonRecordingSpan`s. When they are getting generrated `spanStart` is being emitted and the Cloudflare client was listening to it and added these spans to `_pendingSpans`. However, `spanEnd` was never being called and that is why `_pendingSpans` where never getting less.

With the fix of #21197 the `flushLock` was now finally waiting for these spans to be sent, but they were never being sent and would cause another leak (only under very high load). 

## Open Question

I wonder if it was on purpose that `spanStart` was actually being emitted with `SentryNonRecoringSpan`s, or if there is some edge case I can't think of.