### PR TITLE
fix(core): Avoid asymetric `spanStart` and `spanEnd` emissions

### DIFF
--- a/packages/browser/src/tracing/linkedTraces.ts
+++ b/packages/browser/src/tracing/linkedTraces.ts
@@ -2,7 +2,6 @@ import type { Client, PropagationContext, Span, SpanContextData } from '@sentry/
 import {
   debug,
   getCurrentScope,
-  getRootSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_PREVIOUS_TRACE_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE,
@@ -60,11 +59,7 @@ export function linkTraces(
 
   let inMemoryPreviousTraceInfo = useSessionStorage ? getPreviousTraceFromSessionStorage() : undefined;
 
-  client.on('spanStart', span => {
-    if (getRootSpan(span) !== span) {
-      return;
-    }
-
+  client.on('segmentSpanCreated', span => {
     const oldPropagationContext = getCurrentScope().getPropagationContext();
     inMemoryPreviousTraceInfo = addPreviousTraceSpanLink(inMemoryPreviousTraceInfo, span, oldPropagationContext);
 

--- a/packages/browser/test/tracing/linkedTraces.test.ts
+++ b/packages/browser/test/tracing/linkedTraces.test.ts
@@ -1,6 +1,5 @@
 import type { PropagationContext, Span } from '@sentry/core/browser';
 import {
-  addChildSpanToSpan,
   debug,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SentrySpan,
@@ -22,51 +21,27 @@ import {
 } from '../../src/tracing/linkedTraces';
 
 describe('linkTraces', () => {
-  describe('adds a previous trace span link on span start', () => {
+  describe('adds a previous trace span link on root span creation', () => {
     // @ts-expect-error - mock contains only necessary API
     const client = new BrowserClient({ transport: () => {}, integrations: [], stackParser: () => [] });
 
-    let spanStartCb: (span: Span) => void;
+    let segmentSpanCreatedCb: (span: Span) => void;
 
     // @ts-expect-error - this is fine for testing
     const clientOnSpy = vi.spyOn(client, 'on').mockImplementation((event, cb) => {
       // @ts-expect-error - this is fine for testing
-      if (event === 'spanStart') {
-        spanStartCb = cb;
+      if (event === 'segmentSpanCreated') {
+        segmentSpanCreatedCb = cb;
       }
     });
 
-    it('registers a spanStart handler', () => {
-      expect(clientOnSpy).toHaveBeenCalledWith('spanStart', expect.any(Function));
+    it('registers a segmentSpanCreated handler', () => {
+      expect(clientOnSpy).toHaveBeenCalledWith('segmentSpanCreated', expect.any(Function));
       expect(clientOnSpy).toHaveBeenCalledOnce();
     });
 
     beforeEach(() => {
       linkTraces(client, { linkPreviousTrace: 'in-memory', consistentTraceSampling: false });
-    });
-
-    it("doesn't add a link if the passed span is not the root span", () => {
-      const rootSpan = new SentrySpan({
-        name: 'test',
-        parentSpanId: undefined,
-        sampled: true,
-        spanId: '123',
-        traceId: '456',
-      });
-
-      const childSpan = new SentrySpan({
-        name: 'test',
-        parentSpanId: '123',
-        spanId: '456',
-        traceId: '789',
-        sampled: true,
-      });
-
-      addChildSpanToSpan(rootSpan, childSpan);
-
-      spanStartCb(childSpan);
-
-      expect(spanToJSON(childSpan).links).toBeUndefined();
     });
 
     it('adds a link from the first trace root span to the second trace root span', () => {
@@ -78,7 +53,7 @@ describe('linkTraces', () => {
         traceId: '456',
       });
 
-      spanStartCb(rootSpanTrace1);
+      segmentSpanCreatedCb(rootSpanTrace1);
 
       expect(spanToJSON(rootSpanTrace1).links).toBeUndefined();
 
@@ -90,7 +65,7 @@ describe('linkTraces', () => {
         traceId: 'def',
       });
 
-      spanStartCb(rootSpanTrace2);
+      segmentSpanCreatedCb(rootSpanTrace2);
 
       expect(spanToJSON(rootSpanTrace2).links).toEqual([
         {
@@ -113,7 +88,7 @@ describe('linkTraces', () => {
         traceId: 'def',
       });
 
-      spanStartCb(rootSpanTrace1);
+      segmentSpanCreatedCb(rootSpanTrace1);
 
       expect(spanToJSON(rootSpanTrace1).links).toBeUndefined();
 
@@ -125,7 +100,7 @@ describe('linkTraces', () => {
         traceId: 'def',
       });
 
-      spanStartCb(rootSpan2Trace);
+      segmentSpanCreatedCb(rootSpan2Trace);
 
       expect(spanToJSON(rootSpan2Trace).links).toBeUndefined();
     });
@@ -142,7 +117,7 @@ describe('linkTraces', () => {
     });
 
     it('registers a beforeSampling handler', () => {
-      expect(clientOnSpy).toHaveBeenCalledWith('spanStart', expect.any(Function));
+      expect(clientOnSpy).toHaveBeenCalledWith('segmentSpanCreated', expect.any(Function));
       expect(clientOnSpy).toHaveBeenCalledWith('beforeSampling', expect.any(Function));
       expect(clientOnSpy).toHaveBeenCalledTimes(2);
     });

--- a/packages/cloudflare/src/client.ts
+++ b/packages/cloudflare/src/client.ts
@@ -1,5 +1,5 @@
 import type { ClientOptions, Options, ServerRuntimeClientOptions } from '@sentry/core';
-import { applySdkMetadata, debug, ServerRuntimeClient, spanIsSampled } from '@sentry/core';
+import { applySdkMetadata, debug, ServerRuntimeClient } from '@sentry/core';
 import { DEBUG_BUILD } from './debug-build';
 import type { makeFlushLock } from './flush';
 import type { CloudflareTransportOptions } from './transport';
@@ -44,14 +44,6 @@ export class CloudflareClient extends ServerRuntimeClient {
     this._unsubscribeSpanStart = this.on('spanStart', span => {
       const spanId = span.spanContext().spanId;
       DEBUG_BUILD && debug.log('[CloudflareClient] Span started:', spanId);
-
-      // Negatively sampled spans never emit spanEnd,
-      // so tracking them would cause _pendingSpans to grow unboundedly.
-      // We should fix the inconsistent behavior for NonRecordingSpans in the future but
-      // for now, we just ignore them.
-      if (!spanIsSampled(span)) {
-        return;
-      }
 
       this._pendingSpans.add(spanId);
 

--- a/packages/cloudflare/test/client.test.ts
+++ b/packages/cloudflare/test/client.test.ts
@@ -297,24 +297,6 @@ describe('CloudflareClient', () => {
       await expect(completionPromise).resolves.toBeUndefined();
     });
 
-    it('does not track negatively sampled spans', () => {
-      const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
-
-      const privateClient = client as unknown as {
-        _pendingSpans: Set<string>;
-        _spanCompletionPromise: Promise<void> | null;
-      };
-
-      const nonRecordingSpan = {
-        spanContext: () => ({ spanId: 'non-recording-span-id', traceFlags: 0 }),
-      };
-
-      client.emit('spanStart', nonRecordingSpan as any);
-
-      expect(privateClient._pendingSpans.has('non-recording-span-id')).toBe(false);
-      expect(privateClient._spanCompletionPromise).toBeNull();
-    });
-
     it('does not track spans after dispose', () => {
       const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -621,6 +621,14 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
   /* eslint-disable @typescript-eslint/unified-signatures */
   /**
+   * Register a callback for whenever a segment span is created, regardless of sampling decision.
+   * This fires for every segment span before `spanStart` and is useful for tracking trace lifecycle
+   * independent of whether the trace is sampled.
+   * @returns {() => void} A function that, when executed, removes the registered callback.
+   */
+  public on(hook: 'segmentSpanCreated', callback: (span: Span) => void): () => void;
+
+  /**
    * Register a callback for whenever a span is started.
    * Receives the span as argument.
    * @returns {() => void} A function that, when executed, removes the registered callback.
@@ -941,6 +949,9 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
       hookCallbacks.delete(uniqueCallback);
     };
   }
+
+  /** Fire a hook whenever a segment span is created, regardless of sampling decision. */
+  public emit(hook: 'segmentSpanCreated', span: Span): void;
 
   /** Fire a hook whenever a span starts. */
   public emit(hook: 'spanStart', span: Span): void;

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -314,7 +314,7 @@ export class SentrySpan implements Span {
   /** Emit `spanEnd` when the span is ended. */
   private _onSpanEnded(): void {
     const client = getClient();
-    if (client) {
+    if (client && this._sampled) {
       client.emit('spanEnd', this);
       // Guarding sending standalone v1 spans as v2 streamed spans for now.
       // Otherwise they'd be sent once as v1 spans and again as streamed spans.

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -506,7 +506,7 @@ function _startRootSpan(spanArguments: SentrySpanArguments, scope: Scope, parent
     client.recordDroppedEvent('sample_rate', hasSpanStreamingEnabled(client) ? 'span' : 'transaction');
   }
 
-  if (client) {
+  if (sampled && client) {
     client.emit('spanStart', rootSpan);
   }
 
@@ -554,11 +554,8 @@ function _startChildSpan(parentSpan: Span, scope: Scope, spanArguments: SentrySp
     }
   }
 
-  client.emit('spanStart', childSpan);
-  // If it has an endTimestamp, it's already ended
-  if (spanArguments.endTimestamp) {
-    client.emit('spanEnd', childSpan);
-    client.emit('afterSpanEnd', childSpan);
+  if (sampled) {
+    client.emit('spanStart', childSpan);
   }
 
   return childSpan;

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -506,6 +506,10 @@ function _startRootSpan(spanArguments: SentrySpanArguments, scope: Scope, parent
     client.recordDroppedEvent('sample_rate', hasSpanStreamingEnabled(client) ? 'span' : 'transaction');
   }
 
+  if (client) {
+    client.emit('segmentSpanCreated', rootSpan);
+  }
+
   if (sampled && client) {
     client.emit('spanStart', rootSpan);
   }


### PR DESCRIPTION
This PR fixes a couple of inconsistencies in the core SDK tracing implementation around emitting the `spanStart` and `spanEnd` client hook events.

- Previously, we'd emit `spanStart` but not the `spanEnd` event for negatively sampled child spans. Now, negatively sampled child spans don't emit any events. While after #21367 already fixed a bug from this behaviour, there were other brittle cases in the code that were susceptible to the same bug (idle spans activity counter and profiling span counter)
- Previously, we'd emit `spanStart` and `spanEnd` events for negatively sampled root/segment spans. Now, negatively sampled root/segment spans don't emit any events
- This aligns the core SDK implementation with the POTel SDK implementation (`SentrySpanProcessor`), where negatively sampled spans never emit these hook events.

One annoying case: Our linked traces implementation relied on receiving negatively sampled root spans in its `spanStart` callback to carry over negative sampling decisions if `consistentTraceSampling` was activated. To ensure consistent trace sampling continues to, this PR introduces a new `segmentSpanCreated` hook that fires for all segment spans regardless of sampling decision. 

closes #21368 