### PR TITLE
feat(node-core): Attach log message and fields to pino error events

### DIFF
--- a/dev-packages/node-integration-tests/suites/pino/scenario-error-context.mjs
+++ b/dev-packages/node-integration-tests/suites/pino/scenario-error-context.mjs
@@ -4,7 +4,10 @@ import pino from 'pino';
 const logger = pino({ name: 'myapp' });
 
 Sentry.withIsolationScope(() => {
-  logger.error({ err: new Error('failed to fetch user'), requestId: 'abc-123' }, 'Failed to do X');
+  logger.error(
+    { err: new Error('failed to fetch user'), requestId: 'abc-123', message: 'upstream said Not Found' },
+    'Failed to do X',
+  );
 });
 
 setTimeout(() => {

--- a/dev-packages/node-integration-tests/suites/pino/scenario-error-context.mjs
+++ b/dev-packages/node-integration-tests/suites/pino/scenario-error-context.mjs
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/node';
+import pino from 'pino';
+
+const logger = pino({ name: 'myapp' });
+
+Sentry.withIsolationScope(() => {
+  logger.error({ err: new Error('failed to fetch user'), requestId: 'abc-123' }, 'Failed to do X');
+});
+
+setTimeout(() => {
+  Sentry.withIsolationScope(() => {
+    logger.error({ requestId: 'def-456' }, 'Something went wrong');
+  });
+}, 500);

--- a/dev-packages/node-integration-tests/suites/pino/test.ts
+++ b/dev-packages/node-integration-tests/suites/pino/test.ts
@@ -53,6 +53,13 @@ conditionalTest({ min: 20 })('Pino integration', () => {
               },
             ],
           },
+          contexts: {
+            pino: {
+              name: 'myapp',
+              module: 'authentication',
+              message: 'oh no',
+            },
+          },
         },
       })
       .expect({
@@ -131,6 +138,12 @@ conditionalTest({ min: 20 })('Pino integration', () => {
                 },
               },
             ],
+          },
+          contexts: {
+            pino: {
+              name: 'myapp',
+              message: 'oh no',
+            },
           },
         },
       })
@@ -296,6 +309,54 @@ conditionalTest({ min: 20 })('Pino integration', () => {
       .completed();
   });
 
+  test('attaches log message and fields to captured error events', async () => {
+    const instrumentPath = join(__dirname, 'instrument.mjs');
+
+    await createRunner(__dirname, 'scenario-error-context.mjs')
+      .withMockSentryServer()
+      .withInstrument(instrumentPath)
+      .ignore('transaction')
+      .ignore('log')
+      .expect({
+        event: {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'failed to fetch user',
+                mechanism: {
+                  type: 'auto.log.pino',
+                  handled: true,
+                },
+              },
+            ],
+          },
+          contexts: {
+            pino: {
+              name: 'myapp',
+              requestId: 'abc-123',
+              message: 'Failed to do X',
+            },
+          },
+        },
+      })
+      .expect({
+        event: {
+          message: 'Something went wrong',
+          level: 'error',
+          contexts: {
+            pino: {
+              name: 'myapp',
+              requestId: 'def-456',
+              message: 'Something went wrong',
+            },
+          },
+        },
+      })
+      .start()
+      .completed();
+  });
+
   test('captures logs with custom messageKey and errorKey', async () => {
     const instrumentPath = join(__dirname, 'instrument.mjs');
 
@@ -325,6 +386,12 @@ conditionalTest({ min: 20 })('Pino integration', () => {
                 },
               },
             ],
+          },
+          contexts: {
+            pino: {
+              name: 'myapp',
+              message: 'Custom error key',
+            },
           },
         },
       })

--- a/dev-packages/node-integration-tests/suites/pino/test.ts
+++ b/dev-packages/node-integration-tests/suites/pino/test.ts
@@ -57,7 +57,7 @@ conditionalTest({ min: 20 })('Pino integration', () => {
             pino: {
               name: 'myapp',
               module: 'authentication',
-              message: 'oh no',
+              msg: 'oh no',
             },
           },
         },
