### PR TITLE
fix(core): Use `safeDateNow` calls for `new Date()` reads

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/app/[id]/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/app/[id]/page.tsx
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/nextjs';
+
+// Only `test` is prerendered at build time. `exception` and `message` are generated
+// on-demand at request time.
+export function generateStaticParams() {
+  return [{ id: 'test' }];
+}
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  if (id === 'exception') {
+    Sentry.captureException(new Error('Test error from cache components page'));
+    return <p id="result">Error captured for id exception</p>;
+  }
+
+  if (id === 'message') {
+    Sentry.captureMessage('Test message from cache components page');
+    return <p id="result">Message captured for id message</p>;
+  }
+
+  return <p id="result">Hello, {id}!</p>;
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/tests/cacheComponents.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/tests/cacheComponents.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
 
 test('Should render cached component', async ({ page }) => {
   const serverTxPromise = waitForTransaction('nextjs-16-cacheComponents', async transactionEvent => {
@@ -38,6 +38,34 @@ test('Should generate metadata', async ({ page }) => {
   expect(serverTx.spans?.filter(span => span.op === 'get.todos')).toHaveLength(0);
   await expect(page.locator('#todos-fetched')).toHaveText('Todos fetched: 5');
   await expect(page).toHaveTitle('Cache Components Metadata Test');
+});
+
+// Capturing an event inside a Server Component that is (re)generated at request time must not
+// trip Next.js Cache Components prerender guards (`new Date()` / `crypto`).
+test('Should capture an exception from an on-demand generated Server Component', async ({ page }) => {
+  const errorPromise = waitForError('nextjs-16-cacheComponents', errorEvent => {
+    return errorEvent.exception?.values?.[0]?.value === 'Test error from cache components page';
+  });
+
+  await page.goto('/exception');
+
+  await expect(page.locator('#result')).toHaveText('Error captured for id exception');
+
+  const error = await errorPromise;
+  expect(error.exception?.values?.[0]?.value).toBe('Test error from cache components page');
+});
+
+test('Should capture a message from an on-demand generated Server Component', async ({ page }) => {
+  const messagePromise = waitForError('nextjs-16-cacheComponents', errorEvent => {
+    return errorEvent.message === 'Test message from cache components page';
+  });
+
+  await page.goto('/message');
+
+  await expect(page.locator('#result')).toHaveText('Message captured for id message');
+
+  const message = await messagePromise;
+  expect(message.message).toBe('Test message from cache components page');
 });
 
 test('Should generate metadata async', async ({ page }) => {

--- a/packages/core/src/checkin.ts
+++ b/packages/core/src/checkin.ts
@@ -4,6 +4,7 @@ import type { CheckInEnvelope, CheckInItem, DynamicSamplingContext } from './typ
 import type { SdkMetadata } from './types/sdkmetadata';
 import { dsnToString } from './utils/dsn';
 import { createEnvelope } from './utils/envelope';
+import { safeDateNow } from './utils/randomSafeContext';
 
 /**
  * Create envelope from check in item.
@@ -16,7 +17,7 @@ export function createCheckInEnvelope(
   dsn?: DsnComponents,
 ): CheckInEnvelope {
   const headers: CheckInEnvelope[0] = {
-    sent_at: new Date().toISOString(),
+    sent_at: new Date(safeDateNow()).toISOString(),
   };
 
   if (metadata?.sdk) {

--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -27,6 +27,7 @@ import {
   getSdkMetadataForEnvelopeHeader,
 } from './utils/envelope';
 import { uuid4 } from './utils/misc';
+import { safeDateNow } from './utils/randomSafeContext';
 import { shouldIgnoreSpan } from './utils/should-ignore-span';
 import { showSpanDropWarning, spanToJSON } from './utils/spanUtils';
 
@@ -70,7 +71,7 @@ export function createSessionEnvelope(
 ): SessionEnvelope {
   const sdkInfo = getSdkMetadataForEnvelopeHeader(metadata);
   const envelopeHeaders = {
-    sent_at: new Date().toISOString(),
+    sent_at: new Date(safeDateNow()).toISOString(),
     ...(sdkInfo && { sdk: sdkInfo }),
     ...(!!tunnel && dsn && { dsn: dsnToString(dsn) }),
   };
@@ -134,7 +135,7 @@ export function createSpanEnvelope(spans: [SentrySpan, ...SentrySpan[]], client?
   const tunnel = client?.getOptions().tunnel;
 
   const headers: SpanEnvelope[0] = {
-    sent_at: new Date().toISOString(),
+    sent_at: new Date(safeDateNow()).toISOString(),
     ...(dscHasRequiredProps(dsc) && { trace: dsc }),
     ...(!!tunnel && dsn && { dsn: dsnToString(dsn) }),
   };

--- a/packages/core/src/integrations/http/record-request-session.ts
+++ b/packages/core/src/integrations/http/record-request-session.ts
@@ -4,6 +4,7 @@ import { DEBUG_BUILD } from '../../debug-build';
 import type { Scope } from '../../scope';
 import type { HttpServerResponse } from './types';
 import type { AggregationCounts } from '../../types/session';
+import { safeDateNow } from '../../utils/randomSafeContext';
 import { safeUnref } from '../../utils/timer';
 
 const clientToRequestSessionAggregatesMap = new WeakMap<
@@ -42,7 +43,7 @@ export function recordRequestSession(
     if (client && requestSession) {
       DEBUG_BUILD && debug.log(`Recorded request session with status: ${requestSession.status}`);
 
-      const roundedDate = new Date();
+      const roundedDate = new Date(safeDateNow());
       roundedDate.setSeconds(0, 0);
       const dateBucketKey = roundedDate.toISOString();
 

--- a/packages/core/src/tracing/spans/envelope.ts
+++ b/packages/core/src/tracing/spans/envelope.ts
@@ -4,6 +4,7 @@ import type { SerializedStreamedSpan } from '../../types/span';
 import { dsnToString } from '../../utils/dsn';
 import { createEnvelope, getSdkMetadataForEnvelopeHeader } from '../../utils/envelope';
 import { isBrowser } from '../../utils/isBrowser';
+import { safeDateNow } from '../../utils/randomSafeContext';
 
 /**
  * Creates a span v2 span streaming envelope
@@ -19,7 +20,7 @@ export function createStreamedSpanEnvelope(
   const sdk = getSdkMetadataForEnvelopeHeader(options._metadata);
 
   const headers: StreamedSpanEnvelope[0] = {
-    sent_at: new Date().toISOString(),
+    sent_at: new Date(safeDateNow()).toISOString(),
     ...(dscHasRequiredProps(dsc) && { trace: dsc }),
     ...(sdk && { sdk }),
     ...(!!tunnel && dsn && { dsn: dsnToString(dsn) }),

--- a/packages/core/src/transports/offline.ts
+++ b/packages/core/src/transports/offline.ts
@@ -3,6 +3,7 @@ import type { Envelope } from '../types/envelope';
 import type { InternalBaseTransportOptions, Transport, TransportMakeRequestResponse } from '../types/transport';
 import { debug } from '../utils/debug-logger';
 import { envelopeContainsItemType } from '../utils/envelope';
+import { safeDateNow } from '../utils/randomSafeContext';
 import { parseRetryAfterHeader } from '../utils/ratelimit';
 import { safeUnref } from '../utils/timer';
 
@@ -108,7 +109,7 @@ export function makeOfflineTransport<TO>(
             log('Attempting to send previously queued event');
 
             // We should to update the sent_at timestamp to the current time.
-            found[0].sent_at = new Date().toISOString();
+            found[0].sent_at = new Date(safeDateNow()).toISOString();
 
             void send(found, true).catch(e => {
               log('Failed to retry sending', e);

--- a/packages/core/src/utils/envelope.ts
+++ b/packages/core/src/utils/envelope.ts
@@ -17,6 +17,7 @@ import type { SdkMetadata } from '../types/sdkmetadata';
 import type { SpanJSON } from '../types/span';
 import { dsnToString } from './dsn';
 import { normalize } from './normalize';
+import { safeDateNow } from './randomSafeContext';
 import { GLOBAL_OBJ } from './worldwide';
 
 /**
@@ -255,7 +256,7 @@ export function createEventEnvelopeHeaders(
   const dynamicSamplingContext = event.sdkProcessingMetadata?.dynamicSamplingContext;
   return {
     event_id: event.event_id as string,
-    sent_at: new Date().toISOString(),
+    sent_at: new Date(safeDateNow()).toISOString(),
     ...(sdkInfo && { sdk: sdkInfo }),
     ...(!!tunnel && dsn && { dsn: dsnToString(dsn) }),
     ...(dynamicSamplingContext && {

--- a/packages/core/test/lib/envelope-safe-timestamp.test.ts
+++ b/packages/core/test/lib/envelope-safe-timestamp.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createCheckInEnvelope } from '../../src/checkin';
+import { createEventEnvelope, createSessionEnvelope, createSpanEnvelope } from '../../src/envelope';
+import { SentrySpan } from '../../src/tracing/sentrySpan';
+import type { Event } from '../../src/types/event';
+import { GLOBAL_OBJ } from '../../src/utils/worldwide';
+
+/**
+ * Envelope `sent_at` headers must derive their timestamp from `safeDateNow()` rather than
+ * reading the ambient clock via a bare `new Date()`. Reading the clock directly is disallowed
+ * in some restricted execution contexts (e.g. React Server Component prerendering); the SDK
+ * lets host SDKs install a runner via the `__SENTRY_SAFE_RANDOM_ID_WRAPPER__` global symbol
+ * (see `utils/randomSafeContext`) so that wrapped clock/random reads happen in a permitted
+ * context. These tests assert the envelope creators route their timestamp through that runner.
+ */
+
+const SAFE_RANDOM_SYMBOL = Symbol.for('__SENTRY_SAFE_RANDOM_ID_WRAPPER__');
+
+let inSafeContext = false;
+
+// Install a runner like a host SDK would. Set at module scope so it is resolved by
+// `withRandomSafeContext` before the first call.
+(GLOBAL_OBJ as unknown as Record<symbol, unknown>)[SAFE_RANDOM_SYMBOL] = <T>(cb: () => T): T => {
+  const previous = inSafeContext;
+  inSafeContext = true;
+  try {
+    return cb();
+  } finally {
+    inSafeContext = previous;
+  }
+};
+
+const RealDate = Date;
+
+/**
+ * Runs `fn` with a guarded clock that throws on a bare `new Date()` / `Date.now()` unless the
+ * read happens inside the safe-context runner - mimicking a restricted prerender environment.
+ */
+function runWithGuardedClock<T>(fn: () => T): T {
+  const GuardedDate = class extends RealDate {
+    public constructor(...args: unknown[]) {
+      if (args.length === 0 && !inSafeContext) {
+        throw new Error('Read the ambient clock via `new Date()` outside the safe context');
+      }
+      super(...(args as [number | string | Date]));
+    }
+
+    public static now(): number {
+      if (!inSafeContext) {
+        throw new Error('Read the ambient clock via `Date.now()` outside the safe context');
+      }
+      return RealDate.now();
+    }
+  };
+
+  (globalThis as { Date: DateConstructor }).Date = GuardedDate as unknown as DateConstructor;
+  try {
+    return fn();
+  } finally {
+    (globalThis as { Date: DateConstructor }).Date = RealDate;
+  }
+}
+
+describe('envelope sent_at uses the safe time context', () => {
+  beforeEach(() => {
+    inSafeContext = false;
+  });
+
+  it('createEventEnvelope does not read the ambient clock directly', () => {
+    const event: Event = { event_id: 'abc123', message: 'Test message' };
+    expect(() => runWithGuardedClock(() => createEventEnvelope(event))).not.toThrow();
+  });
+
+  it('createSessionEnvelope does not read the ambient clock directly', () => {
+    expect(() => runWithGuardedClock(() => createSessionEnvelope({ aggregates: [] }))).not.toThrow();
+  });
+
+  it('createSpanEnvelope does not read the ambient clock directly', () => {
+    const span = new SentrySpan({ name: 'test-span', sampled: true });
+    expect(() => runWithGuardedClock(() => createSpanEnvelope([span]))).not.toThrow();
+  });
+
+  it('createCheckInEnvelope does not read the ambient clock directly', () => {
+    expect(() =>
+      runWithGuardedClock(() => createCheckInEnvelope({ check_in_id: 'check-in', monitor_slug: 'slug', status: 'ok' })),
+    ).not.toThrow();
+  });
+});

--- a/packages/eslint-plugin-sdk/src/rules/no-unsafe-random-apis.js
+++ b/packages/eslint-plugin-sdk/src/rules/no-unsafe-random-apis.js
@@ -59,6 +59,8 @@ module.exports = {
         '`crypto.randomUUID()` should be wrapped with `withRandomSafeContext()` to ensure safe random value generation. Use: `withRandomSafeContext(() => crypto.randomUUID())`. You can disable this rule with an eslint-disable comment if this usage is intentional.',
       unsafeCryptoGetRandomValues:
         '`crypto.getRandomValues()` should be wrapped with `withRandomSafeContext()` to ensure safe random value generation. Use: `withRandomSafeContext(() => crypto.getRandomValues(...))`. You can disable this rule with an eslint-disable comment if this usage is intentional.',
+      unsafeDateConstructor:
+        '`new Date()` reads the ambient clock and should be replaced with `new Date(safeDateNow())` (with `safeDateNow()` from `@sentry/core`) to ensure safe time value generation. You can disable this rule with an eslint-disable comment if this usage is intentional.',
     },
   },
   create: function (context) {
@@ -140,6 +142,25 @@ module.exports = {
               messageId: unsafeApi.messageId,
             });
           }
+        }
+      },
+      // Flag the `new Date()` constructor with no arguments, which reads the ambient clock.
+      // `new Date(<number>)` is safe because it does not read the current time.
+      NewExpression(node) {
+        if (isInSafeRandomGeneratorRunner(node)) {
+          return;
+        }
+
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'Date' &&
+          node.arguments.length === 0 &&
+          !isInsidewithRandomSafeContext(node)
+        ) {
+          context.report({
+            node,
+            messageId: 'unsafeDateConstructor',
+          });
         }
       },
     };

