### PR TITLE
feat(core): Default `dataCollection.httpBodies` to all valid body types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Work in this release was contributed by @zhongrenfei1-hub. Thank you for your co
   Sentry.init({
     dataCollection: {
       genAI: { inputs: false, outputs: false },
+      httpBodies: [],
       httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
       cookies: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
       queryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },

--- a/packages/core/src/types/datacollection.ts
+++ b/packages/core/src/types/datacollection.ts
@@ -38,8 +38,9 @@ export interface DataCollection {
   };
 
   /**
-   * Which HTTP body types to collect. An empty array disables body collection.
-   * @default []
+   * Which HTTP body types to collect. An omitted value collects all body types valid for the
+   * platform; an empty array (`[]`) disables body collection.
+   * @default ['incomingRequest', 'outgoingRequest', 'incomingResponse', 'outgoingResponse']
    */
   httpBodies?: HttpBodyCollectionTarget[];
 

--- a/packages/core/src/utils/data-collection/resolveDataCollectionOptions.ts
+++ b/packages/core/src/utils/data-collection/resolveDataCollectionOptions.ts
@@ -5,7 +5,7 @@ const DEFAULTS: ResolvedDataCollection = {
   userInfo: false,
   cookies: true,
   httpHeaders: { request: true, response: true },
-  httpBodies: [],
+  httpBodies: ['incomingRequest', 'outgoingRequest', 'incomingResponse', 'outgoingResponse'],
   queryParams: true,
   genAI: { inputs: true, outputs: true },
   stackFrameVariables: true,

--- a/packages/core/test/lib/utils/data-collection/resolveDataCollectionOptions.test.ts
+++ b/packages/core/test/lib/utils/data-collection/resolveDataCollectionOptions.test.ts
@@ -6,7 +6,7 @@ describe('resolveDataCollectionOptions', () => {
     userInfo: false,
     cookies: true,
     httpHeaders: { request: true, response: true },
-    httpBodies: [],
+    httpBodies: ['incomingRequest', 'outgoingRequest', 'incomingResponse', 'outgoingResponse'],
     queryParams: true,
     genAI: { inputs: true, outputs: true },
     stackFrameVariables: true,
@@ -27,6 +27,12 @@ describe('resolveDataCollectionOptions', () => {
 
     it('returns spec defaults when dataCollection is explicitly set to empty object', () => {
       expect(resolveDataCollectionOptions({ dataCollection: {} })).toEqual(SPEC_DEFAULTS);
+    });
+
+    it('collects all body types by default when dataCollection is set without httpBodies', () => {
+      const result = resolveDataCollectionOptions({ dataCollection: {} });
+
+      expect(result.httpBodies).toEqual(['incomingRequest', 'outgoingRequest', 'incomingResponse', 'outgoingResponse']);
     });
   });
 
@@ -61,7 +67,7 @@ describe('resolveDataCollectionOptions', () => {
       // Explicit dataCollection override
       expect(result.userInfo).toBe(false);
       // Remaining fields use spec defaults (not sendDefaultPii bridge)
-      expect(result.httpBodies).toEqual([]);
+      expect(result.httpBodies).toEqual(['incomingRequest', 'outgoingRequest', 'incomingResponse', 'outgoingResponse']);
       expect(result.genAI).toEqual({ inputs: true, outputs: true });
     });
   });


### PR DESCRIPTION
Updates the `dataCollection.httpBodies` spec default from `[]` (off) to all four valid body types (`incomingRequest`, `outgoingRequest`, `incomingResponse`, `outgoingResponse`), per the updated DataCollection spec (getsentry/sentry-docs#18276).

  This new default applies **only when a user explicitly sets the `dataCollection` option**. The `sendDefaultPii` bridge is left untouched.
  
  closes https://github.com/getsentry/sentry-javascript/issues/21346