### PR TITLE
fix(deno): Use correct paths for `module` and `types` fileds in `package.json`

### DIFF
--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/deno",
   "author": "Sentry",
   "license": "MIT",
-  "module": "build/index.mjs",
-  "types": "build/index.d.ts",
+  "module": "build/esm/index.js",
+  "types": "build/esm/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
The paths `build/index.mjs` and `build/index.d.ts` don't exist. The Deno package builds only to `build/esm/`.

Thowever, the `exports` fields is using the correct paths:
```json
  "exports": {
    "./package.json": "./package.json",
    ".": {
      "import": {
        "types": "./build/esm/index.d.ts",
        "default": "./build/esm/index.js"
      }
    }
  },
```