--- a/packages/eslint-plugin-sdk/test/lib/rules/no-unsafe-random-apis.test.ts
+++ b/packages/eslint-plugin-sdk/test/lib/rules/no-unsafe-random-apis.test.ts
@@ -54,6 +54,19 @@ describe('no-unsafe-random-apis', () => {
         {
           code: 'const x = performance.mark("test")',
         },
+        // `new Date(<value>)` does not read the ambient clock and is safe
+        {
+          code: 'const d = new Date(safeDateNow())',
+        },
+        {
+          code: 'const d = new Date(1234567890)',
+        },
+        {
+          code: 'const d = new Date("2021-01-01")',
+        },
+        {
+          code: 'withRandomSafeContext(() => new Date())',
+        },
       ],
       invalid: [
         // Direct Date.now() calls
@@ -137,6 +150,31 @@ describe('no-unsafe-random-apis', () => {
             },
             {
               messageId: 'unsafeMathRandom',
+            },
+          ],
+        },
+        // Bare `new Date()` constructor reads the ambient clock
+        {
+          code: 'const now = new Date()',
+          errors: [
+            {
+              messageId: 'unsafeDateConstructor',
+            },
+          ],
+        },
+        {
+          code: 'const iso = new Date().toISOString()',
+          errors: [
+            {
+              messageId: 'unsafeDateConstructor',
+            },
+          ],
+        },
+        {
+          code: 'someOtherWrapper(() => new Date())',
+          errors: [
+            {
+              messageId: 'unsafeDateConstructor',
             },
           ],
         },


### PR DESCRIPTION
Several spots in core read the ambient clock directly via a bare `new Date()`. In Next.js Cache Components this throws a `next-prerender-current-time` violation, breaking `captureException`/`captureMessage` in dev and at runtime during ISR/on-demand revalidation.

closes https://github.com/getsentry/sentry-javascript/issues/21333