### PR TITLE
fix(cloudflare): Don't track negatively sampled spans

### DIFF
--- a/packages/cloudflare/src/client.ts
+++ b/packages/cloudflare/src/client.ts
@@ -1,5 +1,5 @@
 import type { ClientOptions, Options, ServerRuntimeClientOptions } from '@sentry/core';
-import { applySdkMetadata, debug, ServerRuntimeClient } from '@sentry/core';
+import { applySdkMetadata, debug, ServerRuntimeClient, spanIsSampled } from '@sentry/core';
 import { DEBUG_BUILD } from './debug-build';
 import type { makeFlushLock } from './flush';
 import type { CloudflareTransportOptions } from './transport';
@@ -44,6 +44,15 @@ export class CloudflareClient extends ServerRuntimeClient {
     this._unsubscribeSpanStart = this.on('spanStart', span => {
       const spanId = span.spanContext().spanId;
       DEBUG_BUILD && debug.log('[CloudflareClient] Span started:', spanId);
+
+      // Negatively sampled spans never emit spanEnd,
+      // so tracking them would cause _pendingSpans to grow unboundedly.
+      // We should fix the inconsistent behavior for NonRecordingSpans in the future but
+      // for now, we just ignore them.
+      if (!spanIsSampled(span)) {
+        return;
+      }
+
       this._pendingSpans.add(spanId);
 
       if (!this._spanCompletionPromise) {

--- a/packages/cloudflare/test/client.test.ts
+++ b/packages/cloudflare/test/client.test.ts
@@ -3,6 +3,8 @@ import { setAsyncLocalStorageAsyncContextStrategy } from '../src/async';
 import { CloudflareClient, type CloudflareClientOptions } from '../src/client';
 import { makeFlushLock } from '../src/flush';
 
+const TRACE_FLAG_SAMPLED = 0x1;
+
 const MOCK_CLIENT_OPTIONS: CloudflareClientOptions = {
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   stackParser: () => [],
@@ -232,7 +234,7 @@ describe('CloudflareClient', () => {
 
       // Emit spanStart
       const mockSpan = {
-        spanContext: () => ({ spanId: 'test-span-id' }),
+        spanContext: () => ({ spanId: 'test-span-id', traceFlags: TRACE_FLAG_SAMPLED }),
       };
       client.emit('spanStart', mockSpan as any);
 
@@ -249,7 +251,7 @@ describe('CloudflareClient', () => {
       };
 
       const mockSpan = {
-        spanContext: () => ({ spanId: 'test-span-id' }),
+        spanContext: () => ({ spanId: 'test-span-id', traceFlags: TRACE_FLAG_SAMPLED }),
       };
 
       // Start span
@@ -269,8 +271,12 @@ describe('CloudflareClient', () => {
         _spanCompletionPromise: Promise<void> | null;
       };
 
-      const mockSpan1 = { spanContext: () => ({ spanId: 'span-1' }) };
-      const mockSpan2 = { spanContext: () => ({ spanId: 'span-2' }) };
+      const mockSpan1 = {
+        spanContext: () => ({ spanId: 'span-1', traceFlags: TRACE_FLAG_SAMPLED }),
+      };
+      const mockSpan2 = {
+        spanContext: () => ({ spanId: 'span-2', traceFlags: TRACE_FLAG_SAMPLED }),
+      };
 
       // Start both spans
       client.emit('spanStart', mockSpan1 as any);
@@ -289,6 +295,24 @@ describe('CloudflareClient', () => {
 
       // The original promise should resolve
       await expect(completionPromise).resolves.toBeUndefined();
+    });
+
+    it('does not track negatively sampled spans', () => {
+      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
+
+      const privateClient = client as unknown as {
+        _pendingSpans: Set<string>;
+        _spanCompletionPromise: Promise<void> | null;
+      };
+
+      const nonRecordingSpan = {
+        spanContext: () => ({ spanId: 'non-recording-span-id', traceFlags: 0 }),
+      };
+
+      client.emit('spanStart', nonRecordingSpan as any);
+
+      expect(privateClient._pendingSpans.has('non-recording-span-id')).toBe(false);
+      expect(privateClient._spanCompletionPromise).toBeNull();
     });
 
     it('does not track spans after dispose', () => {


### PR DESCRIPTION
supersedes https://github.com/getsentry/sentry-javascript/pull/21349 for the time being. This does not fix the case where a `spanStart` event is emitted not a `spanEnd` event isn't. It only locally fixes an occurance of the symptom. We're gonna merge this first to resolve the cloudflare SDK bug but we'll need a more reliable fix than the one I hacked to gether in https://github.com/getsentry/sentry-javascript/pull/21349. 

See https://github.com/getsentry/sentry-javascript/pull/21349#issuecomment-4649406890