### PR TITLE
fix(core,browser,react): Add `react-native` export condition to resolve dual ESM/CJS bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,6 @@ Work in this release was contributed by @zhongrenfei1-hub. Thank you for your co
   });
   ```
 
-<details>
-  <summary> <strong>Internal Changes</strong> </summary>
-
-- ref(core): Add `react-native` export condition to `@sentry/core`, `@sentry/browser`, and `@sentry/react` ([#21362](https://github.com/getsentry/sentry-javascript/pull/21362))
-
-</details>
-
 ## 10.56.0
 
 ### Important Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ Work in this release was contributed by @zhongrenfei1-hub. Thank you for your co
   });
   ```
 
+<details>
+  <summary> <strong>Internal Changes</strong> </summary>
+
+- ref(core): Add `react-native` export condition to `@sentry/core`, `@sentry/browser`, and `@sentry/react` ([#21362](https://github.com/getsentry/sentry-javascript/pull/21362))
+
+</details>
+
 ## 10.56.0
 
 ### Important Changes

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -18,6 +18,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "react-native": "./build/esm/index.js",
       "import": {
         "types": "./build/types/index.d.ts",
         "default": "./build/esm/index.js"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -19,6 +19,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./build/npm/types/index.d.ts",
+      "react-native": "./build/npm/esm/prod/index.js",
       "development": {
         "import": "./build/npm/esm/dev/index.js",
         "require": "./build/npm/cjs/dev/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,10 @@
   "exports": {
     "./package.json": "./package.json",
     "./server": {
+      "react-native": {
+        "types": "./build/types/server.d.ts",
+        "default": "./build/esm/server.js"
+      },
       "import": {
         "types": "./build/types/server.d.ts",
         "default": "./build/esm/server.js"
@@ -32,6 +36,10 @@
       }
     },
     "./browser": {
+      "react-native": {
+        "types": "./build/types/browser.d.ts",
+        "default": "./build/esm/browser.js"
+      },
       "import": {
         "types": "./build/types/browser.d.ts",
         "default": "./build/esm/browser.js"
@@ -42,6 +50,10 @@
       }
     },
     ".": {
+      "react-native": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
+      },
       "import": {
         "types": "./build/types/index.d.ts",
         "default": "./build/esm/index.js"

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -18,6 +18,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "react-native": "./build/npm/esm/index.js",
       "import": {
         "types": "./build/npm/types/index.d.ts",
         "default": "./build/npm/esm/index.js"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,6 +18,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "react-native": {
+        "types": "./build/types/index.d.ts",
+        "default": "./build/esm/index.js"
+      },
       "import": {
         "types": "./build/types/index.d.ts",
         "default": "./build/esm/index.js"

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -8,6 +8,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "react-native": "./build/npm/esm/index.js",
       "import": {
         "types": "./build/npm/types/index.d.ts",
         "default": "./build/npm/esm/index.js"

--- a/packages/replay-internal/package.json
+++ b/packages/replay-internal/package.json
@@ -8,6 +8,7 @@
   "exports": {
     "./package.json": "./package.json",
     "./worker-bundler": {
+      "react-native": "./build/npm/esm/worker-bundler.js",
       "import": {
         "types": "./build/npm/types/worker-bundler.d.ts",
         "default": "./build/npm/esm/worker-bundler.js"
@@ -18,6 +19,7 @@
       }
     },
     ".": {
+      "react-native": "./build/npm/esm/index.js",
       "import": {
         "types": "./build/npm/types/index.d.ts",
         "default": "./build/npm/esm/index.js"


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [x] Link an issue if there is one related to your pull request. If no issue is linked, one will be auto-generated and linked.

Closes getsentry/sentry-react-native#6262

## Summary

Since React Native 0.79 (April 2025), Metro enables `unstable_enablePackageExports` by default. `@sentry/core`, `@sentry/browser`, and `@sentry/react` only export `import`/`require` conditions. Due to a Metro `isESMImport` detection issue, some dependencies resolve to CJS while others resolve to ESM — causing **both full module trees** to be bundled into native apps.

This adds a `react-native` export condition (pointing to ESM) to all three packages. Metro includes `react-native` in its default condition names, so it matches first and always resolves to ESM — bypassing the `import`/`require` ambiguity.

### Impact

- **~1 MB of unnecessary CJS code** eliminated from every RN 0.79+ app shipped to stores
- Hermes compiles everything in the bundle — there is no dead code elimination after Metro

### Bundle analysis (sentry-react-native sample app, Android)

| | @sentry/core files | Bundle size |
|---|---|---|
| Before | 338 CJS + 338 ESM = 676 | 5.09 MB |
| After | 0 CJS + 338 ESM = 338 | 4.56 MB |

### Safety

The `react-native` condition is **only recognized by Metro** (React Native). It has no effect on:
- **Node.js** — not a recognized condition
- **Webpack / esbuild / Vite** — not in default condition names
- **Any non-RN bundler** — falls through to `import`/`require` as before

### Changes

- `packages/core/package.json` — Add `react-native` condition to `.`, `./browser`, `./server` subpaths
- `packages/browser/package.json` — Add `react-native` condition to `.` (points to prod ESM build)
- `packages/react/package.json` — Add `react-native` condition to `.`