### PR TITLE
ref(node): Streamline generic-pool

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/instrument.mjs
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/scenario.mjs
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/node';
+import genericPool from 'generic-pool';
+
+// generic-pool v2 uses the callback-based API: `new Pool(factory)` with `factory.create(callback)`
+// and `pool.acquire((err, client) => ...)`.
+const Pool = genericPool.Pool;
+
+const pool = new Pool({
+  name: 'test',
+  create: callback => callback(null, { id: Math.random() }),
+  destroy: () => {},
+  max: 10,
+  min: 2,
+});
+
+function acquire() {
+  return new Promise((resolve, reject) => {
+    pool.acquire((err, client) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      pool.release(client);
+      resolve();
+    });
+  });
+}
+
+async function run() {
+  await Sentry.startSpan(
+    {
+      op: 'transaction',
+      name: 'Test Transaction',
+    },
+    async () => {
+      await acquire();
+      await acquire();
+    },
+  );
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/test.ts
@@ -1,0 +1,43 @@
+import { afterAll, describe, expect } from 'vitest';
+import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+
+describe('genericPool v2 auto instrumentation', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario.mjs',
+    'instrument.mjs',
+    (createRunner, test) => {
+      test('should auto-instrument `generic-pool` v2 when calling pool.acquire()', async () => {
+        const EXPECTED_TRANSACTION = {
+          transaction: 'Test Transaction',
+          spans: expect.arrayContaining([
+            expect.objectContaining({
+              description: expect.stringMatching(/^generic-pool\.ac?quire/),
+              origin: 'auto.db.otel.generic_pool',
+              data: {
+                'sentry.origin': 'auto.db.otel.generic_pool',
+              },
+              status: 'ok',
+            }),
+
+            expect.objectContaining({
+              description: expect.stringMatching(/^generic-pool\.ac?quire/),
+              origin: 'auto.db.otel.generic_pool',
+              data: {
+                'sentry.origin': 'auto.db.otel.generic_pool',
+              },
+              status: 'ok',
+            }),
+          ]),
+        };
+
+        await createRunner().expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
+      });
+    },
+    { additionalDependencies: { 'generic-pool': '^2.5.0' } },
+  );
+});

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/test.ts
@@ -16,7 +16,7 @@ describe('genericPool v2 auto instrumentation', () => {
           transaction: 'Test Transaction',
           spans: expect.arrayContaining([
             expect.objectContaining({
-              description: expect.stringMatching(/^generic-pool\.ac?quire/),
+              description: 'generic-pool.acquire',
               origin: 'auto.db.otel.generic_pool',
               data: {
                 'sentry.origin': 'auto.db.otel.generic_pool',
@@ -25,7 +25,7 @@ describe('genericPool v2 auto instrumentation', () => {
             }),
 
             expect.objectContaining({
-              description: expect.stringMatching(/^generic-pool\.ac?quire/),
+              description: 'generic-pool.acquire',
               origin: 'auto.db.otel.generic_pool',
               data: {
                 'sentry.origin': 'auto.db.otel.generic_pool',

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
@@ -12,7 +12,7 @@ describe('genericPool auto instrumentation', () => {
         transaction: 'Test Transaction',
         spans: expect.arrayContaining([
           expect.objectContaining({
-            description: expect.stringMatching(/^generic-pool\.ac?quire/),
+            description: 'generic-pool.acquire',
             origin: 'auto.db.otel.generic_pool',
             data: {
               'sentry.origin': 'auto.db.otel.generic_pool',
@@ -21,7 +21,7 @@ describe('genericPool auto instrumentation', () => {
           }),
 
           expect.objectContaining({
-            description: expect.stringMatching(/^generic-pool\.ac?quire/),
+            description: 'generic-pool.acquire',
             origin: 'auto.db.otel.generic_pool',
             data: {
               'sentry.origin': 'auto.db.otel.generic_pool',

--- a/packages/node/src/integrations/tracing/genericPool/index.ts
+++ b/packages/node/src/integrations/tracing/genericPool/index.ts
@@ -21,12 +21,8 @@ const _genericPoolIntegration = (() => {
       instrumentationWrappedCallback?.(() =>
         client.on('spanStart', span => {
           const spanJSON = spanToJSON(span);
-
           const spanDescription = spanJSON.description;
-
-          // typo in emitted span for version <= 0.38.0 of @opentelemetry/instrumentation-generic-pool
-          const isGenericPoolSpan =
-            spanDescription === 'generic-pool.aquire' || spanDescription === 'generic-pool.acquire';
+          const isGenericPoolSpan = spanDescription === 'generic-pool.acquire';
 
           if (isGenericPoolSpan) {
             span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.generic_pool');

--- a/packages/node/src/integrations/tracing/genericPool/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/genericPool/vendored/instrumentation.ts
@@ -18,22 +18,24 @@
  * - Upstream version: @opentelemetry/instrumentation-generic-pool@0.61.0
  * - Minor TypeScript strictness adjustments for this repository's compiler settings
  */
-/* eslint-disable */
 
 import * as api from '@opentelemetry/api';
-import {
-  InstrumentationBase,
-  InstrumentationConfig,
-  InstrumentationNodeModuleDefinition,
-  isWrapped,
-} from '@opentelemetry/instrumentation';
-
-import type * as genericPool from './generic-pool-types';
-
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { InstrumentationBase, InstrumentationNodeModuleDefinition, isWrapped } from '@opentelemetry/instrumentation';
 import { SDK_VERSION } from '@sentry/core';
+import type * as genericPool from './generic-pool-types';
 
 const MODULE_NAME = 'generic-pool';
 const PACKAGE_NAME = '@sentry/instrumentation-generic-pool';
+
+type AcquireFn = (this: unknown, ...args: unknown[]) => unknown;
+interface PoolConstructor {
+  (...args: unknown[]): unknown;
+  prototype: { acquire: AcquireFn };
+}
+interface GenericPoolModule {
+  Pool: PoolConstructor;
+}
 
 export class GenericPoolInstrumentation extends InstrumentationBase {
   // only used for v2 - v2.3)
@@ -48,16 +50,16 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
       new InstrumentationNodeModuleDefinition(
         MODULE_NAME,
         ['>=3.0.0 <4'],
-        moduleExports => {
-          const Pool: any = moduleExports.Pool;
+        (moduleExports: GenericPoolModule) => {
+          const Pool = moduleExports.Pool;
           if (isWrapped(Pool.prototype.acquire)) {
             this._unwrap(Pool.prototype, 'acquire');
           }
           this._wrap(Pool.prototype, 'acquire', this._acquirePatcher.bind(this));
           return moduleExports;
         },
-        moduleExports => {
-          const Pool: any = moduleExports.Pool;
+        (moduleExports: GenericPoolModule) => {
+          const Pool = moduleExports.Pool;
           this._unwrap(Pool.prototype, 'acquire');
           return moduleExports;
         },
@@ -65,16 +67,16 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
       new InstrumentationNodeModuleDefinition(
         MODULE_NAME,
         ['>=2.4.0 <3'],
-        moduleExports => {
-          const Pool: any = moduleExports.Pool;
+        (moduleExports: GenericPoolModule) => {
+          const Pool = moduleExports.Pool;
           if (isWrapped(Pool.prototype.acquire)) {
             this._unwrap(Pool.prototype, 'acquire');
           }
           this._wrap(Pool.prototype, 'acquire', this._acquireWithCallbacksPatcher.bind(this));
           return moduleExports;
         },
-        moduleExports => {
-          const Pool: any = moduleExports.Pool;
+        (moduleExports: GenericPoolModule) => {
+          const Pool = moduleExports.Pool;
           this._unwrap(Pool.prototype, 'acquire');
           return moduleExports;
         },
@@ -82,7 +84,7 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
       new InstrumentationNodeModuleDefinition(
         MODULE_NAME,
         ['>=2.0.0 <2.4'],
-        moduleExports => {
+        (moduleExports: GenericPoolModule) => {
           this._isDisabled = false;
           if (isWrapped(moduleExports.Pool)) {
             this._unwrap(moduleExports, 'Pool');
@@ -90,7 +92,7 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
           this._wrap(moduleExports, 'Pool', this._poolWrapper.bind(this));
           return moduleExports;
         },
-        moduleExports => {
+        (moduleExports: GenericPoolModule) => {
           // since the object is created on the fly every time, we need to use
           // a boolean switch here to disable the instrumentation
           this._isDisabled = true;
@@ -100,14 +102,15 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
     ];
   }
 
-  private _acquirePatcher(original: genericPool.Pool<unknown>['acquire']) {
+  private _acquirePatcher(original: AcquireFn) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const instrumentation = this;
-    return function wrapped_acquire(this: genericPool.Pool<unknown>, ...args: any[]) {
+    return function wrapped_acquire(this: genericPool.Pool<unknown>, ...args: unknown[]) {
       const parent = api.context.active();
       const span = instrumentation.tracer.startSpan('generic-pool.acquire', {}, parent);
 
       return api.context.with(api.trace.setSpan(parent, span), () => {
-        return original.call(this, ...args).then(
+        return (original.call(this, ...args) as PromiseLike<unknown>).then(
           (value: unknown) => {
             span.end();
             return value;
@@ -122,18 +125,24 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
     };
   }
 
-  private _poolWrapper(original: any) {
+  private _poolWrapper(original: AcquireFn) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const instrumentation = this;
-    return function wrapped_pool(this: any) {
-      const pool = original.apply(this, arguments);
+    return function wrapped_pool(this: unknown, ...args: unknown[]) {
+      const pool = original.apply(this, args) as { acquire: AcquireFn };
       instrumentation._wrap(pool, 'acquire', instrumentation._acquireWithCallbacksPatcher.bind(instrumentation));
       return pool;
     };
   }
 
-  private _acquireWithCallbacksPatcher(original: any) {
+  private _acquireWithCallbacksPatcher(original: AcquireFn) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const instrumentation = this;
-    return function wrapped_acquire(this: genericPool.Pool<unknown>, cb: Function, priority: number) {
+    return function wrapped_acquire(
+      this: genericPool.Pool<unknown>,
+      cb: (err: unknown, client: unknown) => unknown,
+      priority: number,
+    ) {
       // only used for v2 - v2.3
       if (instrumentation._isDisabled) {
         return original.call(this, cb, priority);
@@ -149,7 +158,7 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
             // Not checking whether cb is a function because
             // the original code doesn't do that either.
             if (cb) {
-              return cb(err, client);
+              cb(err, client);
             }
           },
           priority,

--- a/packages/node/src/integrations/tracing/genericPool/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/genericPool/vendored/instrumentation.ts
@@ -30,7 +30,6 @@ const PACKAGE_NAME = '@sentry/instrumentation-generic-pool';
 
 type AcquireFn = (this: unknown, ...args: unknown[]) => unknown;
 interface PoolConstructor {
-  (...args: unknown[]): unknown;
   prototype: { acquire: AcquireFn };
 }
 interface GenericPoolModule {
@@ -125,11 +124,11 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
     };
   }
 
-  private _poolWrapper(original: AcquireFn) {
+  private _poolWrapper(original: (this: unknown, ...args: unknown[]) => { acquire: AcquireFn }) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const instrumentation = this;
     return function wrapped_pool(this: unknown, ...args: unknown[]) {
-      const pool = original.apply(this, args) as { acquire: AcquireFn };
+      const pool = original.apply(this, args);
       instrumentation._wrap(pool, 'acquire', instrumentation._acquireWithCallbacksPatcher.bind(instrumentation));
       return pool;
     };
@@ -157,6 +156,7 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
             span.end();
             // Not checking whether cb is a function because
             // the original code doesn't do that either.
+            // The callback's return value is unused by generic-pool, so we don't return it.
             if (cb) {
               cb(err, client);
             }

--- a/packages/node/test/integrations/tracing/genericPool.test.ts
+++ b/packages/node/test/integrations/tracing/genericPool.test.ts
@@ -1,0 +1,65 @@
+import { context, trace } from '@opentelemetry/api';
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { GenericPoolInstrumentation } from '../../../src/integrations/tracing/genericPool/vendored/instrumentation';
+import { cleanupOtel, mockSdkInit } from '../../helpers/mockSdkInit';
+
+// A minimal stand-in for the v3 `generic-pool` module: a `Pool` class with a promise-based `acquire`.
+// A fresh class per test keeps each test patching its own prototype (no cross-test contamination).
+function createPoolModule(): { Pool: new () => { acquire: () => Promise<string> } } {
+  class FakePool {
+    public acquire(): Promise<string> {
+      return Promise.resolve('client');
+    }
+  }
+  return { Pool: FakePool };
+}
+
+describe('GenericPoolInstrumentation', () => {
+  const memoryExporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(memoryExporter)] });
+
+  let instrumentation: GenericPoolInstrumentation;
+
+  beforeEach(() => {
+    // `mockSdkInit` gives us a working context manager so `context.with(...)` propagates the active span.
+    mockSdkInit({ tracesSampleRate: 1 });
+    instrumentation = new GenericPoolInstrumentation();
+    instrumentation.setTracerProvider(provider);
+    memoryExporter.reset();
+  });
+
+  afterEach(() => {
+    instrumentation.disable();
+    cleanupOtel();
+  });
+
+  it('attaches the acquire span to the parent span', async () => {
+    const moduleExports = createPoolModule();
+    // index 0 is the v3 (`>=3.0.0 <4`) module definition with the promise-based patcher.
+    const def = instrumentation.getModuleDefinitions()[0]!;
+    def.patch!(moduleExports);
+
+    const parent = provider.getTracer('test').startSpan('parent');
+    await context.with(trace.setSpan(context.active(), parent), async () => {
+      await new moduleExports.Pool().acquire();
+    });
+    parent.end();
+
+    const acquireSpan = memoryExporter.getFinishedSpans().find(span => span.name === 'generic-pool.acquire');
+    expect(acquireSpan).toBeDefined();
+    expect(acquireSpan!.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
+  });
+
+  it('does not create a span when disabled', async () => {
+    const moduleExports = createPoolModule();
+    const def = instrumentation.getModuleDefinitions()[0]!;
+    // Patch then unpatch to mimic the instrumentation being disabled.
+    def.patch!(moduleExports);
+    def.unpatch!(moduleExports);
+
+    await new moduleExports.Pool().acquire();
+
+    expect(memoryExporter.getFinishedSpans()).toHaveLength(0);
+  });
+});

--- a/packages/node/test/integrations/tracing/genericPool.test.ts
+++ b/packages/node/test/integrations/tracing/genericPool.test.ts
@@ -1,11 +1,17 @@
+/*
+ * Tests ported from @opentelemetry/instrumentation-generic-pool@0.61.0
+ * Original source: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-generic-pool
+ * Licensed under the Apache License, Version 2.0
+ */
+
 import { context, trace } from '@opentelemetry/api';
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { GenericPoolInstrumentation } from '../../../src/integrations/tracing/genericPool/vendored/instrumentation';
 import { cleanupOtel, mockSdkInit } from '../../helpers/mockSdkInit';
 
-// A minimal stand-in for the v3 `generic-pool` module: a `Pool` class with a promise-based `acquire`.
-// A fresh class per test keeps each test patching its own prototype (no cross-test contamination).
+// Create a fake `generic-pool` module.
+// A fresh class per test avoids patching a shared prototype across tests.
 function createPoolModule(): { Pool: new () => { acquire: () => Promise<string> } } {
   class FakePool {
     public acquire(): Promise<string> {
@@ -22,7 +28,6 @@ describe('GenericPoolInstrumentation', () => {
   let instrumentation: GenericPoolInstrumentation;
 
   beforeEach(() => {
-    // `mockSdkInit` gives us a working context manager so `context.with(...)` propagates the active span.
     mockSdkInit({ tracesSampleRate: 1 });
     instrumentation = new GenericPoolInstrumentation();
     instrumentation.setTracerProvider(provider);
@@ -34,9 +39,8 @@ describe('GenericPoolInstrumentation', () => {
     cleanupOtel();
   });
 
-  it('attaches the acquire span to the parent span', async () => {
+  it('should attach it to the parent span', async () => {
     const moduleExports = createPoolModule();
-    // index 0 is the v3 (`>=3.0.0 <4`) module definition with the promise-based patcher.
     const def = instrumentation.getModuleDefinitions()[0]!;
     def.patch!(moduleExports);
 
@@ -51,7 +55,7 @@ describe('GenericPoolInstrumentation', () => {
     expect(acquireSpan!.parentSpanContext?.spanId).toBe(parent.spanContext().spanId);
   });
 
-  it('does not create a span when disabled', async () => {
+  it('should not create anything if disabled', async () => {
     const moduleExports = createPoolModule();
     const def = instrumentation.getModuleDefinitions()[0]!;
     // Patch then unpatch to mimic the instrumentation being disabled.

--- a/packages/node/test/integrations/tracing/genericPool.test.ts
+++ b/packages/node/test/integrations/tracing/genericPool.test.ts
@@ -11,7 +11,6 @@ import { GenericPoolInstrumentation } from '../../../src/integrations/tracing/ge
 import { cleanupOtel, mockSdkInit } from '../../helpers/mockSdkInit';
 
 // Create a fake `generic-pool` module.
-// A fresh class per test avoids patching a shared prototype across tests.
 function createPoolModule(): { Pool: new () => { acquire: () => Promise<string> } } {
   class FakePool {
     public acquire(): Promise<string> {


### PR DESCRIPTION
Streamlines the vendored `@opentelemetry/instrumentation-generic-pool`:

- Extend test coverage: added a `generic-pool` v2 integration suite (`genericPool-v2`) alongside the existing v3 one, so both major versions are exercised. Ported unit tests from upstream.
- Removed the eslint-disable and updated the formatting and types to make the linter happy.

This one has three supported version ranges with different instrumentation paths (`2.0 - <2.4`, `2.4 - <3.0`, `>3.0`). The only path that is still heavily used is `>3.0` based on [npm downloads](https://www.npmjs.com/package/generic-pool?activeTab=versions). In the future we can think about dropping v2 support, which would allow us to slim this instrumentation down quite a bit.

Closes #20727