### PR TITLE
fix(tanstackstart-react): Preserve middleware context types

### DIFF
--- a/packages/tanstackstart-react/src/client/index.ts
+++ b/packages/tanstackstart-react/src/client/index.ts
@@ -1,7 +1,11 @@
 // import/export got a false positive, and affects most of our index barrel files
 // can be removed once following issue is fixed: https://github.com/import-js/eslint-plugin-import/issues/703
 /* eslint-disable import/export */
-import type { TanStackMiddlewareBase } from '../common/types';
+import type {
+  SentryGlobalFunctionMiddleware,
+  SentryGlobalRequestMiddleware,
+  TanStackMiddlewareBase,
+} from '../common/types';
 import type { CreateSentryTunnelRouteOptions } from '../server/tunnelRoute';
 
 export * from '@sentry/react';
@@ -20,13 +24,21 @@ export function wrapMiddlewaresWithSentry<T extends TanStackMiddlewareBase>(midd
  * No-op stub for client-side builds.
  * The actual implementation is server-only, but this stub is needed to prevent rendering errors.
  */
-export const sentryGlobalRequestMiddleware: TanStackMiddlewareBase = { '~types': undefined, options: {} };
+export const sentryGlobalRequestMiddleware: SentryGlobalRequestMiddleware = {
+  '~types': undefined as unknown as SentryGlobalRequestMiddleware['~types'],
+  _types: undefined as unknown as SentryGlobalRequestMiddleware['_types'],
+  options: {},
+};
 
 /**
  * No-op stub for client-side builds.
  * The actual implementation is server-only, but this stub is needed to prevent rendering errors.
  */
-export const sentryGlobalFunctionMiddleware: TanStackMiddlewareBase = { '~types': undefined, options: {} };
+export const sentryGlobalFunctionMiddleware: SentryGlobalFunctionMiddleware = {
+  '~types': undefined as unknown as SentryGlobalFunctionMiddleware['~types'],
+  _types: undefined as unknown as SentryGlobalFunctionMiddleware['_types'],
+  options: {},
+};
 
 /**
  * No-op stub for client-side builds.

--- a/packages/tanstackstart-react/src/common/index.ts
+++ b/packages/tanstackstart-react/src/common/index.ts
@@ -1,1 +1,6 @@
-export type { TanStackMiddlewareBase, MiddlewareWrapperOptions } from './types';
+export type {
+  TanStackMiddlewareBase,
+  MiddlewareWrapperOptions,
+  SentryGlobalFunctionMiddleware,
+  SentryGlobalRequestMiddleware,
+} from './types';

--- a/packages/tanstackstart-react/src/common/types.ts
+++ b/packages/tanstackstart-react/src/common/types.ts
@@ -1,6 +1,72 @@
 export type TanStackMiddlewareBase = {
+  '~types': unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  '~types': any;
+  options: { server?: (...args: any[]) => any };
+};
+
+/**
+ * Structurally mirrors TanStack Start's `RequestMiddlewareTypes` for a middleware that contributes
+ * nothing to the middleware chain. The context-related fields are deliberately typed as `undefined`
+ * rather than `any`: TanStack Start merges middleware context types through these fields, so an
+ * `any` here would turn the inferred `context` of every subsequent middleware and handler into `any`.
+ */
+type SentryRequestMiddlewareTypes = {
+  type: 'request';
+  middlewares: undefined;
+  allInput: undefined;
+  allOutput: undefined;
+  serverContext: undefined;
+  allServerContext: undefined;
+};
+
+/**
+ * Structurally mirrors TanStack Start's `FunctionMiddlewareTypes` for a middleware that contributes
+ * nothing to the middleware chain (see `SentryRequestMiddlewareTypes`).
+ */
+type SentryFunctionMiddlewareTypes = {
+  type: 'function';
+  middlewares: undefined;
+  input: undefined;
+  allInput: undefined;
+  output: undefined;
+  allOutput: undefined;
+  clientContext: undefined;
+  allClientContextBeforeNext: undefined;
+  allClientContextAfterNext: undefined;
+  serverContext: undefined;
+  serverSendContext: undefined;
+  allServerSendContext: undefined;
+  allServerContext: undefined;
+  clientSendContext: undefined;
+  allClientSendContext: undefined;
+  validator: undefined;
+  inputValidator: undefined;
+};
+
+/**
+ * Type of the `sentryGlobalRequestMiddleware` export.
+ *
+ * Declares the middleware type information under both `~types` (TanStack Start >=1.143) and
+ * `_types` (older versions) so the middleware satisfies `AnyRequestMiddleware` across the
+ * supported version range.
+ */
+export type SentryGlobalRequestMiddleware = {
+  '~types': SentryRequestMiddlewareTypes;
+  _types: SentryRequestMiddlewareTypes;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  options: { server?: (...args: any[]) => any };
+};
+
+/**
+ * Type of the `sentryGlobalFunctionMiddleware` export.
+ *
+ * Declares the middleware type information under both `~types` (TanStack Start >=1.143) and
+ * `_types` (older versions) so the middleware satisfies `AnyFunctionMiddleware` across the
+ * supported version range.
+ */
+export type SentryGlobalFunctionMiddleware = {
+  '~types': SentryFunctionMiddlewareTypes;
+  _types: SentryFunctionMiddlewareTypes;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options: { server?: (...args: any[]) => any };
 };

--- a/packages/tanstackstart-react/src/server/globalMiddleware.ts
+++ b/packages/tanstackstart-react/src/server/globalMiddleware.ts
@@ -6,7 +6,7 @@ import {
   spanToJSON,
   updateSpanName,
 } from '@sentry/core';
-import type { TanStackMiddlewareBase } from '../common/types';
+import type { SentryGlobalFunctionMiddleware, SentryGlobalRequestMiddleware } from '../common/types';
 import { SENTRY_INTERNAL } from './middleware';
 
 type ServerFnMeta = {
@@ -67,8 +67,10 @@ function createSentryFunctionMiddlewareHandler(mechanismType: string) {
  * Global request middleware that captures errors from API route requests.
  * Should be added as the first entry in the `requestMiddleware` array of `createStart()`.
  */
-export const sentryGlobalRequestMiddleware: TanStackMiddlewareBase = {
-  '~types': undefined,
+export const sentryGlobalRequestMiddleware: SentryGlobalRequestMiddleware = {
+  // `~types`/`_types` only exist on the type level in TanStack Start middlewares and hold no runtime value
+  '~types': undefined as unknown as SentryGlobalRequestMiddleware['~types'],
+  _types: undefined as unknown as SentryGlobalRequestMiddleware['_types'],
 
   options: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -80,8 +82,10 @@ export const sentryGlobalRequestMiddleware: TanStackMiddlewareBase = {
  * Global function middleware that captures errors from server function invocations.
  * Should be added as the first entry in the `functionMiddleware` array of `createStart()`.
  */
-export const sentryGlobalFunctionMiddleware: TanStackMiddlewareBase = {
-  '~types': undefined,
+export const sentryGlobalFunctionMiddleware: SentryGlobalFunctionMiddleware = {
+  // `~types`/`_types` only exist on the type level in TanStack Start middlewares and hold no runtime value
+  '~types': undefined as unknown as SentryGlobalFunctionMiddleware['~types'],
+  _types: undefined as unknown as SentryGlobalFunctionMiddleware['_types'],
 
   options: {
     server: createSentryFunctionMiddlewareHandler('auto.middleware.tanstackstart.server_function') as (


### PR DESCRIPTION
The global middlewares were types as `TanStackMiddlewareBase` with `~types: any`. TSS merges these context types, folding over all contexts ending up with types that cary over, .e.g

```js
{
    [x: string]: any;
    [x: number]: any;
    [x: symbol]: any;
    db: { query: (sql: string) => Promise<string[]> };
}
```

We now mirror TSS's middleware types instead with all contexct and validator fields set to `undefined`, which is what a context-free middleware resolves to.

**Note**: We use both the newer `~types` and the older `_types` to be compatible with our supported TSS range.

<hr>

Pre-fix: 
<img width="1013" height="331" alt="Screenshot 2026-06-10 at 14 56 37" src="https://github.com/user-attachments/assets/df883384-87fd-43dc-9a67-7f75c3a54f86" />

Post-fix: 
<img width="999" height="346" alt="Screenshot 2026-06-10 at 14 55 34" src="https://github.com/user-attachments/assets/25d22bf7-25d7-47f5-8643-fa026aa318c7" />

Fixes: #21433


