### PR TITLE
 feat(hono): Add HTTP connection info to server spans

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hono-4/src/entry.bun.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/entry.bun.ts
@@ -9,6 +9,7 @@ app.use(
     dsn: process.env.E2E_TEST_DSN,
     environment: 'qa',
     tracesSampleRate: 1.0,
+    dataCollection: { userInfo: true },
     tunnel: 'http://localhost:3031/',
   }),
 );

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/entry.cloudflare.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/entry.cloudflare.ts
@@ -9,6 +9,7 @@ app.use(
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tracesSampleRate: 1.0,
+    dataCollection: { userInfo: true },
     tunnel: 'http://localhost:3031/',
   })),
 );

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/instrument.node.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/instrument.node.ts
@@ -4,5 +4,6 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,
+  dataCollection: { userInfo: true },
   tunnel: 'http://localhost:3031/',
 });

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
@@ -50,12 +50,14 @@ test('attaches HTTP connection info to the server transaction', async ({ baseURL
     expect(data['client.port']).toEqual(expect.any(Number));
     expect(data['network.peer.port']).toBe(data['client.port']);
     expect(data['network.type']).toMatch(/^ipv[46]$/);
-  } else {
+  } else if (RUNTIME === 'cloudflare') {
     // Cloudflare Workers expose no port, address family, or transport.
     // This could change in the future and checking for the absence of these fields allows us to notice if/when that happens.
     expect(data['client.port']).toBeUndefined();
     expect(data['network.peer.port']).toBeUndefined();
     expect(data['network.type']).toBeUndefined();
+  } else {
+    throw new Error(`No tests for runtime: ${RUNTIME}`);
   }
 
   // Only available in `hono/deno`
@@ -88,6 +90,8 @@ test("preserves the baseline network.* server span attributes that the SDK sends
     // Doesn't set net.*, network.*, or client.* attributes
   } else if (RUNTIME === 'cloudflare') {
     expect(data['network.protocol.name']).toBe('HTTP/1.1');
+  } else {
+    throw new Error(`No tests for runtime: ${RUNTIME}`);
   }
 });
 

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
@@ -62,6 +62,35 @@ test('attaches HTTP connection info to the server transaction', async ({ baseURL
   expect(data['network.transport']).toBeUndefined();
 });
 
+// Regression guard against connection info attributes.
+// The conninfo middleware must only *add* attributes, never replace or clear existing ones.
+// These are the baseline attributes the server transaction carries *without* the conninfo feature
+test("preserves the baseline network.* server span attributes that the SDK sends without Hono's conninfo", async ({
+  baseURL,
+}) => {
+  const transactionPromise = waitForTransaction(APP_NAME, event => {
+    return event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /';
+  });
+
+  const response = await fetch(`${baseURL}/`);
+  expect(response.status).toBe(200);
+
+  const transaction = await transactionPromise;
+  const data = transaction.contexts?.trace?.data ?? {};
+
+  if (RUNTIME === 'node') {
+    expect(data['net.host.name']).toBe('localhost');
+    expect(data['net.transport']).toBe('ip_tcp');
+    expect(data['net.host.ip']).toEqual(expect.any(String));
+    expect(data['net.peer.ip']).toEqual(expect.any(String));
+    expect(data['net.peer.port']).toEqual(expect.any(Number));
+  } else if (RUNTIME === 'bun') {
+    // Doesn't set net.*, network.*, or client.* attributes
+  } else if (RUNTIME === 'cloudflare') {
+    expect(data['network.protocol.name']).toBe('HTTP/1.1');
+  }
+});
+
 test('sends a transaction for a route that throws', async ({ baseURL }) => {
   const transactionPromise = waitForTransaction(APP_NAME, event => {
     return event.contexts?.trace?.op === 'http.server' && !!event.transaction?.includes('/error/');

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
@@ -51,7 +51,7 @@ test('attaches HTTP connection info to the server transaction', async ({ baseURL
     expect(data['network.peer.port']).toBe(data['client.port']);
     expect(data['network.type']).toMatch(/^ipv[46]$/);
   } else {
-    // Cloudflare Workers only expose no port, address family, or transport.
+    // Cloudflare Workers expose no port, address family, or transport.
     // This could change in the future and checking for the absence of these fields allows us to notice if/when that happens.
     expect(data['client.port']).toBeUndefined();
     expect(data['network.peer.port']).toBeUndefined();

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
-import { APP_NAME } from './constants';
+import { APP_NAME, RUNTIME } from './constants';
 
 test('sends a transaction for the index route', async ({ baseURL }) => {
   const transactionPromise = waitForTransaction(APP_NAME, event => {
@@ -26,6 +26,40 @@ test('sends a transaction for a parameterized route', async ({ baseURL }) => {
   const transaction = await transactionPromise;
   expect(transaction.transaction).toBe('GET /test-param/:paramId');
   expect(transaction.contexts?.trace?.op).toBe('http.server');
+});
+
+test('attaches HTTP connection info to the server transaction', async ({ baseURL, page }) => {
+  page.on('console', msg => {
+    console.log(`PAGE LOG: ${msg.text()}`);
+  });
+  const transactionPromise = waitForTransaction(APP_NAME, event => {
+    return event.contexts?.trace?.op === 'http.server' && event.transaction === 'GET /';
+  });
+
+  const response = await fetch(`${baseURL}/`);
+  expect(response.status).toBe(200);
+
+  const transaction = await transactionPromise;
+  const data = transaction.contexts?.trace?.data ?? {};
+
+  expect(data['client.address']).toEqual(expect.any(String));
+  expect(data['network.peer.address']).toBe(data['client.address']);
+
+  if (RUNTIME === 'node' || RUNTIME === 'bun') {
+    // Node (@hono/node-server) and Bun expose socket-level port and address family.
+    expect(data['client.port']).toEqual(expect.any(Number));
+    expect(data['network.peer.port']).toBe(data['client.port']);
+    expect(data['network.type']).toMatch(/^ipv[46]$/);
+  } else {
+    // Cloudflare Workers only expose no port, address family, or transport.
+    // This could change in the future and checking for the absence of these fields allows us to notice if/when that happens.
+    expect(data['client.port']).toBeUndefined();
+    expect(data['network.peer.port']).toBeUndefined();
+    expect(data['network.type']).toBeUndefined();
+  }
+
+  // Only available in `hono/deno`
+  expect(data['network.transport']).toBeUndefined();
 });
 
 test('sends a transaction for a route that throws', async ({ baseURL }) => {

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -83,6 +83,7 @@
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.x",
+    "@hono/node-server": "^1.x",
     "@sentry/bun": "10.57.0",
     "@sentry/cloudflare": "10.57.0",
     "@sentry/node": "10.57.0",
@@ -90,6 +91,9 @@
   },
   "peerDependenciesMeta": {
     "@cloudflare/workers-types": {
+      "optional": true
+    },
+    "@hono/node-server": {
       "optional": true
     },
     "@sentry/bun": {
@@ -104,6 +108,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20250922.0",
+    "@hono/node-server": "^1.19.10",
     "@types/node": "^18.19.1",
     "wrangler": "4.62.0"
   },

--- a/packages/hono/src/bun/middleware.ts
+++ b/packages/hono/src/bun/middleware.ts
@@ -1,5 +1,6 @@
 import { type BaseTransportOptions, debug, type Options } from '@sentry/core';
 import { init } from './sdk';
+import { getConnInfo } from 'hono/bun';
 import type { Env, Hono, MiddlewareHandler } from 'hono';
 import { requestHandler, responseHandler } from '../shared/middlewareHandlers';
 import { applyPatches } from '../shared/applyPatches';
@@ -18,7 +19,7 @@ export const sentry = <E extends Env>(app: Hono<E>, options: HonoBunOptions): Mi
   applyPatches(app);
 
   return async (context, next) => {
-    requestHandler(context);
+    requestHandler(context, getConnInfo);
 
     await next(); // Handler runs in between Request above ⤴ and Response below ⤵
 

--- a/packages/hono/src/cloudflare/middleware.ts
+++ b/packages/hono/src/cloudflare/middleware.ts
@@ -1,5 +1,6 @@
 import { withSentry } from '@sentry/cloudflare';
 import { applySdkMetadata, type BaseTransportOptions, debug, type Options } from '@sentry/core';
+import { getConnInfo } from 'hono/cloudflare-workers';
 import type { Env, Hono, MiddlewareHandler } from 'hono';
 import { buildFilteredIntegrations } from '../shared/buildFilteredIntegrations';
 import { LOW_QUALITY_TRANSACTION_PATTERNS } from '../shared/lowQualityTransactionPatterns';
@@ -44,7 +45,7 @@ export function sentry<E extends Env>(
         ? options(context.env as E['Bindings']).shouldHandleError
         : options.shouldHandleError;
 
-    requestHandler(context);
+    requestHandler(context, getConnInfo);
 
     await next(); // Handler runs in between Request above ⤴ and Response below ⤵
 

--- a/packages/hono/src/node/middleware.ts
+++ b/packages/hono/src/node/middleware.ts
@@ -1,4 +1,5 @@
 import { type BaseTransportOptions, consoleSandbox, debug, getClient, type Options } from '@sentry/core';
+import { getConnInfo } from '@hono/node-server/conninfo';
 import type { Env, Hono, MiddlewareHandler } from 'hono';
 import { requestHandler, responseHandler } from '../shared/middlewareHandlers';
 import { applyPatches } from '../shared/applyPatches';
@@ -42,7 +43,7 @@ export const sentry = <E extends Env>(app: Hono<E>, options?: SentryHonoMiddlewa
   applyPatches(app);
 
   return async (context, next) => {
-    requestHandler(context);
+    requestHandler(context, getConnInfo);
 
     await next(); // Handler runs in between Request above ⤴ and Response below ⤵
 

--- a/packages/hono/src/shared/middlewareHandlers.ts
+++ b/packages/hono/src/shared/middlewareHandlers.ts
@@ -69,7 +69,7 @@ function setConnInfoAttributes(context: Context, getConnInfo: GetConnInfo, isola
   });
 
   if (ipAddress) {
-    isolationScope.setUser({ ip_address: ipAddress });
+    isolationScope.setUser({ ...isolationScope.getUser(), ip_address: ipAddress });
   }
 }
 

--- a/packages/hono/src/shared/middlewareHandlers.ts
+++ b/packages/hono/src/shared/middlewareHandlers.ts
@@ -56,7 +56,7 @@ function setConnInfoAttributes(context: Context, getConnInfo: GetConnInfo, isola
 
   const { address, port, transport, addressType } = remote || {};
 
-  // Only collect client IP if `userInfo` is enabled (this primarily for setting data with `.setUser` but we in this case we cannot check for `dataCollection.headers` or similar)
+  // Only collect client IP if `userInfo` is enabled (this is primarily for setting data with `.setUser`, but in this case we cannot check for `dataCollection.headers` or similar)
   const ipAddress = address && getClient()?.getDataCollectionOptions().userInfo ? address : undefined;
 
   getRootSpan(activeSpan).setAttributes({

--- a/packages/hono/src/shared/middlewareHandlers.ts
+++ b/packages/hono/src/shared/middlewareHandlers.ts
@@ -14,11 +14,12 @@ import { routePath } from 'hono/route';
 import { hasFetchEvent } from '../utils/hono-context';
 import { defaultShouldHandleError } from './defaultShouldHandleError';
 import { type SentryHonoMiddlewareOptions } from '../shared/types';
+import { type GetConnInfo } from 'hono/conninfo';
 
 /**
  * Request handler for Hono framework
  */
-export function requestHandler(context: Context): void {
+export function requestHandler(context: Context, getConnInfo?: GetConnInfo): void {
   const defaultScope = getDefaultIsolationScope();
   const currentIsolationScope = getIsolationScope();
 
@@ -29,6 +30,47 @@ export function requestHandler(context: Context): void {
   isolationScope.setSDKProcessingMetadata({
     normalizedRequest: winterCGRequestToRequestData(hasFetchEvent(context) ? context.event.request : context.req.raw),
   });
+
+  if (getConnInfo) {
+    setConnInfoAttributes(context, getConnInfo, isolationScope);
+  }
+}
+
+/**
+ * Adds HTTP connection info (client IP, port, transport, address type) from Hono's `getConnInfo`
+ * helper to the root (server) span and the isolation scope.
+ */
+function setConnInfoAttributes(context: Context, getConnInfo: GetConnInfo, isolationScope: Scope): void {
+  const activeSpan = getActiveSpan();
+  if (!activeSpan) {
+    return;
+  }
+
+  let remote: ReturnType<GetConnInfo>['remote'] | undefined;
+  try {
+    remote = getConnInfo(context).remote;
+  } catch {
+    // The helper can throw when the underlying socket/env is unavailable (e.g. unsupported runtime).
+    return;
+  }
+
+  const { address, port, transport, addressType } = remote || {};
+
+  // Only collect client IP if `userInfo` is enabled (this primarily for setting data with `.setUser` but we in this case we cannot check for `dataCollection.headers` or similar)
+  const ipAddress = address && getClient()?.getDataCollectionOptions().userInfo ? address : undefined;
+
+  getRootSpan(activeSpan).setAttributes({
+    'client.port': port,
+    'network.peer.port': port,
+    'network.transport': transport,
+    'network.type': addressType?.toLowerCase(),
+    'client.address': ipAddress,
+    'network.peer.address': ipAddress,
+  });
+
+  if (ipAddress) {
+    isolationScope.setUser({ ip_address: ipAddress });
+  }
 }
 
 /**

--- a/packages/hono/test/bun/middleware.test.ts
+++ b/packages/hono/test/bun/middleware.test.ts
@@ -10,6 +10,12 @@ vi.mock('@sentry/bun', () => ({
   init: vi.fn(),
 }));
 
+// `hono/bun` eagerly imports Bun-only modules (e.g. SSG) that reference the `Bun` global,
+// which is not available under Vitest/Node. We only use its `getConnInfo` helper.
+vi.mock('hono/bun', () => ({
+  getConnInfo: vi.fn(() => ({ remote: {} })),
+}));
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 const { init: initBunMock } = await vi.importMock<typeof import('@sentry/bun')>('@sentry/bun');
 

--- a/packages/hono/test/node/middleware.test.ts
+++ b/packages/hono/test/node/middleware.test.ts
@@ -8,6 +8,10 @@ vi.mock('@sentry/node', () => ({
   init: vi.fn(),
 }));
 
+vi.mock('@hono/node-server/conninfo', () => ({
+  getConnInfo: vi.fn(() => ({ remote: {} })),
+}));
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 const { init: initNodeMock } = await vi.importMock<typeof import('@sentry/node')>('@sentry/node');
 

--- a/packages/hono/test/shared/middlewareHandlers.test.ts
+++ b/packages/hono/test/shared/middlewareHandlers.test.ts
@@ -12,21 +12,41 @@ vi.mock('../../src/utils/hono-context', () => ({
 
 const mockSetTransactionName = vi.fn();
 const mockSetSDKProcessingMetadata = vi.fn();
+const mockSetUser = vi.fn();
+
+// Minimal stand-in for a real span's attribute store. `setAttributes` delegates to `setAttribute`,
+// like a real span, so tests can assert on the resulting attribute *state* rather than on which
+// setter overload was used. Unset attributes read back as `undefined`, matching span behavior.
+let rootSpanAttributes: Record<string, unknown> = {};
+const mockRootSpan = {
+  setAttribute: vi.fn((key: string, value: unknown) => {
+    rootSpanAttributes[key] = value;
+  }),
+  setAttributes: vi.fn((attributes: Record<string, unknown>) => {
+    for (const [key, value] of Object.entries(attributes)) {
+      rootSpanAttributes[key] = value;
+    }
+  }),
+  updateName: vi.fn(),
+};
 
 vi.mock('@sentry/core', async () => {
   const actual = await vi.importActual('@sentry/core');
   return {
     ...actual,
     getActiveSpan: vi.fn(() => null),
+    getRootSpan: vi.fn(() => mockRootSpan),
     getIsolationScope: vi.fn(() => ({
       setTransactionName: mockSetTransactionName,
       setSDKProcessingMetadata: mockSetSDKProcessingMetadata,
+      setUser: mockSetUser,
     })),
     getClient: vi.fn(() => undefined),
   };
 });
 
 const getClientMock = SentryCore.getClient as ReturnType<typeof vi.fn>;
+const getActiveSpanMock = SentryCore.getActiveSpan as ReturnType<typeof vi.fn>;
 
 function createMockContext(status: number, error?: Error): unknown {
   return {
@@ -225,5 +245,118 @@ describe('responseHandler', () => {
 
       expect(mockSetTransactionName).toHaveBeenCalledWith('GET /test');
     });
+  });
+});
+
+describe('requestHandler — connection info', () => {
+  const activeSpan = { updateName: vi.fn(), setAttribute: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rootSpanAttributes = {};
+    getActiveSpanMock.mockReturnValue(activeSpan);
+  });
+
+  function getConnInfoStub(remote: Record<string, unknown>): () => { remote: Record<string, unknown> } {
+    return vi.fn(() => ({ remote }));
+  }
+
+  function mockUserInfo(userInfo: boolean): void {
+    getClientMock.mockReturnValue({
+      getDataCollectionOptions: () => ({ userInfo }),
+    });
+  }
+
+  it('sets non-PII attributes (port, transport, type) regardless of userInfo', () => {
+    mockUserInfo(false);
+    const getConnInfo = getConnInfoStub({ port: 54321, transport: 'tcp', addressType: 'IPv4' });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    requestHandler(createMockContext(200) as any, getConnInfo as any);
+
+    expect(rootSpanAttributes['client.port']).toBe(54321);
+    expect(rootSpanAttributes['network.peer.port']).toBe(54321);
+    expect(rootSpanAttributes['network.transport']).toBe('tcp');
+    expect(rootSpanAttributes['network.type']).toBe('ipv4');
+    expect(rootSpanAttributes['client.address']).toBeUndefined();
+  });
+
+  it('sets IP-bearing attributes and user.ip_address when userInfo is true', () => {
+    mockUserInfo(true);
+    const getConnInfo = getConnInfoStub({ address: '203.0.113.5', port: 443, addressType: 'IPv6' });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    requestHandler(createMockContext(200) as any, getConnInfo as any);
+
+    expect(rootSpanAttributes['client.address']).toBe('203.0.113.5');
+    expect(rootSpanAttributes['network.peer.address']).toBe('203.0.113.5');
+    expect(rootSpanAttributes['network.type']).toBe('ipv6');
+    expect(mockSetUser).toHaveBeenCalledWith({ ip_address: '203.0.113.5' });
+  });
+
+  it('omits IP-bearing attributes when userInfo is false', () => {
+    mockUserInfo(false);
+    const getConnInfo = getConnInfoStub({ address: '203.0.113.5', port: 8080 });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    requestHandler(createMockContext(200) as any, getConnInfo as any);
+
+    expect(rootSpanAttributes['client.address']).toBeUndefined();
+    expect(rootSpanAttributes['network.peer.address']).toBeUndefined();
+    expect(mockSetUser).not.toHaveBeenCalled();
+    // Non-PII data is still recorded.
+    expect(rootSpanAttributes['client.port']).toBe(8080);
+  });
+
+  it('sets no connection attributes when remote info is empty', () => {
+    mockUserInfo(true);
+    const getConnInfo = getConnInfoStub({});
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    requestHandler(createMockContext(200) as any, getConnInfo as any);
+
+    expect(rootSpanAttributes['client.port']).toBeUndefined();
+    expect(rootSpanAttributes['network.peer.port']).toBeUndefined();
+    expect(rootSpanAttributes['network.transport']).toBeUndefined();
+    expect(rootSpanAttributes['network.type']).toBeUndefined();
+    expect(rootSpanAttributes['client.address']).toBeUndefined();
+    expect(mockSetUser).not.toHaveBeenCalled();
+  });
+
+  it('does not throw or set attributes when getConnInfo throws', () => {
+    mockUserInfo(true);
+    const getConnInfo = vi.fn(() => {
+      throw new Error('socket unavailable');
+    });
+
+    expect(() =>
+      // oxlint-disable-next-line typescript/no-explicit-any
+      requestHandler(createMockContext(200) as any, getConnInfo as any),
+    ).not.toThrow();
+    expect(rootSpanAttributes['client.port']).toBeUndefined();
+    expect(rootSpanAttributes['client.address']).toBeUndefined();
+    expect(mockSetUser).not.toHaveBeenCalled();
+  });
+
+  it('does not set connection attributes when there is no active span', () => {
+    mockUserInfo(true);
+    getActiveSpanMock.mockReturnValue(null);
+    const getConnInfo = getConnInfoStub({ address: '203.0.113.5', port: 443 });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    requestHandler(createMockContext(200) as any, getConnInfo as any);
+
+    expect(getConnInfo).not.toHaveBeenCalled();
+    expect(rootSpanAttributes).toEqual({});
+  });
+
+  it('is a no-op when getConnInfo is not provided', () => {
+    mockUserInfo(true);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    requestHandler(createMockContext(200) as any);
+
+    expect(rootSpanAttributes['client.port']).toBeUndefined();
+    expect(mockSetUser).not.toHaveBeenCalled();
   });
 });

--- a/packages/hono/test/shared/middlewareHandlers.test.ts
+++ b/packages/hono/test/shared/middlewareHandlers.test.ts
@@ -14,9 +14,6 @@ const mockSetTransactionName = vi.fn();
 const mockSetSDKProcessingMetadata = vi.fn();
 const mockSetUser = vi.fn();
 
-// Minimal stand-in for a real span's attribute store. `setAttributes` delegates to `setAttribute`,
-// like a real span, so tests can assert on the resulting attribute *state* rather than on which
-// setter overload was used. Unset attributes read back as `undefined`, matching span behavior.
 let rootSpanAttributes: Record<string, unknown> = {};
 const mockRootSpan = {
   setAttribute: vi.fn((key: string, value: unknown) => {

--- a/packages/hono/test/shared/middlewareHandlers.test.ts
+++ b/packages/hono/test/shared/middlewareHandlers.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../src/utils/hono-context', () => ({
 const mockSetTransactionName = vi.fn();
 const mockSetSDKProcessingMetadata = vi.fn();
 const mockSetUser = vi.fn();
+const mockGetUser = vi.fn<() => Record<string, unknown>>(() => ({}));
 
 let rootSpanAttributes: Record<string, unknown> = {};
 const mockRootSpan = {
@@ -37,6 +38,7 @@ vi.mock('@sentry/core', async () => {
       setTransactionName: mockSetTransactionName,
       setSDKProcessingMetadata: mockSetSDKProcessingMetadata,
       setUser: mockSetUser,
+      getUser: mockGetUser,
     })),
     getClient: vi.fn(() => undefined),
   };
@@ -251,6 +253,7 @@ describe('requestHandler — connection info', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     rootSpanAttributes = {};
+    mockGetUser.mockReturnValue({});
     getActiveSpanMock.mockReturnValue(activeSpan);
   });
 
@@ -289,6 +292,21 @@ describe('requestHandler — connection info', () => {
     expect(rootSpanAttributes['network.peer.address']).toBe('203.0.113.5');
     expect(rootSpanAttributes['network.type']).toBe('ipv6');
     expect(mockSetUser).toHaveBeenCalledWith({ ip_address: '203.0.113.5' });
+  });
+
+  it('merges ip_address into the existing user without overwriting other fields', () => {
+    mockUserInfo(true);
+    mockGetUser.mockReturnValue({ id: 'user-123', email: 'jane@example.com' });
+    const getConnInfo = getConnInfoStub({ address: '203.0.113.5', port: 443 });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    requestHandler(createMockContext(200) as any, getConnInfo as any);
+
+    expect(mockSetUser).toHaveBeenCalledWith({
+      id: 'user-123',
+      email: 'jane@example.com',
+      ip_address: '203.0.113.5',
+    });
   });
 
   it('omits IP-bearing attributes when userInfo is false', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4938,7 +4938,7 @@
     "@hapi/bourne" "^3.0.0"
     "@hapi/hoek" "^11.0.2"
 
-"@hono/node-server@^1.19.13":
+"@hono/node-server@^1.19.10", "@hono/node-server@^1.19.13":
   version "1.19.14"
   resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
   integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==


### PR DESCRIPTION
Adds HTTP connection info to Hono server spans using Hono's [`getConnInfo`](https://hono.dev/docs/helpers/conninfo) helper.

Part of https://github.com/getsentry/sentry-javascript/issues/20401