@@ -142,7 +142,7 @@ conditionalTest({ min: 20 })('Pino integration', () => {
           contexts: {
             pino: {
               name: 'myapp',
-              message: 'oh no',
+              msg: 'oh no',
             },
           },
         },
@@ -335,7 +335,8 @@ conditionalTest({ min: 20 })('Pino integration', () => {
             pino: {
               name: 'myapp',
               requestId: 'abc-123',
-              message: 'Failed to do X',
+              message: 'upstream said Not Found',
+              msg: 'Failed to do X',
             },
           },
         },
@@ -348,7 +349,7 @@ conditionalTest({ min: 20 })('Pino integration', () => {
             pino: {
               name: 'myapp',
               requestId: 'def-456',
-              message: 'Something went wrong',
+              msg: 'Something went wrong',
             },
           },
         },

--- a/packages/node-core/src/integrations/pino.ts
+++ b/packages/node-core/src/integrations/pino.ts
@@ -152,8 +152,24 @@ const _pinoIntegration = defineIntegration((userOptions: DeepPartial<PinoOptions
         }
 
         if (options.error.levels.includes(level)) {
+          const errorKey = getPinoKey(self, 'pino.errorKey', 'err');
+
+          // Attach the log message and remaining log fields (e.g. child logger
+          // bindings, merge object fields) to the event. The serialized error is
+          // excluded since it is captured as the event exception itself.
+          const pinoContext: Record<string, unknown> = {};
+          for (const [key, value] of Object.entries(resultObj)) {
+            if (key !== errorKey && key !== messageKey) {
+              pinoContext[key] = value;
+            }
+          }
+          if (logMessage) {
+            pinoContext.message = logMessage;
+          }
+
           const captureContext = {
             level: severityLevelFromString(level),
+            contexts: { pino: pinoContext },
           };
 
           withScope(scope => {
@@ -168,7 +184,7 @@ const _pinoIntegration = defineIntegration((userOptions: DeepPartial<PinoOptions
               return event;
             });
 
-            const error = captureObj[getPinoKey(self, 'pino.errorKey', 'err')];
+            const error = captureObj[errorKey];
             if (error) {
               captureException(error, captureContext);
               return;

--- a/packages/node-core/src/integrations/pino.ts
+++ b/packages/node-core/src/integrations/pino.ts
@@ -164,7 +164,7 @@ const _pinoIntegration = defineIntegration((userOptions: DeepPartial<PinoOptions
             }
           }
           if (logMessage) {
-            pinoContext.message = logMessage;
+            pinoContext[messageKey] = logMessage;
           }
 
           const captureContext = {


### PR DESCRIPTION
The `pinoIntegration` previously captured error events with no context beyond the error itself. For `logger.error(err, 'Failed to do X')`, the log message was dropped entirely, as were all other fields on the log line (child logger bindings, merge object fields like request IDs, the logger `name`).

This PR attaches a `pino` context to events captured via `error.levels` — on both the `captureException` and `captureMessage` paths — containing:

- the formatted log message, stored under the logger's resolved `messageKey` (`msg` by default), so user merge fields named e.g. `message` are never clobbered
- all remaining fields of the serialized log line (child logger bindings, merge object fields, logger `name`, ...)

The serialized error itself is excluded from the context since it is already captured as the event exception, and the `level`/`time`/`pid`/`hostname` housekeeping fields are stripped, matching the existing log capture path. Custom `messageKey`/`errorKey` configurations are respected, and the fields are taken from the serialized log line, so pino redaction/serializers still apply.

Example: `logger.error({ err, requestId: 'abc-123' }, 'Failed to do X')` now produces an error event with

```json
{
  "contexts": {
    "pino": {
      "name": "myapp",
      "requestId": "abc-123",
      "msg": "Failed to do X"
    }
  }
}
```

Fixes #17969
