### PR TITLE
fix(react-router): Mark instrumentation API "active" on invokation

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.client.tsx
@@ -16,10 +16,11 @@ Sentry.init({
   tracePropagationTargets: [/^\//],
 });
 
-// Get the client instrumentation from the Sentry integration
-// NOTE: As of React Router 7.x, HydratedRouter does NOT invoke these hooks in Framework Mode.
-// The client-side instrumentation is prepared for when React Router adds support.
-// Client-side navigation is currently handled by the legacy instrumentHydratedRouter() approach.
+// Get the client instrumentation from the Sentry integration.
+// As of React Router 7.15+, HydratedRouter invokes the client instrumentation hooks (`navigate`
+// and `fetch`) in Framework Mode, so navigation and fetcher spans are created via the
+// instrumentation API (origin `auto.*.react_router.instrumentation_api`). The legacy
+// instrumentHydratedRouter() subscribe still runs to parameterize navigation span names.
 const sentryClientInstrumentation = [tracing.clientInstrumentation];
 
 startTransition(() => {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/tests/performance/fetcher.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/tests/performance/fetcher.client.test.ts
@@ -2,43 +2,42 @@ import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 import { APP_NAME } from '../constants';
 
-// Known React Router limitation: HydratedRouter doesn't invoke instrumentation API
-// hooks on the client-side in Framework Mode. This includes the router.fetch hook.
+// As of React Router 7.15+, HydratedRouter invokes the client `fetch` hook in Framework Mode.
+// A fetcher submission produces a `function.react_router.fetcher` transaction
+// (origin `auto.function.react_router.instrumentation_api`) that nests the client action/loader
+// spans and the `http.client` spans for the underlying `.data` requests.
 // See: https://github.com/remix-run/react-router/discussions/13749
-// Using test.fixme to auto-detect when React Router fixes this upstream.
 
-test.describe('client - instrumentation API fetcher (upstream limitation)', () => {
-  test.fixme('should instrument fetcher with instrumentation API origin', async ({ page }) => {
-    const serverTxPromise = waitForTransaction(APP_NAME, async transactionEvent => {
+test.describe('client - instrumentation API fetcher', () => {
+  test('should instrument fetcher with instrumentation API origin', async ({ page }) => {
+    // Wait for the client pageload to finish so HydratedRouter is hydrated and the fetcher
+    // submission goes through the instrumented client `fetch` path (not a full-document POST).
+    const pageloadTxPromise = waitForTransaction(APP_NAME, async transactionEvent => {
       return (
-        transactionEvent.transaction === 'GET /performance/fetcher-test' &&
-        transactionEvent.contexts?.trace?.op === 'http.server'
+        transactionEvent.transaction === '/performance/fetcher-test' &&
+        transactionEvent.contexts?.trace?.op === 'pageload'
       );
+    });
+
+    const fetcherTxPromise = waitForTransaction(APP_NAME, async transactionEvent => {
+      return transactionEvent.contexts?.trace?.op === 'function.react_router.fetcher';
     });
 
     await page.goto(`/performance/fetcher-test`);
-    await serverTxPromise;
-
-    // Wait for the fetcher action transaction
-    const fetcherTxPromise = waitForTransaction(APP_NAME, async transactionEvent => {
-      return (
-        transactionEvent.contexts?.trace?.op === 'function.react_router.fetcher' &&
-        transactionEvent.contexts?.trace?.data?.['sentry.origin'] === 'auto.function.react_router.instrumentation_api'
-      );
-    });
+    await pageloadTxPromise;
 
     await page.locator('#fetcher-submit').click();
 
     const fetcherTx = await fetcherTxPromise;
 
-    expect(fetcherTx).toMatchObject({
-      contexts: {
-        trace: {
-          op: 'function.react_router.fetcher',
-          origin: 'auto.function.react_router.instrumentation_api',
-        },
-      },
-    });
+    expect(fetcherTx.contexts?.trace?.origin).toBe('auto.function.react_router.instrumentation_api');
+
+    // The fetcher transaction nests the client action span and the http.client span(s) for the
+    // underlying `.data` request(s) - i.e. the OTel/browser fetch span is parented by the fetcher
+    // span, not emitted standalone.
+    const spanOps = (fetcherTx.spans ?? []).map(span => span.op);
+    expect(spanOps).toContain('function.react_router.client_action');
+    expect(spanOps).toContain('http.client');
   });
 
   test('should still send server action transaction when fetcher submits', async ({ page }) => {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes.ts
@@ -19,5 +19,6 @@ export default [
     route('server-loader', 'routes/performance/server-loader.tsx'),
     route('server-action', 'routes/performance/server-action.tsx'),
     route('with-middleware', 'routes/performance/with-middleware.tsx'),
+    route('redis', 'routes/performance/redis.tsx'),
   ]),
 ] satisfies RouteConfig;

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/index.tsx
@@ -10,6 +10,7 @@ export default function PerformancePage() {
         <Link to={{ pathname: '/performance/with/object-nav', search: '?foo=bar' }}>Object Navigate</Link>
         <Link to={{ search: '?query=test' }}>Search Only Navigate</Link>
         <Link to="/performance/server-loader">Server Loader</Link>
+        <Link to="/performance/redis">Redis</Link>
       </nav>
     </div>
   );

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/redis.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/routes/performance/redis.tsx
@@ -1,0 +1,22 @@
+import Redis from 'ioredis';
+import type { Route } from './+types/redis';
+
+const redis = new Redis();
+
+export async function loader() {
+  const key = 'cache:greeting';
+  await redis.set(key, 'hello from react-router');
+  const value = await redis.get(key);
+
+  return { value };
+}
+
+export default function RedisPage({ loaderData }: Route.ComponentProps) {
+  const { value } = loaderData;
+  return (
+    <div>
+      <h1>Redis Page</h1>
+      <div id="redis-value">{value}</div>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/docker-compose.yml
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  redis:
+    image: redis:8
+    restart: always
+    container_name: e2e-tests-react-router-7-redis
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 1s
+      timeout: 3s
+      retries: 30

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/global-setup.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/global-setup.mjs
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Boot Redis here (rather than in the `start` script) so the cold `redis:8` image
+// pull happens outside Playwright's webServer startup-timeout window. `--wait`
+// blocks until the healthcheck passes;
+export default async function globalSetup() {
+  execSync('docker compose up -d --wait', { cwd: __dirname, stdio: 'inherit' });
+}

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/package.json
@@ -10,6 +10,7 @@
     "@react-router/node": "^7.13.0",
     "@react-router/serve": "^7.13.0",
     "@sentry/react-router": "file:../../packed/sentry-react-router-packed.tgz",
+    "ioredis": "^5.4.1",
     "isbot": "^5.1.17"
   },
   "devDependencies": {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/playwright.config.mjs
@@ -1,8 +1,13 @@
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+import { fileURLToPath } from 'url';
 
-const config = getPlaywrightConfig({
-  startCommand: `PORT=3030 pnpm start`,
-  port: 3030,
-});
+const config = getPlaywrightConfig(
+  {
+    startCommand: `PORT=3030 pnpm start`,
+    port: 3030,
+  },
+  // Boot Redis before the tests run, outside the webServer startup-timeout window.
+  { globalSetup: fileURLToPath(new URL('./global-setup.mjs', import.meta.url)) },
+);
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/tests/performance/redis.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/tests/performance/redis.server.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+import { APP_NAME } from '../constants';
+
+test.describe('server - redis db spans', () => {
+  test('server loader emits db.redis child spans on the http.server transaction', async ({ page }) => {
+    const txPromise = waitForTransaction(APP_NAME, async transactionEvent => {
+      return (
+        transactionEvent.transaction === 'GET /performance/redis' &&
+        (transactionEvent.spans?.some(span => span.op === 'db.redis') ?? false)
+      );
+    });
+
+    await page.goto('/performance/redis');
+
+    const transaction = await txPromise;
+
+    expect(transaction.contexts?.trace?.op).toBe('http.server');
+    const redisSpans = transaction.spans!.filter(span => span.op === 'db.redis');
+
+    // loader runs SET then GET => at least two redis command spans
+    expect(redisSpans.length).toBeGreaterThanOrEqual(2);
+
+    // every redis span is a child span tagged as the redis system
+    expect(redisSpans.every(span => span.data?.['db.system'] === 'redis')).toBe(true);
+    expect(redisSpans.every(span => typeof span.parent_span_id === 'string')).toBe(true);
+    expect(redisSpans.some(span => span.data?.['net.peer.port'] === 6379)).toBe(true);
+
+    // db.statement starts with the command name (e.g. "set cache:greeting ...", "get cache:greeting")
+    const statements = redisSpans.map(span => String(span.data?.['db.statement'] ?? '').toLowerCase());
+    expect(statements.some(statement => statement.startsWith('set'))).toBe(true);
+    expect(statements.some(statement => statement.startsWith('get'))).toBe(true);
+  });
+});

--- a/packages/react-router/src/server/createServerInstrumentation.ts
+++ b/packages/react-router/src/server/createServerInstrumentation.ts
@@ -44,11 +44,12 @@ export function createSentryServerInstrumentation(
 ): ServerInstrumentation {
   const { captureErrors = true } = options;
 
-  markInstrumentationApiUsed();
-  DEBUG_BUILD && debug.log('React Router server instrumentation API enabled.');
+  DEBUG_BUILD && debug.log('React Router server instrumentation created.');
 
   return {
     handler(handler: InstrumentableRequestHandler) {
+      // Mark the instrumentation API active only when React Router actually invokes this
+      markInstrumentationApiUsed();
       handler.instrument({
         async request(handleRequest, info) {
           const pathname = getPathFromRequest(info.request);
@@ -115,6 +116,8 @@ export function createSentryServerInstrumentation(
     },
 
     route(route: InstrumentableRoute) {
+      // Also mark active here, in case route registration runs (mirrors the handler callback above).
+      markInstrumentationApiUsed();
       const routeId = route.id;
 
       route.instrument({

--- a/packages/react-router/test/server/createServerInstrumentation.test.ts
+++ b/packages/react-router/test/server/createServerInstrumentation.test.ts
@@ -62,10 +62,31 @@ describe('createSentryServerInstrumentation', () => {
     expect(typeof instrumentation.route).toBe('function');
   });
 
-  it('should set the global flag when created', () => {
+  it('should NOT set the global flag when created (only when React Router invokes the registration)', () => {
     expect((globalThis as any).__sentryReactRouterServerInstrumentationUsed).toBeUndefined();
 
     createSentryServerInstrumentation();
+
+    // Creating the instrumentation must not mark the API active. On React Router versions that
+    // don't support the instrumentations API, the registration callbacks are never invoked, so
+    // the legacy OTel data-loader path and wrapServerLoader/wrapServerAction must stay active.
+    expect((globalThis as any).__sentryReactRouterServerInstrumentationUsed).toBeUndefined();
+  });
+
+  it('should set the global flag when React Router invokes the handler registration', () => {
+    const instrumentation = createSentryServerInstrumentation();
+    expect((globalThis as any).__sentryReactRouterServerInstrumentationUsed).toBeUndefined();
+
+    instrumentation.handler?.({ instrument: vi.fn() });
+
+    expect((globalThis as any).__sentryReactRouterServerInstrumentationUsed).toBe(true);
+  });
+
+  it('should set the global flag when React Router invokes the route registration', () => {
+    const instrumentation = createSentryServerInstrumentation();
+    expect((globalThis as any).__sentryReactRouterServerInstrumentationUsed).toBeUndefined();
+
+    instrumentation.route?.({ id: 'test-route', index: false, path: '/test', instrument: vi.fn() });
 
     expect((globalThis as any).__sentryReactRouterServerInstrumentationUsed).toBe(true);
   });
@@ -582,9 +603,14 @@ describe('isInstrumentationApiUsed', () => {
     expect(isInstrumentationApiUsed()).toBe(true);
   });
 
-  it('should return true after createSentryServerInstrumentation is called', () => {
+  it('should return true only after React Router invokes the instrumentation registration', () => {
     expect(isInstrumentationApiUsed()).toBe(false);
-    createSentryServerInstrumentation();
+
+    const instrumentation = createSentryServerInstrumentation();
+    // Not active yet - React Router has not invoked the registration callbacks.
+    expect(isInstrumentationApiUsed()).toBe(false);
+
+    instrumentation.handler?.({ instrument: vi.fn() });
     expect(isInstrumentationApiUsed()).toBe(true);
   });
 });


### PR DESCRIPTION
Marks the instrumentation API only active when it is actually invoked. Unsupported versions otherwise get no instrumentation at all.

