### PR TITLE
test(react-router): Add Redis-backed DB-span coverage to rr7

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes.ts
@@ -19,5 +19,6 @@ export default [
     route('server-loader', 'routes/performance/server-loader.tsx'),
     route('server-action', 'routes/performance/server-action.tsx'),
     route('with-middleware', 'routes/performance/with-middleware.tsx'),
+    route('redis', 'routes/performance/redis.tsx'),
   ]),
 ] satisfies RouteConfig;

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/index.tsx
@@ -10,6 +10,7 @@ export default function PerformancePage() {
         <Link to={{ pathname: '/performance/with/object-nav', search: '?foo=bar' }}>Object Navigate</Link>
         <Link to={{ search: '?query=test' }}>Search Only Navigate</Link>
         <Link to="/performance/server-loader">Server Loader</Link>
+        <Link to="/performance/redis">Redis</Link>
       </nav>
     </div>
   );

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/redis.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/redis.tsx
@@ -1,0 +1,22 @@
+import Redis from 'ioredis';
+import type { Route } from './+types/redis';
+
+const redis = new Redis();
+
+export async function loader() {
+  const key = 'cache:greeting';
+  await redis.set(key, 'hello from react-router');
+  const value = await redis.get(key);
+
+  return { value };
+}
+
+export default function RedisPage({ loaderData }: Route.ComponentProps) {
+  const { value } = loaderData;
+  return (
+    <div>
+      <h1>Redis Page</h1>
+      <div id="redis-value">{value}</div>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/docker-compose.yml
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  redis:
+    image: redis:8
+    restart: always
+    container_name: e2e-tests-react-router-7-redis
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 1s
+      timeout: 3s
+      retries: 30

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/global-setup.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/global-setup.mjs
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Boot Redis here (rather than in the `start` script) so the cold `redis:8` image
+// pull happens outside Playwright's webServer startup-timeout window. `--wait`
+// blocks until the healthcheck passes;
+export default async function globalSetup() {
+  execSync('docker compose up -d --wait', { cwd: __dirname, stdio: 'inherit' });
+}

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/package.json
@@ -10,6 +10,7 @@
     "@react-router/node": "^7.13.0",
     "@react-router/serve": "^7.13.0",
     "@sentry/react-router": "file:../../packed/sentry-react-router-packed.tgz",
+    "ioredis": "^5.4.1",
     "isbot": "^5.1.17"
   },
   "devDependencies": {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/playwright.config.mjs
@@ -1,8 +1,13 @@
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+import { fileURLToPath } from 'url';
 
-const config = getPlaywrightConfig({
-  startCommand: `PORT=3030 pnpm start`,
-  port: 3030,
-});
+const config = getPlaywrightConfig(
+  {
+    startCommand: `PORT=3030 pnpm start`,
+    port: 3030,
+  },
+  // Boot Redis before the tests run, outside the webServer startup-timeout window.
+  { globalSetup: fileURLToPath(new URL('./global-setup.mjs', import.meta.url)) },
+);
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/tests/performance/redis.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/tests/performance/redis.server.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+import { APP_NAME } from '../constants';
+
+test.describe('server - redis db spans', () => {
+  test('server loader emits db.redis child spans on the http.server transaction', async ({ page }) => {
+    const txPromise = waitForTransaction(APP_NAME, async transactionEvent => {
+      return (
+        transactionEvent.transaction === 'GET /performance/redis' &&
+        (transactionEvent.spans?.some(span => span.op === 'db.redis') ?? false)
+      );
+    });
+
+    await page.goto('/performance/redis');
+
+    const transaction = await txPromise;
+
+    expect(transaction.contexts?.trace?.op).toBe('http.server');
+    const redisSpans = transaction.spans!.filter(span => span.op === 'db.redis');
+
+    // loader runs SET then GET => at least two redis command spans
+    expect(redisSpans.length).toBeGreaterThanOrEqual(2);
+
+    // every redis span is a child span tagged as the redis system
+    expect(redisSpans.every(span => span.data?.['db.system'] === 'redis')).toBe(true);
+    expect(redisSpans.every(span => typeof span.parent_span_id === 'string')).toBe(true);
+    expect(redisSpans.some(span => span.data?.['net.peer.port'] === 6379)).toBe(true);
+
+    // db.statement starts with the command name (e.g. "set cache:greeting ...", "get cache:greeting")
+    const statements = redisSpans.map(span => String(span.data?.['db.statement'] ?? '').toLowerCase());
+    expect(statements.some(statement => statement.startsWith('set'))).toBe(true);
+    expect(statements.some(statement => statement.startsWith('get'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds an OTel auto-instrumented DB integration (Redis via `ioredis`) to the `react-router-7-framework` e2e app as a regression guard for upcoming changes to our React Router instrumentation strategy.
  
closes #21389