### PR TITLE
chore: Bump volta node version from 20.19.2 to 20.19.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "yalc:publish": "nx run-many -t yalc:publish"
   },
   "volta": {
-    "node": "20.19.2",
+    "node": "20.19.5",
     "yarn": "1.22.22",
     "pnpm": "9.15.9"
   },


### PR DESCRIPTION
Our aws-serverless layer build failed because `pkg-entry-points@1.1.2` requires Node >= 20.19.5.

This should not affect the SDK builds.
