### PR TITLE
feat(react-router): Always build client instrumentation and deprecate  `useInstrumentationAPI`

### DIFF
--- a/packages/react-router/src/client/tracingIntegration.ts
+++ b/packages/react-router/src/client/tracingIntegration.ts
@@ -17,12 +17,7 @@ export interface ReactRouterTracingIntegrationOptions {
    */
   instrumentationOptions?: CreateSentryClientInstrumentationOptions;
 
-  /**
-   * Enable React Router's instrumentation API.
-   * When true, prepares for use with HydratedRouter's `instrumentations` prop.
-   * @experimental
-   * @default false
-   */
+  /** @deprecated `clientInstrumentation` is always built, so this flag is a no-op. Will be removed in a future major. */
   useInstrumentationAPI?: boolean;
 }
 
@@ -31,9 +26,8 @@ export interface ReactRouterTracingIntegrationOptions {
  */
 export interface ReactRouterTracingIntegration extends Integration {
   /**
-   * Client instrumentation for React Router's instrumentation API.
-   * Lazily initialized on first access.
-   * @experimental HydratedRouter doesn't invoke these hooks in Framework Mode yet.
+   * Client instrumentation to pass to `HydratedRouter`'s `instrumentations` prop.
+   * @experimental
    */
   readonly clientInstrumentation: ClientInstrumentation;
 }
@@ -50,18 +44,9 @@ export function reactRouterTracingIntegration(
     instrumentNavigation: false,
   });
 
-  let clientInstrumentationInstance: ClientInstrumentation | undefined;
-
-  if (options.useInstrumentationAPI || options.instrumentationOptions) {
-    clientInstrumentationInstance = createSentryClientInstrumentation(options.instrumentationOptions);
-  }
-
-  const getClientInstrumentation = (): ClientInstrumentation => {
-    if (!clientInstrumentationInstance) {
-      clientInstrumentationInstance = createSentryClientInstrumentation(options.instrumentationOptions);
-    }
-    return clientInstrumentationInstance;
-  };
+  // Built eagerly so it can be passed to HydratedRouter's `instrumentations` prop. This has no
+  // side effects - the API is only marked "used" once React Router invokes the `router()` hook.
+  const clientInstrumentationInstance = createSentryClientInstrumentation(options.instrumentationOptions);
 
   return {
     ...browserTracingIntegrationInstance,
@@ -71,7 +56,7 @@ export function reactRouterTracingIntegration(
       instrumentHydratedRouter();
     },
     get clientInstrumentation(): ClientInstrumentation {
-      return getClientInstrumentation();
+      return clientInstrumentationInstance;
     },
   };
 }

--- a/packages/react-router/test/client/tracingIntegration.test.ts
+++ b/packages/react-router/test/client/tracingIntegration.test.ts
@@ -41,152 +41,39 @@ describe('reactRouterTracingIntegration', () => {
   });
 
   describe('clientInstrumentation', () => {
-    it('provides clientInstrumentation property', () => {
+    it('builds clientInstrumentation by default (no option required)', () => {
       const integration = reactRouterTracingIntegration();
 
       expect(integration.clientInstrumentation).toBeDefined();
-    });
-
-    it('lazily creates clientInstrumentation only when accessed', () => {
-      const integration = reactRouterTracingIntegration();
-
-      // Flag should not be set yet (lazy initialization)
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBeUndefined();
-
-      // Access the instrumentation
-      const instrumentation = integration.clientInstrumentation;
-
-      // Flag is still NOT set - it only gets set when router() is called by React Router
-      // This is important for Framework Mode where router() is never called
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBeUndefined();
-      expect(instrumentation).toBeDefined();
-      expect(typeof instrumentation.router).toBe('function');
-      expect(typeof instrumentation.route).toBe('function');
-
-      // Simulate React Router calling router() - this is what sets the flag
-      const mockInstrument = vi.fn();
-      instrumentation.router?.({ instrument: mockInstrument });
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBe(true);
+      expect(typeof integration.clientInstrumentation.router).toBe('function');
+      expect(typeof integration.clientInstrumentation.route).toBe('function');
     });
 
     it('returns the same clientInstrumentation instance on multiple accesses', () => {
       const integration = reactRouterTracingIntegration();
 
-      const first = integration.clientInstrumentation;
-      const second = integration.clientInstrumentation;
-
-      expect(first).toBe(second);
+      expect(integration.clientInstrumentation).toBe(integration.clientInstrumentation);
     });
 
-    it('passes options to createSentryClientInstrumentation', () => {
-      const integration = reactRouterTracingIntegration({
-        instrumentationOptions: {
-          captureErrors: false,
-        },
-      });
+    it('passes instrumentationOptions to createSentryClientInstrumentation', () => {
+      const integration = reactRouterTracingIntegration({ instrumentationOptions: { captureErrors: false } });
 
-      const instrumentation = integration.clientInstrumentation;
-
-      // The instrumentation is created - we can verify by checking it has the expected shape
-      expect(instrumentation).toBeDefined();
-      expect(typeof instrumentation.router).toBe('function');
-      expect(typeof instrumentation.route).toBe('function');
-    });
-
-    it('eagerly creates instrumentation when useInstrumentationAPI is true', () => {
-      // Flag should not be set before creating integration
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBeUndefined();
-
-      // Create integration with useInstrumentationAPI: true
-      const integration = reactRouterTracingIntegration({ useInstrumentationAPI: true });
-
-      // Flag should NOT be set just by creating integration - only when router() is called
-      // This is critical for Framework Mode where router() is never called
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBeUndefined();
-
-      // Verify instrumentation was eagerly created (accessible immediately)
       expect(integration.clientInstrumentation).toBeDefined();
-
-      // Simulate React Router calling router() - this is what sets the flag
-      const mockInstrument = vi.fn();
-      integration.clientInstrumentation?.router?.({ instrument: mockInstrument });
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBe(true);
+      expect(typeof integration.clientInstrumentation.router).toBe('function');
     });
 
-    it('eagerly creates instrumentation when instrumentationOptions is provided', () => {
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBeUndefined();
-
-      const integration = reactRouterTracingIntegration({ instrumentationOptions: {} });
-
-      // Flag should NOT be set just by creating integration - only when router() is called
-      // This is critical for Framework Mode where router() is never called
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBeUndefined();
-
-      // Verify instrumentation was eagerly created (accessible immediately)
-      expect(integration.clientInstrumentation).toBeDefined();
-
-      // Simulate React Router calling router() - this is what sets the flag
-      const mockInstrument = vi.fn();
-      integration.clientInstrumentation?.router?.({ instrument: mockInstrument });
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBe(true);
-    });
-
-    it('calls instrumentHydratedRouter when useInstrumentationAPI is true', () => {
-      vi.spyOn(sentryBrowser, 'browserTracingIntegration').mockImplementation(() => ({
-        setup: vi.fn(),
-        afterAllSetup: vi.fn(),
-        name: 'BrowserTracing',
-      }));
-      const instrumentSpy = vi.spyOn(hydratedRouterModule, 'instrumentHydratedRouter').mockImplementation(() => null);
-
-      // Create with useInstrumentationAPI - flag is set eagerly
-      const integration = reactRouterTracingIntegration({ useInstrumentationAPI: true });
-
-      // afterAllSetup runs
-      integration.afterAllSetup?.({} as Client);
-
-      // instrumentHydratedRouter is called for both pageload and navigation handling
-      // (In Framework Mode, HydratedRouter doesn't invoke client hooks, so legacy instrumentation remains active)
-      expect(instrumentSpy).toHaveBeenCalled();
-    });
-
-    it('Framework Mode regression: isClientInstrumentationApiUsed returns false when router() is never called', () => {
-      // This is a critical regression test for Framework Mode (e.g., Remix).
-      //
-      // Scenario:
-      // 1. User sets useInstrumentationAPI: true in reactRouterTracingIntegration options
-      // 2. createSentryClientInstrumentation() is called eagerly during SDK init
-      // 3. BUT in Framework Mode, React Router doesn't invoke the instrumentations API,
-      //    so router() method is NEVER called by the framework
-      // 4. The SENTRY_CLIENT_INSTRUMENTATION_FLAG must NOT be set in this case
-      // 5. isClientInstrumentationApiUsed() must return false
-      // 6. This allows legacy instrumentation in hydratedRouter.ts to create navigation spans
-      //
-      // Without this behavior, Framework Mode would have ZERO navigation spans because:
-      // - The flag would be set (disabling legacy instrumentation)
-      // - But router() was never called (so instrumentation API doesn't create spans either)
+    it('does not mark the instrumentation API used until React Router invokes router()', () => {
+      // Building the instrumentation must NOT set the flag - otherwise the legacy
+      // instrumentHydratedRouter() fallback would be disabled on React Router versions (< 7.15)
+      // that never invoke the hooks, leaving those apps with no navigation spans.
+      const integration = reactRouterTracingIntegration();
 
       expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBeUndefined();
-
-      // Create integration with useInstrumentationAPI: true (simulating user config)
-      const integration = reactRouterTracingIntegration({ useInstrumentationAPI: true });
-
-      // Access the instrumentation (simulating what would happen during setup)
-      const instrumentation = integration.clientInstrumentation;
-      expect(instrumentation).toBeDefined();
-
-      // CRITICAL: Flag is NOT set because router() was never called
-      // This simulates Framework Mode where the framework doesn't call our hooks
-      expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBeUndefined();
-
-      // isClientInstrumentationApiUsed() returns false - legacy instrumentation will work
       expect(isClientInstrumentationApiUsed()).toBe(false);
 
-      // Now simulate what happens in Library Mode: React Router calls router()
-      const mockInstrument = vi.fn();
-      instrumentation.router?.({ instrument: mockInstrument });
+      // React Router invoking router() (>= 7.15, Framework Mode) is what flips the flag.
+      integration.clientInstrumentation.router?.({ instrument: vi.fn() });
 
-      // After router() is called, flag IS set and isClientInstrumentationApiUsed() returns true
       expect((GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_CLIENT_INSTRUMENTATION_FLAG]).toBe(true);
       expect(isClientInstrumentationApiUsed()).toBe(true);
     });


### PR DESCRIPTION
This is basically the first step in making the instrumentation API the default without breaking unsupported versions.

- always build the client instrumentation for the instrumentation api, as we changed detection for this in https://github.com/getsentry/sentry-javascript/pull/21420 
- deprecate `useInstrumentationAPI` (becomes a no-op)


closes https://github.com/getsentry/sentry-javascript/issues/21393